### PR TITLE
fix(ui): Use isLast in the tags tree

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -99,6 +99,7 @@ function getTagTreeRows({
   uniqueKey,
   event,
   project,
+  isLast,
 }: EventTagsTreeRowProps & {uniqueKey: string}): React.ReactNode[] {
   const subtreeTags = Object.keys(content.subtree);
   const subtreeRows = subtreeTags.reduce<React.ReactNode[]>((rows, tag, i) => {
@@ -123,6 +124,7 @@ function getTagTreeRows({
       data-test-id="tag-tree-row"
       event={event}
       project={project}
+      isLast={isLast}
     />,
     ...subtreeRows,
   ];


### PR DESCRIPTION
This fixes the stem in the tag tree.

Before:
<img width="3364" height="2126" alt="CleanShot 2025-09-11 at 11 03 02@2x" src="https://github.com/user-attachments/assets/d3a5d62a-16a1-4f44-94a8-cd568918084a" />

After:
<img width="3364" height="2126" alt="CleanShot 2025-09-11 at 11 03 12@2x" src="https://github.com/user-attachments/assets/70a10d28-59e4-435d-94e2-4d4efcd55a8a" />


