### PR TITLE
fix(settings): Fix team selector behavior

### DIFF
--- a/static/app/views/settings/components/teamSelect/teamSelectForProject.tsx
+++ b/static/app/views/settings/components/teamSelect/teamSelectForProject.tsx
@@ -6,7 +6,6 @@ import {Button} from 'sentry/components/core/button';
 import {Link} from 'sentry/components/core/link';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import {TeamBadge} from 'sentry/components/idBadge/teamBadge';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
@@ -105,7 +104,7 @@ function TeamSelect({
         />
       </PanelHeader>
 
-      <PanelBody>{isLoadingTeams ? <LoadingIndicator /> : renderBody()}</PanelBody>
+      <PanelBody>{renderBody()}</PanelBody>
     </Panel>
   );
 }

--- a/static/app/views/settings/components/teamSelect/utils.tsx
+++ b/static/app/views/settings/components/teamSelect/utils.tsx
@@ -113,7 +113,6 @@ export function DropdownAddTeam({
       emptyMessage={t('No Teams')}
       loading={isLoadingTeams}
       searchable
-      disableSearchFilter
       onSearch={onSearch}
       menuHeaderTrailingItems={createTeam}
     />


### PR DESCRIPTION
Closes RTC-1152

Searching the dropdown was causing the page list to show a loading indicator. It was also not filtering the list correctly.

Before:

https://github.com/user-attachments/assets/31bddcea-6a8b-4df7-a17d-f1887763b2ff

After:

https://github.com/user-attachments/assets/efaa207a-9b02-424f-a747-1ac74c214f4f

