### PR TITLE
feat(preprod): add size analysis loading state

### DIFF
--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -70,6 +70,7 @@ def transform_preprod_artifact_to_build_details(
     artifact: PreprodArtifact,
 ) -> BuildDetailsApiResponse:
     size_info = None
+    size_metrics = None
     try:
         size_metrics = PreprodArtifactSizeMetrics.objects.filter(
             preprod_artifact=artifact,

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -48,6 +48,7 @@ class BuildDetailsSizeInfo(BaseModel):
 class BuildDetailsApiResponse(BaseModel):
     id: str
     state: PreprodArtifact.ArtifactState
+    size_analysis_state: PreprodArtifactSizeMetrics.SizeAnalysisState | None = None
     app_info: BuildDetailsAppInfo
     vcs_info: BuildDetailsVcsInfo
     size_info: BuildDetailsSizeInfo | None = None
@@ -115,6 +116,7 @@ def transform_preprod_artifact_to_build_details(
     return BuildDetailsApiResponse(
         id=artifact.id,
         state=artifact.state,
+        size_analysis_state=size_metrics.state if size_metrics else None,
         app_info=app_info,
         vcs_info=vcs_info,
         size_info=size_info,


### PR DESCRIPTION
Previously the loading state in the UI was being handled by looking at the `artifact` state, but we set that to PROCESSED as soon as we do the lightweight parsing. This new field should let us differentiate the two.