### PR TITLE
ref(grouping): Consolidate snapshot test logic into decorator

### DIFF
--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -1,88 +1,24 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from sentry.grouping.fingerprinting.rules import FingerprintRuleJSON
 from sentry.grouping.variants import BaseVariant, CustomFingerprintVariant, expose_fingerprint_dict
-from sentry.models.project import Project
 from sentry.services.eventstore.models import Event
 from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all
-from tests.sentry.grouping import (
-    FULL_PIPELINE_CONFIGS,
-    GROUPING_INPUTS_DIR,
-    MANUAL_SAVE_CONFIGS,
-    GroupingInput,
-    dump_variant,
-    get_snapshot_path,
-    with_grouping_configs,
-    with_grouping_inputs,
-)
+from tests.sentry.grouping import dump_variant, run_as_grouping_inputs_snapshot_test
 
 
-@django_db_all
-@with_grouping_inputs("grouping_input", GROUPING_INPUTS_DIR)
-@with_grouping_configs(MANUAL_SAVE_CONFIGS)
+@run_as_grouping_inputs_snapshot_test
 @patch("sentry.grouping.strategies.newstyle.logging.exception")
-def test_variants_with_manual_save(
+def test_variants(
     mock_exception_logger: MagicMock,
-    config_name: str,
-    grouping_input: GroupingInput,
-    insta_snapshot: InstaSnapshotter,
-) -> None:
-    """
-    Run the variant snapshot tests using a minimal (and much more performant) save process.
-
-    Because manually cherry-picking only certain parts of the save process to run makes us much more
-    likely to fall out of sync with reality, when we're in CI, for safety we only do this when
-    testing older grouping configs. Locally, if `SENTRY_FAST_GROUPING_SNAPSHOTS` is set in the
-    environment, this is used for the default confing, too.
-    """
-    event = grouping_input.create_event(config_name, use_full_ingest_pipeline=False)
-    variants = event.get_grouping_variants()
-    _assert_and_snapshot_results(
-        event, variants, config_name, grouping_input.filename, insta_snapshot, mock_exception_logger
-    )
-
-
-@django_db_all
-@with_grouping_inputs("grouping_input", GROUPING_INPUTS_DIR)
-@with_grouping_configs(FULL_PIPELINE_CONFIGS)
-@patch("sentry.grouping.strategies.newstyle.logging.exception")
-def test_variants_with_full_pipeline(
-    mock_exception_logger: MagicMock,
-    config_name: str,
-    grouping_input: GroupingInput,
-    insta_snapshot: InstaSnapshotter,
-    default_project: Project,
-) -> None:
-    """
-    Run the variant snapshot tests using the full `EventManager.save` process.
-
-    This is the most realistic way to test, but it's also slow, because it requires the overhead of
-    set-up/tear-down/general interaction with our full postgres database. We therefore only do it
-    when testing the current grouping config in CI, and rely on a much faster manual test (above)
-    when testing previous grouping configs. (When testing locally, the faster test can be used for
-    the default config as well if `SENTRY_FAST_GROUPING_SNAPSHOTS` is set in the environment.)
-    """
-
-    event = grouping_input.create_event(
-        config_name, use_full_ingest_pipeline=True, project=default_project
-    )
-    variants = event.get_grouping_variants()
-
-    _assert_and_snapshot_results(
-        event, variants, config_name, grouping_input.filename, insta_snapshot, mock_exception_logger
-    )
-
-
-def _assert_and_snapshot_results(
     event: Event,
     variants: dict[str, BaseVariant],
     config_name: str,
-    input_file: str,
-    insta_snapshot: InstaSnapshotter,
-    mock_exception_logger: MagicMock,
+    create_snapshot: InstaSnapshotter,
+    **kwargs: Any,
 ) -> None:
     # Make sure the event was annotated with the grouping config
     assert event.get_grouping_config()["id"] == config_name
@@ -99,12 +35,7 @@ def _assert_and_snapshot_results(
         dump_variant(variant, lines, 1)
     output = "\n".join(lines)
 
-    insta_snapshot(
-        output,
-        # Manually set the snapshot path so that both of the tests above will file their snapshots
-        # in the same spot
-        reference_file=get_snapshot_path(__file__, input_file, "test_variants", config_name),
-    )
+    create_snapshot(output)
 
 
 @django_db_all


### PR DESCRIPTION
We currently run the grouping snapshot tests two different ways - a slower, safer way for the default grouping config, and a faster, marginally less safe way for older grouping configs. There's a lot of overlap between the respective tests, and that overlap is doubled because we do the same thing in both `test_variants.py` and `test_grouphash_metadata.py`. Further, each test needs a fair amount of overhead/setup.

We now want to add snapshot tests for grouping info. Rather than end up with six copies of all that machinery, this PR consolidates each test pair's logic into one, and pulls all of the setup and much of what each test was doing into a decorator. It then switches both the variants and grouphash metadata tests to using it. (The fact that no snapshots change shows that the new version is equivalent to the old.)

To make things easier to review, the new grouping info snapshot tests (and the corresponding snapshots) are added in a separate PR. For a sense of scale, though, note that in that PR the added test is 5 lines of code, whereas doing it the old way would have taken 74 lines.