### PR TITLE
ref(grouping): Use underscores for grouping component ids

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -381,7 +381,7 @@ class CSPGroupingComponent(
 class ExpectCTGroupingComponent(
     BaseGroupingComponent[HostnameGroupingComponent | SaltGroupingComponent]
 ):
-    id: str = "expect-ct"
+    id: str = "expect_ct"
 
 
 class ExpectStapleGroupingComponent(

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -387,7 +387,7 @@ class ExpectCTGroupingComponent(
 class ExpectStapleGroupingComponent(
     BaseGroupingComponent[HostnameGroupingComponent | SaltGroupingComponent]
 ):
-    id: str = "expect-staple"
+    id: str = "expect_staple"
 
 
 class HPKPGroupingComponent(

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -199,7 +199,7 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]](
 
 
 class ContextLineGroupingComponent(BaseGroupingComponent[str]):
-    id: str = "context-line"
+    id: str = "context_line"
 
 
 class ErrorTypeGroupingComponent(BaseGroupingComponent[str]):

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -233,7 +233,7 @@ class NSErrorCodeGroupingComponent(BaseGroupingComponent[int]):
 class NSErrorGroupingComponent(
     BaseGroupingComponent[NSErrorDomainGroupingComponent | NSErrorCodeGroupingComponent]
 ):
-    id: str = "ns-error"
+    id: str = "ns_error"
 
 
 FrameGroupingComponentChildren = (

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -334,7 +334,7 @@ class ExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingComponen
 
 
 class ChainedExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingComponent]):
-    id: str = "chained-exception"
+    id: str = "chained_exception"
     frame_counts: Counter[str]
     reverse_when_serializing: bool = False
 

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -419,7 +419,7 @@ def _get_stacktrace_hashing_metadata(
         ),
         "num_stacktraces": (
             len(contributing_component.values)
-            if contributing_component.id == "chained-exception"
+            if contributing_component.id == "chained_exception"
             else 1
         ),
     }

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -532,8 +532,8 @@ def _get_template_hashing_metadata(
 
     if subcomponents_by_id["filename"].values:
         metadata["template_name"] = subcomponents_by_id["filename"].values[0]
-    if subcomponents_by_id["context-line"].values:
-        metadata["template_context_line"] = subcomponents_by_id["context-line"].values[0]
+    if subcomponents_by_id["context_line"].values:
+        metadata["template_context_line"] = subcomponents_by_id["context_line"].values[0]
 
     return metadata
 

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -205,7 +205,7 @@ def _process_frames(
         frame_dict = extract_values_from_frame_values(frame.get("values", []))
         filename = extract_filename(frame_dict) or "None"
 
-        if not _is_snipped_context_line(frame_dict["context-line"]):
+        if not _is_snipped_context_line(frame_dict["context_line"]):
             frame_metrics["found_non_snipped_context_line"] = True
 
         if not frame_dict["filename"]:
@@ -216,21 +216,21 @@ def _process_frames(
         # TODO: Don't let this, and the metric below, hang around forever. It's only to
         # help us get a sense of whether it's worthwhile trying to more accurately
         # detect, and then exclude, frames containing HTML
-        if frame_dict["filename"].endswith("html") or "<html>" in frame_dict["context-line"]:
+        if frame_dict["filename"].endswith("html") or "<html>" in frame_dict["context_line"]:
             frame_metrics["html_frame_count"] += 1
 
         if is_base64_encoded_frame(frame_dict):
             continue
 
         frame_strings.append(
-            f'  File "{filename}", function {frame_dict["function"]}\n    {frame_dict["context-line"]}\n'
+            f'  File "{filename}", function {frame_dict["function"]}\n    {frame_dict["context_line"]}\n'
         )
 
     return frame_strings, frame_metrics
 
 
 def extract_values_from_frame_values(values: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
-    frame_dict = {"filename": "", "function": "", "context-line": "", "module": ""}
+    frame_dict = {"filename": "", "function": "", "context_line": "", "module": ""}
     for frame_values in values:
         if frame_values.get("id") in frame_dict:
             frame_dict[frame_values["id"]] = _get_value_if_exists(frame_values)

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -82,7 +82,7 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
         exceptions = system_component
 
     # Handle chained exceptions
-    if exceptions and exceptions[0].get("id") == "chained-exception":
+    if exceptions and exceptions[0].get("id") == "chained_exception":
         exceptions = exceptions[0].get("values")
 
     metrics.distribution("seer.grouping.exceptions.length", len(exceptions))

--- a/src/sentry/types/grouphash_metadata.py
+++ b/src/sentry/types/grouphash_metadata.py
@@ -83,7 +83,7 @@ class SecurityHashingMetadata(TypedDict):
     Transparency, Online Certificate Status Protocol Stapling, or HTTP Public Key Pinning) reports
     """
 
-    # Either "csp", "expect_ct", "expect-staple", or "hpkp"
+    # Either "csp", "expect_ct", "expect_staple", or "hpkp"
     security_report_type: str
     # Domain name of the blocked address
     blocked_host: str

--- a/src/sentry/types/grouphash_metadata.py
+++ b/src/sentry/types/grouphash_metadata.py
@@ -83,7 +83,7 @@ class SecurityHashingMetadata(TypedDict):
     Transparency, Online Certificate Status Protocol Stapling, or HTTP Public Key Pinning) reports
     """
 
-    # Either "csp", "expect-ct", "expect-staple", or "hpkp"
+    # Either "csp", "expect_ct", "expect-staple", or "hpkp"
     security_report_type: str
     # Domain name of the blocked address
     blocked_host: str

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-10T21:59:45.323709+00:00'
+created: '2025-09-11T18:40:11.825571+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -41,7 +41,7 @@ contributing variants:
                 "stripped_application_code"
           type*
             "<redacted>"
-          ns-error*
+          ns_error*
             domain*
               "<redacted>"
             code*
@@ -70,7 +70,7 @@ contributing variants:
                 "stripped_application_code"
           type*
             "<redacted>"
-          ns-error*
+          ns_error*
             domain*
               "<redacted>"
             code*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:25.375715+00:00'
+created: '2025-09-11T18:40:11.901214+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -35,35 +35,35 @@ contributing variants:
                 "sentry.utils.safe"
               function*
                 "safe_execute"
-              context-line*
+              context_line*
                 "result = func(*args, **kwargs)"
             frame* (marked in-app by the client)
               module*
                 "sentry.utils.services"
               function*
                 "<lambda>"
-              context-line*
+              context_line*
                 "context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)"
             frame* (marked in-app by the client)
               module*
                 "getsentry.quotas"
               function*
                 "is_rate_limited"
-              context-line*
+              context_line*
                 "return super(SubscriptionQuota, self).is_rate_limited(project, key=key)"
             frame* (marked in-app by the client)
               module*
                 "sentry.quotas.redis"
               function*
                 "is_rate_limited"
-              context-line*
+              context_line*
                 "rejections = is_rate_limited(client, keys, args)"
             frame* (marked in-app by the client)
               module*
                 "sentry.utils.redis"
               function*
                 "call_script"
-              context-line*
+              context_line*
                 "return script(keys, args, client)"
           type*
             "ConnectionError"
@@ -79,77 +79,77 @@ contributing variants:
                 "sentry.utils.safe"
               function*
                 "safe_execute"
-              context-line*
+              context_line*
                 "result = func(*args, **kwargs)"
             frame*
               module*
                 "sentry.utils.services"
               function*
                 "<lambda>"
-              context-line*
+              context_line*
                 "context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)"
             frame*
               module*
                 "getsentry.quotas"
               function*
                 "is_rate_limited"
-              context-line*
+              context_line*
                 "return super(SubscriptionQuota, self).is_rate_limited(project, key=key)"
             frame*
               module*
                 "sentry.quotas.redis"
               function*
                 "is_rate_limited"
-              context-line*
+              context_line*
                 "rejections = is_rate_limited(client, keys, args)"
             frame*
               module*
                 "sentry.utils.redis"
               function*
                 "call_script"
-              context-line*
+              context_line*
                 "return script(keys, args, client)"
             frame*
               module*
                 "redis.client"
               function*
                 "__call__"
-              context-line*
+              context_line*
                 "return client.evalsha(self.sha, len(keys), *args)"
             frame*
               module*
                 "redis.client"
               function*
                 "evalsha"
-              context-line*
+              context_line*
                 "return self.execute_command('EVALSHA', sha, numkeys, *keys_and_args)"
             frame*
               module*
                 "redis.client"
               function*
                 "execute_command"
-              context-line*
+              context_line*
                 "return self.parse_response(connection, command_name, **options)"
             frame*
               module*
                 "redis.client"
               function*
                 "parse_response"
-              context-line*
+              context_line*
                 "response = connection.read_response()"
             frame*
               module*
                 "redis.connection"
               function*
                 "read_response"
-              context-line*
+              context_line*
                 "response = self._parser.read_response()"
             frame*
               module*
                 "redis.connection"
               function*
                 "read_response"
-              context-line*
+              context_line*
                 "(e.args,))"
           type*
             "ConnectionError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:51:31.432361+00:00'
+created: '2025-09-11T18:40:11.921846+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -35,7 +35,7 @@ contributing variants:
                 "dogpark.js"
               function*
                 "playFetch"
-              context-line*
+              context_line*
                 "raise FailedToFetchError('Charlie didn't bring the ball back!');"
           type*
             "FailedToFetchError"
@@ -51,14 +51,14 @@ contributing variants:
                 "router.js"
               function*
                 "handleRequest"
-              context-line*
+              context_line*
                 "return handler(request);"
             frame*
               filename*
                 "dogpark.js"
               function*
                 "playFetch"
-              context-line*
+              context_line*
                 "raise FailedToFetchError('Charlie didn't bring the ball back!');"
           type*
             "FailedToFetchError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:03.784088+00:00'
+created: '2025-09-11T18:40:11.948664+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -35,7 +35,7 @@ contributing variants:
                 "router.js"
               function*
                 "handleRequest"
-              context-line*
+              context_line*
                 "return handler(request);"
           type*
             "FailedToFetchError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-10T21:59:45.683752+00:00'
+created: '2025-09-11T18:40:12.271965+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -29,7 +29,7 @@ contributing variants:
         exception*
           type*
             "iOS_Swift.SampleError"
-          ns-error*
+          ns_error*
             domain*
               "iOS_Swift.SampleError"
             code*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:27.263161+00:00'
+created: '2025-09-11T21:13:34.911117+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -25,10 +25,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "669cb6664e0f5fed38665da04e464f7e"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             stacktrace*
               frame* (marked in-app by the client)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:30.322927+00:00'
+created: '2025-09-11T18:40:12.356006+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,10 +23,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "e2bf1e0628b7b1824a9b63dec7a079a3"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             type*
               "System.Exception"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-20T17:23:52.422319+00:00'
+created: '2025-09-11T18:40:12.397134+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,10 +23,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "93b26686d00504b4e5aa1cb0244d8b37"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             type*
               "InnerException"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-18T22:50:00.757680+00:00'
+created: '2025-09-11T18:40:12.377006+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,10 +23,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "93b26686d00504b4e5aa1cb0244d8b37"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             type*
               "InnerException"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-18T22:50:08.530297+00:00'
+created: '2025-09-11T18:40:12.433749+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,10 +23,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "028157fe357e4592e39eacb32eafa2db"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             type*
               "InnermostException"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:30.532099+00:00'
+created: '2025-09-11T18:40:12.451453+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,10 +23,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "f0078a82f351095ba595daa7d493aa3c"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             type*
               "MyApp.Exception"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-18T22:50:14.422428+00:00'
+created: '2025-09-11T18:40:12.470733+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,10 +23,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "93b26686d00504b4e5aa1cb0244d8b37"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             type*
               "InnerException"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:30.982447+00:00'
+created: '2025-09-11T18:40:12.591762+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,10 +23,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "17022e0561e9b6e6351723a08aa81b18"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             type*
               "MyApp.Exception"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:31.061381+00:00'
+created: '2025-09-11T18:40:12.610912+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,10 +23,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "f0078a82f351095ba595daa7d493aa3c"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             type*
               "MyApp.Exception"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:28.589930+00:00'
+created: '2025-09-11T21:13:35.237698+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -25,10 +25,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "d505dfb9059ac63c11955233323a9100"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             stacktrace*
               frame* (marked in-app by the client)
@@ -59,10 +59,10 @@ contributing variants:
               "One or more errors occurred."
   system*
     hash: "4f9cc6a81f4eb34f9e917374f281b9dc"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       system*
-        chained-exception*
+        chained_exception*
           exception*
             stacktrace*
               frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_types.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_types.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:31.388880+00:00'
+created: '2025-09-11T18:40:12.707275+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,10 +23,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "bca604b98cb4637167eb6190a92e8933"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             type*
               "MyApp.SuchWowException"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:31.331309+00:00'
+created: '2025-09-11T18:40:12.683636+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,10 +23,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "fca0fd23f09e8da4481304ef2a531100"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             type*
               "MyApp.CoolException"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:31.468845+00:00'
+created: '2025-09-11T18:40:12.730331+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,12 +33,12 @@ contributing variants:
             frame*
               module*
                 "app/components/modals/createTeamModal"
-              context-line*
+              context_line*
                 "onError(err);"
             frame*
               module*
                 "app/views/settings/components/forms/form"
-              context-line*
+              context_line*
                 "this.model.submitError(error);"
           type*
             "TypeError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/expectct.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/expectct.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:50:31.761139+00:00'
+created: '2025-09-11T18:40:12.890172+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: violation
 hashing_metadata: {
   "blocked_host": "example.com",
-  "security_report_type": "expect-ct"
+  "security_report_type": "expect_ct"
 }
 ---
 metrics with tags: {
@@ -15,17 +15,17 @@ metrics with tags: {
     "is_hybrid_fingerprint": "False"
   },
   "grouping.grouphashmetadata.event_hashing_metadata.violation": {
-    "security_report_type": "expect-ct"
+    "security_report_type": "expect_ct"
   }
 }
 ---
 contributing variants:
   default*
     hash: "3d2933f4b5ec459ec8d569a398fd328c"
-    contributing component: expect-ct
+    contributing component: expect_ct
     component:
       default*
-        expect-ct*
+        expect_ct*
           salt* (a static salt)
             "expect-ct"
           hostname*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:32.695941+00:00'
+created: '2025-09-11T18:40:13.131406+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -32,12 +32,12 @@ contributing variants:
           frame*
             function*
               "test"
-            context-line*
+            context_line*
               "hello world"
           frame*
             filename*
               "foo.js"
             function*
               "test"
-            context-line*
+            context_line*
               "hello world"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:33.065634+00:00'
+created: '2025-09-11T18:40:13.192010+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -32,5 +32,5 @@ contributing variants:
           frame*
             function*
               "test"
-            context-line*
+            context_line*
               "hello world"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:33.231415+00:00'
+created: '2025-09-11T18:40:13.211297+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -32,5 +32,5 @@ contributing variants:
           frame*
             function*
               "test"
-            context-line*
+            context_line*
               "hello world"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-08-11T23:13:29.871161+00:00'
+created: '2025-09-11T18:40:13.644431+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -32,5 +32,5 @@ contributing variants:
           frame*
             filename*
               "foo.py"
-            context-line*
+            context_line*
               "foo bar"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-07-18T18:37:27.312233+00:00'
+created: '2025-09-11T18:40:14.091144+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -40,84 +40,84 @@ contributing variants:
                 "sentry.tasks.base"
               function*
                 "_wrapped"
-              context-line*
+              context_line*
                 "result = func(*args, **kwargs)"
             frame* (marked in-app by the client)
               module*
                 "sentry.tasks.store"
               function*
                 "process_event"
-              context-line*
+              context_line*
                 "return _do_process_event(cache_key, start_time, event_id, process_event)"
             frame* (marked in-app by the client)
               module*
                 "sentry.tasks.store"
               function*
                 "_do_process_event"
-              context-line*
+              context_line*
                 "new_data = process_stacktraces(data)"
             frame* (marked in-app by the client)
               module*
                 "sentry.stacktraces"
               function*
                 "process_stacktraces"
-              context-line*
+              context_line*
                 "if processor.preprocess_step(processing_task):"
             frame* (marked in-app by the client)
               module*
                 "sentry.lang.native.plugin"
               function*
                 "preprocess_step"
-              context-line*
+              context_line*
                 "referenced_images=referenced_images,"
             frame* (marked in-app by the client)
               module*
                 "sentry.lang.native.symbolizer"
               function*
                 "__init__"
-              context-line*
+              context_line*
                 "with_conversion_errors=True)"
             frame* (marked in-app by the client)
               module*
                 "sentry.models.debugfile"
               function*
                 "get_symcaches"
-              context-line*
+              context_line*
                 "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
             frame* (marked in-app by the client)
               module*
                 "sentry.models.debugfile"
               function*
                 "_load_cachefiles_via_fs"
-              context-line*
+              context_line*
                 "model.cache_file.save_to(cachefile_path)"
             frame* (marked in-app by the client)
               module*
                 "sentry.models.file"
               function*
                 "save_to"
-              context-line*
+              context_line*
                 "delete=False).detach_tempfile()"
             frame* (marked in-app by the client)
               module*
                 "sentry.models.file"
               function*
                 "_get_chunked_blob"
-              context-line*
+              context_line*
                 "delete=delete"
             frame* (marked in-app by the client)
               module*
                 "sentry.models.file"
               function*
                 "__init__"
-              context-line*
+              context_line*
                 "self._prefetch(prefetch_to, delete)"
             frame* (marked in-app by the client)
               module*
                 "sentry.models.file"
               function*
                 "_prefetch"
-              context-line*
+              context_line*
                 "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
           type*
             "SoftTimeLimitExceeded"
@@ -135,119 +135,119 @@ contributing variants:
                 "sentry.tasks.base"
               function*
                 "_wrapped"
-              context-line*
+              context_line*
                 "result = func(*args, **kwargs)"
             frame*
               module*
                 "sentry.tasks.store"
               function*
                 "process_event"
-              context-line*
+              context_line*
                 "return _do_process_event(cache_key, start_time, event_id, process_event)"
             frame*
               module*
                 "sentry.tasks.store"
               function*
                 "_do_process_event"
-              context-line*
+              context_line*
                 "new_data = process_stacktraces(data)"
             frame*
               module*
                 "sentry.stacktraces"
               function*
                 "process_stacktraces"
-              context-line*
+              context_line*
                 "if processor.preprocess_step(processing_task):"
             frame*
               module*
                 "sentry.lang.native.plugin"
               function*
                 "preprocess_step"
-              context-line*
+              context_line*
                 "referenced_images=referenced_images,"
             frame*
               module*
                 "sentry.lang.native.symbolizer"
               function*
                 "__init__"
-              context-line*
+              context_line*
                 "with_conversion_errors=True)"
             frame*
               module*
                 "sentry.models.debugfile"
               function*
                 "get_symcaches"
-              context-line*
+              context_line*
                 "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
             frame*
               module*
                 "sentry.models.debugfile"
               function*
                 "_load_cachefiles_via_fs"
-              context-line*
+              context_line*
                 "model.cache_file.save_to(cachefile_path)"
             frame*
               module*
                 "sentry.models.file"
               function*
                 "save_to"
-              context-line*
+              context_line*
                 "delete=False).detach_tempfile()"
             frame*
               module*
                 "sentry.models.file"
               function*
                 "_get_chunked_blob"
-              context-line*
+              context_line*
                 "delete=delete"
             frame*
               module*
                 "sentry.models.file"
               function*
                 "__init__"
-              context-line*
+              context_line*
                 "self._prefetch(prefetch_to, delete)"
             frame*
               module*
                 "sentry.models.file"
               function*
                 "_prefetch"
-              context-line*
+              context_line*
                 "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
             frame*
               module*
                 "concurrent.futures._base"
               function*
                 "__exit__"
-              context-line*
+              context_line*
                 "self.shutdown(wait=True)"
             frame*
               module*
                 "concurrent.futures.thread"
               function*
                 "shutdown"
-              context-line*
+              context_line*
                 "t.join(sys.maxint)"
             frame*
               module*
                 "threading"
               function*
                 "join"
-              context-line*
+              context_line*
                 "self.__block.wait(delay)"
             frame*
               module*
                 "threading"
               function*
                 "wait"
-              context-line*
+              context_line*
                 "_sleep(delay)"
             frame*
               module*
                 "billiard.pool"
               function*
                 "soft_timeout_sighandler"
-              context-line*
+              context_line*
                 "raise SoftTimeLimitExceeded()"
           type*
             "SoftTimeLimitExceeded"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:38.713071+00:00'
+created: '2025-09-11T21:13:36.940819+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -25,10 +25,10 @@ metrics with tags: {
 contributing variants:
   system*
     hash: "1959b227a7cf6acf7f3fd401b5d9f09b"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       system*
-        chained-exception*
+        chained_exception*
           exception*
             stacktrace*
               frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:37.866024+00:00'
+created: '2025-09-11T18:40:14.533348+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,22 +33,22 @@ contributing variants:
             frame* (marked in-app by the client)
               module*
                 "app/components/lazyLoad"
-              context-line*
+              context_line*
                 "this.setState({"
             frame* (marked in-app by the client)
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
-              context-line*
+              context_line*
                 "this.fetchData();"
             frame* (marked in-app by the client)
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
-              context-line*
+              context_line*
                 "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
             frame* (marked in-app by the client)
               module*
                 "app/api"
-              context-line*
+              context_line*
                 "const preservedError = new Error();"
           type*
             "NotFoundError"
@@ -62,47 +62,47 @@ contributing variants:
             frame*
               module*
                 "usr/src/getsentry/src/sentry/node_modules/core-js/modules/_microtask"
-              context-line*
+              context_line*
                 "fn();"
             frame*
               module*
                 "usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise"
-              context-line*
+              context_line*
                 "while (chain.length > i) run(chain[i++]); // variable length - can't use forEach"
             frame*
               module*
                 "usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise"
-              context-line*
+              context_line*
                 "result = handler(value); // may throw"
             frame*
               module*
                 "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
-              context-line*
+              context_line*
                 "asyncGeneratorStep(gen, resolve, reject, _next, _throw, \"next\", value);"
             frame*
               module*
                 "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
-              context-line*
+              context_line*
                 "var info = gen[key](arg);"
             frame*
               module*
                 "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-              context-line*
+              context_line*
                 "return this._invoke(method, arg);"
             frame*
               module*
                 "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-              context-line*
+              context_line*
                 "var record = tryCatch(innerFn, self, context);"
             frame*
               module*
                 "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-              context-line*
+              context_line*
                 "return { type: \"normal\", arg: fn.call(obj, arg) };"
             frame*
               module*
                 "app/components/lazyLoad"
-              context-line*
+              context_line*
                 "this.setState({"
             frame*
               module*
@@ -137,17 +137,17 @@ contributing variants:
             frame*
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
-              context-line*
+              context_line*
                 "this.fetchData();"
             frame*
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
-              context-line*
+              context_line*
                 "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
             frame*
               module*
                 "app/api"
-              context-line*
+              context_line*
                 "const preservedError = new Error();"
           type*
             "NotFoundError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:37.967829+00:00'
+created: '2025-09-11T18:40:14.552908+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,22 +33,22 @@ contributing variants:
             frame* (marked in-app by the client)
               module*
                 "app/components/lazyLoad"
-              context-line*
+              context_line*
                 "this.setState({"
             frame* (marked in-app by the client)
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
-              context-line*
+              context_line*
                 "this.fetchData();"
             frame* (marked in-app by the client)
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
-              context-line*
+              context_line*
                 "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
             frame* (marked in-app by the client)
               module*
                 "app/api"
-              context-line*
+              context_line*
                 "const preservedError = new Error();"
           type*
             "NotFoundError"
@@ -62,27 +62,27 @@ contributing variants:
             frame*
               module*
                 "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
-              context-line*
+              context_line*
                 "asyncGeneratorStep(gen, resolve, reject, _next, _throw, \"next\", value);"
             frame*
               module*
                 "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
-              context-line*
+              context_line*
                 "var info = gen[key](arg);"
             frame*
               module*
                 "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-              context-line*
+              context_line*
                 "var record = tryCatch(innerFn, self, context);"
             frame*
               module*
                 "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-              context-line*
+              context_line*
                 "return { type: \"normal\", arg: fn.call(obj, arg) };"
             frame*
               module*
                 "app/components/lazyLoad"
-              context-line*
+              context_line*
                 "this.setState({"
             frame*
               module*
@@ -117,17 +117,17 @@ contributing variants:
             frame*
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
-              context-line*
+              context_line*
                 "this.fetchData();"
             frame*
               module*
                 "app/views/groupDetails/shared/groupEventDetails"
-              context-line*
+              context_line*
                 "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
             frame*
               module*
                 "app/api"
-              context-line*
+              context_line*
                 "const preservedError = new Error();"
           type*
             "NotFoundError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:38.161169+00:00'
+created: '2025-09-11T18:40:14.592678+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,21 +33,21 @@ contributing variants:
             frame* (marked in-app by the client)
               filename*
                 "server.php"
-              context-line*
+              context_line*
                 "require_once __DIR__.'/public/index.php';"
             frame* (marked in-app by the client)
               filename*
                 "index.php"
               function*
                 "require_once"
-              context-line*
+              context_line*
                 "$request = Illuminate\\Http\\Request::capture()"
             frame* (marked in-app by the client)
               filename*
                 "web.php"
               function*
                 "Illuminate\\Routing\\RouteFileRegistrar::{closure}"
-              context-line*
+              context_line*
                 "throw new Exception('LARAVEL TEST');"
           type*
             "Exception"
@@ -61,350 +61,350 @@ contributing variants:
             frame*
               filename*
                 "server.php"
-              context-line*
+              context_line*
                 "require_once __DIR__.'/public/index.php';"
             frame*
               filename*
                 "index.php"
               function*
                 "require_once"
-              context-line*
+              context_line*
                 "$request = Illuminate\\Http\\Request::capture()"
             frame*
               filename*
                 "kernel.php"
               function*
                 "Illuminate\\Foundation\\Http\\Kernel::handle"
-              context-line*
+              context_line*
                 "$response = $this->sendRequestThroughRouter($request);"
             frame*
               filename*
                 "kernel.php"
               function*
                 "Illuminate\\Foundation\\Http\\Kernel::sendRequestThroughRouter"
-              context-line*
+              context_line*
                 "->then($this->dispatchToRouter());"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Pipeline\\Pipeline::then"
-              context-line*
+              context_line*
                 "return $pipeline($this->passable);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-              context-line*
+              context_line*
                 "return $callable($passable);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-              context-line*
+              context_line*
                 "? $pipe->{$this->method}(...$parameters)"
             frame*
               filename*
                 "checkformaintenancemode.php"
               function*
                 "Illuminate\\Foundation\\Http\\Middleware\\CheckForMaintenanceMode::handle"
-              context-line*
+              context_line*
                 "return $next($request);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-              context-line*
+              context_line*
                 "return $callable($passable);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-              context-line*
+              context_line*
                 "? $pipe->{$this->method}(...$parameters)"
             frame*
               filename*
                 "validatepostsize.php"
               function*
                 "Illuminate\\Foundation\\Http\\Middleware\\ValidatePostSize::handle"
-              context-line*
+              context_line*
                 "return $next($request);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-              context-line*
+              context_line*
                 "return $callable($passable);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-              context-line*
+              context_line*
                 "? $pipe->{$this->method}(...$parameters)"
             frame*
               filename*
                 "transformsrequest.php"
               function*
                 "Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle"
-              context-line*
+              context_line*
                 "return $next($request);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-              context-line*
+              context_line*
                 "return $callable($passable);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-              context-line*
+              context_line*
                 "? $pipe->{$this->method}(...$parameters)"
             frame*
               filename*
                 "transformsrequest.php"
               function*
                 "Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle"
-              context-line*
+              context_line*
                 "return $next($request);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-              context-line*
+              context_line*
                 "return $callable($passable);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-              context-line*
+              context_line*
                 "? $pipe->{$this->method}(...$parameters)"
             frame*
               filename*
                 "trustproxies.php"
               function*
                 "Fideloper\\Proxy\\TrustProxies::handle"
-              context-line*
+              context_line*
                 "return $next($request);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-              context-line*
+              context_line*
                 "return $destination($passable);"
             frame*
               filename*
                 "kernel.php"
               function*
                 "Illuminate\\Foundation\\Http\\Kernel::Illuminate\\Foundation\\Http\\{closure}"
-              context-line*
+              context_line*
                 "return $this->router->dispatch($request);"
             frame*
               filename*
                 "router.php"
               function*
                 "Illuminate\\Routing\\Router::dispatch"
-              context-line*
+              context_line*
                 "return $this->dispatchToRoute($request);"
             frame*
               filename*
                 "router.php"
               function*
                 "Illuminate\\Routing\\Router::dispatchToRoute"
-              context-line*
+              context_line*
                 "return $this->runRoute($request, $this->findRoute($request));"
             frame*
               filename*
                 "router.php"
               function*
                 "Illuminate\\Routing\\Router::runRoute"
-              context-line*
+              context_line*
                 "$this->runRouteWithinStack($route, $request)"
             frame*
               filename*
                 "router.php"
               function*
                 "Illuminate\\Routing\\Router::runRouteWithinStack"
-              context-line*
+              context_line*
                 "});"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Pipeline\\Pipeline::then"
-              context-line*
+              context_line*
                 "return $pipeline($this->passable);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-              context-line*
+              context_line*
                 "return $callable($passable);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-              context-line*
+              context_line*
                 "? $pipe->{$this->method}(...$parameters)"
             frame*
               filename*
                 "encryptcookies.php"
               function*
                 "Illuminate\\Cookie\\Middleware\\EncryptCookies::handle"
-              context-line*
+              context_line*
                 "return $this->encrypt($next($this->decrypt($request)));"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-              context-line*
+              context_line*
                 "return $callable($passable);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-              context-line*
+              context_line*
                 "? $pipe->{$this->method}(...$parameters)"
             frame*
               filename*
                 "addqueuedcookiestoresponse.php"
               function*
                 "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse::handle"
-              context-line*
+              context_line*
                 "$response = $next($request);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-              context-line*
+              context_line*
                 "return $callable($passable);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-              context-line*
+              context_line*
                 "? $pipe->{$this->method}(...$parameters)"
             frame*
               filename*
                 "startsession.php"
               function*
                 "Illuminate\\Session\\Middleware\\StartSession::handle"
-              context-line*
+              context_line*
                 "$response = $next($request), $session"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-              context-line*
+              context_line*
                 "return $callable($passable);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-              context-line*
+              context_line*
                 "? $pipe->{$this->method}(...$parameters)"
             frame*
               filename*
                 "shareerrorsfromsession.php"
               function*
                 "Illuminate\\View\\Middleware\\ShareErrorsFromSession::handle"
-              context-line*
+              context_line*
                 "return $next($request);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-              context-line*
+              context_line*
                 "return $callable($passable);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-              context-line*
+              context_line*
                 "? $pipe->{$this->method}(...$parameters)"
             frame*
               filename*
                 "verifycsrftoken.php"
               function*
                 "Illuminate\\Foundation\\Http\\Middleware\\VerifyCsrfToken::handle"
-              context-line*
+              context_line*
                 "return tap($next($request), function ($response) use ($request) {"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-              context-line*
+              context_line*
                 "return $callable($passable);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-              context-line*
+              context_line*
                 "? $pipe->{$this->method}(...$parameters)"
             frame*
               filename*
                 "substitutebindings.php"
               function*
                 "Illuminate\\Routing\\Middleware\\SubstituteBindings::handle"
-              context-line*
+              context_line*
                 "return $next($request);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-              context-line*
+              context_line*
                 "return $destination($passable);"
             frame*
               filename*
                 "router.php"
               function*
                 "Illuminate\\Routing\\Router::Illuminate\\Routing\\{closure}"
-              context-line*
+              context_line*
                 "$request, $route->run()"
             frame*
               filename*
                 "route.php"
               function*
                 "Illuminate\\Routing\\Route::run"
-              context-line*
+              context_line*
                 "return $this->runCallable();"
             frame*
               filename*
                 "route.php"
               function*
                 "Illuminate\\Routing\\Route::runCallable"
-              context-line*
+              context_line*
                 "$this->parametersWithoutNulls(), new ReflectionFunction($this->action['uses'])"
             frame*
               filename*
                 "web.php"
               function*
                 "Illuminate\\Routing\\RouteFileRegistrar::{closure}"
-              context-line*
+              context_line*
                 "throw new Exception('LARAVEL TEST');"
           type*
             "Exception"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:38.055277+00:00'
+created: '2025-09-11T18:40:14.571273+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,7 +33,7 @@ contributing variants:
             frame* (marked in-app by the client)
               filename*
                 "server.php"
-              context-line*
+              context_line*
                 "require_once __DIR__.'/public/index.php';"
           type*
             "Exception"
@@ -47,21 +47,21 @@ contributing variants:
             frame*
               filename*
                 "server.php"
-              context-line*
+              context_line*
                 "require_once __DIR__.'/public/index.php';"
             frame*
               filename*
                 "pipeline.php"
               function* (anonymous class method)
                 "run"
-              context-line*
+              context_line*
                 "return $callable($passable);"
             frame*
               filename*
                 "pipeline.php"
               function*
                 "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-              context-line*
+              context_line*
                 "? $pipe->{$this->method}(...$parameters)"
           type*
             "Exception"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:40.066191+00:00'
+created: '2025-09-11T18:40:14.965913+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -35,7 +35,7 @@ contributing variants:
                 "hub"
               function* (trimmed javascript function)
                 "withScope"
-              context-line*
+              context_line*
                 "*/"
             frame* (marked in-app by the client)
               module*
@@ -45,21 +45,21 @@ contributing variants:
                 "hub.ts"
               function* (trimmed javascript function)
                 "captureException"
-              context-line*
+              context_line*
                 "if (maxBreadcrumbs <= 0) {"
             frame* (marked in-app by the client)
               module*
                 "hub"
               function* (trimmed javascript function)
                 "invokeClient"
-              context-line*
+              context_line*
                 "* @returns Scope, the new cloned scope"
             frame* (marked in-app by the client)
               module*
                 "baseclient.ts"
               function* (trimmed javascript function)
                 "captureException"
-              context-line*
+              context_line*
                 "promisedEvent"
             frame* (marked in-app by the client)
               module*
@@ -80,7 +80,7 @@ contributing variants:
                 "hub"
               function* (trimmed javascript function)
                 "withScope"
-              context-line*
+              context_line*
                 "*/"
             frame*
               module*
@@ -90,45 +90,45 @@ contributing variants:
                 "jest-mock.build:index"
               function* (trimmed javascript function)
                 "mockConstructor [as captureException]"
-              context-line*
+              context_line*
                 "return fn.apply(this, arguments);"
             frame*
               module*
                 "jest-mock.build:index"
-              context-line*
+              context_line*
                 "})();"
             frame*
               module*
                 "jest-mock.build:index"
               function*
                 "finalReturnValue"
-              context-line*
+              context_line*
                 "return specificMockImpl.apply(this, arguments);"
             frame*
               module*
                 "jest-mock.build:index"
-              context-line*
+              context_line*
                 "return original.apply(this, arguments);"
             frame*
               module*
                 "hub.ts"
               function* (trimmed javascript function)
                 "captureException"
-              context-line*
+              context_line*
                 "if (maxBreadcrumbs <= 0) {"
             frame*
               module*
                 "hub"
               function* (trimmed javascript function)
                 "invokeClient"
-              context-line*
+              context_line*
                 "* @returns Scope, the new cloned scope"
             frame*
               module*
                 "baseclient.ts"
               function* (trimmed javascript function)
                 "captureException"
-              context-line*
+              context_line*
                 "promisedEvent"
             frame*
               module*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:40.238320+00:00'
+created: '2025-09-11T21:13:37.800606+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -25,10 +25,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "c52ebcc2d9d0780a23c7d99831678830"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             stacktrace*
               frame* (marked in-app by the client)
@@ -43,10 +43,10 @@ contributing variants:
               "hello world"
   system*
     hash: "669cb6664e0f5fed38665da04e464f7e"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       system*
-        chained-exception*
+        chained_exception*
           exception*
             stacktrace*
               frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:40.328924+00:00'
+created: '2025-09-11T18:40:15.033167+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -35,14 +35,14 @@ contributing variants:
                 "sentry.web.frontend.release_webhook"
               function*
                 "post"
-              context-line*
+              context_line*
                 "hook.handle(request)"
             frame* (marked in-app by the client)
               module*
                 "sentry_plugins.heroku.plugin"
               function*
                 "handle"
-              context-line*
+              context_line*
                 "email = request.POST['user']"
           type*
             "MultiValueDictKeyError"
@@ -58,21 +58,21 @@ contributing variants:
                 "sentry.web.frontend.release_webhook"
               function*
                 "post"
-              context-line*
+              context_line*
                 "hook.handle(request)"
             frame*
               module*
                 "sentry_plugins.heroku.plugin"
               function*
                 "handle"
-              context-line*
+              context_line*
                 "email = request.POST['user']"
             frame*
               module*
                 "django.utils.datastructures"
               function*
                 "__getitem__"
-              context-line*
+              context_line*
                 "raise MultiValueDictKeyError(repr(key))"
           type*
             "MultiValueDictKeyError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:42.815332+00:00'
+created: '2025-09-11T18:40:15.058271+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -35,21 +35,21 @@ contributing variants:
                 "django.core.handlers.base"
               function*
                 "get_response"
-              context-line*
+              context_line*
                 "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
             frame*
               module*
                 "django.views.generic.base"
               function*
                 "view"
-              context-line*
+              context_line*
                 "return self.dispatch(request, *args, **kwargs)"
             frame*
               module*
                 "django.utils.decorators"
               function*
                 "_wrapper"
-              context-line*
+              context_line*
                 "return bound_func(*args, **kwargs)"
           type*
             "MultiValueDictKeyError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:40.509301+00:00'
+created: '2025-09-11T18:40:15.078945+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -35,14 +35,14 @@ contributing variants:
                 "sentry.utils.safe"
               function*
                 "safe_execute"
-              context-line*
+              context_line*
                 "result = func(*args, **kwargs)"
             frame* (marked in-app by the client)
               module*
                 "sentry.integrations.slack.notify_action"
               function*
                 "send_notification"
-              context-line*
+              context_line*
                 "resp.raise_for_status()"
           type*
             "HTTPError"
@@ -58,21 +58,21 @@ contributing variants:
                 "sentry.utils.safe"
               function*
                 "safe_execute"
-              context-line*
+              context_line*
                 "result = func(*args, **kwargs)"
             frame*
               module*
                 "sentry.integrations.slack.notify_action"
               function*
                 "send_notification"
-              context-line*
+              context_line*
                 "resp.raise_for_status()"
             frame*
               module*
                 "requests.models"
               function*
                 "raise_for_status"
-              context-line*
+              context_line*
                 "raise HTTPError(http_error_msg, response=self)"
           type*
             "HTTPError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-20T20:36:08.247077+00:00'
+created: '2025-09-11T18:40:15.157158+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,10 +23,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "11e6467c8358a9366c6538f95dcd7bd4"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             type*
               "Error"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-20T20:36:08.117220+00:00'
+created: '2025-09-11T18:40:15.125491+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,10 +23,10 @@ metrics with tags: {
 contributing variants:
   app*
     hash: "5f209162115f576bedbaf6f0ad30e5aa"
-    contributing component: chained-exception
+    contributing component: chained_exception
     component:
       app*
-        chained-exception*
+        chained_exception*
           exception*
             type*
               "TypeError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:40.629665+00:00'
+created: '2025-09-11T18:40:15.179434+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -33,12 +33,12 @@ contributing variants:
             frame* (marked in-app by the client)
               module*
                 "App"
-              context-line*
+              context_line*
                 "<Button"
             frame* (marked in-app by the client)
               module*
                 "App"
-              context-line*
+              context_line*
                 "<Button"
           type*
             "TypeError"
@@ -52,52 +52,52 @@ contributing variants:
             frame*
               module*
                 "react-native/Libraries/BatchedBridge/MessageQueue"
-              context-line*
+              context_line*
                 "return this.flushedQueue();"
             frame*
               module*
                 "react-native/Libraries/BatchedBridge/MessageQueue"
-              context-line*
+              context_line*
                 "this._inCall--;"
             frame*
               module*
                 "react-native/Libraries/BatchedBridge/MessageQueue"
-              context-line*
+              context_line*
                 "return this.flushedQueue();"
             frame*
               module*
                 "react-native/Libraries/BatchedBridge/MessageQueue"
-              context-line*
+              context_line*
                 "this._lastFlush = new Date().getTime();"
             frame*
               module*
                 "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-              context-line*
+              context_line*
                 "_receiveRootNodeIDEvent(index, eventTopLevelType, i);"
             frame*
               module*
                 "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-              context-line*
+              context_line*
                 "batchedUpdates(function() {"
             frame*
               module*
                 "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-              context-line*
+              context_line*
                 "return _batchedUpdates(fn, bookkeeping);"
             frame*
               module*
                 "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-              context-line*
+              context_line*
                 "return fn(a);"
             frame*
               module*
                 "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-              context-line*
+              context_line*
                 "(forEachAccumulated(events, executeDispatchesAndReleaseTopLevel),"
             frame*
               module*
                 "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-              context-line*
+              context_line*
                 "Array.isArray(arr) ? arr.forEach(cb, scope) : arr && cb.call(scope, arr);"
             frame*
               function*
@@ -105,57 +105,57 @@ contributing variants:
             frame*
               module*
                 "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-              context-line*
+              context_line*
                 "executeDispatch(e, !1, dispatchListeners, dispatchInstances);"
             frame*
               module*
                 "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-              context-line*
+              context_line*
                 "ReactErrorUtils.invokeGuardedCallbackAndCatchFirstError("
             frame*
               module*
                 "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-              context-line*
+              context_line*
                 "ReactErrorUtils.invokeGuardedCallback.apply(this, arguments);"
             frame*
               module*
                 "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-              context-line*
+              context_line*
                 "invokeGuardedCallback.apply(ReactErrorUtils, arguments);"
             frame*
               module*
                 "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-              context-line*
+              context_line*
                 "var funcArgs = Array.prototype.slice.call(arguments, 3);"
             frame*
               module*
                 "react-native/Libraries/Components/Touchable/Touchable"
-              context-line*
+              context_line*
                 "touchableHandleResponderRelease: function(e) {"
             frame*
               module*
                 "react-native/Libraries/Components/Touchable/Touchable"
-              context-line*
+              context_line*
                 "this._performSideEffectsForTransition(curState, nextState, signal, e);"
             frame*
               module*
                 "react-native/Libraries/Components/Touchable/Touchable"
-              context-line*
+              context_line*
                 "this.touchableHandlePress(e);"
             frame*
               module*
                 "react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android"
-              context-line*
+              context_line*
                 "this.props.onPress && this.props.onPress(e);"
             frame*
               module*
                 "App"
-              context-line*
+              context_line*
                 "<Button"
             frame*
               module*
                 "App"
-              context-line*
+              context_line*
                 "<Button"
           type*
             "TypeError"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/template_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/template_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:43.680038+00:00'
+created: '2025-09-11T18:40:15.471979+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -25,5 +25,5 @@ contributing variants:
         template*
           filename*
             "foo.html"
-          context-line*
+          context_line*
             "{% invalid template tag %}"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.801457+00:00'
+created: '2025-09-11T21:52:17.074658+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1016,7 +1016,7 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
-              "id": "ns-error",
+              "id": "ns_error",
               "name": null,
               "values": [
                 {
@@ -2087,7 +2087,7 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
-              "id": "ns-error",
+              "id": "ns_error",
               "name": null,
               "values": [
                 {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.876198+00:00'
+created: '2025-09-11T21:52:17.149180+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -59,7 +59,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = func(*args, **kwargs)"
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)"
@@ -147,7 +147,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return super(SubscriptionQuota, self).is_rate_limited(project, key=key)"
@@ -191,7 +191,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "rejections = is_rate_limited(client, keys, args)"
@@ -235,7 +235,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return script(keys, args, client)"
@@ -279,7 +279,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return client.evalsha(self.sha, len(keys), *args)"
@@ -323,7 +323,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return self.execute_command('EVALSHA', sha, numkeys, *keys_and_args)"
@@ -367,7 +367,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return self.parse_response(connection, command_name, **options)"
@@ -411,7 +411,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "response = connection.read_response()"
@@ -455,7 +455,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "response = self._parser.read_response()"
@@ -499,7 +499,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "(e.args,))"
@@ -654,7 +654,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = func(*args, **kwargs)"
@@ -698,7 +698,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)"
@@ -742,7 +742,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return super(SubscriptionQuota, self).is_rate_limited(project, key=key)"
@@ -786,7 +786,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "rejections = is_rate_limited(client, keys, args)"
@@ -830,7 +830,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return script(keys, args, client)"
@@ -874,7 +874,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return client.evalsha(self.sha, len(keys), *args)"
@@ -918,7 +918,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return self.execute_command('EVALSHA', sha, numkeys, *keys_and_args)"
@@ -962,7 +962,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return self.parse_response(connection, command_name, **options)"
@@ -1006,7 +1006,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "response = connection.read_response()"
@@ -1050,7 +1050,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "response = self._parser.read_response()"
@@ -1094,7 +1094,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "(e.args,))"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.908323+00:00'
+created: '2025-09-11T21:52:17.169747+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -57,7 +57,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return server.serve(port);"
@@ -99,7 +99,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return handler(request);"
@@ -141,7 +141,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return withMetrics(handler, metricName, tags);"
@@ -183,7 +183,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise FailedToFetchError('Charlie didn't bring the ball back!');"
@@ -293,7 +293,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return server.serve(port);"
@@ -335,7 +335,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return handler(request);"
@@ -377,7 +377,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return withMetrics(handler, metricName, tags);"
@@ -419,7 +419,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise FailedToFetchError('Charlie didn't bring the ball back!');"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.948949+00:00'
+created: '2025-09-11T21:52:17.190016+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -57,7 +57,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return server.serve(port);"
@@ -99,7 +99,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return handler(request);"
@@ -141,7 +141,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return withMetrics(handler, metricName, tags);"
@@ -251,7 +251,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return server.serve(port);"
@@ -293,7 +293,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return handler(request);"
@@ -335,7 +335,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return withMetrics(handler, metricName, tags);"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.400309+00:00'
+created: '2025-09-11T21:52:17.392787+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -59,7 +59,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = func(*args, **kwargs)"
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return _do_process_event(cache_key, start_time, event_id, process_event)"
@@ -147,7 +147,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "new_data = process_stacktraces(data)"
@@ -191,7 +191,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "if processor.preprocess_step(processing_task):"
@@ -235,7 +235,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "referenced_images=referenced_images,"
@@ -279,7 +279,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "with_conversion_errors=True)"
@@ -323,7 +323,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
@@ -367,7 +367,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "model.cache_file.save_to(cachefile_path)"
@@ -411,7 +411,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=False).detach_tempfile()"
@@ -455,7 +455,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=delete"
@@ -499,7 +499,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self._prefetch(prefetch_to, delete)"
@@ -543,7 +543,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
@@ -587,7 +587,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.shutdown(wait=True)"
@@ -631,7 +631,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "t.join(sys.maxint)"
@@ -675,7 +675,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.__block.wait(delay)"
@@ -719,7 +719,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "_sleep(delay)"
@@ -763,7 +763,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise SoftTimeLimitExceeded()"
@@ -891,7 +891,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = func(*args, **kwargs)"
@@ -935,7 +935,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return _do_process_event(cache_key, start_time, event_id, process_event)"
@@ -979,7 +979,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "new_data = process_stacktraces(data)"
@@ -1023,7 +1023,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "if processor.preprocess_step(processing_task):"
@@ -1067,7 +1067,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "referenced_images=referenced_images,"
@@ -1111,7 +1111,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "with_conversion_errors=True)"
@@ -1155,7 +1155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
@@ -1199,7 +1199,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "model.cache_file.save_to(cachefile_path)"
@@ -1243,7 +1243,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=False).detach_tempfile()"
@@ -1287,7 +1287,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=delete"
@@ -1331,7 +1331,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self._prefetch(prefetch_to, delete)"
@@ -1375,7 +1375,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
@@ -1419,7 +1419,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.shutdown(wait=True)"
@@ -1463,7 +1463,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "t.join(sys.maxint)"
@@ -1507,7 +1507,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.__block.wait(delay)"
@@ -1551,7 +1551,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "_sleep(delay)"
@@ -1595,7 +1595,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise SoftTimeLimitExceeded()"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.364759+00:00'
+created: '2025-09-11T21:52:17.371465+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -59,7 +59,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = func(*args, **kwargs)"
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return _do_process_event(cache_key, start_time, event_id, process_event)"
@@ -147,7 +147,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "new_data = process_stacktraces(data)"
@@ -191,7 +191,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "if processor.preprocess_step(processing_task):"
@@ -235,7 +235,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "referenced_images=referenced_images,"
@@ -279,7 +279,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "with_conversion_errors=True)"
@@ -323,7 +323,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
@@ -367,7 +367,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "model.cache_file.save_to(cachefile_path)"
@@ -411,7 +411,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=False).detach_tempfile()"
@@ -455,7 +455,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=delete"
@@ -499,7 +499,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self._prefetch(prefetch_to, delete)"
@@ -543,7 +543,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
@@ -587,7 +587,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.shutdown(wait=True)"
@@ -631,7 +631,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "t.join(sys.maxint)"
@@ -675,7 +675,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.__block.wait(delay)"
@@ -719,7 +719,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "_sleep(delay)"
@@ -763,7 +763,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise SoftTimeLimitExceeded()"
@@ -890,7 +890,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = func(*args, **kwargs)"
@@ -934,7 +934,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return _do_process_event(cache_key, start_time, event_id, process_event)"
@@ -978,7 +978,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "new_data = process_stacktraces(data)"
@@ -1022,7 +1022,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "if processor.preprocess_step(processing_task):"
@@ -1066,7 +1066,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "referenced_images=referenced_images,"
@@ -1110,7 +1110,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "with_conversion_errors=True)"
@@ -1154,7 +1154,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
@@ -1198,7 +1198,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "model.cache_file.save_to(cachefile_path)"
@@ -1242,7 +1242,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=False).detach_tempfile()"
@@ -1286,7 +1286,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=delete"
@@ -1330,7 +1330,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self._prefetch(prefetch_to, delete)"
@@ -1374,7 +1374,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
@@ -1418,7 +1418,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.shutdown(wait=True)"
@@ -1462,7 +1462,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "t.join(sys.maxint)"
@@ -1506,7 +1506,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.__block.wait(delay)"
@@ -1550,7 +1550,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "_sleep(delay)"
@@ -1594,7 +1594,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise SoftTimeLimitExceeded()"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.526178+00:00'
+created: '2025-09-11T21:52:17.413269+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -59,7 +59,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = func(*args, **kwargs)"
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return _do_process_event(cache_key, start_time, event_id, process_event)"
@@ -147,7 +147,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "new_data = process_stacktraces(data)"
@@ -191,7 +191,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "if processor.preprocess_step(processing_task):"
@@ -235,7 +235,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "referenced_images=referenced_images,"
@@ -279,7 +279,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "with_conversion_errors=True)"
@@ -323,7 +323,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
@@ -367,7 +367,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "model.cache_file.save_to(cachefile_path)"
@@ -411,7 +411,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=False).detach_tempfile()"
@@ -455,7 +455,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=delete"
@@ -499,7 +499,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self._prefetch(prefetch_to, delete)"
@@ -543,7 +543,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
@@ -587,7 +587,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.shutdown(wait=True)"
@@ -631,7 +631,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "t.join(sys.maxint)"
@@ -675,7 +675,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.__block.wait(delay)"
@@ -719,7 +719,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "_sleep(delay)"
@@ -763,7 +763,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise SoftTimeLimitExceeded()"
@@ -885,7 +885,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = func(*args, **kwargs)"
@@ -929,7 +929,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return _do_process_event(cache_key, start_time, event_id, process_event)"
@@ -973,7 +973,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "new_data = process_stacktraces(data)"
@@ -1017,7 +1017,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "if processor.preprocess_step(processing_task):"
@@ -1061,7 +1061,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "referenced_images=referenced_images,"
@@ -1105,7 +1105,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "with_conversion_errors=True)"
@@ -1149,7 +1149,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
@@ -1193,7 +1193,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "model.cache_file.save_to(cachefile_path)"
@@ -1237,7 +1237,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=False).detach_tempfile()"
@@ -1281,7 +1281,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=delete"
@@ -1325,7 +1325,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self._prefetch(prefetch_to, delete)"
@@ -1369,7 +1369,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
@@ -1413,7 +1413,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.shutdown(wait=True)"
@@ -1457,7 +1457,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "t.join(sys.maxint)"
@@ -1501,7 +1501,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.__block.wait(delay)"
@@ -1545,7 +1545,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "_sleep(delay)"
@@ -1589,7 +1589,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise SoftTimeLimitExceeded()"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.592789+00:00'
+created: '2025-09-11T21:52:17.452681+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -36,7 +36,7 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
-              "id": "ns-error",
+              "id": "ns_error",
               "name": null,
               "values": [
                 {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.662562+00:00'
+created: '2025-09-11T21:52:17.497094+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {
@@ -186,7 +186,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": false,
           "hint": "ignored because hash matches app variant",
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.737096+00:00'
+created: '2025-09-11T21:52:17.538747+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.791731+00:00'
+created: '2025-09-11T21:52:17.578207+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.767705+00:00'
+created: '2025-09-11T21:52:17.559569+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.854389+00:00'
+created: '2025-09-11T21:52:17.617682+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.876266+00:00'
+created: '2025-09-11T21:52:17.636080+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.897011+00:00'
+created: '2025-09-11T21:52:17.654078+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.038220+00:00'
+created: '2025-09-11T21:52:17.744859+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.064848+00:00'
+created: '2025-09-11T21:52:17.772851+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.146804+00:00'
+created: '2025-09-11T21:52:17.824399+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {
@@ -289,7 +289,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.224729+00:00'
+created: '2025-09-11T21:52:17.872231+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.183704+00:00'
+created: '2025-09-11T21:52:17.849793+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.256033+00:00'
+created: '2025-09-11T21:52:17.894510+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -57,7 +57,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "onError(err);"
@@ -101,7 +101,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this.model.submitError(error);"
@@ -211,7 +211,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "onError(err);"
@@ -255,7 +255,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this.model.submitError(error);"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/expectct.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/expectct.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.476182+00:00'
+created: '2025-09-11T21:52:18.042146+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "expect-ct",
+          "id": "expect_ct",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.745617+00:00'
+created: '2025-09-11T21:52:18.284752+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -51,7 +51,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
-                  "id": "context-line",
+                  "id": "context_line",
                   "name": null,
                   "values": [
                     "hello world"
@@ -93,7 +93,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
-                  "id": "context-line",
+                  "id": "context_line",
                   "name": null,
                   "values": [
                     "hello world"
@@ -133,7 +133,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": false,
                   "hint": "discarded because from URL origin and no function",
-                  "id": "context-line",
+                  "id": "context_line",
                   "name": null,
                   "values": [
                     "hello world"
@@ -217,7 +217,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
-                  "id": "context-line",
+                  "id": "context_line",
                   "name": null,
                   "values": [
                     "hello world"
@@ -259,7 +259,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
-                  "id": "context-line",
+                  "id": "context_line",
                   "name": null,
                   "values": [
                     "hello world"
@@ -299,7 +299,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": false,
                   "hint": "discarded because from URL origin and no function",
-                  "id": "context-line",
+                  "id": "context_line",
                   "name": null,
                   "values": [
                     "hello world"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.803737+00:00'
+created: '2025-09-11T21:52:18.352722+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -51,7 +51,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
-                  "id": "context-line",
+                  "id": "context_line",
                   "name": null,
                   "values": [
                     "hello world"
@@ -135,7 +135,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
-                  "id": "context-line",
+                  "id": "context_line",
                   "name": null,
                   "values": [
                     "hello world"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.835746+00:00'
+created: '2025-09-11T21:52:18.374156+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -51,7 +51,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
-                  "id": "context-line",
+                  "id": "context_line",
                   "name": null,
                   "values": [
                     "hello world"
@@ -135,7 +135,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
-                  "id": "context-line",
+                  "id": "context_line",
                   "name": null,
                   "values": [
                     "hello world"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.365740+00:00'
+created: '2025-09-11T21:52:18.826716+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -51,7 +51,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
-                  "id": "context-line",
+                  "id": "context_line",
                   "name": null,
                   "values": [
                     "foo bar"
@@ -135,7 +135,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 {
                   "contributes": true,
                   "hint": null,
-                  "id": "context-line",
+                  "id": "context_line",
                   "name": null,
                   "values": [
                     "foo bar"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.921511+00:00'
+created: '2025-09-11T21:52:19.308138+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -64,7 +64,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = func(*args, **kwargs)"
@@ -108,7 +108,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return _do_process_event(cache_key, start_time, event_id, process_event)"
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "new_data = process_stacktraces(data)"
@@ -196,7 +196,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "if processor.preprocess_step(processing_task):"
@@ -240,7 +240,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "referenced_images=referenced_images,"
@@ -284,7 +284,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "with_conversion_errors=True)"
@@ -328,7 +328,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
@@ -372,7 +372,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "model.cache_file.save_to(cachefile_path)"
@@ -416,7 +416,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=False).detach_tempfile()"
@@ -460,7 +460,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=delete"
@@ -504,7 +504,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self._prefetch(prefetch_to, delete)"
@@ -548,7 +548,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
@@ -592,7 +592,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.shutdown(wait=True)"
@@ -636,7 +636,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "t.join(sys.maxint)"
@@ -680,7 +680,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.__block.wait(delay)"
@@ -724,7 +724,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "_sleep(delay)"
@@ -768,7 +768,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise SoftTimeLimitExceeded()"
@@ -890,7 +890,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = func(*args, **kwargs)"
@@ -934,7 +934,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return _do_process_event(cache_key, start_time, event_id, process_event)"
@@ -978,7 +978,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "new_data = process_stacktraces(data)"
@@ -1022,7 +1022,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "if processor.preprocess_step(processing_task):"
@@ -1066,7 +1066,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "referenced_images=referenced_images,"
@@ -1110,7 +1110,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "with_conversion_errors=True)"
@@ -1154,7 +1154,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
@@ -1198,7 +1198,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "model.cache_file.save_to(cachefile_path)"
@@ -1242,7 +1242,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=False).detach_tempfile()"
@@ -1286,7 +1286,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=delete"
@@ -1330,7 +1330,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self._prefetch(prefetch_to, delete)"
@@ -1374,7 +1374,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
@@ -1418,7 +1418,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.shutdown(wait=True)"
@@ -1462,7 +1462,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "t.join(sys.maxint)"
@@ -1506,7 +1506,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.__block.wait(delay)"
@@ -1550,7 +1550,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "_sleep(delay)"
@@ -1594,7 +1594,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise SoftTimeLimitExceeded()"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.946438+00:00'
+created: '2025-09-11T21:52:19.331104+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -59,7 +59,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = func(*args, **kwargs)"
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return _do_process_event(cache_key, start_time, event_id, process_event)"
@@ -147,7 +147,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "new_data = process_stacktraces(data)"
@@ -191,7 +191,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "if processor.preprocess_step(processing_task):"
@@ -235,7 +235,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "referenced_images=referenced_images,"
@@ -279,7 +279,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "with_conversion_errors=True)"
@@ -323,7 +323,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
@@ -367,7 +367,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "model.cache_file.save_to(cachefile_path)"
@@ -411,7 +411,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=False).detach_tempfile()"
@@ -455,7 +455,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=delete"
@@ -499,7 +499,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self._prefetch(prefetch_to, delete)"
@@ -543,7 +543,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
@@ -587,7 +587,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.shutdown(wait=True)"
@@ -631,7 +631,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "t.join(sys.maxint)"
@@ -675,7 +675,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.__block.wait(delay)"
@@ -719,7 +719,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "_sleep(delay)"
@@ -763,7 +763,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise SoftTimeLimitExceeded()"
@@ -890,7 +890,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = func(*args, **kwargs)"
@@ -934,7 +934,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return _do_process_event(cache_key, start_time, event_id, process_event)"
@@ -978,7 +978,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "new_data = process_stacktraces(data)"
@@ -1022,7 +1022,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "if processor.preprocess_step(processing_task):"
@@ -1066,7 +1066,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "referenced_images=referenced_images,"
@@ -1110,7 +1110,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "with_conversion_errors=True)"
@@ -1154,7 +1154,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
@@ -1198,7 +1198,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "model.cache_file.save_to(cachefile_path)"
@@ -1242,7 +1242,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=False).detach_tempfile()"
@@ -1286,7 +1286,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "delete=delete"
@@ -1330,7 +1330,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self._prefetch(prefetch_to, delete)"
@@ -1374,7 +1374,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
@@ -1418,7 +1418,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.shutdown(wait=True)"
@@ -1462,7 +1462,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "t.join(sys.maxint)"
@@ -1506,7 +1506,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "self.__block.wait(delay)"
@@ -1550,7 +1550,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "_sleep(delay)"
@@ -1594,7 +1594,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise SoftTimeLimitExceeded()"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.088397+00:00'
+created: '2025-09-11T21:52:19.425210+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": false,
           "hint": "ignored because this variant does not have a contributing stacktrace, but the system variant does",
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {
@@ -2021,7 +2021,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.492197+00:00'
+created: '2025-09-11T21:52:19.792155+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -59,7 +59,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "fn();"
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "while (chain.length > i) run(chain[i++]); // variable length - can't use forEach"
@@ -147,7 +147,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = handler(value); // may throw"
@@ -191,7 +191,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "asyncGeneratorStep(gen, resolve, reject, _next, _throw, \"next\", value);"
@@ -235,7 +235,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "var info = gen[key](arg);"
@@ -279,7 +279,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return this._invoke(method, arg);"
@@ -323,7 +323,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "var record = tryCatch(innerFn, self, context);"
@@ -367,7 +367,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return { type: \"normal\", arg: fn.call(obj, arg) };"
@@ -411,7 +411,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this.setState({"
@@ -455,7 +455,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} !==typeof a&&\"function\"!==typeof a&&null!=a?B(\"85\"):void 0;this.updater.enqueueSetState(this,a,b,\"setState\")};E.prototype.forceUpdate=functi {snip}"
@@ -499,7 +499,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} );e.payload=b;void 0!==c&&null!==c&&(e.callback=c);ff(a,e);If(a,d)},enqueueReplaceState:function(a,b,c){a=a._reactInternalFiber;var d=Gf();d {snip}"
@@ -543,7 +543,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} );else if(c=b.expirationTime,0===c||a<c)b.expirationTime=a;V||(W?Wg&&(Y=b,Z=1,Xg(b,1,!0)):1===a?Yg(1,null):Zg(b,a))}$g>ah&&($g=0,t(\"185\"))}} {snip}"
@@ -587,7 +587,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} ),qh(),oh(),lh=kh;else for(;null!==Y&&0!==Z&&(0===a||a>=Z);)Xg(Y,Z,!0),qh();null!==hh&&(ch=0,dh=null);0!==Z&&Zg(Y,Z);hh=null;eh=!1;$g=0;mh=n {snip}"
@@ -631,7 +631,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finishedWork,null!==d&&rh( {snip}"
@@ -675,7 +675,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} nate;q=Q;p=y;switch(q.tag){case 2:case 3:var X=q.stateNode;if(q.effectTag&4)if(null===oc)X.props=q.memoizedProps,X.state=q.memoizedState,X.c {snip}"
@@ -719,7 +719,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this.fetchData();"
@@ -763,7 +763,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
@@ -807,7 +807,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "const preservedError = new Error();"
@@ -919,7 +919,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "fn();"
@@ -963,7 +963,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "while (chain.length > i) run(chain[i++]); // variable length - can't use forEach"
@@ -1007,7 +1007,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = handler(value); // may throw"
@@ -1051,7 +1051,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "asyncGeneratorStep(gen, resolve, reject, _next, _throw, \"next\", value);"
@@ -1095,7 +1095,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "var info = gen[key](arg);"
@@ -1139,7 +1139,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return this._invoke(method, arg);"
@@ -1183,7 +1183,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "var record = tryCatch(innerFn, self, context);"
@@ -1227,7 +1227,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return { type: \"normal\", arg: fn.call(obj, arg) };"
@@ -1271,7 +1271,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this.setState({"
@@ -1315,7 +1315,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} !==typeof a&&\"function\"!==typeof a&&null!=a?B(\"85\"):void 0;this.updater.enqueueSetState(this,a,b,\"setState\")};E.prototype.forceUpdate=functi {snip}"
@@ -1359,7 +1359,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} );e.payload=b;void 0!==c&&null!==c&&(e.callback=c);ff(a,e);If(a,d)},enqueueReplaceState:function(a,b,c){a=a._reactInternalFiber;var d=Gf();d {snip}"
@@ -1403,7 +1403,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} );else if(c=b.expirationTime,0===c||a<c)b.expirationTime=a;V||(W?Wg&&(Y=b,Z=1,Xg(b,1,!0)):1===a?Yg(1,null):Zg(b,a))}$g>ah&&($g=0,t(\"185\"))}} {snip}"
@@ -1447,7 +1447,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} ),qh(),oh(),lh=kh;else for(;null!==Y&&0!==Z&&(0===a||a>=Z);)Xg(Y,Z,!0),qh();null!==hh&&(ch=0,dh=null);0!==Z&&Zg(Y,Z);hh=null;eh=!1;$g=0;mh=n {snip}"
@@ -1491,7 +1491,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finishedWork,null!==d&&rh( {snip}"
@@ -1535,7 +1535,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} nate;q=Q;p=y;switch(q.tag){case 2:case 3:var X=q.stateNode;if(q.effectTag&4)if(null===oc)X.props=q.memoizedProps,X.state=q.memoizedState,X.c {snip}"
@@ -1579,7 +1579,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this.fetchData();"
@@ -1623,7 +1623,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
@@ -1667,7 +1667,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "const preservedError = new Error();"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.514076+00:00'
+created: '2025-09-11T21:52:19.817288+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -92,7 +92,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "asyncGeneratorStep(gen, resolve, reject, _next, _throw, \"next\", value);"
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "var info = gen[key](arg);"
@@ -180,7 +180,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "var record = tryCatch(innerFn, self, context);"
@@ -224,7 +224,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return { type: \"normal\", arg: fn.call(obj, arg) };"
@@ -268,7 +268,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this.setState({"
@@ -312,7 +312,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} ructor=G;m(H,E.prototype);H.isPureReactComponent=!0;var I={current:null,currentDispatcher:null},J=Object.prototype.hasOwnProperty,K={key:!0, {snip}"
@@ -356,7 +356,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} &(e.callback=c);ff(a,e);If(a,d)},enqueueForceUpdate:function(a,b){a=a._reactInternalFiber;var c=Gf();c=Hf(c,a);var d=df(c);d.tag=2;void 0!=="
@@ -400,7 +400,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "var U=null,T=null,ch=0,dh=void 0,V=!1,Y=null,Z=0,Vg=0,eh=!1,fh=!1,gh=null,hh=null,W=!1,Wg=!1,Ug=!1,ih=null,jh=ba.unstable_now(),kh=(jh/10|0) {snip}"
@@ -444,7 +444,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "function Xg(a,b,c){V?t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finis {snip}"
@@ -488,7 +488,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "function rh(a,b,c){var d=a.firstBatch;if(null!==d&&d._expirationTime<=c&&(null===ih?ih=[d]:ih.push(d),d._defer)){a.finishedWork=b;a.expirati {snip}"
@@ -532,7 +532,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} .__reactInternalSnapshotBeforeUpdate)}var kg=q.updateQueue;null!==kg&&(X.props=q.memoizedProps,X.state=q.memoizedState,lf(q,kg,X,p));break;c {snip}"
@@ -576,7 +576,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this.fetchData();"
@@ -620,7 +620,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
@@ -664,7 +664,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "const preservedError = new Error();"
@@ -809,7 +809,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "asyncGeneratorStep(gen, resolve, reject, _next, _throw, \"next\", value);"
@@ -853,7 +853,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "var info = gen[key](arg);"
@@ -897,7 +897,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "var record = tryCatch(innerFn, self, context);"
@@ -941,7 +941,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return { type: \"normal\", arg: fn.call(obj, arg) };"
@@ -985,7 +985,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this.setState({"
@@ -1029,7 +1029,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} ructor=G;m(H,E.prototype);H.isPureReactComponent=!0;var I={current:null,currentDispatcher:null},J=Object.prototype.hasOwnProperty,K={key:!0, {snip}"
@@ -1073,7 +1073,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} &(e.callback=c);ff(a,e);If(a,d)},enqueueForceUpdate:function(a,b){a=a._reactInternalFiber;var c=Gf();c=Hf(c,a);var d=df(c);d.tag=2;void 0!=="
@@ -1117,7 +1117,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "var U=null,T=null,ch=0,dh=void 0,V=!1,Y=null,Z=0,Vg=0,eh=!1,fh=!1,gh=null,hh=null,W=!1,Wg=!1,Ug=!1,ih=null,jh=ba.unstable_now(),kh=(jh/10|0) {snip}"
@@ -1161,7 +1161,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "function Xg(a,b,c){V?t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finis {snip}"
@@ -1205,7 +1205,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "function rh(a,b,c){var d=a.firstBatch;if(null!==d&&d._expirationTime<=c&&(null===ih?ih=[d]:ih.push(d),d._defer)){a.finishedWork=b;a.expirati {snip}"
@@ -1249,7 +1249,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} .__reactInternalSnapshotBeforeUpdate)}var kg=q.updateQueue;null!==kg&&(X.props=q.memoizedProps,X.state=q.memoizedState,lf(q,kg,X,p));break;c {snip}"
@@ -1293,7 +1293,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this.fetchData();"
@@ -1337,7 +1337,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
@@ -1381,7 +1381,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "const preservedError = new Error();"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.558784+00:00'
+created: '2025-09-11T21:52:19.860032+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -55,7 +55,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "require_once __DIR__.'/public/index.php';"
@@ -97,7 +97,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "$request = Illuminate\\Http\\Request::capture()"
@@ -139,7 +139,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "$response = $this->sendRequestThroughRouter($request);"
@@ -181,7 +181,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "->then($this->dispatchToRouter());"
@@ -223,7 +223,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $pipeline($this->passable);"
@@ -265,7 +265,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -307,7 +307,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -349,7 +349,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $next($request);"
@@ -391,7 +391,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -433,7 +433,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -475,7 +475,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $next($request);"
@@ -517,7 +517,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -559,7 +559,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -601,7 +601,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $next($request);"
@@ -643,7 +643,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -685,7 +685,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -727,7 +727,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $next($request);"
@@ -769,7 +769,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -811,7 +811,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -853,7 +853,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $next($request);"
@@ -895,7 +895,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $destination($passable);"
@@ -937,7 +937,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $this->router->dispatch($request);"
@@ -979,7 +979,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $this->dispatchToRoute($request);"
@@ -1021,7 +1021,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $this->runRoute($request, $this->findRoute($request));"
@@ -1063,7 +1063,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "$this->runRouteWithinStack($route, $request)"
@@ -1105,7 +1105,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "});"
@@ -1147,7 +1147,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $pipeline($this->passable);"
@@ -1189,7 +1189,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -1231,7 +1231,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -1273,7 +1273,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $this->encrypt($next($this->decrypt($request)));"
@@ -1315,7 +1315,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -1357,7 +1357,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -1399,7 +1399,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "$response = $next($request);"
@@ -1441,7 +1441,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -1483,7 +1483,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -1525,7 +1525,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "$response = $next($request), $session"
@@ -1567,7 +1567,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -1609,7 +1609,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -1651,7 +1651,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $next($request);"
@@ -1693,7 +1693,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -1735,7 +1735,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -1777,7 +1777,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return tap($next($request), function ($response) use ($request) {"
@@ -1819,7 +1819,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -1861,7 +1861,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -1903,7 +1903,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $next($request);"
@@ -1945,7 +1945,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $destination($passable);"
@@ -1987,7 +1987,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "$request, $route->run()"
@@ -2029,7 +2029,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $this->runCallable();"
@@ -2071,7 +2071,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "$this->parametersWithoutNulls(), new ReflectionFunction($this->action['uses'])"
@@ -2113,7 +2113,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "throw new Exception('LARAVEL TEST');"
@@ -2221,7 +2221,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "require_once __DIR__.'/public/index.php';"
@@ -2263,7 +2263,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "$request = Illuminate\\Http\\Request::capture()"
@@ -2305,7 +2305,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "$response = $this->sendRequestThroughRouter($request);"
@@ -2347,7 +2347,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "->then($this->dispatchToRouter());"
@@ -2389,7 +2389,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $pipeline($this->passable);"
@@ -2431,7 +2431,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -2473,7 +2473,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -2515,7 +2515,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $next($request);"
@@ -2557,7 +2557,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -2599,7 +2599,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -2641,7 +2641,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $next($request);"
@@ -2683,7 +2683,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -2725,7 +2725,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -2767,7 +2767,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $next($request);"
@@ -2809,7 +2809,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -2851,7 +2851,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -2893,7 +2893,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $next($request);"
@@ -2935,7 +2935,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -2977,7 +2977,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -3019,7 +3019,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $next($request);"
@@ -3061,7 +3061,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $destination($passable);"
@@ -3103,7 +3103,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $this->router->dispatch($request);"
@@ -3145,7 +3145,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $this->dispatchToRoute($request);"
@@ -3187,7 +3187,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $this->runRoute($request, $this->findRoute($request));"
@@ -3229,7 +3229,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "$this->runRouteWithinStack($route, $request)"
@@ -3271,7 +3271,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "});"
@@ -3313,7 +3313,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $pipeline($this->passable);"
@@ -3355,7 +3355,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -3397,7 +3397,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -3439,7 +3439,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $this->encrypt($next($this->decrypt($request)));"
@@ -3481,7 +3481,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -3523,7 +3523,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -3565,7 +3565,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "$response = $next($request);"
@@ -3607,7 +3607,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -3649,7 +3649,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -3691,7 +3691,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "$response = $next($request), $session"
@@ -3733,7 +3733,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -3775,7 +3775,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -3817,7 +3817,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $next($request);"
@@ -3859,7 +3859,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -3901,7 +3901,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -3943,7 +3943,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return tap($next($request), function ($response) use ($request) {"
@@ -3985,7 +3985,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -4027,7 +4027,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -4069,7 +4069,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $next($request);"
@@ -4111,7 +4111,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $destination($passable);"
@@ -4153,7 +4153,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "$request, $route->run()"
@@ -4195,7 +4195,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $this->runCallable();"
@@ -4237,7 +4237,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "$this->parametersWithoutNulls(), new ReflectionFunction($this->action['uses'])"
@@ -4279,7 +4279,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "throw new Exception('LARAVEL TEST');"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.534562+00:00'
+created: '2025-09-11T21:52:19.836386+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -55,7 +55,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "require_once __DIR__.'/public/index.php';"
@@ -97,7 +97,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -139,7 +139,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"
@@ -247,7 +247,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "require_once __DIR__.'/public/index.php';"
@@ -289,7 +289,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return $callable($passable);"
@@ -331,7 +331,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "? $pipe->{$this->method}(...$parameters)"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.758213+00:00'
+created: '2025-09-11T21:52:20.042661+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -59,7 +59,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} o,r;for(b&&(o=i.domain)&&o.exit();t;){r=t.fn,t=t.next;try{r()}catch(o){throw t?n():e=void 0,o}}e=void 0,o&&o.enter()};if(b)n=function(){i.n {snip}"
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} ,M):b(n)):M(o)}catch(t){a&&!i&&a.exit(),M(t)}};n.length>p;)i(n[p++]);t._c=[],t._n=!1,e&&!t._h&&x(t)})}},x=function(t){d.call(b,function(){va {snip}"
@@ -147,7 +147,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} ry{c?(r||(2==t._h&&T(t),t._h=1),!0===c?n=o:(a&&a.enter(),n=c(o),a&&(a.exit(),i=!0)),n===e.promise?M(y(\"Promise-chain cycle\")):(p=N(n))?p.cal {snip}"
@@ -191,7 +191,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} ply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.lo {snip}"
@@ -235,7 +235,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
@@ -279,7 +279,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
@@ -323,7 +323,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
@@ -367,7 +367,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
@@ -411,7 +411,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} (e.t0)&&n<I)){e.next=12;break}return n++,e.abrupt(\"return\",a());case 12:throw e.t0;case 13:case\"end\":return e.stop()}},e,this,[[0,7]])}));re {snip}"
@@ -455,7 +455,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} urn e.stop()}},e,this,[[0,7]])}));return function(){return e.apply(this,arguments)}}(),e.abrupt(\"return\",a());case 3:case\"end\":return e.stop {snip}"
@@ -499,7 +499,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} unction(t){return function(){var e=this,o=arguments;return new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)} {snip}"
@@ -543,7 +543,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} function(t){O(this,L,\"Promise\",\"_h\"),s(t),o.call(this);try{t(M(H,this,1),M(C,this,1))}catch(t){C.call(this,t)}},(o=function(t){this._c=[],th {snip}"
@@ -587,7 +587,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.load(n(1467))},,function( {snip}"
@@ -631,7 +631,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,funct {snip}"
@@ -675,7 +675,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
@@ -719,7 +719,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
@@ -763,7 +763,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
@@ -807,7 +807,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
@@ -851,7 +851,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} r(;;)switch(e.prev=e.next){case 0:return e.prev=0,e.next=3,t();case 3:return r=e.sent,e.abrupt(\"return\",r.default||r);case 7:if(e.prev=7,e.t {snip}"
@@ -895,7 +895,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} orgId/issues/:groupId/\",componentPromise:function(){return n.e(75).then(n.bind(null,2497))},component:Object(cs.default)(Zt.a)},b.a.createEl {snip}"
@@ -939,7 +939,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} \"+i+\")\");o.type=a,o.request=i,n[1](o)}r[e]=void 0}};var c=setTimeout(function(){i({type:\"timeout\",target:s})},12e4);s.onerror=s.onload=i,do {snip}"
@@ -983,7 +983,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} ism:{data:{function:Dt(t)},handled:!0,type:\"instrument\"}}),t.apply(this,e)}},t.prototype.wrapRAF=function(t){return function(e){return t(Et( {snip}"
@@ -1093,7 +1093,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} o,r;for(b&&(o=i.domain)&&o.exit();t;){r=t.fn,t=t.next;try{r()}catch(o){throw t?n():e=void 0,o}}e=void 0,o&&o.enter()};if(b)n=function(){i.n {snip}"
@@ -1137,7 +1137,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} ,M):b(n)):M(o)}catch(t){a&&!i&&a.exit(),M(t)}};n.length>p;)i(n[p++]);t._c=[],t._n=!1,e&&!t._h&&x(t)})}},x=function(t){d.call(b,function(){va {snip}"
@@ -1181,7 +1181,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} ry{c?(r||(2==t._h&&T(t),t._h=1),!0===c?n=o:(a&&a.enter(),n=c(o),a&&(a.exit(),i=!0)),n===e.promise?M(y(\"Promise-chain cycle\")):(p=N(n))?p.cal {snip}"
@@ -1225,7 +1225,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} ply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.lo {snip}"
@@ -1269,7 +1269,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
@@ -1313,7 +1313,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
@@ -1357,7 +1357,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
@@ -1401,7 +1401,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
@@ -1445,7 +1445,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} (e.t0)&&n<I)){e.next=12;break}return n++,e.abrupt(\"return\",a());case 12:throw e.t0;case 13:case\"end\":return e.stop()}},e,this,[[0,7]])}));re {snip}"
@@ -1489,7 +1489,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} urn e.stop()}},e,this,[[0,7]])}));return function(){return e.apply(this,arguments)}}(),e.abrupt(\"return\",a());case 3:case\"end\":return e.stop {snip}"
@@ -1533,7 +1533,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} unction(t){return function(){var e=this,o=arguments;return new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)} {snip}"
@@ -1577,7 +1577,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} function(t){O(this,L,\"Promise\",\"_h\"),s(t),o.call(this);try{t(M(H,this,1),M(C,this,1))}catch(t){C.call(this,t)}},(o=function(t){this._c=[],th {snip}"
@@ -1621,7 +1621,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.load(n(1467))},,function( {snip}"
@@ -1665,7 +1665,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,funct {snip}"
@@ -1709,7 +1709,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
@@ -1753,7 +1753,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
@@ -1797,7 +1797,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
@@ -1841,7 +1841,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
@@ -1885,7 +1885,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} r(;;)switch(e.prev=e.next){case 0:return e.prev=0,e.next=3,t();case 3:return r=e.sent,e.abrupt(\"return\",r.default||r);case 7:if(e.prev=7,e.t {snip}"
@@ -1929,7 +1929,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} orgId/issues/:groupId/\",componentPromise:function(){return n.e(75).then(n.bind(null,2497))},component:Object(cs.default)(Zt.a)},b.a.createEl {snip}"
@@ -1973,7 +1973,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} \"+i+\")\");o.type=a,o.request=i,n[1](o)}r[e]=void 0}};var c=setTimeout(function(){i({type:\"timeout\",target:s})},12e4);s.onerror=s.onload=i,do {snip}"
@@ -2017,7 +2017,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": false,
                       "hint": "discarded because line too long",
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "{snip} ism:{data:{function:Dt(t)},handled:!0,type:\"instrument\"}}),t.apply(this,e)}},t.prototype.wrapRAF=function(t){return function(e){return t(Et( {snip}"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.987902+00:00'
+created: '2025-09-11T21:52:20.256685+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -59,7 +59,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "*/"
@@ -138,7 +138,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return fn.apply(this, arguments);"
@@ -182,7 +182,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "})();"
@@ -226,7 +226,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return specificMockImpl.apply(this, arguments);"
@@ -270,7 +270,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return original.apply(this, arguments);"
@@ -314,7 +314,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "if (maxBreadcrumbs <= 0) {"
@@ -358,7 +358,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "* @returns Scope, the new cloned scope"
@@ -402,7 +402,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "promisedEvent"
@@ -549,7 +549,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "*/"
@@ -628,7 +628,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return fn.apply(this, arguments);"
@@ -672,7 +672,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "})();"
@@ -716,7 +716,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return specificMockImpl.apply(this, arguments);"
@@ -760,7 +760,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return original.apply(this, arguments);"
@@ -804,7 +804,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "if (maxBreadcrumbs <= 0) {"
@@ -848,7 +848,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "* @returns Scope, the new cloned scope"
@@ -892,7 +892,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "promisedEvent"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.029252+00:00'
+created: '2025-09-11T21:52:20.294724+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {
@@ -186,7 +186,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.051435+00:00'
+created: '2025-09-11T21:52:20.313532+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -59,7 +59,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return self.dispatch(request, *args, **kwargs)"
@@ -147,7 +147,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return bound_func(*args, **kwargs)"
@@ -191,7 +191,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return view_func(*args, **kwargs)"
@@ -235,7 +235,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return func(self, *args2, **kwargs2)"
@@ -279,7 +279,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
@@ -323,7 +323,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return handler(request, *args, **kwargs)"
@@ -367,7 +367,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "hook.handle(request)"
@@ -411,7 +411,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "email = request.POST['user']"
@@ -455,7 +455,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise MultiValueDictKeyError(repr(key))"
@@ -567,7 +567,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
@@ -611,7 +611,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return self.dispatch(request, *args, **kwargs)"
@@ -655,7 +655,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return bound_func(*args, **kwargs)"
@@ -699,7 +699,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return view_func(*args, **kwargs)"
@@ -743,7 +743,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return func(self, *args2, **kwargs2)"
@@ -787,7 +787,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
@@ -831,7 +831,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return handler(request, *args, **kwargs)"
@@ -875,7 +875,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "hook.handle(request)"
@@ -919,7 +919,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "email = request.POST['user']"
@@ -963,7 +963,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise MultiValueDictKeyError(repr(key))"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.072095+00:00'
+created: '2025-09-11T21:52:20.332587+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -59,7 +59,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return self.dispatch(request, *args, **kwargs)"
@@ -147,7 +147,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return bound_func(*args, **kwargs)"
@@ -191,7 +191,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return view_func(*args, **kwargs)"
@@ -235,7 +235,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return func(self, *args2, **kwargs2)"
@@ -279,7 +279,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
@@ -323,7 +323,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return handler(request, *args, **kwargs)"
@@ -367,7 +367,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "hook.handle(request)"
@@ -411,7 +411,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "email = request.POST['user']"
@@ -455,7 +455,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise MultiValueDictKeyError(repr(key))"
@@ -567,7 +567,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
@@ -611,7 +611,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return self.dispatch(request, *args, **kwargs)"
@@ -655,7 +655,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return bound_func(*args, **kwargs)"
@@ -699,7 +699,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return view_func(*args, **kwargs)"
@@ -743,7 +743,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return func(self, *args2, **kwargs2)"
@@ -787,7 +787,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
@@ -831,7 +831,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return handler(request, *args, **kwargs)"
@@ -875,7 +875,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "hook.handle(request)"
@@ -919,7 +919,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "email = request.POST['user']"
@@ -963,7 +963,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise MultiValueDictKeyError(repr(key))"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.092895+00:00'
+created: '2025-09-11T21:52:20.353456+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -59,7 +59,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = func(*args, **kwargs)"
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "resp.raise_for_status()"
@@ -147,7 +147,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise HTTPError(http_error_msg, response=self)"
@@ -302,7 +302,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "result = func(*args, **kwargs)"
@@ -346,7 +346,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "resp.raise_for_status()"
@@ -390,7 +390,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "raise HTTPError(http_error_msg, response=self)"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.183052+00:00'
+created: '2025-09-11T21:52:20.408625+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.151372+00:00'
+created: '2025-09-11T21:52:20.390956+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -14,7 +14,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         {
           "contributes": true,
           "hint": null,
-          "id": "chained-exception",
+          "id": "chained_exception",
           "name": null,
           "values": [
             {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.235942+00:00'
+created: '2025-09-11T21:52:20.429390+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -59,7 +59,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return this.flushedQueue();"
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this._inCall--;"
@@ -147,7 +147,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return this.flushedQueue();"
@@ -191,7 +191,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this._lastFlush = new Date().getTime();"
@@ -235,7 +235,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "_receiveRootNodeIDEvent(index, eventTopLevelType, i);"
@@ -279,7 +279,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "batchedUpdates(function() {"
@@ -323,7 +323,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return _batchedUpdates(fn, bookkeeping);"
@@ -367,7 +367,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return fn(a);"
@@ -411,7 +411,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "(forEachAccumulated(events, executeDispatchesAndReleaseTopLevel),"
@@ -455,7 +455,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "Array.isArray(arr) ? arr.forEach(cb, scope) : arr && cb.call(scope, arr);"
@@ -530,7 +530,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "executeDispatch(e, !1, dispatchListeners, dispatchInstances);"
@@ -574,7 +574,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "ReactErrorUtils.invokeGuardedCallbackAndCatchFirstError("
@@ -618,7 +618,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "ReactErrorUtils.invokeGuardedCallback.apply(this, arguments);"
@@ -662,7 +662,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "invokeGuardedCallback.apply(ReactErrorUtils, arguments);"
@@ -706,7 +706,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "var funcArgs = Array.prototype.slice.call(arguments, 3);"
@@ -750,7 +750,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "touchableHandleResponderRelease: function(e) {"
@@ -794,7 +794,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this._performSideEffectsForTransition(curState, nextState, signal, e);"
@@ -838,7 +838,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this.touchableHandlePress(e);"
@@ -882,7 +882,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this.props.onPress && this.props.onPress(e);"
@@ -926,7 +926,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "<Button"
@@ -970,7 +970,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "<Button"
@@ -1082,7 +1082,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return this.flushedQueue();"
@@ -1126,7 +1126,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this._inCall--;"
@@ -1170,7 +1170,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return this.flushedQueue();"
@@ -1214,7 +1214,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this._lastFlush = new Date().getTime();"
@@ -1258,7 +1258,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "_receiveRootNodeIDEvent(index, eventTopLevelType, i);"
@@ -1302,7 +1302,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "batchedUpdates(function() {"
@@ -1346,7 +1346,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return _batchedUpdates(fn, bookkeeping);"
@@ -1390,7 +1390,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "return fn(a);"
@@ -1434,7 +1434,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "(forEachAccumulated(events, executeDispatchesAndReleaseTopLevel),"
@@ -1478,7 +1478,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "Array.isArray(arr) ? arr.forEach(cb, scope) : arr && cb.call(scope, arr);"
@@ -1553,7 +1553,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "executeDispatch(e, !1, dispatchListeners, dispatchInstances);"
@@ -1597,7 +1597,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "ReactErrorUtils.invokeGuardedCallbackAndCatchFirstError("
@@ -1641,7 +1641,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "ReactErrorUtils.invokeGuardedCallback.apply(this, arguments);"
@@ -1685,7 +1685,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "invokeGuardedCallback.apply(ReactErrorUtils, arguments);"
@@ -1729,7 +1729,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "var funcArgs = Array.prototype.slice.call(arguments, 3);"
@@ -1773,7 +1773,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "touchableHandleResponderRelease: function(e) {"
@@ -1817,7 +1817,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this._performSideEffectsForTransition(curState, nextState, signal, e);"
@@ -1861,7 +1861,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this.touchableHandlePress(e);"
@@ -1905,7 +1905,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "this.props.onPress && this.props.onPress(e);"
@@ -1949,7 +1949,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "<Button"
@@ -1993,7 +1993,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     {
                       "contributes": true,
                       "hint": null,
-                      "id": "context-line",
+                      "id": "context_line",
                       "name": null,
                       "values": [
                         "<Button"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/template_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/template_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.615416+00:00'
+created: '2025-09-11T21:52:20.723435+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -29,7 +29,7 @@ source: tests/sentry/grouping/test_grouping_info.py
             {
               "contributes": true,
               "hint": null,
-              "id": "context-line",
+              "id": "context_line",
               "name": null,
               "values": [
                 "{% invalid template tag %}"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-10T21:59:07.939080+00:00'
+created: '2025-09-11T18:38:49.335294+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -123,7 +123,7 @@ app:
               "stripped_application_code"
         type*
           "<redacted>"
-        ns-error*
+        ns_error*
           domain*
             "<redacted>"
           code*
@@ -249,7 +249,7 @@ system:
               "stripped_application_code"
         type*
           "<redacted>"
-        ns-error*
+        ns_error*
           domain*
             "<redacted>"
           code*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:21:49.005158+00:00'
+created: '2025-09-11T18:38:49.425980+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "safe.py"
             function*
               "safe_execute"
-            context-line*
+            context_line*
               "result = func(*args, **kwargs)"
           frame* (marked in-app by the client)
             module*
@@ -26,7 +26,7 @@ app:
               "services.py"
             function*
               "<lambda>"
-            context-line*
+            context_line*
               "context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)"
           frame* (marked in-app by the client)
             module*
@@ -35,7 +35,7 @@ app:
               "quotas.py"
             function*
               "is_rate_limited"
-            context-line*
+            context_line*
               "return super(SubscriptionQuota, self).is_rate_limited(project, key=key)"
           frame* (marked in-app by the client)
             module*
@@ -44,7 +44,7 @@ app:
               "redis.py"
             function*
               "is_rate_limited"
-            context-line*
+            context_line*
               "rejections = is_rate_limited(client, keys, args)"
           frame* (marked in-app by the client)
             module*
@@ -53,7 +53,7 @@ app:
               "redis.py"
             function*
               "call_script"
-            context-line*
+            context_line*
               "return script(keys, args, client)"
           frame (marked out of app by the client)
             module*
@@ -62,7 +62,7 @@ app:
               "client.py"
             function*
               "__call__"
-            context-line*
+            context_line*
               "return client.evalsha(self.sha, len(keys), *args)"
           frame (marked out of app by the client)
             module*
@@ -71,7 +71,7 @@ app:
               "client.py"
             function*
               "evalsha"
-            context-line*
+            context_line*
               "return self.execute_command('EVALSHA', sha, numkeys, *keys_and_args)"
           frame (marked out of app by the client)
             module*
@@ -80,7 +80,7 @@ app:
               "client.py"
             function*
               "execute_command"
-            context-line*
+            context_line*
               "return self.parse_response(connection, command_name, **options)"
           frame (marked out of app by the client)
             module*
@@ -89,7 +89,7 @@ app:
               "client.py"
             function*
               "parse_response"
-            context-line*
+            context_line*
               "response = connection.read_response()"
           frame (marked out of app by the client)
             module*
@@ -98,7 +98,7 @@ app:
               "connection.py"
             function*
               "read_response"
-            context-line*
+            context_line*
               "response = self._parser.read_response()"
           frame (marked out of app by the client)
             module*
@@ -107,7 +107,7 @@ app:
               "connection.py"
             function*
               "read_response"
-            context-line*
+            context_line*
               "(e.args,))"
         type*
           "ConnectionError"
@@ -136,7 +136,7 @@ system:
               "safe.py"
             function*
               "safe_execute"
-            context-line*
+            context_line*
               "result = func(*args, **kwargs)"
           frame*
             module*
@@ -145,7 +145,7 @@ system:
               "services.py"
             function*
               "<lambda>"
-            context-line*
+            context_line*
               "context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)"
           frame*
             module*
@@ -154,7 +154,7 @@ system:
               "quotas.py"
             function*
               "is_rate_limited"
-            context-line*
+            context_line*
               "return super(SubscriptionQuota, self).is_rate_limited(project, key=key)"
           frame*
             module*
@@ -163,7 +163,7 @@ system:
               "redis.py"
             function*
               "is_rate_limited"
-            context-line*
+            context_line*
               "rejections = is_rate_limited(client, keys, args)"
           frame*
             module*
@@ -172,7 +172,7 @@ system:
               "redis.py"
             function*
               "call_script"
-            context-line*
+            context_line*
               "return script(keys, args, client)"
           frame*
             module*
@@ -181,7 +181,7 @@ system:
               "client.py"
             function*
               "__call__"
-            context-line*
+            context_line*
               "return client.evalsha(self.sha, len(keys), *args)"
           frame*
             module*
@@ -190,7 +190,7 @@ system:
               "client.py"
             function*
               "evalsha"
-            context-line*
+            context_line*
               "return self.execute_command('EVALSHA', sha, numkeys, *keys_and_args)"
           frame*
             module*
@@ -199,7 +199,7 @@ system:
               "client.py"
             function*
               "execute_command"
-            context-line*
+            context_line*
               "return self.parse_response(connection, command_name, **options)"
           frame*
             module*
@@ -208,7 +208,7 @@ system:
               "client.py"
             function*
               "parse_response"
-            context-line*
+            context_line*
               "response = connection.read_response()"
           frame*
             module*
@@ -217,7 +217,7 @@ system:
               "connection.py"
             function*
               "read_response"
-            context-line*
+            context_line*
               "response = self._parser.read_response()"
           frame*
             module*
@@ -226,7 +226,7 @@ system:
               "connection.py"
             function*
               "read_response"
-            context-line*
+            context_line*
               "(e.args,))"
         type*
           "ConnectionError"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:40:58.821209+00:00'
+created: '2025-09-11T18:38:49.449922+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,28 +15,28 @@ app:
               "app.js"
             function*
               "runApp"
-            context-line*
+            context_line*
               "return server.serve(port);"
           frame (marked out of app by stack trace rule (function:handleRequest -app))
             filename*
               "router.js"
             function*
               "handleRequest"
-            context-line*
+            context_line*
               "return handler(request);"
           frame (marked in-app by stack trace rule (function:recordMetrics +app) but ignored by stack trace rule (function:recordMetrics -group))
             filename*
               "metrics.js"
             function*
               "recordMetrics"
-            context-line*
+            context_line*
               "return withMetrics(handler, metricName, tags);"
           frame* (marked in-app by stack trace rule (function:playFetch +app))
             filename*
               "dogpark.js"
             function*
               "playFetch"
-            context-line*
+            context_line*
               "raise FailedToFetchError('Charlie didn't bring the ball back!');"
         type*
           "FailedToFetchError"
@@ -55,28 +55,28 @@ system:
               "app.js"
             function*
               "runApp"
-            context-line*
+            context_line*
               "return server.serve(port);"
           frame*
             filename*
               "router.js"
             function*
               "handleRequest"
-            context-line*
+            context_line*
               "return handler(request);"
           frame (ignored by stack trace rule (function:recordMetrics -group))
             filename*
               "metrics.js"
             function*
               "recordMetrics"
-            context-line*
+            context_line*
               "return withMetrics(handler, metricName, tags);"
           frame*
             filename*
               "dogpark.js"
             function*
               "playFetch"
-            context-line*
+            context_line*
               "raise FailedToFetchError('Charlie didn't bring the ball back!');"
         type*
           "FailedToFetchError"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:40:58.941841+00:00'
+created: '2025-09-11T18:38:49.476934+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,21 +15,21 @@ app:
               "app.js"
             function*
               "runApp"
-            context-line*
+            context_line*
               "return server.serve(port);"
           frame (marked out of app by stack trace rule (function:handleRequest -app))
             filename*
               "router.js"
             function*
               "handleRequest"
-            context-line*
+            context_line*
               "return handler(request);"
           frame (marked in-app by stack trace rule (function:recordMetrics +app) but ignored by stack trace rule (function:recordMetrics -group))
             filename*
               "metrics.js"
             function*
               "recordMetrics"
-            context-line*
+            context_line*
               "return withMetrics(handler, metricName, tags);"
         type*
           "FailedToFetchError"
@@ -48,21 +48,21 @@ system:
               "app.js"
             function*
               "runApp"
-            context-line*
+            context_line*
               "return server.serve(port);"
           frame*
             filename*
               "router.js"
             function*
               "handleRequest"
-            context-line*
+            context_line*
               "return handler(request);"
           frame (ignored by stack trace rule (function:recordMetrics -group))
             filename*
               "metrics.js"
             function*
               "recordMetrics"
-            context-line*
+            context_line*
               "return withMetrics(handler, metricName, tags);"
         type*
           "FailedToFetchError"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-07-18T18:34:09.566790+00:00'
+created: '2025-09-11T18:38:49.689064+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "base.py"
             function*
               "_wrapped"
-            context-line*
+            context_line*
               "result = func(*args, **kwargs)"
           frame* (marked in-app by the client)
             module*
@@ -26,7 +26,7 @@ app:
               "store.py"
             function*
               "process_event"
-            context-line*
+            context_line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
           frame* (marked in-app by the client)
             module*
@@ -35,7 +35,7 @@ app:
               "store.py"
             function*
               "_do_process_event"
-            context-line*
+            context_line*
               "new_data = process_stacktraces(data)"
           frame* (marked in-app by the client)
             module*
@@ -44,7 +44,7 @@ app:
               "stacktraces.py"
             function*
               "process_stacktraces"
-            context-line*
+            context_line*
               "if processor.preprocess_step(processing_task):"
           frame* (marked in-app by the client)
             module*
@@ -53,7 +53,7 @@ app:
               "plugin.py"
             function*
               "preprocess_step"
-            context-line*
+            context_line*
               "referenced_images=referenced_images,"
           frame* (marked in-app by the client)
             module*
@@ -62,7 +62,7 @@ app:
               "symbolizer.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "with_conversion_errors=True)"
           frame* (marked in-app by the client)
             module*
@@ -71,7 +71,7 @@ app:
               "debugfile.py"
             function*
               "get_symcaches"
-            context-line*
+            context_line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
           frame* (marked in-app by the client)
             module*
@@ -80,7 +80,7 @@ app:
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
-            context-line*
+            context_line*
               "model.cache_file.save_to(cachefile_path)"
           frame* (marked in-app by the client)
             module*
@@ -89,7 +89,7 @@ app:
               "file.py"
             function*
               "save_to"
-            context-line*
+            context_line*
               "delete=False).detach_tempfile()"
           frame* (marked in-app by the client)
             module*
@@ -98,7 +98,7 @@ app:
               "file.py"
             function*
               "_get_chunked_blob"
-            context-line*
+            context_line*
               "delete=delete"
           frame* (marked in-app by the client)
             module*
@@ -107,7 +107,7 @@ app:
               "file.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "self._prefetch(prefetch_to, delete)"
           frame* (marked in-app by the client)
             module*
@@ -116,7 +116,7 @@ app:
               "file.py"
             function*
               "_prefetch"
-            context-line*
+            context_line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
           frame (marked out of app by the client)
             module*
@@ -125,7 +125,7 @@ app:
               "_base.py"
             function*
               "__exit__"
-            context-line*
+            context_line*
               "self.shutdown(wait=True)"
           frame (marked out of app by the client)
             module*
@@ -134,7 +134,7 @@ app:
               "thread.py"
             function*
               "shutdown"
-            context-line*
+            context_line*
               "t.join(sys.maxint)"
           frame (marked out of app by the client)
             module*
@@ -143,7 +143,7 @@ app:
               "threading.py"
             function*
               "join"
-            context-line*
+            context_line*
               "self.__block.wait(delay)"
           frame (marked out of app by the client)
             module*
@@ -152,7 +152,7 @@ app:
               "threading.py"
             function*
               "wait"
-            context-line*
+            context_line*
               "_sleep(delay)"
           frame (marked out of app by the client)
             module*
@@ -161,7 +161,7 @@ app:
               "pool.py"
             function*
               "soft_timeout_sighandler"
-            context-line*
+            context_line*
               "raise SoftTimeLimitExceeded()"
         type*
           "SoftTimeLimitExceeded"
@@ -187,7 +187,7 @@ system:
               "base.py"
             function*
               "_wrapped"
-            context-line*
+            context_line*
               "result = func(*args, **kwargs)"
           frame*
             module*
@@ -196,7 +196,7 @@ system:
               "store.py"
             function*
               "process_event"
-            context-line*
+            context_line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
           frame*
             module*
@@ -205,7 +205,7 @@ system:
               "store.py"
             function*
               "_do_process_event"
-            context-line*
+            context_line*
               "new_data = process_stacktraces(data)"
           frame*
             module*
@@ -214,7 +214,7 @@ system:
               "stacktraces.py"
             function*
               "process_stacktraces"
-            context-line*
+            context_line*
               "if processor.preprocess_step(processing_task):"
           frame*
             module*
@@ -223,7 +223,7 @@ system:
               "plugin.py"
             function*
               "preprocess_step"
-            context-line*
+            context_line*
               "referenced_images=referenced_images,"
           frame*
             module*
@@ -232,7 +232,7 @@ system:
               "symbolizer.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "with_conversion_errors=True)"
           frame*
             module*
@@ -241,7 +241,7 @@ system:
               "debugfile.py"
             function*
               "get_symcaches"
-            context-line*
+            context_line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
           frame*
             module*
@@ -250,7 +250,7 @@ system:
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
-            context-line*
+            context_line*
               "model.cache_file.save_to(cachefile_path)"
           frame*
             module*
@@ -259,7 +259,7 @@ system:
               "file.py"
             function*
               "save_to"
-            context-line*
+            context_line*
               "delete=False).detach_tempfile()"
           frame*
             module*
@@ -268,7 +268,7 @@ system:
               "file.py"
             function*
               "_get_chunked_blob"
-            context-line*
+            context_line*
               "delete=delete"
           frame*
             module*
@@ -277,7 +277,7 @@ system:
               "file.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "self._prefetch(prefetch_to, delete)"
           frame*
             module*
@@ -286,7 +286,7 @@ system:
               "file.py"
             function*
               "_prefetch"
-            context-line*
+            context_line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
           frame*
             module*
@@ -295,7 +295,7 @@ system:
               "_base.py"
             function*
               "__exit__"
-            context-line*
+            context_line*
               "self.shutdown(wait=True)"
           frame*
             module*
@@ -304,7 +304,7 @@ system:
               "thread.py"
             function*
               "shutdown"
-            context-line*
+            context_line*
               "t.join(sys.maxint)"
           frame*
             module*
@@ -313,7 +313,7 @@ system:
               "threading.py"
             function*
               "join"
-            context-line*
+            context_line*
               "self.__block.wait(delay)"
           frame*
             module*
@@ -322,7 +322,7 @@ system:
               "threading.py"
             function*
               "wait"
-            context-line*
+            context_line*
               "_sleep(delay)"
           frame*
             module*
@@ -331,7 +331,7 @@ system:
               "pool.py"
             function*
               "soft_timeout_sighandler"
-            context-line*
+            context_line*
               "raise SoftTimeLimitExceeded()"
         type*
           "SoftTimeLimitExceeded"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-07-18T18:34:09.185999+00:00'
+created: '2025-09-11T18:38:49.666332+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "base.py"
             function*
               "_wrapped"
-            context-line*
+            context_line*
               "result = func(*args, **kwargs)"
           frame* (marked in-app by the client)
             module*
@@ -26,7 +26,7 @@ app:
               "store.py"
             function*
               "process_event"
-            context-line*
+            context_line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
           frame* (marked in-app by the client)
             module*
@@ -35,7 +35,7 @@ app:
               "store.py"
             function*
               "_do_process_event"
-            context-line*
+            context_line*
               "new_data = process_stacktraces(data)"
           frame* (marked in-app by the client)
             module*
@@ -44,7 +44,7 @@ app:
               "stacktraces.py"
             function*
               "process_stacktraces"
-            context-line*
+            context_line*
               "if processor.preprocess_step(processing_task):"
           frame* (marked in-app by the client)
             module*
@@ -53,7 +53,7 @@ app:
               "plugin.py"
             function*
               "preprocess_step"
-            context-line*
+            context_line*
               "referenced_images=referenced_images,"
           frame* (marked in-app by the client)
             module*
@@ -62,7 +62,7 @@ app:
               "symbolizer.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "with_conversion_errors=True)"
           frame* (marked in-app by the client)
             module*
@@ -71,7 +71,7 @@ app:
               "debugfile.py"
             function*
               "get_symcaches"
-            context-line*
+            context_line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
           frame* (marked in-app by the client)
             module*
@@ -80,7 +80,7 @@ app:
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
-            context-line*
+            context_line*
               "model.cache_file.save_to(cachefile_path)"
           frame* (marked in-app by the client)
             module*
@@ -89,7 +89,7 @@ app:
               "file.py"
             function*
               "save_to"
-            context-line*
+            context_line*
               "delete=False).detach_tempfile()"
           frame* (marked in-app by the client)
             module*
@@ -98,7 +98,7 @@ app:
               "file.py"
             function*
               "_get_chunked_blob"
-            context-line*
+            context_line*
               "delete=delete"
           frame* (marked in-app by the client)
             module*
@@ -107,7 +107,7 @@ app:
               "file.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "self._prefetch(prefetch_to, delete)"
           frame* (marked in-app by the client)
             module*
@@ -116,7 +116,7 @@ app:
               "file.py"
             function*
               "_prefetch"
-            context-line*
+            context_line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
           frame (marked out of app by the client)
             module*
@@ -125,7 +125,7 @@ app:
               "_base.py"
             function*
               "__exit__"
-            context-line*
+            context_line*
               "self.shutdown(wait=True)"
           frame (marked out of app by the client)
             module*
@@ -134,7 +134,7 @@ app:
               "thread.py"
             function*
               "shutdown"
-            context-line*
+            context_line*
               "t.join(sys.maxint)"
           frame (marked out of app by the client)
             module*
@@ -143,7 +143,7 @@ app:
               "threading.py"
             function*
               "join"
-            context-line*
+            context_line*
               "self.__block.wait(delay)"
           frame (marked out of app by the client)
             module*
@@ -152,7 +152,7 @@ app:
               "threading.py"
             function*
               "wait"
-            context-line*
+            context_line*
               "_sleep(delay)"
           frame (marked out of app by the client)
             module*
@@ -161,7 +161,7 @@ app:
               "pool.py"
             function*
               "soft_timeout_sighandler"
-            context-line*
+            context_line*
               "raise SoftTimeLimitExceeded()"
         type*
           "SoftTimeLimitExceeded"
@@ -187,7 +187,7 @@ system:
               "base.py"
             function*
               "_wrapped"
-            context-line*
+            context_line*
               "result = func(*args, **kwargs)"
           frame*
             module*
@@ -196,7 +196,7 @@ system:
               "store.py"
             function*
               "process_event"
-            context-line*
+            context_line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
           frame*
             module*
@@ -205,7 +205,7 @@ system:
               "store.py"
             function*
               "_do_process_event"
-            context-line*
+            context_line*
               "new_data = process_stacktraces(data)"
           frame*
             module*
@@ -214,7 +214,7 @@ system:
               "stacktraces.py"
             function*
               "process_stacktraces"
-            context-line*
+            context_line*
               "if processor.preprocess_step(processing_task):"
           frame*
             module*
@@ -223,7 +223,7 @@ system:
               "plugin.py"
             function*
               "preprocess_step"
-            context-line*
+            context_line*
               "referenced_images=referenced_images,"
           frame*
             module*
@@ -232,7 +232,7 @@ system:
               "symbolizer.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "with_conversion_errors=True)"
           frame*
             module*
@@ -241,7 +241,7 @@ system:
               "debugfile.py"
             function*
               "get_symcaches"
-            context-line*
+            context_line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
           frame*
             module*
@@ -250,7 +250,7 @@ system:
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
-            context-line*
+            context_line*
               "model.cache_file.save_to(cachefile_path)"
           frame*
             module*
@@ -259,7 +259,7 @@ system:
               "file.py"
             function*
               "save_to"
-            context-line*
+            context_line*
               "delete=False).detach_tempfile()"
           frame*
             module*
@@ -268,7 +268,7 @@ system:
               "file.py"
             function*
               "_get_chunked_blob"
-            context-line*
+            context_line*
               "delete=delete"
           frame*
             module*
@@ -277,7 +277,7 @@ system:
               "file.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "self._prefetch(prefetch_to, delete)"
           frame*
             module*
@@ -286,7 +286,7 @@ system:
               "file.py"
             function*
               "_prefetch"
-            context-line*
+            context_line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
           frame*
             module*
@@ -295,7 +295,7 @@ system:
               "_base.py"
             function*
               "__exit__"
-            context-line*
+            context_line*
               "self.shutdown(wait=True)"
           frame*
             module*
@@ -304,7 +304,7 @@ system:
               "thread.py"
             function*
               "shutdown"
-            context-line*
+            context_line*
               "t.join(sys.maxint)"
           frame*
             module*
@@ -313,7 +313,7 @@ system:
               "threading.py"
             function*
               "join"
-            context-line*
+            context_line*
               "self.__block.wait(delay)"
           frame*
             module*
@@ -322,7 +322,7 @@ system:
               "threading.py"
             function*
               "wait"
-            context-line*
+            context_line*
               "_sleep(delay)"
           frame*
             module*
@@ -331,7 +331,7 @@ system:
               "pool.py"
             function*
               "soft_timeout_sighandler"
-            context-line*
+            context_line*
               "raise SoftTimeLimitExceeded()"
         type*
           "SoftTimeLimitExceeded"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-07-18T18:34:10.103531+00:00'
+created: '2025-09-11T18:38:49.713489+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "base.py"
             function*
               "_wrapped"
-            context-line*
+            context_line*
               "result = func(*args, **kwargs)"
           frame* (marked in-app by the client)
             module*
@@ -26,7 +26,7 @@ app:
               "store.py"
             function*
               "process_event"
-            context-line*
+            context_line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
           frame* (marked in-app by the client)
             module*
@@ -35,7 +35,7 @@ app:
               "store.py"
             function*
               "_do_process_event"
-            context-line*
+            context_line*
               "new_data = process_stacktraces(data)"
           frame* (marked in-app by the client)
             module*
@@ -44,7 +44,7 @@ app:
               "stacktraces.py"
             function*
               "process_stacktraces"
-            context-line*
+            context_line*
               "if processor.preprocess_step(processing_task):"
           frame* (marked in-app by the client)
             module*
@@ -53,7 +53,7 @@ app:
               "plugin.py"
             function*
               "preprocess_step"
-            context-line*
+            context_line*
               "referenced_images=referenced_images,"
           frame* (marked in-app by the client)
             module*
@@ -62,7 +62,7 @@ app:
               "symbolizer.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "with_conversion_errors=True)"
           frame* (marked in-app by the client)
             module*
@@ -71,7 +71,7 @@ app:
               "debugfile.py"
             function*
               "get_symcaches"
-            context-line*
+            context_line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
           frame* (marked in-app by the client)
             module*
@@ -80,7 +80,7 @@ app:
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
-            context-line*
+            context_line*
               "model.cache_file.save_to(cachefile_path)"
           frame* (marked in-app by the client)
             module*
@@ -89,7 +89,7 @@ app:
               "file.py"
             function*
               "save_to"
-            context-line*
+            context_line*
               "delete=False).detach_tempfile()"
           frame* (marked in-app by the client)
             module*
@@ -98,7 +98,7 @@ app:
               "file.py"
             function*
               "_get_chunked_blob"
-            context-line*
+            context_line*
               "delete=delete"
           frame* (marked in-app by the client)
             module*
@@ -107,7 +107,7 @@ app:
               "file.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "self._prefetch(prefetch_to, delete)"
           frame* (marked in-app by the client)
             module*
@@ -116,7 +116,7 @@ app:
               "file.py"
             function*
               "_prefetch"
-            context-line*
+            context_line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
           frame (marked out of app by the client)
             module*
@@ -125,7 +125,7 @@ app:
               "_base.py"
             function*
               "__exit__"
-            context-line*
+            context_line*
               "self.shutdown(wait=True)"
           frame (marked out of app by the client)
             module*
@@ -134,7 +134,7 @@ app:
               "thread.py"
             function*
               "shutdown"
-            context-line*
+            context_line*
               "t.join(sys.maxint)"
           frame (marked out of app by the client)
             module*
@@ -143,7 +143,7 @@ app:
               "threading.py"
             function*
               "join"
-            context-line*
+            context_line*
               "self.__block.wait(delay)"
           frame (marked out of app by the client)
             module*
@@ -152,7 +152,7 @@ app:
               "threading.py"
             function*
               "wait"
-            context-line*
+            context_line*
               "_sleep(delay)"
           frame (marked out of app by the client)
             module*
@@ -161,7 +161,7 @@ app:
               "pool.py"
             function*
               "soft_timeout_sighandler"
-            context-line*
+            context_line*
               "raise SoftTimeLimitExceeded()"
         type*
           "SoftTimeLimitExceeded"
@@ -187,7 +187,7 @@ system:
               "base.py"
             function*
               "_wrapped"
-            context-line*
+            context_line*
               "result = func(*args, **kwargs)"
           frame*
             module*
@@ -196,7 +196,7 @@ system:
               "store.py"
             function*
               "process_event"
-            context-line*
+            context_line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
           frame*
             module*
@@ -205,7 +205,7 @@ system:
               "store.py"
             function*
               "_do_process_event"
-            context-line*
+            context_line*
               "new_data = process_stacktraces(data)"
           frame*
             module*
@@ -214,7 +214,7 @@ system:
               "stacktraces.py"
             function*
               "process_stacktraces"
-            context-line*
+            context_line*
               "if processor.preprocess_step(processing_task):"
           frame*
             module*
@@ -223,7 +223,7 @@ system:
               "plugin.py"
             function*
               "preprocess_step"
-            context-line*
+            context_line*
               "referenced_images=referenced_images,"
           frame*
             module*
@@ -232,7 +232,7 @@ system:
               "symbolizer.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "with_conversion_errors=True)"
           frame*
             module*
@@ -241,7 +241,7 @@ system:
               "debugfile.py"
             function*
               "get_symcaches"
-            context-line*
+            context_line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
           frame*
             module*
@@ -250,7 +250,7 @@ system:
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
-            context-line*
+            context_line*
               "model.cache_file.save_to(cachefile_path)"
           frame*
             module*
@@ -259,7 +259,7 @@ system:
               "file.py"
             function*
               "save_to"
-            context-line*
+            context_line*
               "delete=False).detach_tempfile()"
           frame*
             module*
@@ -268,7 +268,7 @@ system:
               "file.py"
             function*
               "_get_chunked_blob"
-            context-line*
+            context_line*
               "delete=delete"
           frame*
             module*
@@ -277,7 +277,7 @@ system:
               "file.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "self._prefetch(prefetch_to, delete)"
           frame*
             module*
@@ -286,7 +286,7 @@ system:
               "file.py"
             function*
               "_prefetch"
-            context-line*
+            context_line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
           frame*
             module*
@@ -295,7 +295,7 @@ system:
               "_base.py"
             function*
               "__exit__"
-            context-line*
+            context_line*
               "self.shutdown(wait=True)"
           frame*
             module*
@@ -304,7 +304,7 @@ system:
               "thread.py"
             function*
               "shutdown"
-            context-line*
+            context_line*
               "t.join(sys.maxint)"
           frame*
             module*
@@ -313,7 +313,7 @@ system:
               "threading.py"
             function*
               "join"
-            context-line*
+            context_line*
               "self.__block.wait(delay)"
           frame*
             module*
@@ -322,7 +322,7 @@ system:
               "threading.py"
             function*
               "wait"
-            context-line*
+            context_line*
               "_sleep(delay)"
           frame*
             module*
@@ -331,7 +331,7 @@ system:
               "pool.py"
             function*
               "soft_timeout_sighandler"
-            context-line*
+            context_line*
               "raise SoftTimeLimitExceeded()"
         type*
           "SoftTimeLimitExceeded"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-10T21:59:08.299380+00:00'
+created: '2025-09-11T18:38:34.961238+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,7 +11,7 @@ app:
       exception*
         type*
           "iOS_Swift.SampleError"
-        ns-error*
+        ns_error*
           domain*
             "iOS_Swift.SampleError"
           code*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2025-04-25T21:21:51.625521+00:00'
+created: '2025-09-11T18:38:49.804766+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "669cb6664e0f5fed38665da04e464f7e"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           stacktrace*
             frame* (marked in-app by the client)
@@ -33,7 +33,7 @@ system:
   contributing component: null
   component:
     system (exception of app takes precedence)
-      chained-exception (ignored because hash matches app variant)
+      chained_exception (ignored because hash matches app variant)
         exception*
           stacktrace*
             frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2024-12-17T22:47:10.442932+00:00'
+created: '2025-09-11T18:38:49.843764+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "e2bf1e0628b7b1824a9b63dec7a079a3"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           type*
             "System.Exception"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2025-06-20T17:19:55.755505+00:00'
+created: '2025-09-11T18:38:49.881067+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "93b26686d00504b4e5aa1cb0244d8b37"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           type*
             "InnerException"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2025-06-18T22:40:06.450787+00:00'
+created: '2025-09-11T18:38:49.862805+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "93b26686d00504b4e5aa1cb0244d8b37"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           type*
             "InnerException"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2025-06-18T22:40:12.929542+00:00'
+created: '2025-09-11T18:38:49.917508+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "028157fe357e4592e39eacb32eafa2db"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           type*
             "InnermostException"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2024-12-17T22:47:10.546909+00:00'
+created: '2025-09-11T18:38:49.935660+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "f0078a82f351095ba595daa7d493aa3c"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           type*
             "MyApp.Exception"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2025-06-18T22:40:16.841222+00:00'
+created: '2025-09-11T18:38:49.954009+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "93b26686d00504b4e5aa1cb0244d8b37"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           type*
             "InnerException"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2024-12-17T22:47:10.785801+00:00'
+created: '2025-09-11T18:38:50.045629+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "17022e0561e9b6e6351723a08aa81b18"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           type*
             "MyApp.Exception"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2024-12-17T22:47:10.831367+00:00'
+created: '2025-09-11T18:38:50.064214+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "f0078a82f351095ba595daa7d493aa3c"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           type*
             "MyApp.Exception"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2025-05-12T23:41:02.990228+00:00'
+created: '2025-09-11T18:38:50.101609+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "d505dfb9059ac63c11955233323a9100"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           stacktrace*
             frame* (marked in-app by the client)
@@ -49,10 +49,10 @@ app:
 --------------------------------------------------------------------------
 system:
   hash: "4f9cc6a81f4eb34f9e917374f281b9dc"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     system*
-      chained-exception*
+      chained_exception*
         exception*
           stacktrace*
             frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_types.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_types.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2024-12-17T22:47:11.021483+00:00'
+created: '2025-09-11T18:38:50.138740+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "bca604b98cb4637167eb6190a92e8933"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           type*
             "MyApp.SuchWowException"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2024-12-17T22:47:10.970525+00:00'
+created: '2025-09-11T18:38:50.119782+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "fca0fd23f09e8da4481304ef2a531100"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           type*
             "MyApp.CoolException"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:21:53.534358+00:00'
+created: '2025-09-11T18:38:50.158076+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,7 +15,7 @@ app:
               "app/components/modals/createTeamModal"
             filename (module takes precedence)
               "createteammodal.jsx"
-            context-line*
+            context_line*
               "onError(err);"
           frame (marked out of app by the client)
             module*
@@ -24,7 +24,7 @@ app:
               "form.jsx"
             function (ignored because sourcemap used and context line available)
               "onError"
-            context-line*
+            context_line*
               "this.model.submitError(error);"
         type*
           "TypeError"
@@ -43,7 +43,7 @@ system:
               "app/components/modals/createTeamModal"
             filename (module takes precedence)
               "createteammodal.jsx"
-            context-line*
+            context_line*
               "onError(err);"
           frame*
             module*
@@ -52,7 +52,7 @@ system:
               "form.jsx"
             function (ignored because sourcemap used and context line available)
               "onError"
-            context-line*
+            context_line*
               "this.model.submitError(error);"
         type*
           "TypeError"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/expectct.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/expectct.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2024-12-17T22:47:11.227105+00:00'
+created: '2025-09-11T18:38:50.290562+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "3d2933f4b5ec459ec8d569a398fd328c"
-  contributing component: expect-ct
+  contributing component: expect_ct
   component:
     default*
-      expect-ct*
+      expect_ct*
         salt* (a static salt)
           "expect-ct"
         hostname*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:11.887049+00:00'
+created: '2025-09-11T18:38:50.541271+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,19 +14,19 @@ app:
             "foo.js"
           function*
             "test"
-          context-line*
+          context_line*
             "hello world"
         frame (non app frame)
           filename*
             "foo.js"
           function*
             "test"
-          context-line*
+          context_line*
             "hello world"
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo.js"
-          context-line (discarded because from URL origin and no function)
+          context_line (discarded because from URL origin and no function)
             "hello world"
 --------------------------------------------------------------------------
 system:
@@ -40,17 +40,17 @@ system:
             "foo.js"
           function*
             "test"
-          context-line*
+          context_line*
             "hello world"
         frame*
           filename*
             "foo.js"
           function*
             "test"
-          context-line*
+          context_line*
             "hello world"
         frame
           filename (ignored because frame points to a URL)
             "foo.js"
-          context-line (discarded because from URL origin and no function)
+          context_line (discarded because from URL origin and no function)
             "hello world"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.058204+00:00'
+created: '2025-09-11T18:38:50.598554+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,7 +14,7 @@ app:
             "foo.py"
           function*
             "test"
-          context-line*
+          context_line*
             "hello world"
 --------------------------------------------------------------------------
 system:
@@ -28,5 +28,5 @@ system:
             "foo.py"
           function*
             "test"
-          context-line*
+          context_line*
             "hello world"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.106213+00:00'
+created: '2025-09-11T18:38:50.617321+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,7 +14,7 @@ app:
             "foo.py"
           function*
             "test"
-          context-line*
+          context_line*
             "hello world"
 --------------------------------------------------------------------------
 system:
@@ -28,5 +28,5 @@ system:
             "foo.py"
           function*
             "test"
-          context-line*
+          context_line*
             "hello world"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-08-08T03:59:14.541023+00:00'
+created: '2025-09-11T18:38:51.004639+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,7 +14,7 @@ app:
             "foo.py"
           function (ignored because sourcemap used and context line available)
             "bar"
-          context-line*
+          context_line*
             "foo bar"
 --------------------------------------------------------------------------
 system:
@@ -28,5 +28,5 @@ system:
             "foo.py"
           function (ignored because sourcemap used and context line available)
             "bar"
-          context-line*
+          context_line*
             "foo bar"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-07-18T18:34:35.502124+00:00'
+created: '2025-09-11T18:38:51.453339+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "base.py"
             function*
               "_wrapped"
-            context-line*
+            context_line*
               "result = func(*args, **kwargs)"
           frame* (marked in-app by the client)
             module*
@@ -26,7 +26,7 @@ app:
               "store.py"
             function*
               "process_event"
-            context-line*
+            context_line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
           frame* (marked in-app by the client)
             module*
@@ -35,7 +35,7 @@ app:
               "store.py"
             function*
               "_do_process_event"
-            context-line*
+            context_line*
               "new_data = process_stacktraces(data)"
           frame* (marked in-app by the client)
             module*
@@ -44,7 +44,7 @@ app:
               "stacktraces.py"
             function*
               "process_stacktraces"
-            context-line*
+            context_line*
               "if processor.preprocess_step(processing_task):"
           frame* (marked in-app by the client)
             module*
@@ -53,7 +53,7 @@ app:
               "plugin.py"
             function*
               "preprocess_step"
-            context-line*
+            context_line*
               "referenced_images=referenced_images,"
           frame* (marked in-app by the client)
             module*
@@ -62,7 +62,7 @@ app:
               "symbolizer.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "with_conversion_errors=True)"
           frame* (marked in-app by the client)
             module*
