### PR TITLE
feat(cursor-agent): Cursor agent integration webhooks

### DIFF
--- a/src/sentry/integrations/coding_agent/integration.py
+++ b/src/sentry/integrations/coding_agent/integration.py
@@ -59,7 +59,7 @@ class CodingAgentIntegration(IntegrationInstallation, abc.ABC):
         """Generate webhook URL for this integration."""
         provider = self.model.provider
 
-        return absolute_uri(f"/extensions/{provider}/webhook/")
+        return absolute_uri(f"/extensions/{provider}/organizations/{self.organization_id}/webhook/")
 
     def launch(self, request: CodingAgentLaunchRequest) -> CodingAgentState:
         """Launch coding agent with webhook callback URL."""

--- a/src/sentry/integrations/coding_agent/integration.py
+++ b/src/sentry/integrations/coding_agent/integration.py
@@ -4,7 +4,7 @@ import abc
 
 from django.utils.translation import gettext_lazy as _
 
-from sentry import options
+from sentry.api.utils import generate_region_url
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationFeatures,
@@ -15,7 +15,6 @@ from sentry.integrations.base import (
 from sentry.integrations.coding_agent.client import CodingAgentClient
 from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
 from sentry.seer.autofix.utils import CodingAgentState
-from sentry.types.region import get_local_region
 from sentry.utils.http import absolute_uri
 
 # Default metadata for coding agent integrations
@@ -61,9 +60,7 @@ class CodingAgentIntegration(IntegrationInstallation, abc.ABC):
         """Generate webhook URL for this integration."""
         return absolute_uri(
             f"/extensions/{self.model.provider}/organizations/{self.organization_id}/webhook/",
-            url_prefix=options.get("system.region-api-url-template").replace(
-                "{region}", get_local_region().name
-            ),
+            url_prefix=generate_region_url(),
         )
 
     def launch(self, request: CodingAgentLaunchRequest) -> CodingAgentState:

--- a/src/sentry/integrations/cursor/urls.py
+++ b/src/sentry/integrations/cursor/urls.py
@@ -1,0 +1,11 @@
+from django.urls import re_path
+
+from .webhooks.handler import CursorWebhookEndpoint
+
+urlpatterns = [
+    re_path(
+        r"^organizations/(?P<organization_id>[^/]+)/webhook/$",
+        CursorWebhookEndpoint.as_view(),
+        name="sentry-extensions-cursor-webhook",
+    ),
+]

--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -187,7 +187,8 @@ class CursorWebhookEndpoint(Endpoint):
         repo_full_name = parsed.path.lstrip("/")
 
         # If the repo isn't in the owner/repo format we can't work with it
-        if not re.match(r"^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$", repo_full_name):
+        # Allow dots in the repository name segment (owner.repo is common)
+        if not re.match(r"^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$", repo_full_name):
             logger.error(
                 "cursor_webhook.repo_format_invalid",
                 extra={"agent_id": agent_id, "source": source},

--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -8,11 +8,13 @@ from typing import Any
 from urllib.parse import urlparse
 
 import orjson
+from django.http import HttpRequest, HttpResponse
 from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.exceptions import MethodNotAllowed, ParseError, PermissionDenied
 from rest_framework.request import Request
+from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -38,12 +40,12 @@ class CursorWebhookEndpoint(Endpoint):
     permission_classes = ()
 
     @method_decorator(csrf_exempt)
-    def dispatch(self, request: Request, *args, **kwargs):
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         if request.method != "POST":
-            raise MethodNotAllowed(request.method)
+            raise MethodNotAllowed(request.method or "unknown")
         return super().dispatch(request, *args, **kwargs)
 
-    def post(self, request: Request, organization_id: int):
+    def post(self, request: Request, organization_id: int) -> Response:
         try:
             payload = orjson.loads(request.body)
         except orjson.JSONDecodeError:

--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+import orjson
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+from django.utils.crypto import constant_time_compare
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.request import Request
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.integrations.services.integration import integration_service
+from sentry.net.http import connection_from_url
+from sentry.seer.autofix.utils import (
+    CodingAgentResult,
+    CodingAgentStateUpdate,
+    CodingAgentStateUpdateRequest,
+    CodingAgentStatus,
+)
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class CursorWebhookEndpoint(Endpoint):
+    owner = ApiOwner.ML_AI
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+    authentication_classes = ()
+    permission_classes = ()
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        if request.method != "POST":
+            return HttpResponse(status=405)
+        return super().dispatch(request, *args, **kwargs)
+
+    def post(self, request: Request, organization_id: int) -> HttpResponse:
+        try:
+            payload = orjson.loads(request.body)
+        except orjson.JSONDecodeError:
+            logger.warning("cursor_webhook.invalid_json")
+            return HttpResponse(status=400)
+
+        event_type = payload.get("event", payload.get("event_type", "unknown"))
+
+        if not self._validate_signature(request, request.body, organization_id):
+            logger.warning("cursor_webhook.invalid_signature")
+            return HttpResponse(status=401)
+
+        self._process_webhook(payload)
+        logger.info("cursor_webhook.success", extra={"event_type": event_type})
+        return HttpResponse(status=204)
+
+    def _get_cursor_integration_secret(self, organization_id: int) -> str | None:
+        """Get webhook secret from Cursor integration."""
+        integrations = integration_service.get_integrations(
+            organization_id=organization_id, providers=["cursor"]
+        )
+
+        for integration in integrations:
+            if integration.provider == "cursor":
+                if "webhook_secret" in integration.metadata:
+                    return integration.metadata["webhook_secret"]
+                else:
+                    logger.error(
+                        "cursor_webhook.no_webhook_secret", extra={"integration": integration}
+                    )
+
+        return None
+
+    def _validate_signature(self, request: Request, raw_body: bytes, organization_id: int) -> bool:
+        """Validate webhook signature."""
+        signature = request.headers.get("X-Webhook-Signature")
+
+        # Get webhook secret from integration
+        secret = self._get_cursor_integration_secret(organization_id)
+
+        if not signature:
+            logger.warning("cursor_webhook.no_signature_provided")
+            raise PermissionDenied("No signature provided")
+
+        if not secret:
+            logger.warning("cursor_webhook.no_webhook_secret_set")
+            raise PermissionDenied("No webhook secret set")
+
+        # Remove "sha256=" prefix if present
+        if signature.startswith("sha256="):
+            signature = signature[7:]
+
+        expected_signature = hmac.new(secret.encode("utf-8"), raw_body, hashlib.sha256).hexdigest()
+
+        is_valid = constant_time_compare(expected_signature, signature)
+        if not is_valid:
+            logger.warning("cursor_webhook.signature_mismatch")
+
+        return is_valid
+
+    def _process_webhook(self, payload: dict[str, Any]) -> None:
+        """Process webhook payload based on event type."""
+        event_type = payload.get("event", "unknown")
+
+        handlers = {
+            "unknown": self._handle_unknown_event,
+            "statusChange": self._handle_status_change,
+        }
+
+        handler = handlers.get(event_type, self._handle_unknown_event)
+        handler(payload)
+
+    def _handle_unknown_event(self, payload: dict[str, Any]) -> None:
+        """Handle unknown event types."""
+        logger.error("cursor_webhook.unknown_event", extra=payload)
+
+    def _handle_status_change(self, payload: dict[str, Any]) -> None:
+        """Handle status change events."""
+        agent_id = payload.get("id")
+        cursor_status = payload.get("status")
+        source = payload.get("source", {})
+        target = payload.get("target", {})
+        pr_url = target.get("prUrl")
+        agent_url = target.get("url")
+        summary = payload.get("summary")
+
+        if not agent_id or not cursor_status:
+            logger.error(
+                "cursor_webhook.status_change_missing_data",
+                extra={"agent_id": agent_id, "status": cursor_status},
+            )
+            return
+
+        status_mapping = {
+            "FINISHED": CodingAgentStatus.COMPLETED,
+            "ERROR": CodingAgentStatus.FAILED,
+        }
+
+        sentry_status = status_mapping.get(cursor_status.upper())
+        if not sentry_status:
+            logger.error(
+                "cursor_webhook.unknown_status",
+                extra={"cursor_status": cursor_status, "agent_id": agent_id},
+            )
+            sentry_status = CodingAgentStatus.FAILED
+
+        logger.info(
+            "cursor_webhook.status_change",
+            extra={
+                "agent_id": agent_id,
+                "cursor_status": cursor_status,
+                "sentry_status": sentry_status.value,
+                "pr_url": pr_url,
+                "summary": summary,
+            },
+        )
+
+        repo_url = source.get("repository", None)
+        if not repo_url:
+            logger.error(
+                "cursor_webhook.repo_not_found",
+                extra={"agent_id": agent_id, "source": source},
+            )
+            return
+
+        # Ensure the repo URL has a protocol for proper parsing
+        if not repo_url.startswith(("http://", "https://")):
+            repo_url = f"https://{repo_url}"
+
+        parsed = urlparse(repo_url)
+        if parsed.netloc != "github.com":
+            logger.error(
+                "cursor_webhook.not_github_repo",
+                extra={"agent_id": agent_id, "repo": repo_url},
+            )
+            return
+
+        repo_provider = "github"
+        repo_full_name = parsed.path.lstrip("/")
+
+        # If the repo isn't in the owner/repo format we can't work with it
+        if not re.match(r"^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$", repo_full_name):
+            logger.error(
+                "cursor_webhook.repo_format_invalid",
+                extra={"agent_id": agent_id, "source": source},
+            )
+            return
+
+        result = CodingAgentResult(
+            repo_full_name=repo_full_name,
+            repo_provider=repo_provider,
+            description=summary or f"Agent {sentry_status.lower()}",
+            pr_url=pr_url if sentry_status == CodingAgentStatus.COMPLETED else None,
+        )
+
+        # Update the coding agent status via Seer API
+        self._update_coding_agent_status(
+            agent_id=agent_id,
+            status=sentry_status,
+            pr_url=pr_url,
+            agent_url=agent_url,
+            result=result,
+        )
+
+    def _update_coding_agent_status(
+        self,
+        agent_id: str,
+        status: CodingAgentStatus,
+        pr_url: str | None = None,
+        agent_url: str | None = None,
+        result: CodingAgentResult | None = None,
+    ):
+        """Update coding agent status via Seer API using the existing state endpoint."""
+        path = "/v1/automation/autofix/coding-agent/state/update"
+
+        updates = CodingAgentStateUpdate(
+            status=status,
+            agent_url=agent_url,
+            results=[result.dict()],
+        )
+
+        update_data = CodingAgentStateUpdateRequest(
+            agent_id=agent_id,
+            updates=updates,
+        )
+
+        body = orjson.dumps(update_data.dict())
+
+        connection_pool = connection_from_url(settings.SEER_AUTOFIX_URL)
+        response = make_signed_seer_api_request(
+            connection_pool,
+            path,
+            body=body,
+            timeout=30,
+        )
+
+        if response.status >= 400:
+            logger.error(
+                "cursor_webhook.seer_update_error",
+                extra={
+                    "agent_id": agent_id,
+                    "status": status.value,
+                    "error": str(response.data.decode("utf-8")),
+                    "status_code": response.status,
+                },
+            )
+        else:
+            logger.info(
+                "cursor_webhook.status_updated_to_seer",
+                extra={
+                    "agent_id": agent_id,
+                    "status": status.value,
+                    "pr_url": pr_url,
+                    "has_result": result is not None,
+                    "status_code": response.status,
+                },
+            )

--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -49,7 +49,7 @@ class CursorWebhookEndpoint(Endpoint):
 
     def post(self, request: Request, organization_id: int) -> Response:
         organization = Organization.objects.get(id=organization_id)
-        if not features.has("organizations:coding-agent", organization):
+        if not features.has("organizations:seer-coding-agent-integrations", organization):
             raise NotFound("Coding agent feature not enabled for this organization")
 
         try:

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -51,6 +51,15 @@ class CodingAgentStatus(StrEnum):
     COMPLETED = "completed"
     FAILED = "failed"
 
+    @classmethod
+    def from_cursor_status(cls, cursor_status: str) -> "CodingAgentStatus | None":
+        status_mapping = {
+            "FINISHED": cls.COMPLETED,
+            "ERROR": cls.FAILED,
+        }
+
+        return status_mapping.get(cursor_status.upper(), None)
+
 
 class AutofixTriggerSource(StrEnum):
     ROOT_CAUSE = "root_cause"

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1321,6 +1321,10 @@ urlpatterns += [
                     r"^discord/",
                     include("sentry.integrations.discord.urls"),
                 ),
+                re_path(
+                    r"^cursor/",
+                    include("sentry.integrations.cursor.urls"),
+                ),
             ]
         ),
     ),

