### PR TITLE
feat(otlp): Add feature flag for otel logs UI

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -310,6 +310,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:relay-otlp-traces-endpoint", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables OTLP Log ingestion in Relay for an entire org.
     manager.add("organizations:relay-otel-logs-endpoint", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enables OTLP Log functionality in the Sentry UI
+    manager.add("organizations:otel-logs-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Prevent AI in the Sentry UI
     manager.add("organizations:prevent-ai", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Prevent AI Configuration Page in the Sentry UI


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-342/add-feature-flag-to-sentry-for-otel-endpoint

Feature flag for frontend for https://github.com/getsentry/sentry/pull/99305 and https://github.com/getsentry/sentry/issues/98649.

`api_expose` set to `True` so it can be used on the frontend.