### PR TITLE
bug(suspect commits): Add User Mappings support for commit author resolution

### DIFF
--- a/src/sentry/integrations/api/bases/external_actor.py
+++ b/src/sentry/integrations/api/bases/external_actor.py
@@ -39,6 +39,7 @@ AVAILABLE_PROVIDERS = {
 
 STRICT_NAME_PROVIDERS = {
     ExternalProviders.GITHUB,
+    ExternalProviders.GITHUB_ENTERPRISE,
     ExternalProviders.GITLAB,
 }
 

--- a/src/sentry/integrations/models/external_actor.py
+++ b/src/sentry/integrations/models/external_actor.py
@@ -46,6 +46,7 @@ class ExternalActor(ReplicatedRegionModel):
         ),
     )
     # The display name i.e. username, team name, channel name.
+    # if provider__in = [GITHUB, GITHUB_ENTERPRISE, GITLAB, CUSTOM], external_name starts with "@"
     external_name = models.TextField()
     # The unique identifier i.e user ID, channel ID.
     external_id = models.TextField(null=True)

--- a/src/sentry/models/commitauthor.py
+++ b/src/sentry/models/commitauthor.py
@@ -62,3 +62,7 @@ class CommitAuthor(Model):
             ).values_list("user_id", flat=True)
         )
         return [u for u in users if u.id in org_member_user_ids]
+
+    def get_username_from_external_id(self) -> str | None:
+        if self.external_id and ":" in self.external_id:
+            return self.external_id.split(":", 1)[1]

--- a/src/sentry/models/commitauthor.py
+++ b/src/sentry/models/commitauthor.py
@@ -29,8 +29,14 @@ class CommitAuthor(Model):
     __relocation_scope__ = RelocationScope.Excluded
 
     organization_id = BoundedBigIntegerField(db_index=True)
+    # display name
     name = models.CharField(max_length=128, null=True)
     email = models.CharField(max_length=200)
+
+    # Format varies by provider:
+    # - GitHub/GitHub Enterprise: "github:username", "github_enterprise:username"
+    # - Other providers: null
+    # - Legacy data(?): integer (rare)
     external_id = models.CharField(max_length=164, null=True)
 
     objects: ClassVar[CommitAuthorManager] = CommitAuthorManager()
@@ -64,5 +70,11 @@ class CommitAuthor(Model):
         return [u for u in users if u.id in org_member_user_ids]
 
     def get_username_from_external_id(self) -> str | None:
-        if self.external_id and ":" in self.external_id:
-            return self.external_id.split(":", 1)[1]
+        """
+        Note: only works for GitHub and GitHub Enterprise
+        """
+        return (
+            self.external_id.split(":", 1)[1]
+            if self.external_id and ":" in self.external_id
+            else None
+        )

--- a/tests/sentry/models/test_commitauthor.py
+++ b/tests/sentry/models/test_commitauthor.py
@@ -1,0 +1,25 @@
+from django.test import SimpleTestCase
+
+from sentry.models.commitauthor import CommitAuthor
+
+
+class CommitAuthorUsernameExtractionTest(SimpleTestCase):
+    def test_get_username_from_external_id(self) -> None:
+        author = CommitAuthor(external_id="github:baxterthehacker")
+        assert author.get_username_from_external_id() == "baxterthehacker"
+
+    def test_get_username_from_external_id_no_external_id(self) -> None:
+        author = CommitAuthor(external_id=None)
+        assert author.get_username_from_external_id() is None
+
+    def test_get_username_from_external_id_empty_external_id(self) -> None:
+        author = CommitAuthor(external_id="")
+        assert author.get_username_from_external_id() is None
+
+    def test_get_username_from_external_id_no_colon(self) -> None:
+        author = CommitAuthor(external_id="justausername")
+        assert author.get_username_from_external_id() is None
+
+    def test_get_username_from_external_id_multiple_colons(self) -> None:
+        author = CommitAuthor(external_id="provider:user:with:colons")
+        assert author.get_username_from_external_id() == "user:with:colons"


### PR DESCRIPTION
## Problem
Anonymous SCM emails (e.g., `123456789+username@users.noreply.github.com`) weren't being resolved to Sentry users despite configured User Mappings, breaking auto-assignment and author attribution across suspect commits, releases, and ownership.

**Root Cause:** `get_users_for_authors()` only performed email-based lookups and ignored ExternalActor (User Mappings) data.

## Solution
- **Added `CommitAuthor.get_username_from_external_id()`** - Extracts usernames from `external_id` field
- **Prioritized User Mappings** - ExternalActor lookup before email lookup (higher signal since manually configured)  
- **Optimized performance** - Batched database queries, return early pattern, extracted helper functions
- **Maintained fallbacks** - Email lookup → CommitAuthor fields for unresolved authors

## Resolution Flow
1. Cache lookup
2. **User Mappings lookup** (new)
3. Email lookup 
4. CommitAuthor fallback
