### PR TITLE
feat(otlp): Add project key settings for otlp logs endpoint

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -112,6 +112,7 @@ export type ProjectKey = {
     crons: string;
     csp: string;
     minidump: string;
+    otlp_logs: string;
     otlp_traces: string;
     playstation: string;
     public: string;

--- a/static/app/views/settings/project/loaderScript.spec.tsx
+++ b/static/app/views/settings/project/loaderScript.spec.tsx
@@ -101,6 +101,7 @@ describe('LoaderScript', () => {
           playstation:
             'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
           otlp_traces: 'http://dev.getsentry.net:8000/api/1/otlp/v1/traces',
+          otlp_logs: 'http://dev.getsentry.net:8000/api/1/otlp/v1/logs',
         },
         public: '188ee45a58094d939428d8585aa6f662',
         secret: 'a33bf9aba64c4bbdaf873bb9023b6d2c',
@@ -242,6 +243,7 @@ describe('LoaderScript', () => {
           playstation:
             'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
           otlp_traces: 'http://dev.getsentry.net:8000/api/1/otlp/v1/traces',
+          otlp_logs: 'http://dev.getsentry.net:8000/api/1/otlp/v1/logs',
         },
         public: '188ee45a58094d939428d8585aa6f662',
         secret: 'a33bf9aba64c4bbdaf873bb9023b6d2c',

--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -69,8 +69,9 @@ export function KeySettings({
     }
   }, [organization, api, onRemove, keyId, projectId]);
 
-  const showOtlp =
+  const showOtlpTraces =
     useOTelFriendlyUI() && project.features.includes('relay-otel-endpoint');
+  const showOtlpLogs = organization.features.includes('relay-otel-logs-endpoint');
 
   return (
     <Fragment>
@@ -149,7 +150,8 @@ export function KeySettings({
                 <ProjectKeyCredentials
                   projectId={`${data.projectId}`}
                   data={data}
-                  showOtlp={showOtlp}
+                  showOtlpTraces={showOtlpTraces}
+                  showOtlpLogs={showOtlpLogs}
                   showPublicKey
                   showSecretKey
                   showProjectId

--- a/static/app/views/settings/project/projectKeys/list/index.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.tsx
@@ -164,6 +164,7 @@ describe('ProjectKeys', () => {
           playstation:
             'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
           otlp_traces: 'http://dev.getsentry.net:8000/api/1/otlp/v1/traces',
+          otlp_logs: 'http://dev.getsentry.net:8000/api/1/otlp/v1/logs',
         },
         dateCreated: '2018-02-28T07:13:51.087Z',
         public: '188ee45a58094d939428d8585aa6f662',

--- a/static/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/static/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -45,8 +45,9 @@ function KeyRow({
   const platform = project.platform || 'other';
   const isBrowserJavaScript = platform === 'javascript';
   const isJsPlatform = platform.startsWith('javascript');
-  const showOtlp =
+  const showOtlpTraces =
     useOTelFriendlyUI() && project.features.includes('relay-otel-endpoint');
+  const showOtlpLogs = project.organization.features.includes('relay-otel-logs-endpoint');
 
   return (
     <Panel>
@@ -99,7 +100,8 @@ function KeyRow({
           <ProjectKeyCredentials
             projectId={`${data.projectId}`}
             data={data}
-            showOtlp={showOtlp}
+            showOtlpTraces={showOtlpTraces}
+            showOtlpLogs={showOtlpLogs}
             showMinidump={!isJsPlatform}
             showUnreal={!isJsPlatform}
             showSecurityEndpoint={!isJsPlatform}

--- a/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
+++ b/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
@@ -14,7 +14,8 @@ type Props = {
   showDsn?: boolean;
   showDsnPublic?: boolean;
   showMinidump?: boolean;
-  showOtlp?: boolean;
+  showOtlpLogs?: boolean;
+  showOtlpTraces?: boolean;
   showProjectId?: boolean;
   showPublicKey?: boolean;
   showSecretKey?: boolean;
@@ -31,7 +32,8 @@ function ProjectKeyCredentials({
   showProjectId = false,
   showPublicKey = false,
   showSecretKey = false,
-  showOtlp = false,
+  showOtlpTraces = false,
+  showOtlpLogs = false,
   showSecurityEndpoint = true,
   showUnreal = true,
 }: Props) {
@@ -82,7 +84,33 @@ function ProjectKeyCredentials({
         </FieldGroup>
       )}
 
-      {showOtlp && (
+      {showOtlpLogs && (
+        <Fragment>
+          <FieldGroup
+            label={t('OTLP Logs Endpoint')}
+            help={t(`Set this URL as your OTLP exporter's log endpoint.`)}
+            inline={false}
+            flexibleControlStateSize
+          >
+            <TextCopyInput aria-label={t('OTLP Logs Endpoint')}>
+              {data.dsn.otlp_logs}
+            </TextCopyInput>
+          </FieldGroup>
+
+          <FieldGroup
+            label={t('OTLP Logs Endpoint Headers')}
+            help={t(`Set these security headers when configuring your OTLP exporter.`)}
+            inline={false}
+            flexibleControlStateSize
+          >
+            <TextCopyInput aria-label={t('OTLP Logs Endpoint Headers')}>
+              {`x-sentry-auth=sentry sentry_key=${data.public}`}
+            </TextCopyInput>
+          </FieldGroup>
+        </Fragment>
+      )}
+
+      {showOtlpTraces && (
         <Fragment>
           <FieldGroup
             label={t('OTLP Traces Endpoint')}

--- a/tests/js/fixtures/projectKeys.ts
+++ b/tests/js/fixtures/projectKeys.ts
@@ -18,6 +18,7 @@ export function ProjectKeysFixture(params: ProjectKey[] = []): ProjectKey[] {
         playstation:
           'http://dev.getsentry.net:8000/api/1/playstation/?sentry_key=188ee45a58094d939428d8585aa6f661',
         otlp_traces: 'http://dev.getsentry.net:8000/api/1/otlp/v1/traces',
+        otlp_logs: 'http://dev.getsentry.net:8000/api/1/otlp/v1/logs',
       },
       public: '188ee45a58094d939428d8585aa6f661',
       secret: 'a33bf9aba64c4bbdaf873bb9023b6d2d',

--- a/tests/js/sentry-test/onboarding/renderWithOnboardingLayout.tsx
+++ b/tests/js/sentry-test/onboarding/renderWithOnboardingLayout.tsx
@@ -78,6 +78,7 @@ export function renderWithOnboardingLayout<
         unreal: 'test-unreal',
         playstation: 'test-playstation',
         otlp_traces: 'test-otlp_traces',
+        otlp_logs: 'test-otlp_logs',
       }}
       platformKey="java-spring-boot"
       activeProductSelection={selectedProducts}


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-346/add-otel-logs-endpoint-to-project-setting-frontend

<img width="1210" height="250" alt="image" src="https://github.com/user-attachments/assets/a265af2d-bbf3-43a6-ac19-a3247c8475b7" />

This PR adds project key settings for the otlp logs endpoint, similar to what we've done for the otlp traces endpoint. 
