### PR TITLE
feat(trace-eap-waterfall): Adding transaction summary link to eap segment spans

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -1,12 +1,14 @@
 import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
+import omit from 'lodash/omit';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Link} from 'sentry/components/core/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import LinkHint from 'sentry/components/structuredEventData/linkHint';
+import {PAGE_URL_PARAM} from 'sentry/constants/pageFilters';
 import {IconGraph} from 'sentry/icons/iconGraph';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -47,6 +49,7 @@ import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceMode
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {useOTelFriendlyUI} from 'sentry/views/performance/otlp/useOTelFriendlyUI';
 import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
+import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {usePerformanceGeneralProjectSettings} from 'sentry/views/performance/utils';
 
 const formatter = new SQLishFormatter();
@@ -110,6 +113,22 @@ export function SpanDescription({
         resolvedModule === ModuleName.DB ? `${space(1)} ${space(2)}` : `${space(1)}`
       }
     >
+      {node.value.is_transaction ? (
+        <Link
+          to={transactionSummaryRouteWithQuery({
+            organization,
+            transaction: node.value.transaction,
+            // Omit the query from the target url, as we dont know where it may have came from
+            // and if its syntax is supported on the target page. In this example, txn search does
+            // not support is:filter type expressions (and possibly other expressions we dont know about)
+            query: omit(location.query, Object.values(PAGE_URL_PARAM).concat('query')),
+            projectID: String(node.value.project_id),
+          })}
+        >
+          <StyledIconGraph type="area" size="xs" />
+          {t('View Summary')}
+        </Link>
+      ) : null}
       <SpanSummaryLink
         op={span.op}
         category={category}


### PR DESCRIPTION
<img width="586" height="363" alt="Screenshot 2025-09-09 at 12 27 33 PM" src="https://github.com/user-attachments/assets/eb778cd1-c7a3-489c-a496-55643dee69b7" />
