### PR TITLE
chore(timeseries): Add more detailed logging for `/events-timeseries/` spot-check

### DIFF
--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -214,6 +214,8 @@ const useDiscoverSeries = <T extends string[]>(
                 : search.formatString()
               : undefined,
             referrer,
+            stripped: JSON.stringify(stripped),
+            converted: JSON.stringify(converted),
           });
           return;
         }


### PR DESCRIPTION
Should have just done that from the get-go. Having the full payloads there is the fastest way to do this, since logs don't guarantee that the associated traces are available, much less the Replays.
