### PR TITLE
feat(trace-drawer): Aligning question tooltip icon

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1344,7 +1344,7 @@ function SectionTitleWithQuestionTooltip({
   tooltipText: string;
 }) {
   return (
-    <Flex gap="xs">
+    <Flex gap="xs" align="center">
       <div>{title}</div>
       <QuestionTooltip title={tooltipText} size="sm" />
     </Flex>


### PR DESCRIPTION
Before:
<img width="248" height="60" alt="Screenshot 2025-09-11 at 12 45 23 PM" src="https://github.com/user-attachments/assets/cfb1c33f-fb1d-4b47-9351-60f1b3d5632d" />

After:
<img width="197" height="68" alt="Screenshot 2025-09-11 at 12 45 45 PM" src="https://github.com/user-attachments/assets/88bcbfef-dc5f-4aa2-80fd-7a65ab9b72f1" />
