### PR TITLE
fix(ui): Wrap detailedError

### DIFF
--- a/static/app/components/errors/detailedError.tsx
+++ b/static/app/components/errors/detailedError.tsx
@@ -76,7 +76,7 @@ function DetailedError({className, heading, message, onRetry, hideSupportLinks}:
 const Wrapper = styled('div')`
   margin: ${space(2)} auto 0 auto;
   padding: ${space(2)};
-  width: max-content;
+  width: fit-content;
 `;
 
 const ErrorHeading = styled('h4')`


### PR DESCRIPTION
I think we want the error messages to wrap rather than overflowing the container.

Before:
<img width="3362" height="2376" alt="CleanShot 2025-09-11 at 18 59 34@2x" src="https://github.com/user-attachments/assets/19356b50-e710-46d9-9030-21cc81e481de" />

After:
<img width="3362" height="2376" alt="CleanShot 2025-09-11 at 18 59 20@2x" src="https://github.com/user-attachments/assets/7d388122-f660-4142-9abb-11f3d286a5af" />
