### PR TITLE
fix(workflow_engine): Remove spammy log

### DIFF
--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -39,13 +39,6 @@ def process_data_source[T](
             len(detectors),
             tags={"query_type": query_type},
         )
-        logger.info(
-            "workflow_engine.process_data_sources detectors",
-            extra={
-                "detectors": [detector.id for detector in detectors],
-                "source_id": data_packet.source_id,
-            },
-        )
     else:
         # XXX: this likely means the rule is muted / detector is disabled
         logger.warning(


### PR DESCRIPTION
# Description
Remove the `workflow_engine.process_data_sources detectors` log which logs each time we successfully get a detector + data source. Removing this log will remove >30,000 logs per minute.