### PR TITLE
fix(tasks) Replace usage_accountant with metrics

### DIFF
--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -122,9 +122,7 @@ def child_process(
     child_worker_init(process_type)
 
     from django.core.cache import cache
-    from usageaccountant import UsageUnit
 
-    from sentry import usage_accountant
     from sentry.taskworker.registry import taskregistry
     from sentry.taskworker.retry import NoRetriesRemainingError
     from sentry.taskworker.state import clear_current_task, current_task, set_current_task
@@ -455,11 +453,10 @@ def child_process(
         )
 
         namespace = taskregistry.get(activation.namespace)
-        usage_accountant.record(
-            resource_id="taskworker",
-            app_feature=namespace.app_feature,
+        metrics.incr(
+            "taskworker.cogs.usage",
             amount=int(execution_duration * 1000),
-            usage_type=UsageUnit.MILLISECONDS,
+            tags={"app_feature": namespace.app_feature},
         )
 
         if (

--- a/tests/sentry/taskworker/test_worker.py
+++ b/tests/sentry/taskworker/test_worker.py
@@ -17,7 +17,6 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     TaskActivation,
 )
 from sentry_sdk.crons import MonitorStatus
-from usageaccountant import UsageUnit
 
 from sentry.taskworker.client.inflight_task_activation import InflightTaskActivation
 from sentry.taskworker.client.processing_result import ProcessingResult
@@ -433,39 +432,6 @@ def test_child_process_remove_start_time_kwargs() -> None:
     result = processed.get()
     assert result.task_id == activation.activation.id
     assert result.status == TASK_ACTIVATION_STATUS_COMPLETE
-
-
-@pytest.mark.django_db
-@mock.patch("sentry.usage_accountant.record")
-def test_child_process_complete_record_usage(mock_record: mock.Mock) -> None:
-    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
-    processed: queue.Queue[ProcessingResult] = queue.Queue()
-    shutdown = Event()
-
-    todo.put(SIMPLE_TASK)
-
-    with override_options({"shared_resources_accounting_enabled": ["taskworker"]}):
-        child_process(
-            todo,
-            processed,
-            shutdown,
-            max_task_count=1,
-            processing_pool_name="test",
-            process_type="fork",
-        )
-
-    assert todo.empty()
-    result = processed.get()
-    assert result.task_id == SIMPLE_TASK.activation.id
-    assert result.status == TASK_ACTIVATION_STATUS_COMPLETE
-
-    assert mock_record.call_count == 1
-    mock_record.assert_called_with(
-        resource_id="taskworker",
-        app_feature="examples",
-        amount=mock.ANY,
-        usage_type=UsageUnit.MILLISECONDS,
-    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The usage data we're recording isn't being stored and instead of debugging why it will be more time-efficient to use a metrics query instead.

Refs STREAM-448