### PR TITLE
feat(tasks) Start using taskworkers by default

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -154,7 +154,7 @@ x-sentry-service-config:
     # Uptime monitoring
     uptime-results:
       description: Kafka consumer for uptime monitoring results
-    worker:
+    celery-worker:
       description: Worker that processes tasks from celery
 
   modes:
@@ -190,7 +190,8 @@ x-sentry-service-config:
         process-spans,
         ingest-occurrences,
         process-segments,
-        worker,
+        taskbroker,
+        taskworker,
       ]
     crons:
       [
@@ -202,7 +203,8 @@ x-sentry-service-config:
         monitors-clock-tick,
         monitors-clock-tasks,
         monitors-incident-occurrences,
-        worker,
+        taskbroker,
+        taskworker,
       ]
     profiling:
       [
@@ -215,7 +217,8 @@ x-sentry-service-config:
         ingest-transactions,
         ingest-profiles,
         ingest-occurrences,
-        worker,
+        taskbroker,
+        taskworker,
         post-process-forwarder-errors,
         post-process-forwarder-transactions,
       ]
@@ -228,7 +231,8 @@ x-sentry-service-config:
         ingest-replay-recordings,
         ingest-events,
         ingest-transactions,
-        worker,
+        taskbroker,
+        taskworker,
       ]
     ingest:
       [
@@ -236,7 +240,8 @@ x-sentry-service-config:
         postgres,
         relay,
         spotlight,
-        worker,
+        taskbroker,
+        taskworker,
         ingest-events,
         ingest-transactions,
         ingest-attachments,
@@ -270,7 +275,8 @@ x-sentry-service-config:
         relay,
         snuba,
         spotlight,
-        worker,
+        taskbroker,
+        taskworker,
         vroom,
       ]
     full:
@@ -301,9 +307,9 @@ x-sentry-service-config:
         post-process-forwarder-errors,
         post-process-forwarder-transactions,
         post-process-forwarder-issue-platform,
+        taskbroker,
         taskworker,
         taskworker-scheduler,
-        worker,
       ]
 
 x-programs:
@@ -359,7 +365,7 @@ x-programs:
     command: sentry run consumer metrics-subscription-results --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
   generic-metrics-subscription-results:
     command: sentry run consumer generic-metrics-subscription-results --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
-  worker:
+  celery-worker:
     command: sentry run worker -c 1 --autoreload
 
 services:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1842,12 +1842,6 @@ else:
         **TASKWORKER_REGION_SCHEDULES,
     }
 
-TASKWORKER_HIGH_THROUGHPUT_NAMESPACES = {
-    "ingest.profiling",
-    "ingest.transactions",
-    "ingest.errors",
-}
-
 # Sentry logs to two major places: stdout, and its internal project.
 # To disable logging to the internal project, add a logger whose only
 # handler is 'console' and disable propagating upwards.
@@ -4132,3 +4126,6 @@ if ngrok_host and SILO_DEVSERVER:
     # the region API URL template is set to the ngrok host.
     SENTRY_OPTIONS["system.region-api-url-template"] = f"https://{{region}}.{ngrok_host}"
     SENTRY_FEATURES["system:multi-region"] = True
+
+if IS_DEV:
+    SENTRY_OPTIONS["taskworker.enabled"] = True


### PR DESCRIPTION
Make taskworkers the default worker runtime in `devserver`. Switch the `--workers` flag to start taskworkers instead of celery workers. I've also added `--celery-worker` in case anyone needs it.

To run tasks locally one first needs to run `devservices up --mode=taskbroker` or one of the product specific profiles like tracing, replay, crons, profiling, or ingest. This will start both a worker and broker. Once the worker is running with devservices, it can brought to the foreground with `devservices foreground taskworker`.

The `devserver --worker` option can be used when you've daemonized taskbroker outside of devservices.

Refs STREAM-395