### PR TITLE
feat(logs): Move base query into separate context

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -37,12 +37,12 @@ export function OurlogsSection({
   group: Group;
   project: Project;
 }) {
+  const traceId = event.contexts?.trace?.trace_id;
   return (
-    <LogsQueryParamsProvider source="state">
+    <LogsQueryParamsProvider source="state" freeze={traceId ? {traceId} : undefined}>
       <LogsPageParamsProvider
         analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
         isTableFrozen
-        limitToTraceId={event.contexts?.trace?.trace_id}
       >
         <LogsPageDataProvider>
           <OurlogsSectionContent event={event} group={group} project={project} />
@@ -70,7 +70,7 @@ function OurlogsSectionContent({
   const viewAllButtonRef = useRef<HTMLButtonElement>(null);
   const sharedHoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const limitToTraceId = event.contexts?.trace?.trace_id;
+  const traceId = event.contexts?.trace?.trace_id;
   const onOpenLogsDrawer = useCallback(
     (e: React.MouseEvent, expandedLogId?: string) => {
       e.stopPropagation();
@@ -79,11 +79,13 @@ function OurlogsSectionContent({
       });
       openDrawer(
         () => (
-          <LogsQueryParamsProvider source="state">
+          <LogsQueryParamsProvider
+            source="state"
+            freeze={traceId ? {traceId} : undefined}
+          >
             <LogsPageParamsProvider
               analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
               isTableFrozen
-              limitToTraceId={limitToTraceId}
             >
               <LogsPageDataProvider>
                 <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
@@ -111,7 +113,7 @@ function OurlogsSectionContent({
         }
       );
     },
-    [group, event, project, openDrawer, organization, limitToTraceId]
+    [group, event, project, openDrawer, organization, traceId]
   );
 
   const onEmbeddedRowClick = useCallback(
@@ -123,7 +125,7 @@ function OurlogsSectionContent({
   if (!feature) {
     return null;
   }
-  if (!limitToTraceId) {
+  if (!traceId) {
     // If there isn't a traceId (eg. profiling issue), we shouldn't show logs since they are trace specific.
     // We may change this in the future if we have a trace-group or we generate trace sids for these issue types.
     return null;

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -11,7 +11,6 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {
   defaultLogFields,
   getLogFieldsFromLocation,
@@ -78,10 +77,6 @@ interface LogsPageParams {
    * E.g., message.parameters.0
    */
   readonly aggregateParam?: string;
-  /**
-   * The base search, which doesn't appear in the URL or the search bar, used for adding traceid etc.
-   */
-  readonly baseSearch?: MutableSearch;
 
   /**
    * E.g., message.template
@@ -92,18 +87,7 @@ interface LogsPageParams {
    * The id of the query, if a saved query.
    */
   readonly id?: string;
-  /**
-   * If provided, add a 'trace:{trace id}' to all queries.
-   * Used in embedded views like error page and trace page.
-   * Can be an array of trace IDs on some pages (eg. replays)
-   */
-  readonly limitToTraceId?: string | string[];
 
-  /**
-   * If provided, ignores the project in the location and uses the provided project IDs.
-   * Useful for cross-project traces when project is in the location.
-   */
-  readonly projectIds?: number[];
   /**
    * The title of the query, if a saved query.
    */
@@ -134,16 +118,10 @@ interface LogsPageParamsProviderProps {
     refreshInterval?: number;
   };
   isTableFrozen?: boolean;
-  limitToProjectIds?: number[];
-  limitToSpanId?: string;
-  limitToTraceId?: string | string[];
 }
 
 export function LogsPageParamsProvider({
   children,
-  limitToTraceId,
-  limitToSpanId,
-  limitToProjectIds,
   isTableFrozen,
   analyticsPageSource,
   _testContext,
@@ -156,22 +134,6 @@ export function LogsPageParamsProvider({
   const [cursorForFrozenPages, setCursorForFrozenPages] = useState('');
 
   const search = isTableFrozen ? searchForFrozenPages : new MutableSearch(logsQuery);
-  let baseSearch: MutableSearch | undefined = undefined;
-
-  const traceIds = Array.isArray(limitToTraceId)
-    ? limitToTraceId
-    : limitToTraceId
-      ? [limitToTraceId]
-      : undefined;
-
-  if (traceIds?.length) {
-    baseSearch = baseSearch ?? new MutableSearch('');
-    const traceIdValue = `[${traceIds.join(',')}]`;
-    baseSearch.addFilterValue(OurLogKnownFieldKey.TRACE_ID, traceIdValue);
-    if (limitToSpanId) {
-      baseSearch.addFilterValue(OurLogKnownFieldKey.PARENT_SPAN_ID, limitToSpanId);
-    }
-  }
 
   const title = getLogTitleFromLocation(location);
   const id = getLogIdFromLocation(location);
@@ -198,10 +160,6 @@ export function LogsPageParamsProvider({
     aggregate,
   ]);
   const mode = getModeFromLocation(location);
-  const pageFilters = usePageFilters();
-  const projectIds = isTableFrozen
-    ? (limitToProjectIds ?? [-1])
-    : pageFilters.selection.projects;
   // TODO we should handle environments in a similar way to projects - otherwise page filters might break embedded views
 
   const cursor = isTableFrozen
@@ -223,10 +181,7 @@ export function LogsPageParamsProvider({
         cursor,
         setCursorForFrozenPages,
         isTableFrozen,
-        baseSearch,
-        projectIds,
         analyticsPageSource,
-        limitToTraceId: traceIds,
         groupBy,
         aggregateFn,
         aggregateParam,
@@ -332,11 +287,6 @@ export function useLogsSearch(): MutableSearch {
   return search;
 }
 
-export function useLogsBaseSearch(): MutableSearch | undefined {
-  const {baseSearch} = useLogsPageParams();
-  return baseSearch;
-}
-
 export function useSetLogsSearch() {
   const setPageParams = useSetLogsPageParams();
   const {setSearchForFrozenPages, isTableFrozen} = useLogsPageParams();
@@ -350,16 +300,6 @@ export function useSetLogsSearch() {
     return setSearchForFrozenPages;
   }
   return setPageParamsCallback;
-}
-
-export function useLogsLimitToTraceId() {
-  const {limitToTraceId} = useLogsPageParams();
-  return limitToTraceId;
-}
-
-export function useLogsIsTableFrozen() {
-  const {isTableFrozen} = useLogsPageParams();
-  return isTableFrozen;
 }
 
 export function usePersistedLogsPageParams() {
@@ -386,11 +326,6 @@ export function useLogsId() {
 export function useLogsTitle() {
   const {title} = useLogsPageParams();
   return title;
-}
-
-export function useLogsProjectIds() {
-  const {projectIds} = useLogsPageParams();
-  return projectIds;
 }
 
 export function useSetLogsSavedQueryInfo() {

--- a/static/app/views/explore/logs/logsFrozenContext.tsx
+++ b/static/app/views/explore/logs/logsFrozenContext.tsx
@@ -125,7 +125,7 @@ export function LogsFrozenContextProvider(
   return <LogsFrozenContext value={value}>{props.children}</LogsFrozenContext>;
 }
 
-export function useLogsFrozenContext() {
+function useLogsFrozenContext() {
   // default to `LogsNotFrozen`
   return _useLogsFrozenContext() ?? {};
 }

--- a/static/app/views/explore/logs/logsFrozenContext.tsx
+++ b/static/app/views/explore/logs/logsFrozenContext.tsx
@@ -1,0 +1,147 @@
+import type {ReactNode, ReactPortal} from 'react';
+import {useMemo} from 'react';
+
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
+import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+
+interface LogsFrozenContextValue {
+  frozen: boolean;
+  projectIds?: number[];
+  search?: MutableSearch;
+  spanId?: string;
+  traceIds?: string[];
+}
+
+const [_LogsFrozenContextProvider, _useLogsFrozenContext, LogsFrozenContext] =
+  createDefinedContext<LogsFrozenContextValue>({
+    name: 'LogsFrozenContext',
+    strict: false,
+  });
+
+interface LogsFrozenForTracesProviderProps {
+  traceIds: string[];
+}
+
+interface LogsFrozenForTraceProviderProps {
+  traceId: string;
+}
+
+interface LogsFrozenForSpanProviderProps {
+  span: {
+    spanId: string;
+    traceId: string;
+    projectIds?: number[];
+  };
+}
+
+type LogsNotFrozenProviderProps = Record<keyof any, never>;
+
+export type LogsFrozenContextProviderProps =
+  | LogsFrozenForTracesProviderProps
+  | LogsFrozenForTraceProviderProps
+  | LogsFrozenForSpanProviderProps
+  | LogsNotFrozenProviderProps;
+
+interface LogsFrozenForTracesProviderWithChildrenProps
+  extends ReactPortal,
+    LogsFrozenForTracesProviderProps {}
+
+interface LogsFrozenForTraceProviderWithChildrenProps
+  extends ReactPortal,
+    LogsFrozenForTraceProviderProps {}
+
+interface LogsFrozenForSpanProviderWithChildrenProps
+  extends ReactPortal,
+    LogsFrozenForSpanProviderProps {}
+
+type LogsFrozenContextProviderWithChildrenProps =
+  | LogsFrozenForTracesProviderWithChildrenProps
+  | LogsFrozenForTraceProviderWithChildrenProps
+  | LogsFrozenForSpanProviderWithChildrenProps
+  | {children: ReactNode};
+
+function isLogsFrozenForTracesProviderWithChildrenProps(
+  value: LogsFrozenContextProviderWithChildrenProps
+): value is LogsFrozenForTracesProviderWithChildrenProps {
+  return value.hasOwnProperty('traceIds');
+}
+
+function isLogsFrozenForTraceProviderWithChildrenProps(
+  value: LogsFrozenContextProviderWithChildrenProps
+): value is LogsFrozenForTraceProviderWithChildrenProps {
+  return value.hasOwnProperty('traceId');
+}
+
+function isLogsFrozenForSpanProviderWithChildrenProps(
+  value: LogsFrozenContextProviderWithChildrenProps
+): value is LogsFrozenForSpanProviderWithChildrenProps {
+  return value.hasOwnProperty('span');
+}
+
+export function LogsFrozenContextProvider(
+  props: LogsFrozenContextProviderWithChildrenProps
+) {
+  const value: LogsFrozenContextValue = useMemo(() => {
+    if (isLogsFrozenForTracesProviderWithChildrenProps(props) && props.traceIds.length) {
+      const search = new MutableSearch('');
+      const traceIds = `[${props.traceIds.join(',')}]`;
+      search.addFilterValue(OurLogKnownFieldKey.TRACE_ID, traceIds);
+      return {
+        frozen: true,
+        search,
+        traceIds: props.traceIds,
+        projectIds: [ALL_ACCESS_PROJECTS],
+      };
+    }
+
+    if (isLogsFrozenForTraceProviderWithChildrenProps(props)) {
+      const search = new MutableSearch('');
+      search.addFilterValue(OurLogKnownFieldKey.TRACE_ID, props.traceId);
+      return {
+        frozen: true,
+        search,
+        traceIds: [props.traceId],
+        projectIds: [ALL_ACCESS_PROJECTS],
+      };
+    }
+
+    if (isLogsFrozenForSpanProviderWithChildrenProps(props)) {
+      const search = new MutableSearch('');
+      search.addFilterValue(OurLogKnownFieldKey.TRACE_ID, props.span.traceId);
+      search.addFilterValue(OurLogKnownFieldKey.PARENT_SPAN_ID, props.span.spanId);
+      return {
+        frozen: true,
+        search,
+        traceIds: [props.span.traceId],
+        projectIds: props.span.projectIds ?? [ALL_ACCESS_PROJECTS],
+      };
+    }
+
+    return {frozen: false};
+  }, [props]);
+
+  return <LogsFrozenContext value={value}>{props.children}</LogsFrozenContext>;
+}
+
+export function useLogsFrozenContext() {
+  // default to `LogsNotFrozen`
+  return _useLogsFrozenContext() ?? {};
+}
+
+export function useLogsFrozenIsFrozen() {
+  return useLogsFrozenContext().frozen;
+}
+
+export function useLogsFrozenProjectIds() {
+  return useLogsFrozenContext().projectIds;
+}
+
+export function useLogsFrozenTraceIds() {
+  return useLogsFrozenContext().traceIds;
+}
+
+export function useLogsFrozenSearch() {
+  return useLogsFrozenContext().search;
+}

--- a/static/app/views/explore/logs/logsQueryParamsProvider.tsx
+++ b/static/app/views/explore/logs/logsQueryParamsProvider.tsx
@@ -1,16 +1,22 @@
 import type {ReactNode} from 'react';
 
+import {
+  LogsFrozenContextProvider,
+  type LogsFrozenContextProviderProps,
+} from 'sentry/views/explore/logs/logsFrozenContext';
 import {LogsLocationQueryParamsProvider} from 'sentry/views/explore/logs/logsLocationQueryParamsProvider';
 import {LogsStateQueryParamsProvider} from 'sentry/views/explore/logs/logsStateQueryParamsProvider';
 
 interface LogsQueryParamsProviderProps {
   children: ReactNode;
   source: 'location' | 'state';
+  freeze?: LogsFrozenContextProviderProps;
 }
 
 export function LogsQueryParamsProvider({
   children,
   source,
+  freeze,
 }: LogsQueryParamsProviderProps) {
   const LogsQueryParamsProviderComponent =
     source === 'location'
@@ -23,5 +29,9 @@ export function LogsQueryParamsProvider({
     throw new Error(`Unknown source for LogsQueryParamsProvider: ${source}`);
   }
 
-  return <LogsQueryParamsProviderComponent>{children}</LogsQueryParamsProviderComponent>;
+  return (
+    <LogsFrozenContextProvider {...freeze}>
+      <LogsQueryParamsProviderComponent>{children}</LogsQueryParamsProviderComponent>
+    </LogsFrozenContextProvider>
+  );
 }

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -34,7 +34,6 @@ import {
 import {
   useLogsAddSearchFilter,
   useLogsAnalyticsPageSource,
-  useLogsIsTableFrozen,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import type {TraceItemDetailsResponse} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {useFetchTraceItemDetailsOnHover} from 'sentry/views/explore/hooks/useTraceItemDetails';
@@ -50,6 +49,7 @@ import {
   LogFieldRenderer,
   SeverityCircleRenderer,
 } from 'sentry/views/explore/logs/fieldRenderers';
+import {useLogsFrozenIsFrozen} from 'sentry/views/explore/logs/logsFrozenContext';
 import {
   DetailsBody,
   DetailsContent,
@@ -558,9 +558,9 @@ function LogRowDetailsActions({
   tableDataRow: OurLogsResponseItem;
 }) {
   const {data, isPending, isError} = fullLogDataResult;
-  const isTableFrozen = useLogsIsTableFrozen();
+  const isFrozen = useLogsFrozenIsFrozen();
   const organization = useOrganization();
-  const showFilterButtons = !isTableFrozen;
+  const showFilterButtons = !isFrozen;
 
   const {onClick: betterCopyToClipboard} = useCopyToClipboard({
     text: isPending || isError ? '' : ourlogToJson(data),

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -229,12 +229,18 @@ export function SpanNodeDetails(
             input={profiles?.type === 'resolved' ? profiles.data : null}
             traceID={profileId ?? profilerId ?? ''}
           >
-            <LogsQueryParamsProvider source="state">
+            <LogsQueryParamsProvider
+              source="state"
+              freeze={{
+                span: {
+                  traceId: props.traceId,
+                  spanId,
+                  projectIds: project ? [Number(project.id)] : undefined,
+                },
+              }}
+            >
               <LogsPageParamsProvider
                 isTableFrozen
-                limitToTraceId={props.traceId}
-                limitToSpanId={spanId}
-                limitToProjectIds={project ? [Number(project.id)] : undefined}
                 analyticsPageSource={LogsAnalyticsPageSource.TRACE_DETAILS}
               >
                 <LogsPageDataProvider>{content}</LogsPageDataProvider>

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -27,10 +27,9 @@ export function TraceViewLogsDataProvider({
   children,
 }: UseTraceViewLogsDataProps) {
   return (
-    <LogsQueryParamsProvider source="state">
+    <LogsQueryParamsProvider source="state" freeze={{traceId: traceSlug}}>
       <LogsPageParamsProvider
         isTableFrozen
-        limitToTraceId={traceSlug}
         analyticsPageSource={LogsAnalyticsPageSource.TRACE_DETAILS}
       >
         <LogsPageDataProvider>{children}</LogsPageDataProvider>

--- a/static/app/views/replays/detail/ourlogs/index.tsx
+++ b/static/app/views/replays/detail/ourlogs/index.tsx
@@ -10,10 +10,7 @@ import {
   LogsPageDataProvider,
   useLogsPageData,
 } from 'sentry/views/explore/contexts/logs/logsPageData';
-import {
-  LogsPageParamsProvider,
-  useLogsLimitToTraceId,
-} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {
   TraceItemAttributeProvider,
   useTraceItemAttributes,
@@ -76,15 +73,14 @@ export default function OurLogs() {
   }
 
   return (
-    <LogsQueryParamsProvider source="state">
+    <LogsQueryParamsProvider source="state" freeze={traceIds ? {traceIds} : undefined}>
       <LogsPageParamsProvider
         analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
         isTableFrozen
-        limitToTraceId={traceIds}
       >
         <LogsPageDataProvider>
           <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
-            <OurLogsContent />
+            <OurLogsContent traceIds={traceIds} />
           </TraceItemAttributeProvider>
         </LogsPageDataProvider>
       </LogsPageParamsProvider>
@@ -92,19 +88,17 @@ export default function OurLogs() {
   );
 }
 
-function OurLogsContent() {
+interface OurLogsContentProps {
+  traceIds?: string[];
+}
+
+function OurLogsContent({traceIds}: OurLogsContentProps) {
   const {attributes: stringAttributes} = useTraceItemAttributes('string');
   const {attributes: numberAttributes} = useTraceItemAttributes('number');
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 
   const {infiniteLogsQueryResult} = useLogsPageData();
   const {data: logItems = [], isPending} = infiniteLogsQueryResult;
-  const limitToTraceId = useLogsLimitToTraceId();
-  const traceIds = Array.isArray(limitToTraceId)
-    ? limitToTraceId
-    : limitToTraceId
-      ? [limitToTraceId]
-      : undefined;
 
   const filterProps = useOurLogFilters({logItems});
   const {items: filteredLogItems, setSearchTerm} = filterProps;


### PR DESCRIPTION
This moves the base query into a separate context so we can get away from page params.