### PR TITLE
feat(detectors): Rollout experimental N+1/MN+1 DB Detectors 

### DIFF
--- a/src/sentry/performance_issues/detectors/experiments/n_plus_one_db_span_detector.py
+++ b/src/sentry/performance_issues/detectors/experiments/n_plus_one_db_span_detector.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
-from sentry.issues.grouptype import PerformanceNPlusOneExperimentalGroupType
+from sentry import features
+from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -75,7 +76,9 @@ class NPlusOneDBSpanExperimentalDetector(PerformanceDetector):
         return True
 
     def is_creation_allowed_for_organization(self, organization: Organization | None) -> bool:
-        return True  # This detector is fully rolled out
+        return features.has(
+            "organizations:experimental-n-plus-one-db-detector-rollout", organization
+        )
 
     def is_creation_allowed_for_project(self, project: Project | None) -> bool:
         return self.settings["detection_enabled"]
@@ -202,7 +205,7 @@ class NPlusOneDBSpanExperimentalDetector(PerformanceDetector):
                 fingerprint=fingerprint,
                 op="db",
                 desc=first_span_description,
-                type=PerformanceNPlusOneExperimentalGroupType,
+                type=PerformanceNPlusOneGroupType,
                 parent_span_ids=[parent_span_id],
                 cause_span_ids=[self.source_span["span_id"]],
                 offender_span_ids=offender_span_ids,

--- a/src/sentry/performance_issues/detectors/experiments/n_plus_one_db_span_detector.py
+++ b/src/sentry/performance_issues/detectors/experiments/n_plus_one_db_span_detector.py
@@ -256,7 +256,7 @@ class NPlusOneDBSpanExperimentalDetector(PerformanceDetector):
     def _fingerprint(self, parent_op: str, parent_hash: str, source_hash: str, n_hash: str) -> str:
         # XXX: this has to be a hardcoded string otherwise grouping will break
         # For the experiment, we also need to modify the hardcoded string so that after re-GA, new groups send notifications.
-        problem_class = "GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES_EXPERIMENTAL"
+        problem_class = "GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES"
         full_fingerprint = hashlib.sha1(
             (str(parent_op) + str(parent_hash) + str(source_hash) + str(n_hash)).encode("utf8"),
         ).hexdigest()

--- a/src/sentry/performance_issues/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/performance_issues/detectors/mn_plus_one_db_span_detector.py
@@ -6,6 +6,7 @@ from collections import deque
 from collections.abc import Sequence
 from typing import Any
 
+from sentry import features
 from sentry.issues.grouptype import (
     PerformanceMNPlusOneDBQueriesGroupType,
     PerformanceNPlusOneGroupType,
@@ -274,7 +275,9 @@ class MNPlusOneDBSpanDetector(PerformanceDetector):
         self.state: MNPlusOneState = SearchingForMNPlusOne(self.settings, self.event())
 
     def is_creation_allowed_for_organization(self, organization: Organization | None) -> bool:
-        return True
+        return not features.has(
+            "organizations:experimental-mn-plus-one-detector-rollout", organization
+        )
 
     def is_creation_allowed_for_project(self, project: Project) -> bool:
         return self.settings["detection_enabled"]

--- a/src/sentry/performance_issues/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/performance_issues/detectors/n_plus_one_db_span_detector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
+from sentry import features
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.organization import Organization
@@ -70,7 +71,9 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
             self.potential_parents[root_span.get("span_id")] = root_span
 
     def is_creation_allowed_for_organization(self, organization: Organization | None) -> bool:
-        return True  # This detector is fully rolled out
+        return not features.has(
+            "organizations:experimental-n-plus-one-db-detector-rollout", organization
+        )
 
     def is_creation_allowed_for_project(self, project: Project | None) -> bool:
         return self.settings["detection_enabled"]

--- a/tests/sentry/performance_issues/experiments/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/performance_issues/experiments/test_m_n_plus_one_db_detector.py
@@ -7,8 +7,8 @@ from unittest.mock import MagicMock, Mock, call, patch
 import pytest
 
 from sentry.issues.grouptype import (
-    PerformanceMNPlusOneDBQueriesExperimentalGroupType,
-    PerformanceNPlusOneExperimentalGroupType,
+    PerformanceMNPlusOneDBQueriesGroupType,
+    PerformanceNPlusOneGroupType,
 )
 from sentry.models.options.project_option import ProjectOption
 from sentry.performance_issues.base import DetectorType
@@ -29,8 +29,8 @@ from sentry.testutils.performance_issues.event_generators import get_event
 @pytest.mark.django_db
 class MNPlusOneDBDetectorTest(TestCase):
     detector = MNPlusOneDBSpanExperimentalDetector
-    fingerprint_type_id = PerformanceMNPlusOneDBQueriesExperimentalGroupType.type_id
-    group_type = PerformanceNPlusOneExperimentalGroupType
+    fingerprint_type_id = PerformanceMNPlusOneDBQueriesGroupType.type_id
+    group_type = PerformanceNPlusOneGroupType
 
     def setUp(self) -> None:
         super().setUp()
@@ -116,7 +116,7 @@ class MNPlusOneDBDetectorTest(TestCase):
                 evidence_display=[],
             )
         ]
-        assert problems[0].title == "N+1 Query (Experimental)"
+        assert problems[0].title == "N+1 Query"
 
     def test_detects_prisma_client_m_n_plus_one(self) -> None:
         event = get_event("m-n-plus-one-db/m-n-plus-one-prisma-client")