@@ -71,7 +71,7 @@ app:
               "debugfile.py"
             function*
               "get_symcaches"
-            context-line*
+            context_line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
           frame* (marked in-app by the client)
             module*
@@ -80,7 +80,7 @@ app:
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
-            context-line*
+            context_line*
               "model.cache_file.save_to(cachefile_path)"
           frame* (marked in-app by the client)
             module*
@@ -89,7 +89,7 @@ app:
               "file.py"
             function*
               "save_to"
-            context-line*
+            context_line*
               "delete=False).detach_tempfile()"
           frame* (marked in-app by the client)
             module*
@@ -98,7 +98,7 @@ app:
               "file.py"
             function*
               "_get_chunked_blob"
-            context-line*
+            context_line*
               "delete=delete"
           frame* (marked in-app by the client)
             module*
@@ -107,7 +107,7 @@ app:
               "file.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "self._prefetch(prefetch_to, delete)"
           frame* (marked in-app by the client)
             module*
@@ -116,7 +116,7 @@ app:
               "file.py"
             function*
               "_prefetch"
-            context-line*
+            context_line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
           frame (marked out of app by the client)
             module*
@@ -125,7 +125,7 @@ app:
               "_base.py"
             function*
               "__exit__"
-            context-line*
+            context_line*
               "self.shutdown(wait=True)"
           frame (marked out of app by the client)
             module*
