### PR TITLE
ref(api): clean up `global-views` from issues count endpoint

### DIFF
--- a/src/sentry/issues/endpoints/organization_issues_count.py
+++ b/src/sentry/issues/endpoints/organization_issues_count.py
@@ -3,7 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import start_span
 
-from sentry import features, search
+from sentry import search
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -86,17 +86,6 @@ class OrganizationIssuesCountEndpoint(OrganizationEndpoint):
 
         if not projects:
             return Response([])
-
-        is_fetching_replay_data = request.headers.get("X-Sentry-Replay-Request") == "1"
-
-        if (
-            len(projects) > 1
-            and not features.has("organizations:global-views", organization, actor=request.user)
-            and not is_fetching_replay_data
-        ):
-            return Response(
-                {"detail": "You do not have the multi project stream feature enabled"}, status=400
-            )
 
         queries = request.GET.getlist("query")
         response = {}

--- a/src/sentry/replays/endpoints/organization_replay_events_meta.py
+++ b/src/sentry/replays/endpoints/organization_replay_events_meta.py
@@ -16,8 +16,10 @@ from sentry.models.organization import Organization
 
 @region_silo_endpoint
 class OrganizationReplayEventsMetaEndpoint(OrganizationEventsV2EndpointBase):
+    # TODO: now that global-views is enabled for all plans, we may be able to consolidate this with the generic OrganizationEventsV2Endpoint
     """The generic Events endpoints require that the `organizations:global-views` feature
     be enabled before they return across multiple projects.
+
 
     This endpoint is purpose built for the Session Replay product which intentionally
     requests data across multiple transactions, and therefore potentially multiple projects.


### PR DESCRIPTION
Removes `global-views` check in this endpoint. Keeping this small since this is the last backend endpoint apart from tests that checks this.

Refs https://linear.app/getsentry/issue/ID-927/deprecate-global-views-flag