### PR TITLE
fix(ourlogs): Replay id needs an alias

### DIFF
--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -63,6 +63,7 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
         simple_sentry_field("environment"),
         simple_sentry_field("message.template"),
         simple_sentry_field("release"),
+        simple_sentry_field("replay.id"),
         simple_sentry_field("trace.parent_span_id"),
         simple_sentry_field("sdk.name"),
         simple_sentry_field("sdk.version"),

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -63,7 +63,7 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
         simple_sentry_field("environment"),
         simple_sentry_field("message.template"),
         simple_sentry_field("release"),
-        simple_sentry_field("replay.id"),
+        simple_sentry_field("replay_id"),
         simple_sentry_field("trace.parent_span_id"),
         simple_sentry_field("sdk.name"),
         simple_sentry_field("sdk.version"),


### PR DESCRIPTION
This aliases replay.id so it doesn't include sentry. in the frontend.
