### PR TITLE
feat(prevent): add mutation and query for syncing repos w/ Codecov

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -69,6 +69,7 @@ from sentry.codecov.endpoints.repository_token_regenerate.repository_token_regen
     RepositoryTokenRegenerateEndpoint,
 )
 from sentry.codecov.endpoints.repository_tokens.repository_tokens import RepositoryTokensEndpoint
+from sentry.codecov.endpoints.sync_repos.sync_repos import SyncReposEndpoint
 from sentry.codecov.endpoints.test_results.test_results import TestResultsEndpoint
 from sentry.codecov.endpoints.test_results_aggregates.test_results_aggregates import (
     TestResultsAggregatesEndpoint,
@@ -1120,6 +1121,11 @@ PREVENT_URLS = [
         r"^owner/(?P<owner>[^/]+)/repository/(?P<repository>[^/]+)/token/regenerate/$",
         RepositoryTokenRegenerateEndpoint.as_view(),
         name="sentry-api-0-repository-token-regenerate",
+    ),
+    re_path(
+        r"^owner/(?P<owner>[^/]+)/repositories/sync/$",
+        SyncReposEndpoint.as_view(),
+        name="sentry-api-0-sync-repos",
     ),
 ]
 

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1125,7 +1125,7 @@ PREVENT_URLS = [
     re_path(
         r"^owner/(?P<owner>[^/]+)/repositories/sync/$",
         SyncReposEndpoint.as_view(),
-        name="sentry-api-0-sync-repos",
+        name="sentry-api-0-repositories-sync",
     ),
 ]
 

--- a/src/sentry/codecov/endpoints/sync_repos/query.py
+++ b/src/sentry/codecov/endpoints/sync_repos/query.py
@@ -1,0 +1,18 @@
+mutation = """
+    mutation SyncRepos {
+        syncRepos {
+          isSyncing
+          error {
+            __typename
+          }
+        }
+      }
+"""
+
+query = """
+    query IsSyncing {
+        me {
+          isSyncing: isSyncingWithGitProvider
+        }
+      }
+"""

--- a/src/sentry/codecov/endpoints/sync_repos/query.py
+++ b/src/sentry/codecov/endpoints/sync_repos/query.py
@@ -2,9 +2,6 @@ mutation = """
     mutation SyncRepos {
         syncRepos {
           isSyncing
-          error {
-            __typename
-          }
         }
       }
 """

--- a/src/sentry/codecov/endpoints/sync_repos/serializers.py
+++ b/src/sentry/codecov/endpoints/sync_repos/serializers.py
@@ -26,9 +26,6 @@ class SyncReposSerializer(serializers.Serializer):
             else:
                 data = graphql_response["data"]["me"]
 
-            if data.get("error"):
-                raise serializers.ValidationError(data["error"]["message"])
-
             response_data = {
                 "is_syncing": data["isSyncing"],
             }

