### PR TITLE
fix(spans-migration): return dropped fields from translation layer

### DIFF
--- a/src/sentry/discover/compare_tables.py
+++ b/src/sentry/discover/compare_tables.py
@@ -233,7 +233,7 @@ def compare_tables_for_dashboard_widget_queries(
         logger.info("Metrics query failed: %s", e)
         has_metrics_error = True
 
-    eap_query_parts = translate_mep_to_eap(
+    eap_query_parts, dropped_fields = translate_mep_to_eap(
         QueryParts(
             query=query,
             selected_columns=selected_columns,

--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -83,7 +83,7 @@ def make_rpc_request(
     query = apply_dataset_query_conditions(SnubaQuery.Type.PERFORMANCE, query, None)
 
     query_parts = QueryParts(selected_columns=[aggregate], query=query, equations=[], orderby=[])
-    query_parts = translate_mep_to_eap(query_parts)
+    query_parts, dropped_fields = translate_mep_to_eap(query_parts)
 
     results = Spans.run_timeseries_query(
         params=snuba_params,

--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -331,7 +331,9 @@ def translate_orderbys(orderbys, equations, dropped_equations, new_equations):
                 # if equation was dropped, drop the orderby too
                 if selected_equation in dropped_equations:
                     dropped_orderby_reason = "equation was dropped"
-                    decoded_orderby = selected_equation
+                    decoded_orderby = (
+                        selected_equation if not is_negated else f"-{selected_equation}"
+                    )
                 else:
                     # check where equation is in list of new equations
                     translated_equation_list, _ = translate_equations([selected_equation])
@@ -341,7 +343,9 @@ def translate_orderbys(orderbys, equations, dropped_equations, new_equations):
                         translated_orderby = [f"equation[{new_equation_index}]"]
                     except (IndexError, ValueError):
                         dropped_orderby_reason = "equation was dropped"
-                        decoded_orderby = selected_equation
+                        decoded_orderby = (
+                            selected_equation if not is_negated else f"-{selected_equation}"
+                        )
             else:
                 dropped_orderby_reason = "no equations in this query"
                 decoded_orderby = orderby

--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -20,6 +20,12 @@ class QueryParts(TypedDict):
     orderby: list[str] | None
 
 
+class DroppedFields(TypedDict):
+    selected_columns: list[str]
+    equations: list[dict[str, list[str]]]
+    orderby: list[dict[str, str]]
+
+
 COLUMNS_TO_DROP = (
     "any",
     "count_miserable",
@@ -402,4 +408,10 @@ def translate_mep_to_eap(query_parts: QueryParts):
         orderby=new_orderbys,
     )
 
-    return eap_query
+    dropped_fields = DroppedFields(
+        selected_columns=dropped_columns,
+        equations=dropped_equations,
+        orderby=dropped_orderbys,
+    )
+
+    return eap_query, dropped_fields

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -75,7 +75,7 @@ def test_mep_to_eap_simple_query(input: str, expected: str) -> None:
         equations=[],
         orderby=[],
     )
-    translated = translate_mep_to_eap(old)
+    translated, dropped = translate_mep_to_eap(old)
 
     assert translated["query"] == expected
 
@@ -140,7 +140,7 @@ def test_mep_to_eap_simple_selected_columns(input: list[str], expected: list[str
         equations=[],
         orderby=[],
     )
-    translated = translate_mep_to_eap(old)
+    translated, dropped = translate_mep_to_eap(old)
 
     assert translated["selected_columns"] == expected
 
@@ -201,7 +201,7 @@ def test_mep_to_eap_simple_equations(input: list[str], expected: list[str]) -> N
         equations=input,
         orderby=[],
     )
-    translated = translate_mep_to_eap(old)
+    translated, dropped = translate_mep_to_eap(old)
 
     assert translated["equations"] == expected
 
@@ -279,6 +279,6 @@ def test_mep_to_eap_simple_orderbys(input: list[str], expected: list[str]) -> No
         ],
         orderby=input,
     )
-    translated = translate_mep_to_eap(old)
+    translated, dropped = translate_mep_to_eap(old)
 
     assert translated["orderby"] == expected

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -81,11 +81,12 @@ def test_mep_to_eap_simple_query(input: str, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "input,expected",
+    "input,expected,dropped",
     [
         pytest.param(
             ["transaction.duration"],
             ["span.duration"],
+            [],
         ),
         pytest.param(
             ["geo.country_code", "geo.city", "geo.region", "geo.subdivision", "geo.subregion"],
@@ -96,14 +97,17 @@ def test_mep_to_eap_simple_query(input: str, expected: str) -> None:
                 "user.geo.subdivision",
                 "user.geo.subregion",
             ],
+            [],
         ),
         pytest.param(
             ["count()", "avg(transaction.duration)"],
             ["count(span.duration)", "avg(span.duration)"],
+            [],
         ),
         pytest.param(
             ["avgIf(transaction.duration,greater,300)"],
             ["avgIf(span.duration,greater,300)"],
+            [],
         ),
         pytest.param(
             [
@@ -118,45 +122,54 @@ def test_mep_to_eap_simple_query(input: str, expected: str) -> None:
                 "p100(span.duration)",
                 "p75(span.duration)",
             ],
+            [],
         ),
         pytest.param(
             ["user_misery(300)", "apdex(300)"],
             ["user_misery(span.duration,300)", "apdex(span.duration,300)"],
+            [],
         ),
         pytest.param(
             ["any(transaction.duration)", "count_miserable(user,300)", "transaction", "count()"],
             ["transaction", "count(span.duration)"],
+            ["any(span.duration)", "count_miserable(user,300)"],
         ),
         pytest.param(
             ["platform.name", "count()"],
             ["platform", "count(span.duration)"],
+            [],
         ),
     ],
 )
-def test_mep_to_eap_simple_selected_columns(input: list[str], expected: list[str]) -> None:
+def test_mep_to_eap_simple_selected_columns(
+    input: list[str], expected: list[str], dropped: list[str]
+) -> None:
     old = QueryParts(
         selected_columns=input,
         query="",
         equations=[],
         orderby=[],
     )
-    translated, dropped = translate_mep_to_eap(old)
+    translated, dropped_fields = translate_mep_to_eap(old)
 
     assert translated["selected_columns"] == expected
+    assert dropped_fields["selected_columns"] == dropped
 
 
 @pytest.mark.parametrize(
-    "input,expected",
+    "input,expected,dropped",
     [
         pytest.param(
             ["equation|count() + 5"],
             ["equation|count(span.duration) + 5"],
+            [],
         ),
         pytest.param(
             [
                 "equation|user_misery(300) + count()",
             ],
             ["equation|user_misery(span.duration,300) + count(span.duration)"],
+            [],
         ),
         pytest.param(
             [
@@ -164,22 +177,46 @@ def test_mep_to_eap_simple_selected_columns(input: list[str], expected: list[str
                 "equation|percentile(transaction.duration,0.437)",
             ],
             ["equation|sum(span.duration) + 5", "equation|p50(span.duration)"],
+            [],
         ),
         pytest.param(
             ["equation|count(span.duration) + 5", "equation|count_web_vitals(user,300) * 3"],
             ["equation|count(span.duration) + 5"],
+            [
+                {
+                    "equation": "equation|count_web_vitals(user,300) * 3",
+                    "reason": ["count_web_vitals(user,300)"],
+                }
+            ],
         ),
         pytest.param(
             ["equation|count(span.duration) + total.count", "equation|count_miserable(user,300)"],
             [],
+            [
+                {
+                    "equation": "equation|count(span.duration) + total.count",
+                    "reason": ["total.count"],
+                },
+                {
+                    "equation": "equation|count_miserable(user,300)",
+                    "reason": ["count_miserable(user,300)"],
+                },
+            ],
         ),
         pytest.param(
             ["equation|transaction.duration * 2"],
             ["equation|span.duration * 2"],
+            [],
         ),
         pytest.param(
             ["equation|(sum(transaction.duration) + 5) + count_miserable(user,300)"],
             [],
+            [
+                {
+                    "equation": "equation|(sum(transaction.duration) + 5) + count_miserable(user,300)",
+                    "reason": ["count_miserable(user,300)"],
+                }
+            ],
         ),
         pytest.param(
             [
@@ -191,31 +228,37 @@ def test_mep_to_eap_simple_selected_columns(input: list[str], expected: list[str
                 "equation|(avg(span.duration) * 2) + p50(span.duration)",
                 "equation|(count_unique(transaction) / 4) * (count_unique(transaction.method) * 2)",
             ],
+            [{"equation": "equation|(total.count * 2) - count()", "reason": ["total.count"]}],
         ),
     ],
 )
-def test_mep_to_eap_simple_equations(input: list[str], expected: list[str]) -> None:
+def test_mep_to_eap_simple_equations(
+    input: list[str], expected: list[str], dropped: list[dict[str, list[str]]]
+) -> None:
     old = QueryParts(
         selected_columns=["id"],
         query="",
         equations=input,
         orderby=[],
     )
-    translated, dropped = translate_mep_to_eap(old)
+    translated, dropped_fields = translate_mep_to_eap(old)
 
     assert translated["equations"] == expected
+    assert dropped_fields["equations"] == dropped
 
 
 @pytest.mark.parametrize(
-    "input,expected",
+    "input,expected,dropped",
     [
         pytest.param(
+            None,
             None,
             None,
         ),
         pytest.param(
             ["-count()"],
             ["-count(span.duration)"],
+            [],
         ),
         pytest.param(
             [
@@ -225,14 +268,17 @@ def test_mep_to_eap_simple_equations(input: list[str], expected: list[str]) -> N
                 "url",
             ],
             ["-transaction.method", "span.duration", "-transaction", "request.url"],
+            [],
         ),
         pytest.param(
             ["-span.op", "browser.name"],
             ["-span.op", "browser.name"],
+            [],
         ),
         pytest.param(
             ["geo.city", "-geo.country_code"],
             ["user.geo.city", "-user.geo.country_code"],
+            [],
         ),
         pytest.param(
             ["-apdex(300)", "user_misery(300)", "count_unique(http.method)"],
@@ -241,10 +287,12 @@ def test_mep_to_eap_simple_equations(input: list[str], expected: list[str]) -> N
                 "user_misery(span.duration,300)",
                 "count_unique(transaction.method)",
             ],
+            [],
         ),
         pytest.param(
             ["-percentile(transaction.duration,0.5000)", "percentile(transaction.duration,0.94)"],
             ["-p50(span.duration)", "p95(span.duration)"],
+            [],
         ),
         pytest.param(
             [
@@ -253,22 +301,51 @@ def test_mep_to_eap_simple_equations(input: list[str], expected: list[str]) -> N
                 "any(transaction.duration)",
             ],
             [],
+            [
+                {
+                    "orderby": "-count_miserable(user,300)",
+                    "reason": "fields were dropped: count_miserable(user,300)",
+                },
+                {
+                    "orderby": "count_web_vitals(user,300)",
+                    "reason": "fields were dropped: count_web_vitals(user,300)",
+                },
+                {
+                    "orderby": "any(transaction.duration)",
+                    "reason": "fields were dropped: any(span.duration)",
+                },
+            ],
         ),
         pytest.param(
             ["-equation|count() + 5"],
             ["-equation|count(span.duration) + 5"],
+            [],
         ),
         pytest.param(
             ["-equation|(count_unique(title) / 4) * (count_unique(http.method) * 2)"],
             ["-equation|(count_unique(transaction) / 4) * (count_unique(transaction.method) * 2)"],
+            [],
         ),
         pytest.param(
-            ["-equation[0]", "equation[1]", "-equation[2]"], ["-equation[0]", "-equation[1]"]
+            ["-equation[0]", "equation[1]", "-equation[2]"],
+            ["-equation[0]", "-equation[1]"],
+            [
+                {
+                    "orderby": "equation|count_miserable(user,300) + 3",
+                    "reason": "equation was dropped",
+                }
+            ],
         ),
-        pytest.param(["equation[3453]"], []),
+        pytest.param(
+            ["equation[3453]"],
+            [],
+            [{"orderby": "equation[3453]", "reason": "equation at this index doesn't exist"}],
+        ),
     ],
 )
-def test_mep_to_eap_simple_orderbys(input: list[str], expected: list[str]) -> None:
+def test_mep_to_eap_simple_orderbys(
+    input: list[str], expected: list[str], dropped: list[dict[str, str]]
+) -> None:
     old = QueryParts(
         selected_columns=["id"],
         query="",
@@ -279,6 +356,7 @@ def test_mep_to_eap_simple_orderbys(input: list[str], expected: list[str]) -> No
         ],
         orderby=input,
     )
-    translated, dropped = translate_mep_to_eap(old)
+    translated, dropped_fields = translate_mep_to_eap(old)
 
     assert translated["orderby"] == expected
+    assert dropped_fields["orderby"] == dropped


### PR DESCRIPTION
I forgot to return the dropped fields from the translation layer so I've added that in. I've changed all instances of this function to return the dropped_fields field. I also need to add this into the discover-> Explore query translation function (after it's merged in). This is just feature additions so it works as expected.
