### PR TITLE
chore(timeseries): Increase spot-check comparison threshold to 7.5%

### DIFF
--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -231,7 +231,7 @@ function comparator(
 ) {
   // Compare numbers by near equality, which makes the comparison less sensitive to small natural variations in value caused by request sequencing
   if (key === 'value' && typeof valueA === 'number' && typeof valueB === 'number') {
-    return areNumbersAlmostEqual(valueA, valueB, 5);
+    return areNumbersAlmostEqual(valueA, valueB, 7.5);
   }
 
   // Otherwise use default deep comparison


### PR DESCRIPTION
Another threshold bump, following https://github.com/getsentry/sentry/pull/99100. 7.5% this time, working towards figuring out what the threshold is realistically. Some of the failures are truly benign, the `/events-timeseries/` endpoint call happens a tiny bit later than the original, and some data falls out of the first bucket.
