### PR TITLE
perf(events): Make Event.get_environment use the cache

### DIFF
--- a/src/sentry/services/eventstore/models.py
+++ b/src/sentry/services/eventstore/models.py
@@ -181,7 +181,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
         from sentry.models.environment import Environment
 
         if not hasattr(self, "_environment_cache"):
-            self._environment_cache = Environment.objects.get(
+            self._environment_cache = Environment.get_for_organization_id(
                 organization_id=self.project.organization_id,
                 name=Environment.get_name_or_default(self.get_tag("environment")),
             )

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -17,6 +17,7 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.types.activity import ActivityType
 from sentry.utils import json
+from sentry.utils.cache import cache
 from sentry.workflow_engine import buffer as workflow_buffer
 from sentry.workflow_engine.models import (
     Action,
@@ -233,6 +234,8 @@ class TestProcessWorkflows(BaseWorkflowTest):
     @patch("sentry.workflow_engine.processors.workflow.logger")
     def test_no_environment(self, mock_logger: MagicMock, mock_incr: MagicMock) -> None:
         Environment.objects.all().delete()
+        cache.clear()
+        self.event_data.event.environment = None
         triggered_workflows = process_workflows(self.event_data, FROZEN_TIME)
 
         assert not triggered_workflows

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -235,7 +235,6 @@ class TestProcessWorkflows(BaseWorkflowTest):
     def test_no_environment(self, mock_logger: MagicMock, mock_incr: MagicMock) -> None:
         Environment.objects.all().delete()
         cache.clear()
-        self.event_data.event.environment = None
         triggered_workflows = process_workflows(self.event_data, FROZEN_TIME)
 
         assert not triggered_workflows


### PR DESCRIPTION
Using get_for_organization_id goes through the standard cache, which should avoid a query in some common flows.
Should be safe be fairly safe; cache duration is 1h, name is part of cache key, and environments don't seem to change much.
