### PR TITLE
chore(timeseries): Remove edge buckets from spot-check comparisons

### DIFF
--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -198,6 +198,13 @@ const useDiscoverSeries = <T extends string[]>(
           stripped.meta.valueUnit = null;
         }
 
+        // Remove the first and last entry in both, since these are sensitive to items falling in/out of buckets between the two requests. Mutating the values is safe here, since these objects are only used for logging, and are not tied to the data that's returned.
+        converted.values.shift();
+        converted.values.pop();
+
+        stripped.values.shift();
+        stripped.values.pop();
+
         if (!isEqualWith(converted, stripped, comparator)) {
           warn(`\`useDiscoverSeries\` found a data difference in responses`, {
             yAxis,


### PR DESCRIPTION
The first and last bucket of a timeseries are very sensitive to timing. If the two calls I'm comparing for the spot-check run at different times, significant data points can make their way into the first and last bucket and falsely report a big change. I'm eliminating that case for now, by removing those buckets from the compared data.
