### PR TITLE
feat(uptime): Support detector as quota seat objects

### DIFF
--- a/src/sentry/quotas/types.py
+++ b/src/sentry/quotas/types.py
@@ -2,5 +2,6 @@ from typing import TypeAlias, Union
 
 from sentry.monitors.models import Monitor
 from sentry.uptime.models import ProjectUptimeSubscription
+from sentry.workflow_engine.models import Detector
 
-SeatObject: TypeAlias = Union[Monitor, ProjectUptimeSubscription]
+SeatObject: TypeAlias = Union[Monitor, ProjectUptimeSubscription, Detector]


### PR DESCRIPTION
Part of [NEW-505: Uptime billing seats need to use detector IDs](https://linear.app/getsentry/issue/NEW-505/uptime-billing-seats-need-to-use-detector-ids)