--- a/src/sentry/codecov/endpoints/sync_repos/serializers.py
+++ b/src/sentry/codecov/endpoints/sync_repos/serializers.py
@@ -18,16 +18,15 @@ class SyncReposSerializer(serializers.Serializer):
         Transform the GraphQL response to the serialized format
         """
         try:
-            request = self.context.get("request")
-            http_method = request.method if request else "UNKNOWN"
+            http_method = self.context.get("http_method") or "UNKNOWN"
 
             if http_method == "POST":
-                data = graphql_response["data"]["syncRepos"]
+                data = graphql_response.get("data").get("syncRepos")
             else:
-                data = graphql_response["data"]["me"]
+                data = graphql_response.get("data").get("me")
 
             response_data = {
-                "is_syncing": data["isSyncing"],
+                "is_syncing": data.get("isSyncing"),
             }
 
             return super().to_representation(response_data)

--- a/src/sentry/codecov/endpoints/sync_repos/serializers.py
+++ b/src/sentry/codecov/endpoints/sync_repos/serializers.py
@@ -21,12 +21,12 @@ class SyncReposSerializer(serializers.Serializer):
             http_method = self.context.get("http_method") or "UNKNOWN"
 
             if http_method == "POST":
-                data = graphql_response.get("data").get("syncRepos")
+                data = graphql_response["data"]["syncRepos"]
             else:
-                data = graphql_response.get("data").get("me")
+                data = graphql_response["data"]["me"]
 
             response_data = {
-                "is_syncing": data.get("isSyncing"),
+                "is_syncing": data["isSyncing"],
             }
 
             return super().to_representation(response_data)

--- a/src/sentry/codecov/endpoints/sync_repos/serializers.py
+++ b/src/sentry/codecov/endpoints/sync_repos/serializers.py
@@ -1,0 +1,52 @@
+import logging
+
+import sentry_sdk
+from rest_framework import serializers
+
+logger = logging.getLogger(__name__)
+
+
+class SyncReposSerializer(serializers.Serializer):
+    """
+    Serializer for a sync repository response
+    """
+
+    is_syncing = serializers.BooleanField()
+
+    def to_representation(self, graphql_response):
+        """
+        Transform the GraphQL response to the serialized format
+        """
+        try:
+            request = self.context.get("request")
+            http_method = request.method if request else "UNKNOWN"
+
+            if http_method == "POST":
+                data = graphql_response["data"]["syncRepos"]
+            else:
+                data = graphql_response["data"]["me"]
+
+            if data.get("error"):
+                raise serializers.ValidationError(data["error"]["message"])
+
+            response_data = {
+                "is_syncing": data["isSyncing"],
+            }
+
+            return super().to_representation(response_data)
+
+        except (KeyError, TypeError) as e:
+            sentry_sdk.capture_exception(e)
+            logger.exception(
+                "Error parsing GraphQL response",
+                extra={
+                    "error": str(e),
+                    "endpoint": "sync-repos",
+                    "response_keys": (
+                        list(graphql_response.keys())
+                        if isinstance(graphql_response, dict)
+                        else None
+                    ),
+                },
+            )
+            raise

--- a/src/sentry/codecov/endpoints/sync_repos/sync_repos.py
+++ b/src/sentry/codecov/endpoints/sync_repos/sync_repos.py
@@ -1,0 +1,65 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
+from sentry.codecov.base import CodecovEndpoint
+from sentry.codecov.client import CodecovApiClient
+from sentry.codecov.endpoints.sync_repos.query import mutation, query
+from sentry.codecov.endpoints.sync_repos.serializers import SyncReposSerializer
+from sentry.integrations.services.integration.model import RpcIntegration
+
+
+@extend_schema(tags=["Prevent"])
+@region_silo_endpoint
+class SyncReposEndpoint(CodecovEndpoint):
+    owner = ApiOwner.CODECOV
+    publish_status = {
+        "POST": ApiPublishStatus.PUBLIC,
+    }
+
+    @extend_schema(
+        operation_id="Syncs repositories from an integrated org with GitHub",
+        parameters=[],
+        request=None,
+        responses={
+            200: SyncReposSerializer,
+            400: RESPONSE_BAD_REQUEST,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def post(self, request: Request, owner: RpcIntegration, **kwargs) -> Response:
+        """
+        Syncs repositories for an integrated organization with GitHub.
+        """
+
+        owner_slug = owner.name
+
+        variables = {}
+
+        client = CodecovApiClient(git_provider_org=owner_slug)
+        graphql_response = client.query(query=mutation, variables=variables)
+        serializer = SyncReposSerializer(context={"request": request})
+        is_syncing = serializer.to_representation(graphql_response.json())
+
+        return Response(is_syncing)
+
+    def get(self, request: Request, owner: RpcIntegration, **kwargs) -> Response:
+        """
+        Gets syncing status for repositories in integrated organization.
+        """
+
+        owner_slug = owner.name
+
+        variables = {}
+
+        client = CodecovApiClient(git_provider_org=owner_slug)
+        graphql_response = client.query(query=query, variables=variables)
+        serializer = SyncReposSerializer(context={"request": request})
+        is_syncing = serializer.to_representation(graphql_response.json())
+
+        return Response(is_syncing)

--- a/src/sentry/codecov/endpoints/sync_repos/sync_repos.py
+++ b/src/sentry/codecov/endpoints/sync_repos/sync_repos.py
@@ -19,6 +19,7 @@ class SyncReposEndpoint(CodecovEndpoint):
     owner = ApiOwner.CODECOV
     publish_status = {
         "POST": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PUBLIC,
     }
 
     @extend_schema(
@@ -48,6 +49,17 @@ class SyncReposEndpoint(CodecovEndpoint):
 
         return Response(is_syncing)
 
+    @extend_schema(
+        operation_id="Gets syncing status from an integrated org",
+        parameters=[],
+        request=None,
+        responses={
+            200: SyncReposSerializer,
+            400: RESPONSE_BAD_REQUEST,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     def get(self, request: Request, owner: RpcIntegration, **kwargs) -> Response:
         """
         Gets syncing status for repositories in integrated organization.

