### PR TITLE
chore(comparative workflows): Update cohort selection

### DIFF
--- a/static/app/views/explore/hooks/useSuspectAttributes.tsx
+++ b/static/app/views/explore/hooks/useSuspectAttributes.tsx
@@ -43,7 +43,6 @@ function useSuspectAttributes({
   const enableQuery = boxSelectOptions.boxCoordRange !== null;
   const {
     x: [x1, x2],
-    y: [y1, y2],
   } = boxSelectOptions.boxCoordRange!;
 
   // Ensure that we pass the existing queries in the search bar to the suspect attributes queries
@@ -65,39 +64,9 @@ function useSuspectAttributes({
   const plottedFunctionName = parsedFunction?.name;
   const plottedFunctionParameter = parsedFunction?.arguments[0];
 
-  const useYAxisCoords = plottedFunctionName !== 'count' && plottedFunctionParameter;
-
   // Add the selected region by x-axis to the query, timestamp: [x1, x2]
   selectedRegionQuery.addFilterValue(FieldKey.TIMESTAMP, `>=${formattedStartTimestamp}`);
   selectedRegionQuery.addFilterValue(FieldKey.TIMESTAMP, `<=${formattedEndTimestamp}`);
-
-  // If selected region query is 'timestamp >= x0 and timestamp <= x1 and span.duration >= y0 and span.duration <= y1',
-  // then the baseline region query should be '((timestamp < x0 or timestamp > x1) or (span.duration < y0 or span.duration > y1))'.
-  // This is only required if the y-axis aggregate is not count.
-  if (useYAxisCoords) {
-    baselineRegionQuery.addOp('(');
-  }
-
-  // Add the baseline region by x-axis to the query, timestamp: <x1 or timestamp:>x2
-  baselineRegionQuery.addDisjunctionFilterValues(FieldKey.TIMESTAMP, [
-    `<${formattedStartTimestamp}`,
-    `>${formattedEndTimestamp}`,
-  ]);
-
-  // If the y-axis aggregate is not count, we add the field that has been aggregated on, to the queries to complete the boxed region.
-  // For example, if the y-axis is avg(span.duration), we add span.duration: [y1, y2] to query in the selected region
-  // and span.duration: <y1 or span.duration:>y2 to the baseline query.
-  if (useYAxisCoords) {
-    selectedRegionQuery.addFilterValue(plottedFunctionParameter, `>=${y1}`);
-    selectedRegionQuery.addFilterValue(plottedFunctionParameter, `<=${y2}`);
-
-    baselineRegionQuery.addOp('OR');
-    baselineRegionQuery.addDisjunctionFilterValues(plottedFunctionParameter, [
-      `<${y1}`,
-      `>${y2}`,
-    ]);
-    baselineRegionQuery.addOp(')');
-  }
 
   const query1 = selectedRegionQuery.formatString();
   const query2 = baselineRegionQuery.formatString();
@@ -108,9 +77,18 @@ function useSuspectAttributes({
       query_1: query1,
       query_2: query2,
       dataset,
+      function_name: plottedFunctionName,
+      function_parameter: plottedFunctionParameter,
       sampling: SAMPLING_MODE.NORMAL,
     };
-  }, [query1, query2, pageFilters, dataset]);
+  }, [
+    query1,
+    query2,
+    pageFilters,
+    dataset,
+    plottedFunctionName,
+    plottedFunctionParameter,
+  ]);
 
   return useApiQuery<SuspectAttributesResult>(
     [

--- a/static/app/views/explore/hooks/useSuspectAttributes.tsx
+++ b/static/app/views/explore/hooks/useSuspectAttributes.tsx
@@ -2,7 +2,6 @@ import {useMemo} from 'react';
 
 import {pageFiltersToQueryParams} from 'sentry/components/organizations/pageFilters/parse';
 import {getUtcDateString} from 'sentry/utils/dates';
-import {parseFunction} from 'sentry/utils/discover/fields';
 import {FieldKey} from 'sentry/utils/fields';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -60,10 +59,6 @@ function useSuspectAttributes({
   const formattedStartTimestamp = getUtcDateString(startTimestamp);
   const formattedEndTimestamp = getUtcDateString(endTimestamp);
 
-  const parsedFunction = parseFunction(chartInfo.yAxis);
-  const plottedFunctionName = parsedFunction?.name;
-  const plottedFunctionParameter = parsedFunction?.arguments[0];
-
   // Add the selected region by x-axis to the query, timestamp: [x1, x2]
   selectedRegionQuery.addFilterValue(FieldKey.TIMESTAMP, `>=${formattedStartTimestamp}`);
   selectedRegionQuery.addFilterValue(FieldKey.TIMESTAMP, `<=${formattedEndTimestamp}`);
@@ -77,18 +72,11 @@ function useSuspectAttributes({
       query_1: query1,
       query_2: query2,
       dataset,
-      function_name: plottedFunctionName,
-      function_parameter: plottedFunctionParameter,
+      function: chartInfo.yAxis,
+      above: 1,
       sampling: SAMPLING_MODE.NORMAL,
     };
-  }, [
-    query1,
-    query2,
-    pageFilters,
-    dataset,
-    plottedFunctionName,
-    plottedFunctionParameter,
-  ]);
+  }, [query1, query2, pageFilters, dataset, chartInfo.yAxis]);
 
   return useApiQuery<SuspectAttributesResult>(
     [


### PR DESCRIPTION
- Disable segmenting the cohort by y-axis
- Remove segmenting by `timestamp` on baseline while preserving user submitted query from search
- Only segment by `timestamp` on suspect while preserving user submitted query from search
- Pass along a few more parameters to the BE
  - `plottedFunctionName` and `plottedFunctionParameter` to allow for segmenting cohorts by numerical values
  
Specifically, we want the sus cohort to be all spans within the selected time range (x-axis from the user's selection) AND values above/below the function of the selection. The baseline will then be all the other points (total - sus)
  
BE PR to update the cohorts: https://github.com/getsentry/sentry/pull/99189

Ideally, should not actually have the selection tool be a box that can adjust the y-axis but just the default which only can highlight over the x-axis. Can include that as a followup.