### PR TITLE
ref(uptime): Pass detectors to the quotas system

### DIFF
--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -618,7 +618,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         # XXX: Since project_subscription is mutable, the delete sets the id to null. So we're unable
         # to compare the calls directly. Instead, we add a side effect to the mock so that it keeps track of
         # the values we want to check.
-        assert remove_call_vals == [(DataCategory.UPTIME, self.project_subscription.id)]
+        assert remove_call_vals == [(DataCategory.UPTIME, self.detector.id)]
 
         fingerprint = build_detector_fingerprint_component(self.detector).encode("utf-8")
         hashed_fingerprint = md5(fingerprint).hexdigest()

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -652,7 +652,7 @@ class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
             detector.refresh_from_db()
 
         assert UptimeSubscription.objects.filter(id=other_sub.uptime_subscription_id).exists()
-        mock_remove_seat.assert_called_with(DataCategory.UPTIME, mock.ANY)
+        mock_remove_seat.assert_called_with(DataCategory.UPTIME, detector)
 
     @mock.patch("sentry.quotas.backend.remove_seat")
     def test_single_subscriptions(self, mock_remove_seat: mock.MagicMock) -> None:
@@ -674,7 +674,7 @@ class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
 
         with pytest.raises(UptimeSubscription.DoesNotExist):
             proj_sub.uptime_subscription.refresh_from_db()
-        mock_remove_seat.assert_called_with(DataCategory.UPTIME, mock.ANY)
+        mock_remove_seat.assert_called_with(DataCategory.UPTIME, detector)
 
 
 class RemoveUptimeSubscriptionIfUnusedTest(UptimeTestCase):
@@ -767,7 +767,7 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
         proj_sub.refresh_from_db()
         assert proj_sub.status == ObjectStatus.DISABLED
         assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
-        mock_disable_seat.assert_called_with(DataCategory.UPTIME, proj_sub)
+        mock_disable_seat.assert_called_with(DataCategory.UPTIME, detector)
 
         detector.refresh_from_db()
         assert not detector.enabled
@@ -799,7 +799,7 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
         assert proj_sub.status == ObjectStatus.DISABLED
         assert proj_sub.uptime_subscription.uptime_status == UptimeStatus.OK
         assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
-        mock_disable_seat.assert_called_with(DataCategory.UPTIME, proj_sub)
+        mock_disable_seat.assert_called_with(DataCategory.UPTIME, detector)
 
         detector.refresh_from_db()
         assert not detector.enabled
@@ -897,8 +897,8 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
         assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.ACTIVE.value
 
         # Seat assignment was called
-        mock_check_assign_seat.assert_called_with(DataCategory.UPTIME, proj_sub)
-        mock_assign_seat.assert_called_with(DataCategory.UPTIME, proj_sub)
+        mock_check_assign_seat.assert_called_with(DataCategory.UPTIME, detector)
+        mock_assign_seat.assert_called_with(DataCategory.UPTIME, detector)
 
         detector.refresh_from_db()
         assert detector.enabled
@@ -941,7 +941,7 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
         detector.refresh_from_db()
         assert not detector.enabled
 
-        mock_check_assign_seat.assert_called_with(DataCategory.UPTIME, proj_sub)
+        mock_check_assign_seat.assert_called_with(DataCategory.UPTIME, detector)
         mock_assign_seat.assert_not_called()
 
     @mock.patch("sentry.quotas.backend.check_assign_seat")


### PR DESCRIPTION
This is part 2 of migrating billing seats from ProjectUptimeSubscription
to Detectors.

> Update sentry uptime quota usage to always pass Detectors. These are translated back to ProjectUptimeSubscription seat identifier in the billing side as mentioned previously. This will be the only required change in sentry.

Requires https://github.com/getsentry/getsentry/pull/18368