### PR TITLE
fix(autofix): Fix overlapping report a bug button with seer drawer buttons

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -440,6 +440,7 @@ const SeerDrawerBody = styled(DrawerBody)`
   * {
     direction: ltr;
   }
+  padding-bottom: 80px;
 `;
 
 const Header = styled('h3')`


### PR DESCRIPTION
Adds some padding to fix an issue with the `Report a Bug` button overlapping on top of the Seer Drawer button bar when scrolled to the bottom of the screen. 

Before
<img width="503" height="171" alt="image" src="https://github.com/user-attachments/assets/f77b966e-fe22-4bdc-ae7f-3c776e1b1776" />
After
<img width="414" height="178" alt="image" src="https://github.com/user-attachments/assets/2e2565bb-2a00-4b79-ac28-4a74edc22415" />
