### PR TITLE
chore(nav-cleanup): Remove legacy pathname util logic

### DIFF
--- a/static/app/utils/profiling/routes.tsx
+++ b/static/app/utils/profiling/routes.tsx
@@ -8,17 +8,11 @@ import {
   isContinuousProfileReference,
   isTransactionProfileReference,
 } from 'sentry/utils/profiling/guards/profile';
-import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 
-const LEGACY_PROFILING_BASE_PATHNAME = 'profiling';
 const PROFILING_BASE_PATHNAME = 'explore/profiling';
 
 function generateProfilingRoute({organization}: {organization: Organization}): Path {
-  if (prefersStackedNav(organization)) {
-    return `/organizations/${organization.slug}/${PROFILING_BASE_PATHNAME}/`;
-  }
-
-  return `/organizations/${organization.slug}/${LEGACY_PROFILING_BASE_PATHNAME}/`;
+  return `/organizations/${organization.slug}/${PROFILING_BASE_PATHNAME}/`;
 }
 
 export function generateProfileFlamechartRoute({
@@ -30,11 +24,7 @@ export function generateProfileFlamechartRoute({
   profileId: Trace['id'];
   projectSlug: Project['slug'];
 }): string {
-  if (prefersStackedNav(organization)) {
-    return `/organizations/${organization.slug}/${PROFILING_BASE_PATHNAME}/profile/${projectSlug}/${profileId}/flamegraph/`;
-  }
-
-  return `/organizations/${organization.slug}/${LEGACY_PROFILING_BASE_PATHNAME}/profile/${projectSlug}/${profileId}/flamegraph/`;
+  return `/organizations/${organization.slug}/${PROFILING_BASE_PATHNAME}/profile/${projectSlug}/${profileId}/flamegraph/`;
 }
 
 function generateContinuousProfileFlamechartRoute({
@@ -44,11 +34,7 @@ function generateContinuousProfileFlamechartRoute({
   organization: Organization;
   projectSlug: Project['slug'];
 }): string {
-  if (prefersStackedNav(organization)) {
-    return `/organizations/${organization.slug}/${PROFILING_BASE_PATHNAME}/profile/${projectSlug}/flamegraph/`;
-  }
-
-  return `/organizations/${organization.slug}/${LEGACY_PROFILING_BASE_PATHNAME}/profile/${projectSlug}/flamegraph/`;
+  return `/organizations/${organization.slug}/${PROFILING_BASE_PATHNAME}/profile/${projectSlug}/flamegraph/`;
 }
 
 function generateProfileDifferentialFlamegraphRoute({
@@ -58,11 +44,7 @@ function generateProfileDifferentialFlamegraphRoute({
   organization: Organization;
   projectSlug: Project['slug'];
 }): string {
-  if (prefersStackedNav(organization)) {
-    return `/organizations/${organization.slug}/${PROFILING_BASE_PATHNAME}/profile/${projectSlug}/differential-flamegraph/`;
-  }
-
-  return `/organizations/${organization.slug}/${LEGACY_PROFILING_BASE_PATHNAME}/profile/${projectSlug}/differential-flamegraph/`;
+  return `/organizations/${organization.slug}/${PROFILING_BASE_PATHNAME}/profile/${projectSlug}/differential-flamegraph/`;
 }
 
 export function generateProfileDifferentialFlamegraphRouteWithQuery({

--- a/static/app/views/alerts/pathnames.tsx
+++ b/static/app/views/alerts/pathnames.tsx
@@ -1,8 +1,6 @@
 import type {Organization} from 'sentry/types/organization';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 
-const LEGACY_ALERTS_BASE_PATHNAME = 'alerts';
 const ALERTS_BASE_PATHNAME = 'issues/alerts';
 
 export function makeAlertsPathname({
@@ -13,8 +11,6 @@ export function makeAlertsPathname({
   path: '/' | `/${string}/`;
 }) {
   return normalizeUrl(
-    prefersStackedNav(organization)
-      ? `/organizations/${organization.slug}/${ALERTS_BASE_PATHNAME}${path}`
-      : `/organizations/${organization.slug}/${LEGACY_ALERTS_BASE_PATHNAME}${path}`
+    `/organizations/${organization.slug}/${ALERTS_BASE_PATHNAME}${path}`
   );
 }

--- a/static/app/views/discover/pathnames.tsx
+++ b/static/app/views/discover/pathnames.tsx
@@ -1,8 +1,6 @@
 import type {Organization} from 'sentry/types/organization';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 
-const LEGACY_DISCOVER_BASE_PATHNAME = 'discover';
 const DISCOVER_BASE_PATHNAME = 'explore/discover';
 
 export function makeDiscoverPathname({
@@ -13,8 +11,6 @@ export function makeDiscoverPathname({
   path: '/' | `/${string}/`;
 }) {
   return normalizeUrl(
-    prefersStackedNav(organization)
-      ? `/organizations/${organization.slug}/${DISCOVER_BASE_PATHNAME}${path}`
-      : `/organizations/${organization.slug}/${LEGACY_DISCOVER_BASE_PATHNAME}${path}`
+    `/organizations/${organization.slug}/${DISCOVER_BASE_PATHNAME}${path}`
   );
 }

--- a/static/app/views/organizationStats/pathname.tsx
+++ b/static/app/views/organizationStats/pathname.tsx
@@ -1,8 +1,5 @@
 import type {Organization} from 'sentry/types/organization';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
-
-const LEGACY_STATS_BASE_PATHNAME = 'stats';
 
 export function makeStatsPathname({
   path,
@@ -11,9 +8,5 @@ export function makeStatsPathname({
   organization: Organization;
   path: '/' | `/${string}/`;
 }) {
-  return normalizeUrl(
-    prefersStackedNav(organization)
-      ? `/settings/${organization.slug}/stats${path}`
-      : `/organizations/${organization.slug}/${LEGACY_STATS_BASE_PATHNAME}${path}`
-  );
+  return normalizeUrl(`/settings/${organization.slug}/stats${path}`);
 }

--- a/static/app/views/projects/pathname.tsx
+++ b/static/app/views/projects/pathname.tsx
@@ -1,8 +1,6 @@
 import type {Organization} from 'sentry/types/organization';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 
-const LEGACY_PROJECTS_BASE_PATHNAME = 'projects';
 const PROJECTS_BASE_PATHNAME = 'insights/projects';
 
 export function makeProjectsPathname({
@@ -13,8 +11,6 @@ export function makeProjectsPathname({
   path: '/' | `/${string}/`;
 }) {
   return normalizeUrl(
-    prefersStackedNav(organization)
-      ? `/organizations/${organization.slug}/${PROJECTS_BASE_PATHNAME}${path}`
-      : `/organizations/${organization.slug}/${LEGACY_PROJECTS_BASE_PATHNAME}${path}`
+    `/organizations/${organization.slug}/${PROJECTS_BASE_PATHNAME}${path}`
   );
 }

--- a/static/app/views/releases/utils/pathnames.tsx
+++ b/static/app/views/releases/utils/pathnames.tsx
@@ -2,13 +2,11 @@ import type {Location} from 'history';
 
 import type {Organization} from 'sentry/types/organization';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 import {
   cleanReleaseCursors,
   ReleasesDrawerFields,
 } from 'sentry/views/releases/drawer/utils';
 
-const LEGACY_RELEASES_BASE_PATHNAME = 'releases';
 const RELEASES_BASE_PATHNAME = 'explore/releases';
 
 export function makeReleasesPathname({
@@ -19,9 +17,7 @@ export function makeReleasesPathname({
   path: '/' | `/${string}/`;
 }) {
   return normalizeUrl(
-    prefersStackedNav(organization)
-      ? `/organizations/${organization.slug}/${RELEASES_BASE_PATHNAME}${path}`
-      : `/organizations/${organization.slug}/${LEGACY_RELEASES_BASE_PATHNAME}${path}`
+    `/organizations/${organization.slug}/${RELEASES_BASE_PATHNAME}${path}`
   );
 }
 

--- a/static/app/views/replays/pathnames.tsx
+++ b/static/app/views/replays/pathnames.tsx
@@ -1,8 +1,6 @@
 import type {Organization} from 'sentry/types/organization';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 
-const LEGACY_REPLAYS_BASE_PATHNAME = 'replays';
 const REPLAYS_BASE_PATHNAME = 'explore/replays';
 
 export function makeReplaysPathname({
@@ -13,8 +11,6 @@ export function makeReplaysPathname({
   path: '/' | `/${string}/`;
 }) {
   return normalizeUrl(
-    prefersStackedNav(organization)
-      ? `/organizations/${organization.slug}/${REPLAYS_BASE_PATHNAME}${path}`
-      : `/organizations/${organization.slug}/${LEGACY_REPLAYS_BASE_PATHNAME}${path}`
+    `/organizations/${organization.slug}/${REPLAYS_BASE_PATHNAME}${path}`
   );
 }

--- a/static/app/views/traces/pathnames.tsx
+++ b/static/app/views/traces/pathnames.tsx
@@ -1,8 +1,6 @@
 import type {Organization} from 'sentry/types/organization';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 
-const LEGACY_TRACES_BASE_PATHNAME = 'traces';
 const TRACES_BASE_PATHNAME = 'explore/traces';
 
 export function makeTracesPathname({
@@ -13,8 +11,6 @@ export function makeTracesPathname({
   path: '/' | `/${string}/`;
 }) {
   return normalizeUrl(
-    prefersStackedNav(organization)
-      ? `/organizations/${organization.slug}/${TRACES_BASE_PATHNAME}${path}`
-      : `/organizations/${organization.slug}/${LEGACY_TRACES_BASE_PATHNAME}${path}`
+    `/organizations/${organization.slug}/${TRACES_BASE_PATHNAME}${path}`
   );
 }

--- a/static/app/views/userFeedback/pathnames.tsx
+++ b/static/app/views/userFeedback/pathnames.tsx
@@ -1,8 +1,6 @@
 import type {Organization} from 'sentry/types/organization';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 
-const LEGACY_FEEDBACK_BASE_PATHNAME = 'feedback';
 const FEEDBACK_BASE_PATHNAME = 'issues/feedback';
 
 export function makeFeedbackPathname({
@@ -13,8 +11,6 @@ export function makeFeedbackPathname({
   path: '/' | `/${string}/`;
 }) {
   return normalizeUrl(
-    prefersStackedNav(organization)
-      ? `/organizations/${organization.slug}/${FEEDBACK_BASE_PATHNAME}${path}`
-      : `/organizations/${organization.slug}/${LEGACY_FEEDBACK_BASE_PATHNAME}${path}`
+    `/organizations/${organization.slug}/${FEEDBACK_BASE_PATHNAME}${path}`
   );
 }


### PR DESCRIPTION
Ref RTC-1154

One part of a large cleanup of old navigation code, now that all users are forced into the new experience.

This focuses on the pathname creation utils