### PR TITLE
chore(detectors): Add tag to detection metric 

### DIFF
--- a/src/sentry/performance_issues/performance_detection.py
+++ b/src/sentry/performance_issues/performance_detection.py
@@ -402,6 +402,7 @@ def _detect_performance_problems(
             detectors,
             sdk_span,
             organization,
+            project,
             standalone=standalone,
         )
 
@@ -506,6 +507,7 @@ def report_metrics_for_detectors(
     detectors: Sequence[PerformanceDetector],
     sdk_span: Any,
     organization: Organization,
+    project: Project,
     standalone: bool = False,
 ) -> None:
     all_detected_problems = [i for d in detectors for i in d.stored_problems]
@@ -593,7 +595,15 @@ def report_metrics_for_detectors(
 
         set_tag(f"_pi_{detector_key}", span_id)
 
-        op_tags = {"is_standalone_spans": standalone}
+        op_tags = {
+            "is_standalone_spans": standalone,
+            "is_creation_allowed": all(
+                [
+                    detector.is_creation_allowed_for_organization(organization),
+                    detector.is_creation_allowed_for_project(project),
+                ]
+            ),
+        }
         for problem in detected_problems.values():
             op = problem.op
             op_tags[f"op_{op}"] = True

--- a/tests/sentry/performance_issues/test_performance_detection.py
+++ b/tests/sentry/performance_issues/test_performance_detection.py
@@ -460,7 +460,11 @@ class PerformanceDetectionTest(TestCase):
             call(
                 "performance.performance_issue.uncompressed_assets",
                 1,
-                tags={"op_resource.script": True, "is_standalone_spans": False},
+                tags={
+                    "op_resource.script": True,
+                    "is_standalone_spans": False,
+                    "is_creation_allowed": True,
+                },
             )
             in incr_mock.mock_calls
         )


### PR DESCRIPTION
this pr adds a tag so we know if the project/org has creation enabled for that detector. right now we see if detection is on, detect problems (and record metrics), but then discard if creation isn't enabled. this will give us more insight into more many problems we are detecting but discarding 