### PR TITLE
fix(typing): Fix formatting error in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -370,7 +370,6 @@ module = [
     "sentry.buffer.*",
     "sentry.build.*",
     "sentry.charts.*",
-    "sentry.core.endpoints.organization_member_requests_*",
     "sentry.dashboards.*",
     "sentry.data_export.*",
     "sentry.data_secrecy.*",


### PR DESCRIPTION
Unfortunately mypy runs on module-level matching — we can't match files like this (and it's complaining on every run that we're trying to do so).
