### PR TITLE
fix(aci): exclude ticket creation actions if org doesn't have feature

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_available_action_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_available_action_index.py
@@ -3,6 +3,7 @@ from typing import TypedDict
 
 from drf_spectacular.utils import extend_schema
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -30,6 +31,7 @@ from sentry.workflow_engine.processors.action import (
     get_notification_plugins_for_org,
 )
 from sentry.workflow_engine.registry import action_handler_registry
+from sentry.workflow_engine.types import ActionHandler
 
 
 class AvailableIntegration(TypedDict):
@@ -63,6 +65,8 @@ class OrganizationAvailableActionIndexEndpoint(OrganizationEndpoint):
         """
         Returns a list of available actions for a given org
         """
+        can_create_tickets = features.has("organizations:integrations-ticket-rules", organization)
+
         integration_services = get_integration_services(organization.id)
 
         provider_integrations: dict[str, list[AvailableIntegration]] = defaultdict(list)
@@ -80,6 +84,10 @@ class OrganizationAvailableActionIndexEndpoint(OrganizationEndpoint):
 
         actions = []
         for action_type, handler in action_handler_registry.registrations.items():
+            # skip ticket creation actions if organization doesn't have the feature
+            if not can_create_tickets and handler.group == ActionHandler.Group.TICKET_CREATION:
+                continue
+
             # add integration actions
             if hasattr(handler, "provider_slug"):
                 integrations = provider_integrations.get(handler.provider_slug, [])

--- a/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
@@ -12,6 +12,7 @@ from sentry.plugins.base.manager import PluginManager
 from sentry.plugins.sentry_webhooks.plugin import WebHooksPlugin
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils.registry import Registry
 from sentry.workflow_engine.models.action import Action
@@ -284,6 +285,28 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
                     {"id": str(self.github_integration.id), "name": self.github_integration.name}
                 ],
             },
+        ]
+
+    @with_feature({"organizations:integrations-ticket-rules": False})
+    def test_does_not_return_ticket_actions_without_feature(self) -> None:
+        self.setup_integrations()
+
+        response = self.get_success_response(
+            self.organization.slug,
+            status_code=200,
+        )
+        assert len(response.data) == 1
+        assert response.data == [
+            # only notification actions are returned
+            {
+                "type": Action.Type.SLACK,
+                "handlerGroup": ActionHandler.Group.NOTIFICATION.value,
+                "configSchema": {},
+                "dataSchema": {},
+                "integrations": [
+                    {"id": str(self.slack_integration.id), "name": self.slack_integration.name}
+                ],
+            }
         ]
 
     def test_integrations_with_services(self) -> None:


### PR DESCRIPTION
ticket creation integrations/actions are limited to certain paid plans, so the available actions endpoint should only return those options if the organization has the `organizations:integrations-ticket-rules` feature flag