### PR TITLE
Always assign Ids from the server-side

### DIFF
--- a/src/sentry/objectstore/service.py
+++ b/src/sentry/objectstore/service.py
@@ -96,16 +96,12 @@ class Client:
     def put(
         self,
         contents: bytes | IO[bytes],
-        id: str | None = None,
         compression: Compression | Literal["none"] | None = None,
         metadata: dict[str, str] | None = None,
         expiration_policy: ExpirationPolicy | None = None,
     ) -> str:
         """
         Uploads the given `contents` to blob storage.
-
-        If no `id` is provided, one will be automatically generated and returned
-        from this function.
 
         The client will select the configured `default_compression` if none is given
         explicitly.
@@ -133,7 +129,7 @@ class Client:
         with measure_storage_operation("put", self._usecase) as metric_emitter:
             response = self._pool.request(
                 "PUT",
-                f"/{id}" if id else "/",
+                "/",
                 body=body,
                 headers=headers,
                 preload_content=True,

--- a/tests/sentry/objectstore/test_objectstore.py
+++ b/tests/sentry/objectstore/test_objectstore.py
@@ -19,10 +19,9 @@ def test_stores_uncompressed() -> None:
     ).for_organization(12345)
 
     body = b"oh hai!"
-    stored_id = client.put(body, "foo", compression="none")
-    assert stored_id == "foo"
+    stored_id = client.put(body, compression="none")
 
-    result = client.get("foo")
+    result = client.get(stored_id)
 
     assert result.metadata.compression is None
     assert result.payload.read() == b"oh hai!"
@@ -35,17 +34,16 @@ def test_uses_zstd_by_default() -> None:
     ).for_organization(12345)
 
     body = b"oh hai!"
-    stored_id = client.put(body, "foo")
-    assert stored_id == "foo"
+    stored_id = client.put(body)
 
     # when the user indicates that it does not want decompression, it gets zstd
-    result = client.get("foo", decompress=False)
+    result = client.get(stored_id, decompress=False)
 
     assert result.metadata.compression == "zstd"
     assert zstandard.decompress(result.payload.read(), 1024) == b"oh hai!"
 
     # otherwise, the client does the decompression
-    result = client.get("foo")
+    result = client.get(stored_id)
 
     assert result.metadata.compression is None
     assert result.payload.read() == b"oh hai!"
@@ -58,10 +56,9 @@ def test_deletes_stored_stuff() -> None:
     ).for_organization(12345)
 
     body = b"oh hai!"
-    stored_id = client.put(body, "foo")
-    assert stored_id == "foo"
+    stored_id = client.put(body)
 
-    client.delete("foo")
+    client.delete(stored_id)
 
     with pytest.raises(ClientError):
-        client.get("foo")
+        client.get(stored_id)


### PR DESCRIPTION
We have changed the objectstore in such a way that it always assigns Ids from the server-side, so encode that invariant in the API.