### PR TITLE
Remove unnecessary log statement

### DIFF
--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -230,15 +230,6 @@ def _generate_integration_to_files_mapping(
             )
 
             if not src_path:
-                logger.info(
-                    "process_commit_context_all_frames.code_mapping_stack_root_mismatch",
-                    extra={
-                        **extra,
-                        "code_mapping_id": code_mapping.id,
-                        "stacktrace_path": stacktrace_path,
-                        "stack_root": code_mapping.stack_root,
-                    },
-                )
                 continue
 
             if "\\" in src_path or '"' in src_path:


### PR DESCRIPTION
Removes an unnecessary `logger.info` call in `src/sentry/integrations/utils/commit_context.py`. This log statement, related to `code_mapping_stack_root_mismatch`, was redundant and did not provide significant debugging value.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/C07T7SFG7DH/p1757523834361529?thread_ts=1757523834.361529&cid=C07T7SFG7DH)

<a href="https://cursor.com/background-agent?bcId=bc-ca7e4ab9-d3b1-4e52-b8ee-f9187d077ea3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca7e4ab9-d3b1-4e52-b8ee-f9187d077ea3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

