### PR TITLE
fix(metric_stats): Fix tests and mocks

### DIFF
--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -44,14 +44,12 @@ def call_endpoint(client, relay, private_key):
         "replay.relay-snuba-publishing-disabled.sample-rate": 1.0,
         "relay.metric-bucket-distribution-encodings": {
             "custom": "array",
-            "metric_stats": "array",
             "profiles": "array",
             "spans": "array",
             "transactions": "array",
         },
         "relay.metric-bucket-set-encodings": {
             "custom": "base64",
-            "metric_stats": "base64",
             "profiles": "base64",
             "spans": "base64",
             "transactions": "base64",
@@ -66,21 +64,6 @@ def test_global_config() -> None:
     # It is not allowed to specify `None` as default for an option.
     if not config["options"]["relay.span-normalization.allowed_hosts"]:
         del config["options"]["relay.span-normalization.allowed_hosts"]
-
-    # NOTE (vgrozdanic): temporary fix for the test, until metric_stats is completely removed
-    # from sentry codebase. It has been removed from relay, without being first removed from
-    # sentry
-    if "metric_stats" in config["options"]["relay.metric-bucket-distribution-encodings"]:
-        del config["options"]["relay.metric-bucket-distribution-encodings"]["metric_stats"]
-
-    if "metric_stats" in normalized["options"]["relay.metric-bucket-distribution-encodings"]:
-        del normalized["options"]["relay.metric-bucket-distribution-encodings"]["metric_stats"]
-
-    if "metric_stats" in config["options"]["relay.metric-bucket-set-encodings"]:
-        del config["options"]["relay.metric-bucket-set-encodings"]["metric_stats"]
-
-    if "metric_stats" in normalized["options"]["relay.metric-bucket-set-encodings"]:
-        del normalized["options"]["relay.metric-bucket-set-encodings"]["metric_stats"]
 
     assert normalized == config
 


### PR DESCRIPTION
Continuation of https://github.com/getsentry/sentry/pull/99276.

`sentry-relay` has been bumped to a newest version, so now we can remove `metric_stats` from mocks.
