### PR TITLE
chore(alerts): Remove rate limit logger

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -689,16 +689,8 @@ class SubscriptionProcessor:
             and self.subscription.project.id in last_incident_projects
             and ((timezone.now() - last_incident.date_added).seconds / 60) <= 10
         ):
-            rate_limit_string = "incidents.alert_rules.hit_rate_limit"
-            metrics.incr(rate_limit_string)
-            logger.info(
-                rate_limit_string,
-                extra={
-                    "last_incident_id": last_incident.id,
-                    "project_id": self.subscription.project.id,
-                    "trigger_id": trigger.id,
-                },
-            )
+            metrics.incr("incidents.alert_rules.hit_rate_limit")
+
             return None
         # 'threshold_period' - how many times an alert value must exceed the threshold to fire/resolve the alert
         if self.trigger_alert_counts[trigger.id] >= self.alert_rule.threshold_period:

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
@@ -473,8 +473,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             ],
         )
 
-    @patch("sentry.incidents.subscription_processor.logger.info")
-    def test_no_new_incidents_within_ten_minutes(self, mock_logger) -> None:
+    def test_no_new_incidents_within_ten_minutes(self) -> None:
         """
         Verify that a new incident is not made for the same rule, trigger, and
         subscription if an incident was already made within the last 10 minutes.
@@ -507,14 +506,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                 ),
             ],
             any_order=True,
-        )
-        mock_logger.assert_called_with(
-            "incidents.alert_rules.hit_rate_limit",
-            extra={
-                "last_incident_id": original_incident.id,
-                "project_id": self.sub.project.id,
-                "trigger_id": trigger.id,
-            },
         )
 
     def test_incident_made_after_ten_minutes(self) -> None:


### PR DESCRIPTION
I innocuously swapped this from metrics to logs yesterday in https://github.com/getsentry/sentry/pull/99050 but I don't think it's all that necessary so let's remove the logs unless we find that we need it later.