### PR TITLE
fix(detectors): default query injection detector to off for PHP/Go

### DIFF
--- a/src/sentry/core/endpoints/team_projects.py
+++ b/src/sentry/core/endpoints/team_projects.py
@@ -7,7 +7,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import audit_log
+from sentry import audit_log, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -28,6 +28,9 @@ from sentry.constants import PROJECT_SLUG_MAX_LENGTH, RESERVED_PROJECT_SLUGS, Ob
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
+from sentry.performance_issues.detectors.disable_detectors import (
+    set_default_disabled_detectors,
+)
 from sentry.seer.similarity.utils import (
     project_is_seer_eligible,
     set_default_project_autofix_automation_tuning,
@@ -40,9 +43,11 @@ ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '
 
 
 def apply_default_project_settings(organization: Organization, project: Project) -> None:
-    # Turns on some inbound filters by default for new Javascript platform projects
     if project.platform and project.platform.startswith("javascript"):
         set_default_inbound_filters(project, organization)
+
+    if features.has("organizations:disable-detectors-on-project-creation", organization):
+        set_default_disabled_detectors(project)
 
     set_default_symbol_sources(project)
 

--- a/src/sentry/core/endpoints/team_projects.py
+++ b/src/sentry/core/endpoints/team_projects.py
@@ -28,9 +28,7 @@ from sentry.constants import PROJECT_SLUG_MAX_LENGTH, RESERVED_PROJECT_SLUGS, Ob
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
-from sentry.performance_issues.detectors.disable_detectors import (
-    set_default_disabled_detectors,
-)
+from sentry.performance_issues.detectors.disable_detectors import set_default_disabled_detectors
 from sentry.seer.similarity.utils import (
     project_is_seer_eligible,
     set_default_project_autofix_automation_tuning,

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -88,6 +88,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:continuous-profiling-vroomrs-processing", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable transaction profiles processing with vroomrs
     manager.add("projects:transaction-profiling-vroomrs-processing", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Disable certain detectors (based on platform) upon Project creation
+    manager.add("organizations:disable-detectors-on-project-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable querying profile candidates with exponentially growing datetime range chunks
     manager.add("organizations:profiling-flamegraph-use-increased-chunks-query-strategy", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable daily summary

--- a/src/sentry/performance_issues/detectors/disable_detectors.py
+++ b/src/sentry/performance_issues/detectors/disable_detectors.py
@@ -1,0 +1,58 @@
+from typing import TypedDict
+
+from sentry import projectoptions
+from sentry.models.project import Project
+
+
+class DetectorDisablingConfig(TypedDict):
+    detector_project_option: str
+    languages_to_disable: set[str]
+
+
+SETTINGS_PROJECT_OPTION_KEY = "sentry:performance_issue_settings"
+
+DEFAULT_DETECTOR_DISABLING_CONFIGS: list[DetectorDisablingConfig] = [
+    {
+        "detector_project_option": "db_query_injection_detection_enabled",
+        "languages_to_disable": {
+            "php",
+            "php-laravel",
+            "php-symfony",
+            "go",
+            "go-echo",
+            "go-fasthttp",
+            "go-fiber",
+            "go-gin",
+            "go-http",
+            "go-iris",
+            "go-martini",
+            "go-negroni",
+        },
+    }
+]
+
+
+def set_default_disabled_detectors(project: Project) -> None:
+    performance_issue_settings_default = projectoptions.get_well_known_default(
+        SETTINGS_PROJECT_OPTION_KEY,
+        project=project,
+    )
+    performance_issue_settings = project.get_option(
+        SETTINGS_PROJECT_OPTION_KEY, default=performance_issue_settings_default
+    )
+
+    disabled_by_config_keys = set()
+    for disable_config in DEFAULT_DETECTOR_DISABLING_CONFIGS:
+        if project.platform in disable_config["languages_to_disable"]:
+            disabled_by_config_keys.add(disable_config["detector_project_option"])
+
+    disabled_by_config = {k: False for k in disabled_by_config_keys}
+
+    project.update_option(
+        SETTINGS_PROJECT_OPTION_KEY,
+        {
+            **performance_issue_settings_default,
+            **performance_issue_settings,
+            **disabled_by_config,
+        },
+    )

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -84,6 +84,8 @@ register(key="filters:filtered-transaction", default="1")
 # extracted performance metrics.
 register(key="sentry:transaction_metrics_custom_tags", epoch_defaults={1: []})
 
+# c.f. set_default_disabled_detectors, which can disable detectors on project creation
+# for specific platforms
 DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS = {
     "uncompressed_assets_detection_enabled": True,
     "consecutive_http_spans_detection_enabled": True,


### PR DESCRIPTION
This detector was overly noisy for these platforms. We previously ran a script to turn off the detector en masse for existing projects; this PR sets a matching default for new projects.

(We should have probably changed the default first and will run a makeup job for any projects created in the interim.)