### PR TITLE
fix(mcp-insights): Pass selection to explore on error links

### DIFF
--- a/static/app/views/insights/mcp/components/mcpPromptsTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpPromptsTable.tsx
@@ -43,6 +43,7 @@ const rightAlignColumns = new Set([
 
 export function McpPromptsTable() {
   const organization = useOrganization();
+  const {selection} = usePageFilters();
   const query = useCombinedQuery(`span.op:mcp.server has:${SpanFields.MCP_PROMPT_NAME}`);
   const tableDataRequest = useSpanTableData({
     query,
@@ -102,6 +103,7 @@ export function McpPromptsTable() {
               total={dataRow['count()']}
               issuesLink={getExploreUrl({
                 query: `${query} span.status:internal_error ${SpanFields.MCP_PROMPT_NAME}:${dataRow[SpanFields.MCP_PROMPT_NAME]}`,
+                selection,
                 organization,
                 referrer: MCPReferrer.MCP_PROMPT_TABLE,
               })}
@@ -116,7 +118,7 @@ export function McpPromptsTable() {
           return <div />;
       }
     },
-    [tableDataRequest, organization, query]
+    [tableDataRequest, organization, query, selection]
   );
 
   return (

--- a/static/app/views/insights/mcp/components/mcpResourcesTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpResourcesTable.tsx
@@ -43,6 +43,7 @@ const rightAlignColumns = new Set([
 
 export function McpResourcesTable() {
   const organization = useOrganization();
+  const {selection} = usePageFilters();
   const query = useCombinedQuery(`span.op:mcp.server has:${SpanFields.MCP_RESOURCE_URI}`);
   const tableDataRequest = useSpanTableData({
     query,
@@ -102,6 +103,7 @@ export function McpResourcesTable() {
               total={dataRow['count()']}
               issuesLink={getExploreUrl({
                 query: `${query} span.status:internal_error ${SpanFields.MCP_RESOURCE_URI}:${dataRow[SpanFields.MCP_RESOURCE_URI]}`,
+                selection,
                 organization,
                 referrer: MCPReferrer.MCP_RESOURCE_TABLE,
               })}
@@ -116,7 +118,7 @@ export function McpResourcesTable() {
           return <div />;
       }
     },
-    [tableDataRequest, organization, query]
+    [tableDataRequest, organization, query, selection]
   );
 
   return (

--- a/static/app/views/insights/mcp/components/mcpToolsTable.tsx
+++ b/static/app/views/insights/mcp/components/mcpToolsTable.tsx
@@ -43,6 +43,7 @@ const rightAlignColumns = new Set([
 
 export function McpToolsTable() {
   const organization = useOrganization();
+  const {selection} = usePageFilters();
   const query = useCombinedQuery(`span.op:mcp.server has:${SpanFields.MCP_TOOL_NAME}`);
   const tableDataRequest = useSpanTableData({
     query,
@@ -102,6 +103,7 @@ export function McpToolsTable() {
               total={dataRow['count()']}
               issuesLink={getExploreUrl({
                 query: `${query} span.status:internal_error ${SpanFields.MCP_TOOL_NAME}:${dataRow[SpanFields.MCP_TOOL_NAME]}`,
+                selection,
                 organization,
                 referrer: MCPReferrer.MCP_TOOL_TABLE,
               })}
@@ -116,7 +118,7 @@ export function McpToolsTable() {
           return <div />;
       }
     },
-    [tableDataRequest, organization, query]
+    [tableDataRequest, organization, query, selection]
   );
 
   return (


### PR DESCRIPTION
Pass page filters selection to explore on error links to ensure the same project and timeframe to be selected.