### PR TITLE
perf(aci): Cache error Detector lookups

### DIFF
--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -21,6 +21,7 @@ from sentry.db.models.utils import is_model_attr_cached
 from sentry.issues import grouptype
 from sentry.issues.grouptype import GroupType
 from sentry.models.owner_base import OwnerModel
+from sentry.utils.cache import cache
 from sentry.workflow_engine.models import DataCondition
 
 from .json_config import JSONConfigBase
@@ -86,6 +87,20 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         "fingerprinting_rules": "sentry:fingerprinting_rules",
         "resolve_age": "sentry:resolve_age",
     }
+
+    CACHE_TTL = 60 * 10
+
+    @classmethod
+    def get_error_detector_for_project(cls, project_id: int) -> Detector:
+        from sentry.grouping.grouptype import ErrorGroupType
+
+        detector_type = ErrorGroupType.slug
+        cache_key = f"detector:by_proj_type:{project_id}:{detector_type}"
+        detector = cache.get(cache_key)
+        if detector is None:
+            detector = cls.objects.get(project_id=project_id, type=ErrorGroupType.slug)
+            cache.set(cache_key, detector, cls.CACHE_TTL)
+        return detector
 
     @property
     def group_type(self) -> builtins.type[GroupType]:

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -91,11 +91,16 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
     CACHE_TTL = 60 * 10
 
     @classmethod
+    def _get_detector_project_type_cache_key(cls, project_id: int, detector_type: str) -> str:
+        """Generate cache key for detector lookup by project and type."""
+        return f"detector:by_proj_type:{project_id}:{detector_type}"
+
+    @classmethod
     def get_error_detector_for_project(cls, project_id: int) -> Detector:
         from sentry.grouping.grouptype import ErrorGroupType
 
         detector_type = ErrorGroupType.slug
-        cache_key = f"detector:by_proj_type:{project_id}:{detector_type}"
+        cache_key = cls._get_detector_project_type_cache_key(project_id, detector_type)
         detector = cache.get(cache_key)
         if detector is None:
             detector = cls.objects.get(project_id=project_id, type=ErrorGroupType.slug)

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -23,8 +23,6 @@ logger = logging.getLogger(__name__)
 
 
 def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
-    from sentry.grouping.grouptype import ErrorGroupType
-
     evt = event_data.event
 
     if not isinstance(evt, GroupEvent):
@@ -37,7 +35,7 @@ def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
     try:
         if issue_occurrence is None or evt.group.issue_type.detector_settings is None:
             # if there are no detector settings, default to the error detector
-            detector = Detector.objects.get(project_id=evt.project_id, type=ErrorGroupType.slug)
+            detector = Detector.get_error_detector_for_project(evt.project_id)
         else:
             detector = Detector.objects.get(
                 id=issue_occurrence.evidence_data.get("detector_id", None)


### PR DESCRIPTION
When processing error events, we look up the Detector by project and type.
We can avoid going to the database for the overwhelming majority of events by caching error detectors by project.
These detectors are present for all projects and long-lived, so little risk of inconsistency due to caching.