### PR TITLE
chore(discord): tighten a lot of typing for discord components

### DIFF
--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -11,6 +11,7 @@ from rest_framework import status
 
 from sentry import options
 from sentry.integrations.client import ApiClient
+from sentry.integrations.discord.message_builder.base.base import DiscordMessage
 from sentry.integrations.discord.utils.consts import DISCORD_ERROR_CODES, DISCORD_USER_ERRORS
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.shared_integrations.exceptions import ApiError
@@ -231,7 +232,7 @@ class DiscordClient(ApiClient):
         )
         self.logger.info("handled discord success", extra=log_params)
 
-    def send_message(self, channel_id: str, message: dict[str, object]) -> None:
+    def send_message(self, channel_id: str, message: DiscordMessage) -> None:
         """
         Send a message to the specified channel.
         """

--- a/src/sentry/integrations/discord/message_builder/base/__init__.py
+++ b/src/sentry/integrations/discord/message_builder/base/__init__.py
@@ -1,4 +1,0 @@
-from .base import *  # noqa: F401,F403
-from .component import *  # noqa: F401,F403
-from .embed import *  # noqa: F401,F403
-from .flags import *  # noqa: F401,F403

--- a/src/sentry/integrations/discord/message_builder/base/base.py
+++ b/src/sentry/integrations/discord/message_builder/base/base.py
@@ -1,8 +1,23 @@
 from __future__ import annotations
 
-from .component import DiscordMessageComponent
-from .embed import DiscordMessageEmbed
-from .flags import DiscordMessageFlags
+from typing import NotRequired, TypedDict
+
+from sentry.integrations.discord.message_builder.base.component.base import (
+    DiscordMessageComponent,
+    DiscordMessageComponentDict,
+)
+from sentry.integrations.discord.message_builder.base.embed.base import (
+    DiscordMessageEmbed,
+    DiscordMessageEmbedDict,
+)
+from sentry.integrations.discord.message_builder.base.flags import DiscordMessageFlags
+
+
+class DiscordMessage(TypedDict):
+    content: str
+    components: NotRequired[list[DiscordMessageComponentDict]]
+    embeds: NotRequired[list[DiscordMessageEmbedDict]]
+    flags: NotRequired[int]
 
 
 class DiscordMessageBuilder:
@@ -25,7 +40,7 @@ class DiscordMessageBuilder:
         self.components = components
         self.flags = flags
 
-    def build(self, notification_uuid: str | None = None) -> dict[str, object]:
+    def build(self, notification_uuid: str | None = None) -> DiscordMessage:
         return self._build(
             self.content,
             self.embeds,
@@ -39,16 +54,18 @@ class DiscordMessageBuilder:
         embeds: list[DiscordMessageEmbed] | None = None,
         components: list[DiscordMessageComponent] | None = None,
         flags: DiscordMessageFlags | None = None,
-    ) -> dict[str, object]:
+    ) -> DiscordMessage:
         """
         Helper method for building arbitrary Discord messages.
         """
