### PR TITLE
fix(reprocessing): Reprocess even when attachments are missing

### DIFF
--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -318,7 +318,8 @@ def _merge_full_response(data, response):
 def process_minidump(symbolicator: Symbolicator, data: Any) -> Any:
     minidump = get_event_attachment(data, MINIDUMP_ATTACHMENT_TYPE)
     if not minidump:
-        logger.error("Missing minidump for minidump event")
+        # This happens when an org runs out of attachment quota.
+        logger.warning("Missing minidump for minidump event")
         return
 
     # We do module rewriting only for Electron minidumps.

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -188,11 +188,6 @@ def pull_event_data(project_id: int, event_id: str) -> ReprocessableEvent:
             project_id=project_id, event_id=event_id, type__in=list(required_attachment_types)
         )
     )
-    missing_attachment_types = required_attachment_types - {ea.type for ea in attachments}
-
-    if missing_attachment_types:
-        raise CannotReprocess("attachment.not_found")
-
     return ReprocessableEvent(event=event, data=data, attachments=attachments)
 
 

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -488,6 +488,76 @@ def test_nodestore_missing(
 
 @django_db_all
 @pytest.mark.snuba
+@mock.patch("sentry.reprocessing2.logger")
+@mock.patch("sentry.lang.native.processing.logger")
+def test_minidump_missing(
+    mock_logger_native_processing,
+    mock_logger_reprocessing,
+    default_project,
+    reset_snuba,
+    process_and_save,
+    django_cache,
+):
+
+    event_id = process_and_save(
+        {
+            "platform": "native",
+            "exception": {
+                "values": [
+                    {
+                        "type": "Crash",
+                        "value": "Application crashed",
+                        "mechanism": {"type": "minidump", "handled": False},
+                    }
+                ]
+            },
+        }
+    )
+
+    # Regular processing logs an error because of missing minidump.
+    assert mock_logger_native_processing.error.call_args_list == [
+        (("Missing minidump for minidump event",),)
+    ]
+    assert mock_logger_native_processing.warning.call_count == 0
+
+    event = eventstore.backend.get_event_by_id(default_project.id, event_id)
+    assert event is not None
+    assert event.group is not None
+    old_group = event.group
+
+    with BurstTaskRunner() as burst:
+        reprocess_group(default_project.id, event.group_id, max_events=1, remaining_events="keep")
+
+        burst(max_jobs=100)
+
+    assert event.group_id is not None
+    assert is_group_finished(event.group_id)
+
+    new_event = eventstore.backend.get_event_by_id(default_project.id, event_id)
+
+    assert new_event is not None
+    assert new_event.group is not None
+    assert not new_event.data.get("errors")
+    assert new_event.group_id != event.group_id
+    assert new_event.data["contexts"]["reprocessing"]["original_issue_id"] == old_group.id
+
+    assert new_event.group.times_seen == 1
+
+    assert not Group.objects.filter(id=old_group.id).exists()
+    assert GroupRedirect.objects.get(previous_group_id=old_group.id).group_id == new_event.group_id
+
+    assert mock_logger_reprocessing.warning.call_count == 0
+    assert mock_logger_reprocessing.error.call_count == 0
+
+    # Same error is logged during reprocessing
+    assert mock_logger_native_processing.error.call_args_list == 2 * [
+        (("Missing minidump for minidump event",),)
+    ]
+    assert mock_logger_native_processing.warning.call_count == 0
+
+
+@django_db_all
+@pytest.mark.snuba
 def test_apply_new_fingerprinting_rules(
     default_project,
     reset_snuba,

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -514,11 +514,10 @@ def test_minidump_missing(
         }
     )
 
-    # Regular processing logs an error because of missing minidump.
-    assert mock_logger_native_processing.error.call_args_list == [
+    # Regular processing logs a warning because of missing minidump.
+    assert mock_logger_native_processing.warning.call_args_list == [
         (("Missing minidump for minidump event",),)
     ]
-    assert mock_logger_native_processing.warning.call_count == 0
 
     event = eventstore.backend.get_event_by_id(default_project.id, event_id)
     assert event is not None
@@ -549,11 +548,10 @@ def test_minidump_missing(
     assert mock_logger_reprocessing.warning.call_count == 0
     assert mock_logger_reprocessing.error.call_count == 0
 
-    # Same error is logged during reprocessing
-    assert mock_logger_native_processing.error.call_args_list == 2 * [
+    # Same error as the one above is logged during reprocessing
+    assert mock_logger_native_processing.warning.call_args_list == 2 * [
         (("Missing minidump for minidump event",),)
     ]
-    assert mock_logger_native_processing.warning.call_count == 0
 
 
 @django_db_all


### PR DESCRIPTION
Reprocessing previously skipped over events that did not have required attachments such as its minidump in store, for example because of attachment quota being exhausted. This had the side effect that newly configured fingerprint rules are also not applied to events with missing minidumps, leading to inconsistent behavior.

As far as my tests go, we can safely skip the required attachments check and force reprocessing even when minidumps are missing.

Fixes INGEST-556