### PR TITLE
feat(preprod): Update release meta endpoint to support preprod builds info

### DIFF
--- a/src/sentry/preprod/utils.py
+++ b/src/sentry/preprod/utils.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import re
+from typing import NamedTuple
+
+
+class ParsedReleaseVersion(NamedTuple):
+    """Parsed components of a release version string."""
+
+    app_id: str
+    build_version: str
+
+
+def parse_release_version(release_version: str) -> ParsedReleaseVersion | None:
+    """
+    Parse release version string into app_id and build_version components.
+
+    Expected formats:
+    1. "app_id@version+build_number" -> returns (app_id, version)
+    2. "app_id@version" -> returns (app_id, version)
+
+    Args:
+        release_version: The release version string to parse
+
+    Returns:
+        ParsedReleaseVersion with app_id and build_version, or None if parsing fails
+    """
+    # Parse app_id and version, ignoring build_number if present
+    version_match = re.match(r"^([^@]+)@([^+]+)(?:\+.*)?$", release_version)
+
+    if version_match:
+        app_id, build_version = version_match.groups()
+        return ParsedReleaseVersion(app_id=app_id, build_version=build_version)
+
+    return None


### PR DESCRIPTION
<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
