### PR TITLE
fix(metric_stats): Ignore metric stats in tests for now

### DIFF
--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -67,6 +67,15 @@ def test_global_config() -> None:
     if not config["options"]["relay.span-normalization.allowed_hosts"]:
         del config["options"]["relay.span-normalization.allowed_hosts"]
 
+    # NOTE (vgrozdanic): temporary fix for the test, until metric_stats is completely removed
+    # from sentry codebase. It has been removed from relay, without being first removed from
+    # sentry
+    if "metric_stats" in config["options"]["relay.metric-bucket-distribution-encodings"]:
+        del config["options"]["relay.metric-bucket-distribution-encodings"]["metric_stats"]
+
+    if "metric_stats" in config["options"]["relay.metric-bucket-set-encodings"]:
+        del config["options"]["relay.metric-bucket-set-encodings"]["metric_stats"]
+
     assert normalized == config
 
 

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -73,8 +73,14 @@ def test_global_config() -> None:
     if "metric_stats" in config["options"]["relay.metric-bucket-distribution-encodings"]:
         del config["options"]["relay.metric-bucket-distribution-encodings"]["metric_stats"]
 
+    if "metric_stats" in normalized["options"]["relay.metric-bucket-distribution-encodings"]:
+        del normalized["options"]["relay.metric-bucket-distribution-encodings"]["metric_stats"]
+
     if "metric_stats" in config["options"]["relay.metric-bucket-set-encodings"]:
         del config["options"]["relay.metric-bucket-set-encodings"]["metric_stats"]
+
+    if "metric_stats" in normalized["options"]["relay.metric-bucket-set-encodings"]:
+        del normalized["options"]["relay.metric-bucket-set-encodings"]["metric_stats"]
 
     assert normalized == config
 


### PR DESCRIPTION
In https://github.com/getsentry/relay/pull/5097 we have removed the `metric_stats` completely from the relay, but it is still generated as a part of global config in Sentry. This is now preventing us to bump `sentry-relay` package (https://github.com/getsentry/sentry/pull/99205), because the tests are failing.

Clean up plan:
- stop checking for `metric_stats` in test
- bump `sentry-relay` dependency 
- remove `metric_stats` from sentry codebase



Code used to find the diff:
```py
    for key, value in normalized.items():
        if value != config[key]:
            import difflib
            import pprint

            config_str = pprint.pformat(config[key], width=120, sort_dicts=True)
            value_str = pprint.pformat(value, width=120, sort_dicts=True)
            diff = "\n".join(
                difflib.unified_diff(
                    config_str.splitlines(),
                    value_str.splitlines(),
                    fromfile="config",
                    tofile="normalized",
                    lineterm="",
                )
            )
            print(f"Difference for key '{key}':\n{diff}")
            raise Exception(f"Value for key {key} is not equal to other value")
```