@@ -134,7 +134,7 @@ app:
               "thread.py"
             function*
               "shutdown"
-            context-line*
+            context_line*
               "t.join(sys.maxint)"
           frame (marked out of app by the client)
             module*
@@ -143,7 +143,7 @@ app:
               "threading.py"
             function*
               "join"
-            context-line*
+            context_line*
               "self.__block.wait(delay)"
           frame (marked out of app by the client)
             module*
@@ -152,7 +152,7 @@ app:
               "threading.py"
             function*
               "wait"
-            context-line*
+            context_line*
               "_sleep(delay)"
           frame (marked out of app by the client)
             module*
@@ -161,7 +161,7 @@ app:
               "pool.py"
             function*
               "soft_timeout_sighandler"
-            context-line*
+            context_line*
               "raise SoftTimeLimitExceeded()"
         type*
           "SoftTimeLimitExceeded"
@@ -184,7 +184,7 @@ system:
               "base.py"
             function*
               "_wrapped"
-            context-line*
+            context_line*
               "result = func(*args, **kwargs)"
           frame*
             module*
@@ -193,7 +193,7 @@ system:
               "store.py"
             function*
               "process_event"
-            context-line*
+            context_line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
           frame*
             module*
@@ -202,7 +202,7 @@ system:
               "store.py"
             function*
               "_do_process_event"
