### PR TITLE
fix(dashboards): Delay binding events on release bubbles

### DIFF
--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -595,7 +595,8 @@ export function useReleaseBubbles({
         trackLegend(params);
       };
 
-      if (echartsInstance) {
+      // @ts-expect-error `getModel` is private, but we access it to prevent binding mouse events to an instance of ECharts that hasn't been fully initialized. A more robust pattern is to attach mouse events using `onChartReady` instead of `ref`, but that causes manually bound mouse events to be overridden by the contents of the `onEvents` prop, since `onChartReady` only fires once, while the `ref` fires more often, and the manual events are re-added.
+      if (echartsInstance?.getModel()) {
         /**
          * MouseListeners for echarts. This includes drawing a highlighted area on the
          * main chart when a release bubble is hovered over.


### PR DESCRIPTION
Do not bind event listeners until the ECharts model is available. This prevents dispatching events before the canvas can be measured. Closes JAVASCRIPT-33AN.

A few notes on this:

- this popped up after the ECharts 6.0 upgrade, but is actually related to the upgrade of `echarts-for-react`. The newer version uses asynchronous ECharts initialization, which `await`s until the `"finish"` event on the chart fires (when animations complete), which leaves a small amount of time when the events are bound but the chart model is not initialized
- since the ref fires very often (probably too often), the events a re-bound often, and waiting until the model is ready works fine

Scroll for more discussion, but the full fix would involve using `onChartReady`, since that ensures that the chart model is available.
