### PR TITLE
feat(autofix): Trigger and see coding agents state

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -11,6 +11,10 @@ describe('AutofixRootCause', () => {
       method: 'POST',
       body: {success: true},
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/coding-agents/',
+      body: {integrations: []},
+    });
   });
 
   afterEach(() => {

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -303,16 +303,18 @@ function AutofixRootCauseDisplay({
     integration => integration.provider === 'cursor'
   );
 
-  const handleLaunchCursorAgent = () => {
+  const handleLaunchCodingAgent = () => {
     if (!cursorIntegration) {
       return;
     }
 
     launchCodingAgent({
       integrationId: cursorIntegration.id,
+      agentName: cursorIntegration.name,
+      triggerSource: 'root_cause',
     });
 
-    trackAnalytics('autofix.cursor_agent.launch_from_root_cause', {
+    trackAnalytics('autofix.coding_agent.launch_from_root_cause', {
       organization,
       group_id: groupId,
     });
@@ -327,6 +329,14 @@ function AutofixRootCauseDisplay({
     setIsProvidingSolution(false);
     setSolutionText('');
   };
+
+  // Shared UI state for "Find Solution" controls
+  const isRootCauseAlreadySelected = Boolean(
+    rootCauseSelection && 'cause_id' in rootCauseSelection
+  );
+  const findSolutionPriority: React.ComponentProps<typeof Button>['priority'] =
+    isRootCauseAlreadySelected ? 'default' : 'primary';
+  const findSolutionTitle = t('Let Seer plan a solution to this issue');
 
   const handleSubmitSolution = (e: React.FormEvent) => {
     e.preventDefault();
@@ -486,15 +496,11 @@ function AutofixRootCauseDisplay({
               <ButtonBar merged gap="0">
                 <Button
                   size="sm"
-                  priority={
-                    rootCauseSelection && 'cause_id' in rootCauseSelection
-                      ? 'default'
-                      : 'primary'
-                  }
+                  priority={findSolutionPriority}
                   busy={isSelectingRootCause}
                   disabled={isLoadingAgents}
                   onClick={handleSelectRootCause}
-                  title={t('Let Seer plan a solution to this issue')}
+                  title={findSolutionTitle}
                 >
                   {t('Find Solution')}
                 </Button>
@@ -503,7 +509,7 @@ function AutofixRootCauseDisplay({
                     {
                       key: 'cursor-agent',
                       label: t('Send to Cursor Background Agent'),
-                      onAction: handleLaunchCursorAgent,
+                      onAction: handleLaunchCodingAgent,
                       disabled: isLoadingAgents || isLaunchingAgent,
                     },
                   ]}
@@ -511,11 +517,7 @@ function AutofixRootCauseDisplay({
                     <DropdownTrigger
                       {...triggerProps}
                       size="sm"
-                      priority={
-                        rootCauseSelection && 'cause_id' in rootCauseSelection
-                          ? 'default'
-                          : 'primary'
-                      }
+                      priority={findSolutionPriority}
                       busy={isLaunchingAgent}
                       disabled={isLoadingAgents}
                       aria-label={t('More solution options')}
@@ -527,14 +529,10 @@ function AutofixRootCauseDisplay({
             ) : (
               <Button
                 size="sm"
-                priority={
-                  rootCauseSelection && 'cause_id' in rootCauseSelection
-                    ? 'default'
-                    : 'primary'
-                }
+                priority={findSolutionPriority}
                 busy={isSelectingRootCause}
                 onClick={handleSelectRootCause}
-                title={t('Let Seer plan a solution to this issue')}
+                title={findSolutionTitle}
               >
                 {t('Find Solution')}
               </Button>

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -7,18 +7,31 @@ import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {TextArea} from 'sentry/components/core/textarea';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
 import {
   type AutofixRootCauseData,
   type AutofixRootCauseSelection,
   type CommentThread,
 } from 'sentry/components/events/autofix/types';
-import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
+import {
+  makeAutofixQueryKey,
+  useCodingAgentIntegrations,
+  useLaunchCodingAgent,
+} from 'sentry/components/events/autofix/useAutofix';
 import {formatRootCauseWithEvent} from 'sentry/components/events/autofix/utils';
-import {IconArrow, IconChat, IconClose, IconCopy, IconFocus} from 'sentry/icons';
+import {
+  IconArrow,
+  IconChat,
+  IconChevron,
+  IconClose,
+  IconCopy,
+  IconFocus,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {singleLineRenderer} from 'sentry/utils/marked/marked';
 import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import testableTransition from 'sentry/utils/testableTransition';
@@ -246,6 +259,7 @@ function AutofixRootCauseDisplay({
   event,
 }: AutofixRootCauseProps) {
   const cause = causes[0];
+  const organization = useOrganization();
   const iconFocusRef = useRef<HTMLDivElement>(null);
   const descriptionRef = useRef<HTMLDivElement | null>(null);
   const [isProvidingSolution, setIsProvidingSolution] = useState(false);
@@ -254,6 +268,13 @@ function AutofixRootCauseDisplay({
     groupId,
     runId,
   });
+  const {data: codingAgentResponse, isLoading: isLoadingAgents} =
+    useCodingAgentIntegrations();
+  const codingAgentIntegrations = codingAgentResponse?.integrations ?? [];
+  const {mutate: launchCodingAgent, isPending: isLaunchingAgent} = useLaunchCodingAgent(
+    groupId,
+    runId
+  );
 
   const handleSelectDescription = () => {
     if (descriptionRef.current) {
@@ -275,6 +296,26 @@ function AutofixRootCauseDisplay({
     } else {
       addErrorMessage(t('No root cause available.'));
     }
+  };
+
+  // Find Cursor integration specifically
+  const cursorIntegration = codingAgentIntegrations.find(
+    integration => integration.provider === 'cursor'
+  );
+
+  const handleLaunchCursorAgent = () => {
+    if (!cursorIntegration) {
+      return;
+    }
+
+    launchCodingAgent({
+      integrationId: cursorIntegration.id,
+    });
+
+    trackAnalytics('autofix.cursor_agent.launch_from_root_cause', {
+      organization,
+      group_id: groupId,
+    });
   };
 
   const handleMySolution = () => {
@@ -441,19 +482,63 @@ function AutofixRootCauseDisplay({
             >
               {t('Give Solution')}
             </Button>
-            <Button
-              size="sm"
-              priority={
-                rootCauseSelection && 'cause_id' in rootCauseSelection
-                  ? 'default'
-                  : 'primary'
-              }
-              busy={isSelectingRootCause}
-              onClick={handleSelectRootCause}
-              title={t('Let Seer plan a solution to this issue')}
-            >
-              {t('Find Solution')}
-            </Button>
+            {cursorIntegration ? (
+              <ButtonBar merged gap="0">
+                <Button
+                  size="sm"
+                  priority={
+                    rootCauseSelection && 'cause_id' in rootCauseSelection
+                      ? 'default'
+                      : 'primary'
+                  }
+                  busy={isSelectingRootCause}
+                  disabled={isLoadingAgents}
+                  onClick={handleSelectRootCause}
+                  title={t('Let Seer plan a solution to this issue')}
+                >
+                  {t('Find Solution')}
+                </Button>
+                <DropdownMenu
+                  items={[
+                    {
+                      key: 'cursor-agent',
+                      label: t('Send to Cursor Background Agent'),
+                      onAction: handleLaunchCursorAgent,
+                      disabled: isLoadingAgents || isLaunchingAgent,
+                    },
+                  ]}
+                  trigger={(triggerProps: any, isOpen: boolean) => (
+                    <DropdownTrigger
+                      {...triggerProps}
+                      size="sm"
+                      priority={
+                        rootCauseSelection && 'cause_id' in rootCauseSelection
+                          ? 'default'
+                          : 'primary'
+                      }
+                      busy={isLaunchingAgent}
+                      disabled={isLoadingAgents}
+                      aria-label={t('More solution options')}
+                      icon={<IconChevron direction={isOpen ? 'up' : 'down'} size="xs" />}
+                    />
+                  )}
+                />
+              </ButtonBar>
+            ) : (
+              <Button
+                size="sm"
+                priority={
+                  rootCauseSelection && 'cause_id' in rootCauseSelection
+                    ? 'default'
+                    : 'primary'
+                }
+                busy={isSelectingRootCause}
+                onClick={handleSelectRootCause}
+                title={t('Let Seer plan a solution to this issue')}
+              >
+                {t('Find Solution')}
+              </Button>
+            )}
           </ButtonBar>
         )}
       </BottomButtonContainer>
@@ -570,4 +655,10 @@ const SolutionFormRow = styled('div')`
 const SolutionInput = styled(TextArea)`
   flex: 1;
   resize: none;
+`;
+
+const DropdownTrigger = styled(Button)`
+  box-shadow: none;
+  border-radius: 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0;
+  border-left: none;
 `;

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -507,7 +507,7 @@ function AutofixRootCauseDisplay({
                       disabled: isLoadingAgents || isLaunchingAgent,
                     },
                   ]}
-                  trigger={(triggerProps: any, isOpen: boolean) => (
+                  trigger={(triggerProps, isOpen) => (
                     <DropdownTrigger
                       {...triggerProps}
                       size="sm"

--- a/static/app/components/events/autofix/autofixSteps.spec.tsx
+++ b/static/app/components/events/autofix/autofixSteps.spec.tsx
@@ -10,6 +10,10 @@ import {AutofixStatus, AutofixStepType} from 'sentry/components/events/autofix/t
 describe('AutofixSteps', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/coding-agents/',
+      body: {integrations: []},
+    });
   });
 
   const defaultProps = {

--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -308,8 +308,8 @@ const ResultDescription = styled('div')<{status: CodingAgentStatus}>`
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
-  height: ${p => p.size};
-  width: ${p => p.size};
+  height: ${p => p.size}px;
+  width: ${p => p.size}px;
   margin: 0;
   margin-bottom: ${p => p.theme.space['2xs']};
 `;

--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -17,7 +17,6 @@ import {
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconCode, IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {singleLineRenderer} from 'sentry/utils/marked/marked';
 import testableTransition from 'sentry/utils/testableTransition';
 
@@ -98,8 +97,8 @@ function CodingAgentCard({codingAgentState, repo}: CodingAgentCardProps) {
                         <Button
                           size="sm"
                           icon={<IconOpen />}
-                          analyticsEventName="Autofix: Open Cursor Agent"
-                          analyticsEventKey="autofix.cursor_agent.open"
+                          analyticsEventName="Autofix: Open Coding Agent"
+                          analyticsEventKey="autofix.coding_agent.open"
                         >
                           {t('Open in Cursor')}
                         </Button>
@@ -112,8 +111,8 @@ function CodingAgentCard({codingAgentState, repo}: CodingAgentCardProps) {
                           <Button
                             size="sm"
                             icon={<IconOpen />}
-                            analyticsEventName="Autofix: Open Cursor Agent PR"
-                            analyticsEventKey="autofix.cursor_agent.open_pr"
+                            analyticsEventName="Autofix: Open Coding Agent PR"
+                            analyticsEventKey="autofix.coding_agent.open_pr"
                             priority="primary"
                           >
                             {t('View Pull Request')}
@@ -126,11 +125,9 @@ function CodingAgentCard({codingAgentState, repo}: CodingAgentCardProps) {
                 <Content>
                   <CardHeader>
                     <AgentTitle>{codingAgentState.name}</AgentTitle>
-                    <div>
-                      <Tag type={getTagType(codingAgentState.status)}>
-                        {getStatusText(codingAgentState.status)}
-                      </Tag>
-                    </div>
+                    <Tag type={getTagType(codingAgentState.status)}>
+                      {getStatusText(codingAgentState.status)}
+                    </Tag>
                   </CardHeader>
 
                   <CardContent>
@@ -230,7 +227,7 @@ const HeaderWrapper = styled('div')`
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-  gap: ${space(1)};
+  gap: ${p => p.theme.space.md};
   padding: ${p => p.theme.space.xl} 0 ${p => p.theme.space.md} 0;
 `;
 
@@ -304,7 +301,7 @@ const ResultItem = styled('div')`
 
 const ResultDescription = styled('div')<{status: CodingAgentStatus}>`
   color: ${p =>
-    p.status === CodingAgentStatus.FAILED ? p.theme.red300 : p.theme.textColor};
+    p.status === CodingAgentStatus.FAILED ? p.theme.errorText : p.theme.textColor};
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`

--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import {AnimatePresence, motion, type AnimationProps} from 'framer-motion';
+import {AnimatePresence, motion, type MotionNodeAnimationOptions} from 'framer-motion';
 
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
@@ -19,7 +19,7 @@ import {space} from 'sentry/styles/space';
 import {singleLineRenderer} from 'sentry/utils/marked/marked';
 import testableTransition from 'sentry/utils/testableTransition';
 
-const animationProps: AnimationProps = {
+const animationProps: MotionNodeAnimationOptions = {
   exit: {opacity: 0},
   initial: {opacity: 0},
   animate: {opacity: 1},

--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -1,0 +1,340 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import {AnimatePresence, motion, type AnimationProps} from 'framer-motion';
+
+import {Button} from 'sentry/components/core/button';
+import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import {ExternalLink} from 'sentry/components/core/link';
+import {DateTime} from 'sentry/components/dateTime';
+import {
+  CodingAgentProvider,
+  CodingAgentStatus,
+  type CodingAgentState,
+  type SeerRepoDefinition,
+} from 'sentry/components/events/autofix/types';
+import Spinner from 'sentry/components/forms/spinner';
+import {IconCode, IconOpen} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {singleLineRenderer} from 'sentry/utils/marked/marked';
+import testableTransition from 'sentry/utils/testableTransition';
+
+const animationProps: AnimationProps = {
+  exit: {opacity: 0},
+  initial: {opacity: 0},
+  animate: {opacity: 1},
+  transition: testableTransition({duration: 0.3}),
+};
+
+interface CodingAgentCardProps {
+  codingAgentState: CodingAgentState;
+  repo?: SeerRepoDefinition;
+}
+
+function CodingAgentCard({codingAgentState, repo}: CodingAgentCardProps) {
+  const getStatusColor = (status: CodingAgentStatus) => {
+    switch (status) {
+      case CodingAgentStatus.PENDING:
+      case CodingAgentStatus.RUNNING:
+        return 'yellow300';
+      case CodingAgentStatus.COMPLETED:
+        return 'green300';
+      case CodingAgentStatus.FAILED:
+        return 'red300';
+      default:
+        return 'gray300';
+    }
+  };
+
+  const getStatusText = (status: CodingAgentStatus) => {
+    switch (status) {
+      case CodingAgentStatus.PENDING:
+        return t('Pending...');
+      case CodingAgentStatus.RUNNING:
+        return t('Running');
+      case CodingAgentStatus.COMPLETED:
+        return t('Completed');
+      case CodingAgentStatus.FAILED:
+        return t('Failed');
+      default:
+        return status;
+    }
+  };
+
+  const shouldShowSpinner = (status: CodingAgentStatus) => {
+    return status === CodingAgentStatus.PENDING || status === CodingAgentStatus.RUNNING;
+  };
+
+  const getProviderName = (provider: CodingAgentProvider) => {
+    switch (provider) {
+      case CodingAgentProvider.CURSOR_BACKGROUND_AGENT:
+        return t('Cursor Background Agent');
+      default:
+        return t('Coding Agent');
+    }
+  };
+
+  return (
+    <React.Fragment>
+      <VerticalLine />
+      <StepCard>
+        <ContentWrapper>
+          <AnimatePresence>
+            <AnimationWrapper key="coding-agent" {...animationProps}>
+              <StyledCard>
+                <HeaderWrapper>
+                  <HeaderText>
+                    <IconCode size="sm" color="purple400" />
+                    {getProviderName(codingAgentState.provider)}
+                  </HeaderText>
+                  <ButtonBar>
+                    {codingAgentState.agent_url && (
+                      <ExternalLink href={codingAgentState.agent_url}>
+                        <Button
+                          size="sm"
+                          icon={<IconOpen />}
+                          analyticsEventName="Autofix: Open Cursor Agent"
+                          analyticsEventKey="autofix.cursor_agent.open"
+                        >
+                          {t('Open in Cursor')}
+                        </Button>
+                      </ExternalLink>
+                    )}
+                    {codingAgentState.results
+                      ?.filter(result => result.pr_url)
+                      .map(({pr_url}) => (
+                        <ExternalLink key={pr_url} href={pr_url ?? ''}>
+                          <Button
+                            size="sm"
+                            icon={<IconOpen />}
+                            analyticsEventName="Autofix: Open Cursor Agent PR"
+                            analyticsEventKey="autofix.cursor_agent.open_pr"
+                            priority="primary"
+                          >
+                            {t('View Pull Request')}
+                          </Button>
+                        </ExternalLink>
+                      ))}
+                  </ButtonBar>
+                </HeaderWrapper>
+
+                <Content>
+                  <CardHeader>
+                    <AgentTitle>{codingAgentState.name}</AgentTitle>
+                    <div>
+                      <StatusBadge
+                        status={codingAgentState.status}
+                        color={getStatusColor(codingAgentState.status)}
+                      >
+                        {shouldShowSpinner(codingAgentState.status) && (
+                          <SpinnerWrapper>
+                            <Spinner />
+                          </SpinnerWrapper>
+                        )}
+                        {getStatusText(codingAgentState.status)}
+                      </StatusBadge>
+                    </div>
+                  </CardHeader>
+
+                  <CardContent>
+                    {/* Show results for completed or failed agents */}
+                    {codingAgentState.results && codingAgentState.results.length > 0 && (
+                      <ResultsSection>
+                        {codingAgentState.status === CodingAgentStatus.FAILED && (
+                          <Label>{t('Error')}</Label>
+                        )}
+                        {codingAgentState.results.map((result, index) => (
+                          <ResultItem key={index}>
+                            <ResultDescription
+                              status={codingAgentState.status}
+                              dangerouslySetInnerHTML={{
+                                __html: singleLineRenderer(result.description),
+                              }}
+                            />
+                            {result.branch_name && (
+                              <DetailRow>
+                                <Label>{t('Branch')}:</Label>
+                                <Value>{result.branch_name}</Value>
+                              </DetailRow>
+                            )}
+                          </ResultItem>
+                        ))}
+                      </ResultsSection>
+                    )}
+
+                    {repo && (
+                      <DetailRow>
+                        <Label>{t('Repository')}:</Label>
+                        <Value>
+                          {repo.owner}/{repo.name}
+                        </Value>
+                      </DetailRow>
+                    )}
+
+                    <DetailRow>
+                      {t('Started')}
+                      <DateTime date={codingAgentState.started_at} />
+                    </DetailRow>
+                  </CardContent>
+                </Content>
+              </StyledCard>
+            </AnimationWrapper>
+          </AnimatePresence>
+        </ContentWrapper>
+      </StepCard>
+    </React.Fragment>
+  );
+}
+
+const VerticalLine = styled('div')`
+  width: 0;
+  height: ${p => p.theme.space['3xl']};
+  border-left: 2px solid ${p => p.theme.subText};
+  margin-left: 16px;
+  margin-bottom: -1px;
+`;
+
+const StepCard = styled('div')`
+  overflow: hidden;
+
+  :last-child {
+    margin-bottom: 0;
+  }
+`;
+
+const ContentWrapper = styled(motion.div)`
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows 300ms;
+  will-change: grid-template-rows;
+
+  > div {
+    /* So that focused element outlines don't get cut off */
+    padding: 0 1px;
+    overflow: hidden;
+  }
+`;
+
+const AnimationWrapper = styled(motion.div)``;
+
+const StyledCard = styled('div')`
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  overflow: hidden;
+  box-shadow: ${p => p.theme.dropShadowMedium};
+  padding-left: ${p => p.theme.space.xl};
+  padding-right: ${p => p.theme.space.xl};
+`;
+
+const HeaderWrapper = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: ${space(1)};
+  padding: ${p => p.theme.space.xl} 0 ${p => p.theme.space.md} 0;
+`;
+
+const HeaderText = styled('div')`
+  font-weight: bold;
+  font-size: ${p => p.theme.fontSize.lg};
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.md};
+`;
+
+const Content = styled('div')`
+  padding: ${p => p.theme.space.md} 0 ${p => p.theme.space.xl} 0;
+`;
+
+const CardHeader = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.xs};
+  margin-bottom: ${p => p.theme.space.md};
+`;
+
+const AgentTitle = styled('h4')`
+  margin: 0 0 ${p => p.theme.space.xs} 0;
+  font-size: ${p => p.theme.fontSize.md};
+  color: ${p => p.theme.textColor};
+`;
+
+const StatusBadge = styled('span')<{color: string; status: CodingAgentStatus}>`
+  display: inline-flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.md};
+  border-radius: ${p => p.theme.borderRadius};
+  font-size: ${p => p.theme.fontSize.sm};
+  font-weight: 600;
+  text-transform: uppercase;
+  background-color: ${p => (p.theme as any)[p.color] || p.theme.gray300};
+  color: ${p => p.theme.white};
+`;
+
+const SpinnerWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  width: 12px;
+  height: 12px;
+
+  > div {
+    width: 12px !important;
+    height: 12px !important;
+    border-width: 1.5px !important;
+    border-left-color: ${p => p.theme.white};
+    margin: 0 !important;
+  }
+`;
+
+const CardContent = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.sm};
+`;
+
+const DetailRow = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+  font-size: ${p => p.theme.fontSize.sm};
+  color: ${p => p.theme.subText};
+`;
+
+const Label = styled('span')`
+  font-weight: 600;
+  color: ${p => p.theme.subText};
+  min-width: 80px;
+`;
+
+const Value = styled('span')`
+  color: ${p => p.theme.textColor};
+  font-family: ${p => p.theme.text.familyMono};
+  font-size: ${p => p.theme.fontSize.sm};
+`;
+
+const ResultsSection = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.md};
+  margin-bottom: ${p => p.theme.space.md};
+`;
+
+const ResultItem = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.xs};
+  padding: ${p => p.theme.space.md} 0;
+  &:not(:last-child) {
+    border-bottom: 1px solid ${p => p.theme.innerBorder};
+  }
+`;
+
+const ResultDescription = styled('div')<{status: CodingAgentStatus}>`
+  color: ${p =>
+    p.status === CodingAgentStatus.FAILED ? p.theme.red300 : p.theme.textColor};
+  line-height: 1.4;
+`;
+
+export default CodingAgentCard;

--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -85,7 +85,11 @@ function CodingAgentCard({codingAgentState, repo}: CodingAgentCardProps) {
               <StyledCard>
                 <HeaderWrapper>
                   <HeaderText>
-                    <IconCode size="sm" color="purple400" />
+                    {shouldShowSpinner(codingAgentState.status) ? (
+                      <StyledLoadingIndicator size={16} />
+                    ) : (
+                      <IconCode size="md" color="purple400" />
+                    )}
                     {getProviderName(codingAgentState.provider)}
                   </HeaderText>
                   <ButtonBar>
@@ -124,9 +128,6 @@ function CodingAgentCard({codingAgentState, repo}: CodingAgentCardProps) {
                     <AgentTitle>{codingAgentState.name}</AgentTitle>
                     <div>
                       <Tag type={getTagType(codingAgentState.status)}>
-                        {shouldShowSpinner(codingAgentState.status) && (
-                          <LoadingIndicator size={12} />
-                        )}
                         {getStatusText(codingAgentState.status)}
                       </Tag>
                     </div>
@@ -304,4 +305,11 @@ const ResultItem = styled('div')`
 const ResultDescription = styled('div')<{status: CodingAgentStatus}>`
   color: ${p =>
     p.status === CodingAgentStatus.FAILED ? p.theme.red300 : p.theme.textColor};
+`;
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  height: ${p => p.size};
+  width: ${p => p.size};
+  margin: 0;
+  margin-bottom: ${p => p.theme.space['2xs']};
 `;

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -39,7 +39,7 @@ type AutofixOptions = {
   iterative_feedback?: boolean;
 };
 
-export interface CodingAgentResult {
+interface CodingAgentResult {
   branch_name: string | null;
   description: string;
   pr_url: string | null;

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -39,6 +39,35 @@ type AutofixOptions = {
   iterative_feedback?: boolean;
 };
 
+export interface CodingAgentResult {
+  branch_name: string | null;
+  description: string;
+  pr_url: string | null;
+  repo_full_name: string;
+  repo_provider: string;
+}
+
+export enum CodingAgentStatus {
+  PENDING = 'pending',
+  RUNNING = 'running',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+}
+
+export enum CodingAgentProvider {
+  CURSOR_BACKGROUND_AGENT = 'cursor_background_agent',
+}
+
+export interface CodingAgentState {
+  id: string;
+  name: string;
+  provider: CodingAgentProvider;
+  started_at: string;
+  status: CodingAgentStatus;
+  agent_url?: string;
+  results?: CodingAgentResult[];
+}
+
 type CodebaseState = {
   is_readable: boolean | null;
   is_writeable: boolean | null;
@@ -60,6 +89,7 @@ export type AutofixData = {
   codebase_indexing?: {
     status: 'COMPLETED';
   };
+  coding_agents?: Record<string, CodingAgentState>;
   completed_at?: string | null;
   error_message?: string;
   options?: AutofixOptions;

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -318,23 +318,30 @@ export function useCodingAgentIntegrations() {
   });
 }
 
+interface LaunchCodingAgentParams {
+  agentName: string;
+  integrationId: string;
+  triggerSource?: 'root_cause' | 'solution';
+}
+
 export function useLaunchCodingAgent(groupId: string, runId: string) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (params: {integrationId: string}) => {
+    mutationFn: (params: LaunchCodingAgentParams) => {
       return fetchMutation({
         url: `/organizations/${organization.slug}/integrations/coding-agents/`,
         method: 'POST',
         data: {
           integration_id: parseInt(params.integrationId, 10),
           run_id: parseInt(runId, 10),
+          trigger_source: params.triggerSource,
         },
       });
     },
-    onSuccess: () => {
-      addSuccessMessage('Cursor agent launched successfully');
+    onSuccess: (_, params) => {
+      addSuccessMessage(`${params.agentName} agent launched successfully`);
       queryClient.invalidateQueries({
         queryKey: makeAutofixQueryKey(organization.slug, groupId, false),
       });
@@ -342,8 +349,8 @@ export function useLaunchCodingAgent(groupId: string, runId: string) {
         queryKey: makeAutofixQueryKey(organization.slug, groupId, true),
       });
     },
-    onError: () => {
-      addErrorMessage('Failed to launch Cursor agent');
+    onError: (_, params) => {
+      addErrorMessage(`Failed to launch ${params.agentName} agent`);
     },
   });
 }

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -1,15 +1,19 @@
 import {useCallback, useMemo, useState} from 'react';
 
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {
   AutofixStatus,
   AutofixStepType,
+  CodingAgentStatus,
   type AutofixData,
   type GroupWithAutofix,
 } from 'sentry/components/events/autofix/types';
 import type {Event} from 'sentry/types/event';
 import {
+  fetchMutation,
   setApiQueryData,
   useApiQuery,
+  useMutation,
   useQueryClient,
   type ApiQueryKey,
   type UseApiQueryOptions,
@@ -127,6 +131,18 @@ const isPolling = (
 
   // Continue polling if there's an active comment thread, even if the run is completed
   if (!isSidebar && hasActiveCommentThread) {
+    return true;
+  }
+
+  // Poll while coding agent state is pending or running
+  if (
+    autofixData.coding_agents &&
+    Object.values(autofixData.coding_agents).some(
+      agent =>
+        agent.status === CodingAgentStatus.PENDING ||
+        agent.status === CodingAgentStatus.RUNNING
+    )
+  ) {
     return true;
   }
 
@@ -287,3 +303,47 @@ export const useAiAutofix = (
     reset,
   };
 };
+
+export function useCodingAgentIntegrations() {
+  const organization = useOrganization();
+
+  return useApiQuery<{
+    integrations: Array<{
+      id: string;
+      name: string;
+      provider: string;
+    }>;
+  }>([`/organizations/${organization.slug}/integrations/coding-agents/`], {
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useLaunchCodingAgent(groupId: string, runId: string) {
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: {integrationId: string}) => {
+      return fetchMutation({
+        url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+        method: 'POST',
+        data: {
+          integration_id: parseInt(params.integrationId, 10),
+          run_id: parseInt(runId, 10),
+        },
+      });
+    },
+    onSuccess: () => {
+      addSuccessMessage('Cursor agent launched successfully');
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(organization.slug, groupId, false),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(organization.slug, groupId, true),
+      });
+    },
+    onError: () => {
+      addErrorMessage('Failed to launch Cursor agent');
+    },
+  });
+}


### PR DESCRIPTION
If there are coding agent integrations installed, we show them in a dropdown on the root cause card to trigger them

<img width="837" height="473" alt="CleanShot 2025-09-09 at 15 48 15" src="https://github.com/user-attachments/assets/92ac1e65-bb40-40fd-8561-db4a778d5634" />

And each coding agent shows up as a state card at the very bottom.

<img width="1051" height="332" alt="CleanShot 2025-09-08 at 14 47 17" src="https://github.com/user-attachments/assets/d9110989-45a4-4439-8200-d0ace088ad1e" />
