### PR TITLE
ref(feedback): improve summary test coverage (>4x speedup)

### DIFF
--- a/tests/sentry/feedback/__init__.py
+++ b/tests/sentry/feedback/__init__.py
@@ -34,7 +34,9 @@ def create_dummy_openai_response(*args: object, **kwargs: Any) -> ChatCompletion
     )
 
 
-def mock_feedback_event(project_id: int, dt: datetime | None = None) -> dict[str, Any]:
+def mock_feedback_event(
+    project_id: int, dt: datetime | None = None, message: str | None = None
+) -> dict[str, Any]:
     if dt is None:
         dt = datetime.now(UTC)
 
@@ -63,7 +65,7 @@ def mock_feedback_event(project_id: int, dt: datetime | None = None) -> dict[str
             "feedback": {
                 "contact_email": "josh.ferge@sentry.io",
                 "name": "Josh Ferge",
-                "message": "Testing!!",
+                "message": message or "Testing!!",
                 "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
                 "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
             },

--- a/tests/sentry/feedback/endpoints/test_organization_feedback_summary.py
+++ b/tests/sentry/feedback/endpoints/test_organization_feedback_summary.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from sentry.feedback.endpoints.organization_feedback_summary import get_summary_from_seer
 from sentry.feedback.lib.utils import FeedbackCreationSource
 from sentry.feedback.usecases.ingest.create_feedback import create_feedback_issue
+from sentry.models.project import Project
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
@@ -75,11 +76,11 @@ class OrganizationFeedbackSummaryTest(APITestCase):
         )
         self.mock_min_feedbacks_patcher = patch(
             "sentry.feedback.endpoints.organization_feedback_summary.MIN_FEEDBACKS_TO_SUMMARIZE",
-            10,
+            1,
         )
         self.mock_has_seer_access = self.mock_has_seer_access_patcher.start()
         self.mock_get_summary_from_seer = self.mock_get_summary_from_seer_patcher.start()
-        self.mock_min_feedbacks = self.mock_min_feedbacks_patcher.start()
+        self.mock_min_feedbacks_patcher.start()
 
     def tearDown(self) -> None:
         self.mock_has_seer_access_patcher.stop()
@@ -87,11 +88,9 @@ class OrganizationFeedbackSummaryTest(APITestCase):
         self.mock_min_feedbacks_patcher.stop()
         super().tearDown()
 