--- a/tests/sentry/integrations/cursor/test_webhook.py
+++ b/tests/sentry/integrations/cursor/test_webhook.py
@@ -1,0 +1,281 @@
+import hashlib
+import hmac
+from typing import Any
+from unittest.mock import patch
+
+import orjson
+import pytest
+from django.urls import reverse
+from rest_framework.exceptions import MethodNotAllowed
+
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import Feature
+
+
+class TestCursorWebhook(APITestCase):
+    endpoint = "sentry-extensions-cursor-webhook"
+
+    def setUp(self):
+        super().setUp()
+        # Create a Cursor integration linked to this organization
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor",
+            name="Cursor Agent",
+            external_id="cursor",
+            metadata={
+                "api_key": "test_api_key_123",
+                "domain_name": "cursor.sh",
+                "webhook_secret": "secret123",
+            },
+        )
+        self.installation = self.integration.get_installation(organization_id=self.organization.id)
+
+    def _url(self) -> str:
+        return reverse(
+            "sentry-extensions-cursor-webhook",
+            kwargs={"organization_id": self.organization.id},
+        )
+
+    def _signed_headers(self, body: bytes, secret: str | None = None) -> dict[str, str]:
+        used_secret = secret or self.integration.metadata["webhook_secret"]
+        signature = hmac.new(used_secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+        return {"HTTP_X_WEBHOOK_SIGNATURE": f"sha256={signature}"}
+
+    def _build_status_payload(
+        self,
+        *,
+        id: str = "agent-1",
+        status: str = "FINISHED",
+        repo: str = "github.com/testorg/testrepo",
+        ref: str | None = "main",
+        pr_url: str | None = "https://github.com/testorg/testrepo/pull/1",
+        agent_url: str | None = "https://cursor.sh/agents/1",
+        summary: str | None = "All done",
+    ) -> dict[str, Any]:
+        return {
+            "event": "statusChange",
+            "id": id,
+            "status": status,
+            "source": {"repository": repo, "ref": ref},
+            "target": {"prUrl": pr_url, "url": agent_url},
+            "summary": summary,
+        }
+
+    @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
+    def test_happy_path_finished(self, mock_update_state):
+        payload = self._build_status_payload(status="FINISHED")
+        body = orjson.dumps(payload)
+        headers = self._signed_headers(body)
+
+        with Feature({"organizations:ai-issues-autofix": True}):
+            response = self.client.post(
+                self._url(), data=body, content_type="application/json", **headers
+            )
+
+        assert response.status_code == 204
+        # Validate call to update_coding_agent_state
+        assert mock_update_state.call_count == 1
+        args, kwargs = mock_update_state.call_args
+        assert kwargs["agent_id"] == "agent-1"
+        assert kwargs["status"].name == "COMPLETED"
+        assert kwargs["agent_url"] == "https://cursor.sh/agents/1"
+        result = kwargs["result"]
+        assert result.repo_full_name == "testorg/testrepo"
+        assert result.repo_provider == "github"
+        assert result.pr_url == "https://github.com/testorg/testrepo/pull/1"
+
+    def test_invalid_method(self):
+        with pytest.raises(MethodNotAllowed):
+            self.client.get(self._url())
+
+    def test_invalid_json(self):
+        body = b"{bad json}"
+        headers = self._signed_headers(body)
+        response = self.client.post(
+            self._url(),
+            data=body,
+            content_type="application/json",
+            **headers,
+        )
+        assert response.status_code == 400
+
+    def test_missing_signature(self):
+        payload = self._build_status_payload()
+        body = orjson.dumps(payload)
+        response = self.client.post(self._url(), data=body, content_type="application/json")
+        assert response.status_code == 403
+
+    def test_invalid_signature(self):
+        payload = self._build_status_payload()
+        body = orjson.dumps(payload)
+        headers = {"HTTP_X_WEBHOOK_SIGNATURE": "sha256=deadbeef"}
+        response = self.client.post(
+            self._url(),
+            data=body,
+            content_type="application/json",
+            **headers,
+        )
+        assert response.status_code == 403
+
+    @patch(
+        "sentry.integrations.cursor.webhooks.handler.CursorWebhookEndpoint._get_cursor_integration_secret",
+        return_value=None,
+    )
+    def test_no_webhook_secret_set(self, _mock_secret):
+        payload = self._build_status_payload()
+        body = orjson.dumps(payload)
+        # Provide any signature header so we hit secret lookup path
+        headers = {"HTTP_X_WEBHOOK_SIGNATURE": "sha256=deadbeef"}
+        response = self.client.post(
+            self._url(),
+            data=body,
+            content_type="application/json",
+            **headers,
+        )
+        assert response.status_code == 403
+
+    @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
+    def test_error_status_maps_to_failed(self, mock_update_state):
+        payload = self._build_status_payload(status="ERROR", pr_url=None)
+        body = orjson.dumps(payload)
+        headers = self._signed_headers(body)
+
+        response = self.client.post(
+            self._url(),
+            data=body,
+            content_type="application/json",
+            **headers,
+        )
+        assert response.status_code == 204
+
+        args, kwargs = mock_update_state.call_args
+        assert kwargs["status"].name == "FAILED"
+        # pr_url should be None for failures
+        assert kwargs["result"].pr_url is None
+
+    @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
+    def test_unknown_status_logs_and_defaults_to_failed(self, mock_update_state):
+        payload = self._build_status_payload(status="WEIRD")
+        body = orjson.dumps(payload)
+        headers = self._signed_headers(body)
+
+        response = self.client.post(
+            self._url(),
+            data=body,
+            content_type="application/json",
+            **headers,
+        )
+        assert response.status_code == 204
+        args, kwargs = mock_update_state.call_args
+        assert kwargs["status"].name == "FAILED"
+
+    def test_missing_agent_id_or_status(self):
+        # Missing id
+        body = orjson.dumps(self._build_status_payload(id=None))
+        headers = self._signed_headers(body)
+        resp = self.client.post(
+            self._url(),
+            data=body,
+            content_type="application/json",
+            **headers,
+        )
+        assert resp.status_code == 204
+        # Missing status
+        payload = self._build_status_payload()
+        payload.pop("status")
+        body = orjson.dumps(payload)
+        headers = self._signed_headers(body)
+        resp = self.client.post(
+            self._url(),
+            data=body,
+            content_type="application/json",
+            **headers,
+        )
+        assert resp.status_code == 204
+
+    @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
+    def test_repo_variants_and_validation(self, mock_update_state):
+        # Missing repo
+        payload = self._build_status_payload()
+        payload["source"].pop("repository")
+        body = orjson.dumps(payload)
+        headers = self._signed_headers(body)
+        resp = self.client.post(
+            self._url(),
+            data=body,
+            content_type="application/json",
+            **headers,
+        )
+        assert resp.status_code == 204
+        mock_update_state.assert_not_called()
+
+        # Non-github host
+        payload = self._build_status_payload(repo="https://gitlab.com/testorg/testrepo")
+        body = orjson.dumps(payload)
+        headers = self._signed_headers(body)
+        resp = self.client.post(
+            self._url(),
+            data=body,
+            content_type="application/json",
+            **headers,
+        )
+        assert resp.status_code == 204
+        mock_update_state.assert_not_called()
+
+        # Bad format path
+        payload = self._build_status_payload(repo="github.com/not-a-valid-path")
+        body = orjson.dumps(payload)
+        headers = self._signed_headers(body)
+        resp = self.client.post(
+            self._url(),
+            data=body,
+            content_type="application/json",
+            **headers,
+        )
+        assert resp.status_code == 204
+        mock_update_state.assert_not_called()
+
+        # No scheme but valid host should work
+        payload = self._build_status_payload(repo="github.com/testorg/testrepo")
+        body = orjson.dumps(payload)
+        headers = self._signed_headers(body)
+        resp = self.client.post(
+            self._url(),
+            data=body,
+            content_type="application/json",
+            **headers,
+        )
+        assert resp.status_code == 204
+        assert mock_update_state.call_count >= 0
+
+    @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
+    def test_signature_without_prefix(self, mock_update_state):
+        payload = self._build_status_payload(status="FINISHED")
+        body = orjson.dumps(payload)
+        secret = self.integration.metadata["webhook_secret"]
+        signature = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+        headers = {"HTTP_X_WEBHOOK_SIGNATURE": signature}
+
+        response = self.client.post(
+            self._url(),
+            data=body,
+            content_type="application/json",
+            **headers,
+        )
+        assert response.status_code == 204
+
+    @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
+    def test_seer_api_error_is_caught(self, mock_update_state):
+        from sentry.seer.models import SeerApiError
+
+        mock_update_state.side_effect = SeerApiError("boom", status=500)
+        payload = self._build_status_payload(status="FINISHED")
+        body = orjson.dumps(payload)
+        headers = self._signed_headers(body)
+
+        response = self.client.post(
+            self._url(), data=body, content_type="application/json", **headers
+        )
+        assert response.status_code == 204
+        # Even with exception, endpoint must not raise

--- a/tests/sentry/integrations/cursor/test_webhook.py
+++ b/tests/sentry/integrations/cursor/test_webhook.py
@@ -197,6 +197,15 @@ class TestCursorWebhook(APITestCase):
         assert resp.status_code == 204
         assert mock_update_state.call_count == 1
 
+        # Dotted repo name should be accepted
+        mock_update_state.reset_mock()
+        payload = self._build_status_payload(repo="github.com/testorg/test.repo")
+        body = orjson.dumps(payload)
+        headers = self._signed_headers(body)
+        resp = self._post_with_headers(body, headers)
+        assert resp.status_code == 204
+        assert mock_update_state.call_count == 1
+
     @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
     def test_signature_without_prefix(self, mock_update_state):
         payload = self._build_status_payload(status="FINISHED")

--- a/tests/sentry/integrations/cursor/test_webhook.py
+++ b/tests/sentry/integrations/cursor/test_webhook.py
@@ -195,7 +195,7 @@ class TestCursorWebhook(APITestCase):
         headers = self._signed_headers(body)
         resp = self._post_with_headers(body, headers)
         assert resp.status_code == 204
-        assert mock_update_state.call_count >= 0
+        assert mock_update_state.call_count == 1
 
     @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
     def test_signature_without_prefix(self, mock_update_state):

--- a/tests/sentry/middleware/integrations/test_parsers_defined.py
+++ b/tests/sentry/middleware/integrations/test_parsers_defined.py
@@ -28,8 +28,8 @@ def test_parsers_for_all_extension_urls() -> None:
     for pattern in url_patterns:
         [_, provider, _trailing] = pattern.split("/", maxsplit=2)
 
-        # Ignore dynamic segments
-        if provider[0] in {"(", "["} or provider == "external-install":
+        # Ignore dynamic segments or providers without middleware parsers
+        if provider[0] in {"(", "["} or provider in {"external-install", "cursor"}:
             continue
 
         # Ensure the expected module exists


### PR DESCRIPTION
Follow-up to PR #99077 in the stack.

Handles webhooks and verifying webhooks signatures from the cursor agent.

Registers the URL pattern and updates it in the integration because we need the organization id to get the webhook secret.

Stores the updated coding agent state in seer