### PR TITLE
fix(ecosystem): Parse github urls with urlparse

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -77,6 +77,7 @@ from sentry.web.helpers import render_to_response
 from .client import GitHubApiClient, GitHubBaseClient, GithubSetupApiClient
 from .issues import GitHubIssuesSpec
 from .repository import GitHubRepositoryProvider
+from .utils import parse_github_blob_url
 
 logger = logging.getLogger("sentry.integrations.github")
 
@@ -258,13 +259,11 @@ class GitHubIntegration(
         return f"https://github.com/{repo.name}/blob/{branch}/{filepath}"
 
     def extract_branch_from_source_url(self, repo: Repository, url: str) -> str:
-        url = url.replace(f"{repo.url}/blob/", "")
-        branch, _, _ = url.partition("/")
+        branch, _ = parse_github_blob_url(repo.url, url)
         return branch
 
     def extract_source_path_from_source_url(self, repo: Repository, url: str) -> str:
-        url = url.replace(f"{repo.url}/blob/", "")
-        _, _, source_path = url.partition("/")
+        _, source_path = parse_github_blob_url(repo.url, url)
         return source_path
 
     def get_repositories(

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -259,10 +259,14 @@ class GitHubIntegration(
         return f"https://github.com/{repo.name}/blob/{branch}/{filepath}"
 
     def extract_branch_from_source_url(self, repo: Repository, url: str) -> str:
+        if not repo.url:
+            return ""
         branch, _ = parse_github_blob_url(repo.url, url)
         return branch
 
     def extract_source_path_from_source_url(self, repo: Repository, url: str) -> str:
+        if not repo.url:
+            return ""
         _, source_path = parse_github_blob_url(repo.url, url)
         return source_path
 

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -21,7 +21,7 @@ from sentry.integrations.base import (
 from sentry.integrations.github.constants import ISSUE_LOCKED_ERROR_MESSAGE, RATE_LIMITED_MESSAGE
 from sentry.integrations.github.integration import GitHubIntegrationProvider, build_repository_query
 from sentry.integrations.github.issues import GitHubIssuesSpec
-from sentry.integrations.github.utils import get_jwt
+from sentry.integrations.github.utils import get_jwt, parse_github_blob_url
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.repository.model import RpcRepository
@@ -225,13 +225,11 @@ class GitHubEnterpriseIntegration(
         return f"{repo.url}/blob/{branch}/{filepath}"
 
     def extract_branch_from_source_url(self, repo: Repository, url: str) -> str:
-        url = url.replace(f"{repo.url}/blob/", "")
-        branch, _, _ = url.partition("/")
+        branch, _ = parse_github_blob_url(repo.url, url)
         return branch
 
     def extract_source_path_from_source_url(self, repo: Repository, url: str) -> str:
-        url = url.replace(f"{repo.url}/blob/", "")
-        _, _, source_path = url.partition("/")
+        _, source_path = parse_github_blob_url(repo.url, url)
         return source_path
 
     def search_issues(self, query: str | None, **kwargs):

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -225,10 +225,14 @@ class GitHubEnterpriseIntegration(
         return f"{repo.url}/blob/{branch}/{filepath}"
 
     def extract_branch_from_source_url(self, repo: Repository, url: str) -> str:
+        if not repo.url:
+            return ""
         branch, _ = parse_github_blob_url(repo.url, url)
         return branch
 
     def extract_source_path_from_source_url(self, repo: Repository, url: str) -> str:
+        if not repo.url:
+            return ""
         _, source_path = parse_github_blob_url(repo.url, url)
         return source_path
 

--- a/tests/sentry/integrations/github/test_utils.py
+++ b/tests/sentry/integrations/github/test_utils.py
@@ -1,0 +1,41 @@
+import pytest
+
+from sentry.integrations.github.utils import parse_github_blob_url
+
+
+@pytest.mark.parametrize(
+    "repo_url,source_url,expected_branch,expected_path",
+    [
+        (
+            "https://github.com/owner/repo",
+            "https://github.com/owner/repo/blob/main/path/to/file.py",
+            "main",
+            "path/to/file.py",
+        ),
+        (
+            # Trailing slash on repo URL should be handled
+            "https://github.com/owner/repo/",
+            "https://github.com/owner/repo/blob/main/path/to/file.py",
+            "main",
+            "path/to/file.py",
+        ),
+        (
+            # GitHub Enterprise style URL
+            "https://github.example.org/org/repo",
+            "https://github.example.org/org/repo/blob/master/src/app/index.ts",
+            "master",
+            "src/app/index.ts",
+        ),
+        (
+            # No '/blob/' segment → not parseable
+            "https://github.com/owner/repo",
+            "https://github.com/owner/repo/tree/main/path/to/file.py",
+            "",
+            "",
+        ),
+    ],
+)
+def test_parse_github_blob_url(repo_url, source_url, expected_branch, expected_path):
+    branch, path = parse_github_blob_url(repo_url, source_url)
+    assert branch == expected_branch
+    assert path == expected_path


### PR DESCRIPTION
Fix branch extraction for GitHub blob URLs that could return “https:” when repo.url didn’t match exactly (e.g. trailing slashes). Now we normalize and parse with a shared helper used by GitHub and GHE.
