### PR TITLE
feat(self-hosted): Introduce setting to toggle air-gapped environments

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -168,6 +168,10 @@ SENTRY_DISALLOWED_IPS: tuple[str, ...] = (
 # search domains.
 SENTRY_ENSURE_FQDN = False
 
+# When running in an air gap environment, set this to True to disable external
+# network calls and features that require internet connectivity.
+SENTRY_AIR_GAP = False
+
 # XXX [!!]: When adding a new key here BE SURE to configure it in getsentry, as
 #           it can not be `default`. The default cluster in sentry.io
 #           production is NOT a true redis cluster and WILL error in prod.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3459,14 +3459,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Controls whether the async task fetches AI model prices from
-# external sources and stores them in cache.
-register(
-    "ai.model-costs.enable-external-price-fetch",
-    type=Bool,
-    default=True,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 register(
     "commit.dual-write-start-date",
     type=String,

--- a/src/sentry/relay/config/ai_model_costs.py
+++ b/src/sentry/relay/config/ai_model_costs.py
@@ -3,7 +3,6 @@ from typing import Required, TypedDict
 
 from django.conf import settings
 
-from sentry import options
 from sentry.utils.cache import cache
 
 logger = logging.getLogger(__name__)
@@ -39,7 +38,7 @@ def ai_model_costs_config() -> AIModelCosts | None:
     Returns:
         AIModelCosts object containing cost information for AI models
     """
-    if not options.get("ai.model-costs.enable-external-price-fetch"):
+    if settings.SENTRY_AIR_GAP:
         return None
 
     cached_costs = cache.get(AI_MODEL_COSTS_CACHE_KEY)

--- a/src/sentry/tasks/ai_agent_monitoring.py
+++ b/src/sentry/tasks/ai_agent_monitoring.py
@@ -2,6 +2,8 @@ import logging
 import re
 from typing import Any
 
+from django.conf import settings
+
 from sentry import options
 from sentry.http import safe_urlopen
 from sentry.relay.config.ai_model_costs import (
@@ -119,8 +121,8 @@ def fetch_ai_model_costs() -> None:
     OpenRouter prices take precedence over models.dev prices.
     """
 
-    if not options.get("ai.model-costs.enable-external-price-fetch"):
-        # if this feature is disabled, we don't need to fetch model costs
+    # this task shouldn't be run in an air gap environment
+    if settings.SENTRY_AIR_GAP:
         return
 
     models_dict: dict[ModelId, AIModelCostV2] = {}


### PR DESCRIPTION
Some functionalities of Sentry require outbound network calls, which are impossible in air-gapped self hosted environments.

This PR introduces a setting which can be toggled in self-hosted settings file to stop those kind of tasks from executing.
