### PR TITLE
perf(aci): Ensure Event.project.organization is populated from cache

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -433,7 +433,7 @@ def process_workflows(
             raise ValueError("Unable to determine the detector for the event")
 
         log_context.add_extras(detector_id=detector.id)
-        organization = detector.project.organization
+        organization = event_data.event.project.organization
 
         # set the detector / org information asap, this is used in `get_environment_by_event` as well.
         WorkflowEventContext.set(


### PR DESCRIPTION
We end up needing Project and Organization in a few places, and ensuring the Event has it and populated from cache can potentially avoid 2 queries. They're cheap queries typically, but in a task so high volume as process_workflows_event, this could be potentially a noticeable help when the database is heavily loaded.
