### PR TITLE
fix(explore): fix expected attribute name for span status message

### DIFF
--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -40,7 +40,7 @@ export enum SpanFields {
   NAME = 'span.name',
   KIND = 'span.kind',
   SPAN_STATUS = 'span.status',
-  STATUS_MESSAGE = 'span.status_message',
+  STATUS_MESSAGE = 'span.status.message',
   RELEASE = 'release',
   PROJECT_ID = 'project.id',
   SPAN_STATUS_CODE = 'span.status_code',


### PR DESCRIPTION
The backend [uses `span.status.message`](https://github.com/getsentry/sentry/blob/8ff086abba628770bae31a4c6d90f04fdbdfbaea/src/sentry/search/eap/spans/attributes.py#L130), but the frontend was using `span.status_message`. As a result, the tooltip describing this property was missing when searched by the user.

Fixes [OPE-65](https://linear.app/getsentry/issue/OPE-65/spanstatusmessage-isnt-autocompleting-in-explore-etc).