@@ -151,8 +151,8 @@ class MNPlusOneDBDetectorTest(TestCase):
         assert len(problems) == 1
         problem = problems[0]
 
-        assert problem.type == PerformanceNPlusOneExperimentalGroupType
-        assert problem.fingerprint == "1-1911-44f4f3cc14f0f8d0c5ae372e5e8c80e7ba84f413"
+        assert problem.type == PerformanceNPlusOneGroupType
+        assert problem.fingerprint == "1-1011-44f4f3cc14f0f8d0c5ae372e5e8c80e7ba84f413"
 
         assert len(problem.offender_span_ids) == num_offender_spans
         assert problem.evidence_data is not None
@@ -167,8 +167,8 @@ class MNPlusOneDBDetectorTest(TestCase):
         event = get_event("m-n-plus-one-db/m-n-plus-one-prisma-client-different-descriptions")
         assert len(self.find_problems(event)) == 1
         problem = self.find_problems(event)[0]
-        assert problem.type == PerformanceNPlusOneExperimentalGroupType
-        assert problem.fingerprint == "1-1911-50301e409950f4b1cc0a02d9d172684b4020ae32"
+        assert problem.type == PerformanceNPlusOneGroupType
+        assert problem.fingerprint == "1-1011-50301e409950f4b1cc0a02d9d172684b4020ae32"
         assert len(problem.offender_span_ids) == 10
         assert problem.evidence_data is not None
         assert problem.evidence_data["number_repeating_spans"] == str(10)

--- a/tests/sentry/performance_issues/experiments/test_n_plus_one_db_span_detector.py
+++ b/tests/sentry/performance_issues/experiments/test_n_plus_one_db_span_detector.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-from sentry.issues.grouptype import PerformanceNPlusOneExperimentalGroupType
+from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.options.project_option import ProjectOption
 from sentry.performance_issues.base import DetectorType
@@ -23,7 +23,7 @@ from sentry.testutils.performance_issues.event_generators import get_event
 
 @pytest.mark.django_db
 class NPlusOneDBSpanExperimentalDetectorTest(unittest.TestCase):
-    fingerprint_prefix = "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES_EXPERIMENTAL"
+    fingerprint_prefix = "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES"
 
     def setUp(self) -> None:
         super().setUp()
@@ -53,7 +53,7 @@ class NPlusOneDBSpanExperimentalDetectorTest(unittest.TestCase):
                 fingerprint=f"{self.fingerprint_prefix}-8d86357da4d8a866b19c97670edee38d037a7bc8",
                 op="db",
                 desc="SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = 1 LIMIT 21",
-                type=PerformanceNPlusOneExperimentalGroupType,
+                type=PerformanceNPlusOneGroupType,
                 parent_span_ids=["8dd7a5869a4f4583"],
                 cause_span_ids=["9179e43ae844b174"],
                 offender_span_ids=[
@@ -127,7 +127,7 @@ class NPlusOneDBSpanExperimentalDetectorTest(unittest.TestCase):
                 fingerprint=f"{self.fingerprint_prefix}-8d86357da4d8a866b19c97670edee38d037a7bc8",
                 op="db",
                 desc="SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
-                type=PerformanceNPlusOneExperimentalGroupType,
+                type=PerformanceNPlusOneGroupType,
                 parent_span_ids=["8dd7a5869a4f4583"],
                 cause_span_ids=["9179e43ae844b174"],
                 offender_span_ids=[
@@ -186,7 +186,7 @@ class NPlusOneDBSpanExperimentalDetectorTest(unittest.TestCase):
             PerformanceProblem(
                 fingerprint=f"{self.fingerprint_prefix}-e55ea09e1cff0ca2369f287cf624700f98cf4b50",
                 op="db",
-                type=PerformanceNPlusOneExperimentalGroupType,
+                type=PerformanceNPlusOneGroupType,
                 desc='SELECT "expense_expenses"."id", "expense_expenses"."report_id", "expense_expenses"."amount" FROM "expense_expenses" WHERE "expense_expenses"."report_id" = %s',
                 parent_span_ids=["81a4b462bdc5c764"],
                 cause_span_ids=["99797d06e2fa9750"],
@@ -250,7 +250,7 @@ class NPlusOneDBSpanExperimentalDetectorTest(unittest.TestCase):
                 fingerprint=f"{self.fingerprint_prefix}-8d86357da4d8a866b19c97670edee38d037a7bc8",
                 op="db",
                 desc="SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
-                type=PerformanceNPlusOneExperimentalGroupType,
+                type=PerformanceNPlusOneGroupType,
                 parent_span_ids=["8dd7a5869a4f4583"],
                 cause_span_ids=["9179e43ae844b174"],
                 offender_span_ids=[
@@ -310,7 +310,7 @@ class NPlusOneDBSpanExperimentalDetectorTest(unittest.TestCase):
                 fingerprint=f"{self.fingerprint_prefix}-4e7d5e9be7cb7af2dc8af3ab6be354707e3ab2bc",
                 op="db",
                 desc='{"filter":{"productid":{"buffer":"?"}},"find":"reviews"}',
-                type=PerformanceNPlusOneExperimentalGroupType,
+                type=PerformanceNPlusOneGroupType,
                 parent_span_ids=["991fdf5c47a068b0"],
                 cause_span_ids=["398687f1a7e9cf73"],
                 offender_span_ids=offender_spans_ids,


### PR DESCRIPTION
To rollout these detectors 2 changes are made 
1) the experimental detectors will now create the original grouptype, instead of an experimental one
2) organizations with the feature flag will have the experimental detector run, while those without the flag will have the existing detector run