### PR TITLE
feat(ACI): Persist schedule_update_project_config in workflow engine

### DIFF
--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -29,17 +29,17 @@ def fetch_snuba_query(detector: Detector) -> SnubaQuery | None:
     try:
         source_instance = DataSource.objects.get(detector=detector)
     except DataSource.DoesNotExist:
-        return
+        return None
     if source_instance:
         try:
             query_subscription = QuerySubscription.objects.get(id=source_instance.source_id)
         except QuerySubscription.DoesNotExist:
-            return
+            return None
     if query_subscription:
         try:
             snuba_query = SnubaQuery.objects.get(id=query_subscription.snuba_query.id)
         except SnubaQuery.DoesNotExist:
-            return
+            return None
     return snuba_query
 
 

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -6,9 +6,12 @@ from rest_framework import serializers
 from sentry import features, quotas
 from sentry.constants import ObjectStatus
 from sentry.incidents.logic import enable_disable_subscriptions
+from sentry.relay.config.metric_extraction import on_demand_metrics_feature_flags
+from sentry.snuba.metrics.extraction import should_use_on_demand_metrics
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.snuba_query_validator import SnubaQueryValidator
 from sentry.snuba.subscriptions import update_snuba_query
+from sentry.tasks.relay import schedule_invalidate_project_config
 from sentry.workflow_engine.endpoints.validators.base import (
     BaseDataConditionGroupValidator,
     BaseDetectorTypeValidator,
@@ -20,6 +23,50 @@ from sentry.workflow_engine.endpoints.validators.base.data_condition import (
 from sentry.workflow_engine.models import DataSource, Detector
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel, SnubaQueryDataSourceType
+
+
+def fetch_snuba_query(detector: Detector) -> SnubaQuery | None:
+    try:
+        source_instance = DataSource.objects.get(detector=detector)
+    except DataSource.DoesNotExist:
+        return
+    if source_instance:
+        try:
+            query_subscription = QuerySubscription.objects.get(id=source_instance.source_id)
+        except QuerySubscription.DoesNotExist:
+            return
+    if query_subscription:
+        try:
+            snuba_query = SnubaQuery.objects.get(id=query_subscription.snuba_query.id)
+        except SnubaQuery.DoesNotExist:
+            return
+    return snuba_query
+
+
+def schedule_update_project_config(detector: Detector) -> None:
+    """
+    If `should_use_on_demand`, then invalidate the project configs
+    """
+    enabled_features = on_demand_metrics_feature_flags(detector.project.organization)
+    prefilling = "organizations:on-demand-metrics-prefill" in enabled_features
+    if "organizations:on-demand-metrics-extraction" not in enabled_features and not prefilling:
+        return
+
+    snuba_query = fetch_snuba_query(detector)
+    if not snuba_query:
+        return
+
+    should_use_on_demand = should_use_on_demand_metrics(
+        snuba_query.dataset,
+        snuba_query.aggregate,
+        snuba_query.query,
+        None,
+        prefilling,
+    )
+    if should_use_on_demand:
+        schedule_invalidate_project_config(
+            trigger="alerts:create-on-demand-metric", project_id=detector.project.id
+        )
 
 
 class MetricIssueComparisonConditionValidator(BaseDataConditionValidator):
@@ -166,4 +213,12 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
                 self.update_data_source(instance, data_source)
 
         instance.save()
+
+        schedule_update_project_config(instance)
         return instance
+
+    def create(self, validated_data: dict[str, Any]):
+        detector = super().create(validated_data)
+
+        schedule_update_project_config(detector)
+        return detector

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -24,6 +24,7 @@ from sentry.constants import ObjectStatus
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.grouping.grouptype import ErrorGroupType
+from sentry.incidents.metric_issue_detector import schedule_update_project_config
 from sentry.issues import grouptype
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -201,6 +202,7 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
 
         RegionScheduledDeletion.schedule(detector, days=0, actor=request.user)
         detector.update(status=ObjectStatus.PENDING_DELETION)
+        schedule_update_project_config(detector)
         create_audit_entry(
             request=request,
             organization=detector.project.organization,

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -24,6 +24,7 @@ from sentry.constants import ObjectStatus
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.grouping.grouptype import ErrorGroupType
+from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.metric_issue_detector import schedule_update_project_config
 from sentry.issues import grouptype
 from sentry.models.organization import Organization
@@ -202,7 +203,10 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
 
         RegionScheduledDeletion.schedule(detector, days=0, actor=request.user)
         detector.update(status=ObjectStatus.PENDING_DELETION)
-        schedule_update_project_config(detector)
+
+        if detector.type == MetricIssue.slug:
+            schedule_update_project_config(detector)
+
         create_audit_entry(
             request=request,
             organization=detector.project.organization,

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -186,8 +186,11 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
         assert snuba_query.environment == self.environment
         assert snuba_query.event_types == [SnubaQueryEventType.EventType.ERROR]
 
+    @mock.patch("sentry.incidents.metric_issue_detector.schedule_update_project_config")
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
-    def test_create_with_valid_data(self, mock_audit: mock.MagicMock) -> None:
+    def test_create_with_valid_data(
+        self, mock_audit: mock.MagicMock, mock_schedule_update_project_config
+    ) -> None:
         validator = MetricIssueDetectorValidator(
             data=self.valid_data,
             context=self.context,
@@ -220,6 +223,7 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
             event=audit_log.get_event_id("DETECTOR_ADD"),
             data=detector.get_audit_log_data(),
         )
+        mock_schedule_update_project_config.assert_called_once_with(detector)
 
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
     def test_anomaly_detection(self, mock_audit: mock.MagicMock) -> None:

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest import mock
 
 import pytest
 from django.utils import timezone
@@ -198,7 +199,8 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         assert snuba_query.query == "updated query"
         assert snuba_query.time_window == 300
 
-    def test_update(self) -> None:
+    @mock.patch("sentry.incidents.metric_issue_detector.schedule_update_project_config")
+    def test_update(self, mock_schedule_update_project_config: mock.MagicMock) -> None:
         with self.tasks():
             response = self.get_success_response(
                 self.organization.slug,
@@ -224,6 +226,7 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         query_subscription = QuerySubscription.objects.get(id=data_source.source_id)
         snuba_query = SnubaQuery.objects.get(id=query_subscription.snuba_query.id)
         self.assert_snuba_query_updated(snuba_query)
+        mock_schedule_update_project_config.assert_called_once_with(detector)
 
     def test_update_add_data_condition(self) -> None:
         """
@@ -669,7 +672,8 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
 class OrganizationDetectorDetailsDeleteTest(OrganizationDetectorDetailsBaseTest):
     method = "DELETE"
 
-    def test_simple(self) -> None:
+    @mock.patch("sentry.incidents.metric_issue_detector.schedule_update_project_config")
+    def test_simple(self, mock_schedule_update_project_config) -> None:
         with outbox_runner():
             self.get_success_response(self.organization.slug, self.detector.id)
 
@@ -684,6 +688,7 @@ class OrganizationDetectorDetailsDeleteTest(OrganizationDetectorDetailsBaseTest)
             ).exists()
         self.detector.refresh_from_db()
         assert self.detector.status == ObjectStatus.PENDING_DELETION
+        mock_schedule_update_project_config.assert_called_once_with(self.detector)
 
     def test_error_group_type(self) -> None:
         """

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -672,7 +672,9 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
 class OrganizationDetectorDetailsDeleteTest(OrganizationDetectorDetailsBaseTest):
     method = "DELETE"
 
-    @mock.patch("sentry.incidents.metric_issue_detector.schedule_update_project_config")
+    @mock.patch(
+        "sentry.workflow_engine.endpoints.organization_detector_details.schedule_update_project_config"
+    )
     def test_simple(self, mock_schedule_update_project_config) -> None:
         with outbox_runner():
             self.get_success_response(self.organization.slug, self.detector.id)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -817,8 +817,11 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             "detail": ErrorDetail(string="The requested resource does not exist", code="error")
         }
 
+    @mock.patch("sentry.incidents.metric_issue_detector.schedule_update_project_config")
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
-    def test_valid_creation(self, mock_audit: mock.MagicMock) -> None:
+    def test_valid_creation(
+        self, mock_audit: mock.MagicMock, mock_schedule_update_project_config
+    ) -> None:
         with self.tasks():
             response = self.get_success_response(
                 self.organization.slug,
@@ -878,6 +881,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             event=mock.ANY,
             data=detector.get_audit_log_data(),
         )
+        mock_schedule_update_project_config.assert_called_once_with(detector)
 
     def test_invalid_workflow_ids(self) -> None:
         # Workflow doesn't exist at all


### PR DESCRIPTION
Persist the behavior of `schedule_update_project_config` from https://github.com/getsentry/sentry/blob/master/src/sentry/incidents/logic.py#L2013 in workflow engine. When we switch over to using workflow engine only we will no longer be calling the existing function in `logic.py`.