-    def _make_valid_seer_response(self) -> MockSeerResponse:
-        return MockSeerResponse(
-            200,
-            json_data={"data": "Test summary of feedback"},
-        )
+    def save_feedback(self, project: Project, message: str, dt: datetime | None = None) -> None:
+        event = mock_feedback_event(project.id, message=message, dt=dt)
+        create_feedback_issue(event, project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
     def test_get_feedback_summary_without_feature_flag(self) -> None:
         response = self.get_error_response(self.org.slug)
@@ -103,171 +102,31 @@ class OrganizationFeedbackSummaryTest(APITestCase):
             response = self.get_error_response(self.org.slug)
             assert response.status_code == 403
 
-    def test_get_feedback_summary_basic(self) -> None:
-        for _ in range(15):
-            event = mock_feedback_event(self.project1.id)
-            create_feedback_issue(
-                event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
+    @patch("sentry.feedback.endpoints.organization_feedback_summary.cache")
+    def test_get_feedback_summary_cache_miss(self, mock_cache: MagicMock) -> None:
+        mock_cache.get.return_value = None
+        self.save_feedback(self.project1, "hello")
 
         with self.feature(self.features):
             response = self.get_success_response(self.org.slug)
 
         assert response.data["success"] is True
         assert response.data["summary"] == "Test summary of feedback"
-        assert response.data["numFeedbacksUsed"] == 15
-
-    def test_get_feedback_summary_with_date_filter(self) -> None:
-        # 12 feedbacks that are created immediately
-        for _ in range(12):
-            event = mock_feedback_event(self.project1.id)
-            create_feedback_issue(
-                event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
-
-        # 8 feedbacks that were created ~21 days ago, which will not be included in the summary
-        for _ in range(8):
-            event = mock_feedback_event(self.project1.id, dt=datetime.now(UTC) - timedelta(days=21))
-            create_feedback_issue(
-                event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
-
-        params = {
-            "statsPeriod": "14d",
+        assert response.data["numFeedbacksUsed"] == 1
+        assert self.mock_get_summary_from_seer.call_count == 1
+        assert self.mock_get_summary_from_seer.call_args[0][0] == ["hello"]
+        mock_cache.set.assert_called_once()
+        assert mock_cache.set.call_args[0][1] == {
+            "summary": "Test summary of feedback",
+            "numFeedbacksUsed": 1,
         }
-
-        with self.feature(self.features):
-            response = self.get_success_response(self.org.slug, **params)
-
-        assert response.data["success"] is True
-        assert response.data["summary"] == "Test summary of feedback"
-        assert response.data["numFeedbacksUsed"] == 12
-
-    def test_get_feedback_summary_with_project_filter(self) -> None:
-        for _ in range(10):
-            event = mock_feedback_event(self.project1.id)
-            create_feedback_issue(
-                event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
-
-        for _ in range(12):
-            event = mock_feedback_event(self.project2.id)
-            create_feedback_issue(
-                event, self.project2, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
-
-        params = {
-            "project": [self.project1.id],
-        }
-
-        with self.feature(self.features):
-            response = self.get_success_response(self.org.slug, **params)
-
-        assert response.data["success"] is True
-        assert response.data["summary"] == "Test summary of feedback"
-        assert response.data["numFeedbacksUsed"] == 10
-
-    def test_get_feedback_summary_with_many_project_filter_as_list(self) -> None:
-        for _ in range(10):
-            event = mock_feedback_event(self.project1.id)
-            create_feedback_issue(
-                event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
-
-        for _ in range(12):
-            event = mock_feedback_event(self.project2.id)
-            create_feedback_issue(
-                event, self.project2, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
-
-        params = {
-            "project": [self.project1.id, self.project2.id],
-        }
-
-        with self.feature(self.features):
-            response = self.get_success_response(self.org.slug, **params)
-
-        assert response.data["success"] is True
-        assert response.data["summary"] == "Test summary of feedback"
-        assert response.data["numFeedbacksUsed"] == 22
-
-    def test_get_feedback_summary_with_many_project_filter_separate(self) -> None:
-        for _ in range(10):
-            event = mock_feedback_event(self.project1.id)
-            create_feedback_issue(
-                event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
-
-        for _ in range(12):
-            event = mock_feedback_event(self.project2.id)
-            create_feedback_issue(
-                event, self.project2, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
-
-        with self.feature(self.features):
-            response = self.client.get(
-                f"{self.url}?project={self.project1.id}&project={self.project2.id}"
-            )
-
-        assert response.status_code == 200
-        assert response.data["success"] is True
-        assert response.data["summary"] == "Test summary of feedback"
-        assert response.data["numFeedbacksUsed"] == 22
-
-    def test_get_feedback_summary_too_few_feedbacks(self) -> None:
-        for _ in range(9):
-            event = mock_feedback_event(self.project2.id)
-            create_feedback_issue(
-                event, self.project2, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
-
-        with self.feature(self.features):
-            response = self.get_success_response(self.org.slug)
-
-        assert response.data["success"] is False
-
-    @patch(
-        "sentry.feedback.endpoints.organization_feedback_summary.MAX_FEEDBACKS_TO_SUMMARIZE_CHARS",
-        1000,
-    )
-    def test_get_feedback_summary_character_limit(self) -> None:
-        # Create 9 older feedbacks with normal size, skipped due to the middle one exceeding the character limit
-        for _ in range(9):
-            event = mock_feedback_event(self.project1.id, dt=datetime.now(UTC) - timedelta(hours=3))
-            create_feedback_issue(
-                event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
-
-        event = mock_feedback_event(self.project1.id, dt=datetime.now(UTC) - timedelta(hours=2))
-        event["contexts"]["feedback"]["message"] = "a" * 2000
-        create_feedback_issue(event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
-
-        for _ in range(12):
-            event = mock_feedback_event(self.project1.id, dt=datetime.now(UTC) - timedelta(hours=1))
-            create_feedback_issue(
-                event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
-
-        with self.feature(self.features):
-            response = self.get_success_response(self.org.slug)
-
-        assert response.data["success"] is True
-        assert response.data["summary"] == "Test summary of feedback"
-        assert response.data["numFeedbacksUsed"] == 12
 
     @patch("sentry.feedback.endpoints.organization_feedback_summary.cache")
     def test_get_feedback_summary_cache_hit(self, mock_cache: MagicMock) -> None:
-
         mock_cache.get.return_value = {
             "summary": "Test cached summary of feedback",
             "numFeedbacksUsed": 13,
         }
-
-        for _ in range(15):
-            event = mock_feedback_event(self.project1.id)
-            create_feedback_issue(
-                event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
 
         with self.feature(self.features):
             response = self.get_success_response(self.org.slug)
@@ -279,33 +138,95 @@ class OrganizationFeedbackSummaryTest(APITestCase):
         mock_cache.get.assert_called_once()
         mock_cache.set.assert_not_called()
 
-    @patch("sentry.feedback.endpoints.organization_feedback_summary.cache")
-    def test_get_feedback_summary_cache_miss(self, mock_cache: MagicMock) -> None:
-        mock_cache.get.return_value = None
+    def test_get_feedback_summary_with_date_filter(self) -> None:
+        # Created immediately
+        self.save_feedback(self.project1, "New feedback")
 
-        for _ in range(15):
-            event = mock_feedback_event(self.project1.id)
-            create_feedback_issue(
-                event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+        # Created ~21 days ago - will not be included in the summary
+        self.save_feedback(self.project1, "Old feedback", dt=datetime.now(UTC) - timedelta(days=21))
+
+        with self.feature(self.features):
+            response = self.get_success_response(self.org.slug, statsPeriod="14d")
+
+        assert response.data["success"] is True
+        assert response.data["summary"] == "Test summary of feedback"
+        assert response.data["numFeedbacksUsed"] == 1
+        assert self.mock_get_summary_from_seer.call_count == 1
+        assert self.mock_get_summary_from_seer.call_args[0][0] == ["New feedback"]
+
+    @patch("sentry.feedback.endpoints.organization_feedback_summary.cache")
+    def test_get_feedback_summary_project_filter(self, mock_cache: MagicMock) -> None:
+        mock_cache.get.return_value = None
+        self.save_feedback(self.project1, "Project 1 feedback")
+
+        # Created ~21 days ago - will not be included in the summary
+        self.save_feedback(self.project2, "Project 2 feedback")
+
+        with self.feature(self.features):
+            response = self.get_success_response(self.org.slug, project=[self.project1.id])
+
+        assert response.data["success"] is True
+        assert response.data["summary"] == "Test summary of feedback"
+        assert response.data["numFeedbacksUsed"] == 1
+        assert self.mock_get_summary_from_seer.call_count == 1
+        assert set(self.mock_get_summary_from_seer.call_args[0][0]) == {"Project 1 feedback"}
+
+        with self.feature(self.features):
+            response = self.get_success_response(
+                self.org.slug, project=[self.project1.id, self.project2.id]
             )
+
+        assert response.data["success"] is True
+        assert response.data["summary"] == "Test summary of feedback"
+        assert response.data["numFeedbacksUsed"] == 2
+        assert self.mock_get_summary_from_seer.call_count == 2
+        assert set(self.mock_get_summary_from_seer.call_args[0][0]) == {
+            "Project 1 feedback",
+            "Project 2 feedback",
+        }
+
+        with self.feature(self.features):
+            response = self.client.get(
+                f"{self.url}?project={self.project1.id}&project={self.project2.id}"
+            )
+
+        assert response.data["success"] is True
+        assert response.data["summary"] == "Test summary of feedback"
+        assert response.data["numFeedbacksUsed"] == 2
+        assert self.mock_get_summary_from_seer.call_count == 3
+        assert set(self.mock_get_summary_from_seer.call_args[0][0]) == {
+            "Project 1 feedback",
+            "Project 2 feedback",
+        }
+
+    def test_get_feedback_summary_too_few_feedbacks(self) -> None:
+        with self.feature(self.features):
+            response = self.get_success_response(self.org.slug)
+
+        assert response.data["success"] is False
+
+    @patch(
+        "sentry.feedback.endpoints.organization_feedback_summary.MAX_FEEDBACKS_TO_SUMMARIZE_CHARS",
+        1,
+    )
+    def test_get_feedback_summary_character_limit(self) -> None:
+        self.save_feedback(self.project1, "a", dt=datetime.now(UTC) - timedelta(hours=3))
+        self.save_feedback(self.project1, "b", dt=datetime.now(UTC) - timedelta(hours=2))
+        self.save_feedback(self.project1, "c", dt=datetime.now(UTC) - timedelta(hours=1))
 
         with self.feature(self.features):
             response = self.get_success_response(self.org.slug)
 
         assert response.data["success"] is True
         assert response.data["summary"] == "Test summary of feedback"
-        assert response.data["numFeedbacksUsed"] == 15
-        mock_cache.get.assert_called_once()
-        mock_cache.set.assert_called_once()
+        assert response.data["numFeedbacksUsed"] == 1
+        assert self.mock_get_summary_from_seer.call_count == 1
+        # Most recent is prioritized.
+        assert self.mock_get_summary_from_seer.call_args[0][0] == ["c"]
 
     def test_get_summary_from_seer_failed(self) -> None:
         self.mock_get_summary_from_seer.return_value = None
-
-        for _ in range(15):
-            event = mock_feedback_event(self.project1.id)
-            create_feedback_issue(
-                event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
+        self.save_feedback(self.project1, "hello")
 
         with self.feature(self.features):
             response = self.get_error_response(self.org.slug)

--- a/tests/sentry/feedback/endpoints/test_organization_feedback_summary.py
+++ b/tests/sentry/feedback/endpoints/test_organization_feedback_summary.py
@@ -4,11 +4,43 @@ from unittest.mock import MagicMock, patch
 import requests
 from django.urls import reverse
 
+from sentry.feedback.endpoints.organization_feedback_summary import get_summary_from_seer
 from sentry.feedback.lib.utils import FeedbackCreationSource
 from sentry.feedback.usecases.ingest.create_feedback import create_feedback_issue
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test
+from sentry.utils import json
 from tests.sentry.feedback import MockSeerResponse, mock_feedback_event
+
+
+@patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
+def test_get_summary_from_seer_basic(mock_make_seer_api_request: MagicMock) -> None:
+    mock_make_seer_api_request.return_value = MockSeerResponse(
+        200,
+        json_data={"data": "Test summary of feedback"},
+    )
+
+    summary = get_summary_from_seer(["hello world"])
+    assert summary == "Test summary of feedback"
+    assert mock_make_seer_api_request.call_count == 1
+    body = mock_make_seer_api_request.call_args[1]["body"]
+    assert json.loads(body.decode("utf-8")) == {"feedbacks": ["hello world"]}
+
+
+@patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
+def test_get_summary_from_seer_timeout(mock_make_seer_api_request: MagicMock) -> None:
+    mock_make_seer_api_request.side_effect = requests.exceptions.Timeout("Request timed out")
+    assert get_summary_from_seer(["hello world"]) is None
+
+
+@patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
+def test_get_summary_from_seer_http_errors(mock_make_seer_api_request: MagicMock) -> None:
+    for status in [400, 401, 403, 404, 429, 500, 502, 503, 504]:
+        mock_make_seer_api_request.return_value = MockSeerResponse(
+            status=status,
+            json_data={"error": "Test error"},
+        )
+        assert get_summary_from_seer(["hello world"]) is None
 
 
 @region_silo_test
@@ -31,14 +63,28 @@ class OrganizationFeedbackSummaryTest(APITestCase):
             self.endpoint,
             kwargs={"organization_id_or_slug": self.org.slug},
         )
+
+        # Mock patchers.
         self.mock_has_seer_access_patcher = patch(
             "sentry.feedback.endpoints.organization_feedback_summary.has_seer_access",
             return_value=True,
         )
+        self.mock_get_summary_from_seer_patcher = patch(
+            "sentry.feedback.endpoints.organization_feedback_summary.get_summary_from_seer",
+            return_value="Test summary of feedback",
+        )
+        self.mock_min_feedbacks_patcher = patch(
+            "sentry.feedback.endpoints.organization_feedback_summary.MIN_FEEDBACKS_TO_SUMMARIZE",
+            10,
+        )
         self.mock_has_seer_access = self.mock_has_seer_access_patcher.start()
+        self.mock_get_summary_from_seer = self.mock_get_summary_from_seer_patcher.start()
+        self.mock_min_feedbacks = self.mock_min_feedbacks_patcher.start()
 
     def tearDown(self) -> None:
         self.mock_has_seer_access_patcher.stop()
+        self.mock_get_summary_from_seer_patcher.stop()
+        self.mock_min_feedbacks_patcher.stop()
         super().tearDown()
 
     def _make_valid_seer_response(self) -> MockSeerResponse:
@@ -57,10 +103,7 @@ class OrganizationFeedbackSummaryTest(APITestCase):
             response = self.get_error_response(self.org.slug)
             assert response.status_code == 403
 
-    @patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
-    def test_get_feedback_summary_basic(self, mock_make_seer_api_request: MagicMock) -> None:
-        mock_make_seer_api_request.return_value = self._make_valid_seer_response()
-
+    def test_get_feedback_summary_basic(self) -> None:
         for _ in range(15):
             event = mock_feedback_event(self.project1.id)
             create_feedback_issue(
@@ -74,12 +117,7 @@ class OrganizationFeedbackSummaryTest(APITestCase):
         assert response.data["summary"] == "Test summary of feedback"
         assert response.data["numFeedbacksUsed"] == 15
 
-    @patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
-    def test_get_feedback_summary_with_date_filter(
-        self, mock_make_seer_api_request: MagicMock
-    ) -> None:
-        mock_make_seer_api_request.return_value = self._make_valid_seer_response()
-
+    def test_get_feedback_summary_with_date_filter(self) -> None:
         # 12 feedbacks that are created immediately
         for _ in range(12):
             event = mock_feedback_event(self.project1.id)
@@ -105,12 +143,7 @@ class OrganizationFeedbackSummaryTest(APITestCase):
         assert response.data["summary"] == "Test summary of feedback"
         assert response.data["numFeedbacksUsed"] == 12
 
-    @patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
-    def test_get_feedback_summary_with_project_filter(
-        self, mock_make_seer_api_request: MagicMock
-    ) -> None:
-        mock_make_seer_api_request.return_value = self._make_valid_seer_response()
-
+    def test_get_feedback_summary_with_project_filter(self) -> None:
         for _ in range(10):
             event = mock_feedback_event(self.project1.id)
             create_feedback_issue(
@@ -134,12 +167,7 @@ class OrganizationFeedbackSummaryTest(APITestCase):
         assert response.data["summary"] == "Test summary of feedback"
         assert response.data["numFeedbacksUsed"] == 10
 
-    @patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
-    def test_get_feedback_summary_with_many_project_filter_as_list(
-        self, mock_make_seer_api_request: MagicMock
-    ) -> None:
-        mock_make_seer_api_request.return_value = self._make_valid_seer_response()
-
+    def test_get_feedback_summary_with_many_project_filter_as_list(self) -> None:
         for _ in range(10):
             event = mock_feedback_event(self.project1.id)
             create_feedback_issue(
@@ -163,12 +191,7 @@ class OrganizationFeedbackSummaryTest(APITestCase):
         assert response.data["summary"] == "Test summary of feedback"
         assert response.data["numFeedbacksUsed"] == 22
 
-    @patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
-    def test_get_feedback_summary_with_many_project_filter_separate(
-        self, mock_make_seer_api_request: MagicMock
-    ) -> None:
-        mock_make_seer_api_request.return_value = self._make_valid_seer_response()
-
+    def test_get_feedback_summary_with_many_project_filter_separate(self) -> None:
         for _ in range(10):
             event = mock_feedback_event(self.project1.id)
             create_feedback_issue(
@@ -191,12 +214,7 @@ class OrganizationFeedbackSummaryTest(APITestCase):
         assert response.data["summary"] == "Test summary of feedback"
         assert response.data["numFeedbacksUsed"] == 22
 
-    @patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
-    def test_get_feedback_summary_too_few_feedbacks(
-        self, mock_make_seer_api_request: MagicMock
-    ) -> None:
-        mock_make_seer_api_request.return_value = self._make_valid_seer_response()
-
+    def test_get_feedback_summary_too_few_feedbacks(self) -> None:
         for _ in range(9):
             event = mock_feedback_event(self.project2.id)
             create_feedback_issue(
@@ -208,14 +226,11 @@ class OrganizationFeedbackSummaryTest(APITestCase):
 
         assert response.data["success"] is False
 
-    @patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
     @patch(
         "sentry.feedback.endpoints.organization_feedback_summary.MAX_FEEDBACKS_TO_SUMMARIZE_CHARS",
         1000,
     )
-    def test_get_feedback_summary_character_limit(self, mock_make_seer_api_request) -> None:
-        mock_make_seer_api_request.return_value = self._make_valid_seer_response()
-
+    def test_get_feedback_summary_character_limit(self) -> None:
         # Create 9 older feedbacks with normal size, skipped due to the middle one exceeding the character limit
         for _ in range(9):
             event = mock_feedback_event(self.project1.id, dt=datetime.now(UTC) - timedelta(hours=3))
@@ -240,49 +255,8 @@ class OrganizationFeedbackSummaryTest(APITestCase):
         assert response.data["summary"] == "Test summary of feedback"
         assert response.data["numFeedbacksUsed"] == 12
 
-    @patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
-    def test_seer_timeout(self, mock_make_seer_api_request: MagicMock) -> None:
-        mock_make_seer_api_request.side_effect = requests.exceptions.Timeout("Request timed out")
-
-        for _ in range(15):
-            event = mock_feedback_event(self.project1.id)
-            create_feedback_issue(
-                event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
-
-        with self.feature(self.features):
-            response = self.get_error_response(self.org.slug)
-
-        assert response.status_code == 500
-        assert response.data["detail"] == "Failed to generate a summary for a list of feedbacks"
-        # Should be called twice: once for summarization URL, once for autofix fallback
-        assert mock_make_seer_api_request.call_count == 2
-
-    @patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
-    def test_seer_http_errors(self, mock_make_seer_api_request: MagicMock) -> None:
-        for status in [400, 401, 403, 404, 429, 500, 502, 503, 504]:
-            mock_make_seer_api_request.return_value = MockSeerResponse(
-                status=status, json_data={"error": "Test error"}
-            )
-
-            for _ in range(15):
-                event = mock_feedback_event(self.project1.id)
-                create_feedback_issue(
-                    event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-                )
-
-            with self.feature(self.features):
-                response = self.get_error_response(self.org.slug)
-
-            assert response.status_code == 500
-            assert response.data["detail"] == "Failed to generate a summary for a list of feedbacks"
-
-    @patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
     @patch("sentry.feedback.endpoints.organization_feedback_summary.cache")
-    def test_get_feedback_summary_cache_hit(
-        self, mock_cache: MagicMock, mock_make_seer_api_request: MagicMock
-    ) -> None:
-        mock_make_seer_api_request.return_value = self._make_valid_seer_response()
+    def test_get_feedback_summary_cache_hit(self, mock_cache: MagicMock) -> None:
 
         mock_cache.get.return_value = {
             "summary": "Test cached summary of feedback",
@@ -305,13 +279,8 @@ class OrganizationFeedbackSummaryTest(APITestCase):
         mock_cache.get.assert_called_once()
         mock_cache.set.assert_not_called()
 
-    @patch("sentry.feedback.endpoints.organization_feedback_summary.make_signed_seer_api_request")
     @patch("sentry.feedback.endpoints.organization_feedback_summary.cache")
-    def test_get_feedback_summary_cache_miss(
-        self, mock_cache: MagicMock, mock_make_seer_api_request: MagicMock
-    ) -> None:
-        mock_make_seer_api_request.return_value = self._make_valid_seer_response()
-
+    def test_get_feedback_summary_cache_miss(self, mock_cache: MagicMock) -> None:
         mock_cache.get.return_value = None
 
         for _ in range(15):
@@ -328,3 +297,18 @@ class OrganizationFeedbackSummaryTest(APITestCase):
         assert response.data["numFeedbacksUsed"] == 15
         mock_cache.get.assert_called_once()
         mock_cache.set.assert_called_once()
+
+    def test_get_summary_from_seer_failed(self) -> None:
+        self.mock_get_summary_from_seer.return_value = None
+
+        for _ in range(15):
+            event = mock_feedback_event(self.project1.id)
+            create_feedback_issue(
+                event, self.project1, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+            )
+
+        with self.feature(self.features):
+            response = self.get_error_response(self.org.slug)
+
+        assert response.status_code == 500
+        assert response.data["detail"] == "Failed to generate a summary for a list of feedbacks"


### PR DESCRIPTION
Noticed these tests were taking way too long, due to mocking >10 feedbacks per test. Local measurements: 
- On master: 48s for 11 tests. 
- Rewrite: 10s for 11 tests.

No change in functionality for src code, except reading seer `response.json()` out of the try-catch (functionally the same, shouldn't raise errors). 

Categories endpoint is up next, as it also mocks 15+ fb per test

[REPLAY-513: \[PR Tracker\] refactor UF backend code and test coverage](https://linear.app/getsentry/issue/REPLAY-513/pr-tracker-refactor-uf-backend-code-and-test-coverage)