### PR TITLE
ref(grouping): More small refactors of grouping snapshot tests

### DIFF
--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -88,7 +88,13 @@ class GroupingInput:
         event_metadata = event_type.get_metadata(data)
         data.update(materialize_metadata(data, event_type, event_metadata))
 
-        return eventstore.backend.create_event(project_id=1, data=data)
+        event = eventstore.backend.create_event(project_id=1, data=data)
+        # Assigning the project after the fact also populates the cache, so that calls to
+        # `event.project` don't fail. (If the `event.project` getter can't pull the project from the
+        # cache it'll look in the database, but since this isn't a real project, that errors out.)
+        event.project = mock.Mock(id=11211231)
+
+        return event
 
     def _save_event_with_pipeline(
         self,

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from sentry.grouping.component import DefaultGroupingComponent, MessageGroupingComponent
 from sentry.grouping.ingest.grouphash_metadata import (
@@ -29,8 +29,6 @@ from tests.sentry.grouping import (
     with_grouping_configs,
     with_grouping_inputs,
 )
-
-dummy_project = Mock(id=11211231)
 
 
 @django_db_all

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -92,18 +92,16 @@ def test_unknown_hash_basis(
         config_name, use_full_ingest_pipeline=True, project=default_project
     )
 
-    # Overwrite the component ids so this stops being recognizable as a known grouping type
+    # Overwrite the component ids and create fake variants so this stops being recognizable as a
+    # known grouping type
     component = DefaultGroupingComponent(
         contributes=True, values=[MessageGroupingComponent(contributes=True)]
     )
     component.id = "not_a_known_component_type"
     component.values[0].id = "dogs_are_great"
+    variants = {"dogs": ComponentVariant(component, None, StrategyConfiguration())}
 
-    with patch.object(
-        event,
-        "get_grouping_variants",
-        return_value={"dogs": ComponentVariant(component, None, StrategyConfiguration())},
-    ):
+    with patch.object(event, "get_grouping_variants", return_value=variants):
         # Overrride the input filename since there isn't a real input which will generate the
         # unknown mock variants, but we still want to create a snapshot as if there were
         _assert_and_snapshot_results(event, config_name, "unknown_variant.json", insta_snapshot)

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -51,10 +51,6 @@ def test_variants_with_manual_save(
     environment, this is used for the default confing, too.
     """
     event = grouping_input.create_event(config_name, use_full_ingest_pipeline=False)
-
-    # This ensures we won't try to touch the DB when getting event variants
-    event.project = dummy_project
-
     _assert_and_snapshot_results(event, config_name, grouping_input.filename, insta_snapshot)
 
 

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -116,12 +116,11 @@ def _assert_and_snapshot_results(
     config_name: str,
     input_file: str,
     insta_snapshot: InstaSnapshotter,
-    project: Project = dummy_project,
 ) -> None:
     lines: list[str] = []
     variants = event.get_grouping_variants()
 
-    metadata = get_grouphash_metadata_data(event, project, variants, config_name)
+    metadata = get_grouphash_metadata_data(event, event.project, variants, config_name)
     hash_basis = metadata["hash_basis"]
     hashing_metadata = metadata["hashing_metadata"]
 

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import cast
-from unittest import mock
 from unittest.mock import MagicMock, patch
 
 from sentry.grouping.fingerprinting.rules import FingerprintRuleJSON
@@ -40,10 +39,6 @@ def test_variants_with_manual_save(
     environment, this is used for the default confing, too.
     """
     event = grouping_input.create_event(config_name, use_full_ingest_pipeline=False)
-
-    # This ensures we won't try to touch the DB when getting event variants
-    event.project = mock.Mock(id=11211231)
-
     _assert_and_snapshot_results(
         event, config_name, grouping_input.filename, insta_snapshot, mock_exception_logger
     )

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -4,7 +4,7 @@ from typing import cast
 from unittest.mock import MagicMock, patch
 
 from sentry.grouping.fingerprinting.rules import FingerprintRuleJSON
-from sentry.grouping.variants import CustomFingerprintVariant, expose_fingerprint_dict
+from sentry.grouping.variants import BaseVariant, CustomFingerprintVariant, expose_fingerprint_dict
 from sentry.models.project import Project
 from sentry.services.eventstore.models import Event
 from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all
@@ -39,8 +39,9 @@ def test_variants_with_manual_save(
     environment, this is used for the default confing, too.
     """
     event = grouping_input.create_event(config_name, use_full_ingest_pipeline=False)
+    variants = event.get_grouping_variants()
     _assert_and_snapshot_results(
-        event, config_name, grouping_input.filename, insta_snapshot, mock_exception_logger
+        event, variants, config_name, grouping_input.filename, insta_snapshot, mock_exception_logger
     )
 
 
@@ -68,21 +69,21 @@ def test_variants_with_full_pipeline(
     event = grouping_input.create_event(
         config_name, use_full_ingest_pipeline=True, project=default_project
     )
+    variants = event.get_grouping_variants()
 
     _assert_and_snapshot_results(
-        event, config_name, grouping_input.filename, insta_snapshot, mock_exception_logger
+        event, variants, config_name, grouping_input.filename, insta_snapshot, mock_exception_logger
     )
 
 
 def _assert_and_snapshot_results(
     event: Event,
+    variants: dict[str, BaseVariant],
     config_name: str,
     input_file: str,
     insta_snapshot: InstaSnapshotter,
     mock_exception_logger: MagicMock,
 ) -> None:
-    grouping_variants = event.get_grouping_variants()
-
     # Make sure the event was annotated with the grouping config
     assert event.get_grouping_config()["id"] == config_name
 
@@ -91,7 +92,7 @@ def _assert_and_snapshot_results(
 
     lines: list[str] = []
 
-    for variant_name, variant in sorted(grouping_variants.items()):
+    for variant_name, variant in sorted(variants.items()):
         if lines:
             lines.append("-" * 74)
         lines.append("%s:" % variant_name)


### PR DESCRIPTION
This a follow-up to https://github.com/getsentry/sentry/pull/99172 and is another small refactor of grouping input snapshot tests. (It was split out from https://github.com/getsentry/sentry/pull/99172 in order to make them both easier to review.)

- For events created with the manual save process, set the `project` value when we create the event rather than setting it in multiple tests. Also, in the grouphash metadata tests, pull the project from the event rather than passing it directly to `_assert_and_snapshot_results`.

- Conversely, calculate the variants in the tests themselves and pass them to `_assert_and_snapshot_results` rather than calculating them in the helper. (This will turn out to be useful in an upcoming PR.)