### PR TITLE
feat(typing): Make stronglist-check precommit hook check for malformatted lines

### DIFF
--- a/tests/tools/mypy_helpers/test_check_stronglist.py
+++ b/tests/tools/mypy_helpers/test_check_stronglist.py
@@ -182,6 +182,31 @@ disallow_untyped_defs = true
     assert capsys.readouterr().out == expected
 
 
+def test_wildcards_only_on_module(tmp_path, capsys) -> None:
+    tmp_path.joinpath("a/b").mkdir(parents=True)
+    tmp_path.joinpath("a/b/__init__.py").touch()
+    tmp_path.joinpath("a/bar.py").touch()
+    f = tmp_path.joinpath("f")
+
+    src = """\
+[[tool.mypy.overrides]]
+module = []
+disable_error_code = ["misc"]
+
+[[tool.mypy.overrides]]
+module = ["a.b*"]
+disallow_untyped_defs = true
+"""
+    f.write_text(src)
+
+    assert main((str(f),)) == 1
+
+    expected = f"""\
+{f}: a.b* in stronglist is malformatted; patterns must be fully-qualified module names, optionally with '*' in some components
+"""
+    assert capsys.readouterr().out == expected
+
+
 def test_stronglist_existence_ok_src_layout(tmp_path) -> None:
     src = """\
 [[tool.mypy.overrides]]

--- a/tools/mypy_helpers/check_stronglist.py
+++ b/tools/mypy_helpers/check_stronglist.py
@@ -45,6 +45,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             elif pat == f"{prev}.*":
                 print(f"{filename}: {prev} in stronglist is redundant with {pat}")
                 retv = 1
+            elif pat.endswith("*") and not pat.endswith(".*"):
+                print(
+                    f"{filename}: {pat} in stronglist is malformatted; patterns must be fully-qualified module names, optionally with '*' in some components"
+                )
+                retv = 1
             else:
                 prev = pat
 


### PR DESCRIPTION
Unfortunately mypy runs on module-level matching — we can't match files like `sentry.foo.bar*` (and it complaining on every run if we try to do so).

This PR checks to make sure that we aren't trying to do file-level wildcards in a very simple way — simply by seeing if we're ending a line with `*` without the module-level `.*`. Open to suggestions on improvement.