-            context-line*
+            context_line*
               "new_data = process_stacktraces(data)"
           frame*
             module*
@@ -211,7 +211,7 @@ system:
               "stacktraces.py"
             function*
               "process_stacktraces"
-            context-line*
+            context_line*
               "if processor.preprocess_step(processing_task):"
           frame*
             module*
@@ -220,7 +220,7 @@ system:
               "plugin.py"
             function*
               "preprocess_step"
-            context-line*
+            context_line*
               "referenced_images=referenced_images,"
           frame*
             module*
@@ -229,7 +229,7 @@ system:
               "symbolizer.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "with_conversion_errors=True)"
           frame*
             module*
@@ -238,7 +238,7 @@ system:
               "debugfile.py"
             function*
               "get_symcaches"
-            context-line*
+            context_line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
           frame*
             module*
@@ -247,7 +247,7 @@ system:
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
-            context-line*
+            context_line*
               "model.cache_file.save_to(cachefile_path)"
           frame*
             module*
@@ -256,7 +256,7 @@ system:
               "file.py"
             function*
               "save_to"
-            context-line*
+            context_line*
               "delete=False).detach_tempfile()"
           frame*
             module*
@@ -265,7 +265,7 @@ system:
               "file.py"
             function*
               "_get_chunked_blob"
