### PR TITLE
feat(otlp): Add otel logs endpoint to project key serializer

### DIFF
--- a/src/sentry/api/serializers/models/project_key.py
+++ b/src/sentry/api/serializers/models/project_key.py
@@ -29,6 +29,7 @@ class DSN(TypedDict):
     cdn: str
     playstation: str
     otlp_traces: str
+    otlp_logs: str
 
 
 class BrowserSDK(TypedDict):
@@ -98,6 +99,7 @@ class ProjectKeySerializer(Serializer):
                 "cdn": obj.js_sdk_loader_cdn_url,
                 "playstation": obj.playstation_endpoint,
                 "otlp_traces": obj.otlp_traces_endpoint,
+                "otlp_logs": obj.otlp_logs_endpoint,
             },
             "browserSdkVersion": get_selected_browser_sdk_version(obj),
             "browserSdk": {"choices": get_browser_sdk_version_choices(obj.project)},

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -19,6 +19,7 @@ KEY_RATE_LIMIT = {
         "minidump": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/minidump/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "playstation": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/playstation/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "otlp_traces": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/otlp/v1/traces",
+        "otlp_logs": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/otlp/v1/logs",
         "nel": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/nel/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "unreal": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/unreal/a785682ddda719b7a8a4011110d75598/",
         "cdn": "https://js.sentry-cdn.com/a785682ddda719b7a8a4011110d75598.min.js",

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -272,6 +272,12 @@ class ProjectKey(Model):
         return f"{endpoint}/api/{self.project_id}/otlp/v1/traces"
 
     @property
+    def otlp_logs_endpoint(self):
+        endpoint = self.get_endpoint()
+
+        return f"{endpoint}/api/{self.project_id}/otlp/v1/logs"
+
+    @property
     def unreal_endpoint(self) -> str:
         return f"{self.get_endpoint()}/api/{self.project_id}/unreal/{self.public_key}/"
 

--- a/tests/sentry/core/endpoints/test_project_keys.py
+++ b/tests/sentry/core/endpoints/test_project_keys.py
@@ -55,6 +55,21 @@ class ListProjectKeysTest(APITestCase):
         assert response.status_code == 200
         assert response.data[0]["dsn"]["otlp_traces"] == key.otlp_traces_endpoint
 
+    def test_otlp_logs_endpoint(self) -> None:
+        project = self.create_project()
+        key = ProjectKey.objects.get_or_create(project=project)[0]
+        self.login_as(user=self.user)
+        url = reverse(
+            "sentry-api-0-project-keys",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response.data[0]["dsn"]["otlp_logs"] == key.otlp_logs_endpoint
+
     def test_use_case(self) -> None:
         """Regular user can access user DSNs but not internal DSNs"""
         project = self.create_project()


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-345/add-otel-logs-endpoint-to-project-key-model

We're working on adding a OTLP endpoint for logs: https://github.com/getsentry/sentry/issues/98649.

This PR adds an `otlp_logs` field to the DSN so we can serialize an OTLP logs url into the project key response.

Similar to the work on https://github.com/getsentry/sentry/pull/96204.