### PR TITLE
chore(releases): Make dual writing commits the default path and remove feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -74,8 +74,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:prevent-test-analytics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the improved command menu (Cmd+K)
     manager.add("organizations:command-menu-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable dual writing Commits and CommitFileChanges to the new models in `releases/`
-    manager.add("organizations:commit-retention-dual-writing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable continuous profiling
     manager.add("organizations:continuous-profiling", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enabled for beta orgs

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -470,7 +470,7 @@ class PushEventWebhook(GitHubWebhook):
                         )
 
                     if file_changes:
-                        bulk_create_commit_file_changes(organization, file_changes)
+                        bulk_create_commit_file_changes(file_changes)
                         post_bulk_create(file_changes)
 
             except IntegrityError:

--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from django.utils.datastructures import OrderedSet
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.analytics.events.integration_commit_context_all_frames import (
     IntegrationsFailedToFetchCommitContextAllFrames,
     IntegrationsSuccessfullyFetchedCommitContextAllFrames,
@@ -140,14 +140,7 @@ def get_or_create_commit_from_blame(
             key=blame.commit.commitId,
         )
         if commit.message == "":
-            organization = Organization.objects.get(id=organization_id)
-            new_commit = None
-            if features.has("organizations:commit-retention-dual-writing", organization):
-                try:
-                    new_commit = NewCommit.objects.get(id=commit.id)
-                except NewCommit.DoesNotExist:
-                    pass
-
+            new_commit = NewCommit.objects.get(id=commit.id)
             update_commit(commit, new_commit, message=blame.commit.commitMessage)
 
         return commit

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -155,7 +155,7 @@ def set_commit(idx, data, release):
             )
             for patched_file in patch_set
         ]
-        bulk_create_commit_file_changes(release.organization, file_changes)
+        bulk_create_commit_file_changes(file_changes)
 
     try:
         with atomic_transaction(using=router.db_for_write(ReleaseCommit)):

--- a/src/sentry/releases/commits.py
+++ b/src/sentry/releases/commits.py
@@ -37,10 +37,7 @@ def get_dual_write_start_date() -> datetime | None:
         return None
 
 
-def _dual_write_commit(
-    organization: Organization,
-    old_commit: OldCommit,
-) -> Commit:
+def _dual_write_commit(old_commit: OldCommit) -> Commit:
     """Helper to create or ensure a commit exists in the new table if dual write is enabled."""
     commit_data = {
         "organization_id": old_commit.organization_id,
@@ -58,7 +55,6 @@ def _dual_write_commit(
         logger.info(
             "dual_write_commit_created",
             extra={
-                "organization_id": organization.id,
                 "commit_id": old_commit.id,
                 "commit_key": old_commit.key,
             },
@@ -92,7 +88,7 @@ def create_commit(
             message=message,
             **commit_kwargs,
         )
-        new_commit = _dual_write_commit(organization, old_commit)
+        new_commit = _dual_write_commit(old_commit)
     return old_commit, new_commit
 
 
@@ -127,7 +123,7 @@ def get_or_create_commit(
             defaults=defaults,
         )
 
-        new_commit = _dual_write_commit(organization, old_commit)
+        new_commit = _dual_write_commit(old_commit)
 
     return old_commit, new_commit, created
 

--- a/src/sentry/releases/commits.py
+++ b/src/sentry/releases/commits.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 
 from django.db import router
 
-from sentry import features, options
+from sentry import options
 from sentry.models.commit import Commit as OldCommit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.commitfilechange import CommitFileChange as OldCommitFileChange
@@ -40,11 +40,8 @@ def get_dual_write_start_date() -> datetime | None:
 def _dual_write_commit(
     organization: Organization,
     old_commit: OldCommit,
-) -> Commit | None:
+) -> Commit:
     """Helper to create or ensure a commit exists in the new table if dual write is enabled."""
-    if not features.has("organizations:commit-retention-dual-writing", organization):
-        return None
-
     commit_data = {
         "organization_id": old_commit.organization_id,
         "repository_id": old_commit.repository_id,
@@ -76,7 +73,7 @@ def create_commit(
     message: str | None = None,
     author: CommitAuthor | None = None,
     date_added: datetime | None = None,
-) -> tuple[OldCommit, Commit | None]:
+) -> tuple[OldCommit, Commit]:
     with atomic_transaction(
         using=(
             router.db_for_write(OldCommit),
@@ -106,7 +103,7 @@ def get_or_create_commit(
     message: str | None = None,
     author: CommitAuthor | None = None,
     date_added: datetime | None = None,
-) -> tuple[OldCommit, Commit | None, bool]:
+) -> tuple[OldCommit, Commit, bool]:
     """
     Gets or creates a commit with dual write support.
     """
@@ -135,12 +132,8 @@ def get_or_create_commit(
     return old_commit, new_commit, created
 
 
-def update_commit(old_commit: OldCommit, new_commit: Commit | None, **fields) -> None:
+def update_commit(old_commit: OldCommit, new_commit: Commit, **fields) -> None:
     """Update a commit in both tables if dual write is enabled."""
-    if new_commit is None:
-        old_commit.update(**fields)
-        return
-
     with atomic_transaction(
         using=(
             router.db_for_write(OldCommit),
@@ -152,14 +145,13 @@ def update_commit(old_commit: OldCommit, new_commit: Commit | None, **fields) ->
 
 
 def bulk_create_commit_file_changes(
-    organization: Organization,
     file_changes: list[OldCommitFileChange],
-) -> tuple[list[OldCommitFileChange], list[CommitFileChange] | None]:
+) -> tuple[list[OldCommitFileChange], list[CommitFileChange]]:
     """
     Bulk creates commit file changes with dual write support.
     """
     if not file_changes:
-        return [], None
+        return [], []
 
     with atomic_transaction(
         using=(
@@ -172,40 +164,38 @@ def bulk_create_commit_file_changes(
             ignore_conflicts=True,
             batch_size=100,
         )
-        new_file_changes = None
-        if features.has("organizations:commit-retention-dual-writing", organization):
-            # Since ignore_conflicts doesn't return IDs, fetch all file changes for the commits
-            # and match them up by filename and type
-            commit_ids = {fc.commit_id for fc in file_changes}
+        new_file_changes = []
+        # Since ignore_conflicts doesn't return IDs, fetch all file changes for the commits
+        # and match them up by filename and type
+        commit_ids = {fc.commit_id for fc in file_changes}
 
-            existing_old_fcs = OldCommitFileChange.objects.filter(
-                commit_id__in=commit_ids,
-            )
-            existing_lookup = {
-                (old_fc.commit_id, old_fc.filename, old_fc.type): old_fc
-                for old_fc in existing_old_fcs
-            }
+        existing_old_fcs = OldCommitFileChange.objects.filter(
+            commit_id__in=commit_ids,
+        )
+        existing_lookup = {
+            (old_fc.commit_id, old_fc.filename, old_fc.type): old_fc for old_fc in existing_old_fcs
+        }
 
-            new_file_change_objects = []
-            for fc in file_changes:
-                key = (fc.commit_id, fc.filename, fc.type)
-                if key in existing_lookup:
-                    old_fc = existing_lookup[key]
-                    new_file_change_objects.append(
-                        CommitFileChange(
-                            id=old_fc.id,
-                            organization_id=old_fc.organization_id,
-                            commit_id=old_fc.commit_id,
-                            filename=old_fc.filename,
-                            type=old_fc.type,
-                        )
+        new_file_change_objects = []
+        for fc in file_changes:
+            key = (fc.commit_id, fc.filename, fc.type)
+            if key in existing_lookup:
+                old_fc = existing_lookup[key]
+                new_file_change_objects.append(
+                    CommitFileChange(
+                        id=old_fc.id,
+                        organization_id=old_fc.organization_id,
+                        commit_id=old_fc.commit_id,
+                        filename=old_fc.filename,
+                        type=old_fc.type,
                     )
-
-            if new_file_change_objects:
-                new_file_changes = CommitFileChange.objects.bulk_create(
-                    new_file_change_objects,
-                    ignore_conflicts=True,
-                    batch_size=100,
                 )
+
+        if new_file_change_objects:
+            new_file_changes = CommitFileChange.objects.bulk_create(
+                new_file_change_objects,
+                ignore_conflicts=True,
+                batch_size=100,
+            )
 
     return old_file_changes, new_file_changes

--- a/src/sentry/releases/tasks.py
+++ b/src/sentry/releases/tasks.py
@@ -3,7 +3,6 @@ import logging
 from django.core.cache import cache
 from django.db import router
 
-from sentry import features
 from sentry.locks import locks
 from sentry.models.commit import Commit as OldCommit
 from sentry.models.commitfilechange import CommitFileChange as OldCommitFileChange
@@ -55,9 +54,6 @@ def backfill_commits_for_release(
         return
 
     bind_organization_context(organization)
-
-    if not features.has("organizations:commit-retention-dual-writing", organization):
-        return
 
     cache_key = f"commit-backfill:release:{release_id}"
     if cache.get(cache_key):

--- a/src/sentry_plugins/github/webhooks/events/push.py
+++ b/src/sentry_plugins/github/webhooks/events/push.py
@@ -188,7 +188,7 @@ class PushEventWebhook(Webhook):
                         )
 
                     if file_changes:
-                        bulk_create_commit_file_changes(organization, file_changes)
+                        bulk_create_commit_file_changes(file_changes)
 
             except IntegrityError:
                 pass

--- a/tests/sentry/models/test_releaseenvironment.py
+++ b/tests/sentry/models/test_releaseenvironment.py
@@ -94,54 +94,52 @@ class BackfillTriggerTest(TestCase):
 
     def test_triggers_backfill_when_crossing_dual_write_start_date(self):
         dual_write_start = timezone.now() - timedelta(hours=1)
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            with override_options({"commit.dual-write-start-date": dual_write_start.isoformat()}):
-                old_last_seen = dual_write_start - timedelta(days=1)
-                ReleaseEnvironment.objects.create(
-                    organization_id=self.project.organization_id,
-                    project_id=self.project.id,
-                    release_id=self.release.id,
-                    environment_id=self.environment.id,
-                    first_seen=old_last_seen,
-                    last_seen=old_last_seen,
-                )
-                assert not Commit.objects.filter(id=self.old_commit.id).exists()
+        with override_options({"commit.dual-write-start-date": dual_write_start.isoformat()}):
+            old_last_seen = dual_write_start - timedelta(days=1)
+            ReleaseEnvironment.objects.create(
+                organization_id=self.project.organization_id,
+                project_id=self.project.id,
+                release_id=self.release.id,
+                environment_id=self.environment.id,
+                first_seen=old_last_seen,
+                last_seen=old_last_seen,
+            )
+            assert not Commit.objects.filter(id=self.old_commit.id).exists()
 
-                new_last_seen = timezone.now()
-                with self.tasks():
-                    ReleaseEnvironment.get_or_create(
-                        project=self.project,
-                        release=self.release,
-                        environment=self.environment,
-                        datetime=new_last_seen,
-                    )
-                assert Commit.objects.filter(id=self.old_commit.id).exists()
-                new_commit = Commit.objects.get(id=self.old_commit.id)
-                assert new_commit.key == "abc123"
-                assert new_commit.message == "Test commit"
+            new_last_seen = timezone.now()
+            with self.tasks():
+                ReleaseEnvironment.get_or_create(
+                    project=self.project,
+                    release=self.release,
+                    environment=self.environment,
+                    datetime=new_last_seen,
+                )
+            assert Commit.objects.filter(id=self.old_commit.id).exists()
+            new_commit = Commit.objects.get(id=self.old_commit.id)
+            assert new_commit.key == "abc123"
+            assert new_commit.message == "Test commit"
 
     def test_no_trigger_when_already_after_dual_write_start(self):
         dual_write_start = timezone.now() - timedelta(hours=2)
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            with override_options({"commit.dual-write-start-date": dual_write_start.isoformat()}):
-                old_last_seen = dual_write_start + timedelta(hours=1)
-                ReleaseEnvironment.objects.create(
-                    organization_id=self.project.organization_id,
-                    project_id=self.project.id,
-                    release_id=self.release.id,
-                    environment_id=self.environment.id,
-                    first_seen=old_last_seen,
-                    last_seen=old_last_seen,
+        with override_options({"commit.dual-write-start-date": dual_write_start.isoformat()}):
+            old_last_seen = dual_write_start + timedelta(hours=1)
+            ReleaseEnvironment.objects.create(
+                organization_id=self.project.organization_id,
+                project_id=self.project.id,
+                release_id=self.release.id,
+                environment_id=self.environment.id,
+                first_seen=old_last_seen,
+                last_seen=old_last_seen,
+            )
+            new_last_seen = timezone.now()
+            with self.tasks():
+                ReleaseEnvironment.get_or_create(
+                    project=self.project,
+                    release=self.release,
+                    environment=self.environment,
+                    datetime=new_last_seen,
                 )
-                new_last_seen = timezone.now()
-                with self.tasks():
-                    ReleaseEnvironment.get_or_create(
-                        project=self.project,
-                        release=self.release,
-                        environment=self.environment,
-                        datetime=new_last_seen,
-                    )
-                assert not Commit.objects.filter(id=self.old_commit.id).exists()
+            assert not Commit.objects.filter(id=self.old_commit.id).exists()
 
     def test_no_trigger_when_dual_write_not_configured(self):
         old_last_seen = timezone.now() - timedelta(days=1)
@@ -166,25 +164,24 @@ class BackfillTriggerTest(TestCase):
     def test_no_trigger_when_last_seen_not_bumped(self):
         dual_write_start = timezone.now() - timedelta(hours=1)
 
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            with override_options({"commit.dual-write-start-date": dual_write_start.isoformat()}):
-                old_last_seen = dual_write_start - timedelta(days=1)
-                ReleaseEnvironment.objects.create(
-                    organization_id=self.project.organization_id,
-                    project_id=self.project.id,
-                    release_id=self.release.id,
-                    environment_id=self.environment.id,
-                    first_seen=old_last_seen,
-                    last_seen=old_last_seen,
+        with override_options({"commit.dual-write-start-date": dual_write_start.isoformat()}):
+            old_last_seen = dual_write_start - timedelta(days=1)
+            ReleaseEnvironment.objects.create(
+                organization_id=self.project.organization_id,
+                project_id=self.project.id,
+                release_id=self.release.id,
+                environment_id=self.environment.id,
+                first_seen=old_last_seen,
+                last_seen=old_last_seen,
+            )
+
+            new_last_seen = old_last_seen + timedelta(seconds=30)
+            with self.tasks():
+                ReleaseEnvironment.get_or_create(
+                    project=self.project,
+                    release=self.release,
+                    environment=self.environment,
+                    datetime=new_last_seen,
                 )
 
-                new_last_seen = old_last_seen + timedelta(seconds=30)
-                with self.tasks():
-                    ReleaseEnvironment.get_or_create(
-                        project=self.project,
-                        release=self.release,
-                        environment=self.environment,
-                        datetime=new_last_seen,
-                    )
-
-                assert not Commit.objects.filter(id=self.old_commit.id).exists()
+            assert not Commit.objects.filter(id=self.old_commit.id).exists()

--- a/tests/sentry/releases/test_commits.py
+++ b/tests/sentry/releases/test_commits.py
@@ -36,65 +36,44 @@ class CreateCommitDualWriteTest(TestCase):
             name="Test Author",
         )
 
-    def test_create_commit_without_feature_flag(self):
-        """Test that only the old commit is created when feature flag is disabled"""
-        with self.feature({"organizations:commit-retention-dual-writing": False}):
-            old_commit, new_commit = create_commit(
-                organization=self.organization,
-                repo_id=self.repo.id,
-                key="abc123",
-                message="Test commit message",
-                author=self.author,
-            )
-            assert old_commit is not None
-            assert old_commit.organization_id == self.organization.id
-            assert old_commit.repository_id == self.repo.id
-            assert old_commit.key == "abc123"
-            assert old_commit.message == "Test commit message"
-            assert old_commit.author == self.author
-            assert new_commit is None
-            assert not Commit.objects.filter(key="abc123").exists()
+    def test_create_commit(self):
+        """Test that both commits are created"""
+        old_commit, new_commit = create_commit(
+            organization=self.organization,
+            repo_id=self.repo.id,
+            key="def456",
+            message="Test commit with dual write",
+            author=self.author,
+        )
 
-    def test_create_commit_with_feature_flag(self):
-        """Test that both commits are created when feature flag is enabled"""
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            old_commit, new_commit = create_commit(
-                organization=self.organization,
-                repo_id=self.repo.id,
-                key="def456",
-                message="Test commit with dual write",
-                author=self.author,
-            )
-
-            assert old_commit.organization_id == self.organization.id
-            assert old_commit.repository_id == self.repo.id
-            assert old_commit.key == "def456"
-            assert old_commit.message == "Test commit with dual write"
-            assert old_commit.author == self.author
-            assert new_commit is not None
-            assert new_commit.organization_id == self.organization.id
-            assert new_commit.repository_id == self.repo.id
-            assert new_commit.key == "def456"
-            assert new_commit.message == "Test commit with dual write"
-            assert new_commit.author == self.author
+        assert old_commit.organization_id == self.organization.id
+        assert old_commit.repository_id == self.repo.id
+        assert old_commit.key == "def456"
+        assert old_commit.message == "Test commit with dual write"
+        assert old_commit.author == self.author
+        assert new_commit is not None
+        assert new_commit.organization_id == self.organization.id
+        assert new_commit.repository_id == self.repo.id
+        assert new_commit.key == "def456"
+        assert new_commit.message == "Test commit with dual write"
+        assert new_commit.author == self.author
 
     def test_create_commit_preserves_primary_key(self):
         """Test that the new commit uses the same primary key as the old commit"""
         # First, create some commits WITHOUT dual write to advance the auto-increment
         # This ensures the tables don't just happen to have the same ID by chance
-        with self.feature({"organizations:commit-retention-dual-writing": False}):
-            OldCommit.objects.create(
-                organization_id=self.organization.id,
-                repository_id=self.repo.id,
-                key="dummy1",
-                message="Dummy commit 1",
-            )
-            dummy_commit2 = OldCommit.objects.create(
-                organization_id=self.organization.id,
-                repository_id=self.repo.id,
-                key="dummy2",
-                message="Dummy commit 2",
-            )
+        OldCommit.objects.create(
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+            key="dummy1",
+            message="Dummy commit 1",
+        )
+        dummy_commit2 = OldCommit.objects.create(
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+            key="dummy2",
+            message="Dummy commit 2",
+        )
 
         # Now manually create a commit in the new table with a different ID
         # to ensure the auto-increment sequences are out of sync
@@ -106,77 +85,73 @@ class CreateCommitDualWriteTest(TestCase):
         )
 
         # Now test that dual write preserves the old commit's ID
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            old_commit, new_commit = create_commit(
-                organization=self.organization,
-                repo_id=self.repo.id,
-                key="ghi789",
-                message="Test PK preservation",
-                author=self.author,
-            )
+        old_commit, new_commit = create_commit(
+            organization=self.organization,
+            repo_id=self.repo.id,
+            key="ghi789",
+            message="Test PK preservation",
+            author=self.author,
+        )
 
-            assert new_commit is not None
-            assert new_commit.id == old_commit.id
-            # The IDs should NOT be sequential with the manual commit we created
-            assert new_commit.id != manual_new_commit.id + 1
-            assert old_commit.id > dummy_commit2.id
-            fetched_new = Commit.objects.get(id=old_commit.id)
-            assert fetched_new.key == "ghi789"
-            assert fetched_new.organization_id == self.organization.id
+        assert new_commit is not None
+        assert new_commit.id == old_commit.id
+        # The IDs should NOT be sequential with the manual commit we created
+        assert new_commit.id != manual_new_commit.id + 1
+        assert old_commit.id > dummy_commit2.id
+        fetched_new = Commit.objects.get(id=old_commit.id)
+        assert fetched_new.key == "ghi789"
+        assert fetched_new.organization_id == self.organization.id
 
     def test_create_commit_with_custom_date(self):
         """Test that custom date_added is preserved in both models"""
         custom_date = timezone.now().replace(year=2020, month=1, day=1)
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            old_commit, new_commit = create_commit(
-                organization=self.organization,
-                repo_id=self.repo.id,
-                key="jkl012",
-                message="Test with custom date",
-                author=self.author,
-                date_added=custom_date,
-            )
-            assert old_commit.date_added == custom_date
-            assert new_commit is not None
-            assert new_commit.date_added == custom_date
+        old_commit, new_commit = create_commit(
+            organization=self.organization,
+            repo_id=self.repo.id,
+            key="jkl012",
+            message="Test with custom date",
+            author=self.author,
+            date_added=custom_date,
+        )
+        assert old_commit.date_added == custom_date
+        assert new_commit is not None
+        assert new_commit.date_added == custom_date
 
     def test_create_commit_with_none_values(self):
         """Test that None values are handled correctly"""
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            old_commit, new_commit = create_commit(
-                organization=self.organization,
-                repo_id=self.repo.id,
-                key="pqr678",
-                message=None,
-                author=None,
-            )
-            assert old_commit.message is None
-            assert old_commit.author is None
-            assert new_commit is not None
-            assert new_commit.message is None
-            assert new_commit.author is None
-            assert new_commit.id == old_commit.id
+        old_commit, new_commit = create_commit(
+            organization=self.organization,
+            repo_id=self.repo.id,
+            key="pqr678",
+            message=None,
+            author=None,
+        )
+        assert old_commit.message is None
+        assert old_commit.author is None
+        assert new_commit is not None
+        assert new_commit.message is None
+        assert new_commit.author is None
+        assert new_commit.id == old_commit.id
 
     def test_create_commit_transaction_atomicity(self):
         """Test that both commits are rolled back when new commit creation fails"""
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            with (
-                patch.object(
-                    Commit.objects,
-                    "get_or_create",
-                    side_effect=OperationalError("Connection failed"),
-                ),
-                pytest.raises(OperationalError),
-            ):
-                create_commit(
-                    organization=self.organization,
-                    repo_id=self.repo.id,
-                    key="test_atomicity_key",
-                    message="This should fail and rollback",
-                    author=self.author,
-                )
-            assert not OldCommit.objects.filter(key="test_atomicity_key").exists()
-            assert not Commit.objects.filter(key="test_atomicity_key").exists()
+        with (
+            patch.object(
+                Commit.objects,
+                "get_or_create",
+                side_effect=OperationalError("Connection failed"),
+            ),
+            pytest.raises(OperationalError),
+        ):
+            create_commit(
+                organization=self.organization,
+                repo_id=self.repo.id,
+                key="test_atomicity_key",
+                message="This should fail and rollback",
+                author=self.author,
+            )
+        assert not OldCommit.objects.filter(key="test_atomicity_key").exists()
+        assert not Commit.objects.filter(key="test_atomicity_key").exists()
 
 
 class GetOrCreateCommitDualWriteTest(TestCase):
@@ -194,105 +169,76 @@ class GetOrCreateCommitDualWriteTest(TestCase):
 
     def test_get_or_create_commit_creates_new(self):
         """Test that get_or_create creates a new commit when it doesn't exist"""
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            old_commit, new_commit, created = get_or_create_commit(
-                organization=self.organization,
-                repo_id=self.repo.id,
-                key="new123",
-                message="New commit message",
-                author=self.author,
-            )
+        old_commit, new_commit, created = get_or_create_commit(
+            organization=self.organization,
+            repo_id=self.repo.id,
+            key="new123",
+            message="New commit message",
+            author=self.author,
+        )
 
-            assert created is True
-            assert old_commit.key == "new123"
-            assert old_commit.message == "New commit message"
-            assert old_commit.author == self.author
+        assert created is True
+        assert old_commit.key == "new123"
+        assert old_commit.message == "New commit message"
+        assert old_commit.author == self.author
 
-            assert new_commit is not None
-            assert new_commit.id == old_commit.id
-            assert new_commit.key == "new123"
-            assert new_commit.message == "New commit message"
-            assert new_commit.author == self.author
+        assert new_commit is not None
+        assert new_commit.id == old_commit.id
+        assert new_commit.key == "new123"
+        assert new_commit.message == "New commit message"
+        assert new_commit.author == self.author
 
     def test_get_or_create_commit_gets_existing(self):
         """Test that get_or_create returns existing commit when it exists"""
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            existing_old, existing_new = create_commit(
-                organization=self.organization,
-                repo_id=self.repo.id,
-                key="existing456",
-                message="Existing commit",
-                author=self.author,
-            )
-            assert existing_new is not None
-            old_commit, new_commit, created = get_or_create_commit(
-                organization=self.organization,
-                repo_id=self.repo.id,
-                key="existing456",
-                message="This should not be used",
-                author=None,
-            )
-            assert created is False
-            assert old_commit.id == existing_old.id
-            assert old_commit.key == "existing456"
-            assert old_commit.message == "Existing commit"
-            assert old_commit.author == self.author
-            assert new_commit is not None
-            assert new_commit.id == existing_new.id
+        existing_old, existing_new = create_commit(
+            organization=self.organization,
+            repo_id=self.repo.id,
+            key="existing456",
+            message="Existing commit",
+            author=self.author,
+        )
+        assert existing_new is not None
+        old_commit, new_commit, created = get_or_create_commit(
+            organization=self.organization,
+            repo_id=self.repo.id,
+            key="existing456",
+            message="This should not be used",
+            author=None,
+        )
+        assert created is False
+        assert old_commit.id == existing_old.id
+        assert old_commit.key == "existing456"
+        assert old_commit.message == "Existing commit"
+        assert old_commit.author == self.author
+        assert new_commit is not None
+        assert new_commit.id == existing_new.id
 
     def test_get_or_create_commit_backfills_to_new_table(self):
         """Test that get_or_create backfills to new table if commit exists only in old table"""
-        with self.feature({"organizations:commit-retention-dual-writing": False}):
-            old_only_commit = OldCommit.objects.create(
-                organization_id=self.organization.id,
-                repository_id=self.repo.id,
-                key="old_only789",
-                message="Old table only",
-                author=self.author,
-            )
+        old_only_commit = OldCommit.objects.create(
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+            key="old_only789",
+            message="Old table only",
+            author=self.author,
+        )
         assert not Commit.objects.filter(id=old_only_commit.id).exists()
 
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            old_commit, new_commit, created = get_or_create_commit(
-                organization=self.organization,
-                repo_id=self.repo.id,
-                key="old_only789",
-                message="Should not be used",
-            )
+        old_commit, new_commit, created = get_or_create_commit(
+            organization=self.organization,
+            repo_id=self.repo.id,
+            key="old_only789",
+            message="Should not be used",
+        )
 
-            assert created is False
-            assert old_commit.id == old_only_commit.id
-            assert old_commit.message == "Old table only"
-            assert new_commit is not None
-            assert new_commit.id == old_only_commit.id
-            assert new_commit.key == "old_only789"
-            assert new_commit.message == "Old table only"
-            assert new_commit.author == self.author
-
-    def test_get_or_create_commit_without_feature_flag(self):
-        """Test that get_or_create only uses old table when feature flag is disabled"""
-        with self.feature({"organizations:commit-retention-dual-writing": False}):
-            old_commit, new_commit, created = get_or_create_commit(
-                organization=self.organization,
-                repo_id=self.repo.id,
-                key="no_flag123",
-                message="Without flag",
-            )
-            assert created is True
-            assert old_commit.key == "no_flag123"
-            assert old_commit.message == "Without flag"
-            assert new_commit is None
-            assert not Commit.objects.filter(key="no_flag123").exists()
-            old_commit2, new_commit2, created2 = get_or_create_commit(
-                organization=self.organization,
-                repo_id=self.repo.id,
-                key="no_flag123",
-                message="Should not be used",
-            )
-            assert created2 is False
-            assert old_commit2.id == old_commit.id
-            assert old_commit2.message == "Without flag"
-            assert new_commit2 is None
+        assert created is False
+        assert old_commit.id == old_only_commit.id
+        assert old_commit.message == "Old table only"
+        assert new_commit is not None
+        assert new_commit.id == old_only_commit.id
+        assert new_commit.key == "old_only789"
+        assert new_commit.message == "Old table only"
+        assert new_commit.author == self.author
 
 
 class UpdateCommitTest(TestCase):
@@ -331,20 +277,6 @@ class UpdateCommitTest(TestCase):
         new_commit.refresh_from_db()
         assert old_commit.message == "Updated message"
         assert new_commit.message == "Updated message"
-
-    def test_update_commit_without_dual_write(self):
-        """Test updating a commit only updates old table when new_commit is None"""
-        old_commit = OldCommit.objects.create(
-            organization_id=self.organization.id,
-            repository_id=self.repo.id,
-            key="def456",
-            message="Initial message",
-            author=self.author,
-        )
-        update_commit(old_commit, None, message="Updated message")
-        old_commit.refresh_from_db()
-        assert old_commit.message == "Updated message"
-        assert not Commit.objects.filter(key="def456").exists()
 
     def test_update_commit_atomic_transaction(self):
         """Test that updates are atomic when dual write is enabled"""
@@ -408,73 +340,45 @@ class CreateCommitFileChangeDualWriteTest(TestCase):
             date_added=self.commit.date_added,
         )
 
-    def test_create_file_change_without_feature_flag(self):
-        """Test that only the old file changes are created when feature flag is disabled"""
-        with self.feature({"organizations:commit-retention-dual-writing": False}):
-            file_changes = [
-                OldCommitFileChange(
-                    organization_id=self.organization.id,
-                    commit_id=self.commit.id,
-                    filename="src/main.py",
-                    type="A",
-                ),
-            ]
-            old_file_changes, new_file_changes = bulk_create_commit_file_changes(
-                organization=self.organization,
-                file_changes=file_changes,
-            )
-            assert len(old_file_changes) == 1
-            assert old_file_changes[0].organization_id == self.organization.id
-            assert old_file_changes[0].commit_id == self.commit.id
-            assert old_file_changes[0].filename == "src/main.py"
-            assert old_file_changes[0].type == "A"
-            assert new_file_changes is None
-            assert not CommitFileChange.objects.filter(filename="src/main.py").exists()
-
-    def test_create_file_change_with_feature_flag(self):
+    def test_create_file_change(self):
         """Test that both file changes are created when feature flag is enabled"""
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            file_changes = [
-                OldCommitFileChange(
-                    organization_id=self.organization.id,
-                    commit_id=self.commit.id,
-                    filename="src/app.py",
-                    type="M",
-                ),
-            ]
-            old_file_changes, new_file_changes = bulk_create_commit_file_changes(
-                organization=self.organization,
-                file_changes=file_changes,
-            )
-            assert len(old_file_changes) == 1
-            assert old_file_changes[0].organization_id == self.organization.id
-            assert old_file_changes[0].commit_id == self.commit.id
-            assert old_file_changes[0].filename == "src/app.py"
-            assert old_file_changes[0].type == "M"
-            assert new_file_changes is not None
-            assert len(new_file_changes) == 1
-            assert new_file_changes[0].organization_id == self.organization.id
-            assert new_file_changes[0].commit_id == self.commit.id
-            assert new_file_changes[0].filename == "src/app.py"
-            assert new_file_changes[0].type == "M"
+        file_changes = [
+            OldCommitFileChange(
+                organization_id=self.organization.id,
+                commit_id=self.commit.id,
+                filename="src/app.py",
+                type="M",
+            ),
+        ]
+        old_file_changes, new_file_changes = bulk_create_commit_file_changes(file_changes)
+        assert len(old_file_changes) == 1
+        assert old_file_changes[0].organization_id == self.organization.id
+        assert old_file_changes[0].commit_id == self.commit.id
+        assert old_file_changes[0].filename == "src/app.py"
+        assert old_file_changes[0].type == "M"
+        assert new_file_changes is not None
+        assert len(new_file_changes) == 1
+        assert new_file_changes[0].organization_id == self.organization.id
+        assert new_file_changes[0].commit_id == self.commit.id
+        assert new_file_changes[0].filename == "src/app.py"
+        assert new_file_changes[0].type == "M"
 
     def test_create_file_change_preserves_primary_key(self):
         """Test that the new file change uses the same primary key as the old file change"""
         # First, create some file changes WITHOUT dual write to advance the auto-increment
         # This ensures the tables don't just happen to have the same ID by chance
-        with self.feature({"organizations:commit-retention-dual-writing": False}):
-            OldCommitFileChange.objects.create(
-                organization_id=self.organization.id,
-                commit_id=self.commit.id,
-                filename="dummy1.py",
-                type="A",
-            )
-            dummy_fc2 = OldCommitFileChange.objects.create(
-                organization_id=self.organization.id,
-                commit_id=self.commit.id,
-                filename="dummy2.py",
-                type="M",
-            )
+        OldCommitFileChange.objects.create(
+            organization_id=self.organization.id,
+            commit_id=self.commit.id,
+            filename="dummy1.py",
+            type="A",
+        )
+        dummy_fc2 = OldCommitFileChange.objects.create(
+            organization_id=self.organization.id,
+            commit_id=self.commit.id,
+            filename="dummy2.py",
+            type="M",
+        )
 
         # Now manually create a file change in the new table with a different ID
         # to ensure the auto-increment sequences are out of sync
@@ -485,140 +389,125 @@ class CreateCommitFileChangeDualWriteTest(TestCase):
             type="D",
         )
 
-        # Now test that dual write preserves the old file change's ID
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            file_changes = [
-                OldCommitFileChange(
-                    organization_id=self.organization.id,
-                    commit_id=self.commit.id,
-                    filename="test_pk.py",
-                    type="M",
-                ),
-            ]
-            old_file_changes, new_file_changes = bulk_create_commit_file_changes(
-                organization=self.organization,
-                file_changes=file_changes,
-            )
-            assert len(old_file_changes) == 1
-            assert new_file_changes is not None
-            assert len(new_file_changes) == 1
-            # With ignore_conflicts, returned objects don't have IDs, so fetch from DB
-            fetched_old = OldCommitFileChange.objects.get(
-                commit_id=self.commit.id, filename="test_pk.py", type="M"
-            )
-            fetched_new = CommitFileChange.objects.get(
-                commit_id=self.commit.id, filename="test_pk.py", type="M"
-            )
-            assert fetched_new.id == fetched_old.id
-            # The IDs should NOT be sequential with the manual file change we created
-            assert fetched_new.id != manual_new_fc.id + 1
-            assert fetched_old.id > dummy_fc2.id
-            assert fetched_new.filename == "test_pk.py"
-            assert fetched_new.organization_id == self.organization.id
+        file_changes = [
+            OldCommitFileChange(
+                organization_id=self.organization.id,
+                commit_id=self.commit.id,
+                filename="test_pk.py",
+                type="M",
+            ),
+        ]
+        old_file_changes, new_file_changes = bulk_create_commit_file_changes(file_changes)
+        assert len(old_file_changes) == 1
+        assert new_file_changes is not None
+        assert len(new_file_changes) == 1
+        # With ignore_conflicts, returned objects don't have IDs, so fetch from DB
+        fetched_old = OldCommitFileChange.objects.get(
+            commit_id=self.commit.id, filename="test_pk.py", type="M"
+        )
+        fetched_new = CommitFileChange.objects.get(
+            commit_id=self.commit.id, filename="test_pk.py", type="M"
+        )
+        assert fetched_new.id == fetched_old.id
+        # The IDs should NOT be sequential with the manual file change we created
+        assert fetched_new.id != manual_new_fc.id + 1
+        assert fetched_old.id > dummy_fc2.id
+        assert fetched_new.filename == "test_pk.py"
+        assert fetched_new.organization_id == self.organization.id
 
     def test_create_file_change_idempotent(self):
         """Test that the operation is idempotent with ignore_conflicts"""
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            # Create a file change first
-            existing_old = OldCommitFileChange.objects.create(
+        # Create a file change first
+        existing_old = OldCommitFileChange.objects.create(
+            organization_id=self.organization.id,
+            commit_id=self.commit.id,
+            filename="unique_file.py",
+            type="A",
+        )
+        # Try to create the same file change again (should be ignored, not error)
+        file_changes = [
+            OldCommitFileChange(
                 organization_id=self.organization.id,
                 commit_id=self.commit.id,
                 filename="unique_file.py",
-                type="A",
-            )
-            # Try to create the same file change again (should be ignored, not error)
-            file_changes = [
-                OldCommitFileChange(
-                    organization_id=self.organization.id,
-                    commit_id=self.commit.id,
-                    filename="unique_file.py",
-                    type="A",  # Same type - exact duplicate
-                ),
-            ]
-            # Should not raise due to ignore_conflicts
-            bulk_create_commit_file_changes(
-                organization=self.organization,
-                file_changes=file_changes,
-            )
+                type="A",  # Same type - exact duplicate
+            ),
+        ]
+        # Should not raise due to ignore_conflicts
+        bulk_create_commit_file_changes(file_changes)
 
-            existing_old.refresh_from_db()
-            assert existing_old.type == "A"
-            # Should have dual written the existing one
-            assert CommitFileChange.objects.filter(
-                commit_id=self.commit.id, filename="unique_file.py"
-            ).exists()
-            new_fc = CommitFileChange.objects.get(
-                commit_id=self.commit.id, filename="unique_file.py"
-            )
-            assert new_fc.id == existing_old.id
+        existing_old.refresh_from_db()
+        assert existing_old.type == "A"
+        # Should have dual written the existing one
+        assert CommitFileChange.objects.filter(
+            commit_id=self.commit.id, filename="unique_file.py"
+        ).exists()
+        new_fc = CommitFileChange.objects.get(commit_id=self.commit.id, filename="unique_file.py")
+        assert new_fc.id == existing_old.id
 
     def test_bulk_create_multiple_file_changes(self):
         """Test that bulk creation works with multiple file changes"""
-        with self.feature({"organizations:commit-retention-dual-writing": True}):
-            file_changes = [
-                OldCommitFileChange(
-                    organization_id=self.organization.id,
-                    commit_id=self.commit.id,
-                    filename="file1.py",
-                    type="A",
-                ),
-                OldCommitFileChange(
-                    organization_id=self.organization.id,
-                    commit_id=self.commit.id,
-                    filename="file2.py",
-                    type="M",
-                ),
-                OldCommitFileChange(
-                    organization_id=self.organization.id,
-                    commit_id=self.commit.id,
-                    filename="file3.py",
-                    type="D",
-                ),
-            ]
+        file_changes = [
+            OldCommitFileChange(
+                organization_id=self.organization.id,
+                commit_id=self.commit.id,
+                filename="file1.py",
+                type="A",
+            ),
+            OldCommitFileChange(
+                organization_id=self.organization.id,
+                commit_id=self.commit.id,
+                filename="file2.py",
+                type="M",
+            ),
+            OldCommitFileChange(
+                organization_id=self.organization.id,
+                commit_id=self.commit.id,
+                filename="file3.py",
+                type="D",
+            ),
+        ]
 
-            old_file_changes, new_file_changes = bulk_create_commit_file_changes(
-                organization=self.organization,
-                file_changes=file_changes,
+        old_file_changes, new_file_changes = bulk_create_commit_file_changes(file_changes)
+
+        assert len(old_file_changes) == 3
+        assert old_file_changes[0].filename == "file1.py"
+        assert old_file_changes[0].type == "A"
+        assert old_file_changes[1].filename == "file2.py"
+        assert old_file_changes[1].type == "M"
+        assert old_file_changes[2].filename == "file3.py"
+        assert old_file_changes[2].type == "D"
+        assert new_file_changes is not None
+        assert len(new_file_changes) == 3
+        assert new_file_changes[0].filename == "file1.py"
+        assert new_file_changes[0].type == "A"
+        assert new_file_changes[1].filename == "file2.py"
+        assert new_file_changes[1].type == "M"
+        assert new_file_changes[2].filename == "file3.py"
+        assert new_file_changes[2].type == "D"
+
+        # With ignore_conflicts, returned objects don't have IDs, so fetch from DB
+        for filename, ftype in [("file1.py", "A"), ("file2.py", "M"), ("file3.py", "D")]:
+            old_fc = OldCommitFileChange.objects.get(
+                commit_id=self.commit.id, filename=filename, type=ftype
             )
-
-            assert len(old_file_changes) == 3
-            assert old_file_changes[0].filename == "file1.py"
-            assert old_file_changes[0].type == "A"
-            assert old_file_changes[1].filename == "file2.py"
-            assert old_file_changes[1].type == "M"
-            assert old_file_changes[2].filename == "file3.py"
-            assert old_file_changes[2].type == "D"
-            assert new_file_changes is not None
-            assert len(new_file_changes) == 3
-            assert new_file_changes[0].filename == "file1.py"
-            assert new_file_changes[0].type == "A"
-            assert new_file_changes[1].filename == "file2.py"
-            assert new_file_changes[1].type == "M"
-            assert new_file_changes[2].filename == "file3.py"
-            assert new_file_changes[2].type == "D"
-
-            # With ignore_conflicts, returned objects don't have IDs, so fetch from DB
-            for filename, ftype in [("file1.py", "A"), ("file2.py", "M"), ("file3.py", "D")]:
-                old_fc = OldCommitFileChange.objects.get(
-                    commit_id=self.commit.id, filename=filename, type=ftype
-                )
-                new_fc = CommitFileChange.objects.get(
-                    commit_id=self.commit.id, filename=filename, type=ftype
-                )
-                assert old_fc.id == new_fc.id
-
-            assert (
-                OldCommitFileChange.objects.filter(
-                    filename__in=["file1.py", "file2.py", "file3.py"]
-                ).count()
-                == 3
+            new_fc = CommitFileChange.objects.get(
+                commit_id=self.commit.id, filename=filename, type=ftype
             )
-            assert (
-                CommitFileChange.objects.filter(
-                    filename__in=["file1.py", "file2.py", "file3.py"]
-                ).count()
-                == 3
-            )
+            assert old_fc.id == new_fc.id
+
+        assert (
+            OldCommitFileChange.objects.filter(
+                filename__in=["file1.py", "file2.py", "file3.py"]
+            ).count()
+            == 3
+        )
+        assert (
+            CommitFileChange.objects.filter(
+                filename__in=["file1.py", "file2.py", "file3.py"]
+            ).count()
+            == 3
+        )
 
 
 class GetDualWriteStartDateTest(TestCase):

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -220,7 +220,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
                 author=self.commit_author,
                 key="existing-commit",
             )
-            _dual_write_commit(self.organization, existing_commit)
+            _dual_write_commit(existing_commit)
             existing_commit.update(message="")
             assert Commit.objects.count() == 2
             event_frames = get_frame_paths(self.event)
@@ -288,7 +288,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
                 key="existing-commit",
             )
             existing_commit.update(message="")
-            _dual_write_commit(self.organization, existing_commit)
+            _dual_write_commit(existing_commit)
             assert Commit.objects.count() == 2
             event_frames = get_frame_paths(self.event)
             process_commit_context(
@@ -746,7 +746,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             key="existing-commit",
         )
         existing_commit.update(message="")
-        _dual_write_commit(self.organization, existing_commit)
+        _dual_write_commit(existing_commit)
 
         # Map blame names to actual blame objects
         blame_mapping = {

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -34,6 +34,7 @@ from sentry.models.pullrequest import (
     PullRequestCommit,
 )
 from sentry.models.repository import Repository
+from sentry.releases.commits import _dual_write_commit
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.commit_context import PR_COMMENT_WINDOW, process_commit_context
@@ -219,6 +220,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
                 author=self.commit_author,
                 key="existing-commit",
             )
+            _dual_write_commit(self.organization, existing_commit)
             existing_commit.update(message="")
             assert Commit.objects.count() == 2
             event_frames = get_frame_paths(self.event)
@@ -286,6 +288,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
                 key="existing-commit",
             )
             existing_commit.update(message="")
+            _dual_write_commit(self.organization, existing_commit)
             assert Commit.objects.count() == 2
             event_frames = get_frame_paths(self.event)
             process_commit_context(
@@ -743,6 +746,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
             key="existing-commit",
         )
         existing_commit.update(message="")
+        _dual_write_commit(self.organization, existing_commit)
 
         # Map blame names to actual blame objects
         blame_mapping = {


### PR DESCRIPTION
Context: https://www.notion.so/sentry/Release-Retention-2028b10e4b5d802ea421c193303becaf

This shouldn't be merged until we're happy with the dual write process running smoothly. This just simplifies our codebase and makes the switchover code more manageable.

<!-- Describe your PR here. -->