### PR TITLE
ref(feedback): fix feedback layout on mobile/small screens

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -37,12 +37,23 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
   const crashReportId = eventData?.contexts?.feedback?.associated_event_id;
 
   const overflowRef = useRef<HTMLDivElement>(null);
+  const messageSectionRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     setTimeout(() => {
-      overflowRef.current?.scrollTo({
-        top: 0,
-        behavior: 'smooth',
-      });
+      // On small screens, scroll to the message section
+      // On bigger screens, scroll the details panel content to top
+      if (window.innerWidth < 768) {
+        messageSectionRef.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      } else {
+        overflowRef.current?.scrollTo({
+          top: 0,
+          behavior: 'smooth',
+        });
+      }
     }, 100);
   }, [feedbackItem.id, overflowRef]);
 
@@ -56,10 +67,12 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
       <AnalyticsArea name="details">
         <FeedbackItemHeader eventData={eventData} feedbackItem={feedbackItem} />
         <OverflowPanelItem ref={overflowRef}>
-          <FeedbackItemSection sectionKey="message">
-            <MessageTitle eventData={eventData} feedbackItem={feedbackItem} />
-            <MessageSection eventData={eventData} feedbackItem={feedbackItem} />
-          </FeedbackItemSection>
+          <div ref={messageSectionRef}>
+            <FeedbackItemSection sectionKey="message">
+              <MessageTitle eventData={eventData} feedbackItem={feedbackItem} />
+              <MessageSection eventData={eventData} feedbackItem={feedbackItem} />
+            </FeedbackItemSection>
+          </div>
 
           <FeedbackUrl eventData={eventData} feedbackItem={feedbackItem} />
 

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -36,7 +36,6 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
   const organization = useOrganization();
   const crashReportId = eventData?.contexts?.feedback?.associated_event_id;
 
-  const overflowRef = useRef<HTMLDivElement>(null);
   const messageSectionRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -46,7 +45,7 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
         block: 'start',
       });
     }, 100);
