### PR TITLE
feat(trace-eap-waterfall): Aligning highlight links content

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -114,7 +114,7 @@ export function SpanDescription({
       }
     >
       {node.value.is_transaction ? (
-        <Link
+        <StyledLink
           to={transactionSummaryRouteWithQuery({
             organization,
             transaction: node.value.transaction,
@@ -125,9 +125,9 @@ export function SpanDescription({
             projectID: String(node.value.project_id),
           })}
         >
-          <StyledIconGraph type="area" size="xs" />
+          <IconGraph type="area" size="xs" />
           {t('View Summary')}
-        </Link>
+        </StyledLink>
       ) : null}
       <SpanSummaryLink
         op={span.op}
@@ -136,7 +136,7 @@ export function SpanDescription({
         project_id={span.project_id.toString()}
         organization={organization}
       />
-      <Link
+      <StyledLink
         to={
           hasExploreEnabled
             ? getSearchInExploreTarget(
@@ -172,9 +172,9 @@ export function SpanDescription({
           }
         }}
       >
-        <StyledIconGraph type="scatter" size="xs" />
+        <IconGraph type="scatter" size="xs" />
         {hasExploreEnabled ? t('More Samples') : t('View Similar Spans')}
-      </Link>
+      </StyledLink>
     </BodyContentWrapper>
   ) : null;
 
@@ -388,8 +388,10 @@ const CodeSnippetWrapper = styled('div')`
   flex: 1;
 `;
 
-const StyledIconGraph = styled(IconGraph)`
-  margin-right: ${space(0.5)};
+const StyledLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
 `;
 
 const BodyContentWrapper = styled('div')<{padding: string}>`

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -114,7 +114,7 @@ export function SpanDescription({
         project_id={node.event?.projectID}
         organization={organization}
       />
-      <Link
+      <StyledLink
         to={
           hasExploreEnabled
             ? getSearchInExploreTarget(
@@ -156,11 +156,11 @@ export function SpanDescription({
           }
         }}
       >
-        <StyledIconGraph type="scatter" size="xs" />
+        <IconGraph type="scatter" size="xs" />
         {hasNewSpansUIFlag || hasExploreEnabled
           ? t('More Samples')
           : t('View Similar Spans')}
-      </Link>
+      </StyledLink>
     </BodyContentWrapper>
   ) : null;
 
@@ -356,10 +356,6 @@ const CodeSnippetWrapper = styled('div')`
   flex: 1;
 `;
 
-const StyledIconGraph = styled(IconGraph)`
-  margin-right: ${space(0.5)};
-`;
-
 const BodyContentWrapper = styled('div')<{padding: string}>`
   display: flex;
   gap: ${space(1)};
@@ -388,4 +384,10 @@ const DescriptionWrapper = styled('div')`
 const StyledDescriptionWrapper = styled(DescriptionWrapper)`
   padding: ${space(1)};
   justify-content: center;
+`;
+
+const StyledLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
 `;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/highlights.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/highlights.tsx
@@ -61,7 +61,7 @@ export function TransactionHighlights(props: HighlightProps) {
 
   const bodyContent = (
     <BodyContentWrapper>
-      <Link
+      <StyledLink
         to={transactionSummaryRouteWithQuery({
           organization: props.organization,
           transaction: props.node.value.transaction,
@@ -72,9 +72,9 @@ export function TransactionHighlights(props: HighlightProps) {
           projectID: String(props.node.value.project_id),
         })}
       >
-        <StyledIconGraph type="area" size="xs" />
+        <IconGraph type="area" size="xs" />
         {t('View Summary')}
-      </Link>
+      </StyledLink>
     </BodyContentWrapper>
   );
 
@@ -96,10 +96,6 @@ export function TransactionHighlights(props: HighlightProps) {
   );
 }
 
-const StyledIconGraph = styled(IconGraph)`
-  margin-right: ${space(1)};
-`;
-
 const HeaderContentWrapper = styled('div')`
   padding: ${space(1)};
   display: flex;
@@ -110,6 +106,12 @@ const HeaderContentWrapper = styled('div')`
   font-size: ${p => p.theme.fontSize.md};
   word-break: break-word;
   line-height: 1.4;
+`;
+
+const StyledLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
 `;
 
 const BodyContentWrapper = styled('div')`


### PR DESCRIPTION
Before:
<img width="586" height="361" alt="Screenshot 2025-09-09 at 1 54 12 PM" src="https://github.com/user-attachments/assets/c3900cdc-ae87-4793-a868-b7c3cf067c6c" />

After:
<img width="520" height="277" alt="Screenshot 2025-09-09 at 1 53 50 PM" src="https://github.com/user-attachments/assets/4e013b4f-4db7-4137-96de-6ab8dc02f833" />
