### PR TITLE
feat(proguard): Option to hide release association

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1243,6 +1243,9 @@ register(
 # contents stored as separate release files.
 register("processing.release-archive-min-files", default=10, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# Hide ProGuard release associations from UI
+register("proguard.hide-release-associations", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # All Relay options (statically authenticated Relays can be registered here)
 register("relay.static_auth", default={}, flags=FLAG_NOSTORE)
 

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -480,6 +480,7 @@ class _ClientConfig:
             "links": dict(self.links),
             "user": self.user_details,
             "isAuthenticated": self.user_details is not None,
+            "hideProguardAssociations": options.get("proguard.hide-release-associations"),
         }
 
 

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -149,6 +149,7 @@ export interface Config {
   enableAnalytics: boolean;
   features: Set<string>;
   gravatarBaseUrl: string;
+  hideProguardAssociations: boolean;
   initialTrace: {
     baggage: string;
     sentry_trace: string;

--- a/static/app/views/settings/projectProguard/associations.tsx
+++ b/static/app/views/settings/projectProguard/associations.tsx
@@ -9,6 +9,7 @@ import ListItem from 'sentry/components/list/listItem';
 import Placeholder from 'sentry/components/placeholder';
 import TextOverflow from 'sentry/components/textOverflow';
 import {t, tn} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
@@ -60,6 +61,11 @@ type Props = {
 };
 
 export function ProguardAssociations({associations, loading}: Props) {
+  // Hide associations when option is enabled
+  if (ConfigStore.get('hideProguardAssociations')) {
+    return null;
+  }
+
   if (loading) {
     return <Placeholder width="200px" height="20px" />;
   }


### PR DESCRIPTION
Add an option which hides the visibility of ProGuard release associations on the ProGuard page.

Closes [ENG-5484](https://linear.app/getsentry/issue/ENG-5484/introduce-feature-flag-to-hide-proguard-release-association)