### PR TITLE
styles(explore): Use short format for explore timestamp

### DIFF
--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -132,7 +132,7 @@ function BaseExploreFieldRenderer({
 
   if (field === 'timestamp') {
     const date = new Date(data.timestamp);
-    rendered = <StyledTimeSince unitStyle="extraShort" date={date} tooltipShowSeconds />;
+    rendered = <StyledTimeSince unitStyle="short" date={date} tooltipShowSeconds />;
   }
 
   if (field === 'trace') {


### PR DESCRIPTION
Use slighly longer format to disambiguate between months and minutes.