### PR TITLE
feat(trace-eap-waterfall): Fixing performance issue trace preview scroll

### DIFF
--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
@@ -181,7 +181,7 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
           }
         }
         for (const o of n.occurrences) {
-          if (o.event_id === props.event.occurrence?.id) {
+          if (o.event_id === props.event.eventID) {
             return true;
           }
         }

--- a/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.tsx
@@ -89,15 +89,12 @@ export class IssuesTraceTree extends TraceTree {
         }
 
         for (const o of n.occurrences) {
-          if (isTransactionNode(n)) {
-            if (o.event_id === event.eventID) {
-              return true;
-            }
-          } else if (o.event_id === event.occurrence?.id) {
+          if (o.event_id === event.eventID) {
             return true;
           }
         }
       }
+
       return false;
     });
 


### PR DESCRIPTION
The trace loads but we are not expanding and highlighting the offending span, due to a mismatch in event ids.

Caused by: https://github.com/getsentry/sentry/pull/98845
