### PR TITLE
fix(eap): Do not apply trace transformation when its not possible

### DIFF
--- a/src/sentry/search/eap/spans/filter_aliases.py
+++ b/src/sentry/search/eap/spans/filter_aliases.py
@@ -1,3 +1,4 @@
+import string
 from typing import Literal
 
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
@@ -221,7 +222,13 @@ def trace_filter_converter(params: SnubaParams, search_filter: SearchFilter) -> 
     value = search_filter.value.value
 
     # special handling for 16 char trace id
-    if operator == "=" and isinstance(value, str) and len(value) >= 8 and len(value) < 32:
+    if (
+        operator == "="
+        and isinstance(value, str)
+        and len(value) >= 8
+        and len(value) < 32
+        and all(c in string.hexdigits for c in value)
+    ):
         pad = 32 - len(value)
         return [
             SearchFilter(SearchKey(constants.TRACE), ">=", SearchValue(value + "0" * pad)),

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -5665,6 +5665,19 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         assert meta["fields"]["failure_count()"] == "integer"
         assert meta["units"]["failure_count()"] is None
 
+    def test_trace_id_glob(self) -> None:
+        response = self.do_request(
+            {
+                "field": ["trace"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "query": "trace:test*",
+                "orderby": "trace",
+            }
+        )
+        assert response.status_code == 400, response.content
+        assert response.data["detail"] == "test% is an invalid value for trace"
+
     def test_short_trace_id_filter(self) -> None:
         trace_ids = [
             "0" * 32,


### PR DESCRIPTION
When the value is a glob, it shouldn't incorrectly apply the transformation.