### PR TITLE
chore(releases): Break foreign keys to `CommitFileChange` in queries

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -441,7 +441,7 @@ class PushEventWebhook(GitHubWebhook):
                         file_changes.append(
                             CommitFileChange(
                                 organization_id=organization.id,
-                                commit=c,
+                                commit_id=c.id,
                                 filename=fname,
                                 type="A",
                             )
@@ -452,7 +452,7 @@ class PushEventWebhook(GitHubWebhook):
                         file_changes.append(
                             CommitFileChange(
                                 organization_id=organization.id,
-                                commit=c,
+                                commit_id=c.id,
                                 filename=fname,
                                 type="D",
                             )
@@ -463,7 +463,7 @@ class PushEventWebhook(GitHubWebhook):
                         file_changes.append(
                             CommitFileChange(
                                 organization_id=organization.id,
-                                commit=c,
+                                commit_id=c.id,
                                 filename=fname,
                                 type="M",
                             )

--- a/src/sentry/models/commitfilechange.py
+++ b/src/sentry/models/commitfilechange.py
@@ -22,7 +22,9 @@ __all__ = ("CommitFileChange",)
 
 class CommitFileChangeManager(BaseManager["CommitFileChange"]):
     def get_count_for_commits(self, commits: Iterable[Any]) -> int:
-        return int(self.filter(commit__in=commits).values("filename").distinct().count())
+        return int(
+            self.filter(commit_id__in=[c.id for c in commits]).values("filename").distinct().count()
+        )
 
 
 @region_silo_model

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -149,7 +149,7 @@ def set_commit(idx, data, release):
         file_changes = [
             CommitFileChange(
                 organization_id=release.organization.id,
-                commit=commit,
+                commit_id=commit.id,
                 filename=patched_file["path"],
                 type=patched_file["type"],
             )

--- a/src/sentry/releases/models.py
+++ b/src/sentry/releases/models.py
@@ -87,7 +87,9 @@ class Commit(Model):
 
 class CommitFileChangeManager(BaseManager["CommitFileChange"]):
     def get_count_for_commits(self, commits: Iterable[Any]) -> int:
-        return int(self.filter(commit__in=commits).values("filename").distinct().count())
+        return int(
+            self.filter(commit_id__in=[c.id for c in commits]).values("filename").distinct().count()
+        )
 
 
 @region_silo_model

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -991,7 +991,7 @@ class Factories:
     @assume_test_silo_mode(SiloMode.REGION)
     def create_commit_file_change(commit, filename):
         return CommitFileChange.objects.get_or_create(
-            organization_id=commit.organization_id, commit=commit, filename=filename, type="M"
+            organization_id=commit.organization_id, commit_id=commit.id, filename=filename, type="M"
         )
 
     @staticmethod

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -96,31 +96,64 @@ def _get_commit_file_changes(
     # build a single query to get all of the commit file that might match the first n frames
     path_query = reduce(operator.or_, (Q(filename__iendswith=path) for path in filenames))
 
-    commit_file_change_matches = CommitFileChange.objects.filter(path_query, commit__in=commits)
+    commit_file_change_matches = CommitFileChange.objects.filter(
+        path_query, commit_id__in=[c.id for c in commits]
+    )
 
     return list(commit_file_change_matches)
 
 
-def _match_commits_path(
-    commit_file_changes: Sequence[CommitFileChange], path: str
-) -> Sequence[tuple[Commit, int]]:
-    # find commits that match the run time path the best.
-    matching_commits: MutableMapping[int, tuple[Commit, int]] = {}
-    best_score = 1
-    for file_change in commit_file_changes:
-        score = score_path_match_length(file_change.filename, path)
-        if score > best_score:
-            # reset matches for better match.
-            best_score = score
-            matching_commits = {}
-        if score == best_score:
-            # skip 1-score matches when file change is longer than 1 token
-            if score == 1 and len(list(tokenize_path(file_change.filename))) > 1:
-                continue
-            #  we want a list of unique commits that tie for longest match
-            matching_commits[file_change.commit.id] = (file_change.commit, score)
+def _match_commits_paths(
+    commit_file_changes: Sequence[CommitFileChange], path_set: set[str]
+) -> Mapping[str, Sequence[tuple[Commit, int]]]:
+    """
+    Match commits to multiple paths at once, batching the commit fetch.
+    Returns a mapping of path -> list of (commit, score) tuples.
+    """
+    path_matches: MutableMapping[str, MutableMapping[int, int]] = {}
 
-    return list(matching_commits.values())
+    for path in path_set:
+        matching_commit_ids: MutableMapping[int, int] = {}
+        best_score = 1
+
+        for file_change in commit_file_changes:
+            score = score_path_match_length(file_change.filename, path)
+            if score > best_score:
+                # reset matches for better match.
+                best_score = score
+                matching_commit_ids = {}
+            if score == best_score:
+                # skip 1-score matches when file change is longer than 1 token
+                if score == 1 and len(list(tokenize_path(file_change.filename))) > 1:
+                    continue
+                #  we want a list of unique commits that tie for longest match
+                matching_commit_ids[file_change.commit_id] = score
+
+        if matching_commit_ids:
+            path_matches[path] = matching_commit_ids
+
+    all_commit_ids: set[int] = set()
+    for commit_ids in path_matches.values():
+        all_commit_ids.update(commit_ids.keys())
+
+    commits_by_id: Mapping[int, Commit] = {}
+    if all_commit_ids:
+        commits_by_id = {
+            c.id: c for c in Commit.objects.filter(id__in=all_commit_ids).select_related("author")
+        }
+
+    result: MutableMapping[str, Sequence[tuple[Commit, int]]] = {}
+    for path in path_set:
+        if path in path_matches:
+            result[path] = [
+                (commits_by_id[commit_id], score)
+                for commit_id, score in path_matches[path].items()
+                if commit_id in commits_by_id
+            ]
+        else:
+            result[path] = []
+
+    return result
 
 
 class AuthorCommits(TypedDict):
@@ -337,9 +370,9 @@ def get_event_file_committers(
         _get_commit_file_changes(commits, path_set) if path_set else []
     )
 
-    commit_path_matches: Mapping[str, Sequence[tuple[Commit, int]]] = {
-        path: _match_commits_path(file_changes, path) for path in path_set
-    }
+    commit_path_matches: Mapping[str, Sequence[tuple[Commit, int]]] = (
+        _match_commits_paths(file_changes, path_set) if file_changes else {}
+    )
 
     annotated_frames: Sequence[AnnotatedFrame] = [
         {

--- a/src/sentry/utils/mockdata/core.py
+++ b/src/sentry/utils/mockdata/core.py
@@ -534,7 +534,7 @@ def populate_release(
 
             CommitFileChange.objects.get_or_create(
                 organization_id=project.organization_id,
-                commit=commit,
+                commit_id=commit.id,
                 filename=file[0],
                 type=file[1],
             )

--- a/src/sentry_plugins/github/webhooks/events/push.py
+++ b/src/sentry_plugins/github/webhooks/events/push.py
@@ -161,20 +161,29 @@ class PushEventWebhook(Webhook):
                     for fname in commit["added"]:
                         file_changes.append(
                             CommitFileChange(
-                                organization_id=organization_id, commit=c, filename=fname, type="A"
+                                organization_id=organization_id,
+                                commit_id=c.id,
+                                filename=fname,
+                                type="A",
                             )
                         )
 
                     for fname in commit["removed"]:
                         file_changes.append(
                             CommitFileChange(
-                                organization_id=organization_id, commit=c, filename=fname, type="D"
+                                organization_id=organization_id,
+                                commit_id=c.id,
+                                filename=fname,
+                                type="D",
                             )
                         )
                     for fname in commit["modified"]:
                         file_changes.append(
                             CommitFileChange(
-                                organization_id=organization_id, commit=c, filename=fname, type="M"
+                                organization_id=organization_id,
+                                commit_id=c.id,
+                                filename=fname,
+                                type="M",
                             )
                         )
 

--- a/tests/apidocs/endpoints/releases/test_organization_release_commit_files.py
+++ b/tests/apidocs/endpoints/releases/test_organization_release_commit_files.py
@@ -26,11 +26,14 @@ class CommitFileChangeDocsTest(APIDocsTestCase):
             organization_id=project.organization_id, release=release, commit=commit2, order=0
         )
         CommitFileChange.objects.create(
-            organization_id=project.organization_id, commit=commit, filename=".gitignore", type="M"
+            organization_id=project.organization_id,
+            commit_id=commit.id,
+            filename=".gitignore",
+            type="M",
         )
         CommitFileChange.objects.create(
             organization_id=project.organization_id,
-            commit=commit2,
+            commit_id=commit2.id,
             filename="/static/js/widget.js",
             type="A",
         )

--- a/tests/sentry/api/endpoints/test_commit_filechange.py
+++ b/tests/sentry/api/endpoints/test_commit_filechange.py
@@ -47,13 +47,13 @@ class CommitFileChangeTest(APITestCase):
         )
         CommitFileChange.objects.create(
             organization_id=self.project.organization_id,
-            commit=commit,
+            commit_id=commit.id,
             filename=".gitignore",
             type="M",
         )
         CommitFileChange.objects.create(
             organization_id=self.project.organization_id,
-            commit=commit2,
+            commit_id=commit2.id,
             filename="/static/js/widget.js",
             type="A",
         )

--- a/tests/sentry/api/serializers/test_commit_filechange.py
+++ b/tests/sentry/api/serializers/test_commit_filechange.py
@@ -39,7 +39,10 @@ class CommitFileChangeSerializerTest(TestCase):
             order=1,
         )
         cfc = CommitFileChange.objects.create(
-            organization_id=project.organization_id, commit=commit, filename=".gitignore", type="M"
+            organization_id=project.organization_id,
+            commit_id=commit.id,
+            filename=".gitignore",
+            type="M",
         )
         result = serialize(cfc, user)
 
@@ -71,7 +74,10 @@ class CommitFileChangeSerializerTest(TestCase):
             order=1,
         )
         cfc = CommitFileChange.objects.create(
-            organization_id=project.organization_id, commit=commit, filename=".gitignore", type="M"
+            organization_id=project.organization_id,
+            commit_id=commit.id,
+            filename=".gitignore",
+            type="M",
         )
 
         result = serialize(cfc, user)

--- a/tests/sentry/models/test_commitfilechange.py
+++ b/tests/sentry/models/test_commitfilechange.py
@@ -16,7 +16,7 @@ class CommitFileChangeTest(TestCase):
             message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
         )
         CommitFileChange.objects.create(
-            organization_id=organization_id, commit=commit, filename=".gitignore", type="M"
+            organization_id=organization_id, commit_id=commit.id, filename=".gitignore", type="M"
         )
 
         count = CommitFileChange.objects.get_count_for_commits([commit])

--- a/tests/sentry/releases/endpoints/test_organization_release_meta.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_meta.py
@@ -54,11 +54,14 @@ class ReleaseMetaTest(APITestCase):
             organization_id=project.organization_id, release=release, commit=commit2, order=0
         )
         CommitFileChange.objects.create(
-            organization_id=project.organization_id, commit=commit, filename=".gitignore", type="M"
+            organization_id=project.organization_id,
+            commit_id=commit.id,
+            filename=".gitignore",
+            type="M",
         )
         CommitFileChange.objects.create(
             organization_id=project.organization_id,
-            commit=commit2,
+            commit_id=commit2.id,
             filename="/static/js/widget.js",
             type="A",
         )

--- a/tests/sentry/releases/test_models.py
+++ b/tests/sentry/releases/test_models.py
@@ -109,7 +109,7 @@ class CommitFileChangeTest(TestCase):
             message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
         )
         CommitFileChange.objects.create(
-            organization_id=organization_id, commit=commit, filename=".gitignore", type="M"
+            organization_id=organization_id, commit_id=commit.id, filename=".gitignore", type="M"
         )
 
         count = CommitFileChange.objects.get_count_for_commits([commit])

--- a/tests/sentry/tasks/test_code_owners.py
+++ b/tests/sentry/tasks/test_code_owners.py
@@ -104,7 +104,7 @@ class CodeOwnersTest(TestCase):
             )
             CommitFileChange.objects.create(
                 organization_id=self.organization.id,
-                commit=commit,
+                commit_id=commit.id,
                 filename=".github/CODEOWNERS",
                 type="A",
             )