-            context-line*
+            context_line*
               "delete=delete"
           frame*
             module*
@@ -274,7 +274,7 @@ system:
               "file.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "self._prefetch(prefetch_to, delete)"
           frame*
             module*
@@ -283,7 +283,7 @@ system:
               "file.py"
             function*
               "_prefetch"
-            context-line*
+            context_line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
           frame*
             module*
@@ -292,7 +292,7 @@ system:
               "_base.py"
             function*
               "__exit__"
-            context-line*
+            context_line*
               "self.shutdown(wait=True)"
           frame*
             module*
@@ -301,7 +301,7 @@ system:
               "thread.py"
             function*
               "shutdown"
-            context-line*
+            context_line*
               "t.join(sys.maxint)"
           frame*
             module*
@@ -310,7 +310,7 @@ system:
               "threading.py"
             function*
               "join"
-            context-line*
+            context_line*
               "self.__block.wait(delay)"
           frame*
             module*
@@ -319,7 +319,7 @@ system:
               "threading.py"
             function*
               "wait"
-            context-line*
+            context_line*
               "_sleep(delay)"
           frame*
             module*
@@ -328,7 +328,7 @@ system:
               "pool.py"
             function*
               "soft_timeout_sighandler"
-            context-line*
+            context_line*
               "raise SoftTimeLimitExceeded()"
         type*
           "SoftTimeLimitExceeded"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-07-18T18:34:35.801984+00:00'