-  }, [feedbackItem.id]);
+  }, [feedbackItem.id, messageSectionRef]);
 
   const tagsWithoutAi = useMemo(
     () => eventData?.tags.filter(tag => !tag.key.startsWith('ai_categorization.')) ?? [],
@@ -57,7 +56,7 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
     <Fragment>
       <AnalyticsArea name="details">
         <FeedbackItemHeader eventData={eventData} feedbackItem={feedbackItem} />
-        <OverflowPanelItem ref={overflowRef}>
+        <OverflowPanelItem>
           <div ref={messageSectionRef}>
             <FeedbackItemSection sectionKey="message">
               <MessageTitle eventData={eventData} feedbackItem={feedbackItem} />

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -1,5 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useRef} from 'react';
-import {useTheme} from '@emotion/react';
+import {Fragment, useEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import AnalyticsArea from 'sentry/components/analyticsArea';
@@ -26,7 +25,6 @@ import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
-import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
@@ -36,35 +34,19 @@ interface Props {
 
 export default function FeedbackItem({feedbackItem, eventData}: Props) {
   const organization = useOrganization();
-  const theme = useTheme();
   const crashReportId = eventData?.contexts?.feedback?.associated_event_id;
 
   const overflowRef = useRef<HTMLDivElement>(null);
   const messageSectionRef = useRef<HTMLDivElement>(null);
 
-  const isMobile = useMedia(`(max-width: ${theme.breakpoints.md})`);
-
-  const scrollToContent = useCallback(() => {
-    // On small screens, scroll to the message section
-    // On bigger screens, scroll the details panel content to top
-    if (isMobile) {
+  useEffect(() => {
+    setTimeout(() => {
       messageSectionRef.current?.scrollIntoView({
         behavior: 'smooth',
         block: 'start',
       });
-    } else {
-      overflowRef.current?.scrollTo({
-        top: 0,
-        behavior: 'smooth',
-      });
-    }
-  }, [isMobile]);
-
-  useEffect(() => {
-    setTimeout(() => {
-      scrollToContent();
     }, 100);
-  }, [feedbackItem.id, scrollToContent]);
+  }, [feedbackItem.id]);
 
   const tagsWithoutAi = useMemo(
     () => eventData?.tags.filter(tag => !tag.key.startsWith('ai_categorization.')) ?? [],

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -36,16 +36,15 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
   const organization = useOrganization();
   const crashReportId = eventData?.contexts?.feedback?.associated_event_id;
 
-  const messageSectionRef = useRef<HTMLDivElement>(null);
-
+  const overflowRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     setTimeout(() => {
-      messageSectionRef.current?.scrollIntoView({
+      overflowRef.current?.scrollTo({
+        top: 0,
         behavior: 'smooth',
-        block: 'start',
       });
     }, 100);
-  }, [feedbackItem.id, messageSectionRef]);
+  }, [feedbackItem.id, overflowRef]);
 
   const tagsWithoutAi = useMemo(
     () => eventData?.tags.filter(tag => !tag.key.startsWith('ai_categorization.')) ?? [],
@@ -56,13 +55,11 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
     <Fragment>
       <AnalyticsArea name="details">
         <FeedbackItemHeader eventData={eventData} feedbackItem={feedbackItem} />
-        <OverflowPanelItem>
-          <div ref={messageSectionRef}>
-            <FeedbackItemSection sectionKey="message">
-              <MessageTitle eventData={eventData} feedbackItem={feedbackItem} />
-              <MessageSection eventData={eventData} feedbackItem={feedbackItem} />
-            </FeedbackItemSection>
-          </div>
+        <OverflowPanelItem ref={overflowRef}>
+          <FeedbackItemSection sectionKey="message">
+            <MessageTitle eventData={eventData} feedbackItem={feedbackItem} />
+            <MessageSection eventData={eventData} feedbackItem={feedbackItem} />
+          </FeedbackItemSection>
 
           <FeedbackUrl eventData={eventData} feedbackItem={feedbackItem} />
 

--- a/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
+++ b/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
@@ -1,9 +1,9 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {AlertLink} from 'sentry/components/core/alert/alertLink';
 import {Button, type ButtonProps} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {Flex} from 'sentry/components/core/layout';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import DropdownButton from 'sentry/components/dropdownButton';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -89,7 +89,7 @@ export function StreamlinedExternalIssueList({
   }
 
   return (
-    <Fragment>
+    <Flex direction="row" gap="md">
       {linkedIssues.length > 0 && (
         <IssueActionWrapper>
           {linkedIssues.map(linkedIssue => (
@@ -200,11 +200,11 @@ export function StreamlinedExternalIssueList({
           })}
         </IssueActionWrapper>
       )}
-    </Fragment>
+    </Flex>
   );
 }
 
-const IssueActionWrapper = styled('div')`
+const IssueActionWrapper = styled('span')`
   display: flex;
   flex-wrap: wrap;
   gap: ${space(1)};

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -104,11 +104,14 @@ const SummaryListContainer = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(1)};
+  min-height: 0; /* Allow flex children to shrink */
+  overflow: hidden; /* Ensure proper scrolling behavior */
 `;
 
 const LayoutGrid = styled('div')`
   overflow: hidden;
   flex-grow: 1;
+  height: 100%;
 
   display: grid;
   gap: ${space(2)};
@@ -133,6 +136,7 @@ const LayoutGrid = styled('div')`
 
   @media (max-width: ${p => p.theme.breakpoints.md}) {
     grid-template-columns: 1fr;
+    grid-template-rows: max-content minmax(600px, 1fr) max-content;
     grid-template-areas:
       'top'
       'list'
@@ -155,6 +159,7 @@ const LayoutGrid = styled('div')`
 const Container = styled(FluidHeight)`
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
+  min-height: 0; /* Allow flex children to shrink below their content size */
 `;
 
 const SetupContainer = styled('div')`

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -22,7 +22,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
-import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 
 export default function FeedbackListPage() {
   const organization = useOrganization();
@@ -104,14 +103,11 @@ const SummaryListContainer = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(1)};
-  min-height: 0; /* Allow flex children to shrink */
-  overflow: hidden; /* Ensure proper scrolling behavior */
 `;
 
 const LayoutGrid = styled('div')`
   overflow: hidden;
   flex-grow: 1;
-  height: 100%;
 
   display: grid;
   gap: ${space(2)};
@@ -134,21 +130,13 @@ const LayoutGrid = styled('div')`
     'top top'
     'list details';
 
-  @media (max-width: ${p => p.theme.breakpoints.md}) {
+  @media (max-width: ${p => p.theme.breakpoints.lg}) {
     grid-template-columns: 1fr;
-    grid-template-rows: max-content minmax(600px, 1fr) max-content;
+    grid-template-rows: max-content minmax(50vh, 1fr) max-content;
     grid-template-areas:
       'top'
       'list'
       'details';
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
-    grid-template-columns: minmax(195px, 1fr) 1.5fr;
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    grid-template-columns: 390px 1fr;
   }
 
   @media (min-width: ${p => p.theme.breakpoints.lg}) {
@@ -156,10 +144,14 @@ const LayoutGrid = styled('div')`
   }
 `;
 
-const Container = styled(FluidHeight)`
+const Container = styled('div')`
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
-  min-height: 0; /* Allow flex children to shrink below their content size */
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 `;
 
 const SetupContainer = styled('div')`
@@ -172,6 +164,11 @@ const FiltersContainer = styled('div')`
   flex-grow: 1;
   gap: ${space(1)};
   align-items: flex-start;
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    flex-direction: column;
+    align-items: stretch;
+  }
 `;
 
 /**

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -113,13 +113,7 @@ const LayoutGrid = styled('div')`
   gap: ${space(2)};
   place-items: stretch;
 
-  @media (max-width: ${p => p.theme.breakpoints.md}) {
-    padding: ${space(2)};
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
-    padding: ${space(2)};
-  }
+  padding: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints.lg}) {
     padding: ${space(2)} ${space(4)};

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -144,10 +144,6 @@ const LayoutGrid = styled('div')`
   }
 
   @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    grid-template-columns: 390px 1fr;
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints.lg}) {
     grid-template-columns: minmax(390px, 1fr) 2fr;
   }
 `;

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -103,6 +103,8 @@ const SummaryListContainer = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(1)};
+  min-width: 0; /* Allow content to shrink */
+  overflow: hidden; /* Prevent overflow */
 `;
 
 const LayoutGrid = styled('div')`
@@ -130,13 +132,20 @@ const LayoutGrid = styled('div')`
     'top top'
     'list details';
 
-  @media (max-width: ${p => p.theme.breakpoints.lg}) {
+  @media (max-width: ${p => p.theme.breakpoints.md}) {
     grid-template-columns: 1fr;
-    grid-template-rows: max-content minmax(50vh, 1fr) max-content;
     grid-template-areas:
       'top'
       'list'
       'details';
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    grid-template-columns: minmax(195px, 1fr) 1.5fr;
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.lg}) {
+    grid-template-columns: 390px 1fr;
   }
 
   @media (min-width: ${p => p.theme.breakpoints.lg}) {

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -164,6 +164,7 @@ const FiltersContainer = styled('div')`
   gap: ${space(1)};
   align-items: flex-start;
 
+  /* moves search bar to second row on small screens */
   @media (max-width: ${p => p.theme.breakpoints.sm}) {
     flex-direction: column;
     align-items: stretch;

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -103,8 +103,6 @@ const SummaryListContainer = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(1)};
-  min-width: 0; /* Allow content to shrink */
-  overflow: hidden; /* Prevent overflow */
 `;
 
 const LayoutGrid = styled('div')`
@@ -134,6 +132,7 @@ const LayoutGrid = styled('div')`
 
   @media (max-width: ${p => p.theme.breakpoints.md}) {
     grid-template-columns: 1fr;
+    grid-template-rows: max-content minmax(50vh, 1fr) max-content;
     grid-template-areas:
       'top'
       'list'
@@ -160,6 +159,7 @@ const Container = styled('div')`
   flex-direction: column;
   flex: 1;
   min-height: 0;
+  overflow: hidden;
 `;
 
 const SetupContainer = styled('div')`

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -151,7 +151,6 @@ const Container = styled('div')`
   flex-direction: column;
   flex: 1;
   min-height: 0;
-  overflow: hidden;
 `;
 
 const SetupContainer = styled('div')`


### PR DESCRIPTION
relates to https://linear.app/getsentry/issue/REPLAY-684/user-feedback-layout-on-small-screens-is-broken

on small screens (ex. mobile), uf index was broken. the infinite list scrolling did not appear, and it was not responsively resizing. search bar was not on a new line, and the grid items did not shrink appropriately, leading to horizontal scroll.

before:
<img width="444" height="687" alt="SCR-20250909-onxg" src="https://github.com/user-attachments/assets/50eeac60-5f7f-46f4-96a3-850af171a8f0" />

after:

https://github.com/user-attachments/assets/b737dbc0-e340-40f9-b224-c77480b01d7b



responsive testing:


https://github.com/user-attachments/assets/20437eca-82f3-47f7-a789-87b624a7bf82


