### PR TITLE
feat(performance): makes all webvital issue fingerprints unique with a uuid

### DIFF
--- a/src/sentry/issues/endpoints/project_user_issue.py
+++ b/src/sentry/issues/endpoints/project_user_issue.py
@@ -94,7 +94,10 @@ class WebVitalsUserIssueFormatter(BaseUserIssueFormatter):
     def create_fingerprint(self) -> list[str]:
         vital = self.data.get("vital", "")
         transaction = self.data.get("transaction", "")
-        return [f"insights-web-vitals-{vital}-{transaction}"]
+        # We add a uuid to force uniqueness on the fingerprint
+        # This is because we do not want historic autofix runs to be connected to new issue events
+        uuid = uuid4().hex
+        return [f"insights-web-vitals-{vital}-{transaction}-{uuid}"]
 
     def get_tags(self) -> dict:
         vital = self.data.get("vital", "")

--- a/tests/sentry/issues/endpoints/test_project_user_issue.py
+++ b/tests/sentry/issues/endpoints/test_project_user_issue.py
@@ -147,7 +147,7 @@ class ProjectUserIssueEndpointTest(APITestCase):
 
     @with_feature("organizations:performance-web-vitals-seer-suggestions")
     @with_feature("organizations:issue-web-vitals-ingest")
-    def test_web_vitals_issue_fingerprint_consistency(self) -> None:
+    def test_web_vitals_issue_fingerprint_uniqueness(self) -> None:
         data = {
             "transaction": "/test-transaction",
             "issueType": WebVitalsGroup.slug,
@@ -180,5 +180,8 @@ class ProjectUserIssueEndpointTest(APITestCase):
         fingerprint1 = call1_args[1]["occurrence"].fingerprint
         fingerprint2 = call2_args[1]["occurrence"].fingerprint
 
-        assert fingerprint1 == fingerprint2
-        assert fingerprint1 == ["insights-web-vitals-lcp-/test-transaction"]
+        assert len(fingerprint1) == 1
+        assert len(fingerprint2) == 1
+        assert fingerprint1[0].startswith("insights-web-vitals-lcp-/test-transaction-")
+        assert fingerprint2[0].startswith("insights-web-vitals-lcp-/test-transaction-")
+        assert fingerprint1 != fingerprint2


### PR DESCRIPTION
Updates Web Vital issue fingerprints to be completely unique by appending a uuid to the fingerprint. We want this primarily because:
- New Web Vital issues will not get grouped to resolved issues and display out of date autofix runs in the Web Vitals UI
- Prevents scenario where a user may trigger autofix on a reopened Web Vital issue using an old event and trace.
- Avoids overwriting previous autofix runs and solutions on resolved issues, which users may want to keep for historical purposes