### PR TITLE
fix(replays): Lower max-pending-futures default limit

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -81,6 +81,9 @@ def ingest_replay_recordings_options() -> list[click.Option]:
     """Return a list of ingest-replay-recordings options."""
     options = multiprocessing_options(default_max_batch_size=10)
     options.append(click.Option(["--threads", "num_threads"], type=int, default=4))
+    options.append(
+        click.Option(["--max-pending-futures", "max_pending_futures"], type=int, default=100)
+    )
     return options
 
 

--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -45,7 +45,7 @@ class ProcessReplayRecordingStrategyFactory(ProcessingStrategyFactory[KafkaPaylo
         output_block_size: int | None,
         num_threads: int = 4,  # Defaults to 4 for self-hosted.
         force_synchronous: bool = False,  # Force synchronous runner (only used in test suite).
-        max_pending_futures: int = 512,
+        max_pending_futures: int = 100,
     ) -> None:
         # For information on configuring this consumer refer to this page:
         #   https://getsentry.github.io/arroyo/strategies/run_task_with_multiprocessing.html


### PR DESCRIPTION
Large queue depth is putting unnecessary amounts of memory pressure on the consumer. We also make the limit configurable from the command line.