### PR TITLE
fix(ui): Fix transpilation by avoiding choking GHA cpu

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
   "proxyURL": "http://localhost:8000",
   "scripts": {
     "test": "NODE_OPTIONS='--experimental-transform-types' node scripts/test.js --watch",
-    "test-ci": "NODE_OPTIONS='--experimental-transform-types' node scripts/test.js --ci --maxWorkers=100% --colors",
+    "test-ci": "NODE_OPTIONS='--experimental-transform-types' node scripts/test.js --ci --maxWorkers=75% --colors",
     "test-debug": "NODE_OPTIONS='--experimental-transform-types' node --inspect-brk scripts/test.js --runInBand",
     "test-precommit": "NODE_OPTIONS='--experimental-transform-types' node scripts/test.js --bail --findRelatedTests -u",
     "test-staged": "NODE_OPTIONS='--experimental-transform-types' node scripts/test.js --findRelatedTests $(git diff --name-only --cached)",


### PR DESCRIPTION
### Summary
maxWorker [setting](https://jestjs.io/docs/cli#--maxworkersnumstring) is recommended to max-1 for the main thread, we're at 100% and transpilation times seem to vary wildly, which leads me to suspect the CI's minimal resources are choking at times. Linux is [currently](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories) 4 cpus for public GH hosted runners, so setting this to 75% to see if it helps.

Locally, transpilation takes a small amount of time (~1-2 seconds) and is very cpu bound, but the missing time in our jest traces would indicate that transpilation is far longer. 
<img width="578" height="87" alt="Screenshot 2025-09-09 at 2 28 54 PM" src="https://github.com/user-attachments/assets/3eb7f543-56d5-4568-a5dd-de3afb0c3f9c" />
