### PR TITLE
feat(timeseries): This adds an incomplete key to the timeseries

### DIFF
--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any, Literal, NotRequired, TypedDict
 
 import sentry_sdk
@@ -43,6 +43,10 @@ TOP_EVENTS_DATASETS = {
     transactions,
 }
 
+# Assumed ingestion delay for timeseries, this is a static number for now just to match how the frontend was doing it
+INGESTION_DELAY = 90
+INGESTION_DELAY_MESSAGE = "This bucket is incomplete because events may still be processing"
+
 
 class StatsMeta(TypedDict):
     dataset: str
@@ -53,10 +57,12 @@ class StatsMeta(TypedDict):
 class Row(TypedDict):
     timestamp: float
     value: float
+    incomplete: bool
     comparisonValue: NotRequired[float]
     sampleCount: NotRequired[float]
     sampleRate: NotRequired[float]
     confidence: NotRequired[Literal["low", "high"] | None]
+    incompleteReason: NotRequired[str]
 
 
 class SeriesMeta(TypedDict):
@@ -308,30 +314,38 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
         rollup: int,
         dataset,
     ) -> StatsResponse:
+        # We need the current timestamp for the Ingestion Delay incomplete reason
+        now = datetime.now().timestamp()
         response = StatsResponse(
             meta=StatsMeta(
                 dataset=DATASET_LABELS[dataset],
                 start=snuba_params.start_date.timestamp() * 1000,
                 end=snuba_params.end_date.timestamp() * 1000,
             ),
-            timeSeries=self.serialize_result(result, axes, rollup),
+            timeSeries=self.serialize_result(result, axes, rollup, now),
         )
         return response
 
     def serialize_result(
-        self, result: SnubaTSResult | dict[str, SnubaTSResult], axes: list[str], rollup: int
+        self,
+        result: SnubaTSResult | dict[str, SnubaTSResult],
+        axes: list[str],
+        rollup: int,
+        now: float,
     ) -> list[TimeSeries]:
         serialized_result = []
         if isinstance(result, SnubaTSResult):
             for axis in axes:
-                serialized_result.append(self.serialize_timeseries(result, axis, rollup))
+                serialized_result.append(self.serialize_timeseries(result, axis, rollup, now))
         else:
             for key, value in result.items():
                 for axis in axes:
-                    serialized_result.append(self.serialize_timeseries(value, axis, rollup))
+                    serialized_result.append(self.serialize_timeseries(value, axis, rollup, now))
         return serialized_result
 
-    def serialize_timeseries(self, result: SnubaTSResult, axis: str, rollup: int) -> TimeSeries:
+    def serialize_timeseries(
+        self, result: SnubaTSResult, axis: str, rollup: int, now: float
+    ) -> TimeSeries:
         unit, field_type = self.get_unit_and_type(axis, result.data["meta"]["fields"][axis])
         series_meta = SeriesMeta(
             valueType=field_type,
@@ -354,7 +368,11 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
 
         timeseries_values = []
         for row in result.data["data"]:
-            value_row = Row(timestamp=row["time"] * 1000, value=row.get(axis, 0))
+            value_row = Row(timestamp=row["time"] * 1000, value=row.get(axis, 0), incomplete=False)
+
+            if incomplete := self.check_incomplete(now, row):
+                value_row["incomplete"] = True
+                value_row["incompleteReason"] = incomplete
             if "comparisonCount" in row:
                 value_row["comparisonValue"] = row["comparisonCount"]
             timeseries_values.append(value_row)
@@ -377,3 +395,9 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
         timeseries["values"] = timeseries_values
 
         return timeseries
+
+    def check_incomplete(self, now: float, row: dict[str, Any]) -> str | None:
+        if now - row["time"] < INGESTION_DELAY:
+            return INGESTION_DELAY_MESSAGE
+        else:
+            return None

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -357,7 +357,8 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
                 "value": 1,
             },
             {
-                "incomplete": False,
+                "incomplete": True,
+                "incompleteReason": INGESTION_DELAY_MESSAGE,
                 "timestamp": self.start.timestamp() * 1000 + 3_600_000 * 1,
                 "value": 2,
             },

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -38,6 +38,7 @@ def build_expected_timeseries(
     expected_value = []
     for index, value in enumerate(expected):
         current_value = {
+            "incomplete": False,
             "timestamp": start.timestamp() * 1000 + interval * index,
             "value": value,
         }


### PR DESCRIPTION
- This matches how the frontend decides which buckets are still incomplete by marking buckets that occurred in the last 90 seconds