### PR TITLE
feat(aci): add warnings on automation list view for invalid actions

### DIFF
--- a/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
@@ -1,7 +1,7 @@
 import {TitleCell} from 'sentry/components/workflowEngine/gridCell/titleCell';
-import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import useOrganization from 'sentry/utils/useOrganization';
+import {getAutomationActionsWarning} from 'sentry/views/automations/hooks/utils';
 import {makeAutomationDetailsPathname} from 'sentry/views/automations/pathnames';
 
 interface Props {
@@ -15,7 +15,7 @@ export default function AutomationTitleCell({automation}: Props) {
   const inactiveCount = allActions.filter(action => action.status === 'disabled').length;
   const totalCount = allActions.length;
 
-  const warning = getWarning({inactiveCount, totalCount});
+  const warning = getAutomationActionsWarning({inactiveCount, totalCount});
 
   return (
     <TitleCell
@@ -26,34 +26,4 @@ export default function AutomationTitleCell({automation}: Props) {
       warning={warning}
     />
   );
-}
-
-function getWarning({
-  inactiveCount,
-  totalCount,
-}: {
-  inactiveCount: number;
-  totalCount: number;
-}) {
-  if (totalCount === 0) {
-    return {
-      color: 'danger' as const,
-      message: t('You must add an action for this automation to run.'),
-    };
-  }
-  if (inactiveCount === totalCount) {
-    return {
-      color: 'danger' as const,
-      message: t(
-        'Automation is invalid because no actions can run. Actions need to be reconfigured.'
-      ),
-    };
-  }
-  if (inactiveCount > 0) {
-    return {
-      color: 'warning' as const,
-      message: t('One or more actions need to be reconfigured in order to run.'),
-    };
-  }
-  return null;
 }

--- a/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
@@ -1,4 +1,5 @@
 import {TitleCell} from 'sentry/components/workflowEngine/gridCell/titleCell';
+import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeAutomationDetailsPathname} from 'sentry/views/automations/pathnames';
@@ -10,12 +11,49 @@ interface Props {
 export default function AutomationTitleCell({automation}: Props) {
   const organization = useOrganization();
 
+  const allActions = automation.actionFilters.flatMap(filter => filter.actions ?? []);
+  const inactiveCount = allActions.filter(action => action.status === 'disabled').length;
+  const totalCount = allActions.length;
+
+  const warning = getWarning({inactiveCount, totalCount});
+
   return (
     <TitleCell
       name={automation.name}
       link={makeAutomationDetailsPathname(organization.slug, automation.id)}
       systemCreated={!automation.createdBy}
       disabled={!automation.enabled}
+      warning={warning}
     />
   );
+}
+
+function getWarning({
+  inactiveCount,
+  totalCount,
+}: {
+  inactiveCount: number;
+  totalCount: number;
+}) {
+  if (totalCount === 0) {
+    return {
+      color: 'danger' as const,
+      message: t('You must add an action for this automation to run.'),
+    };
+  }
+  if (inactiveCount === totalCount) {
+    return {
+      color: 'danger' as const,
+      message: t(
+        'Automation is invalid because no actions can run. Actions need to be reconfigured.'
+      ),
+    };
+  }
+  if (inactiveCount > 0) {
+    return {
+      color: 'warning' as const,
+      message: t('One or more actions need to be reconfigured in order to run.'),
+    };
+  }
+  return null;
 }

--- a/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
@@ -11,11 +11,7 @@ interface Props {
 export default function AutomationTitleCell({automation}: Props) {
   const organization = useOrganization();
 
-  const allActions = automation.actionFilters.flatMap(filter => filter.actions ?? []);
-  const inactiveCount = allActions.filter(action => action.status === 'disabled').length;
-  const totalCount = allActions.length;
-
-  const warning = getAutomationActionsWarning({inactiveCount, totalCount});
+  const warning = getAutomationActionsWarning(automation);
 
   return (
     <TitleCell

--- a/static/app/components/workflowEngine/gridCell/titleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/titleCell.tsx
@@ -5,12 +5,8 @@ import {Link} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconSentry, IconWarning} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
+import type {StatusWarning} from 'sentry/types/workflowEngine/automations';
 import {defined} from 'sentry/utils';
-
-export type TitleWarning = {
-  color: 'danger' | 'warning';
-  message: string;
-};
 
 export type TitleCellProps = {
   link: string;
@@ -19,7 +15,7 @@ export type TitleCellProps = {
   details?: React.ReactNode;
   disabled?: boolean;
   systemCreated?: boolean;
-  warning?: TitleWarning | null;
+  warning?: StatusWarning | null;
 };
 
 export function TitleCell({

--- a/static/app/components/workflowEngine/gridCell/titleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/titleCell.tsx
@@ -1,7 +1,9 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Flex} from 'sentry/components/core/layout';
 import {Link} from 'sentry/components/core/link';
+import {Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconSentry, IconWarning} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
@@ -36,10 +38,10 @@ export function TitleCell({
           <Fragment>
             &mdash;
             <Tooltip title={warning.message}>
-              <WarningWrapper>
-                {warning.color === 'danger' && <InvalidText>Invalid</InvalidText>}
+              <Flex gap="sm" align="center">
+                {warning.color === 'danger' && <Text variant="danger">Invalid</Text>}
                 <IconWarning color={warning.color} />
-              </WarningWrapper>
+              </Flex>
             </Tooltip>
           </Fragment>
         )}
@@ -64,18 +66,6 @@ const NameText = styled('span')`
 `;
 
 const DisabledText = styled('span')`
-  flex-shrink: 0;
-`;
-
-const InvalidText = styled('span')`
-  flex-shrink: 0;
-  color: ${p => p.theme.danger};
-`;
-
-const WarningWrapper = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.sm};
   flex-shrink: 0;
 `;
 

--- a/static/app/components/workflowEngine/gridCell/titleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/titleCell.tsx
@@ -1,9 +1,16 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Link} from 'sentry/components/core/link';
-import {IconSentry} from 'sentry/icons';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {IconSentry, IconWarning} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+
+export type TitleWarning = {
+  color: 'danger' | 'warning';
+  message: string;
+};
 
 export type TitleCellProps = {
   link: string;
@@ -12,6 +19,7 @@ export type TitleCellProps = {
   details?: React.ReactNode;
   disabled?: boolean;
   systemCreated?: boolean;
+  warning?: TitleWarning | null;
 };
 
 export function TitleCell({
@@ -21,12 +29,24 @@ export function TitleCell({
   link,
   disabled = false,
   className,
+  warning,
 }: TitleCellProps) {
   return (
     <TitleWrapper to={link} className={className}>
       <Name>
         <NameText>{name}</NameText>
         {systemCreated && <CreatedBySentryIcon size="xs" color="subText" />}
+        {warning && (
+          <Fragment>
+            &mdash;
+            <Tooltip title={warning.message}>
+              <WarningWrapper>
+                {warning.color === 'danger' && <InvalidText>Invalid</InvalidText>}
+                <IconWarning color={warning.color} />
+              </WarningWrapper>
+            </Tooltip>
+          </Fragment>
+        )}
         {disabled && <DisabledText>&mdash; Disabled</DisabledText>}
       </Name>
       {defined(details) && <DetailsWrapper>{details}</DetailsWrapper>}
@@ -51,6 +71,18 @@ const DisabledText = styled('span')`
   flex-shrink: 0;
 `;
 
+const InvalidText = styled('span')`
+  flex-shrink: 0;
+  color: ${p => p.theme.danger};
+`;
+
+const WarningWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.sm};
+  flex-shrink: 0;
+`;
+
 const CreatedBySentryIcon = styled(IconSentry)`
   flex-shrink: 0;
 `;
@@ -64,7 +96,7 @@ const TitleWrapper = styled(Link)`
   min-height: 20px;
 
   &:hover {
-    ${Name} {
+    ${NameText} {
       text-decoration: underline;
     }
   }

--- a/static/app/types/workflowEngine/actions.tsx
+++ b/static/app/types/workflowEngine/actions.tsx
@@ -1,9 +1,11 @@
+import type {ObjectStatus} from 'sentry/types/core';
 import type {IssueConfigField} from 'sentry/types/integrations';
 
 export interface Action {
   config: ActionConfig;
   data: Record<string, any>;
   id: string;
+  status: ObjectStatus;
   type: ActionType;
   integrationId?: string;
 }

--- a/static/app/types/workflowEngine/automations.tsx
+++ b/static/app/types/workflowEngine/automations.tsx
@@ -32,3 +32,11 @@ export type AutomationStats = {
   count: number;
   date: string;
 };
+
+/**
+ * Warning information about the status of actions in an automation.
+ */
+export type StatusWarning = {
+  color: 'danger' | 'warning';
+  message: string;
+};

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -515,6 +515,7 @@ function addIfAction(
               integrationId: defaultIntegration.id,
             }),
             data: actionNodesMap.get(actionHandler.type)?.defaultData || {},
+            status: 'active',
           },
         ],
       };

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -1,6 +1,6 @@
 import {t} from 'sentry/locale';
 import type {ActionType} from 'sentry/types/workflowEngine/actions';
-import type {Automation} from 'sentry/types/workflowEngine/automations';
+import type {Automation, StatusWarning} from 'sentry/types/workflowEngine/automations';
 import type {DataConditionGroup} from 'sentry/types/workflowEngine/dataConditions';
 import {
   DataConditionGroupLogicType,
@@ -20,6 +20,36 @@ export function getAutomationActions(automation: Automation): ActionType[] {
         .filter(x => x)
     ),
   ] as ActionType[];
+}
+
+export function getAutomationActionsWarning({
+  inactiveCount,
+  totalCount,
+}: {
+  inactiveCount: number;
+  totalCount: number;
+}): StatusWarning | null {
+  if (totalCount === 0) {
+    return {
+      color: 'danger' as const,
+      message: t('You must add an action for this automation to run.'),
+    };
+  }
+  if (inactiveCount === totalCount) {
+    return {
+      color: 'danger' as const,
+      message: t(
+        'Automation is invalid because no actions can run. Actions need to be reconfigured.'
+      ),
+    };
+  }
+  if (inactiveCount > 0) {
+    return {
+      color: 'warning' as const,
+      message: t('One or more actions need to be reconfigured in order to run.'),
+    };
+  }
+  return null;
 }
 
 export function useAutomationProjectIds(automation: Automation): string[] {

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -22,13 +22,13 @@ export function getAutomationActions(automation: Automation): ActionType[] {
   ] as ActionType[];
 }
 
-export function getAutomationActionsWarning({
-  inactiveCount,
-  totalCount,
-}: {
-  inactiveCount: number;
-  totalCount: number;
-}): StatusWarning | null {
+export function getAutomationActionsWarning(
+  automation: Automation
+): StatusWarning | null {
+  const allActions = automation.actionFilters.flatMap(filter => filter.actions ?? []);
+  const inactiveCount = allActions.filter(action => action.status === 'disabled').length;
+  const totalCount = allActions.length;
+
   if (totalCount === 0) {
     return {
       color: 'danger' as const,

--- a/tests/js/fixtures/automations.ts
+++ b/tests/js/fixtures/automations.ts
@@ -33,7 +33,7 @@ export function AutomationFixture(params: Partial<Automation> = {}): Automation 
   };
 }
 
-function ActionFilterFixture(
+export function ActionFilterFixture(
   params: Partial<DataConditionGroup> = {}
 ): DataConditionGroup {
   return {
@@ -66,6 +66,7 @@ export function ActionFixture(params: Partial<Action> = {}): Action {
       targetType: ActionTarget.SPECIFIC,
     },
     data: {},
+    status: 'active',
     ...params,
   };
 }


### PR DESCRIPTION
now that actions have a `status`, we can flag disabled actions on the automation list view

as of now, actions are only disabled when the integration is uninstalled (therefore the action is considered misconfigured since the integration installation no longer exists)

case 1: one ore more (but not all) actions are disabled
<img width="247" height="92" alt="Screenshot 2025-09-10 at 4 07 57 PM" src="https://github.com/user-attachments/assets/1eb4de5a-de6c-47af-9c0d-d0767db97b6c" />

case 2: all actions are disabled
<img width="389" height="110" alt="Screenshot 2025-09-10 at 4 33 59 PM" src="https://github.com/user-attachments/assets/2270bbfe-3446-4dc9-96a3-72e1133c08f0" />

case 3: automation has no actions
<img width="355" height="104" alt="Screenshot 2025-09-10 at 4 06 30 PM" src="https://github.com/user-attachments/assets/e83cb39d-7029-4c95-bb55-23e4c7f7ee98" />
