### PR TITLE
feat(searchbar): add small_integer value type for more granular suggestions

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric.tsx
@@ -44,22 +44,5 @@ export function getSmallNumericSuggestions(inputValue: string): SuggestionSectio
   if (!inputValue) {
     return DEFAULT_SMALL_NUMERIC_SUGGESTIONS;
   }
-
-  if (isNumeric(inputValue)) {
-    const value = parseFloat(inputValue);
-    // Shows suggestions up to 10000, e.g. 32 -> 320, 3200
-    return [
-      {
-        sectionText: '',
-        suggestions: (value ? [10, 100, 1000] : [])
-          .filter(multiplier => value * multiplier <= 10000)
-          .map(multiplier => ({
-            value: `${value * multiplier}`,
-          })),
-      },
-    ];
-  }
-
-  // If the value is not numeric, don't show any suggestions
   return [];
 }

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric.tsx
@@ -47,11 +47,11 @@ export function getSmallNumericSuggestions(inputValue: string): SuggestionSectio
 
   if (isNumeric(inputValue)) {
     const value = parseFloat(inputValue);
-    // Shows suggestions up to 10000, e.g. 32, 320, 3200
+    // Shows suggestions up to 10000, e.g. 32 -> 320, 3200
     return [
       {
         sectionText: '',
-        suggestions: [1, 10, 100, 1000]
+        suggestions: (value ? [10, 100, 1000] : [])
           .filter(multiplier => value * multiplier <= 10000)
           .map(multiplier => ({
             value: `${value * multiplier}`,

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric.tsx
@@ -32,3 +32,34 @@ export function getNumericSuggestions(inputValue: string): SuggestionSection[] {
   // If the value is not numeric, don't show any suggestions
   return [];
 }
+
+const DEFAULT_SMALL_NUMERIC_SUGGESTIONS: SuggestionSection[] = [
+  {
+    sectionText: '',
+    suggestions: [{value: '1'}, {value: '10'}, {value: '100'}, {value: '1000'}],
+  },
+];
+
+export function getSmallNumericSuggestions(inputValue: string): SuggestionSection[] {
+  if (!inputValue) {
+    return DEFAULT_SMALL_NUMERIC_SUGGESTIONS;
+  }
+
+  if (isNumeric(inputValue)) {
+    const value = parseFloat(inputValue);
+    // Shows suggestions up to 10000, e.g. 32, 320, 3200
+    return [
+      {
+        sectionText: '',
+        suggestions: [1, 10, 100, 1000]
+          .filter(multiplier => value * multiplier <= 10000)
+          .map(multiplier => ({
+            value: `${value * multiplier}`,
+          })),
+      },
+    ];
+  }
+
+  // If the value is not numeric, don't show any suggestions
+  return [];
+}

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils.tsx
@@ -6,7 +6,10 @@ import {escapeTagValue} from 'sentry/components/searchQueryBuilder/tokens/filter
 import {DEFAULT_BOOLEAN_SUGGESTIONS} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/boolean';
 import {getRelativeDateSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/date';
 import {getDurationSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/duration';
-import {getNumericSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric';
+import {
+  getNumericSuggestions,
+  getSmallNumericSuggestions,
+} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric';
 import {getSizeSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/size';
 import type {SuggestionSection} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/types';
 import {Token, type TokenResult} from 'sentry/components/searchSyntax/parser';
@@ -28,6 +31,8 @@ export function getValueSuggestions({
     case FieldValueType.NUMBER:
     case FieldValueType.INTEGER:
       return getNumericSuggestions(filterValue);
+    case FieldValueType.SMALL_INTEGER:
+      return getSmallNumericSuggestions(filterValue);
     case FieldValueType.DURATION:
       return getDurationSuggestions(filterValue, token);
     case FieldValueType.SIZE:
@@ -67,6 +72,7 @@ export function cleanFilterValue({
       }
       return null;
     case FieldValueType.INTEGER:
+    case FieldValueType.SMALL_INTEGER:
       if (FILTER_VALUE_INT.test(value)) {
         return value;
       }

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -50,6 +50,8 @@ export function getDefaultValueForValueType(valueType: FieldValueType | null): s
     case FieldValueType.INTEGER:
     case FieldValueType.NUMBER:
       return '100';
+    case FieldValueType.SMALL_INTEGER:
+      return '1';
     case FieldValueType.DATE:
       return '-24h';
     case FieldValueType.DURATION:
@@ -122,6 +124,7 @@ export function getInitialFilterText(
 
   switch (valueType) {
     case FieldValueType.INTEGER:
+    case FieldValueType.SMALL_INTEGER:
     case FieldValueType.NUMBER:
     case FieldValueType.DURATION:
     case FieldValueType.SIZE:

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -47,6 +47,7 @@ function getSearchConfigFromKeys(
         break;
       case FieldValueType.NUMBER:
       case FieldValueType.INTEGER:
+      case FieldValueType.SMALL_INTEGER:
       case FieldValueType.PERCENTAGE:
         config.numericKeys.add(key);
         break;

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -292,6 +292,7 @@ export enum FieldValueType {
   RATE = 'rate',
   PERCENT_CHANGE = 'percent_change',
   SCORE = 'score',
+  SMALL_INTEGER = 'small_integer',
 }
 
 export enum WebVital {
@@ -2587,7 +2588,7 @@ const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
   [ReplayFieldKey.ACTIVITY]: {
     desc: t('Amount of activity in the replay from 0 to 10'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.INTEGER,
+    valueType: FieldValueType.SMALL_INTEGER,
   },
   [ReplayFieldKey.BROWSER_NAME]: {
     desc: t('Name of the browser'),
@@ -2602,47 +2603,47 @@ const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
   [ReplayFieldKey.COUNT_DEAD_CLICKS]: {
     desc: t('Number of dead clicks in the replay'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.INTEGER,
+    valueType: FieldValueType.SMALL_INTEGER,
   },
   [ReplayFieldKey.COUNT_RAGE_CLICKS]: {
     desc: t('Number of rage clicks in the replay'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.INTEGER,
+    valueType: FieldValueType.SMALL_INTEGER,
   },
   [ReplayFieldKey.COUNT_ERRORS]: {
     desc: t('Number of issues in the replay with level=error'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.INTEGER,
+    valueType: FieldValueType.SMALL_INTEGER,
   },
   [ReplayFieldKey.COUNT_INFOS]: {
     desc: t('Number of issues in the replay with level=info'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.INTEGER,
+    valueType: FieldValueType.SMALL_INTEGER,
   },
   [ReplayFieldKey.COUNT_SCREENS]: {
     desc: t('Number of screens visited within the replay. Alias of count_urls.'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.INTEGER,
+    valueType: FieldValueType.SMALL_INTEGER,
   },
   [ReplayFieldKey.COUNT_SEGMENTS]: {
     desc: t('Number of segments in the replay'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.INTEGER,
+    valueType: FieldValueType.SMALL_INTEGER,
   },
   [ReplayFieldKey.COUNT_TRACES]: {
     desc: t('Number of traces in the replay'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.INTEGER,
+    valueType: FieldValueType.SMALL_INTEGER,
   },
   [ReplayFieldKey.COUNT_URLS]: {
     desc: t('Number of urls visited within the replay'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.INTEGER,
+    valueType: FieldValueType.SMALL_INTEGER,
   },
   [ReplayFieldKey.COUNT_WARNINGS]: {
     desc: t('Number of issues in the replay with level=warning'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.INTEGER,
+    valueType: FieldValueType.SMALL_INTEGER,
   },
   [ReplayFieldKey.DURATION]: {
     desc: t('Duration of the replay, in seconds'),

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -292,7 +292,7 @@ export enum FieldValueType {
   RATE = 'rate',
   PERCENT_CHANGE = 'percent_change',
   SCORE = 'score',
-  SMALL_INTEGER = 'small_integer',
+  SMALL_INTEGER = 'small_integer', // Value suggestions are 1-1000.
 }
 
 export enum WebVital {

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -5,6 +5,7 @@ import type {ThresholdsConfig} from 'sentry/views/dashboards/widgetBuilder/build
 type AttributeValueType =
   | 'number'
   | 'integer'
+  | 'small_integer'
   | 'date'
   | 'boolean'
   | 'duration'


### PR DESCRIPTION
The default suggestions for replay count fields are too high. These counts (see REPLAY_FIELD_DEFINITIONS  in the diff) are within a single replay and unlikely to go above 1k.
<img width="476" height="294" alt="Screenshot 2025-09-10 at 9 41 47 AM" src="https://github.com/user-attachments/assets/d7fe174a-0c85-4e36-9008-6e0afc3ca39a" />

This PR creates and uses a new value type in SearchQueryBuilder which suggests `[1, 10, 100, 1000]`. 

Closes [REPLAY-421: Review auto-suggestion values for replay counts](https://linear.app/getsentry/issue/REPLAY-421/review-auto-suggestion-values-for-replay-counts)


(Removed, now shows no suggestions if a value is typed)
~~Typing a value will show suggestions <=10k like this:~~
3: 30, 300, 3000
32: 320, 3200
3267: blank
0: blank (tested on dev-ui)

After:
<img width="342" height="138" alt="Screenshot 2025-09-10 at 11 34 03 AM" src="https://github.com/user-attachments/assets/a7735a6f-926f-4d76-8237-91f09294265e" />

<img width="207" height="57" alt="Screenshot 2025-09-10 at 11 33 49 AM" src="https://github.com/user-attachments/assets/de908322-1e13-4837-8c6b-ee7094f4c0e4" />
