### PR TITLE
chore(preprod): Bump timeouts for file download related endpoints

### DIFF
--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -44,6 +44,9 @@ ENDPOINT_TIMEOUT_OVERRIDE = {
     "sentry-api-0-organization-release-files": 90.0,
     "sentry-api-0-project-release-files": 90.0,
     "sentry-api-0-dsym-files": 90.0,
+    "sentry-api-0-installable-preprod-artifact-download": 90.0,
+    "sentry-api-0-project-preprod-artifact-download": 90.0,
+    "sentry-api-0-project-preprod-artifact-size-analysis-download": 90.0,
 }
 
 # stream 0.5 MB at a time


### PR DESCRIPTION
We noticed that for `sentry-api-0-project-preprod-artifact-download` Which downloads a mobile build from the monolith to our microservice, timeouts would occasionally happen for larger files

I've added our three file download paths just to make sure that we ensure maximum stability 