### PR TITLE
ref(grouping): Add `NSError` subcomponent types

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -222,7 +222,17 @@ class ModuleGroupingComponent(BaseGroupingComponent[str]):
     id: str = "module"
 
 
-class NSErrorGroupingComponent(BaseGroupingComponent[str | int]):
+class NSErrorDomainGroupingComponent(BaseGroupingComponent[str]):
+    id: str = "domain"
+
+
+class NSErrorCodeGroupingComponent(BaseGroupingComponent[int]):
+    id: str = "code"
+
+
+class NSErrorGroupingComponent(
+    BaseGroupingComponent[NSErrorDomainGroupingComponent | NSErrorCodeGroupingComponent]
+):
     id: str = "ns-error"
 
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -17,6 +17,8 @@ from sentry.grouping.component import (
     FrameGroupingComponent,
     FunctionGroupingComponent,
     ModuleGroupingComponent,
+    NSErrorCodeGroupingComponent,
+    NSErrorDomainGroupingComponent,
     NSErrorGroupingComponent,
     StacktraceGroupingComponent,
     ThreadsGroupingComponent,
@@ -529,11 +531,12 @@ def single_exception(
             type_component.update(contributes=False, hint="ignored because exception is synthetic")
 
         if exception.mechanism.meta and "ns_error" in exception.mechanism.meta:
+            ns_error = exception.mechanism.meta["ns_error"]
             ns_error_component = NSErrorGroupingComponent(
                 values=[
-                    exception.mechanism.meta["ns_error"].get("domain"),
-                    exception.mechanism.meta["ns_error"].get("code"),
-                ],
+                    NSErrorDomainGroupingComponent(values=[ns_error.get("domain")]),
+                    NSErrorCodeGroupingComponent(values=[ns_error.get("code")]),
+                ]
             )
 
     if exception.stacktrace is not None:

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:24.945868+00:00'
+created: '2025-09-10T21:59:45.323709+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -42,8 +42,10 @@ contributing variants:
           type*
             "<redacted>"
           ns-error*
-            "<redacted>"
-            2
+            domain*
+              "<redacted>"
+            code*
+              2
   system*
     hash: "47481871aa8d5ab5729cf2db78ce3032"
     contributing component: exception
@@ -69,5 +71,7 @@ contributing variants:
           type*
             "<redacted>"
           ns-error*
-            "<redacted>"
-            2
+            domain*
+              "<redacted>"
+            code*
+              2

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:28.895227+00:00'
+created: '2025-09-10T21:59:45.683752+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -30,5 +30,7 @@ contributing variants:
           type*
             "iOS_Swift.SampleError"
           ns-error*
-            "iOS_Swift.SampleError"
-            0
+            domain*
+              "iOS_Swift.SampleError"
+            code*
+              0

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.404459+00:00'
+created: '2025-09-10T21:59:26.081057+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {
@@ -1019,8 +1019,24 @@ source: tests/sentry/grouping/test_grouping_inputs.py
               "id": "ns-error",
               "name": null,
               "values": [
-                "<redacted>",
-                2
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "domain",
+                  "name": null,
+                  "values": [
+                    "<redacted>"
+                  ]
+                },
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "code",
+                  "name": null,
+                  "values": [
+                    2
+                  ]
+                }
               ]
             },
             {
@@ -2074,8 +2090,24 @@ source: tests/sentry/grouping/test_grouping_inputs.py
               "id": "ns-error",
               "name": null,
               "values": [
-                "<redacted>",
-                2
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "domain",
+                  "name": null,
+                  "values": [
+                    "<redacted>"
+                  ]
+                },
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "code",
+                  "name": null,
+                  "values": [
+                    2
+                  ]
+                }
               ]
             },
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.183690+00:00'
+created: '2025-09-10T21:59:26.474607+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {
@@ -39,8 +39,24 @@ source: tests/sentry/grouping/test_grouping_inputs.py
               "id": "ns-error",
               "name": null,
               "values": [
-                "iOS_Swift.SampleError",
-                0
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "domain",
+                  "name": null,
+                  "values": [
+                    "iOS_Swift.SampleError"
+                  ]
+                },
+                {
+                  "contributes": true,
+                  "hint": null,
+                  "id": "code",
+                  "name": null,
+                  "values": [
+                    0
+                  ]
+                }
               ]
             },
             {

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:40:58.067213+00:00'
+created: '2025-09-10T21:59:07.939080+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -124,8 +124,10 @@ app:
         type*
           "<redacted>"
         ns-error*
-          "<redacted>"
-          2
+          domain*
+            "<redacted>"
+          code*
+            2
 --------------------------------------------------------------------------
 system:
   hash: "47481871aa8d5ab5729cf2db78ce3032"
@@ -248,5 +250,7 @@ system:
         type*
           "<redacted>"
         ns-error*
-          "<redacted>"
-          2
+          domain*
+            "<redacted>"
+          code*
+            2

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:41:00.802468+00:00'
+created: '2025-09-10T21:59:08.299380+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,8 +12,10 @@ app:
         type*
           "iOS_Swift.SampleError"
         ns-error*
-          "iOS_Swift.SampleError"
-          0
+          domain*
+            "iOS_Swift.SampleError"
+          code*
+            0
         value (ignored because ns-error info takes precedence)
           "Code=<int> Description=The operation couldn’t be completed. (iOS_Swift.SampleError error <int>.)"
       threads (exception of app takes precedence)


### PR DESCRIPTION
In the grouping component trees we create as part of calculating an event's hash, there is only one place where a leaf component wraps multiple primitives: in `NSErrorGroupingComponent`, we take the `domain` and `code` values from the mechanism metadata and put them together, unlabeled, into the component's `values` list. This in turn means they're missing labels when we display the trees in the grouping info section of the issue details page.

To fix that problem, this PR introduces two new grouping component classes, `NSErrorDomainGroupingComponent` and `NSErrorCodeGroupingComponent`, and uses each to wrap their respective values within the `NSErrorGroupingComponent`'s `values` list.