### PR TITLE
ref(replay): update processing error message

### DIFF
--- a/static/app/components/events/eventReplay/staticReplayPreview.tsx
+++ b/static/app/components/events/eventReplay/staticReplayPreview.tsx
@@ -66,7 +66,7 @@ export function StaticReplayPreview({
     >
       <PlayerContainer data-test-id="player-container">
         {replay?.hasProcessingErrors() ? (
-          <ReplayProcessingError processingErrors={replay.processingErrors()} />
+          <ReplayProcessingError />
         ) : (
           <Fragment>
             <StaticPanel>

--- a/static/app/components/replays/player/replayLoadingState.tsx
+++ b/static/app/components/replays/player/replayLoadingState.tsx
@@ -68,7 +68,7 @@ export default function ReplayLoadingState({
     return renderProcessingError ? (
       renderProcessingError(readerResult)
     ) : (
-      <ReplayProcessingError processingErrors={readerResult.replay.processingErrors()} />
+      <ReplayProcessingError />
     );
   }
   return children({replay: readerResult.replay});

--- a/static/app/components/replays/replayProcessingError.tsx
+++ b/static/app/components/replays/replayProcessingError.tsx
@@ -9,7 +9,6 @@ import {space} from 'sentry/styles/space';
 import {useReplayReader} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
 
 interface Props {
-  processingErrors: readonly string[];
   className?: string;
 }
 
@@ -28,13 +27,14 @@ export default function ReplayProcessingError({className}: Props) {
   }, [sdk]);
 
   return (
-    <StyledAlert type="error" className={className}>
+    <StyledAlert type="info" className={className}>
       <Heading>{t('Replay Not Found')}</Heading>
-      <p>{t('The replay you are looking for was not found.')}</p>
-      <p>{t('The replay might be missing events or metadata.')}</p>
+      <p>
+        {t('The replay you are looking for was not found due to a processing error.')}
+      </p>
       <p>
         {t(
-          'Or there may be an issue loading the actions from the server, click to try loading the Replay again.'
+          'The replay might be missing critical events or metadata, or there may be an issue loading the actions from the server.'
         )}
       </p>
       <ul>
@@ -45,7 +45,7 @@ export default function ReplayProcessingError({className}: Props) {
           )}
         </li>
         <li>
-          {tct('If all else fails, [link:contact us] with more details', {
+          {tct('If all else fails, feel free to [link:contact us] with more details.', {
             link: (
               <ExternalLink href="https://github.com/getsentry/sentry/issues/new/choose" />
             ),

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -105,7 +105,7 @@ export default function ReplayView({toggleFullscreen, isLoading}: Props) {
               </Panel>
             </FluidHeight>
           ) : !isFetching && replay?.hasProcessingErrors() ? (
-            <ReplayProcessingError processingErrors={replay.processingErrors()} />
+            <ReplayProcessingError />
           ) : (
             <FluidHeight>
               {isVideoReplay && needsJetpackComposePiiWarning ? (

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -39,10 +39,10 @@ export default function ReplayDetailsPage({readerResult}: Props) {
           <NotFound />
         </Layout.Page>
       )}
-      renderProcessingError={({replay}) => (
+      renderProcessingError={() => (
         <Layout.Page withPadding>
           <Flex direction="column">
-            <ReplayProcessingError processingErrors={replay!.processingErrors()} />
+            <ReplayProcessingError />
           </Flex>
         </Layout.Page>
       )}


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-682/update-the-processing-error-banner-on-replay-details-colour-and-copy

update the processing error message on replay details to be more specific, and also change it to have the purple `info` theme rather than red `error`.

also turns out the `processingErrors` prop being passed in wasn't being used, so i removed it.

before:
<img width="721" height="219" alt="SCR-20250909-mcvs" src="https://github.com/user-attachments/assets/6ff7fd20-cd97-437d-8c68-be837099933d" />


after:
<img width="1030" height="422" alt="SCR-20250909-mbgn-2" src="https://github.com/user-attachments/assets/dbf1b5f3-095c-4c28-96a6-33909acac429" />

