### PR TITLE
ref(releases): add clarifying text on release tooltip

### DIFF
--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -157,7 +157,10 @@ function ReleaseCard({
                   </TextOverflow>
                 )}
               </PackageName>
-              <TimeSince date={lastDeploy?.dateFinished || dateCreated} />
+              <TimeSince
+                tooltipPrefix={lastDeploy?.dateFinished ? t('Finished:') : t('Created:')}
+                date={lastDeploy?.dateFinished || dateCreated}
+              />
               {lastDeploy?.dateFinished && ` \u007C ${lastDeploy.environment}`}
               &nbsp;
             </PackageContainer>


### PR DESCRIPTION
add clarifying text to show what the date on the release index means

<img width="357" height="241" alt="SCR-20250909-knjo" src="https://github.com/user-attachments/assets/40f8e701-21dd-4e5d-a5fa-5496a5728e32" />


relates to user feedback: https://sentry.sentry.io/issues/feedback/?alert_rule_id=16206265&alert_type=issue&end=2025-08-06T06%3A59%3A59&feedbackSlug=javascript%3A6866538078&notification_uuid=2572f781-e81e-4274-a9a5-4b2855f2797f&project=11276&referrer=slack&start=2025-08-05T07%3A00%3A00

Fixes REPLAY-688