### PR TITLE
fix(analytics): fix bug in serialization of SentryAppSchemaValidationError

### DIFF
--- a/src/sentry/analytics/events/sentry_app_schema_validation_error.py
+++ b/src/sentry/analytics/events/sentry_app_schema_validation_error.py
@@ -16,7 +16,7 @@ class SentryAppSchemaValidationError(analytics.Event):
     # TODO (fabian): see above
     def serialize(self) -> dict[str, Any]:
         serialized = super().serialize()
-        serialized["data"]["schema"] = serialized["data"].pop("app_schema")
+        serialized["schema"] = serialized.pop("app_schema")
         return serialized
 
 

--- a/tests/sentry/analytics/test_event.py
+++ b/tests/sentry/analytics/test_event.py
@@ -7,6 +7,9 @@ import pytest
 from sentry.analytics import Event, eventclass
 from sentry.analytics.attribute import Attribute
 from sentry.analytics.event import EventEnvelope
+from sentry.analytics.events.sentry_app_schema_validation_error import (
+    SentryAppSchemaValidationError,
+)
 from sentry.testutils.cases import TestCase
 
 
@@ -123,3 +126,45 @@ class EventTest(TestCase):
     def test_map_with_instance(self) -> None:
         result = ExampleEvent(id="1", map=DummyType())  # type: ignore[arg-type]
         assert result.serialize()["map"] == {"key": "value"}
+
+    def test_sentry_app_schema_validation_error_serialization(self) -> None:
+        event = SentryAppSchemaValidationError(
+            app_schema='{"name": "test-app", "version": "1.0"}',
+            user_id=12345,
+            sentry_app_id=67890,
+            sentry_app_name="Test App",
+            organization_id=54321,
+            error_message="Invalid schema format",
+        )
+
+        serialized = event.serialize()
+
+        assert serialized == {
+            "schema": '{"name": "test-app", "version": "1.0"}',
+            "user_id": 12345,
+            "sentry_app_id": 67890,
+            "sentry_app_name": "Test App",
+            "organization_id": 54321,
+            "error_message": "Invalid schema format",
+        }
+        assert "app_schema" not in serialized
+
+    def test_sentry_app_schema_validation_error_serialization_with_optional_fields(self) -> None:
+        event = SentryAppSchemaValidationError(
+            app_schema='{"name": "test-app"}',
+            sentry_app_name="Test App",
+            organization_id=54321,
+            error_message="Invalid schema",
+        )
+
+        serialized = event.serialize()
+
+        assert serialized == {
+            "schema": '{"name": "test-app"}',
+            "user_id": None,
+            "sentry_app_id": None,
+            "sentry_app_name": "Test App",
+            "organization_id": 54321,
+            "error_message": "Invalid schema",
+        }
+        assert "app_schema" not in serialized


### PR DESCRIPTION
- The current serialize method in `SentryAppSchemaValidationError` assumes there to be a data field - there is not, hence this fails. This PR fixes that by correcting the logic and adding a test to verify functionality.

Fixes SENTRY-4MZW
Closes TET-1133