### PR TITLE
ref(uptime): Remove compat useDetectorId flag

### DIFF
--- a/static/app/actionCreators/uptime.tsx
+++ b/static/app/actionCreators/uptime.tsx
@@ -25,8 +25,6 @@ export async function updateUptimeRule(
       {
         method: 'PUT',
         data,
-        // TODO(epurkhiser): Can be removed once these APIs only take detectors
-        query: {useDetectorId: 1},
       }
     );
     clearIndicators();
@@ -61,8 +59,6 @@ export async function deleteUptimeRule(
       `/projects/${org.slug}/${uptimeRule.projectSlug}/uptime/${uptimeRule.detectorId}/`,
       {
         method: 'DELETE',
-        // TODO(epurkhiser): Can be removed once these APIs only take detectors
-        query: {useDetectorId: 1},
       }
     );
     clearIndicators();

--- a/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
@@ -624,7 +624,7 @@ describe('AlertRulesList', () => {
     renderGlobalModal();
 
     const deleteMock = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/uptime/${uptimeRule.detectorId}/?useDetectorId=1`,
+      url: `/projects/${organization.slug}/${project.slug}/uptime/${uptimeRule.detectorId}/`,
       method: 'DELETE',
       body: {},
     });

--- a/static/app/views/alerts/list/rules/alertRulesList.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.tsx
@@ -155,7 +155,7 @@ function AlertRulesList() {
     const deleteEndpoints: Record<CombinedAlertType, string> = {
       [CombinedAlertType.ISSUE]: `/projects/${organization.slug}/${projectId}/rules/${id}/`,
       [CombinedAlertType.METRIC]: `/organizations/${organization.slug}/alert-rules/${id}/`,
-      [CombinedAlertType.UPTIME]: `/projects/${organization.slug}/${projectId}/uptime/${id}/?useDetectorId=1`,
+      [CombinedAlertType.UPTIME]: `/projects/${organization.slug}/${projectId}/uptime/${id}/`,
       [CombinedAlertType.CRONS]: `/projects/${organization.slug}/${projectId}/monitors/${id}/`,
     };
 

--- a/static/app/views/alerts/rules/uptime/details.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/details.spec.tsx
@@ -24,7 +24,6 @@ describe('UptimeAlertDetails', () => {
     });
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/uptime/1/checks/`,
-      query: {useDetectorId: '1'},
       body: [],
     });
     MockApiClient.addMockResponse({
@@ -38,7 +37,6 @@ describe('UptimeAlertDetails', () => {
   it('renders', async () => {
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/uptime/1/`,
-      query: {useDetectorId: '1'},
       body: UptimeRuleFixture({name: 'Uptime Test Rule'}),
     });
 
@@ -55,7 +53,6 @@ describe('UptimeAlertDetails', () => {
   it('shows a message for invalid uptime alert', async () => {
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/uptime/2/`,
-      query: {useDetectorId: '1'},
       statusCode: 404,
     });
 
@@ -74,12 +71,10 @@ describe('UptimeAlertDetails', () => {
   it('disables and enables the rule', async () => {
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/uptime/2/`,
-      query: {useDetectorId: '1'},
       statusCode: 404,
     });
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/uptime/1/`,
-      query: {useDetectorId: '1'},
       body: UptimeRuleFixture({name: 'Uptime Test Rule'}),
     });
 
@@ -94,7 +89,6 @@ describe('UptimeAlertDetails', () => {
 
     const disableMock = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/uptime/1/`,
-      query: {useDetectorId: '1'},
       method: 'PUT',
       body: UptimeRuleFixture({name: 'Uptime Test Rule', status: 'disabled'}),
     });
@@ -111,7 +105,6 @@ describe('UptimeAlertDetails', () => {
 
     const enableMock = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/uptime/1/`,
-      query: {useDetectorId: '1'},
       method: 'PUT',
       body: UptimeRuleFixture({name: 'Uptime Test Rule', status: 'active'}),
     });

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx
@@ -66,7 +66,7 @@ describe('Uptime Alert Form', () => {
     await selectEvent.select(input('Owner'), 'Foo Bar');
 
     const updateMock = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/uptime/?useDetectorId=1`,
+      url: `/projects/${organization.slug}/${project.slug}/uptime/`,
       method: 'POST',
     });
 
@@ -150,7 +150,7 @@ describe('Uptime Alert Form', () => {
     await userEvent.type(input('URL'), '/test');
 
     const updateMock = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/uptime/${rule.detectorId}/?useDetectorId=1`,
+      url: `/projects/${organization.slug}/${project.slug}/uptime/${rule.detectorId}/`,
       method: 'PUT',
     });
 
@@ -212,7 +212,7 @@ describe('Uptime Alert Form', () => {
     await selectEvent.select(input('Owner'), 'Foo Bar');
 
     const updateMock = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/uptime/${rule.detectorId}/?useDetectorId=1`,
+      url: `/projects/${organization.slug}/${project.slug}/uptime/${rule.detectorId}/`,
       method: 'PUT',
     });
 
@@ -329,7 +329,7 @@ describe('Uptime Alert Form', () => {
     await userEvent.type(name, 'New Uptime Rule');
 
     const updateMock = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/uptime/?useDetectorId=1`,
+      url: `/projects/${organization.slug}/${project.slug}/uptime/`,
       method: 'POST',
     });
 

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -105,8 +105,8 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
         const projectSlug = formModel.getValue<string>('projectSlug');
         const selectedProject = projects.find(p => p.slug === projectSlug);
         const apiEndpoint = rule
-          ? `/projects/${organization.slug}/${projectSlug}/uptime/${rule.detectorId}/?useDetectorId=1`
-          : `/projects/${organization.slug}/${projectSlug}/uptime/?useDetectorId=1`;
+          ? `/projects/${organization.slug}/${projectSlug}/uptime/${rule.detectorId}/`
+          : `/projects/${organization.slug}/${projectSlug}/uptime/`;
 
         function onSubmitSuccess(response: any) {
           navigate(

--- a/static/app/views/insights/uptime/utils/useUptimeChecks.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeChecks.tsx
@@ -35,8 +35,6 @@ function makeUptimeChecksQueryKey({
         start,
         end,
         statsPeriod,
-        // TODO(epurkhiser): Can be removed once these APIs only take detectors
-        useDetectorId: 1,
       },
     },
   ];

--- a/static/app/views/insights/uptime/utils/useUptimeRule.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeRule.tsx
@@ -21,10 +21,6 @@ export function useUptimeRule(
 
   const queryKey: ApiQueryKey = [
     `/projects/${organization.slug}/${projectSlug}/uptime/${detectorId}/`,
-    {
-      // TODO(epurkhiser): Can be removed once these APIs only take detectors
-      query: {useDetectorId: 1},
-    },
   ];
   return useApiQuery<UptimeRule>(queryKey, {staleTime: 0, ...options});
 }
@@ -44,10 +40,6 @@ export function setUptimeRuleData({
 }: SetUptimeRuleDataOptions) {
   const queryKey: ApiQueryKey = [
     `/projects/${organizationSlug}/${projectSlug}/uptime/${uptimeRule.detectorId}/`,
-    {
-      // TODO(epurkhiser): Can be removed once these APIs only take detectors
-      query: {useDetectorId: 1},
-    },
   ];
   setApiQueryData(queryClient, queryKey, uptimeRule);
 }


### PR DESCRIPTION
Requires https://github.com/getsentry/sentry/pull/98794

Once we've removed ProjectUptimeSubscription from the endpoints we'll no
longer need to pass in this compat flag