### PR TITLE
Update rust sdk logs minimum version

### DIFF
--- a/static/app/gettingStartedDocs/rust/rust.tsx
+++ b/static/app/gettingStartedDocs/rust/rust.tsx
@@ -15,7 +15,7 @@ import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersi
 
 type Params = DocsParams;
 
-const getInstallSnippet = (params: Params, defaultVersion = '0.39.0') => {
+const getInstallSnippet = (params: Params, defaultVersion = '0.42.0') => {
   const version = getPackageVersion(params, 'sentry.rust', defaultVersion);
   return params.isLogsSelected
     ? `
@@ -131,7 +131,7 @@ const logsOnboarding: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            'Logs in Rust are supported in Sentry Rust SDK version [code:0.39.0] and above. Additionally, the [code:logs] feature flag needs to be enabled.',
+            'Logs in Rust are supported in Sentry Rust SDK version [code:0.42.0] and above. Additionally, the [code:logs] feature flag needs to be enabled.',
             {
               code: <code />,
             }
@@ -140,7 +140,7 @@ const logsOnboarding: OnboardingConfig = {
         {
           type: 'code',
           language: 'rust',
-          code: getInstallSnippet(params, '0.39.0'),
+          code: getInstallSnippet(params, '0.42.0'),
         },
       ],
     },


### PR DESCRIPTION
<!-- Describe your PR here. -->
Updates the minimum required Rust SDK version for logs onboarding to `0.42.0`. This change reflects that meaningful integration, particularly with tracing, is only available from version `0.42.0` onwards, ensuring users get a functional experience.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/C081M1KEQ0L/p1757591812830469?thread_ts=1757591812.830469&cid=C081M1KEQ0L)

<a href="https://cursor.com/background-agent?bcId=bc-3b9197b8-6d11-4e8d-8229-4b38d1afe953">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3b9197b8-6d11-4e8d-8229-4b38d1afe953">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