@@ -156,7 +156,7 @@ class CodeOwnersTest(TestCase):
             )
             CommitFileChange.objects.create(
                 organization_id=self.organization.id,
-                commit=commit,
+                commit_id=commit.id,
                 filename=".github/CODEOWNERS",
                 type="A",
             )
@@ -179,7 +179,7 @@ class CodeOwnersTest(TestCase):
             )
             CommitFileChange.objects.create(
                 organization_id=self.organization.id,
-                commit=commit,
+                commit_id=commit.id,
                 filename=".github/CODEOWNERS",
                 type="A",
             )
@@ -199,7 +199,7 @@ class CodeOwnersTest(TestCase):
             )
             CommitFileChange.objects.create(
                 organization_id=self.organization.id,
-                commit=commit,
+                commit_id=commit.id,
                 filename="CODEOWNERS",
                 type="M",
             )
@@ -219,7 +219,7 @@ class CodeOwnersTest(TestCase):
             )
             CommitFileChange.objects.create(
                 organization_id=self.organization.id,
-                commit=commit,
+                commit_id=commit.id,
                 filename=".github/CODEOWNERS",
                 type="D",
             )
@@ -239,7 +239,7 @@ class CodeOwnersTest(TestCase):
             )
             CommitFileChange.objects.create(
                 organization_id=self.organization.id,
-                commit=commit,
+                commit_id=commit.id,
                 filename="src/main.py",
                 type="A",
             )
@@ -259,13 +259,13 @@ class CodeOwnersTest(TestCase):
             )
             change1 = CommitFileChange(
                 organization_id=self.organization.id,
-                commit=commit,
+                commit_id=commit.id,
                 filename=".github/CODEOWNERS",
                 type="M",
             )
             change2 = CommitFileChange(
                 organization_id=self.organization.id,
-                commit=commit,
+                commit_id=commit.id,
                 filename="src/main.py",
                 type="A",
             )
@@ -286,13 +286,13 @@ class CodeOwnersTest(TestCase):
             )
             change1 = CommitFileChange(
                 organization_id=self.organization.id,
-                commit=commit,
+                commit_id=commit.id,
                 filename=".github/CODEOWNERS",
                 type="M",
             )
             change2 = CommitFileChange(
                 organization_id=self.organization.id,
-                commit=commit,
+                commit_id=commit.id,
                 filename="src/main.py",
                 type="A",
             )


### PR DESCRIPTION
We need to move this table over to another database since we're running out of disk space. This stops using joins to this table so that we can break the fk.