+created: '2025-09-11T18:38:51.472839+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "base.py"
             function*
               "_wrapped"
-            context-line*
+            context_line*
               "result = func(*args, **kwargs)"
           frame* (marked in-app by the client)
             module*
@@ -26,7 +26,7 @@ app:
               "store.py"
             function*
               "process_event"
-            context-line*
+            context_line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
           frame* (marked in-app by the client)
             module*
@@ -35,7 +35,7 @@ app:
               "store.py"
             function*
               "_do_process_event"
-            context-line*
+            context_line*
               "new_data = process_stacktraces(data)"
           frame* (marked in-app by the client)
             module*
@@ -44,7 +44,7 @@ app:
               "stacktraces.py"
             function*
               "process_stacktraces"
-            context-line*
+            context_line*
               "if processor.preprocess_step(processing_task):"
           frame* (marked in-app by the client)
             module*
@@ -53,7 +53,7 @@ app:
               "plugin.py"
             function*
               "preprocess_step"
-            context-line*
+            context_line*
               "referenced_images=referenced_images,"
           frame* (marked in-app by the client)
             module*
@@ -62,7 +62,7 @@ app:
               "symbolizer.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "with_conversion_errors=True)"
           frame* (marked in-app by the client)
             module*
@@ -71,7 +71,7 @@ app:
               "debugfile.py"
             function*
               "get_symcaches"
-            context-line*
+            context_line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
           frame* (marked in-app by the client)
             module*
@@ -80,7 +80,7 @@ app:
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
-            context-line*
+            context_line*
               "model.cache_file.save_to(cachefile_path)"
           frame* (marked in-app by the client)
             module*
@@ -89,7 +89,7 @@ app:
               "file.py"
             function*
               "save_to"
-            context-line*
+            context_line*
               "delete=False).detach_tempfile()"
           frame* (marked in-app by the client)
             module*
@@ -98,7 +98,7 @@ app:
               "file.py"
             function*
               "_get_chunked_blob"
-            context-line*
+            context_line*
               "delete=delete"
           frame* (marked in-app by the client)
             module*
@@ -107,7 +107,7 @@ app:
               "file.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "self._prefetch(prefetch_to, delete)"
           frame* (marked in-app by the client)
             module*
@@ -116,7 +116,7 @@ app:
               "file.py"
             function*
               "_prefetch"
-            context-line*
+            context_line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
           frame (marked out of app by the client)
             module*
@@ -125,7 +125,7 @@ app:
               "_base.py"
             function*
               "__exit__"
-            context-line*
+            context_line*
               "self.shutdown(wait=True)"
           frame (marked out of app by the client)
             module*
@@ -134,7 +134,7 @@ app:
               "thread.py"
             function*
               "shutdown"
-            context-line*
+            context_line*
               "t.join(sys.maxint)"
           frame (marked out of app by the client)
             module*
@@ -143,7 +143,7 @@ app:
               "threading.py"
             function*
               "join"
-            context-line*
+            context_line*
               "self.__block.wait(delay)"
           frame (marked out of app by the client)
             module*
@@ -152,7 +152,7 @@ app:
               "threading.py"
             function*
               "wait"
-            context-line*
+            context_line*
               "_sleep(delay)"
           frame (marked out of app by the client)
             module*
@@ -161,7 +161,7 @@ app:
               "pool.py"
             function*
               "soft_timeout_sighandler"
-            context-line*
+            context_line*
               "raise SoftTimeLimitExceeded()"
         type*
           "SoftTimeLimitExceeded"
@@ -187,7 +187,7 @@ system:
               "base.py"
             function*
               "_wrapped"
-            context-line*
+            context_line*
               "result = func(*args, **kwargs)"
           frame*
             module*
@@ -196,7 +196,7 @@ system:
               "store.py"
             function*
               "process_event"
-            context-line*
+            context_line*
               "return _do_process_event(cache_key, start_time, event_id, process_event)"
           frame*
             module*
@@ -205,7 +205,7 @@ system:
               "store.py"
             function*
               "_do_process_event"
-            context-line*
+            context_line*
               "new_data = process_stacktraces(data)"
           frame*
             module*
@@ -214,7 +214,7 @@ system:
               "stacktraces.py"
             function*
               "process_stacktraces"
-            context-line*
+            context_line*
               "if processor.preprocess_step(processing_task):"
           frame*
             module*
@@ -223,7 +223,7 @@ system:
               "plugin.py"
             function*
               "preprocess_step"
-            context-line*
+            context_line*
               "referenced_images=referenced_images,"
           frame*
             module*
@@ -232,7 +232,7 @@ system:
               "symbolizer.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "with_conversion_errors=True)"
           frame*
             module*
@@ -241,7 +241,7 @@ system:
               "debugfile.py"
             function*
               "get_symcaches"
-            context-line*
+            context_line*
               "symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"
           frame*
             module*
@@ -250,7 +250,7 @@ system:
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
-            context-line*
+            context_line*
               "model.cache_file.save_to(cachefile_path)"
           frame*
             module*
@@ -259,7 +259,7 @@ system:
               "file.py"
             function*
               "save_to"
-            context-line*
+            context_line*
               "delete=False).detach_tempfile()"
           frame*
             module*
@@ -268,7 +268,7 @@ system:
               "file.py"
             function*
               "_get_chunked_blob"
-            context-line*
+            context_line*
               "delete=delete"
           frame*
             module*
@@ -277,7 +277,7 @@ system:
               "file.py"
             function*
               "__init__"
-            context-line*
+            context_line*
               "self._prefetch(prefetch_to, delete)"
           frame*
             module*
@@ -286,7 +286,7 @@ system:
               "file.py"
             function*
               "_prefetch"
-            context-line*
+            context_line*
               "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
           frame*
             module*
@@ -295,7 +295,7 @@ system:
               "_base.py"
             function*
               "__exit__"
-            context-line*
+            context_line*
               "self.shutdown(wait=True)"
           frame*
             module*
@@ -304,7 +304,7 @@ system:
               "thread.py"
             function*
               "shutdown"
-            context-line*
+            context_line*
               "t.join(sys.maxint)"
           frame*
             module*
@@ -313,7 +313,7 @@ system:
               "threading.py"
             function*
               "join"
-            context-line*
+            context_line*
               "self.__block.wait(delay)"
           frame*
             module*
@@ -322,7 +322,7 @@ system:
               "threading.py"
             function*
               "wait"
-            context-line*
+            context_line*
               "_sleep(delay)"
           frame*
             module*
@@ -331,7 +331,7 @@ system:
               "pool.py"
             function*
               "soft_timeout_sighandler"
-            context-line*
+            context_line*
               "raise SoftTimeLimitExceeded()"
         type*
           "SoftTimeLimitExceeded"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:41:14.420857+00:00'
+created: '2025-09-11T18:38:51.571589+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   contributing component: null
   component:
     app (exception of system takes precedence)
-      chained-exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+      chained_exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         exception*
           stacktrace (ignored because it contains no in-app frames)
             frame (marked out of app by the client)
@@ -402,10 +402,10 @@ default:
 --------------------------------------------------------------------------
 system:
   hash: "1959b227a7cf6acf7f3fd401b5d9f09b"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     system*
-      chained-exception*
+      chained_exception*
         exception*
           stacktrace*
             frame (ignored by stack trace rule (module:io.sentry.* -group))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:09.739839+00:00'
+created: '2025-09-11T18:38:52.013439+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "_microtask.js"
             function (ignored because sourcemap used and context line available)
               "M"
-            context-line*
+            context_line*
               "fn();"
           frame (marked out of app by the client)
             module*
@@ -26,7 +26,7 @@ app:
               "es6.promise.js"
             function (ignored because sourcemap used and context line available)
               "fn"
-            context-line*
+            context_line*
               "while (chain.length > i) run(chain[i++]); // variable length - can't use forEach"
           frame (marked out of app by the client)
             module*
@@ -35,7 +35,7 @@ app:
               "es6.promise.js"
             function (ignored because sourcemap used and context line available)
               "run"
-            context-line*
+            context_line*
               "result = handler(value); // may throw"
           frame (marked out of app by the client)
             module*
@@ -44,7 +44,7 @@ app:
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "_next"
-            context-line*
+            context_line*
               "asyncGeneratorStep(gen, resolve, reject, _next, _throw, \"next\", value);"
           frame (marked out of app by the client)
             module*
@@ -53,7 +53,7 @@ app:
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "asyncGeneratorStep"
-            context-line*
+            context_line*
               "var info = gen[key](arg);"
           frame (marked out of app by the client)
             module*
@@ -62,7 +62,7 @@ app:
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "key"
-            context-line*
+            context_line*
               "return this._invoke(method, arg);"
           frame (marked out of app by the client)
             module*
@@ -71,7 +71,7 @@ app:
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "this"
-            context-line*
+            context_line*
               "var record = tryCatch(innerFn, self, context);"
           frame (marked out of app by the client)
             module*
@@ -80,7 +80,7 @@ app:
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "tryCatch"
-            context-line*
+            context_line*
               "return { type: \"normal\", arg: fn.call(obj, arg) };"
           frame* (marked in-app by the client)
             module*
@@ -89,7 +89,7 @@ app:
               "lazyload.jsx"
             function (ignored because sourcemap used and context line available)
               "fn"
-            context-line*
+            context_line*
               "this.setState({"
           frame (marked out of app by the client)
             module*
@@ -98,7 +98,7 @@ app:
               "react.production.min.js"
             function*
               "this"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} !==typeof a&&\"function\"!==typeof a&&null!=a?B(\"85\"):void 0;this.updater.enqueueSetState(this,a,b,\"setState\")};E.prototype.forceUpdate=functi {snip}"
           frame (marked out of app by the client)
             module*
@@ -107,7 +107,7 @@ app:
               "react-dom.production.min.js"
             function*
               "this"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} );e.payload=b;void 0!==c&&null!==c&&(e.callback=c);ff(a,e);If(a,d)},enqueueReplaceState:function(a,b,c){a=a._reactInternalFiber;var d=Gf();d {snip}"
           frame (marked out of app by the client)
             module*
@@ -116,7 +116,7 @@ app:
               "react-dom.production.min.js"
             function*
               "If"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} );else if(c=b.expirationTime,0===c||a<c)b.expirationTime=a;V||(W?Wg&&(Y=b,Z=1,Xg(b,1,!0)):1===a?Yg(1,null):Zg(b,a))}$g>ah&&($g=0,t(\"185\"))}} {snip}"
           frame (marked out of app by the client)
             module*
@@ -125,7 +125,7 @@ app:
               "react-dom.production.min.js"
             function*
               "Yg"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} ),qh(),oh(),lh=kh;else for(;null!==Y&&0!==Z&&(0===a||a>=Z);)Xg(Y,Z,!0),qh();null!==hh&&(ch=0,dh=null);0!==Z&&Zg(Y,Z);hh=null;eh=!1;$g=0;mh=n {snip}"
           frame (marked out of app by the client)
             module*
@@ -134,7 +134,7 @@ app:
               "react-dom.production.min.js"
             function*
               "Xg"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finishedWork,null!==d&&rh( {snip}"
           frame (marked out of app by the client)
             module*
@@ -143,7 +143,7 @@ app:
               "react-dom.production.min.js"
             function*
               "rh"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} nate;q=Q;p=y;switch(q.tag){case 2:case 3:var X=q.stateNode;if(q.effectTag&4)if(null===oc)X.props=q.memoizedProps,X.state=q.memoizedState,X.c {snip}"
           frame* (marked in-app by the client)
             module*
@@ -152,7 +152,7 @@ app:
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "X"
-            context-line*
+            context_line*
               "this.fetchData();"
           frame* (marked in-app by the client)
             module*
@@ -161,7 +161,7 @@ app:
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "this"
-            context-line*
+            context_line*
               "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
           frame* (marked in-app by the client)
             module*
@@ -170,7 +170,7 @@ app:
               "api.jsx"
             function (ignored because sourcemap used and context line available)
               "fetchGroupEventAndMarkSeen"
-            context-line*
+            context_line*
               "const preservedError = new Error();"
         type*
           "NotFoundError"
@@ -191,7 +191,7 @@ system:
               "_microtask.js"
             function (ignored because sourcemap used and context line available)
               "M"
-            context-line*
+            context_line*
               "fn();"
           frame*
             module*
@@ -200,7 +200,7 @@ system:
               "es6.promise.js"
             function (ignored because sourcemap used and context line available)
               "fn"
-            context-line*
+            context_line*
               "while (chain.length > i) run(chain[i++]); // variable length - can't use forEach"
           frame*
             module*
@@ -209,7 +209,7 @@ system:
               "es6.promise.js"
             function (ignored because sourcemap used and context line available)
               "run"
-            context-line*
+            context_line*
               "result = handler(value); // may throw"
           frame*
             module*
@@ -218,7 +218,7 @@ system:
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "_next"
-            context-line*
+            context_line*
               "asyncGeneratorStep(gen, resolve, reject, _next, _throw, \"next\", value);"
           frame*
             module*
@@ -227,7 +227,7 @@ system:
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "asyncGeneratorStep"
-            context-line*
+            context_line*
               "var info = gen[key](arg);"
           frame*
             module*
@@ -236,7 +236,7 @@ system:
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "key"
-            context-line*
+            context_line*
               "return this._invoke(method, arg);"
           frame*
             module*
@@ -245,7 +245,7 @@ system:
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "this"
-            context-line*
+            context_line*
               "var record = tryCatch(innerFn, self, context);"
           frame*
             module*
@@ -254,7 +254,7 @@ system:
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "tryCatch"
-            context-line*
+            context_line*
               "return { type: \"normal\", arg: fn.call(obj, arg) };"
           frame*
             module*
@@ -263,7 +263,7 @@ system:
               "lazyload.jsx"
             function (ignored because sourcemap used and context line available)
               "fn"
-            context-line*
+            context_line*
               "this.setState({"
           frame*
             module*
@@ -272,7 +272,7 @@ system:
               "react.production.min.js"
             function*
               "this"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} !==typeof a&&\"function\"!==typeof a&&null!=a?B(\"85\"):void 0;this.updater.enqueueSetState(this,a,b,\"setState\")};E.prototype.forceUpdate=functi {snip}"
           frame*
             module*
@@ -281,7 +281,7 @@ system:
               "react-dom.production.min.js"
             function*
               "this"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} );e.payload=b;void 0!==c&&null!==c&&(e.callback=c);ff(a,e);If(a,d)},enqueueReplaceState:function(a,b,c){a=a._reactInternalFiber;var d=Gf();d {snip}"
           frame*
             module*
@@ -290,7 +290,7 @@ system:
               "react-dom.production.min.js"
             function*
               "If"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} );else if(c=b.expirationTime,0===c||a<c)b.expirationTime=a;V||(W?Wg&&(Y=b,Z=1,Xg(b,1,!0)):1===a?Yg(1,null):Zg(b,a))}$g>ah&&($g=0,t(\"185\"))}} {snip}"
           frame*
             module*
@@ -299,7 +299,7 @@ system:
               "react-dom.production.min.js"
             function*
               "Yg"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} ),qh(),oh(),lh=kh;else for(;null!==Y&&0!==Z&&(0===a||a>=Z);)Xg(Y,Z,!0),qh();null!==hh&&(ch=0,dh=null);0!==Z&&Zg(Y,Z);hh=null;eh=!1;$g=0;mh=n {snip}"
           frame*
             module*
@@ -308,7 +308,7 @@ system:
               "react-dom.production.min.js"
             function*
               "Xg"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finishedWork,null!==d&&rh( {snip}"
           frame*
             module*
@@ -317,7 +317,7 @@ system:
               "react-dom.production.min.js"
             function*
               "rh"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} nate;q=Q;p=y;switch(q.tag){case 2:case 3:var X=q.stateNode;if(q.effectTag&4)if(null===oc)X.props=q.memoizedProps,X.state=q.memoizedState,X.c {snip}"
           frame*
             module*
@@ -326,7 +326,7 @@ system:
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "X"
-            context-line*
+            context_line*
               "this.fetchData();"
           frame*
             module*
@@ -335,7 +335,7 @@ system:
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "this"
-            context-line*
+            context_line*
               "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
           frame*
             module*
@@ -344,7 +344,7 @@ system:
               "api.jsx"
             function (ignored because sourcemap used and context line available)
               "fetchGroupEventAndMarkSeen"
-            context-line*
+            context_line*
               "const preservedError = new Error();"
         type*
           "NotFoundError"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:41:17.287905+00:00'
+created: '2025-09-11T18:38:52.035654+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app:
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "_next"
-            context-line*
+            context_line*
               "asyncGeneratorStep(gen, resolve, reject, _next, _throw, \"next\", value);"
           frame (marked out of app by the client)
             module*
@@ -31,7 +31,7 @@ app:
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "asyncGeneratorStep"
-            context-line*
+            context_line*
               "var info = gen[key](arg);"
           frame (marked out of app by the client)
             module*
@@ -40,7 +40,7 @@ app:
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "key"
-            context-line*
+            context_line*
               "var record = tryCatch(innerFn, self, context);"
           frame (marked out of app by the client)
             module*
@@ -49,7 +49,7 @@ app:
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "tryCatch"
-            context-line*
+            context_line*
               "return { type: \"normal\", arg: fn.call(obj, arg) };"
           frame* (marked in-app by the client)
             module*
@@ -58,7 +58,7 @@ app:
               "lazyload.jsx"
             function (ignored because sourcemap used and context line available)
               "call"
-            context-line*
+            context_line*
               "this.setState({"
           frame (marked out of app by the client)
             module*
@@ -67,7 +67,7 @@ app:
               "react.production.min.js"
             function*
               "setState"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} ructor=G;m(H,E.prototype);H.isPureReactComponent=!0;var I={current:null,currentDispatcher:null},J=Object.prototype.hasOwnProperty,K={key:!0, {snip}"
           frame (marked out of app by the client)
             module*
@@ -76,7 +76,7 @@ app:
               "react-dom.production.min.js"
             function*
               "enqueueSetState"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} &(e.callback=c);ff(a,e);If(a,d)},enqueueForceUpdate:function(a,b){a=a._reactInternalFiber;var c=Gf();c=Hf(c,a);var d=df(c);d.tag=2;void 0!=="
           frame (marked out of app by the client)
             module*
@@ -85,7 +85,7 @@ app:
               "react-dom.production.min.js"
             function*
               "tag"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "var U=null,T=null,ch=0,dh=void 0,V=!1,Y=null,Z=0,Vg=0,eh=!1,fh=!1,gh=null,hh=null,W=!1,Wg=!1,Ug=!1,ih=null,jh=ba.unstable_now(),kh=(jh/10|0) {snip}"
           frame (marked out of app by the client)
             module*
@@ -94,7 +94,7 @@ app:
               "react-dom.production.min.js"
             function*
               "Yg"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "function Xg(a,b,c){V?t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finis {snip}"
           frame (marked out of app by the client)
             module*
@@ -103,7 +103,7 @@ app:
               "react-dom.production.min.js"
             function*
               "Xg"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "function rh(a,b,c){var d=a.firstBatch;if(null!==d&&d._expirationTime<=c&&(null===ih?ih=[d]:ih.push(d),d._defer)){a.finishedWork=b;a.expirati {snip}"
           frame (marked out of app by the client)
             module*
@@ -112,7 +112,7 @@ app:
               "react-dom.production.min.js"
             function*
               "ih"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} .__reactInternalSnapshotBeforeUpdate)}var kg=q.updateQueue;null!==kg&&(X.props=q.memoizedProps,X.state=q.memoizedState,lf(q,kg,X,p));break;c {snip}"
           frame* (marked in-app by the client)
             module*
@@ -121,7 +121,7 @@ app:
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "q"
-            context-line*
+            context_line*
               "this.fetchData();"
           frame* (marked in-app by the client)
             module*
@@ -130,7 +130,7 @@ app:
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "fetchData"
-            context-line*
+            context_line*
               "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
           frame* (marked in-app by the client)
             module*
@@ -139,7 +139,7 @@ app:
               "api.jsx"
             function (ignored because sourcemap used and context line available)
               "fetchGroupEventAndMarkSeen"
