### PR TITLE
Properly delete discarded stored attachments

### DIFF
--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -75,8 +75,13 @@ class CachedAttachment:
 
     def delete(self):
         if self.stored_id:
-            # TODO: delete the stored file
-            raise NotImplementedError()
+            # This `delete` method will be called unconditionally at the end of
+            # processing to clear the attachments "cache", after attachments
+            # from the cache have been persisted.
+            # This whole logic has to function differently for already stored attachments.
+            # They will rather be deleted explicitly during processing when
+            # the whole event is discarded, or the attachment is filtered.
+            return
 
         for key in self.chunk_keys:
             self._cache.inner.delete(key)

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -1,3 +1,5 @@
-from sentry.objectstore.service import ClientBuilder
+from sentry.objectstore.service import Client, ClientBuilder
+
+__all__ = ["Client", "ClientBuilder", "attachments"]
 
 attachments = ClientBuilder("attachments")


### PR DESCRIPTION
When processing happens with stored attachments, and the event is being discarded after processing, we have to delete the stored attachments as well.

---

Ref FS-104