### PR TITLE
fix(ui): Fix small icons on build details page

### DIFF
--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -162,7 +162,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
           </SegmentedControl>
         )}
         {selectedContent === 'treemap' && (
-          <InputGroup style={{width: '100%'}}>
+          <InputGroup style={{flexGrow: 1}}>
             <InputGroup.LeadingItems>
               <IconSearch />
             </InputGroup.LeadingItems>


### PR DESCRIPTION
Before:
<img width="656" height="302" alt="CleanShot 2025-09-11 at 14 31 53@2x" src="https://github.com/user-attachments/assets/7d04f5fa-6cce-4fcb-b500-84aaf0310a26" />


After:
<img width="702" height="322" alt="CleanShot 2025-09-11 at 14 30 10@2x" src="https://github.com/user-attachments/assets/06e842db-7882-4266-8443-224bd4048e49" />
