### PR TITLE
chore(relocation): Fix class method parameter

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -137,7 +137,7 @@ class BaseModel(models.Model):
         return self.__relocation_scope__
 
     @classmethod
-    def get_relocation_ordinal_fields(self, _json_model: Any) -> list[str] | None:
+    def get_relocation_ordinal_fields(cls, _json_model: Any) -> list[str] | None:
         """
         Retrieves the custom ordinal fields for models that may be re-used at import time (that is,
         the `write_relocation_import()` method may return an `ImportKind` besides
@@ -146,10 +146,10 @@ class BaseModel(models.Model):
         correctly with respect to one another.
         """
 
-        if self.__relocation_custom_ordinal__ is None:
+        if cls.__relocation_custom_ordinal__ is None:
             return None
 
-        return self.__relocation_custom_ordinal__
+        return cls.__relocation_custom_ordinal__
 
     @classmethod
     def get_possible_relocation_scopes(cls) -> set[RelocationScope]:


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry/pull/99235, which changed the first parameter of a `UserOption` class method to `cls`, doing the same thing in the base class.