### PR TITLE
feat(ai): Populate global config with operation type map

### DIFF
--- a/src/sentry/relay/config/ai_operation_type_map.py
+++ b/src/sentry/relay/config/ai_operation_type_map.py
@@ -1,0 +1,37 @@
+from typing import Literal, Required, TypedDict
+
+AI_OPERATION_TYPE_VALUE = Literal["agent", "ai_client", "tool", "handoff", "guardrails"]
+
+AI_OPERATION_TYPE_MAP: dict[AI_OPERATION_TYPE_VALUE, list[str]] = {
+    "agent": [
+        "ai.run.generateText",
+        "ai.run.generateObject",
+        "gen_ai.invoke_agent",
+        "ai.pipeline.generate_text",
+        "ai.pipeline.generate_object",
+        "ai.pipeline.stream_text",
+        "ai.pipeline.stream_object",
+        "gen_ai.create_agent",
+    ],
+    "tool": ["gen_ai.execute_tool"],
+    "handoff": ["gen_ai.handoff"],
+    "ai_client": ["*"],  # default fallback
+}
+
+
+class AIOperationTypeMap(TypedDict):
+    version: Required[int]
+    operationTypes: Required[dict[str, str]]
+
+
+def ai_operation_type_map_config() -> AIOperationTypeMap:
+    operation_type_map = {}
+    # creates reverse map from operation to operation type
+    for operation_type, operations in AI_OPERATION_TYPE_MAP.items():
+        for operation in operations:
+            operation_type_map[operation] = operation_type
+
+    return {
+        "version": 1,
+        "operationTypes": operation_type_map,
+    }

--- a/src/sentry/relay/config/ai_operation_type_map.py
+++ b/src/sentry/relay/config/ai_operation_type_map.py
@@ -21,7 +21,7 @@ AI_OPERATION_TYPE_MAP: dict[AI_OPERATION_TYPE_VALUE, list[str]] = {
 
 class AIOperationTypeMap(TypedDict):
     version: Required[int]
-    operationTypes: Required[dict[str, str]]
+    operationTypes: Required[dict[str, AI_OPERATION_TYPE_VALUE]]
 
 
 def ai_operation_type_map_config() -> AIOperationTypeMap:

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -2,6 +2,10 @@ from typing import Any, TypedDict
 
 import sentry.options
 from sentry.relay.config.ai_model_costs import AIModelCosts, ai_model_costs_config
+from sentry.relay.config.ai_operation_type_map import (
+    AIOperationTypeMap,
+    ai_operation_type_map_config,
+)
 from sentry.relay.config.measurements import MeasurementsConfig, get_measurements_config
 from sentry.relay.config.metric_extraction import (
     MetricExtractionGroups,
@@ -39,6 +43,7 @@ class SpanOpDefaults(TypedDict):
 class GlobalConfig(TypedDict, total=False):
     measurements: MeasurementsConfig
     aiModelCosts: AIModelCosts | None
+    aiOperationTypeMap: AIOperationTypeMap
     metricExtraction: MetricExtractionGroups
     filters: GenericFiltersConfig | None
     spanOpDefaults: SpanOpDefaults
@@ -78,6 +83,7 @@ def get_global_config() -> GlobalConfig:
     global_config: GlobalConfig = {
         "measurements": get_measurements_config(),
         "aiModelCosts": ai_model_costs_config(),
+        "aiOperationTypeMap": ai_operation_type_map_config(),
         "metricExtraction": global_metric_extraction_groups(),
         "spanOpDefaults": span_op_defaults(),
     }

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -144,3 +144,35 @@ def test_global_config_valid_with_generic_filters() -> None:
 def test_global_config_histogram_outliers(insta_snapshot) -> None:
     config = get_global_config()
     insta_snapshot(config["metricExtraction"])
+
+
+@django_db_all
+def test_global_config_ai_operation_type_map() -> None:
+    config = get_global_config()
+
+    assert "aiOperationTypeMap" in config
+    ai_operation_type_map = config["aiOperationTypeMap"]
+
+    assert ai_operation_type_map["version"] == 1
+
+    expected_mappings = {
+        "ai.run.generateText": "agent",
+        "ai.run.generateObject": "agent",
+        "gen_ai.invoke_agent": "agent",
+        "ai.pipeline.generate_text": "agent",
+        "ai.pipeline.generate_object": "agent",
+        "ai.pipeline.stream_text": "agent",
+        "ai.pipeline.stream_object": "agent",
+        "gen_ai.create_agent": "agent",
+        "gen_ai.execute_tool": "tool",
+        "gen_ai.handoff": "handoff",
+    }
+
+    operation_types = ai_operation_type_map["operationTypes"]
+    for operation, expected_type in expected_mappings.items():
+        assert operation in operation_types
+        assert operation_types[operation] == expected_type
+
+    # verify the wildcard mapping for ai_client
+    assert "*" in operation_types
+    assert operation_types["*"] == "ai_client"


### PR DESCRIPTION
Populates global config with `aiOperationTypeMap` which maps `span.op` to `gen_ai.operation.type` attribute and it is used in relay.


Closes [TET-1092: Introduce `gen_ai.operation.type` attribute](https://linear.app/getsentry/issue/TET-1092/introduce-gen-aioperationtype-attribute)