-        message: dict[str, object] = {}
-        message["content"] = content
-        message["embeds"] = [] if embeds is None else [embed.build() for embed in embeds]
-        message["components"] = (
+        embeds_list = [] if embeds is None else [embed.build() for embed in embeds]
+        components_list = (
             [] if components is None else [component.build() for component in components]
         )
+
+        message = DiscordMessage(content=content, embeds=embeds_list, components=components_list)
+
         if flags is not None:
             message["flags"] = flags.value
+
         return message

--- a/src/sentry/integrations/discord/message_builder/base/component/__init__.py
+++ b/src/sentry/integrations/discord/message_builder/base/component/__init__.py
@@ -1,8 +1,3 @@
-from .action_row import DiscordActionRow  # noqa: F401,F403
-from .base import *  # noqa: F401,F403
-from .button import *  # noqa: F401,F403
-
-
 class DiscordComponentCustomIds:
     """
     Constant to track these ids across modules

--- a/src/sentry/integrations/discord/message_builder/base/component/action_row.py
+++ b/src/sentry/integrations/discord/message_builder/base/component/action_row.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import TypedDict
 
-from .base import DiscordMessageComponent
+from .base import DiscordMessageComponent, DiscordMessageComponentDict
+
+
+class DiscordActionRowDict(TypedDict):
+    type: int
+    components: list[DiscordMessageComponentDict]  # Components can be buttons, select menus, etc.
 
 
 class DiscordActionRowError(Exception):
@@ -21,7 +27,7 @@ class DiscordActionRow(DiscordMessageComponent):
         self.components = components
         super().__init__(type=1)
 
-    def build(self) -> dict[str, object]:
+    def build(self) -> DiscordActionRowDict:
         # We need to override this build method because we need to call build
         # on subcomponents
-        return {"type": self.type, "components": [c.build() for c in self.components]}
+        return DiscordActionRowDict(type=self.type, components=[c.build() for c in self.components])

--- a/src/sentry/integrations/discord/message_builder/base/component/base.py
+++ b/src/sentry/integrations/discord/message_builder/base/component/base.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+from typing import TypedDict
+
+
+class DiscordMessageComponentDict(TypedDict):
+    type: int
+
 
 class DiscordMessageComponent:
     """
@@ -14,6 +20,5 @@ class DiscordMessageComponent:
     def __init__(self, type: int) -> None:
         self.type = type
 
-    def build(self) -> dict[str, object]:
-        attributes = vars(self).items()
-        return {k: v for k, v in attributes if v is not None}
+    def build(self) -> DiscordMessageComponentDict:
+        return DiscordMessageComponentDict(type=self.type)

--- a/src/sentry/integrations/discord/message_builder/base/component/button.py
+++ b/src/sentry/integrations/discord/message_builder/base/component/button.py
@@ -1,6 +1,16 @@
 from __future__ import annotations
 
-from .base import DiscordMessageComponent
+from typing import NotRequired
+
+from .base import DiscordMessageComponent, DiscordMessageComponentDict
+
+
+class DiscordButtonDict(DiscordMessageComponentDict):
+    style: int
+    custom_id: str
+    label: NotRequired[str]
+    url: NotRequired[str]
+    disabled: NotRequired[bool]
 
 
 class DiscordButtonStyle:
@@ -27,3 +37,15 @@ class DiscordButton(DiscordMessageComponent):
         self.url = url
         self.disabled = disabled
         super().__init__(type=2)
+
+    def build(self) -> DiscordButtonDict:
+        button = DiscordButtonDict(type=self.type, style=self.style, custom_id=self.custom_id)
+
+        if self.label is not None:
+            button["label"] = self.label
+        if self.url is not None:
+            button["url"] = self.url
+        if self.disabled is not None:
+            button["disabled"] = self.disabled
+
+        return button

--- a/src/sentry/integrations/discord/message_builder/base/component/select_menu.py
+++ b/src/sentry/integrations/discord/message_builder/base/component/select_menu.py
@@ -1,8 +1,28 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import NotRequired, TypedDict
 
-from sentry.integrations.discord.message_builder.base.component.base import DiscordMessageComponent
+from sentry.integrations.discord.message_builder.base.component.base import (
+    DiscordMessageComponent,
+    DiscordMessageComponentDict,
+)
+
+
+class DiscordSelectMenuOptionDict(TypedDict):
+    label: str
+    value: str
+    description: NotRequired[str]
+    default: NotRequired[bool]
+
+
+class DiscordSelectMenuDict(DiscordMessageComponentDict):
+    custom_id: str
+    options: list[DiscordSelectMenuOptionDict]
+    placeholder: NotRequired[str]
+    min_values: NotRequired[int]
+    max_values: NotRequired[int]
+    disabled: NotRequired[bool]
 
 
 class DiscordSelectMenuOption:
@@ -18,9 +38,15 @@ class DiscordSelectMenuOption:
         self.description = description
         self.default = default
 
-    def build(self) -> dict[str, object]:
-        attributes = vars(self).items()
-        return {k: v for k, v in attributes if v is not None}
+    def build(self) -> DiscordSelectMenuOptionDict:
+        option = DiscordSelectMenuOptionDict(label=self.label, value=self.value)
+
+        if self.description is not None:
+            option["description"] = self.description
+        if self.default is not None:
+            option["default"] = self.default
+
+        return option
 
 
 class DiscordSelectMenu(DiscordMessageComponent):
@@ -48,7 +74,18 @@ class DiscordSelectMenu(DiscordMessageComponent):
         self.max_values = max_values
         self.disabled = disabled
 
-    def build(self) -> dict[str, object]:
-        select_menu = super().build()
-        select_menu["options"] = [o.build() for o in self.options]
+    def build(self) -> DiscordSelectMenuDict:
+        select_menu = DiscordSelectMenuDict(
+            type=self.type, custom_id=self.custom_id, options=[o.build() for o in self.options]
+        )
+
+        if self.placeholder is not None:
+            select_menu["placeholder"] = self.placeholder
+        if self.min_values is not None:
+            select_menu["min_values"] = self.min_values
+        if self.max_values is not None:
+            select_menu["max_values"] = self.max_values
+        if self.disabled is not None:
+            select_menu["disabled"] = self.disabled
+
         return select_menu

--- a/src/sentry/integrations/discord/message_builder/base/embed/__init__.py
+++ b/src/sentry/integrations/discord/message_builder/base/embed/__init__.py
@@ -1,4 +1,0 @@
-from .base import *  # noqa: F401,F403
-from .field import *  # noqa: F401,F403
-from .footer import *  # noqa: F401,F403
-from .image import *  # noqa: F401,F403

--- a/src/sentry/integrations/discord/message_builder/base/embed/base.py
+++ b/src/sentry/integrations/discord/message_builder/base/embed/base.py
@@ -2,10 +2,31 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import datetime
+from typing import NotRequired, TypedDict
 
-from sentry.integrations.discord.message_builder.base.embed.field import DiscordMessageEmbedField
-from sentry.integrations.discord.message_builder.base.embed.footer import DiscordMessageEmbedFooter
-from sentry.integrations.discord.message_builder.base.embed.image import DiscordMessageEmbedImage
+from sentry.integrations.discord.message_builder.base.embed.field import (
+    DiscordMessageEmbedField,
+    DiscordMessageEmbedFieldDict,
+)
+from sentry.integrations.discord.message_builder.base.embed.footer import (
+    DiscordMessageEmbedFooter,
+    DiscordMessageEmbedFooterDict,
+)
+from sentry.integrations.discord.message_builder.base.embed.image import (
+    DiscordMessageEmbedImage,
+    DiscordMessageEmbedImageDict,
+)
+
+
+class DiscordMessageEmbedDict(TypedDict):
+    title: NotRequired[str]
+    description: NotRequired[str]
+    url: NotRequired[str]
+    color: NotRequired[int]
+    footer: NotRequired[DiscordMessageEmbedFooterDict]
+    fields: NotRequired[Iterable[DiscordMessageEmbedFieldDict]]
+    timestamp: NotRequired[str]
+    image: NotRequired[DiscordMessageEmbedImageDict]
 
 
 class DiscordMessageEmbed:
@@ -37,19 +58,23 @@ class DiscordMessageEmbed:
         self.timestamp = timestamp
         self.image = image
 
-    def build(self) -> dict[str, object]:
-        attributes = vars(self).items()
-        embed = {k: v for k, v in attributes if v is not None}
+    def build(self) -> DiscordMessageEmbedDict:
+        embed: DiscordMessageEmbedDict = {}
 
+        if self.title is not None:
+            embed["title"] = self.title
+        if self.description is not None:
+            embed["description"] = self.description
+        if self.url is not None:
+            embed["url"] = self.url
+        if self.color is not None:
+            embed["color"] = self.color
         if self.footer is not None:
             embed["footer"] = self.footer.build()
-
         if self.fields is not None:
             embed["fields"] = [field.build() for field in self.fields]
-
         if self.timestamp is not None:
             embed["timestamp"] = self.timestamp.isoformat()
-
         if self.image is not None:
             embed["image"] = self.image.build()
 

--- a/src/sentry/integrations/discord/message_builder/base/embed/field.py
+++ b/src/sentry/integrations/discord/message_builder/base/embed/field.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+from typing import TypedDict
+
+
+class DiscordMessageEmbedFieldDict(TypedDict):
+    name: str
+    value: str
+    inline: bool
+
 
 class DiscordMessageEmbedField:
     def __init__(self, name: str, value: str, inline: bool = False) -> None:
@@ -7,6 +15,8 @@ class DiscordMessageEmbedField:
         self.value = value
         self.inline = inline
 
-    def build(self) -> dict[str, str]:
-        attributes = vars(self).items()
-        return {k: v for k, v in attributes if v is not None}
+    def build(self) -> DiscordMessageEmbedFieldDict:
+        embed_field = DiscordMessageEmbedFieldDict(
+            name=self.name, value=self.value, inline=self.inline
+        )
+        return embed_field

--- a/src/sentry/integrations/discord/message_builder/base/embed/footer.py
+++ b/src/sentry/integrations/discord/message_builder/base/embed/footer.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+from typing import NotRequired, TypedDict
+
+
+class DiscordMessageEmbedFooterDict(TypedDict):
+    text: str
+    icon_url: NotRequired[str]
+    proxy_icon_url: NotRequired[str]
+
 
 class DiscordMessageEmbedFooter:
     def __init__(
@@ -9,6 +17,12 @@ class DiscordMessageEmbedFooter:
         self.icon_url = icon_url
         self.proxy_icon_url = proxy_icon_url
 
-    def build(self) -> dict[str, str]:
-        attributes = vars(self).items()
-        return {k: v for k, v in attributes if v}
+    def build(self) -> DiscordMessageEmbedFooterDict:
+        embed_footer = DiscordMessageEmbedFooterDict(text=self.text)
+
+        if self.icon_url is not None:
+            embed_footer["icon_url"] = self.icon_url
+        if self.proxy_icon_url is not None:
+            embed_footer["proxy_icon_url"] = self.proxy_icon_url
+
+        return embed_footer

--- a/src/sentry/integrations/discord/message_builder/base/embed/image.py
+++ b/src/sentry/integrations/discord/message_builder/base/embed/image.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+from typing import NotRequired, TypedDict
+
+
+class DiscordMessageEmbedImageDict(TypedDict):
+    url: str
+    proxy_url: NotRequired[str]
+    height: NotRequired[int]
+    width: NotRequired[int]
+
 
 class DiscordMessageEmbedImage:
     def __init__(
@@ -14,6 +23,14 @@ class DiscordMessageEmbedImage:
         self.height = height
         self.width = width
 
-    def build(self) -> dict[str, str]:
-        attributes = vars(self).items()
-        return {k: v for k, v in attributes if v}
+    def build(self) -> DiscordMessageEmbedImageDict:
+        embed_image = DiscordMessageEmbedImageDict(url=self.url)
+
+        if self.proxy_url is not None:
+            embed_image["proxy_url"] = self.proxy_url
+        if self.height is not None:
+            embed_image["height"] = self.height
+        if self.width is not None:
+            embed_image["width"] = self.width
+
+        return embed_image

--- a/src/sentry/integrations/discord/message_builder/issues.py
+++ b/src/sentry/integrations/discord/message_builder/issues.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from sentry import features, tagstore
 from sentry.integrations.discord.message_builder import LEVEL_TO_COLOR
-from sentry.integrations.discord.message_builder.base.base import DiscordMessageBuilder
+from sentry.integrations.discord.message_builder.base.base import (
+    DiscordMessage,
+    DiscordMessageBuilder,
+)
 from sentry.integrations.discord.message_builder.base.component.action_row import DiscordActionRow
 from sentry.integrations.discord.message_builder.base.component.base import DiscordMessageComponent
 from sentry.integrations.discord.message_builder.base.component.button import DiscordButton
@@ -48,7 +51,7 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
         self.issue_details = issue_details
         self.notification = notification
 
-    def build(self, notification_uuid: str | None = None) -> dict[str, object]:
+    def build(self, notification_uuid: str | None = None) -> DiscordMessage:
         project = Project.objects.get_from_cache(id=self.group.project_id)
         event_for_tags = self.event or self.group.get_latest_event()
         timestamp = (

--- a/src/sentry/integrations/discord/message_builder/metric_alerts.py
+++ b/src/sentry/integrations/discord/message_builder/metric_alerts.py
@@ -5,7 +5,10 @@ from datetime import datetime
 
 from sentry.incidents.typings.metric_detector import AlertContext, MetricIssueContext
 from sentry.integrations.discord.message_builder import INCIDENT_COLOR_MAPPING, LEVEL_TO_COLOR
-from sentry.integrations.discord.message_builder.base.base import DiscordMessageBuilder
+from sentry.integrations.discord.message_builder.base.base import (
+    DiscordMessage,
+    DiscordMessageBuilder,
+)
 from sentry.integrations.discord.message_builder.base.embed.base import DiscordMessageEmbed
 from sentry.integrations.discord.message_builder.base.embed.image import DiscordMessageEmbedImage
 from sentry.integrations.metric_alerts import incident_attachment_info
@@ -27,7 +30,7 @@ class DiscordMetricAlertMessageBuilder(DiscordMessageBuilder):
         self.date_started = date_started
         self.chart_url = chart_url
 
-    def build(self, notification_uuid: str | None = None) -> dict[str, object]:
+    def build(self, notification_uuid: str | None = None) -> DiscordMessage:
         data = incident_attachment_info(
             organization=self.organization,
             alert_context=self.alert_context,

--- a/tests/sentry/rules/processing/test_processor.py
+++ b/tests/sentry/rules/processing/test_processor.py
@@ -1043,7 +1043,7 @@ class RuleProcessorTestFilters(TestCase):
             in mock_post.call_args[1]["data"]["attachments"][0]["content"]["body"][0]["text"]
         )
 
-    @patch("sentry.integrations.discord.message_builder.base.DiscordMessageBuilder._build")
+    @patch("sentry.integrations.discord.message_builder.base.base.DiscordMessageBuilder._build")
     def test_discord_title_link_notification_uuid(self, mock_build: MagicMock) -> None:
         integration = self.create_integration(
             organization=self.organization,


### PR DESCRIPTION
part of notification platform ([ECO-616](https://linear.app/getsentry/issue/ECO-616/add-discord-notificationprovider))

For the Discord provider renderer, we don't use any Discord sdk or library for typing. As a result, there is no definitions to steal and use for our own purposes like Slack. 

As a result, I've decided to re-purpose our current Discord component definitions and make the dictionary definitions more concrete (i.e remove all `dict[str,object]`).  

I've also removed some unnecessary `__init__` files which were causing circular imports