### PR TITLE
fix(eap): Handle invalid operators

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -464,6 +464,8 @@ class SearchResolver:
             elif term.operator == "NOT IN":
                 operator = ComparisonFilter.OP_NOT_LIKE
                 is_list = True
+            else:
+                raise InvalidSearchQuery(f"Cannot use operator: {term.operator} with wildcards")
 
             if is_list:
                 raw_value = cast(list[str], term.value.raw_value)


### PR DESCRIPTION
- Throw a better error if >= or <= show up with wildcards
- Not adding a test for this because there shouldn't be a valid way to get here anyways, the current way to cause it is fixed in 99319 so adding a test will just become redundant after that merges