### PR TITLE
ref(releases): validate statsPeriod before passing to endpoint

### DIFF
--- a/static/app/components/organizations/pageFilters/parse.tsx
+++ b/static/app/components/organizations/pageFilters/parse.tsx
@@ -18,7 +18,15 @@ type ParamValue = string[] | SingleParamValue;
 const STATS_PERIOD_PATTERN = '^(\\d+)([hdmsw])?(-\\w+)?$';
 
 /**
- * Parses a stats period into `period` and `periodLength`
+ * Parses a stats period string into its numeric value and time unit.
+ *
+ * @param input - A stats period string (e.g., "1h", "30m", "7d", "2w") or IntervalPeriod object
+ * @returns An object with `period` (numeric string) and `periodLength` (time unit), or undefined if invalid
+ *
+ * @example
+ * parseStatsPeriod("1h") // returns { period: "1", periodLength: "h" }
+ * parseStatsPeriod("30m") // returns { period: "30", periodLength: "m" }
+ * parseStatsPeriod("invalid") // returns undefined
  */
 export function parseStatsPeriod(input: string | IntervalPeriod) {
   const result = input.match(STATS_PERIOD_PATTERN);

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -25,6 +25,7 @@ import {ReleaseStatus} from 'sentry/types/release';
 import {DemoTourElement, DemoTourStep} from 'sentry/utils/demoMode/demoTours';
 import {SEMVER_TAGS} from 'sentry/utils/discover/fields';
 import {useApiQuery, type ApiQueryKey} from 'sentry/utils/queryClient';
+import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -40,6 +41,7 @@ import {isMobileRelease} from 'sentry/views/releases/utils';
 import ReleasesDisplayOptions, {ReleasesDisplayOption} from './releasesDisplayOptions';
 import ReleasesSortOptions from './releasesSortOptions';
 import ReleasesStatusOptions, {ReleasesStatusOption} from './releasesStatusOptions';
+import {validateSummaryStatsPeriod} from './utils';
 
 const RELEASE_FILTER_KEYS = [
   ...Object.values(SEMVER_TAGS),
@@ -69,7 +71,9 @@ function makeReleaseListQueryKey({
     cursor: location.query.cursor,
     query: location.query.query,
     sort: location.query.sort,
-    summaryStatsPeriod: location.query.statsPeriod,
+    summaryStatsPeriod: validateSummaryStatsPeriod(
+      decodeScalar(location.query.statsPeriod)
+    ),
     per_page: 20,
     flatten: activeSort === ReleasesSortOption.DATE ? 0 : 1,
     adoptionStages: 1,

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -350,7 +350,7 @@ export default function ReleasesList() {
               <DatePageFilter
                 disallowArbitraryRelativeRanges
                 menuFooterMessage={t(
-                  'Changing this date range will recalculate the release metrics. Since only specific date ranges are allowed, we recommend selecting from one of the predefined options above.'
+                  'Changing this date range will recalculate the release metrics. Select a supported date range from the options above.'
                 )}
               />
             </ReleasesPageFilterBar>

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -94,6 +94,26 @@ export default function ReleasesList() {
   const location = useLocation();
   const navigate = useNavigate();
 
+  // date filter should reflect updated statsPeriod value
+  useEffect(() => {
+    const currentStatsPeriod = decodeScalar(location.query.statsPeriod);
+    const validatedStatsPeriod = validateSummaryStatsPeriod(currentStatsPeriod);
+
+    // if the validated value is different from the current value, update the URL
+    if (currentStatsPeriod && currentStatsPeriod !== validatedStatsPeriod) {
+      navigate(
+        {
+          pathname: location.pathname,
+          query: {
+            ...location.query,
+            statsPeriod: validatedStatsPeriod,
+          },
+        },
+        {replace: true}
+      );
+    }
+  }, [navigate, location.pathname, location.query]);
+
   const activeQuery = useMemo(() => {
     const {query: locationQuery} = location.query;
     return typeof locationQuery === 'string' ? locationQuery : '';
@@ -330,7 +350,7 @@ export default function ReleasesList() {
               <DatePageFilter
                 disallowArbitraryRelativeRanges
                 menuFooterMessage={t(
-                  'Changing this date range will recalculate the release metrics.'
+                  'Changing this date range will recalculate the release metrics. Since only specific date ranges are allowed, we recommend selecting from one of the predefined options above.'
                 )}
               />
             </ReleasesPageFilterBar>

--- a/static/app/views/releases/list/utils.tsx
+++ b/static/app/views/releases/list/utils.tsx
@@ -28,11 +28,11 @@ export function parseStatsPeriodToSeconds(statsPeriod: string): number | null {
     case 'm':
       return value * 60;
     case 'h':
-      return value * 3600;
+      return value * 60 * 60;
     case 'd':
-      return value * 86400;
+      return value * 24 * 60 * 60;
     case 'w':
-      return value * 604800; // 7 days
+      return value * 7 * 24 * 60 * 60;
     default:
       return null;
   }

--- a/static/app/views/releases/list/utils.tsx
+++ b/static/app/views/releases/list/utils.tsx
@@ -65,7 +65,7 @@ export function validateSummaryStatsPeriod(statsPeriod: string | undefined): str
 
   const inputSeconds = parseStatsPeriodToSeconds(statsPeriod);
   if (inputSeconds === null) {
-    // If we can't parse the input, return 7d
+    // if we can't parse the input, return 7d
     return '7d';
   }
 

--- a/static/app/views/releases/list/utils.tsx
+++ b/static/app/views/releases/list/utils.tsx
@@ -1,0 +1,79 @@
+import {parseStatsPeriod} from 'sentry/components/organizations/pageFilters/parse';
+
+// matches src/sentry/snuba/sessions.py
+const STATS_PERIODS: Record<string, number> = {
+  '1h': 3600,
+  '24h': 86400,
+  '1d': 86400,
+  '48h': 172800,
+  '2d': 172800,
+  '7d': 604800,
+  '14d': 1209600,
+  '30d': 2592000,
+  '90d': 7776000,
+};
+
+export function parseStatsPeriodToSeconds(statsPeriod: string): number | null {
+  const parsed = parseStatsPeriod(statsPeriod);
+  if (!parsed) {
+    return null;
+  }
+
+  const {period, periodLength} = parsed;
+  const value = parseInt(period!, 10);
+
+  switch (periodLength) {
+    case 's':
+      return value;
+    case 'm':
+      return value * 60;
+    case 'h':
+      return value * 3600;
+    case 'd':
+      return value * 86400;
+    case 'w':
+      return value * 604800; // 7 days
+    default:
+      return null;
+  }
+}
+
+/**
+ * Validates a release summaryStatsPeriod string against the allowed values and returns the closest match.
+ * The valid values are based on src/sentry/snuba/sessions.py. Invalid or undefined statsPeriods are defaulted to "7d".
+ *
+ * @param statsPeriod - A stats period string (e.g., "1h", "30m", "7d", "2w") to validate, or undefined
+ * @returns A valid stats period string from STATS_PERIODS
+ *
+ * @example
+ * validateSummaryStatsPeriod("1h") // returns "1h" (exact match)
+ * validateSummaryStatsPeriod("45m") // returns "1h"
+ * validateSummaryStatsPeriod("3d") // returns "2d"
+ * validateSummaryStatsPeriod("invalid") // returns "7d"
+ * validateSummaryStatsPeriod(undefined) // returns "7d"
+ */
+export function validateSummaryStatsPeriod(statsPeriod: string | undefined): string {
+  const validStatsPeriods = Object.keys(STATS_PERIODS);
+
+  if (!statsPeriod) {
+    return '7d';
+  }
+
+  if (validStatsPeriods.includes(statsPeriod)) {
+    return statsPeriod;
+  }
+
+  const inputSeconds = parseStatsPeriodToSeconds(statsPeriod);
+  if (inputSeconds === null) {
+    // If we can't parse the input, return 7d
+    return '7d';
+  }
+
+  const closestPeriod = validStatsPeriods.reduce((closest, current) => {
+    const currentDiff = Math.abs((STATS_PERIODS[current] ?? 0) - inputSeconds);
+    const closestDiff = Math.abs((STATS_PERIODS[closest] ?? 0) - inputSeconds);
+    return currentDiff < closestDiff ? current : closest;
+  });
+
+  return closestPeriod;
+}

--- a/static/app/views/releases/list/utils.tsx
+++ b/static/app/views/releases/list/utils.tsx
@@ -1,6 +1,6 @@
 import {parseStatsPeriod} from 'sentry/components/organizations/pageFilters/parse';
 
-// matches src/sentry/snuba/sessions.py
+// the keys should match STATS_PERIODS in src/sentry/snuba/sessions.py
 const STATS_PERIODS: Record<string, number> = {
   '1h': 3600,
   '24h': 86400,
@@ -13,7 +13,7 @@ const STATS_PERIODS: Record<string, number> = {
   '90d': 7776000,
 };
 
-export function parseStatsPeriodToSeconds(statsPeriod: string): number | null {
+function parseStatsPeriodToSeconds(statsPeriod: string): number | null {
   const parsed = parseStatsPeriod(statsPeriod);
   if (!parsed) {
     return null;


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-115/time-range-on-releases-doesnt-support-custom-ranges-on-sentryio

we can't support custom time ranges on the releases endpoint (we have specific summary periods defined in `src/sentry/snuba/sessions.py`:

https://github.com/getsentry/sentry/blob/089571495a1e96da57b0c4e567aa8aed6fcfc658/src/sentry/snuba/sessions.py#L13-L23

but we should validate the user requested stats period, before passing it to the endpoint, to avoid validation errors.

### before: 3m -> error

<img width="1354" height="243" alt="SCR-20250909-mtbj" src="https://github.com/user-attachments/assets/69c81bde-26da-453a-8416-aa2cd26608d8" />


these changes take the user requested stats period and returns the valid option closest to it.

### after: 3m -> 1h

https://github.com/user-attachments/assets/b326c0b4-4232-4d7a-a102-3a000827435a

also update the messaging on the filter to be clearer about the allowed values:
<img width="239" height="486" alt="SCR-20250909-noly" src="https://github.com/user-attachments/assets/b9690cb6-62ea-4c3e-91f7-550b84f5bacb" />