-            context-line*
+            context_line*
               "const preservedError = new Error();"
         type*
           "NotFoundError"
@@ -165,7 +165,7 @@ system:
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "_next"
-            context-line*
+            context_line*
               "asyncGeneratorStep(gen, resolve, reject, _next, _throw, \"next\", value);"
           frame*
             module*
@@ -174,7 +174,7 @@ system:
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "asyncGeneratorStep"
-            context-line*
+            context_line*
               "var info = gen[key](arg);"
           frame*
             module*
@@ -183,7 +183,7 @@ system:
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "key"
-            context-line*
+            context_line*
               "var record = tryCatch(innerFn, self, context);"
           frame*
             module*
@@ -192,7 +192,7 @@ system:
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "tryCatch"
-            context-line*
+            context_line*
               "return { type: \"normal\", arg: fn.call(obj, arg) };"
           frame*
             module*
@@ -201,7 +201,7 @@ system:
               "lazyload.jsx"
             function (ignored because sourcemap used and context line available)
               "call"
-            context-line*
+            context_line*
               "this.setState({"
           frame*
             module*
@@ -210,7 +210,7 @@ system:
               "react.production.min.js"
             function*
               "setState"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} ructor=G;m(H,E.prototype);H.isPureReactComponent=!0;var I={current:null,currentDispatcher:null},J=Object.prototype.hasOwnProperty,K={key:!0, {snip}"
           frame*
             module*
@@ -219,7 +219,7 @@ system:
               "react-dom.production.min.js"
             function*
               "enqueueSetState"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} &(e.callback=c);ff(a,e);If(a,d)},enqueueForceUpdate:function(a,b){a=a._reactInternalFiber;var c=Gf();c=Hf(c,a);var d=df(c);d.tag=2;void 0!=="
           frame*
             module*
@@ -228,7 +228,7 @@ system:
               "react-dom.production.min.js"
             function*
               "tag"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "var U=null,T=null,ch=0,dh=void 0,V=!1,Y=null,Z=0,Vg=0,eh=!1,fh=!1,gh=null,hh=null,W=!1,Wg=!1,Ug=!1,ih=null,jh=ba.unstable_now(),kh=(jh/10|0) {snip}"
           frame*
             module*
@@ -237,7 +237,7 @@ system:
               "react-dom.production.min.js"
             function*
               "Yg"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "function Xg(a,b,c){V?t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finis {snip}"
           frame*
             module*
@@ -246,7 +246,7 @@ system:
               "react-dom.production.min.js"
             function*
               "Xg"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "function rh(a,b,c){var d=a.firstBatch;if(null!==d&&d._expirationTime<=c&&(null===ih?ih=[d]:ih.push(d),d._defer)){a.finishedWork=b;a.expirati {snip}"
           frame*
             module*
@@ -255,7 +255,7 @@ system:
               "react-dom.production.min.js"
             function*
               "ih"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} .__reactInternalSnapshotBeforeUpdate)}var kg=q.updateQueue;null!==kg&&(X.props=q.memoizedProps,X.state=q.memoizedState,lf(q,kg,X,p));break;c {snip}"
           frame*
             module*
@@ -264,7 +264,7 @@ system:
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "q"
-            context-line*
+            context_line*
               "this.fetchData();"
           frame*
             module*
@@ -273,7 +273,7 @@ system:
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "fetchData"
-            context-line*
+            context_line*
               "fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)"
           frame*
             module*
@@ -282,7 +282,7 @@ system:
               "api.jsx"
             function (ignored because sourcemap used and context line available)
               "fetchGroupEventAndMarkSeen"
-            context-line*
+            context_line*
               "const preservedError = new Error();"
         type*
           "NotFoundError"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:10.083814+00:00'
+created: '2025-09-11T18:38:52.081424+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,350 +13,350 @@ app:
           frame* (marked in-app by the client)
             filename*
               "server.php"
-            context-line*
+            context_line*
               "require_once __DIR__.'/public/index.php';"
           frame* (marked in-app by the client)
             filename*
               "index.php"
             function*
               "require_once"
-            context-line*
+            context_line*
               "$request = Illuminate\\Http\\Request::capture()"
           frame (marked out of app by the client)
             filename*
               "kernel.php"
             function*
               "Illuminate\\Foundation\\Http\\Kernel::handle"
-            context-line*
+            context_line*
               "$response = $this->sendRequestThroughRouter($request);"
           frame (marked out of app by the client)
             filename*
               "kernel.php"
             function*
               "Illuminate\\Foundation\\Http\\Kernel::sendRequestThroughRouter"
-            context-line*
+            context_line*
               "->then($this->dispatchToRouter());"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::then"
-            context-line*
+            context_line*
               "return $pipeline($this->passable);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame (marked out of app by the client)
             filename*
               "checkformaintenancemode.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\CheckForMaintenanceMode::handle"
-            context-line*
+            context_line*
               "return $next($request);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame (marked out of app by the client)
             filename*
               "validatepostsize.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\ValidatePostSize::handle"
-            context-line*
+            context_line*
               "return $next($request);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame (marked out of app by the client)
             filename*
               "transformsrequest.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle"
-            context-line*
+            context_line*
               "return $next($request);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame (marked out of app by the client)
             filename*
               "transformsrequest.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle"
-            context-line*
+            context_line*
               "return $next($request);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame (marked out of app by the client)
             filename*
               "trustproxies.php"
             function*
               "Fideloper\\Proxy\\TrustProxies::handle"
-            context-line*
+            context_line*
               "return $next($request);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $destination($passable);"
           frame (marked out of app by the client)
             filename*
               "kernel.php"
             function*
               "Illuminate\\Foundation\\Http\\Kernel::Illuminate\\Foundation\\Http\\{closure}"
-            context-line*
+            context_line*
               "return $this->router->dispatch($request);"
           frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::dispatch"
-            context-line*
+            context_line*
               "return $this->dispatchToRoute($request);"
           frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::dispatchToRoute"
-            context-line*
+            context_line*
               "return $this->runRoute($request, $this->findRoute($request));"
           frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::runRoute"
-            context-line*
+            context_line*
               "$this->runRouteWithinStack($route, $request)"
           frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::runRouteWithinStack"
-            context-line*
+            context_line*
               "});"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::then"
-            context-line*
+            context_line*
               "return $pipeline($this->passable);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame (marked out of app by the client)
             filename*
               "encryptcookies.php"
             function*
               "Illuminate\\Cookie\\Middleware\\EncryptCookies::handle"
-            context-line*
+            context_line*
               "return $this->encrypt($next($this->decrypt($request)));"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame (marked out of app by the client)
             filename*
               "addqueuedcookiestoresponse.php"
             function*
               "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse::handle"
-            context-line*
+            context_line*
               "$response = $next($request);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame (marked out of app by the client)
             filename*
               "startsession.php"
             function*
               "Illuminate\\Session\\Middleware\\StartSession::handle"
-            context-line*
+            context_line*
               "$response = $next($request), $session"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame (marked out of app by the client)
             filename*
               "shareerrorsfromsession.php"
             function*
               "Illuminate\\View\\Middleware\\ShareErrorsFromSession::handle"
-            context-line*
+            context_line*
               "return $next($request);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame (marked out of app by the client)
             filename*
               "verifycsrftoken.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\VerifyCsrfToken::handle"
-            context-line*
+            context_line*
               "return tap($next($request), function ($response) use ($request) {"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame (marked out of app by the client)
             filename*
               "substitutebindings.php"
             function*
               "Illuminate\\Routing\\Middleware\\SubstituteBindings::handle"
-            context-line*
+            context_line*
               "return $next($request);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $destination($passable);"
           frame (marked out of app by the client)
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "$request, $route->run()"
           frame (marked out of app by the client)
             filename*
               "route.php"
             function*
               "Illuminate\\Routing\\Route::run"
-            context-line*
+            context_line*
               "return $this->runCallable();"
           frame (marked out of app by the client)
             filename*
               "route.php"
             function*
               "Illuminate\\Routing\\Route::runCallable"
-            context-line*
+            context_line*
               "$this->parametersWithoutNulls(), new ReflectionFunction($this->action['uses'])"
           frame* (marked in-app by the client)
             filename*
               "web.php"
             function*
               "Illuminate\\Routing\\RouteFileRegistrar::{closure}"
-            context-line*
+            context_line*
               "throw new Exception('LARAVEL TEST');"
         type*
           "Exception"
@@ -373,350 +373,350 @@ system:
           frame*
             filename*
               "server.php"
-            context-line*
+            context_line*
               "require_once __DIR__.'/public/index.php';"
           frame*
             filename*
               "index.php"
             function*
               "require_once"
-            context-line*
+            context_line*
               "$request = Illuminate\\Http\\Request::capture()"
           frame*
             filename*
               "kernel.php"
             function*
               "Illuminate\\Foundation\\Http\\Kernel::handle"
-            context-line*
+            context_line*
               "$response = $this->sendRequestThroughRouter($request);"
           frame*
             filename*
               "kernel.php"
             function*
               "Illuminate\\Foundation\\Http\\Kernel::sendRequestThroughRouter"
-            context-line*
+            context_line*
               "->then($this->dispatchToRouter());"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::then"
-            context-line*
+            context_line*
               "return $pipeline($this->passable);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame*
             filename*
               "checkformaintenancemode.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\CheckForMaintenanceMode::handle"
-            context-line*
+            context_line*
               "return $next($request);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame*
             filename*
               "validatepostsize.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\ValidatePostSize::handle"
-            context-line*
+            context_line*
               "return $next($request);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame*
             filename*
               "transformsrequest.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle"
-            context-line*
+            context_line*
               "return $next($request);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame*
             filename*
               "transformsrequest.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle"
-            context-line*
+            context_line*
               "return $next($request);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame*
             filename*
               "trustproxies.php"
             function*
               "Fideloper\\Proxy\\TrustProxies::handle"
-            context-line*
+            context_line*
               "return $next($request);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $destination($passable);"
           frame*
             filename*
               "kernel.php"
             function*
               "Illuminate\\Foundation\\Http\\Kernel::Illuminate\\Foundation\\Http\\{closure}"
-            context-line*
+            context_line*
               "return $this->router->dispatch($request);"
           frame*
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::dispatch"
-            context-line*
+            context_line*
               "return $this->dispatchToRoute($request);"
           frame*
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::dispatchToRoute"
-            context-line*
+            context_line*
               "return $this->runRoute($request, $this->findRoute($request));"
           frame*
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::runRoute"
-            context-line*
+            context_line*
               "$this->runRouteWithinStack($route, $request)"
           frame*
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::runRouteWithinStack"
-            context-line*
+            context_line*
               "});"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::then"
-            context-line*
+            context_line*
               "return $pipeline($this->passable);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame*
             filename*
               "encryptcookies.php"
             function*
               "Illuminate\\Cookie\\Middleware\\EncryptCookies::handle"
-            context-line*
+            context_line*
               "return $this->encrypt($next($this->decrypt($request)));"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame*
             filename*
               "addqueuedcookiestoresponse.php"
             function*
               "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse::handle"
-            context-line*
+            context_line*
               "$response = $next($request);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame*
             filename*
               "startsession.php"
             function*
               "Illuminate\\Session\\Middleware\\StartSession::handle"
-            context-line*
+            context_line*
               "$response = $next($request), $session"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame*
             filename*
               "shareerrorsfromsession.php"
             function*
               "Illuminate\\View\\Middleware\\ShareErrorsFromSession::handle"
-            context-line*
+            context_line*
               "return $next($request);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame*
             filename*
               "verifycsrftoken.php"
             function*
               "Illuminate\\Foundation\\Http\\Middleware\\VerifyCsrfToken::handle"
-            context-line*
+            context_line*
               "return tap($next($request), function ($response) use ($request) {"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
           frame*
             filename*
               "substitutebindings.php"
             function*
               "Illuminate\\Routing\\Middleware\\SubstituteBindings::handle"
-            context-line*
+            context_line*
               "return $next($request);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "return $destination($passable);"
           frame*
             filename*
               "router.php"
             function*
               "Illuminate\\Routing\\Router::Illuminate\\Routing\\{closure}"
-            context-line*
+            context_line*
               "$request, $route->run()"
           frame*
             filename*
               "route.php"
             function*
               "Illuminate\\Routing\\Route::run"
-            context-line*
+            context_line*
               "return $this->runCallable();"
           frame*
             filename*
               "route.php"
             function*
               "Illuminate\\Routing\\Route::runCallable"
-            context-line*
+            context_line*
               "$this->parametersWithoutNulls(), new ReflectionFunction($this->action['uses'])"
           frame*
             filename*
               "web.php"
             function*
               "Illuminate\\Routing\\RouteFileRegistrar::{closure}"
-            context-line*
+            context_line*
               "throw new Exception('LARAVEL TEST');"
         type*
           "Exception"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:09.959580+00:00'
+created: '2025-09-11T18:38:52.056738+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,21 +13,21 @@ app:
           frame* (marked in-app by the client)
             filename*
               "server.php"
-            context-line*
+            context_line*
               "require_once __DIR__.'/public/index.php';"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function* (anonymous class method)
               "run"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame (marked out of app by the client)
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
         type*
           "Exception"
@@ -44,21 +44,21 @@ system:
           frame*
             filename*
               "server.php"
-            context-line*
+            context_line*
               "require_once __DIR__.'/public/index.php';"
           frame*
             filename*
               "pipeline.php"
             function* (anonymous class method)
               "run"
-            context-line*
+            context_line*
               "return $callable($passable);"
           frame*
             filename*
               "pipeline.php"
             function*
               "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
-            context-line*
+            context_line*
               "? $pipe->{$this->method}(...$parameters)"
         type*
           "Exception"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:11.236295+00:00'
