### PR TITLE
feat(issues): Add option to always run Seer automation on WebVitalsGroup type 

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -221,6 +221,9 @@ class GroupType:
     # Controls whether users are able to manually update the group's priority.
     enable_user_priority_changes = True
 
+    # Controls whether Seer automation is always triggered for this group type.
+    always_trigger_seer_automation = False
+
     def __init_subclass__(cls: type[GroupType], **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         registry.add(cls)
@@ -674,6 +677,8 @@ class WebVitalsGroup(GroupType):
     enable_escalation_detection = False
     enable_status_change_workflow_notifications = False
     enable_workflow_notifications = False
+    # Web Vital issues are always manually created by the user for the purpose of using autofix
+    always_trigger_seer_automation = True
 
 
 def should_create_group(

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -312,7 +312,10 @@ def _run_automation(
 
     group.update(seer_fixability_score=issue_summary.scores.fixability_score)
 
-    if not _is_issue_fixable(group, issue_summary.scores.fixability_score):
+    if (
+        not _is_issue_fixable(group, issue_summary.scores.fixability_score)
+        and not group.issue_type.always_trigger_seer_automation
+    ):
         return
 
     has_budget: bool = quotas.backend.has_available_reserved_budget(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1648,7 +1648,10 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
         return
 
     project = group.project
-    if not project.get_option("sentry:seer_scanner_automation"):
+    if (
+        not project.get_option("sentry:seer_scanner_automation")
+        and not group.issue_type.always_trigger_seer_automation
+    ):
         return
 
     # Don't run if there's already a task in progress for this issue


### PR DESCRIPTION
Adds a `always_trigger_seer_automation` flag that enables always running Seer automation in post process regardless of Seer Scanner settings or fixability rating. 

This is used for Web Vitals issues because they are always created through manual interaction from the user with the intention of running Autofix.