### PR TITLE
fix(interface): Don't pass arbitrary dict as constructor params

### DIFF
--- a/src/sentry/interfaces/base.py
+++ b/src/sentry/interfaces/base.py
@@ -67,7 +67,7 @@ class Interface:
     ephemeral = False
     grouping_variants = ["default"]
 
-    def __init__(self, **data):
+    def __init__(self, data: dict[str, Any] | None = None):
         self._data = data or {}
 
     @classproperty
@@ -116,7 +116,7 @@ class Interface:
         if data is None:
             return None
 
-        return cls(**data)
+        return cls(data)
 
     def get_raw_data(self):
         """Returns the underlying raw data."""


### PR DESCRIPTION
Passing the data dict as a kwarg to the constructor causes occasional problems because 'self' is sometimes a key.
By avoiding the use of kwargs, we avoid this problem.

Fixes SENTRY-4EKJ.