### PR TITLE
Reapply "foldsection: add component tests (#98900)"

### DIFF
--- a/static/app/components/core/disclosure/disclosure.tsx
+++ b/static/app/components/core/disclosure/disclosure.tsx
@@ -1,4 +1,5 @@
 import {createContext, useContext, useRef} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {
   useDisclosure,
@@ -9,6 +10,7 @@ import {usePress} from '@react-aria/interactions';
 import {useDisclosureState, type DisclosureState} from '@react-stately/disclosure';
 
 import {Button} from 'sentry/components/core/button';
+import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import {Container, Flex} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import {IconChevron} from 'sentry/icons';
@@ -129,6 +131,22 @@ const StretchedButton = styled(Button)`
   &:hover {
     background-color: transparent;
   }
+
+  ${p =>
+    p.theme.isChonk
+      ? ''
+      : css`
+          display: flex;
+          box-shadow: none;
+
+          &:hover {
+            background-color: transparent;
+          }
+
+          ${InteractionStateLayer} {
+            display: none;
+          }
+        `}
 `;
 
 interface DisclosureContentProps {

--- a/static/app/components/core/disclosure/disclosure.tsx
+++ b/static/app/components/core/disclosure/disclosure.tsx
@@ -14,8 +14,10 @@ import {Text} from 'sentry/components/core/text';
 import {IconChevron} from 'sentry/icons';
 
 export interface DisclosureProps
-  extends Omit<AriaDisclosureProps, 'isDisabled' | 'isExpanded'> {
+  extends Omit<AriaDisclosureProps, 'isDisabled' | 'isExpanded'>,
+    React.HTMLAttributes<HTMLDivElement> {
   children: NonNullable<React.ReactNode>;
+  as?: 'section' | 'div';
   disabled?: boolean;
   expanded?: boolean;
   ref?: React.Ref<HTMLDivElement | null>;
@@ -39,16 +41,23 @@ function useDisclosureContext() {
   return context;
 }
 
-function DisclosureComponent({children, size = 'md', ref, ...props}: DisclosureProps) {
+function DisclosureComponent({
+  children,
+  size = 'md',
+  ref,
+  onExpandedChange,
+  ...props
+}: DisclosureProps) {
   const panelRef = useRef<HTMLDivElement>(null);
 
   const state = useDisclosureState({
     ...props,
     isExpanded: props.expanded,
+    onExpandedChange,
   });
 
   const {buttonProps, panelProps} = useDisclosure(
-    {...props, isDisabled: props.disabled, isExpanded: props.expanded},
+    {...props, onExpandedChange, isDisabled: props.disabled, isExpanded: props.expanded},
     state,
     panelRef
   );
@@ -57,47 +66,73 @@ function DisclosureComponent({children, size = 'md', ref, ...props}: DisclosureP
     <DisclosureContext.Provider
       value={{buttonProps, panelProps, panelRef, state, context: {size}}}
     >
-      <Flex direction="column" align="start" flex="1 1 100%" ref={ref}>
+      <Flex
+        data-disclosure
+        direction="column"
+        align="start"
+        flex="1 1 100%"
+        ref={ref}
+        {...props}
+      >
         {children}
       </Flex>
     </DisclosureContext.Provider>
   );
 }
 
-interface DisclosureTitleProps {
+interface DisclosureTitleProps extends React.HTMLAttributes<HTMLButtonElement> {
   children?: NonNullable<React.ReactNode>;
   trailingItems?: React.ReactNode;
 }
 
-function Title({children, trailingItems}: DisclosureTitleProps) {
+function Title({children, trailingItems, ...rest}: DisclosureTitleProps) {
   const {buttonProps, state, context} = useDisclosureContext();
 
-  const {isDisabled, ...rest} = buttonProps;
-  const {pressProps} = usePress({...rest});
+  const {isDisabled, ...restProps} = buttonProps;
+  const {pressProps} = usePress({...restProps});
 
   return (
-    <Flex justify="start" gap={context.size} align="center" width="100%">
+    <HoverStyleFlex
+      justify="start"
+      gap={context.size}
+      align="center"
+      width="100%"
+      paddingRight="xs"
+      radius="md"
+    >
       <StretchedButton
         icon={<IconChevron direction={state.isExpanded ? 'down' : 'right'} />}
         disabled={isDisabled}
         size={context.size}
         priority="transparent"
         {...pressProps}
+        {...rest}
       >
         {children}
       </StretchedButton>
       {trailingItems ?? null}
-    </Flex>
+    </HoverStyleFlex>
   );
 }
+
+const HoverStyleFlex = styled(Flex)`
+  &:hover {
+    background-color: ${p => p.theme.backgroundSecondary};
+  }
+`;
 
 const StretchedButton = styled(Button)`
   flex-grow: 1;
   justify-content: flex-start;
+  padding-left: ${p => p.theme.space.xs};
+
+  &:hover {
+    background-color: transparent;
+  }
 `;
 
 interface DisclosureContentProps {
-  children: NonNullable<React.ReactNode>;
+  children: React.ReactNode;
 }
 
 function Content({children}: DisclosureContentProps) {
@@ -109,6 +144,7 @@ function Content({children}: DisclosureContentProps) {
       {...panelProps}
       padding={context.size}
       size={context.size}
+      width="100%"
     >
       <Text as="div" size={context.size}>
         {children}
@@ -118,7 +154,7 @@ function Content({children}: DisclosureContentProps) {
 }
 
 const AlignedContainer = styled(Container)<{size: NonNullable<DisclosureProps['size']>}>`
-  padding-left: ${p => (p.size === 'xs' ? '26px' : p.size === 'sm' ? '34px' : '38px')};
+  padding-left: ${p => (p.size === 'xs' ? '22px' : p.size === 'sm' ? '26px' : '26px')};
 `;
 
 export const Disclosure = Object.assign(DisclosureComponent, {

--- a/static/app/components/core/separator/separator.tsx
+++ b/static/app/components/core/separator/separator.tsx
@@ -1,9 +1,10 @@
+import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
 import type {ContainerProps} from 'sentry/components/core/layout/container';
-import {rc} from 'sentry/components/core/layout/styles';
+import {getMargin, getSpacing, rc} from 'sentry/components/core/layout/styles';
 
-export type SeparatorProps = Pick<ContainerProps, 'border'> & {
+export type SeparatorProps = Pick<ContainerProps, 'border' | 'margin' | 'padding'> & {
   orientation: 'horizontal' | 'vertical';
   children?: never;
 } & Omit<React.HTMLAttributes<HTMLHRElement>, 'aria-orientation'>;
@@ -20,22 +21,27 @@ export const Separator = styled(
   },
   {
     shouldForwardProp: prop => {
-      return !omitSeparatorProps.has(prop as any);
+      if (omitSeparatorProps.has(prop as any)) {
+        return false;
+      }
+      return isPropValid(prop);
     },
   }
 )<SeparatorProps>`
   width: ${p => (p.orientation === 'horizontal' ? 'auto' : '1px')};
   height: ${p => (p.orientation === 'horizontal' ? '1px' : 'auto')};
 
+  ${p => rc('padding', p.padding, p.theme, getSpacing)};
+  ${p => rc('margin', p.margin ?? '0', p.theme, getMargin)};
+
   flex-shrink: 0;
   align-self: stretch;
 
-  margin: 0;
   border: none;
   ${p =>
     rc(
       p.orientation === 'horizontal' ? 'border-bottom' : 'border-left',
-      p.border,
+      p.border ?? 'primary',
       p.theme,
       v => `1px solid ${p.theme.tokens.border[v]} !important`
     )};

--- a/static/app/components/events/eventHydrationDiff/replayDiffSection.tsx
+++ b/static/app/components/events/eventHydrationDiff/replayDiffSection.tsx
@@ -49,7 +49,7 @@ export function ReplayDiffSection({event, group, replayId}: Props) {
         />
       </ReactLazyLoad>
       {/* We have to manually add a section divider since LazyLoad puts the section in a wrapper */}
-      <SectionDivider />
+      <SectionDivider orientation="horizontal" />
     </ErrorBoundary>
   );
 }

--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -179,7 +179,7 @@ export function HighlightsIconSummary({event, group}: HighlightsIconSummaryProps
           <EnvironmentHighlight environmentTag={environmentTag} />
         </ScrollCarousel>
       </IconBar>
-      <SectionDivider style={{marginTop: space(1)}} />
+      <SectionDivider margin="md 0 lg 0" orientation="horizontal" />
     </Fragment>
   ) : null;
 }

--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -358,7 +358,7 @@ export function Content({
               numExceptions: values.length,
             })}
           </p>
-          <SectionDivider />
+          <SectionDivider orientation="horizontal" />
         </Fragment>
       )}
       {children}

--- a/static/app/components/events/interfaces/exception.tsx
+++ b/static/app/components/events/interfaces/exception.tsx
@@ -108,7 +108,9 @@ export function Exception({
             />
             {hasStreamlinedUI && group && (
               <Fragment>
-                {data.values && data.values.length > 1 && <SectionDivider />}
+                {data.values && data.values.length > 1 && (
+                  <SectionDivider orientation="horizontal" />
+                )}
                 <ErrorBoundary
                   mini
                   message={t('There was an error loading the suspect commits')}

--- a/static/app/views/issueDetails/actions/shareModal.tsx
+++ b/static/app/views/issueDetails/actions/shareModal.tsx
@@ -193,7 +193,7 @@ export default function ShareIssueModal({
           </StyledButtonBar>
           {hasPublicShare && (
             <Fragment>
-              <SectionDivider />
+              <SectionDivider orientation="horizontal" />
               <SwitchWrapper>
                 <div>
                   <Title>{t('Create a public link')}</Title>

--- a/static/app/views/issueDetails/streamline/foldSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.spec.tsx
@@ -1,0 +1,452 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {setWindowLocation} from 'sentry-test/utils';
+
+import {Button} from 'sentry/components/core/button';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import localStorageWrapper from 'sentry/utils/localStorage';
+import {SectionKey, useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
+import {
+  FoldSection,
+  getFoldSectionKey,
+} from 'sentry/views/issueDetails/streamline/foldSection';
+
+// Mock dependencies
+jest.mock('sentry/views/issueDetails/streamline/context');
+jest.mock('sentry/utils/analytics', () => ({
+  trackAnalytics: jest.fn(),
+}));
+
+describe('FoldSection', () => {
+  const mockUseIssueDetails = {
+    sectionData: {},
+    detectorDetails: {},
+    eventCount: 0,
+    isSidebarOpen: true,
+    navScrollMargin: 64,
+    dispatch: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    localStorageWrapper.clear();
+    jest.mocked(useIssueDetails).mockReturnValue(mockUseIssueDetails);
+  });
+
+  describe('Basic rendering', () => {
+    it('renders with title and children', () => {
+      render(
+        <FoldSection title="Test Section" sectionKey={SectionKey.HIGHLIGHTS}>
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      expect(screen.getByText('Test Section')).toBeVisible();
+      expect(screen.getByText('Test Content')).toBeVisible();
+    });
+
+    it('renders with custom JSX title', () => {
+      render(
+        <FoldSection title={<span>Custom Title</span>} sectionKey={SectionKey.HIGHLIGHTS}>
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      expect(screen.getByText('Custom Title')).toBeVisible();
+    });
+
+    it('applies accessibility attributes to container', () => {
+      render(
+        <FoldSection title="Test Section" sectionKey={SectionKey.HIGHLIGHTS}>
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      const section = screen.getByTestId('highlights');
+      expect(section).toBeVisible();
+      expect(section).toHaveAttribute('id', 'highlights');
+
+      const expandButton = screen.getByRole('button');
+      expect(expandButton).toHaveAttribute('aria-expanded', 'true');
+      expect(expandButton).toHaveAttribute('aria-label', 'Collapse Test Section Section');
+    });
+
+    it('renders with additional identifier', () => {
+      render(
+        <FoldSection
+          title="Test Section"
+          sectionKey={SectionKey.HIGHLIGHTS}
+          additionalIdentifier="-extra"
+        >
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      expect(screen.getByTestId('highlights-extra')).toHaveAttribute(
+        'id',
+        'highlights-extra'
+      );
+    });
+  });
+
+  describe('Collapse/Expand functionality', () => {
+    it('starts expanded by default', () => {
+      render(
+        <FoldSection title="Test Section" sectionKey={SectionKey.HIGHLIGHTS}>
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      expect(screen.getByTestId('highlights')).toBeVisible();
+      expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('can be collapsed and expanded by clicking', async () => {
+      render(
+        <FoldSection title="Test Section" sectionKey={SectionKey.HIGHLIGHTS}>
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      const expandButton = screen.getByRole('button');
+
+      // Initially expanded
+      expect(screen.getByText('Test Content')).toBeVisible();
+
+      // Click to collapse
+      await userEvent.click(expandButton);
+      expect(screen.queryByText('Test Content')).not.toBeInTheDocument();
+      expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+      expect(expandButton).toHaveAttribute('aria-label', 'View Test Section Section');
+
+      // Click to expand
+      await userEvent.click(expandButton);
+      expect(screen.getByText('Test Content')).toBeVisible();
+      expect(expandButton).toHaveAttribute('aria-expanded', 'true');
+      expect(expandButton).toHaveAttribute('aria-label', 'Collapse Test Section Section');
+    });
+
+    it('starts collapsed when initialCollapse is true', () => {
+      render(
+        <FoldSection
+          title="Test Section"
+          sectionKey={SectionKey.HIGHLIGHTS}
+          initialCollapse
+        >
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      expect(screen.queryByText('Test Content')).not.toBeInTheDocument();
+      expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('tracks analytics when toggling', async () => {
+      render(
+        <FoldSection title="Test Section" sectionKey={SectionKey.HIGHLIGHTS}>
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      const expandButton = screen.getByRole('button');
+      await userEvent.click(expandButton);
+
+      expect(trackAnalytics).toHaveBeenCalledWith('issue_details.section_fold', {
+        sectionKey: 'highlights',
+        organization: expect.any(Object),
+        open: true, // Component tracks the current state BEFORE toggle (was open)
+        org_streamline_only: true,
+      });
+    });
+  });
+
+  describe('Prevent collapse functionality', () => {
+    it('cannot be collapsed when preventCollapse is true', () => {
+      render(
+        <FoldSection
+          title="Test Section"
+          sectionKey={SectionKey.HIGHLIGHTS}
+          preventCollapse
+        >
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      // Button exists but should not be functional when preventCollapse is true
+      const button = screen.getByRole('button');
+      expect(button).toBeVisible();
+      expect(screen.getByText('Test Content')).toBeVisible();
+
+      // Content should always be visible when preventCollapse is true
+      expect(screen.getByText('Test Content')).toBeVisible();
+    });
+
+    it('forces expanded state when preventCollapse is enabled', () => {
+      // Start with collapsed state in localStorage
+      localStorageWrapper.setItem(getFoldSectionKey(SectionKey.HIGHLIGHTS), 'true');
+
+      render(
+        <FoldSection
+          title="Test Section"
+          sectionKey={SectionKey.HIGHLIGHTS}
+          preventCollapse
+        >
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      // Should be expanded despite localStorage value
+      expect(screen.getByText('Test Content')).toBeVisible();
+    });
+  });
+
+  describe('Actions', () => {
+    it('shows actions only when expanded', () => {
+      render(
+        <FoldSection
+          title="Test Section"
+          sectionKey={SectionKey.HIGHLIGHTS}
+          actions={<Button size="xs">Test Action</Button>}
+        >
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      // Actions visible when expanded
+      expect(screen.getByRole('button', {name: 'Test Action'})).toBeVisible();
+    });
+
+    it('hides actions when collapsed', async () => {
+      render(
+        <FoldSection
+          title="Test Section"
+          sectionKey={SectionKey.HIGHLIGHTS}
+          actions={<Button size="xs">Test Action</Button>}
+        >
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      // Collapse the section
+      await userEvent.click(screen.getByRole('button', {name: /Collapse/}));
+
+      // Actions should be hidden
+      expect(screen.queryByRole('button', {name: 'Test Action'})).not.toBeInTheDocument();
+    });
+
+    it('prevents event propagation when clicking actions', async () => {
+      const onActionClick = jest.fn();
+
+      render(
+        <FoldSection
+          title="Test Section"
+          sectionKey={SectionKey.HIGHLIGHTS}
+          actions={
+            <Button size="xs" onClick={onActionClick}>
+              Test Action
+            </Button>
+          }
+        >
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      // Click the action button
+      await userEvent.click(screen.getByRole('button', {name: 'Test Action'}));
+
+      // Action handler should be called
+      expect(onActionClick).toHaveBeenCalled();
+
+      // Section should still be expanded (click didn't propagate)
+      expect(screen.getByText('Test Content')).toBeVisible();
+    });
+  });
+
+  describe('LocalStorage persistence', () => {
+    it('persists collapse state to localStorage', async () => {
+      render(
+        <FoldSection title="Test Section" sectionKey={SectionKey.HIGHLIGHTS}>
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      // Collapse section
+      await userEvent.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        expect(
+          localStorageWrapper.getItem(getFoldSectionKey(SectionKey.HIGHLIGHTS))
+        ).toBe('true');
+      });
+    });
+
+    it('loads initial state from localStorage', () => {
+      // Set collapsed state in localStorage
+      localStorageWrapper.setItem(getFoldSectionKey(SectionKey.HIGHLIGHTS), 'true');
+
+      render(
+        <FoldSection title="Test Section" sectionKey={SectionKey.HIGHLIGHTS}>
+          <div>Test Content</div>
+        </FoldSection>
+      );
+
+      // Should start collapsed
+      expect(screen.queryByText('Test Content')).not.toBeInTheDocument();
+    });
+
+    it('does not persist state when disableCollapsePersistence is true', async () => {
+      render(
+        <FoldSection
+          title="Test Section"
+          sectionKey={SectionKey.HIGHLIGHTS}
+          disableCollapsePersistence
+        >
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      // Collapse section
+      await userEvent.click(screen.getByRole('button'));
+
+      // Wait and verify localStorage was not updated
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(
+        localStorageWrapper.getItem(getFoldSectionKey(SectionKey.HIGHLIGHTS))
+      ).toBeNull();
+    });
+  });
+
+  describe('URL hash navigation', () => {
+    beforeEach(() => {
+      Element.prototype.scrollIntoView = jest.fn();
+      setWindowLocation(
+        'http://localhost:3000/organizations/test-org/issues/123#highlights'
+      );
+    });
+
+    it('provides scroll functionality when element and navScrollMargin are available', async () => {
+      render(
+        <FoldSection title="Test Section" sectionKey={SectionKey.HIGHLIGHTS}>
+          <div>Test Content</div>
+        </FoldSection>
+      );
+
+      const section = screen.getByTestId('highlights');
+      expect(section).toHaveAttribute('id', 'highlights');
+      await waitFor(() => {
+        expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Context integration', () => {
+    it('updates context on mount', () => {
+      render(
+        <FoldSection
+          title="Test Section"
+          sectionKey={SectionKey.HIGHLIGHTS}
+          initialCollapse
+        >
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      expect(mockUseIssueDetails.dispatch).toHaveBeenCalledWith({
+        type: 'UPDATE_EVENT_SECTION',
+        key: 'highlights',
+        config: {initialCollapse: true},
+      });
+    });
+
+    it('does not update context if section already exists', () => {
+      jest.mocked(useIssueDetails).mockReturnValue({
+        ...mockUseIssueDetails,
+        sectionData: {
+          [SectionKey.HIGHLIGHTS]: {key: SectionKey.HIGHLIGHTS},
+        },
+      });
+
+      render(
+        <FoldSection title="Test Section" sectionKey={SectionKey.HIGHLIGHTS}>
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      expect(mockUseIssueDetails.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('uses correct initialCollapse value when preventCollapse is true', () => {
+      render(
+        <FoldSection
+          title="Test Section"
+          sectionKey={SectionKey.HIGHLIGHTS}
+          initialCollapse
+          preventCollapse
+        >
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      expect(mockUseIssueDetails.dispatch).toHaveBeenCalledWith({
+        type: 'UPDATE_EVENT_SECTION',
+        key: 'highlights',
+        config: {initialCollapse: false}, // Should override initialCollapse when preventCollapse is true
+      });
+    });
+  });
+});

--- a/static/app/views/issueDetails/streamline/foldSection.stories.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.stories.tsx
@@ -40,6 +40,29 @@ import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
       </Fragment>
     );
   });
+  story('Default example with trailing items', () => {
+    return (
+      <FoldSection
+        title="Default Section"
+        sectionKey={SectionKey.HIGHLIGHTS}
+        actions={
+          <ButtonBar>
+            <Button size="xs" icon={<IconAdd />}>
+              Add
+            </Button>
+            <Button size="xs" icon={<IconSubtract />}>
+              Remove
+            </Button>
+            <Button size="xs" icon={<IconCopy />}>
+              Copy
+            </Button>
+          </ButtonBar>
+        }
+      >
+        <Lorem />
+      </FoldSection>
+    );
+  });
 
   story('Preventing user from collapsing the section', () => {
     return (

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -1,7 +1,6 @@
-import {
+import React, {
   Fragment,
   useCallback,
-  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -10,9 +9,10 @@ import {
 import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
 
-import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
+import {Disclosure} from 'sentry/components/core/disclosure';
+import {Separator} from 'sentry/components/core/separator';
+import {Text} from 'sentry/components/core/text';
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -59,7 +59,7 @@ export interface FoldSectionProps {
    * Disable the ability for the user to collapse the section
    */
   preventCollapse?: boolean;
-  ref?: React.Ref<HTMLElement>;
+  ref?: React.Ref<HTMLDivElement>;
   style?: CSSProperties;
 }
 
@@ -77,6 +77,41 @@ function useOptionalLocalStorageState(
   return disablePersistence
     ? [localState, setLocalState]
     : [persistedState, setPersistedState];
+}
+
+function useScrollToSection(
+  sectionKey: SectionKey,
+  expanded: boolean,
+  setIsCollapsed: (value: boolean) => void
+): React.RefCallback<HTMLDivElement | null> {
+  const hasAttemptedScroll = useRef(false);
+  const {navScrollMargin} = useIssueDetails();
+
+  const scrollToSection = useCallback(
+    (element: HTMLDivElement | null) => {
+      if (!element || !navScrollMargin || hasAttemptedScroll.current) {
+        return;
+      }
+      // Prevent scrolling to element on rerenders
+      hasAttemptedScroll.current = true;
+
+      // scroll to element if it's the current section on page load
+      if (window.location.hash) {
+        const [, hash] = window.location.hash.split('#');
+        if (hash === sectionKey) {
+          if (!expanded) {
+            setIsCollapsed(false);
+          }
+
+          // Delay scrollIntoView to allow for layout changes to take place
+          setTimeout(() => element?.scrollIntoView(), 100);
+        }
+      }
+    },
+    [sectionKey, navScrollMargin, expanded, setIsCollapsed]
+  );
+
+  return scrollToSection;
 }
 
 export function FoldSection({
@@ -101,38 +136,15 @@ export function FoldSection({
     disableCollapsePersistence
   );
 
-  const hasAttemptedScroll = useRef(false);
+  const expanded = !isCollapsed;
+  const scrollToSection = useScrollToSection(sectionKey, expanded, setIsCollapsed);
 
   // If the section is prevented from collapsing, we need to update the local storage state and open
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (preventCollapse) {
       setIsCollapsed(false);
     }
   }, [preventCollapse, setIsCollapsed]);
-
-  const scrollToSection = useCallback(
-    (element: HTMLElement | null) => {
-      if (!element || !navScrollMargin || hasAttemptedScroll.current) {
-        return;
-      }
-      // Prevent scrolling to element on rerenders
-      hasAttemptedScroll.current = true;
-
-      // scroll to element if it's the current section on page load
-      if (window.location.hash) {
-        const [, hash] = window.location.hash.split('#');
-        if (hash === sectionKey) {
-          if (isCollapsed) {
-            setIsCollapsed(false);
-          }
-
-          // Delay scrollIntoView to allow for layout changes to take place
-          setTimeout(() => element?.scrollIntoView(), 100);
-        }
-      }
-    },
-    [sectionKey, navScrollMargin, isCollapsed, setIsCollapsed]
-  );
 
   useLayoutEffect(() => {
     if (!sectionData.hasOwnProperty(sectionKey)) {
@@ -145,81 +157,54 @@ export function FoldSection({
     }
   }, [sectionData, dispatch, sectionKey, initialCollapse, preventCollapse]);
 
-  // This controls disabling the InteractionStateLayer when hovering over action items. We don't
-  // want selecting an action to appear as though it'll fold/unfold the section.
-  const [isLayerEnabled, setIsLayerEnabled] = useState(true);
+  const onExpandedChange = useCallback(() => {
+    if (preventCollapse) {
+      return;
+    }
+    trackAnalytics('issue_details.section_fold', {
+      sectionKey,
+      organization,
+      open: !isCollapsed,
+      org_streamline_only: organization.streamlineOnly ?? undefined,
+    });
+    setIsCollapsed(!isCollapsed);
+  }, [organization, sectionKey, setIsCollapsed, preventCollapse, isCollapsed]);
 
-  const toggleCollapse = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault(); // Prevent browser summary/details behaviour
-      window.getSelection()?.removeAllRanges(); // Prevent text selection on expand
-      trackAnalytics('issue_details.section_fold', {
-        sectionKey,
-        organization,
-        open: !isCollapsed,
-        org_streamline_only: organization.streamlineOnly ?? undefined,
-      });
-      setIsCollapsed(!isCollapsed);
-    },
-    [organization, sectionKey, isCollapsed, setIsCollapsed]
-  );
-  const labelPrefix = isCollapsed ? t('View') : t('Collapse');
+  const labelPrefix = expanded ? t('Collapse') : t('View');
   const labelSuffix = typeof title === 'string' ? title + t(' Section') : t('Section');
-  // XXX: We should eventually only use titles as string, or explicitly pass them to stay accessible
-  const titleLabel = typeof title === 'string' ? title : sectionKey;
 
   return (
     <Fragment>
-      <Section
+      <DisclosureWithScrollMargin
+        as="section"
+        size="md"
+        role="region"
         ref={mergeRefs(ref, scrollToSection)}
         id={sectionKey + additionalIdentifier}
-        scrollMargin={navScrollMargin ?? 0}
-        role="region"
-        aria-label={titleLabel}
         className={className}
+        // XXX: We should eventually only use titles as string, or explicitly pass them to stay accessible
+        aria-label={typeof title === 'string' ? title : sectionKey}
         data-test-id={dataTestId ?? sectionKey + additionalIdentifier}
+        scrollMargin={navScrollMargin ?? 0}
+        expanded={expanded}
+        onExpandedChange={onExpandedChange}
       >
-        <SectionExpander
-          preventCollapse={preventCollapse}
-          onClick={preventCollapse ? e => e.preventDefault() : toggleCollapse}
-          role="button"
+        <Disclosure.Title
           aria-label={`${labelPrefix} ${labelSuffix}`}
-          aria-expanded={!isCollapsed}
+          trailingItems={expanded ? actions : undefined}
         >
-          <InteractionStateLayer
-            hasSelectedBackground={false}
-            hidden={preventCollapse ? preventCollapse : !isLayerEnabled}
-          />
-          <IconWrapper preventCollapse={preventCollapse}>
-            <IconChevron direction={isCollapsed ? 'right' : 'down'} size="xs" />
-          </IconWrapper>
-          <TitleWithActions preventCollapse={preventCollapse}>
-            <TitleWrapper>{title}</TitleWrapper>
-            {!isCollapsed && (
-              <div
-                onClick={e => e.stopPropagation()}
-                onMouseEnter={() => setIsLayerEnabled(false)}
-                onMouseLeave={() => setIsLayerEnabled(true)}
-              >
-                {actions}
-              </div>
-            )}
-          </TitleWithActions>
-        </SectionExpander>
-        {isCollapsed ? null : (
-          <ErrorBoundary mini>
-            <Content>{children}</Content>
-          </ErrorBoundary>
-        )}
-      </Section>
-      <SectionDivider />
+          <Text size="lg">{title}</Text>
+        </Disclosure.Title>
+        <Disclosure.Content>
+          <ErrorBoundary mini>{expanded ? children : null}</ErrorBoundary>
+        </Disclosure.Content>
+      </DisclosureWithScrollMargin>
+      <SectionDivider orientation="horizontal" margin="lg 0" />
     </Fragment>
   );
 }
 
-export const SectionDivider = styled('hr')`
-  border-color: ${p => p.theme.translucentBorder};
-  margin: ${space(1.5)} 0;
+export const SectionDivider = styled(Separator)`
   &:last-child {
     display: none;
   }
@@ -230,47 +215,6 @@ export const SidebarFoldSection = styled(FoldSection)`
   margin: -${space(1)};
 `;
 
-const Section = styled('section')<{scrollMargin: number}>`
+const DisclosureWithScrollMargin = styled(Disclosure)<{scrollMargin: number}>`
   scroll-margin-top: calc(${space(1)} + ${p => p.scrollMargin ?? 0}px);
-`;
-
-const Content = styled('div')`
-  padding: ${space(0.5)} ${space(0.75)};
-  @media (min-width: ${p => p.theme.breakpoints.xs}) {
-    margin-left: ${p => p.theme.space.xl};
-  }
-`;
-
-const SectionExpander = styled('div')<{preventCollapse: boolean}>`
-  display: grid;
-  grid-template-columns: auto 1fr;
-  column-gap: ${p => p.theme.space.xs};
-  align-items: center;
-  padding: ${space(0.5)} ${space(1.5)};
-  margin: 0 -${space(0.75)};
-  border-radius: ${p => p.theme.borderRadius};
-  cursor: ${p => (p.preventCollapse ? 'initial' : 'pointer')};
-  position: relative;
-`;
-
-const TitleWrapper = styled('div')`
-  font-size: ${p => p.theme.fontSize.lg};
-  font-weight: ${p => p.theme.fontWeight.bold};
-  user-select: none;
-`;
-
-const IconWrapper = styled('div')<{preventCollapse: boolean}>`
-  color: ${p => p.theme.subText};
-  line-height: 0;
-  display: ${p => (p.preventCollapse ? 'none' : 'block')};
-`;
-
-const TitleWithActions = styled('div')<{preventCollapse: boolean}>`
-  display: grid;
-  grid-template-columns: 1fr auto;
-  margin-right: ${p => (p.preventCollapse ? 0 : space(1))};
-  align-items: center;
-  /* Usually the actions are buttons, this height allows actions appearing after opening the
-  details section to not expand the summary */
-  min-height: 26px;
 `;

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.tsx
@@ -134,4 +134,8 @@ const Side = styled(Layout.Side)`
   > div {
     margin-left: ${p => p.theme.space.xl};
   }
+
+  > [data-disclosure] {
+    margin-left: calc(-${p => p.theme.space.lg} + 2px);
+  }
 `;

--- a/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
@@ -128,7 +128,7 @@ function VitalPill({vital, vitalDetails}: VitalPillProps) {
       <div>{description}</div>
       {status === 'none' ? null : (
         <Fragment>
-          <SectionDivider />
+          <SectionDivider orientation="horizontal" />
           <div>
             {formattedMeterValueText} - {STATUS_TEXT[status]}
           </div>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/profiling/profilePreview.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/profiling/profilePreview.tsx
@@ -172,7 +172,7 @@ export function ProfilePreview({
     return (
       <FlamegraphThemeProvider>
         {message}
-        <SectionDivider />
+        <SectionDivider orientation="horizontal" />
         <InterimSection
           title={t('Profile')}
           type="no_instrumentation_profile"


### PR DESCRIPTION
I have forgotten to address an incompatibility between chonk and old UI in my PR to migrate the FoldSection to use the disclosure component. Going forward, I'll keep a note to always review both until UI2 is not released.

The commit that addresses the incompatibility is [#bbb1884](https://github.com/getsentry/sentry/commit/bbb188466b8661842a5d8f771faca63823e016ea). I'm attaching some screenshots from the demo app where the fold sections are used. I've checked both instances of the UI in light and dark mode, and they should now be compatible.

<img width="1698" height="888" alt="CleanShot 2025-09-10 at 18 23 35@2x" src="https://github.com/user-attachments/assets/30293747-b245-4856-be67-2cf9e482b0b5" />

<img width="996" height="574" alt="CleanShot 2025-09-10 at 18 25 12@2x" src="https://github.com/user-attachments/assets/5bfed356-2191-4b41-ba4b-a7ff47cb2361" />

