### PR TITLE
feat(replay): display feedback summary next to name/email

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.spec.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.spec.tsx
@@ -140,8 +140,8 @@ describe('FeedbackItemUsername', () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Foo Bar <foo@bar.com>');
   });
 
-  describe('email subject', () => {
-    it('should include summary in email subject when AI summary is enabled and summary exists', async () => {
+  describe('AI summary functionality', () => {
+    it('should display summary and include it in email subject when AI summary is enabled', async () => {
       seerSetupMock = mockSeerSetup({
         setupAcknowledgement: {orgHasAcknowledged: true},
       });
@@ -160,10 +160,11 @@ describe('FeedbackItemUsername', () => {
         },
       });
 
-      // Wait for the API call to complete
       await waitFor(() => {
         expect(seerSetupMock).toHaveBeenCalled();
       });
+
+      expect(screen.getByText('Login issue with payment flow')).toBeInTheDocument();
 
       const mailtoButton = screen.getByRole('button');
       expect(mailtoButton).toHaveAttribute(
@@ -204,7 +205,7 @@ describe('FeedbackItemUsername', () => {
         seerSetupOverrides: {setupAcknowledgement: {orgHasAcknowledged: true}},
       },
     ])(
-      'should not include summary in email subject when $description',
+      'should not display summary or include it in email subject when $description',
       async ({features, summary, seerSetupOverrides}) => {
         seerSetupMock = mockSeerSetup(seerSetupOverrides);
 
@@ -225,6 +226,10 @@ describe('FeedbackItemUsername', () => {
         await waitFor(() => {
           expect(seerSetupMock).toHaveBeenCalled();
         });
+
+        if (summary) {
+          expect(screen.queryByText(summary)).not.toBeInTheDocument();
+        }
 
         const mailtoButton = screen.getByRole('button');
         expect(mailtoButton).toHaveAttribute(

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.spec.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.spec.tsx
@@ -6,6 +6,21 @@ import FeedbackItemUsername from 'sentry/components/feedback/feedbackItem/feedba
 
 describe('FeedbackItemUsername', () => {
   beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/seer/setup-check/',
+      body: {
+        setupAcknowledgement: {
+          orgHasAcknowledged: true,
+          userHasAcknowledged: true,
+        },
+        billing: {
+          hasAutofixQuota: true,
+          hasScannerQuota: true,
+        },
+      },
+    });
+
     Object.assign(navigator, {
       clipboard: {
         writeText: jest.fn().mockResolvedValue(''),

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.spec.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.spec.tsx
@@ -169,9 +169,7 @@ describe('FeedbackItemUsername', () => {
       const mailtoButton = screen.getByRole('button');
       expect(mailtoButton).toHaveAttribute(
         'href',
-        expect.stringContaining(
-          'subject=Following%20up%20from%20Organization%20Name%3A%20Login%20issue%20with%20payment%20flow'
-        )
+        expect.stringContaining('Login%20issue%20with%20payment%20flow')
       );
     });
 
@@ -234,18 +232,8 @@ describe('FeedbackItemUsername', () => {
         const mailtoButton = screen.getByRole('button');
         expect(mailtoButton).toHaveAttribute(
           'href',
-          expect.stringContaining('subject=Following%20up%20from%20Organization%20Name')
-        );
-        expect(mailtoButton).toHaveAttribute(
-          'href',
           expect.not.stringContaining('Login%20issue%20with%20payment%20flow')
         );
-        if (summary) {
-          expect(mailtoButton).toHaveAttribute(
-            'href',
-            expect.not.stringContaining('%3A%20') // Should not contain ": " after organization name
-          );
-        }
       }
     );
   });

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
 import {Tooltip} from 'sentry/components/core/tooltip';
+import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import {IconMail} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
@@ -22,6 +23,7 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
   const email = feedbackIssue.metadata.contact_email;
 
   const organization = useOrganization();
+  const {setupAcknowledgement, areAiFeaturesAllowed} = useOrganizationSeerSetup();
   const nameOrEmail = name || email;
   const isSameNameAndEmail = name === email;
 
@@ -29,7 +31,8 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
 
   const summary = feedbackIssue.metadata.summary;
   const isAiSummaryEnabled =
-    organization.features.includes('gen-ai-features') &&
+    areAiFeaturesAllowed &&
+    setupAcknowledgement.orgHasAcknowledged &&
     organization.features.includes('user-feedback-ai-titles');
 
   const userNodeId = useId();

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -54,7 +54,12 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
     return <strong>{t('Anonymous User')}</strong>;
   }
 
-  const mailToHref = `mailto:${email}?subject=${encodeURIComponent(`Following up from ${organization.name}`)}&body=${encodeURIComponent(
+  const emailSubject =
+    isAiSummaryEnabled && summary
+      ? `Following up from ${organization.name}: ${summary}`
+      : `Following up from ${organization.name}`;
+
+  const mailToHref = `mailto:${email}?subject=${encodeURIComponent(emailSubject)}&body=${encodeURIComponent(
     feedbackIssue.metadata.message
       .split('\n')
       .map(s => `> ${s}`)

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -28,7 +28,7 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
   const user = name && email && !isSameNameAndEmail ? `${name} <${email}>` : nameOrEmail;
 
   const summary = feedbackIssue.metadata.summary;
-  const isAiTitleEnabled = true; // organization.features.includes('user-feedback-ai-titles');
+  const isAiTitleEnabled = organization.features.includes('user-feedback-ai-titles');
 
   const userNodeId = useId();
 

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -28,7 +28,9 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
   const user = name && email && !isSameNameAndEmail ? `${name} <${email}>` : nameOrEmail;
 
   const summary = feedbackIssue.metadata.summary;
-  const isAiTitleEnabled = organization.features.includes('user-feedback-ai-titles');
+  const isAiSummaryEnabled =
+    organization.features.includes('gen-ai-features') &&
+    organization.features.includes('user-feedback-ai-titles');
 
   const userNodeId = useId();
 
@@ -69,7 +71,7 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
             handleCopyToClipboard();
           }}
         >
-          {isAiTitleEnabled && summary && (
+          {isAiSummaryEnabled && summary && (
             <Fragment>
               <strong>{summary}</strong>
               <Purple>•</Purple>

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -63,34 +63,36 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
 
   return (
     <Flex align="center" gap="md" className={className} style={style}>
-      <Tooltip title={t('Click to copy')} containerDisplayMode="flex">
-        <Flex
-          id={userNodeId}
-          align="center"
-          wrap="wrap"
-          gap="xs"
-          onClick={() => {
-            handleSelectText();
-            handleCopyToClipboard();
-          }}
-        >
-          {isAiSummaryEnabled && summary && (
-            <Fragment>
-              <strong>{summary}</strong>
-              <Purple>•</Purple>
-            </Fragment>
-          )}
-          {isSameNameAndEmail ? (
-            <strong>{name ?? email}</strong>
-          ) : (
-            <Fragment>
-              <strong>{name ?? t('No Name')}</strong>
-              <Purple>•</Purple>
-              <strong>{email ?? t('No Email')}</strong>
-            </Fragment>
-          )}
-        </Flex>
-      </Tooltip>
+      <Flex align="center" wrap="wrap" gap="xs">
+        {isAiSummaryEnabled && summary && (
+          <Fragment>
+            <strong>{summary}</strong>
+            <Purple>•</Purple>
+          </Fragment>
+        )}
+        <Tooltip title={t('Click to copy')} containerDisplayMode="flex">
+          <Flex
+            id={userNodeId}
+            align="center"
+            wrap="wrap"
+            gap="xs"
+            onClick={() => {
+              handleSelectText();
+              handleCopyToClipboard();
+            }}
+          >
+            {isSameNameAndEmail ? (
+              <strong>{name ?? email}</strong>
+            ) : (
+              <Fragment>
+                <strong>{name ?? t('No Name')}</strong>
+                <Purple>•</Purple>
+                <strong>{email ?? t('No Email')}</strong>
+              </Fragment>
+            )}
+          </Flex>
+        </Tooltip>
+      </Flex>
       {email ? (
         <Tooltip title={t(`Email %s`, user)} containerDisplayMode="flex">
           <LinkButton

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -27,6 +27,9 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
 
   const user = name && email && !isSameNameAndEmail ? `${name} <${email}>` : nameOrEmail;
 
+  const summary = feedbackIssue.metadata.summary;
+  const isAiTitleEnabled = true; // organization.features.includes('user-feedback-ai-titles');
+
   const userNodeId = useId();
 
   const handleSelectText = useCallback(() => {
@@ -66,6 +69,12 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
             handleCopyToClipboard();
           }}
         >
+          {isAiTitleEnabled && summary && (
+            <Fragment>
+              <strong>{summary}</strong>
+              <Purple>•</Purple>
+            </Fragment>
+          )}
           {isSameNameAndEmail ? (
             <strong>{name ?? email}</strong>
           ) : (

--- a/static/app/utils/feedback/types.tsx
+++ b/static/app/utils/feedback/types.tsx
@@ -7,6 +7,7 @@ type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
 type FeedbackIssueMetadata = {
   contact_email: null | string;
   message: string;
+  name: null | string;
   title: string;
   value: string;
   sdk?: {
@@ -22,7 +23,7 @@ export type FeedbackIssue = Overwrite<
   {
     issueCategory: 'feedback';
     issueType: 'feedback';
-    metadata: FeedbackIssueMetadata & {name: null | string; initial_priority?: number};
+    metadata: FeedbackIssueMetadata & {initial_priority?: number};
     owners: null | unknown;
     project?: Project;
   }
@@ -35,7 +36,7 @@ export type FeedbackIssueListItem = Overwrite<
   {
     issueCategory: 'feedback';
     issueType: 'feedback';
-    metadata: FeedbackIssueMetadata & {name: string; associated_event_id?: string};
+    metadata: FeedbackIssueMetadata & {associated_event_id?: string};
     owners: null | unknown;
     project?: Project;
   }

--- a/static/app/utils/feedback/types.tsx
+++ b/static/app/utils/feedback/types.tsx
@@ -4,24 +4,25 @@ import type {Project} from 'sentry/types/project';
 
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
 
+type FeedbackIssueMetadata = {
+  contact_email: null | string;
+  message: string;
+  title: string;
+  value: string;
+  sdk?: {
+    name: string;
+    name_normalized: string;
+  };
+  source?: null | string;
+  summary?: null | string;
+};
+
 export type FeedbackIssue = Overwrite<
   BaseGroup & GroupStats,
   {
     issueCategory: 'feedback';
     issueType: 'feedback';
-    metadata: {
-      contact_email: null | string;
-      message: string;
-      name: null | string;
-      title: string;
-      value: string;
-      initial_priority?: number;
-      sdk?: {
-        name: string;
-        name_normalized: string;
-      };
-      source?: null | string;
-    };
+    metadata: FeedbackIssueMetadata & {name: null | string; initial_priority?: number};
     owners: null | unknown;
     project?: Project;
   }
@@ -34,19 +35,7 @@ export type FeedbackIssueListItem = Overwrite<
   {
     issueCategory: 'feedback';
     issueType: 'feedback';
-    metadata: {
-      contact_email: null | string;
-      message: string;
-      name: string;
-      title: string;
-      value: string;
-      associated_event_id?: string;
-      sdk?: {
-        name: string;
-        name_normalized: string;
-      };
-      source?: null | string;
-    };
+    metadata: FeedbackIssueMetadata & {name: string; associated_event_id?: string};
     owners: null | unknown;
     project?: Project;
   }


### PR DESCRIPTION
fixes REPLAY-618

Add an optional `summary` field to `FeedbackIssueMetadata`. This field contains the same content as the existing `title` field (ie, an AI-generated title of the feedback), only without the "User Feedback: " prefix.

- Display `summary` next the user name and email if it exists, the org has seer permissions, the `gen-ai-features` feature flag is true, and the `user-feedback-ai-titles` feature flag is true.
- Make sure "Click to copy" tooltip is centered above the name and email, NOT including the summary.
- Add the summary to the subject of the email when the mail icon is clicked.

Before:
<img width="1002" height="219" alt="Screenshot 2025-09-09 at 1 32 39 PM" src="https://github.com/user-attachments/assets/dcd70913-57bf-474a-a43a-25f02f1ffeee" />

After:
<img width="1002" height="219" alt="Screenshot 2025-09-09 at 1 32 13 PM" src="https://github.com/user-attachments/assets/736267cc-07cb-427a-97e9-956eb64247a0" />