--- a/src/sentry/codecov/endpoints/sync_repos/sync_repos.py
+++ b/src/sentry/codecov/endpoints/sync_repos/sync_repos.py
@@ -6,6 +6,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
+from sentry.apidocs.parameters import GlobalParams
 from sentry.codecov.base import CodecovEndpoint
 from sentry.codecov.client import CodecovApiClient
 from sentry.codecov.endpoints.sync_repos.query import mutation, query
@@ -24,7 +25,9 @@ class SyncReposEndpoint(CodecovEndpoint):
 
     @extend_schema(
         operation_id="Syncs repositories from an integrated org with GitHub",
-        parameters=[],
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+        ],
         request=None,
         responses={
             200: SyncReposSerializer,
@@ -51,7 +54,9 @@ class SyncReposEndpoint(CodecovEndpoint):
 
     @extend_schema(
         operation_id="Gets syncing status from an integrated org",
-        parameters=[],
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+        ],
         request=None,
         responses={
             200: SyncReposSerializer,

--- a/tests/sentry/codecov/endpoints/test_sync_repos.py
+++ b/tests/sentry/codecov/endpoints/test_sync_repos.py
@@ -56,32 +56,6 @@ class SyncReposEndpointTest(APITestCase):
         assert response.data["is_syncing"] is True
 
     @patch("sentry.codecov.endpoints.sync_repos.sync_repos.CodecovApiClient")
-    def test_post_handles_errors(self, mock_codecov_client_class) -> None:
-        """Test that GraphQL errors are properly handled when calling Codecov API"""
-        mock_graphql_response = {
-            "data": {
-                "syncRepos": {
-                    "error": {
-                        "__typename": "UnauthenticatedError",
-                        "message": "You are not authenticated",
-                    },
-                }
-            }
-        }
-
-        mock_codecov_client_instance = Mock()
-        mock_response = Mock()
-        mock_response.json.return_value = mock_graphql_response
-        mock_codecov_client_instance.query.return_value = mock_response
-        mock_codecov_client_class.return_value = mock_codecov_client_instance
-
-        url = self.reverse_url()
-        response = self.client.post(url, data={})
-
-        assert response.status_code == 400
-        assert response.data[0] == "You are not authenticated"
-
-    @patch("sentry.codecov.endpoints.sync_repos.sync_repos.CodecovApiClient")
     def test_get_calls_api(self, mock_codecov_client_class) -> None:
         """Test that gets sync status"""
         mock_graphql_response = {

--- a/tests/sentry/codecov/endpoints/test_sync_repos.py
+++ b/tests/sentry/codecov/endpoints/test_sync_repos.py
@@ -8,7 +8,7 @@ from sentry.testutils.cases import APITestCase
 
 
 class SyncReposEndpointTest(APITestCase):
-    endpoint_name = "sentry-api-0-sync-repos"
+    endpoint_name = "sentry-api-0-repositories-sync"
 
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
This PR adds a mutation and query to sync repos with Codecov's backend.

The mutation triggers a GQL mutation in Codecov, the query fetches the isSyncing status for it.

There is a POST and GET in the endpoint file, both using the same serializer but slightly changing its shape whether its a mutation (POST) or a query (GET).

Closes: https://linear.app/getsentry/issue/CCMRG-1504/connect-sync-repo-button-to-backend