### PR TITLE
fix(widget-builder): Improve visualize rendering with virtualized list

### DIFF
--- a/static/app/components/core/compactSelect/index.tsx
+++ b/static/app/components/core/compactSelect/index.tsx
@@ -14,6 +14,7 @@ import type {
   SelectOptionOrSection,
   SelectOptionOrSectionWithKey,
   SelectSection,
+  VirtualizedMenuOptions,
 } from './types';
 import {getItemsWithKeys} from './utils';
 
@@ -22,12 +23,7 @@ export type {SelectOption, SelectOptionOrSection, SelectSection, SelectKey};
 interface BaseSelectProps<Value extends SelectKey> extends ControlProps {
   options: Array<SelectOptionOrSection<Value>>;
   virtualized?: boolean;
-  virtualizedMenuOptions?: {
-    itemHeight: number;
-    maxHeight: number;
-    minWidth: number;
-    overscan: number;
-  };
+  virtualizedMenuOptions?: VirtualizedMenuOptions;
 }
 
 export interface SingleSelectProps<Value extends SelectKey>

--- a/static/app/components/core/compactSelect/index.tsx
+++ b/static/app/components/core/compactSelect/index.tsx
@@ -21,13 +21,13 @@ export type {SelectOption, SelectOptionOrSection, SelectSection, SelectKey};
 
 interface BaseSelectProps<Value extends SelectKey> extends ControlProps {
   options: Array<SelectOptionOrSection<Value>>;
-  menuOptions?: {
+  virtualized?: boolean;
+  virtualizedMenuOptions?: {
     itemHeight: number;
     maxHeight: number;
     minWidth: number;
     overscan: number;
   };
-  virtualized?: boolean;
 }
 
 export interface SingleSelectProps<Value extends SelectKey>
@@ -76,7 +76,7 @@ function CompactSelect<Value extends SelectKey>({
   sizeLimit,
   sizeLimitMessage,
   virtualized,
-  menuOptions,
+  virtualizedMenuOptions,
 
   // Control props
   grid,
@@ -134,7 +134,7 @@ function CompactSelect<Value extends SelectKey>({
         sizeLimit={sizeLimit}
         sizeLimitMessage={sizeLimitMessage}
         virtualized={virtualized}
-        menuOptions={menuOptions}
+        virtualizedMenuOptions={virtualizedMenuOptions}
         aria-labelledby={triggerId}
       >
         {(item: SelectOptionOrSectionWithKey<Value>) => {

--- a/static/app/components/core/compactSelect/index.tsx
+++ b/static/app/components/core/compactSelect/index.tsx
@@ -21,6 +21,13 @@ export type {SelectOption, SelectOptionOrSection, SelectSection, SelectKey};
 
 interface BaseSelectProps<Value extends SelectKey> extends ControlProps {
   options: Array<SelectOptionOrSection<Value>>;
+  menuOptions?: {
+    itemHeight: number;
+    maxHeight: number;
+    minWidth: number;
+    overscan: number;
+  };
+  virtualized?: boolean;
 }
 
 export interface SingleSelectProps<Value extends SelectKey>
@@ -68,6 +75,8 @@ function CompactSelect<Value extends SelectKey>({
   isOptionDisabled,
   sizeLimit,
   sizeLimitMessage,
+  virtualized,
+  menuOptions,
 
   // Control props
   grid,
@@ -124,6 +133,8 @@ function CompactSelect<Value extends SelectKey>({
         size={size}
         sizeLimit={sizeLimit}
         sizeLimitMessage={sizeLimitMessage}
+        virtualized={virtualized}
+        menuOptions={menuOptions}
         aria-labelledby={triggerId}
       >
         {(item: SelectOptionOrSectionWithKey<Value>) => {

--- a/static/app/components/core/compactSelect/list.tsx
+++ b/static/app/components/core/compactSelect/list.tsx
@@ -80,15 +80,6 @@ interface BaseListProps<Value extends SelectKey>
    */
   label?: React.ReactNode;
   /**
-   * Options for the virtualized list.
-   */
-  menuOptions?: {
-    itemHeight: number;
-    maxHeight: number;
-    minWidth: number;
-    overscan: number;
-  };
-  /**
    * To be called when the user toggle-selects a whole section (applicable when sections
    * have `showToggleAllButton` set to true.) Note: this will be called in addition to
    * and before `onChange`.
@@ -110,6 +101,15 @@ interface BaseListProps<Value extends SelectKey>
    * Enable virtualization for large lists.
    */
   virtualized?: boolean;
+  /**
+   * Options for the virtualized list.
+   */
+  virtualizedMenuOptions?: {
+    itemHeight: number;
+    maxHeight: number;
+    minWidth: number;
+    overscan: number;
+  };
 }
 
 export interface SingleListProps<Value extends SelectKey> extends BaseListProps<Value> {
@@ -159,7 +159,7 @@ function List<Value extends SelectKey>({
   sizeLimitMessage,
   closeOnSelect,
   virtualized = false,
-  menuOptions,
+  virtualizedMenuOptions,
   ...props
 }: SingleListProps<Value> | MultipleListProps<Value>) {
   const {overlayState, registerListState, saveSelectedOptions, search, overlayIsOpen} =
@@ -383,7 +383,7 @@ function List<Value extends SelectKey>({
           sizeLimitMessage={sizeLimitMessage}
           keyDownHandler={keyDownHandler}
           virtualized={virtualized}
-          menuOptions={menuOptions}
+          virtualizedMenuOptions={virtualizedMenuOptions}
         />
       )}
       {multiple &&

--- a/static/app/components/core/compactSelect/list.tsx
+++ b/static/app/components/core/compactSelect/list.tsx
@@ -80,6 +80,15 @@ interface BaseListProps<Value extends SelectKey>
    */
   label?: React.ReactNode;
   /**
+   * Options for the virtualized list.
+   */
+  menuOptions?: {
+    itemHeight: number;
+    maxHeight: number;
+    minWidth: number;
+    overscan: number;
+  };
+  /**
    * To be called when the user toggle-selects a whole section (applicable when sections
    * have `showToggleAllButton` set to true.) Note: this will be called in addition to
    * and before `onChange`.
@@ -97,6 +106,10 @@ interface BaseListProps<Value extends SelectKey>
    * Message to be displayed when some options are hidden due to `sizeLimit`.
    */
   sizeLimitMessage?: string;
+  /**
+   * Enable virtualization for large lists.
+   */
+  virtualized?: boolean;
 }
 
 export interface SingleListProps<Value extends SelectKey> extends BaseListProps<Value> {
@@ -145,6 +158,8 @@ function List<Value extends SelectKey>({
   sizeLimit,
   sizeLimitMessage,
   closeOnSelect,
+  virtualized = false,
+  menuOptions,
   ...props
 }: SingleListProps<Value> | MultipleListProps<Value>) {
   const {overlayState, registerListState, saveSelectedOptions, search, overlayIsOpen} =
@@ -367,6 +382,8 @@ function List<Value extends SelectKey>({
           shouldFocusOnHover={shouldFocusOnHover}
           sizeLimitMessage={sizeLimitMessage}
           keyDownHandler={keyDownHandler}
+          virtualized={virtualized}
+          menuOptions={menuOptions}
         />
       )}
       {multiple &&

--- a/static/app/components/core/compactSelect/list.tsx
+++ b/static/app/components/core/compactSelect/list.tsx
@@ -24,6 +24,7 @@ import type {
   SelectOptionOrSectionWithKey,
   SelectOptionWithKey,
   SelectSection,
+  VirtualizedMenuOptions,
 } from './types';
 import {
   getDisabledOptions,
@@ -104,12 +105,7 @@ interface BaseListProps<Value extends SelectKey>
   /**
    * Options for the virtualized list.
    */
-  virtualizedMenuOptions?: {
-    itemHeight: number;
-    maxHeight: number;
-    minWidth: number;
-    overscan: number;
-  };
+  virtualizedMenuOptions?: VirtualizedMenuOptions;
 }
 
 export interface SingleListProps<Value extends SelectKey> extends BaseListProps<Value> {

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -12,7 +12,11 @@ import {
   ListWrap,
   SizeLimitMessage,
 } from 'sentry/components/core/compactSelect/styles';
-import type {SelectKey, SelectSection} from 'sentry/components/core/compactSelect/types';
+import type {
+  SelectKey,
+  SelectSection,
+  VirtualizedMenuOptions,
+} from 'sentry/components/core/compactSelect/types';
 import {t} from 'sentry/locale';
 import type {FormSize} from 'sentry/utils/theme';
 
@@ -97,19 +101,15 @@ interface ListBoxProps
   /**
    * Options for the virtualized list.
    */
-  virtualizedMenuOptions?: {
-    itemHeight: number;
-    maxHeight: number;
-    minWidth: number;
-    overscan: number;
-  };
+  virtualizedMenuOptions?: VirtualizedMenuOptions;
 }
 
+export const DEFAULT_ITEM_HEIGHT = 40;
+export const DEFAULT_OVERSCAN = 10;
+export const DEFAULT_MAX_HEIGHT = 300;
+const DEFAULT_MIN_WIDTH = 0;
+
 const EMPTY_SET = new Set<never>();
-const DEFAULT_ITEM_HEIGHT = 40;
-const DEFAULT_OVERSCAN = 10;
-const DEFAULT_MIN_WIDTH = 400;
-const DEFAULT_MAX_HEIGHT = 300;
 
 /**
  * A list box with accessibile behaviors & attributes.

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -122,7 +122,7 @@ const EMPTY_SET = new Set<never>();
  * the `grid` prop on CompactSelect to true).
  *
  * When `virtualized` is true, the list will be virtualized for better performance
- * with large datasets. This requires `virtualizedMenuOptions` to be provided.
+ * with large datasets.
  */
 export function ListBox({
   ref,

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -264,7 +264,6 @@ export function ListBox({
           ? {
               height: virtualizer.getTotalSize(),
               position: 'relative',
-              overflow: 'unset',
             }
           : undefined
       }

--- a/static/app/components/core/compactSelect/listBox/option.tsx
+++ b/static/app/components/core/compactSelect/listBox/option.tsx
@@ -20,6 +20,7 @@ export interface ListBoxOptionProps extends AriaOptionProps {
   listState: ListState<any>;
   size: MenuListItemProps['size'];
   showDetails?: boolean;
+  style?: React.CSSProperties;
 }
 
 /**
@@ -31,6 +32,7 @@ export function ListBoxOption({
   listState,
   size,
   showDetails = true,
+  style,
 }: ListBoxOptionProps) {
   const ref = useRef<HTMLLIElement>(null);
   const {
@@ -112,11 +114,12 @@ export function ListBoxOption({
       tooltip={tooltip}
       tooltipOptions={tooltipOptions}
       data-test-id={item.key}
+      style={style}
     />
   );
 }
 
-const StyledMenuListItem = styled(MenuListItem)`
+const StyledMenuListItem = styled(MenuListItem)<{style?: React.CSSProperties}>`
   > ${InnerWrap} {
     padding-left: ${space(1)};
   }

--- a/static/app/components/core/compactSelect/listBox/section.tsx
+++ b/static/app/components/core/compactSelect/listBox/section.tsx
@@ -25,6 +25,7 @@ interface ListBoxSectionProps extends AriaListBoxSectionProps {
   size: ListBoxOptionProps['size'];
   onToggle?: (section: SelectSection<SelectKey>, type: 'select' | 'unselect') => void;
   showDetails?: boolean;
+  style?: React.CSSProperties;
 }
 
 /**
@@ -39,6 +40,7 @@ export function ListBoxSection({
   hiddenOptions,
   showSectionHeaders,
   showDetails = true,
+  style,
 }: ListBoxSectionProps) {
   const {itemProps, headingProps, groupProps} = useListBoxSection({
     heading: item.rendered,
@@ -59,7 +61,7 @@ export function ListBoxSection({
   return (
     <Fragment>
       {showSectionHeaders && <SectionSeparator {...separatorProps} />}
-      <SectionWrap {...itemProps}>
+      <SectionWrap {...itemProps} style={style}>
         {(item.rendered || showToggleAllButton) && showSectionHeaders && (
           <SectionHeader>
             {item.rendered && (

--- a/static/app/components/core/compactSelect/styles.tsx
+++ b/static/app/components/core/compactSelect/styles.tsx
@@ -168,8 +168,8 @@ export const EmptyMessage = styled('p')`
 
   /* Message should only be displayed when _all_ preceding lists are empty */
   display: block;
-  div:has(ul:not(:empty)) + &,
-  ul:not(:empty) + & {
+  div:has(ul:not(:empty)) ~ &,
+  ul:not(:empty) ~ & {
     display: none;
   }
 `;

--- a/static/app/components/core/compactSelect/styles.tsx
+++ b/static/app/components/core/compactSelect/styles.tsx
@@ -168,7 +168,8 @@ export const EmptyMessage = styled('p')`
 
   /* Message should only be displayed when _all_ preceding lists are empty */
   display: block;
-  ul:not(:empty) ~ & {
+  div:has(ul:not(:empty)) + &,
+  ul:not(:empty) + & {
     display: none;
   }
 `;

--- a/static/app/components/core/compactSelect/types.tsx
+++ b/static/app/components/core/compactSelect/types.tsx
@@ -64,3 +64,18 @@ export interface SelectSectionWithKey<Value extends SelectKey>
 export type SelectOptionOrSectionWithKey<Value extends SelectKey> =
   | SelectOptionWithKey<Value>
   | SelectSectionWithKey<Value>;
+
+/**
+ * Options for the virtualized list.
+ */
+export interface VirtualizedMenuOptions {
+  // An estimated height for the items in the list.
+  itemHeight: number;
+  // The maximum height of the list in pixels.
+  maxHeight: number;
+  // The number of items to render outside of the viewport.
+  overscan: number;
+  // The minimum width of the list in pixels. If the minimum width is not provided,
+  // the list will be at most the same size as the trigger button.
+  minWidth?: number;
+}

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -21,6 +21,25 @@ describe('Visualize', () => {
   let organization!: ReturnType<typeof OrganizationFixture>;
   let mockNavigate!: jest.Mock;
 
+  beforeAll(() => {
+    // Required mock for virtualization components used downstream to render tag lists
+    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => ({
+      width: 100,
+      height: 10000,
+      top: 0,
+      left: 0,
+      bottom: 1000,
+      right: 1000,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }));
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
   beforeEach(() => {
     organization = OrganizationFixture({
       features: ['performance-view'],

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
@@ -151,6 +151,7 @@ export function SelectRow({
     <PrimarySelectRow hasColumnParameter={hasColumnParameter}>
       <AggregateCompactSelect
         searchable
+        virtualized
         hasColumnParameter={hasColumnParameter}
         disabled={disabled || aggregateOptions.length <= 1}
         options={aggregateOptions}
@@ -412,6 +413,7 @@ export function SelectRow({
         <SelectWrapper ref={columnSelectRef}>
           <ColumnCompactSelect
             searchable
+            virtualized
             options={columnOptions}
             value={
               field.kind === FieldValueKind.FUNCTION

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
@@ -3,6 +3,11 @@ import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
 import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {
+  DEFAULT_ITEM_HEIGHT,
+  DEFAULT_MAX_HEIGHT,
+  DEFAULT_OVERSCAN,
+} from 'sentry/components/core/compactSelect/listBox';
 import {IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -152,6 +157,13 @@ export function SelectRow({
       <AggregateCompactSelect
         searchable
         virtualized
+        virtualizedMenuOptions={{
+          itemHeight: DEFAULT_ITEM_HEIGHT,
+          maxHeight: DEFAULT_MAX_HEIGHT,
+          overscan: DEFAULT_OVERSCAN,
+          // The trigger for this button is small, so we set a min width to provide a wider menu
+          minWidth: 400,
+        }}
         hasColumnParameter={hasColumnParameter}
         disabled={disabled || aggregateOptions.length <= 1}
         options={aggregateOptions}


### PR DESCRIPTION
Implements `useVirtualizer` to virtualize the compact select list. Useful for lists with a large number of elements, such as the tags selector in widget builder.

It seems like to maintain similar sizing behaviour to without virtualization, we need to provide some more explicit values for the width and height.