### PR TITLE
Pass stored attachment to symbolicator by reference

### DIFF
--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -27,7 +27,7 @@ class CachedAttachment:
         type=None,
         chunks=None,
         data=UNINITIALIZED_DATA,
-        stored_id=None,
+        stored_id: str | None = None,
         cache=None,
         rate_limited=None,
         size=None,

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -332,9 +332,7 @@ def process_minidump(symbolicator: Symbolicator, data: Any) -> Any:
         rewrite_first_module = []
 
     metrics.incr("process.native.symbolicate.request")
-    response = symbolicator.process_minidump(
-        data.get("platform"), minidump.data, rewrite_first_module
-    )
+    response = symbolicator.process_minidump(data.get("platform"), minidump, rewrite_first_module)
 
     if _handle_response_status(data, response):
         _merge_full_response(data, response)
@@ -357,7 +355,7 @@ def process_applecrashreport(symbolicator: Symbolicator, data: Any) -> Any:
         return
 
     metrics.incr("process.native.symbolicate.request")
-    response = symbolicator.process_applecrashreport(data.get("platform"), report.data)
+    response = symbolicator.process_applecrashreport(data.get("platform"), report)
 
     if _handle_response_status(data, response):
         _merge_full_response(data, response)

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from typing import Any, overload
 
 from sentry.attachments import attachment_cache
+from sentry.attachments.base import CachedAttachment
 from sentry.stacktraces.processing import StacktraceInfo
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.safe import get_path
@@ -103,7 +104,7 @@ def signal_from_data(data):
     return None
 
 
-def get_event_attachment(data, attachment_type):
+def get_event_attachment(data: Any, attachment_type: str) -> CachedAttachment | None:
     cache_key = cache_key_for_event(data)
     attachments = attachment_cache.get(cache_key)
     return next((a for a in attachments if a.type == attachment_type), None)


### PR DESCRIPTION
Thus far, the processing pipeline worked in such a way that a symbolcication request would download the cached attachments from the `attachment_cache`, and then send it to symbolicator via a multipart request.

With already stored attachments, we can send the id/key instead, so that Symbolicator can fetch it directly from objectstore, instead of the roundtrip via multipart requests.

---

This is a companion to https://github.com/getsentry/symbolicator/pull/1780
Ref FS-104