### PR TITLE
chore(relocation): Fix parameter in `UserOption` class method

### DIFF
--- a/src/sentry/users/models/user_option.py
+++ b/src/sentry/users/models/user_option.py
@@ -216,7 +216,7 @@ class UserOption(Model):
     __repr__ = sane_repr("user_id", "project_id", "organization_id", "key", "value")
 
     @classmethod
-    def get_relocation_ordinal_fields(self, json_model: Any) -> list[str] | None:
+    def get_relocation_ordinal_fields(cls, json_model: Any) -> list[str] | None:
         # "global" user options (those with no organization and/or project scope) get a custom
         # ordinal; non-global ones use the default ordering.
         org_id = json_model["fields"].get("organization_id", None)


### PR DESCRIPTION
This is a tiny fix that I happened to come across in my travels: though the method in question doesn't actually use it, the first parameter to a class method should really be `cls`, not `self`.