+created: '2025-09-11T18:38:52.318428+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "vendor.js"
             function*
               "M"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} o,r;for(b&&(o=i.domain)&&o.exit();t;){r=t.fn,t=t.next;try{r()}catch(o){throw t?n():e=void 0,o}}e=void 0,o&&o.enter()};if(b)n=function(){i.n {snip}"
           frame (marked out of app by the client)
             module*
@@ -26,7 +26,7 @@ app:
               "vendor.js"
             function (ignored unknown function name)
               "S/<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} ,M):b(n)):M(o)}catch(t){a&&!i&&a.exit(),M(t)}};n.length>p;)i(n[p++]);t._c=[],t._n=!1,e&&!t._h&&x(t)})}},x=function(t){d.call(b,function(){va {snip}"
           frame (marked out of app by the client)
             module*
@@ -35,7 +35,7 @@ app:
               "vendor.js"
             function*
               "i"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} ry{c?(r||(2==t._h&&T(t),t._h=1),!0===c?n=o:(a&&a.enter(),n=c(o),a&&(a.exit(),i=!0)),n===e.promise?M(y(\"Promise-chain cycle\")):(p=N(n))?p.cal {snip}"
           frame (marked out of app by the client)
             module*
@@ -44,7 +44,7 @@ app:
               "vendor.js"
             function*
               "b"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} ply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.lo {snip}"
           frame (marked out of app by the client)
             module*
@@ -53,7 +53,7 @@ app:
               "vendor.js"
             function*
               "n"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
           frame (marked out of app by the client)
             module*
@@ -62,7 +62,7 @@ app:
               "vendor.js"
             function*
               "g/</t[e]"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
           frame (marked out of app by the client)
             module*
@@ -71,7 +71,7 @@ app:
               "vendor.js"
             function (ignored unknown function name)
               "_invoke</<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
           frame (marked out of app by the client)
             module*
@@ -80,7 +80,7 @@ app:
               "vendor.js"
             function*
               "W"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
           frame (marked out of app by the client)
             module*
@@ -89,7 +89,7 @@ app:
               "app.js"
             function (ignored unknown function name)
               "e/<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} (e.t0)&&n<I)){e.next=12;break}return n++,e.abrupt(\"return\",a());case 12:throw e.t0;case 13:case\"end\":return e.stop()}},e,this,[[0,7]])}));re {snip}"
           frame (marked out of app by the client)
             module*
@@ -98,7 +98,7 @@ app:
               "app.js"
             function (ignored unknown function name)
               "e/</a</<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} urn e.stop()}},e,this,[[0,7]])}));return function(){return e.apply(this,arguments)}}(),e.abrupt(\"return\",a());case 3:case\"end\":return e.stop {snip}"
           frame (marked out of app by the client)
             module*
@@ -107,7 +107,7 @@ app:
               "vendor.js"
             function (ignored unknown function name)
               "exports/<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} unction(t){return function(){var e=this,o=arguments;return new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)} {snip}"
           frame (marked out of app by the client)
             module*
@@ -116,7 +116,7 @@ app:
               "vendor.js"
             function*
               "L"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} function(t){O(this,L,\"Promise\",\"_h\"),s(t),o.call(this);try{t(M(H,this,1),M(C,this,1))}catch(t){C.call(this,t)}},(o=function(t){this._c=[],th {snip}"
           frame (marked out of app by the client)
             module*
@@ -125,7 +125,7 @@ app:
               "vendor.js"
             function (ignored unknown function name)
               "exports/</<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.load(n(1467))},,function( {snip}"
           frame (marked out of app by the client)
             module*
@@ -134,7 +134,7 @@ app:
               "vendor.js"
             function*
               "c"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,funct {snip}"
           frame (marked out of app by the client)
             module*
@@ -143,7 +143,7 @@ app:
               "vendor.js"
             function*
               "n"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
           frame (marked out of app by the client)
             module*
@@ -152,7 +152,7 @@ app:
               "vendor.js"
             function*
               "g/</t[e]"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
           frame (marked out of app by the client)
             module*
@@ -161,7 +161,7 @@ app:
               "vendor.js"
             function (ignored unknown function name)
               "_invoke</<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
           frame (marked out of app by the client)
             module*
@@ -170,7 +170,7 @@ app:
               "vendor.js"
             function*
               "W"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
           frame (marked out of app by the client)
             module*
@@ -179,7 +179,7 @@ app:
               "app.js"
             function (ignored unknown function name)
               "e/<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} r(;;)switch(e.prev=e.next){case 0:return e.prev=0,e.next=3,t();case 3:return r=e.sent,e.abrupt(\"return\",r.default||r);case 7:if(e.prev=7,e.t {snip}"
           frame (marked out of app by the client)
             module*
@@ -188,7 +188,7 @@ app:
               "app.js"
             function*
               "componentPromise"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} orgId/issues/:groupId/\",componentPromise:function(){return n.e(75).then(n.bind(null,2497))},component:Object(cs.default)(Zt.a)},b.a.createEl {snip}"
           frame (marked out of app by the client)
             module*
@@ -197,7 +197,7 @@ app:
               "app.js"
             function* (trimmed javascript function)
               "e"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} \"+i+\")\");o.type=a,o.request=i,n[1](o)}r[e]=void 0}};var c=setTimeout(function(){i({type:\"timeout\",target:s})},12e4);s.onerror=s.onload=i,do {snip}"
           frame (marked out of app by the client)
             module*
@@ -206,7 +206,7 @@ app:
               "vendor.js"
             function (ignored unknown function name)
               "wrapTimeFunction/<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} ism:{data:{function:Dt(t)},handled:!0,type:\"instrument\"}}),t.apply(this,e)}},t.prototype.wrapRAF=function(t){return function(e){return t(Et( {snip}"
         type*
           "NS_ERROR_NOT_INITIALIZED"
@@ -225,7 +225,7 @@ system:
               "vendor.js"
             function*
               "M"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} o,r;for(b&&(o=i.domain)&&o.exit();t;){r=t.fn,t=t.next;try{r()}catch(o){throw t?n():e=void 0,o}}e=void 0,o&&o.enter()};if(b)n=function(){i.n {snip}"
           frame*
             module*
@@ -234,7 +234,7 @@ system:
               "vendor.js"
             function (ignored unknown function name)
               "S/<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} ,M):b(n)):M(o)}catch(t){a&&!i&&a.exit(),M(t)}};n.length>p;)i(n[p++]);t._c=[],t._n=!1,e&&!t._h&&x(t)})}},x=function(t){d.call(b,function(){va {snip}"
           frame*
             module*
@@ -243,7 +243,7 @@ system:
               "vendor.js"
             function*
               "i"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} ry{c?(r||(2==t._h&&T(t),t._h=1),!0===c?n=o:(a&&a.enter(),n=c(o),a&&(a.exit(),i=!0)),n===e.promise?M(y(\"Promise-chain cycle\")):(p=N(n))?p.cal {snip}"
           frame*
             module*
@@ -252,7 +252,7 @@ system:
               "vendor.js"
             function*
               "b"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} ply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.lo {snip}"
           frame*
             module*
@@ -261,7 +261,7 @@ system:
               "vendor.js"
             function*
               "n"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
           frame*
             module*
@@ -270,7 +270,7 @@ system:
               "vendor.js"
             function*
               "g/</t[e]"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
           frame*
             module*
@@ -279,7 +279,7 @@ system:
               "vendor.js"
             function (ignored unknown function name)
               "_invoke</<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
           frame*
             module*
@@ -288,7 +288,7 @@ system:
               "vendor.js"
             function*
               "W"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
           frame*
             module*
@@ -297,7 +297,7 @@ system:
               "app.js"
             function (ignored unknown function name)
               "e/<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} (e.t0)&&n<I)){e.next=12;break}return n++,e.abrupt(\"return\",a());case 12:throw e.t0;case 13:case\"end\":return e.stop()}},e,this,[[0,7]])}));re {snip}"
           frame*
             module*
@@ -306,7 +306,7 @@ system:
               "app.js"
             function (ignored unknown function name)
               "e/</a</<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} urn e.stop()}},e,this,[[0,7]])}));return function(){return e.apply(this,arguments)}}(),e.abrupt(\"return\",a());case 3:case\"end\":return e.stop {snip}"
           frame*
             module*
@@ -315,7 +315,7 @@ system:
               "vendor.js"
             function (ignored unknown function name)
               "exports/<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} unction(t){return function(){var e=this,o=arguments;return new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)} {snip}"
           frame*
             module*
@@ -324,7 +324,7 @@ system:
               "vendor.js"
             function*
               "L"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} function(t){O(this,L,\"Promise\",\"_h\"),s(t),o.call(this);try{t(M(H,this,1),M(C,this,1))}catch(t){C.call(this,t)}},(o=function(t){this._c=[],th {snip}"
           frame*
             module*
@@ -333,7 +333,7 @@ system:
               "vendor.js"
             function (ignored unknown function name)
               "exports/</<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.load(n(1467))},,function( {snip}"
           frame*
             module*
@@ -342,7 +342,7 @@ system:
               "vendor.js"
             function*
               "c"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,funct {snip}"
           frame*
             module*
@@ -351,7 +351,7 @@ system:
               "vendor.js"
             function*
               "n"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
           frame*
             module*
@@ -360,7 +360,7 @@ system:
               "vendor.js"
             function*
               "g/</t[e]"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
           frame*
             module*
@@ -369,7 +369,7 @@ system:
               "vendor.js"
             function (ignored unknown function name)
               "_invoke</<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
           frame*
             module*
@@ -378,7 +378,7 @@ system:
               "vendor.js"
             function*
               "W"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
           frame*
             module*
@@ -387,7 +387,7 @@ system:
               "app.js"
             function (ignored unknown function name)
               "e/<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} r(;;)switch(e.prev=e.next){case 0:return e.prev=0,e.next=3,t();case 3:return r=e.sent,e.abrupt(\"return\",r.default||r);case 7:if(e.prev=7,e.t {snip}"
           frame*
             module*
@@ -396,7 +396,7 @@ system:
               "app.js"
             function*
               "componentPromise"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} orgId/issues/:groupId/\",componentPromise:function(){return n.e(75).then(n.bind(null,2497))},component:Object(cs.default)(Zt.a)},b.a.createEl {snip}"
           frame*
             module*
@@ -405,7 +405,7 @@ system:
               "app.js"
             function* (trimmed javascript function)
               "e"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} \"+i+\")\");o.type=a,o.request=i,n[1](o)}r[e]=void 0}};var c=setTimeout(function(){i({type:\"timeout\",target:s})},12e4);s.onerror=s.onload=i,do {snip}"
           frame*
             module*
@@ -414,7 +414,7 @@ system:
               "vendor.js"
             function (ignored unknown function name)
               "wrapTimeFunction/<"
-            context-line (discarded because line too long)
+            context_line (discarded because line too long)
               "{snip} ism:{data:{function:Dt(t)},handled:!0,type:\"instrument\"}}),t.apply(this,e)}},t.prototype.wrapRAF=function(t){return function(e){return t(Et( {snip}"
         type*
           "NS_ERROR_NOT_INITIALIZED"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:12.623025+00:00'
+created: '2025-09-11T18:38:52.612791+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "hub.js"
             function* (trimmed javascript function)
               "withScope"
-            context-line*
+            context_line*
               "*/"
           frame* (marked in-app by the client)
             module*
@@ -33,7 +33,7 @@ app:
               "index.js"
             function* (trimmed javascript function)
               "mockConstructor [as captureException]"
-            context-line*
+            context_line*
               "return fn.apply(this, arguments);"
           frame (marked out of app by the client)
             module*
@@ -42,7 +42,7 @@ app:
               "index.js"
             function (ignored unknown function name)
               "<anonymous>"
-            context-line*
+            context_line*
               "})();"
           frame (marked out of app by the client)
             module*
@@ -51,7 +51,7 @@ app:
               "index.js"
             function*
               "finalReturnValue"
-            context-line*
+            context_line*
               "return specificMockImpl.apply(this, arguments);"
           frame (marked out of app by the client)
             module*
@@ -60,7 +60,7 @@ app:
               "index.js"
             function (ignored unknown function name)
               "<anonymous>"
-            context-line*
+            context_line*
               "return original.apply(this, arguments);"
           frame* (marked in-app by the client)
             module*
@@ -69,7 +69,7 @@ app:
               "hub.ts"
             function* (trimmed javascript function)
               "captureException"
-            context-line*
+            context_line*
               "if (maxBreadcrumbs <= 0) {"
           frame* (marked in-app by the client)
             module*
@@ -78,7 +78,7 @@ app:
               "hub.js"
             function* (trimmed javascript function)
               "invokeClient"
-            context-line*
+            context_line*
               "* @returns Scope, the new cloned scope"
           frame* (marked in-app by the client)
             module*
@@ -87,7 +87,7 @@ app:
               "baseclient.ts"
             function* (trimmed javascript function)
               "captureException"
-            context-line*
+            context_line*
               "promisedEvent"
           frame* (marked in-app by the client)
             module*
@@ -115,7 +115,7 @@ system:
               "hub.js"
             function* (trimmed javascript function)
               "withScope"
-            context-line*
+            context_line*
               "*/"
           frame*
             module*
@@ -131,7 +131,7 @@ system:
               "index.js"
             function* (trimmed javascript function)
               "mockConstructor [as captureException]"
-            context-line*
+            context_line*
               "return fn.apply(this, arguments);"
           frame*
             module*
@@ -140,7 +140,7 @@ system:
               "index.js"
             function (ignored unknown function name)
               "<anonymous>"
-            context-line*
+            context_line*
               "})();"
           frame*
             module*
@@ -149,7 +149,7 @@ system:
               "index.js"
             function*
               "finalReturnValue"
-            context-line*
+            context_line*
               "return specificMockImpl.apply(this, arguments);"
           frame*
             module*
@@ -158,7 +158,7 @@ system:
               "index.js"
             function (ignored unknown function name)
               "<anonymous>"
-            context-line*
+            context_line*
               "return original.apply(this, arguments);"
           frame*
             module*
@@ -167,7 +167,7 @@ system:
               "hub.ts"
             function* (trimmed javascript function)
               "captureException"
-            context-line*
+            context_line*
               "if (maxBreadcrumbs <= 0) {"
           frame*
             module*
@@ -176,7 +176,7 @@ system:
               "hub.js"
             function* (trimmed javascript function)
               "invokeClient"
-            context-line*
+            context_line*
               "* @returns Scope, the new cloned scope"
           frame*
             module*
@@ -185,7 +185,7 @@ system:
               "baseclient.ts"
             function* (trimmed javascript function)
               "captureException"
-            context-line*
+            context_line*
               "promisedEvent"
           frame*
             module*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2025-04-25T21:22:12.945442+00:00'
+created: '2025-09-11T18:38:52.682946+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "c52ebcc2d9d0780a23c7d99831678830"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           stacktrace*
             frame* (marked in-app by the client)
@@ -30,10 +30,10 @@ app:
 --------------------------------------------------------------------------
 system:
   hash: "669cb6664e0f5fed38665da04e464f7e"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     system*
-      chained-exception*
+      chained_exception*
         exception*
           stacktrace*
             frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:41:22.419019+00:00'
+created: '2025-09-11T18:38:52.713142+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "base.py"
             function*
               "get_response"
-            context-line*
+            context_line*
               "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
           frame (marked out of app by the client)
             module*
@@ -26,7 +26,7 @@ app:
               "base.py"
             function*
               "view"
-            context-line*
+            context_line*
               "return self.dispatch(request, *args, **kwargs)"
           frame (marked out of app by the client)
             module*
@@ -35,7 +35,7 @@ app:
               "decorators.py"
             function*
               "_wrapper"
-            context-line*
+            context_line*
               "return bound_func(*args, **kwargs)"
           frame (marked out of app by the client)
             module*
@@ -44,7 +44,7 @@ app:
               "csrf.py"
             function*
               "wrapped_view"
-            context-line*
+            context_line*
               "return view_func(*args, **kwargs)"
           frame (marked out of app by the client)
             module*
@@ -53,7 +53,7 @@ app:
               "decorators.py"
             function*
               "bound_func"
-            context-line*
+            context_line*
               "return func(self, *args2, **kwargs2)"
           frame (marked in-app by the client but ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
@@ -62,7 +62,7 @@ app:
               "release_webhook.py"
             function*
               "dispatch"
-            context-line*
+            context_line*
               "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
           frame (marked out of app by the client)
             module*
@@ -71,7 +71,7 @@ app:
               "base.py"
             function*
               "dispatch"
-            context-line*
+            context_line*
               "return handler(request, *args, **kwargs)"
           frame* (marked in-app by the client)
             module*
@@ -80,7 +80,7 @@ app:
               "release_webhook.py"
             function*
               "post"
-            context-line*
+            context_line*
               "hook.handle(request)"
           frame* (marked in-app by the client)
             module*
@@ -89,7 +89,7 @@ app:
               "plugin.py"
             function*
               "handle"
-            context-line*
+            context_line*
               "email = request.POST['user']"
           frame (marked out of app by the client)
             module*
@@ -98,7 +98,7 @@ app:
               "datastructures.py"
             function*
               "__getitem__"
-            context-line*
+            context_line*
               "raise MultiValueDictKeyError(repr(key))"
         type*
           "MultiValueDictKeyError"
@@ -119,7 +119,7 @@ system:
               "base.py"
             function*
               "get_response"
-            context-line*
+            context_line*
               "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
           frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
@@ -128,7 +128,7 @@ system:
               "base.py"
             function*
               "view"
-            context-line*
+            context_line*
               "return self.dispatch(request, *args, **kwargs)"
           frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
@@ -137,7 +137,7 @@ system:
               "decorators.py"
             function*
               "_wrapper"
-            context-line*
+            context_line*
               "return bound_func(*args, **kwargs)"
           frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
@@ -146,7 +146,7 @@ system:
               "csrf.py"
             function*
               "wrapped_view"
-            context-line*
+            context_line*
               "return view_func(*args, **kwargs)"
           frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
@@ -155,7 +155,7 @@ system:
               "decorators.py"
             function*
               "bound_func"
-            context-line*
+            context_line*
               "return func(self, *args2, **kwargs2)"
           frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
@@ -164,7 +164,7 @@ system:
               "release_webhook.py"
             function*
               "dispatch"
-            context-line*
+            context_line*
               "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
           frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
@@ -173,7 +173,7 @@ system:
               "base.py"
             function*
               "dispatch"
-            context-line*
+            context_line*
               "return handler(request, *args, **kwargs)"
           frame*
             module*
@@ -182,7 +182,7 @@ system:
               "release_webhook.py"
             function*
               "post"
-            context-line*
+            context_line*
               "hook.handle(request)"
           frame*
             module*
@@ -191,7 +191,7 @@ system:
               "plugin.py"
             function*
               "handle"
-            context-line*
+            context_line*
               "email = request.POST['user']"
           frame*
             module*
@@ -200,7 +200,7 @@ system:
               "datastructures.py"
             function*
               "__getitem__"
-            context-line*
+            context_line*
               "raise MultiValueDictKeyError(repr(key))"
         type*
           "MultiValueDictKeyError"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:41:22.757354+00:00'
+created: '2025-09-11T18:38:52.741934+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "base.py"
             function*
               "get_response"
-            context-line*
+            context_line*
               "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
           frame (marked out of app by the client)
             module*
@@ -26,7 +26,7 @@ app:
               "base.py"
             function*
               "view"
-            context-line*
+            context_line*
               "return self.dispatch(request, *args, **kwargs)"
           frame (marked out of app by the client)
             module*
@@ -35,7 +35,7 @@ app:
               "decorators.py"
             function*
               "_wrapper"
-            context-line*
+            context_line*
               "return bound_func(*args, **kwargs)"
           frame (marked out of app by the client)
             module*
@@ -44,7 +44,7 @@ app:
               "csrf.py"
             function*
               "wrapped_view"
-            context-line*
+            context_line*
               "return view_func(*args, **kwargs)"
           frame (marked out of app by the client)
             module*
@@ -53,7 +53,7 @@ app:
               "decorators.py"
             function*
               "bound_func"
-            context-line*
+            context_line*
               "return func(self, *args2, **kwargs2)"
           frame (marked in-app by the client but ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
@@ -62,7 +62,7 @@ app:
               "release_webhook.py"
             function*
               "dispatch"
-            context-line*
+            context_line*
               "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
           frame (marked out of app by the client)
             module*
@@ -71,7 +71,7 @@ app:
               "base.py"
             function*
               "dispatch"
-            context-line*
+            context_line*
               "return handler(request, *args, **kwargs)"
           frame (marked in-app by the client but ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
@@ -80,7 +80,7 @@ app:
               "release_webhook.py"
             function*
               "post"
-            context-line*
+            context_line*
               "hook.handle(request)"
           frame (marked in-app by the client but ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
@@ -89,7 +89,7 @@ app:
               "plugin.py"
             function*
               "handle"
-            context-line*
+            context_line*
               "email = request.POST['user']"
           frame (marked out of app by the client)
             module*
@@ -98,7 +98,7 @@ app:
               "datastructures.py"
             function*
               "__getitem__"
-            context-line*
+            context_line*
               "raise MultiValueDictKeyError(repr(key))"
         type*
           "MultiValueDictKeyError"
@@ -119,7 +119,7 @@ system:
               "base.py"
             function*
               "get_response"
-            context-line*
+            context_line*
               "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
           frame*
             module*
@@ -128,7 +128,7 @@ system:
               "base.py"
             function*
               "view"
-            context-line*
+            context_line*
               "return self.dispatch(request, *args, **kwargs)"
           frame*
             module*
@@ -137,7 +137,7 @@ system:
               "decorators.py"
             function*
               "_wrapper"
-            context-line*
+            context_line*
               "return bound_func(*args, **kwargs)"
           frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
@@ -146,7 +146,7 @@ system:
               "csrf.py"
             function*
               "wrapped_view"
-            context-line*
+            context_line*
               "return view_func(*args, **kwargs)"
           frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
@@ -155,7 +155,7 @@ system:
               "decorators.py"
             function*
               "bound_func"
-            context-line*
+            context_line*
               "return func(self, *args2, **kwargs2)"
           frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
@@ -164,7 +164,7 @@ system:
               "release_webhook.py"
             function*
               "dispatch"
-            context-line*
+            context_line*
               "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
           frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
@@ -173,7 +173,7 @@ system:
               "base.py"
             function*
               "dispatch"
-            context-line*
+            context_line*
               "return handler(request, *args, **kwargs)"
           frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
@@ -182,7 +182,7 @@ system:
               "release_webhook.py"
             function*
               "post"
-            context-line*
+            context_line*
               "hook.handle(request)"
           frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
@@ -191,7 +191,7 @@ system:
               "plugin.py"
             function*
               "handle"
-            context-line*
+            context_line*
               "email = request.POST['user']"
           frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
@@ -200,7 +200,7 @@ system:
               "datastructures.py"
             function*
               "__getitem__"
-            context-line*
+            context_line*
               "raise MultiValueDictKeyError(repr(key))"
         type*
           "MultiValueDictKeyError"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:13.281494+00:00'
+created: '2025-09-11T18:38:52.769061+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "safe.py"
             function*
               "safe_execute"
-            context-line*
+            context_line*
               "result = func(*args, **kwargs)"
           frame* (marked in-app by the client)
             module*
@@ -26,7 +26,7 @@ app:
               "notify_action.py"
             function*
               "send_notification"
-            context-line*
+            context_line*
               "resp.raise_for_status()"
           frame (marked out of app by the client)
             module*
@@ -35,7 +35,7 @@ app:
               "models.py"
             function*
               "raise_for_status"
-            context-line*
+            context_line*
               "raise HTTPError(http_error_msg, response=self)"
         type*
           "HTTPError"
@@ -64,7 +64,7 @@ system:
               "safe.py"
             function*
               "safe_execute"
-            context-line*
+            context_line*
               "result = func(*args, **kwargs)"
           frame*
             module*
@@ -73,7 +73,7 @@ system:
               "notify_action.py"
             function*
               "send_notification"
-            context-line*
+            context_line*
               "resp.raise_for_status()"
           frame*
             module*
@@ -82,7 +82,7 @@ system:
               "models.py"
             function*
               "raise_for_status"
-            context-line*
+            context_line*
               "raise HTTPError(http_error_msg, response=self)"
         type*
           "HTTPError"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2025-06-20T20:34:12.428309+00:00'
+created: '2025-09-11T18:38:52.848113+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "11e6467c8358a9366c6538f95dcd7bd4"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           type*
             "Error"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2025-06-20T20:34:12.329464+00:00'
+created: '2025-09-11T18:38:52.820525+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "5f209162115f576bedbaf6f0ad30e5aa"
-  contributing component: chained-exception
+  contributing component: chained_exception
   component:
     app*
-      chained-exception*
+      chained_exception*
         exception*
           type*
             "TypeError"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:13.414468+00:00'
+created: '2025-09-11T18:38:52.880659+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app:
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "value"
-            context-line*
+            context_line*
               "return this.flushedQueue();"
           frame (marked out of app by the client)
             module*
@@ -26,7 +26,7 @@ app:
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "flushedQueue"
-            context-line*
+            context_line*
               "this._inCall--;"
           frame (marked out of app by the client)
             module*
@@ -35,7 +35,7 @@ app:
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "_inCall"
-            context-line*
+            context_line*
               "return this.flushedQueue();"
           frame (marked out of app by the client)
             module*
@@ -44,7 +44,7 @@ app:
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "flushedQueue"
-            context-line*
+            context_line*
               "this._lastFlush = new Date().getTime();"
           frame (marked out of app by the client)
             module*
@@ -53,7 +53,7 @@ app:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "_lastFlush"
-            context-line*
+            context_line*
               "_receiveRootNodeIDEvent(index, eventTopLevelType, i);"
           frame (marked out of app by the client)
             module*
@@ -62,7 +62,7 @@ app:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "_receiveRootNodeIDEvent"
-            context-line*
+            context_line*
               "batchedUpdates(function() {"
           frame (marked out of app by the client)
             module*
@@ -71,7 +71,7 @@ app:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "batchedUpdates"
-            context-line*
+            context_line*
               "return _batchedUpdates(fn, bookkeeping);"
           frame (marked out of app by the client)
             module*
@@ -80,7 +80,7 @@ app:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "_batchedUpdates"
-            context-line*
+            context_line*
               "return fn(a);"
           frame (marked out of app by the client)
             module*
@@ -89,7 +89,7 @@ app:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "fn"
-            context-line*
+            context_line*
               "(forEachAccumulated(events, executeDispatchesAndReleaseTopLevel),"
           frame (marked out of app by the client)
             module*
@@ -98,7 +98,7 @@ app:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "forEachAccumulated"
-            context-line*
+            context_line*
               "Array.isArray(arr) ? arr.forEach(cb, scope) : arr && cb.call(scope, arr);"
           frame (marked out of app by the client)
             function*
@@ -110,7 +110,7 @@ app:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "D"
-            context-line*
+            context_line*
               "executeDispatch(e, !1, dispatchListeners, dispatchInstances);"
           frame (marked out of app by the client)
             module*
@@ -119,7 +119,7 @@ app:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "executeDispatch"
-            context-line*
+            context_line*
               "ReactErrorUtils.invokeGuardedCallbackAndCatchFirstError("
           frame (marked out of app by the client)
             module*
@@ -128,7 +128,7 @@ app:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "invokeGuardedCallbackAndCatchFirstError"
-            context-line*
+            context_line*
               "ReactErrorUtils.invokeGuardedCallback.apply(this, arguments);"
           frame (marked out of app by the client)
             module*
@@ -137,7 +137,7 @@ app:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "apply"
-            context-line*
+            context_line*
               "invokeGuardedCallback.apply(ReactErrorUtils, arguments);"
           frame (marked out of app by the client)
             module*
@@ -146,7 +146,7 @@ app:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "apply"
-            context-line*
+            context_line*
               "var funcArgs = Array.prototype.slice.call(arguments, 3);"
           frame (marked out of app by the client)
             module*
@@ -155,7 +155,7 @@ app:
               "touchable.js"
             function (ignored because sourcemap used and context line available)
               "arguments"
-            context-line*
+            context_line*
               "touchableHandleResponderRelease: function(e) {"
           frame (marked out of app by the client)
             module*
@@ -164,7 +164,7 @@ app:
               "touchable.js"
             function (ignored because sourcemap used and context line available)
               "_receiveSignal"
-            context-line*
+            context_line*
               "this._performSideEffectsForTransition(curState, nextState, signal, e);"
           frame (marked out of app by the client)
             module*
@@ -173,7 +173,7 @@ app:
               "touchable.js"
             function (ignored because sourcemap used and context line available)
               "_performSideEffectsForTransition"
-            context-line*
+            context_line*
               "this.touchableHandlePress(e);"
           frame (marked out of app by the client)
             module*
@@ -182,7 +182,7 @@ app:
               "touchablenativefeedback.android.js"
             function (ignored because sourcemap used and context line available)
               "this"
-            context-line*
+            context_line*
               "this.props.onPress && this.props.onPress(e);"
           frame* (marked in-app by the client)
             module*
@@ -191,7 +191,7 @@ app:
               "app.js"
             function (ignored because sourcemap used and context line available)
               "onPress"
-            context-line*
+            context_line*
               "<Button"
           frame* (marked in-app by the client)
             module*
@@ -200,7 +200,7 @@ app:
               "app.js"
             function (ignored because sourcemap used and context line available)
               "Button"
-            context-line*
+            context_line*
               "<Button"
         type*
           "TypeError"
@@ -221,7 +221,7 @@ system:
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "value"
-            context-line*
+            context_line*
               "return this.flushedQueue();"
           frame*
             module*
@@ -230,7 +230,7 @@ system:
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "flushedQueue"
-            context-line*
+            context_line*
               "this._inCall--;"
           frame*
             module*
@@ -239,7 +239,7 @@ system:
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "_inCall"
-            context-line*
+            context_line*
               "return this.flushedQueue();"
           frame*
             module*
@@ -248,7 +248,7 @@ system:
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "flushedQueue"
-            context-line*
+            context_line*
               "this._lastFlush = new Date().getTime();"
           frame*
             module*
@@ -257,7 +257,7 @@ system:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "_lastFlush"
-            context-line*
+            context_line*
               "_receiveRootNodeIDEvent(index, eventTopLevelType, i);"
           frame*
             module*
@@ -266,7 +266,7 @@ system:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "_receiveRootNodeIDEvent"
-            context-line*
+            context_line*
               "batchedUpdates(function() {"
           frame*
             module*
@@ -275,7 +275,7 @@ system:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "batchedUpdates"
-            context-line*
+            context_line*
               "return _batchedUpdates(fn, bookkeeping);"
           frame*
             module*
@@ -284,7 +284,7 @@ system:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "_batchedUpdates"
-            context-line*
+            context_line*
               "return fn(a);"
           frame*
             module*
@@ -293,7 +293,7 @@ system:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "fn"
-            context-line*
+            context_line*
               "(forEachAccumulated(events, executeDispatchesAndReleaseTopLevel),"
           frame*
             module*
@@ -302,7 +302,7 @@ system:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "forEachAccumulated"
-            context-line*
+            context_line*
               "Array.isArray(arr) ? arr.forEach(cb, scope) : arr && cb.call(scope, arr);"
           frame*
             function*
@@ -314,7 +314,7 @@ system:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "D"
-            context-line*
+            context_line*
               "executeDispatch(e, !1, dispatchListeners, dispatchInstances);"
           frame*
             module*
@@ -323,7 +323,7 @@ system:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "executeDispatch"
-            context-line*
+            context_line*
               "ReactErrorUtils.invokeGuardedCallbackAndCatchFirstError("
           frame*
             module*
@@ -332,7 +332,7 @@ system:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "invokeGuardedCallbackAndCatchFirstError"
-            context-line*
+            context_line*
               "ReactErrorUtils.invokeGuardedCallback.apply(this, arguments);"
           frame*
             module*
@@ -341,7 +341,7 @@ system:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "apply"
-            context-line*
+            context_line*
               "invokeGuardedCallback.apply(ReactErrorUtils, arguments);"
           frame*
             module*
@@ -350,7 +350,7 @@ system:
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "apply"
-            context-line*
+            context_line*
               "var funcArgs = Array.prototype.slice.call(arguments, 3);"
           frame*
             module*
@@ -359,7 +359,7 @@ system:
               "touchable.js"
             function (ignored because sourcemap used and context line available)
               "arguments"
-            context-line*
+            context_line*
               "touchableHandleResponderRelease: function(e) {"
           frame*
             module*
@@ -368,7 +368,7 @@ system:
               "touchable.js"
             function (ignored because sourcemap used and context line available)
               "_receiveSignal"
-            context-line*
+            context_line*
               "this._performSideEffectsForTransition(curState, nextState, signal, e);"
           frame*
             module*
@@ -377,7 +377,7 @@ system:
               "touchable.js"
             function (ignored because sourcemap used and context line available)
               "_performSideEffectsForTransition"
-            context-line*
+            context_line*
               "this.touchableHandlePress(e);"
           frame*
             module*
@@ -386,7 +386,7 @@ system:
               "touchablenativefeedback.android.js"
             function (ignored because sourcemap used and context line available)
               "this"
-            context-line*
+            context_line*
               "this.props.onPress && this.props.onPress(e);"
           frame*
             module*
@@ -395,7 +395,7 @@ system:
               "app.js"
             function (ignored because sourcemap used and context line available)
               "onPress"
-            context-line*
+            context_line*
               "<Button"
           frame*
             module*
@@ -404,7 +404,7 @@ system:
               "app.js"
             function (ignored because sourcemap used and context line available)
               "Button"
-            context-line*
+            context_line*
               "<Button"
         type*
           "TypeError"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/template_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/template_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:18.946973+00:00'
+created: '2025-09-11T18:38:53.254274+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,5 +11,5 @@ default:
       template*
         filename*
           "foo.html"
-        context-line*
+        context_line*
           "{% invalid template tag %}"

--- a/tests/sentry/issues/endpoints/test_event_grouping_info.py
+++ b/tests/sentry/issues/endpoints/test_event_grouping_info.py
@@ -87,7 +87,7 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
                     stacktrace_component = exception_component_subcomponent
                     for frame_component in stacktrace_component["values"]:
                         for frame_component_subcomponent in frame_component["values"]:
-                            if frame_component_subcomponent["id"] == "context-line":
+                            if frame_component_subcomponent["id"] == "context_line":
                                 context_line_component = frame_component_subcomponent
                                 response_context_lines.append(context_line_component["values"][0])
 

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -72,7 +72,7 @@ class GetStacktraceStringTest(TestCase):
                                                 "values": ["divide_by_zero"],
                                             },
                                             {
-                                                "id": "context-line",
+                                                "id": "context_line",
                                                 "name": None,
                                                 "contributes": True,
                                                 "hint": None,
@@ -115,7 +115,7 @@ class GetStacktraceStringTest(TestCase):
                 "hint": None,
                 "values": [
                     {
-                        "id": "chained-exception",
+                        "id": "chained_exception",
                         "name": None,
                         "contributes": True,
                         "hint": None,
@@ -160,7 +160,7 @@ class GetStacktraceStringTest(TestCase):
                                                         "values": ["divide_by_zero"],
                                                     },
                                                     {
-                                                        "id": "context-line",
+                                                        "id": "context_line",
                                                         "name": None,
                                                         "contributes": True,
                                                         "hint": None,
@@ -226,7 +226,7 @@ class GetStacktraceStringTest(TestCase):
                                                         "values": ["<module>"],
                                                     },
                                                     {
-                                                        "id": "context-line",
+                                                        "id": "context_line",
                                                         "name": None,
                                                         "contributes": True,
                                                         "hint": None,
@@ -262,7 +262,7 @@ class GetStacktraceStringTest(TestCase):
                                                         "values": ["divide_by_zero"],
                                                     },
                                                     {
-                                                        "id": "context-line",
+                                                        "id": "context_line",
                                                         "name": None,
                                                         "contributes": True,
                                                         "hint": None,
@@ -379,7 +379,7 @@ class GetStacktraceStringTest(TestCase):
                                         "values": ["index.php"],
                                     },
                                     {
-                                        "id": "context-line",
+                                        "id": "context_line",
                                         "contributes": True,
                                         "values": ["$server->emit($server->run());"],
                                     },
@@ -472,7 +472,7 @@ class GetStacktraceStringTest(TestCase):
                             "values": ["hello_there"],
                         },
                         {
-                            "id": "context-line",
+                            "id": "context_line",
                             "name": None,
                             "contributes": contributes,
                             "hint": None,


### PR DESCRIPTION
This switches all of our multi-word grouping component ids from using dashes to using underscores, so that they can be used as attribute names in the future.