### PR TITLE
test(ui): Add `renderHookWithProviders` similar to our `render`

### DIFF
--- a/static/app/components/acl/useRole.spec.tsx
+++ b/static/app/components/acl/useRole.spec.tsx
@@ -1,19 +1,11 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {renderHook} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import {useRole} from 'sentry/components/acl/useRole';
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
-import type {Organization} from 'sentry/types/organization';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-
-function createWrapper(organization: Organization) {
-  return function ({children}: {children: React.ReactNode}) {
-    return <OrganizationContext value={organization}>{children}</OrganizationContext>;
-  };
-}
 
 describe('useRole', () => {
   const organization = OrganizationFixture({
@@ -32,8 +24,8 @@ describe('useRole', () => {
   });
 
   it('has a sufficient role', () => {
-    const {result} = renderHook(() => useRole({role: 'attachmentsRole'}), {
-      wrapper: createWrapper(organization),
+    const {result} = renderHookWithProviders(() => useRole({role: 'attachmentsRole'}), {
+      organization,
     });
     expect(result.current.hasRole).toBe(true);
     expect(result.current.roleRequired).toBe('admin');
@@ -45,8 +37,8 @@ describe('useRole', () => {
       orgRole: 'member',
     });
     OrganizationStore.onUpdate(org, {replace: true});
-    const {result} = renderHook(() => useRole({role: 'attachmentsRole'}), {
-      wrapper: createWrapper(org),
+    const {result} = renderHookWithProviders(() => useRole({role: 'attachmentsRole'}), {
+      organization: org,
     });
     expect(result.current.hasRole).toBe(false);
   });
@@ -58,8 +50,8 @@ describe('useRole', () => {
       access: ['org:superuser'],
     });
     OrganizationStore.onUpdate(org, {replace: true});
-    const {result} = renderHook(() => useRole({role: 'attachmentsRole'}), {
-      wrapper: createWrapper(org),
+    const {result} = renderHookWithProviders(() => useRole({role: 'attachmentsRole'}), {
+      organization: org,
     });
     expect(result.current.hasRole).toBe(true);
   });
@@ -67,8 +59,8 @@ describe('useRole', () => {
   it('handles no organization.orgRoleList', () => {
     const org = {...organization, orgRoleList: []};
     OrganizationStore.onUpdate(org, {replace: true});
-    const {result} = renderHook(() => useRole({role: 'attachmentsRole'}), {
-      wrapper: createWrapper(org),
+    const {result} = renderHookWithProviders(() => useRole({role: 'attachmentsRole'}), {
+      organization: org,
     });
     expect(result.current.hasRole).toBe(false);
   });

--- a/static/app/utils/profiling/hooks/useProfileFunctions.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctions.spec.tsx
@@ -1,22 +1,6 @@
-import {useMemo} from 'react';
-
-import {initializeOrg} from 'sentry-test/initializeOrg';
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {useProfileFunctions} from 'sentry/utils/profiling/hooks/useProfileFunctions';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-
-function TestContext({children}: {children: React.ReactNode}) {
-  const {organization} = useMemo(() => initializeOrg(), []);
-
-  return (
-    <QueryClientProvider client={makeTestQueryClient()}>
-      <OrganizationContext value={organization}>{children}</OrganizationContext>
-    </QueryClientProvider>
-  );
-}
 
 describe('useProfileFunctions', () => {
   afterEach(() => {
@@ -29,17 +13,15 @@ describe('useProfileFunctions', () => {
       body: {data: []},
     });
 
-    const hook = renderHook(
-      () =>
-        useProfileFunctions({
-          fields: ['count()'],
-          referrer: '',
-          sort: {
-            key: 'count()',
-            order: 'desc',
-          },
-        }),
-      {wrapper: TestContext}
+    const hook = renderHookWithProviders(() =>
+      useProfileFunctions({
+        fields: ['count()'],
+        referrer: '',
+        sort: {
+          key: 'count()',
+          order: 'desc',
+        },
+      })
     );
     expect(hook.result.current).toMatchObject(
       expect.objectContaining({
@@ -54,17 +36,15 @@ describe('useProfileFunctions', () => {
       body: {data: []},
     });
 
-    const hook = renderHook(
-      () =>
-        useProfileFunctions({
-          fields: ['count()'],
-          referrer: '',
-          sort: {
-            key: 'count()',
-            order: 'desc',
-          },
-        }),
-      {wrapper: TestContext}
+    const hook = renderHookWithProviders(() =>
+      useProfileFunctions({
+        fields: ['count()'],
+        referrer: '',
+        sort: {
+          key: 'count()',
+          order: 'desc',
+        },
+      })
     );
     expect(hook.result.current.isPending).toBe(true);
     expect(hook.result.current.isFetched).toBe(false);

--- a/static/app/utils/replays/useDeleteReplays.spec.tsx
+++ b/static/app/utils/replays/useDeleteReplays.spec.tsx
@@ -1,24 +1,10 @@
-import type {ReactNode} from 'react';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
 import useDeleteReplays from 'sentry/utils/replays/hooks/useDeleteReplays';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-
-function wrapper({children}: {children?: ReactNode}) {
-  const org = OrganizationFixture();
-  return (
-    <QueryClientProvider client={makeTestQueryClient()}>
-      <OrganizationContext value={org}>{children}</OrganizationContext>
-    </QueryClientProvider>
-  );
-}
 
 describe('useDeleteReplays', () => {
   describe('queryOptionsToPayload', () => {
@@ -46,8 +32,7 @@ describe('useDeleteReplays', () => {
     });
 
     it('should parse a an empty queryOptions into default 14d rangeStart & rangeEnd', () => {
-      const {result} = renderHook(useDeleteReplays, {
-        wrapper,
+      const {result} = renderHookWithProviders(useDeleteReplays, {
         initialProps: {projectSlug},
       });
 
@@ -60,8 +45,7 @@ describe('useDeleteReplays', () => {
     });
 
     it('should parse a statsPeriod into rangeStart & rangeEnd', () => {
-      const {result} = renderHook(useDeleteReplays, {
-        wrapper,
+      const {result} = renderHookWithProviders(useDeleteReplays, {
         initialProps: {projectSlug},
       });
 
@@ -78,8 +62,7 @@ describe('useDeleteReplays', () => {
     });
 
     it('should parse a start & end into rangeStart & rangeEnd', () => {
-      const {result} = renderHook(useDeleteReplays, {
-        wrapper,
+      const {result} = renderHookWithProviders(useDeleteReplays, {
         initialProps: {projectSlug},
       });
 

--- a/static/app/utils/useOwners.spec.tsx
+++ b/static/app/utils/useOwners.spec.tsx
@@ -3,14 +3,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import MemberListStore from 'sentry/stores/memberListStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import TeamStore from 'sentry/stores/teamStore';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import {useOwners} from './useOwners';
 
@@ -21,16 +18,6 @@ describe('useOwners', () => {
 
   let teamsRequest: jest.Mock;
   let membersRequest: jest.Mock;
-
-  const queryClient = makeTestQueryClient();
-
-  function Wrapper({children}: {children: React.ReactNode}) {
-    return (
-      <OrganizationContext.Provider value={org}>
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-      </OrganizationContext.Provider>
-    );
-  }
 
   beforeEach(() => {
     MemberListStore.init();
@@ -55,8 +42,7 @@ describe('useOwners', () => {
   });
 
   it('includes members and teams', async () => {
-    const {result} = renderHook(useOwners, {
-      wrapper: Wrapper,
+    const {result} = renderHookWithProviders(useOwners, {
       initialProps: {},
     });
 
@@ -83,8 +69,7 @@ describe('useOwners', () => {
       body: members,
     });
 
-    const {result} = renderHook(useOwners, {
-      wrapper: Wrapper,
+    const {result} = renderHookWithProviders(useOwners, {
       initialProps: {currentValue: ['user:5', 'team:4']},
     });
 

--- a/static/app/utils/useTeamsById.spec.tsx
+++ b/static/app/utils/useTeamsById.spec.tsx
@@ -1,43 +1,26 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {TeamFixture} from 'sentry-fixture/team';
 
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import OrganizationStore from 'sentry/stores/organizationStore';
 import TeamStore from 'sentry/stores/teamStore';
-import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import {useTeamsById} from './useTeamsById';
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-    },
-  },
-});
 
 describe('useTeamsById', () => {
   const org = OrganizationFixture();
   const mockTeams = [TeamFixture()];
 
-  const wrapper = ({children}: {children?: any}) => (
-    <OrganizationContext.Provider value={org}>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </OrganizationContext.Provider>
-  );
-
   beforeEach(() => {
     TeamStore.reset();
     OrganizationStore.onUpdate(org, {replace: true});
-    queryClient.clear();
   });
 
   it('provides teams from the team store', () => {
     TeamStore.loadInitialData(mockTeams);
 
-    const {result} = renderHook(useTeamsById, {wrapper});
+    const {result} = renderHookWithProviders(useTeamsById, {organization: org});
     const {teams} = result.current;
 
     expect(teams).toEqual(mockTeams);
@@ -51,9 +34,9 @@ describe('useTeamsById', () => {
     });
     // TeamStore.loadInitialData not yet called
     expect(TeamStore.getState().loading).toBe(true);
-    const {result} = renderHook(useTeamsById, {
+    const {result} = renderHookWithProviders(useTeamsById, {
       initialProps: {slugs: ['foo']},
-      wrapper,
+      organization: org,
     });
     const {isLoading} = result.current;
     expect(isLoading).toBe(true);
@@ -69,9 +52,9 @@ describe('useTeamsById', () => {
       body: [teamFoo],
     });
 
-    const {result} = renderHook(useTeamsById, {
+    const {result} = renderHookWithProviders(useTeamsById, {
       initialProps: {slugs: ['foo']},
-      wrapper,
+      organization: org,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -89,9 +72,9 @@ describe('useTeamsById', () => {
   it('only loads slugs when needed', () => {
     TeamStore.loadInitialData(mockTeams);
 
-    const {result} = renderHook(useTeamsById, {
+    const {result} = renderHookWithProviders(useTeamsById, {
       initialProps: {slugs: [mockTeams[0]!.slug]},
-      wrapper,
+      organization: org,
     });
 
     const {teams, isLoading} = result.current;
@@ -109,9 +92,9 @@ describe('useTeamsById', () => {
 
     TeamStore.loadInitialData(mockTeams);
 
-    const {result} = renderHook(useTeamsById, {
+    const {result} = renderHookWithProviders(useTeamsById, {
       initialProps: {ids: ['2']},
-      wrapper,
+      organization: org,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -140,9 +123,9 @@ describe('useTeamsById', () => {
 
     TeamStore.loadInitialData(mockTeams);
 
-    const {result} = renderHook(useTeamsById, {
+    const {result} = renderHookWithProviders(useTeamsById, {
       initialProps: {ids: ['2', '3']},
-      wrapper,
+      organization: org,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -161,9 +144,9 @@ describe('useTeamsById', () => {
   it('does not fetch anything if the teams are already loaded', () => {
     TeamStore.loadInitialData(mockTeams);
 
-    const {result} = renderHook(useTeamsById, {
+    const {result} = renderHookWithProviders(useTeamsById, {
       initialProps: {ids: ['1']},
-      wrapper,
+      organization: org,
     });
 
     const {teams, isLoading} = result.current;
@@ -188,9 +171,9 @@ describe('useTeamsById', () => {
     TeamStore.loadInitialData([mockTeamsToFetch[0]!]);
 
     // Request teams 1 and 2
-    const {result} = renderHook(useTeamsById, {
+    const {result} = renderHookWithProviders(useTeamsById, {
       initialProps: {ids: ['1', '2']},
-      wrapper,
+      organization: org,
     });
 
     // Should return both teams

--- a/static/app/views/detectors/hooks/useMetricDetectorAnomalyPeriods.spec.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorAnomalyPeriods.spec.tsx
@@ -1,10 +1,6 @@
-import type {ReactNode} from 'react';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {
   AlertRuleSensitivity,
   AlertRuleThresholdType,
@@ -14,17 +10,8 @@ import {
 import {AnomalyType, type Anomaly} from 'sentry/views/alerts/types';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {useMetricDetectorAnomalyPeriods} from 'sentry/views/detectors/hooks/useMetricDetectorAnomalyPeriods';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 const {organization} = initializeOrg();
-
-function TestContext({children}: {children?: ReactNode}) {
-  return (
-    <QueryClientProvider client={makeTestQueryClient()}>
-      <OrganizationContext value={organization}>{children}</OrganizationContext>
-    </QueryClientProvider>
-  );
-}
 
 describe('useMetricDetectorAnomalyPeriods', () => {
   beforeEach(() => {
@@ -87,25 +74,23 @@ describe('useMetricDetectorAnomalyPeriods', () => {
       },
     ];
 
-    const {result} = renderHook(
-      () =>
-        useMetricDetectorAnomalyPeriods({
-          series,
-          detectorDataset: DetectorDataset.ERRORS,
-          dataset: Dataset.ERRORS,
-          aggregate: 'count()',
-          query: '',
-          eventTypes: [],
-          environment: undefined,
-          projectId: '1',
-          statsPeriod: TimePeriod.SEVEN_DAYS,
-          interval: 900, // 15 minutes
-          thresholdType: AlertRuleThresholdType.ABOVE,
-          sensitivity: AlertRuleSensitivity.MEDIUM,
-          isLoadingSeries: false,
-          enabled: true,
-        }),
-      {wrapper: TestContext}
+    const {result} = renderHookWithProviders(() =>
+      useMetricDetectorAnomalyPeriods({
+        series,
+        detectorDataset: DetectorDataset.ERRORS,
+        dataset: Dataset.ERRORS,
+        aggregate: 'count()',
+        query: '',
+        eventTypes: [],
+        environment: undefined,
+        projectId: '1',
+        statsPeriod: TimePeriod.SEVEN_DAYS,
+        interval: 900, // 15 minutes
+        thresholdType: AlertRuleThresholdType.ABOVE,
+        sensitivity: AlertRuleSensitivity.MEDIUM,
+        isLoadingSeries: false,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {

--- a/static/app/views/explore/hooks/useChartBoxSelect.spec.tsx
+++ b/static/app/views/explore/hooks/useChartBoxSelect.spec.tsx
@@ -1,9 +1,7 @@
 import type EChartsReact from 'echarts-for-react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {act, renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
-
-import {OrganizationContext} from 'sentry/views/organizationContext';
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {EXPLORE_CHART_BRUSH_OPTION, useChartBoxSelect} from './useChartBoxSelect';
 
@@ -43,12 +41,6 @@ describe('useChartBoxSelect', () => {
     },
   };
 
-  const wrapper = ({children}: {children: React.ReactNode}) => (
-    <OrganizationContext.Provider value={organization}>
-      {children}
-    </OrganizationContext.Provider>
-  );
-
   beforeEach(() => {
     jest.clearAllMocks();
     mockChartRef.current = null;
@@ -56,14 +48,14 @@ describe('useChartBoxSelect', () => {
 
   describe('initial state', () => {
     it('should initialize with null brushArea', () => {
-      const {result} = renderHook(
+      const {result} = renderHookWithProviders(
         () =>
           useChartBoxSelect({
             chartRef: mockChartRef,
             chartWrapperRef: mockChartWrapperRef,
             triggerWrapperRef: mockTriggerWrapperRef,
           }),
-        {wrapper}
+        {organization}
       );
       expect(result.current.boxCoordRange).toBeNull();
     });
@@ -71,14 +63,14 @@ describe('useChartBoxSelect', () => {
 
   describe('brush configuration', () => {
     it('should return correct brush configuration when enabled', () => {
-      const {result} = renderHook(
+      const {result} = renderHookWithProviders(
         () =>
           useChartBoxSelect({
             chartRef: mockChartRef,
             chartWrapperRef: mockChartWrapperRef,
             triggerWrapperRef: mockTriggerWrapperRef,
           }),
-        {wrapper}
+        {organization}
       );
 
       expect(result.current.brush).toEqual(EXPLORE_CHART_BRUSH_OPTION);
@@ -119,14 +111,14 @@ describe('useChartBoxSelect', () => {
         getEchartsInstance: () => mockEchartsInstance,
       } as unknown as EChartsReact;
 
-      const {result} = renderHook(
+      const {result} = renderHookWithProviders(
         () =>
           useChartBoxSelect({
             chartRef: mockChartRef,
             chartWrapperRef: mockChartWrapperRef,
             triggerWrapperRef: mockTriggerWrapperRef,
           }),
-        {wrapper}
+        {organization}
       );
 
       const mockEvent = {
@@ -190,14 +182,14 @@ describe('useChartBoxSelect', () => {
         getEchartsInstance: () => mockEchartsInstance,
       } as unknown as EChartsReact;
 
-      const {result} = renderHook(
+      const {result} = renderHookWithProviders(
         () =>
           useChartBoxSelect({
             chartRef: mockChartRef,
             chartWrapperRef: mockChartWrapperRef,
             triggerWrapperRef: mockTriggerWrapperRef,
           }),
-        {wrapper}
+        {organization}
       );
 
       const mockEvent = {
@@ -230,14 +222,14 @@ describe('useChartBoxSelect', () => {
     });
 
     it('should not set brush area if chartRef is null', () => {
-      const {result} = renderHook(
+      const {result} = renderHookWithProviders(
         () =>
           useChartBoxSelect({
             chartRef: mockChartRef,
             chartWrapperRef: mockChartWrapperRef,
             triggerWrapperRef: mockTriggerWrapperRef,
           }),
-        {wrapper}
+        {organization}
       );
 
       const mockEvent = {
@@ -298,14 +290,14 @@ describe('useChartBoxSelect', () => {
         getEchartsInstance: () => mockEchartsInstance,
       } as unknown as EChartsReact;
 
-      const {result} = renderHook(
+      const {result} = renderHookWithProviders(
         () =>
           useChartBoxSelect({
             chartRef: mockChartRef,
             chartWrapperRef: mockChartWrapperRef,
             triggerWrapperRef: mockTriggerWrapperRef,
           }),
-        {wrapper}
+        {organization}
       );
 
       const mockEvent = {

--- a/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
@@ -1,38 +1,16 @@
-import {QueryClientProvider} from '@tanstack/react-query';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
-import {OrganizationFixture} from 'sentry-fixture/organization';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
-
-import type {Organization} from 'sentry/types/organization';
-import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useExploreSpansTable} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
-jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/useNavigate');
 jest.mock('sentry/utils/usePageFilters');
-
-function createWrapper(org: Organization) {
-  return function TestWrapper({children}: {children: React.ReactNode}) {
-    const queryClient = makeTestQueryClient();
-    return (
-      <QueryClientProvider client={queryClient}>
-        <OrganizationContext value={org}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
-  };
-}
 
 describe('useExploreTimeseries', () => {
   let mockNormalRequestUrl: jest.Mock;
 
   beforeEach(() => {
-    jest.mocked(useLocation).mockReturnValue(LocationFixture());
-
     jest.mocked(usePageFilters).mockReturnValue({
       isReady: true,
       desyncedFilters: new Set(),
@@ -78,16 +56,12 @@ describe('useExploreTimeseries', () => {
       ],
       method: 'GET',
     });
-    renderHook(
-      () =>
-        useExploreSpansTable({
-          query: 'test value',
-          enabled: true,
-          limit: 10,
-        }),
-      {
-        wrapper: createWrapper(OrganizationFixture()),
-      }
+    renderHookWithProviders(() =>
+      useExploreSpansTable({
+        query: 'test value',
+        enabled: true,
+        limit: 10,
+      })
     );
 
     expect(mockNormalRequestUrl).toHaveBeenCalledTimes(1);

--- a/static/app/views/explore/hooks/useExploreTimeseries.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.spec.tsx
@@ -1,35 +1,21 @@
-import {QueryClientProvider} from '@tanstack/react-query';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import type {Organization} from 'sentry/types/organization';
-import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {PageParamsProvider} from 'sentry/views/explore/contexts/pageParamsContext';
 import {useExploreTimeseries} from 'sentry/views/explore/hooks/useExploreTimeseries';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/useNavigate');
 jest.mock('sentry/utils/usePageFilters');
 
-function createWrapper(org: Organization) {
+function createWrapper() {
   return function TestWrapper({children}: {children: React.ReactNode}) {
-    const queryClient = makeTestQueryClient();
     return (
-      <QueryClientProvider client={queryClient}>
-        <OrganizationContext value={org}>
-          <SpansQueryParamsProvider>
-            <PageParamsProvider>{children}</PageParamsProvider>
-          </SpansQueryParamsProvider>
-        </OrganizationContext>
-      </QueryClientProvider>
+      <SpansQueryParamsProvider>
+        <PageParamsProvider>{children}</PageParamsProvider>
+      </SpansQueryParamsProvider>
     );
   };
 }
@@ -38,8 +24,6 @@ describe('useExploreTimeseries', () => {
   let mockNormalRequestUrl: jest.Mock;
 
   beforeEach(() => {
-    jest.mocked(useLocation).mockReturnValue(LocationFixture());
-
     jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
     jest.clearAllMocks();
   });
@@ -75,14 +59,14 @@ describe('useExploreTimeseries', () => {
       ],
       method: 'GET',
     });
-    renderHook(
+    renderHookWithProviders(
       () =>
         useExploreTimeseries({
           query: 'test value',
           enabled: true,
         }),
       {
-        wrapper: createWrapper(OrganizationFixture()),
+        additionalWrapper: createWrapper(),
       }
     );
 

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
@@ -1,43 +1,16 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
-import {OrganizationFixture} from 'sentry-fixture/organization';
-
-import {initializeOrg} from 'sentry-test/initializeOrg';
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
-import type {Organization} from 'sentry/types/organization';
 import {FieldKind} from 'sentry/utils/fields';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
-import {useLocation} from 'sentry/utils/useLocation';
 import {useGetTraceItemAttributeValues} from 'sentry/views/explore/hooks/useGetTraceItemAttributeValues';
 import {TraceItemDataset} from 'sentry/views/explore/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-
-jest.mock('sentry/utils/useLocation');
-const mockedUsedLocation = jest.mocked(useLocation);
-
-function createWrapper(organization: Organization) {
-  return function ({children}: {children?: React.ReactNode}) {
-    return (
-      <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext value={organization}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
-  };
-}
 
 describe('useGetTraceItemAttributeValues', () => {
-  const organization = OrganizationFixture({slug: 'org-slug'});
   const attributeKey = 'test.attribute';
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
-    jest.clearAllMocks();
 
-    mockedUsedLocation.mockReturnValue(LocationFixture());
-
-    const {organization: _initOrg} = initializeOrg();
     PageFiltersStore.init();
     PageFiltersStore.onInitializeUrlState(
       {
@@ -75,15 +48,11 @@ describe('useGetTraceItemAttributeValues', () => {
       ],
     });
 
-    const {result} = renderHook(
-      () =>
-        useGetTraceItemAttributeValues({
-          traceItemType: TraceItemDataset.LOGS,
-          type: 'string',
-        }),
-      {
-        wrapper: createWrapper(organization),
-      }
+    const {result} = renderHookWithProviders(() =>
+      useGetTraceItemAttributeValues({
+        traceItemType: TraceItemDataset.LOGS,
+        type: 'string',
+      })
     );
 
     const tag = {
@@ -122,15 +91,11 @@ describe('useGetTraceItemAttributeValues', () => {
       ],
     });
 
-    const {result} = renderHook(
-      () =>
-        useGetTraceItemAttributeValues({
-          traceItemType: TraceItemDataset.LOGS,
-          type: 'number',
-        }),
-      {
-        wrapper: createWrapper(organization),
-      }
+    const {result} = renderHookWithProviders(() =>
+      useGetTraceItemAttributeValues({
+        traceItemType: TraceItemDataset.LOGS,
+        type: 'number',
+      })
     );
 
     const tag = {

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.spec.tsx
@@ -1,42 +1,20 @@
-import {QueryClientProvider} from '@tanstack/react-query';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import type {Organization} from 'sentry/types/organization';
-import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useMultiQueryTimeseries} from 'sentry/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries';
 import {useReadQueriesFromLocation} from 'sentry/views/explore/multiQueryMode/locationUtils';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/useNavigate');
 jest.mock('sentry/utils/usePageFilters');
 jest.mock('sentry/views/explore/multiQueryMode/locationUtils');
-
-function createWrapper(org: Organization) {
-  return function TestWrapper({children}: {children: React.ReactNode}) {
-    const queryClient = makeTestQueryClient();
-    return (
-      <QueryClientProvider client={queryClient}>
-        <OrganizationContext value={org}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
-  };
-}
 
 describe('useMultiQueryTimeseries', () => {
   let mockNormalRequestUrl: jest.Mock;
 
   beforeEach(() => {
-    jest.mocked(useLocation).mockReturnValue(LocationFixture());
-
     jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
     jest.clearAllMocks();
   });
@@ -82,15 +60,11 @@ describe('useMultiQueryTimeseries', () => {
       ],
       method: 'GET',
     });
-    renderHook(
-      () =>
-        useMultiQueryTimeseries({
-          enabled: true,
-          index: 0,
-        }),
-      {
-        wrapper: createWrapper(OrganizationFixture()),
-      }
+    renderHookWithProviders(() =>
+      useMultiQueryTimeseries({
+        enabled: true,
+        index: 0,
+      })
     );
 
     expect(mockNormalRequestUrl).toHaveBeenCalledTimes(1);

--- a/static/app/views/onboarding/useConfigureSdk.spec.tsx
+++ b/static/app/views/onboarding/useConfigureSdk.spec.tsx
@@ -1,17 +1,12 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {act, renderHook} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import * as OnboardingContext from 'sentry/components/onboarding/onboardingContext';
 import {useCreateProject} from 'sentry/components/onboarding/useCreateProject';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
-import type {Organization} from 'sentry/types/organization';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import {useConfigureSdk} from './useConfigureSdk';
 
@@ -45,19 +40,7 @@ function mockCreateProjectHook() {
 
 const mockUseCreateProject = useCreateProject as jest.Mock;
 
-function createWrapper(organization: Organization) {
-  const queryClient = makeTestQueryClient();
-  return function ({children}: {children?: React.ReactNode}) {
-    return (
-      <QueryClientProvider client={queryClient}>
-        <OrganizationContext value={organization}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
-  };
-}
-
 describe('useConfigureSdk', () => {
-  const organization = OrganizationFixture();
   const onComplete = jest.fn();
 
   let createProjectInstance: ReturnType<typeof mockCreateProjectHook>;
@@ -96,17 +79,13 @@ describe('useConfigureSdk', () => {
   });
 
   it('returns loading state correctly', () => {
-    const {result} = renderHook(() => useConfigureSdk({onComplete}), {
-      wrapper: createWrapper(organization),
-    });
+    const {result} = renderHookWithProviders(() => useConfigureSdk({onComplete}));
 
     expect(result.current.isLoadingData).toBe(true);
   });
 
   it('opens the framework suggestion modal if platform is supported', async () => {
-    const {result} = renderHook(() => useConfigureSdk({onComplete}), {
-      wrapper: createWrapper(organization),
-    });
+    const {result} = renderHookWithProviders(() => useConfigureSdk({onComplete}));
 
     await act(async () => {
       await result.current.configureSdk(frameworkModalSupportedPlatform);
@@ -116,9 +95,7 @@ describe('useConfigureSdk', () => {
   });
 
   it('does not open the framework suggestion modal if platform is not supported', async () => {
-    const {result} = renderHook(() => useConfigureSdk({onComplete}), {
-      wrapper: createWrapper(organization),
-    });
+    const {result} = renderHookWithProviders(() => useConfigureSdk({onComplete}));
 
     await act(async () => {
       await result.current.configureSdk(notFrameworkModalSupportedPlatform);
@@ -129,9 +106,7 @@ describe('useConfigureSdk', () => {
   });
 
   it('creates project only once even if called multiple times', async () => {
-    const {result} = renderHook(() => useConfigureSdk({onComplete}), {
-      wrapper: createWrapper(organization),
-    });
+    const {result} = renderHookWithProviders(() => useConfigureSdk({onComplete}));
 
     mockCreateProject.mockImplementation(
       () => new Promise(resolve => setTimeout(resolve, 10))

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.spec.tsx
@@ -1,10 +1,7 @@
-import {QueryClientProvider} from '@tanstack/react-query';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
-
-import {OrganizationContext} from 'sentry/views/organizationContext';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {useTrace} from './useTrace';
 
@@ -25,12 +22,6 @@ describe('useTrace', () => {
     jest.clearAllMocks();
     MockApiClient.clearMockResponses();
   });
-
-  const wrapper = ({children}: {children: React.ReactNode}) => (
-    <QueryClientProvider client={queryClient}>
-      <OrganizationContext value={organization}>{children}</OrganizationContext>
-    </QueryClientProvider>
-  );
 
   describe('tracing endpoint query params', () => {
     const validUUid = '550e8400e29b41d4a716446655440000';
@@ -57,12 +48,10 @@ describe('useTrace', () => {
         body: [],
       });
 
-      renderHook(
-        () =>
-          useTrace({
-            traceSlug: 'test-trace-id',
-          }),
-        {wrapper}
+      renderHookWithProviders(() =>
+        useTrace({
+          traceSlug: 'test-trace-id',
+        })
       );
 
       // Wait for the hook to make the API call
@@ -145,12 +134,10 @@ describe('useTrace', () => {
           body: [],
         });
 
-        renderHook(
-          () =>
-            useTrace({
-              traceSlug: 'trace-test-id',
-            }),
-          {wrapper}
+        renderHookWithProviders(() =>
+          useTrace({
+            traceSlug: 'trace-test-id',
+          })
         );
 
         await waitFor(() => {

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
@@ -1,11 +1,8 @@
-import {QueryClientProvider} from '@tanstack/react-query';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import type {ReplayTrace} from 'sentry/views/replays/detail/trace/useReplayTraces';
 
 import {useTraceMeta} from './useTraceMeta';
@@ -15,7 +12,6 @@ jest.mock('sentry/utils/useSyncedLocalStorageState', () => ({
 }));
 
 const organization = OrganizationFixture();
-const queryClient = makeTestQueryClient();
 
 const mockedReplayTraces: ReplayTrace[] = [
   {
@@ -35,7 +31,6 @@ const mockedReplayTraces: ReplayTrace[] = [
 describe('useTraceMeta', () => {
   beforeEach(() => {
     jest.mocked(useSyncedLocalStorageState).mockReturnValue(['non-eap', jest.fn()]);
-    queryClient.clear();
     jest.clearAllMocks();
   });
 
@@ -87,13 +82,9 @@ describe('useTraceMeta', () => {
       },
     });
 
-    const wrapper = ({children}: {children: React.ReactNode}) => (
-      <QueryClientProvider client={queryClient}>
-        <OrganizationContext value={organization}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
-
-    const {result} = renderHook(() => useTraceMeta(mockedReplayTraces), {wrapper});
+    const {result} = renderHookWithProviders(() => useTraceMeta(mockedReplayTraces), {
+      organization,
+    });
 
     expect(result.current).toEqual({
       data: undefined,
@@ -179,13 +170,9 @@ describe('useTraceMeta', () => {
       },
     });
 
-    const wrapper = ({children}: {children: React.ReactNode}) => (
-      <QueryClientProvider client={queryClient}>
-        <OrganizationContext value={org}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
-
-    const {result} = renderHook(() => useTraceMeta(mockedReplayTraces), {wrapper});
+    const {result} = renderHookWithProviders(() => useTraceMeta(mockedReplayTraces), {
+      organization: org,
+    });
 
     expect(result.current).toEqual({
       data: undefined,
@@ -235,13 +222,9 @@ describe('useTraceMeta', () => {
       statusCode: 400,
     });
 
-    const wrapper = ({children}: {children: React.ReactNode}) => (
-      <QueryClientProvider client={queryClient}>
-        <OrganizationContext value={organization}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
-
-    const {result} = renderHook(() => useTraceMeta(mockedReplayTraces), {wrapper});
+    const {result} = renderHookWithProviders(() => useTraceMeta(mockedReplayTraces), {
+      organization,
+    });
 
     expect(result.current).toEqual({
       data: undefined,
@@ -307,13 +290,9 @@ describe('useTraceMeta', () => {
       },
     });
 
-    const wrapper = ({children}: {children: React.ReactNode}) => (
-      <QueryClientProvider client={queryClient}>
-        <OrganizationContext value={organization}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
-
-    const {result} = renderHook(() => useTraceMeta(mockedReplayTraces), {wrapper});
+    const {result} = renderHookWithProviders(() => useTraceMeta(mockedReplayTraces), {
+      organization,
+    });
 
     expect(result.current).toEqual({
       data: undefined,

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceTree.spec.tsx
@@ -1,10 +1,6 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
-
-import type {Organization} from 'sentry/types/organization';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {
   makeTraceError,
@@ -25,13 +21,11 @@ const getMockedTraceResults = (
     data,
   }) as UseApiQueryResult<TraceSplitResults<TraceTree.Transaction> | undefined, any>;
 
-const organization = OrganizationFixture();
-
-const contextWrapper = (org: Organization) => {
+const contextWrapper = () => {
   return function ({children}: {children: React.ReactNode}) {
     return (
       <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
-        <OrganizationContext value={org}>{children}</OrganizationContext>
+        {children}
       </TraceStateProvider>
     );
   };
@@ -39,14 +33,14 @@ const contextWrapper = (org: Organization) => {
 
 describe('useTraceTree', () => {
   it('returns tree for error case', async () => {
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       () =>
         useTraceTree({
           trace: getMockedTraceResults('error'),
           traceSlug: 'test-trace',
           replay: null,
         }),
-      {wrapper: contextWrapper(organization)}
+      {additionalWrapper: contextWrapper()}
     );
 
     await waitFor(() => {
@@ -55,14 +49,14 @@ describe('useTraceTree', () => {
   });
 
   it('returns tree for loading case', async () => {
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       () =>
         useTraceTree({
           trace: getMockedTraceResults('pending'),
           traceSlug: 'test-trace',
           replay: null,
         }),
-      {wrapper: contextWrapper(organization)}
+      {additionalWrapper: contextWrapper()}
     );
 
     await waitFor(() => {
@@ -71,7 +65,7 @@ describe('useTraceTree', () => {
   });
 
   it('returns tree for empty success case', async () => {
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       () =>
         useTraceTree({
           trace: getMockedTraceResults('success', {
@@ -81,7 +75,7 @@ describe('useTraceTree', () => {
           traceSlug: 'test-trace',
           replay: null,
         }),
-      {wrapper: contextWrapper(organization)}
+      {additionalWrapper: contextWrapper()}
     );
 
     await waitFor(() => {
@@ -125,14 +119,14 @@ describe('useTraceTree', () => {
       ],
     };
 
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       () =>
         useTraceTree({
           trace: getMockedTraceResults('success', mockedTrace),
           traceSlug: 'test-trace',
           replay: null,
         }),
-      {wrapper: contextWrapper(organization)}
+      {additionalWrapper: contextWrapper()}
     );
 
     await waitFor(() => {

--- a/static/app/views/replays/detail/ai/useFetchReplaySummary.spec.tsx
+++ b/static/app/views/replays/detail/ai/useFetchReplaySummary.spec.tsx
@@ -1,12 +1,9 @@
-import {QueryClientProvider} from '@tanstack/react-query';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import useProjectFromId from 'sentry/utils/useProjectFromId';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import {
   ReplaySummaryStatus,
   ReplaySummaryTemp,
@@ -43,18 +40,6 @@ describe('useFetchReplaySummary', () => {
     mockUseProjectFromId.mockReturnValue(mockProject);
   });
 
-  const createWrapper = () => {
-    const queryClient = makeTestQueryClient();
-
-    return function ({children}: {children: React.ReactNode}) {
-      return (
-        <QueryClientProvider client={queryClient}>
-          <OrganizationContext value={mockOrganization}>{children}</OrganizationContext>
-        </QueryClientProvider>
-      );
-    };
-  };
-
   describe('basic functionality', () => {
     it('should fetch summary data successfully', async () => {
       const mockSummaryData = {
@@ -70,8 +55,8 @@ describe('useFetchReplaySummary', () => {
         body: mockSummaryData,
       });
 
-      const {result} = renderHook(() => useFetchReplaySummary(mockReplay), {
-        wrapper: createWrapper(),
+      const {result} = renderHookWithProviders(() => useFetchReplaySummary(mockReplay), {
+        organization: mockOrganization,
       });
 
       await waitFor(() => {
@@ -90,8 +75,8 @@ describe('useFetchReplaySummary', () => {
         body: {detail: 'Internal server error'},
       });
 
-      const {result} = renderHook(() => useFetchReplaySummary(mockReplay), {
-        wrapper: createWrapper(),
+      const {result} = renderHookWithProviders(() => useFetchReplaySummary(mockReplay), {
+        organization: mockOrganization,
       });
 
       await waitFor(() => {
@@ -112,10 +97,10 @@ describe('useFetchReplaySummary', () => {
         },
       });
 
-      const {result} = renderHook(
+      const {result} = renderHookWithProviders(
         () => useFetchReplaySummary(mockReplay, {enabled: false, staleTime: 0}),
         {
-          wrapper: createWrapper(),
+          organization: mockOrganization,
         }
       );
 
@@ -135,10 +120,10 @@ describe('useFetchReplaySummary', () => {
         },
       });
 
-      const {result} = renderHook(
+      const {result} = renderHookWithProviders(
         () => useFetchReplaySummary(mockReplay, {enabled: true, staleTime: 0}),
         {
-          wrapper: createWrapper(),
+          organization: mockOrganization,
         }
       );
 
@@ -169,8 +154,8 @@ describe('useFetchReplaySummary', () => {
         body: startSummaryRequestPromise,
       });
 
-      const {result} = renderHook(() => useFetchReplaySummary(mockReplay), {
-        wrapper: createWrapper(),
+      const {result} = renderHookWithProviders(() => useFetchReplaySummary(mockReplay), {
+        organization: mockOrganization,
       });
 
       // Start the summary mutation
@@ -198,8 +183,8 @@ describe('useFetchReplaySummary', () => {
         body: {status: ReplaySummaryStatus.PROCESSING, data: undefined},
       });
 
-      const {result} = renderHook(() => useFetchReplaySummary(mockReplay), {
-        wrapper: createWrapper(),
+      const {result} = renderHookWithProviders(() => useFetchReplaySummary(mockReplay), {
+        organization: mockOrganization,
       });
 
       await waitFor(() => {
@@ -218,8 +203,8 @@ describe('useFetchReplaySummary', () => {
         },
       });
 
-      const {result} = renderHook(() => useFetchReplaySummary(mockReplay), {
-        wrapper: createWrapper(),
+      const {result} = renderHookWithProviders(() => useFetchReplaySummary(mockReplay), {
+        organization: mockOrganization,
       });
 
       await waitFor(() => {
@@ -235,8 +220,8 @@ describe('useFetchReplaySummary', () => {
         body: {status: ReplaySummaryStatus.ERROR, data: undefined},
       });
 
-      const {result} = renderHook(() => useFetchReplaySummary(mockReplay), {
-        wrapper: createWrapper(),
+      const {result} = renderHookWithProviders(() => useFetchReplaySummary(mockReplay), {
+        organization: mockOrganization,
       });
 
       await waitFor(() => {
@@ -263,9 +248,12 @@ describe('useFetchReplaySummary', () => {
         method: 'POST',
       });
 
-      const {result, rerender} = renderHook(() => useFetchReplaySummary(mockReplay), {
-        wrapper: createWrapper(),
-      });
+      const {result, rerender} = renderHookWithProviders(
+        () => useFetchReplaySummary(mockReplay),
+        {
+          organization: mockOrganization,
+        }
+      );
 
       await waitFor(() => {
         expect(result.current.isPolling).toBe(false);

--- a/static/gsApp/hooks/dashboardsLimit.spec.tsx
+++ b/static/gsApp/hooks/dashboardsLimit.spec.tsx
@@ -1,34 +1,17 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
-import {render, renderHook, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderHookWithProviders,
+  screen,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
-
-import type {Organization} from 'sentry/types/organization';
-import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 
 import {useDashboardsLimit} from './dashboardsLimit';
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-    },
-  },
-});
-
-function createWrapper(organization: Organization) {
-  return function Wrapper({children}: {children?: React.ReactNode}) {
-    return (
-      <QueryClientProvider client={queryClient}>
-        <OrganizationContext value={organization}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
-  };
-}
 
 const mockOrganization = OrganizationFixture({
   features: ['dashboards-plan-limits'],
@@ -41,14 +24,13 @@ const mockOrganizationWithoutFeature = OrganizationFixture({
 describe('useDashboardsLimit', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
-    queryClient.clear();
     SubscriptionStore.init();
   });
 
   it('returns no limits when feature flag is disabled', () => {
-    const wrapper = createWrapper(mockOrganizationWithoutFeature);
-
-    const {result} = renderHook(() => useDashboardsLimit(), {wrapper});
+    const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
+      organization: mockOrganizationWithoutFeature,
+    });
 
     expect(result.current).toEqual({
       hasReachedDashboardLimit: false,
@@ -59,8 +41,6 @@ describe('useDashboardsLimit', () => {
   });
 
   it('handles unlimited dashboards plan without making dashboards request', async () => {
-    const wrapper = createWrapper(mockOrganization);
-
     const subscription = SubscriptionFixture({
       organization: mockOrganization,
       planDetails: {
@@ -78,7 +58,9 @@ describe('useDashboardsLimit', () => {
       body: [],
     });
 
-    const {result} = renderHook(() => useDashboardsLimit(), {wrapper});
+    const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
+      organization: mockOrganization,
+    });
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -96,8 +78,6 @@ describe('useDashboardsLimit', () => {
   });
 
   it('handles no subscription data (defaults to 0)', () => {
-    const wrapper = createWrapper(mockOrganization);
-
     SubscriptionStore.set(mockOrganization.slug, null as any);
 
     const dashboardsRequest = MockApiClient.addMockResponse({
@@ -105,7 +85,9 @@ describe('useDashboardsLimit', () => {
       body: [],
     });
 
-    const {result} = renderHook(() => useDashboardsLimit(), {wrapper});
+    const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
+      organization: mockOrganization,
+    });
 
     expect(result.current.hasReachedDashboardLimit).toBe(true);
     expect(result.current.dashboardsLimit).toBe(0);
@@ -125,8 +107,6 @@ describe('useDashboardsLimit', () => {
   });
 
   it('returns under limit when dashboards count is below limit', async () => {
-    const wrapper = createWrapper(mockOrganization);
-
     const subscription = SubscriptionFixture({
       organization: mockOrganization,
       planDetails: {
@@ -149,7 +129,9 @@ describe('useDashboardsLimit', () => {
       match: [MockApiClient.matchQuery({per_page: 11})],
     });
 
-    const {result} = renderHook(() => useDashboardsLimit(), {wrapper});
+    const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
+      organization: mockOrganization,
+    });
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -166,8 +148,6 @@ describe('useDashboardsLimit', () => {
   });
 
   it('returns at limit when dashboards count equals limit', async () => {
-    const wrapper = createWrapper(mockOrganization);
-
     const subscription = SubscriptionFixture({
       organization: mockOrganization,
       planDetails: {
@@ -191,7 +171,9 @@ describe('useDashboardsLimit', () => {
       match: [MockApiClient.matchQuery({per_page: 4})],
     });
 
-    const {result} = renderHook(() => useDashboardsLimit(), {wrapper});
+    const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
+      organization: mockOrganization,
+    });
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -213,8 +195,6 @@ describe('useDashboardsLimit', () => {
   });
 
   it('returns over limit when dashboards count exceeds limit', async () => {
-    const wrapper = createWrapper(mockOrganization);
-
     const subscription = SubscriptionFixture({
       organization: mockOrganization,
       planDetails: {
@@ -237,7 +217,9 @@ describe('useDashboardsLimit', () => {
       match: [MockApiClient.matchQuery({per_page: 3})],
     });
 
-    const {result} = renderHook(() => useDashboardsLimit(), {wrapper});
+    const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
+      organization: mockOrganization,
+    });
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -259,8 +241,6 @@ describe('useDashboardsLimit', () => {
   });
 
   it('returns loading state when dashboards request is in progress', async () => {
-    const wrapper = createWrapper(mockOrganization);
-
     const subscription = SubscriptionFixture({
       organization: mockOrganization,
       planDetails: {
@@ -279,7 +259,9 @@ describe('useDashboardsLimit', () => {
       match: [MockApiClient.matchQuery({per_page: 11})],
     });
 
-    const {result} = renderHook(() => useDashboardsLimit(), {wrapper});
+    const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
+      organization: mockOrganization,
+    });
 
     // Should still be loading while dashboards request is pending
     expect(result.current.isLoading).toBe(true);
@@ -293,8 +275,6 @@ describe('useDashboardsLimit', () => {
   });
 
   it('handles dashboards API error gracefully', async () => {
-    const wrapper = createWrapper(mockOrganization);
-
     const subscription = SubscriptionFixture({
       organization: mockOrganization,
       planDetails: {
@@ -313,7 +293,9 @@ describe('useDashboardsLimit', () => {
       match: [MockApiClient.matchQuery({per_page: 11})],
     });
 
-    const {result} = renderHook(() => useDashboardsLimit(), {wrapper});
+    const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
+      organization: mockOrganization,
+    });
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -331,8 +313,6 @@ describe('useDashboardsLimit', () => {
   });
 
   it('handles missing subscription planDetails gracefully (defaults to 0)', () => {
-    const wrapper = createWrapper(mockOrganization);
-
     const subscription = SubscriptionFixture({
       organization: mockOrganization,
       planDetails: undefined as any,
@@ -345,7 +325,9 @@ describe('useDashboardsLimit', () => {
       body: [],
     });
 
-    const {result} = renderHook(() => useDashboardsLimit(), {wrapper});
+    const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
+      organization: mockOrganization,
+    });
 
     // Should default to 0 when planDetails is missing
     expect(result.current.hasReachedDashboardLimit).toBe(true);

--- a/tests/js/fixtures/organization.ts
+++ b/tests/js/fixtures/organization.ts
@@ -87,9 +87,8 @@ export function OrganizationFixture(params: Partial<Organization> = {}): Organiz
     storeCrashReports: 0,
     trustedRelays: [],
     defaultAutofixAutomationTuning: 'off',
-    ...params,
-
     orgRoleList: OrgRoleListFixture(),
     teamRoleList: TeamRoleListFixture(),
+    ...params,
   };
 }


### PR DESCRIPTION
Works about the same as render except for `renderHook`. Does not support deprecated routes.

Adds "additionalWrapper" that I felt was missing from render and renderHook that would let you pass additional contexts.

Moved a few tests over to it.