### PR TITLE
fix(ourlogs): Trace logs should accept sort

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_logs.py
+++ b/src/sentry/api/endpoints/organization_trace_logs.py
@@ -118,7 +118,7 @@ class OrganizationTraceLogsEndpoint(OrganizationEventsV2EndpointBase):
         if len(trace_ids) == 0:
             raise ParseError("Need to pass at least one traceId")
 
-        orderby = request.GET.getlist("orderby", ["-timestamp", "-timestamp_precise"])
+        orderby = request.GET.getlist("sort", ["-timestamp", "-timestamp_precise"])
         additional_query = request.GET.get("query")
 
         update_snuba_params_with_timestamp(request, snuba_params)

--- a/tests/snuba/api/endpoints/test_organization_trace_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_logs.py
@@ -118,7 +118,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
         assert log_data["trace"] == trace_id_2
         assert log_data["message"] == "bar"
 
-    def test_orderby(self) -> None:
+    def test_sort(self) -> None:
         trace_id_1 = "1" * 32
         trace_id_2 = "2" * 32
         self.store_ourlogs(
@@ -136,7 +136,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
 
         response = self.client.get(
             self.url,
-            data={"traceId": [trace_id_1, trace_id_2], "orderby": "timestamp"},
+            data={"traceId": [trace_id_1, trace_id_2], "sort": "timestamp"},
             format="json",
         )
         assert response.status_code == 200, response.content
@@ -169,7 +169,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
 
         response = self.client.get(
             self.url,
-            data={"traceId": [trace_id_1, trace_id_2], "orderby": "foobar"},
+            data={"traceId": [trace_id_1, trace_id_2], "sort": "foobar"},
             format="json",
         )
         assert response.status_code == 400, response.content
@@ -292,7 +292,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
 
             response = self.client.get(
                 self.url,
-                data={"traceId": trace_id, "orderby": "timestamp"},
+                data={"traceId": trace_id, "sort": "timestamp"},
                 format="json",
             )
 
@@ -332,7 +332,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
 
             response = self.client.get(
                 self.url,
-                data={"traceId": trace_id, "orderby": "-timestamp"},
+                data={"traceId": trace_id, "sort": "-timestamp"},
                 format="json",
             )
 


### PR DESCRIPTION
### Summary
This should be sort like the rest of the endpoints

