### PR TITLE
fix(eap): Count_if's type was wrong

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -1044,10 +1044,10 @@ class SearchResolver:
                 resolved_argument = parsed_arg.proto_definition
             resolved_arguments.append(resolved_argument)
 
-        # We assume the first argument contains the resolved search_type as this is always the case for now
         if len(parsed_args) == 0 or not isinstance(parsed_args[0], ResolvedAttribute):
             search_type = function_definition.default_search_type
         else:
+            # unless infer_search_type_from_arguments is passed we assume the first argument is the search_type
             search_type = (
                 parsed_args[0].search_type
                 if function_definition.infer_search_type_from_arguments

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -180,7 +180,8 @@ SPAN_CONDITIONAL_AGGREGATE_DEFINITIONS = {
     ),
     "count_if": ConditionalAggregateDefinition(
         internal_function=Function.FUNCTION_COUNT,
-        default_search_type="duration",
+        infer_search_type_from_arguments=False,
+        default_search_type="integer",
         arguments=[
             AttributeArgumentDefinition(
                 attribute_types={

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -5662,6 +5662,8 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         assert len(data) == 1
         assert data[0]["failure_count()"] == 1
         assert meta["dataset"] == "spans"
+        assert meta["fields"]["failure_count()"] == "integer"
+        assert meta["units"]["failure_count()"] is None
 
     def test_short_trace_id_filter(self) -> None:
         trace_ids = [
@@ -5773,6 +5775,8 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
             },
         ]
         assert meta["dataset"] == "spans"
+        assert meta["fields"]["count_if(span.status,equals,success)"] == "integer"
+        assert meta["units"]["count_if(span.status,equals,success)"] is None
 
     def test_count_if_numeric(self) -> None:
         self.store_spans(


### PR DESCRIPTION
- Count_if was defaulting to duration both because it's the default_search_type and because infer_search_type_from_arguments was not set to False