### PR TITLE
ref(timeseries): Use `/events-timeseries/` hook in Database Insights

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -58,7 +58,6 @@ const config: KnipConfig = {
     // TEMPORARY!
     '!static/app/components/core/disclosure/index.tsx',
     '!static/app/components/core/disclosure/disclosure.tsx',
-    '!static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx',
   ],
   compilers: {
     mdx: async text => String(await compile(text)),

--- a/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import {DiscoverSeriesFixture} from 'sentry-fixture/discoverSeries';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -15,6 +16,12 @@ import {ChartWidgetLoader} from './chartWidgetLoader';
 function mockDiscoverSeries(seriesName: string) {
   return DiscoverSeriesFixture({
     seriesName,
+  });
+}
+
+function mockTimeSeries(yAxis: string) {
+  return TimeSeriesFixture({
+    yAxis,
   });
 }
 
@@ -123,6 +130,36 @@ jest.mock('sentry/views/insights/common/queries/useDiscoverSeries', () => ({
       'count()': {
         data: [],
       },
+    },
+    isPending: false,
+    error: null,
+  })),
+}));
+jest.mock('sentry/utils/timeSeries/useFetchEventsTimeSeries', () => ({
+  useFetchSpanTimeSeries: jest.fn(() => ({
+    data: {
+      timeSeries: [
+        mockTimeSeries('epm()'),
+        mockTimeSeries('count(span.duration)'),
+        mockTimeSeries('avg(span.duration)'),
+        mockTimeSeries('p95(span.duration)'),
+        mockTimeSeries('trace_status_rate(internal_error)'),
+        mockTimeSeries('cache_miss_rate()'),
+        mockTimeSeries('http_response_rate(3)'),
+        mockTimeSeries('http_response_rate(4)'),
+        mockTimeSeries('http_response_rate(5)'),
+        mockTimeSeries('avg(span.self_time)'),
+        mockTimeSeries('avg(http.response_content_length)'),
+        mockTimeSeries('avg(http.response_transfer_size)'),
+        mockTimeSeries('avg(http.decoded_response_content_length)'),
+        mockTimeSeries('avg(messaging.message.receive.latency)'),
+        mockTimeSeries('performance_score(measurements.score.lcp)'),
+        mockTimeSeries('performance_score(measurements.score.fcp)'),
+        mockTimeSeries('performance_score(measurements.score.cls)'),
+        mockTimeSeries('performance_score(measurements.score.inp)'),
+        mockTimeSeries('performance_score(measurements.score.ttfb)'),
+        mockTimeSeries('count()'),
+      ],
     },
     isPending: false,
     error: null,

--- a/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 // eslint-disable-next-line import/no-nodejs-modules
 import path from 'node:path';
 
-import {TimeSeriesFixture} from 'sentry-fixture/discoverSeries';
+import {DiscoverSeriesFixture} from 'sentry-fixture/discoverSeries';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -13,7 +13,7 @@ import type {ChartId} from './chartWidgetLoader';
 import {ChartWidgetLoader} from './chartWidgetLoader';
 
 function mockDiscoverSeries(seriesName: string) {
-  return TimeSeriesFixture({
+  return DiscoverSeriesFixture({
     seriesName,
   });
 }

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -14,6 +14,7 @@ import {
   getRetryDelay,
   shouldRetryHandler,
 } from 'sentry/views/insights/common/utils/retryHandlers';
+import type {SpanProperty} from 'sentry/views/insights/types';
 
 import {getIntervalForTimeSeriesQuery} from './getIntervalForTimeSeriesQuery';
 
@@ -30,6 +31,13 @@ interface UseFetchEventsTimeSeriesOptions<Field> {
   sampling?: SamplingMode;
   sort?: Sort;
   topEvents?: number;
+}
+
+export function useFetchSpanTimeSeries<Fields extends SpanProperty>(
+  options: UseFetchEventsTimeSeriesOptions<Fields>,
+  referrer: string
+) {
+  return useFetchEventsTimeSeries<Fields>(DiscoverDatasets.SPANS, options, referrer);
 }
 
 /**

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -131,6 +131,8 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
       // TODO: After merge of ENG-5375 we don't need to run `markDelayedData` on output of `/events-timeseries/`
       const delayedTimeSeries = markDelayedData(timeSeries, INGESTION_DELAY);
 
+      yAxes.add(timeSeries.yAxis);
+
       return new PlottableDataConstructor(delayedTimeSeries, {
         color: COMMON_COLORS(theme)[delayedTimeSeries.yAxis],
         stack: props.stacked && props.visualizationType === 'bar' ? 'all' : undefined,

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -72,10 +72,16 @@ export interface InsightsTimeSeriesWidgetProps
     yAxis?: string[];
   };
   samples?: Samples;
+  /**
+   * During the transition from the `/events-stats/` endpoint to the `/events-timeseries/` endpoint we accept both `timeSeries` and `series` so different components can pass different data. Eventually `series` will go away.
+   */
   series?: DiscoverSeries[];
   showLegend?: TimeSeriesWidgetVisualizationProps['showLegend'];
   showReleaseAs?: 'line' | 'bubble' | 'none';
   stacked?: boolean;
+  /**
+   * During the transition from the `/events-stats/` endpoint to the `/events-timeseries/` endpoint we accept both `timeSeries` and `series` so different components can pass different data. Eventually `timeSeries` will take over.
+   */
   timeSeries?: TimeSeries[];
 }
 

--- a/static/app/views/insights/common/components/widgets/databaseLandingDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/databaseLandingDurationChartWidget.tsx
@@ -4,7 +4,6 @@ import {useDatabaseLandingDurationQuery} from 'sentry/views/insights/common/comp
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {getDurationChartTitle} from 'sentry/views/insights/common/views/spans/types';
 import {Referrer} from 'sentry/views/insights/database/referrers';
-import {DEFAULT_DURATION_AGGREGATE} from 'sentry/views/insights/database/settings';
 
 export default function DatabaseLandingDurationChartWidget(
   props: LoadableChartWidgetProps
@@ -22,7 +21,7 @@ export default function DatabaseLandingDurationChartWidget(
       queryInfo={{search, referrer}}
       id="databaseLandingDurationChartWidget"
       title={getDurationChartTitle('db')}
-      series={[data[`${DEFAULT_DURATION_AGGREGATE}(span.self_time)`]]}
+      timeSeries={data?.timeSeries}
       isLoading={isPending}
       error={error}
     />

--- a/static/app/views/insights/common/components/widgets/databaseLandingThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/databaseLandingThroughputChartWidget.tsx
@@ -23,7 +23,7 @@ export default function DatabaseLandingThroughputChartWidget(
       queryInfo={{search, referrer}}
       id="databaseLandingThroughputChartWidget"
       title={getThroughputChartTitle('db')}
-      series={[data['epm()']]}
+      timeSeries={data?.timeSeries}
       isLoading={isPending}
       error={error}
     />

--- a/static/app/views/insights/common/components/widgets/databaseSummaryDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/databaseSummaryDurationChartWidget.tsx
@@ -1,8 +1,8 @@
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useParams} from 'sentry/utils/useParams';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getDurationChartTitle} from 'sentry/views/insights/common/views/spans/types';
 import {Referrer} from 'sentry/views/insights/database/referrers';
 import {DEFAULT_DURATION_AGGREGATE} from 'sentry/views/insights/database/settings';
@@ -19,12 +19,11 @@ export default function DatabaseSummaryDurationChartWidget(
   const search = MutableSearch.fromQueryObject(filters);
   const referrer = Referrer.SUMMARY_DURATION_CHART;
 
-  const {isPending, data, error} = useSpanSeries(
+  const {isPending, data, error} = useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: [`${DEFAULT_DURATION_AGGREGATE}(${SpanFields.SPAN_SELF_TIME})`],
       enabled: Boolean(groupId),
-      transformAliasToInputFormat: true,
     },
     referrer
   );
@@ -35,7 +34,7 @@ export default function DatabaseSummaryDurationChartWidget(
       queryInfo={{search, referrer}}
       id="databaseSummaryDurationChartWidget"
       title={getDurationChartTitle('db')}
-      series={[data[`${DEFAULT_DURATION_AGGREGATE}(${SpanFields.SPAN_SELF_TIME})`]]}
+      timeSeries={data?.timeSeries}
       isLoading={isPending}
       error={error}
     />

--- a/static/app/views/insights/common/components/widgets/databaseSummaryThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/databaseSummaryThroughputChartWidget.tsx
@@ -1,8 +1,8 @@
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useParams} from 'sentry/utils/useParams';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getThroughputChartTitle} from 'sentry/views/insights/common/views/spans/types';
 import {Referrer} from 'sentry/views/insights/database/referrers';
 import {FIELD_ALIASES} from 'sentry/views/insights/database/settings';
@@ -18,12 +18,11 @@ export default function DatabaseSummaryThroughputChartWidget(
   const search = MutableSearch.fromQueryObject(filters);
   const referrer = Referrer.SUMMARY_THROUGHPUT_CHART;
 
-  const {isPending, data, error} = useSpanSeries(
+  const {isPending, data, error} = useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: ['epm()'],
       enabled: Boolean(groupId),
-      transformAliasToInputFormat: true,
     },
     referrer
   );
@@ -35,7 +34,7 @@ export default function DatabaseSummaryThroughputChartWidget(
       queryInfo={{search, referrer}}
       id="databaseSummaryThroughputChartWidget"
       title={getThroughputChartTitle('db')}
-      series={[data['epm()']]}
+      timeSeries={data?.timeSeries}
       isLoading={isPending}
       error={error}
     />

--- a/static/app/views/insights/common/components/widgets/hooks/useDatabaseLandingDurationQuery.tsx
+++ b/static/app/views/insights/common/components/widgets/hooks/useDatabaseLandingDurationQuery.tsx
@@ -1,5 +1,5 @@
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {Referrer} from 'sentry/views/insights/database/referrers';
 import {DEFAULT_DURATION_AGGREGATE} from 'sentry/views/insights/database/settings';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -10,11 +10,10 @@ type Props = {
 };
 
 export function useDatabaseLandingDurationQuery({search, enabled}: Props) {
-  return useSpanSeries(
+  return useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: [`${DEFAULT_DURATION_AGGREGATE}(${SpanFields.SPAN_SELF_TIME})`],
-      transformAliasToInputFormat: true,
       enabled,
     },
     Referrer.LANDING_DURATION_CHART

--- a/static/app/views/insights/common/components/widgets/hooks/useDatabaseLandingThroughputQuery.tsx
+++ b/static/app/views/insights/common/components/widgets/hooks/useDatabaseLandingThroughputQuery.tsx
@@ -1,5 +1,5 @@
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {Referrer} from 'sentry/views/insights/database/referrers';
 
 type Props = {
@@ -8,11 +8,10 @@ type Props = {
 };
 
 export function useDatabaseLandingThroughputQuery({search, enabled}: Props) {
-  return useSpanSeries(
+  return useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: ['epm()'],
-      transformAliasToInputFormat: true,
       enabled,
     },
     Referrer.LANDING_THROUGHPUT_CHART

--- a/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
@@ -110,7 +110,7 @@ describe('DatabaseLandingPage', () => {
     });
 
     spanChartsRequestMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
       body: {
         'epm()': {
@@ -134,56 +134,50 @@ describe('DatabaseLandingPage', () => {
 
     expect(spanChartsRequestMock).toHaveBeenNthCalledWith(
       1,
-      `/organizations/${organization.slug}/events-stats/`,
+      `/organizations/${organization.slug}/events-timeseries/`,
       expect.objectContaining({
         method: 'GET',
         query: {
-          cursor: undefined,
           dataset: 'spans',
           sampling: SAMPLING_MODE.NORMAL,
           environment: [],
           excludeOther: 0,
-          field: [],
+          groupBy: undefined,
           interval: '30m',
-          orderby: undefined,
+          sort: undefined,
           partial: 1,
-          per_page: 50,
           project: [],
           query:
             'span.category:db !span.op:[db.sql.room,db.redis] has:sentry.normalized_description',
           referrer: 'api.insights.database.landing-throughput-chart',
           statsPeriod: '10d',
           topEvents: undefined,
-          yAxis: 'epm()',
-          transformAliasToInputFormat: '1',
+          yAxis: ['epm()'],
         },
       })
     );
 
     expect(spanChartsRequestMock).toHaveBeenNthCalledWith(
       2,
-      `/organizations/${organization.slug}/events-stats/`,
+      `/organizations/${organization.slug}/events-timeseries/`,
       expect.objectContaining({
         method: 'GET',
         query: {
-          cursor: undefined,
           dataset: 'spans',
           sampling: SAMPLING_MODE.NORMAL,
           environment: [],
           excludeOther: 0,
-          field: [],
+          groupBy: undefined,
           interval: '30m',
-          orderby: undefined,
+          sort: undefined,
           partial: 1,
-          per_page: 50,
           project: [],
           query:
             'span.category:db !span.op:[db.sql.room,db.redis] has:sentry.normalized_description',
           referrer: 'api.insights.database.landing-duration-chart',
           statsPeriod: '10d',
           topEvents: undefined,
-          yAxis: 'avg(span.self_time)',
-          transformAliasToInputFormat: '1',
+          yAxis: ['avg(span.self_time)'],
         },
       })
     );
@@ -255,56 +249,50 @@ describe('DatabaseLandingPage', () => {
 
     expect(spanChartsRequestMock).toHaveBeenNthCalledWith(
       1,
-      `/organizations/${organization.slug}/events-stats/`,
+      `/organizations/${organization.slug}/events-timeseries/`,
       expect.objectContaining({
         method: 'GET',
         query: {
-          cursor: undefined,
           dataset: 'spans',
           sampling: SAMPLING_MODE.NORMAL,
           environment: [],
           excludeOther: 0,
-          field: [],
+          groupBy: undefined,
           interval: '30m',
-          orderby: undefined,
+          sort: undefined,
           partial: 1,
-          per_page: 50,
           project: [],
           query:
             'span.category:db !span.op:[db.sql.room,db.redis] has:sentry.normalized_description span.action:SELECT span.domain:organizations',
           referrer: 'api.insights.database.landing-throughput-chart',
           statsPeriod: '10d',
           topEvents: undefined,
-          yAxis: 'epm()',
-          transformAliasToInputFormat: '1',
+          yAxis: ['epm()'],
         },
       })
     );
 
     expect(spanChartsRequestMock).toHaveBeenNthCalledWith(
       2,
-      `/organizations/${organization.slug}/events-stats/`,
+      `/organizations/${organization.slug}/events-timeseries/`,
       expect.objectContaining({
         method: 'GET',
         query: {
-          cursor: undefined,
           dataset: 'spans',
           sampling: SAMPLING_MODE.NORMAL,
           environment: [],
           excludeOther: 0,
-          field: [],
+          groupBy: undefined,
           interval: '30m',
-          orderby: undefined,
+          sort: undefined,
           partial: 1,
-          per_page: 50,
           project: [],
           query:
             'span.category:db !span.op:[db.sql.room,db.redis] has:sentry.normalized_description span.action:SELECT span.domain:organizations',
           referrer: 'api.insights.database.landing-duration-chart',
           statsPeriod: '10d',
           topEvents: undefined,
-          yAxis: 'avg(span.self_time)',
-          transformAliasToInputFormat: '1',
+          yAxis: ['avg(span.self_time)'],
         },
       })
     );

--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -31,10 +31,7 @@ import {
   QueriesTable,
 } from 'sentry/views/insights/database/components/tables/queriesTable';
 import {useSystemSelectorOptions} from 'sentry/views/insights/database/components/useSystemSelectorOptions';
-import {
-  BASE_FILTERS,
-  DEFAULT_DURATION_AGGREGATE,
-} from 'sentry/views/insights/database/settings';
+import {BASE_FILTERS} from 'sentry/views/insights/database/settings';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
@@ -46,7 +43,6 @@ export function DatabaseLandingPage() {
   const hasModuleData = useHasFirstSpan(moduleName);
   const {search, enabled} = useDatabaseLandingChartFilter();
 
-  const selectedAggregate = DEFAULT_DURATION_AGGREGATE;
   const spanDescription =
     decodeScalar(location.query?.['sentry.normalized_description'], '') ||
     decodeScalar(location.query?.['span.description'], '');
@@ -124,10 +120,9 @@ export function DatabaseLandingPage() {
 
   const isAnyCriticalDataAvailable =
     (queryListResponse.data ?? []).length > 0 ||
-    durationData[`${selectedAggregate}(span.self_time)`].data?.some(
-      ({value}) => value > 0
-    ) ||
-    throughputData['epm()'].data?.some(({value}) => value > 0);
+    [...(durationData?.timeSeries ?? []), ...(throughputData?.timeSeries ?? [])]
+      .flatMap(timeSeries => timeSeries.values)
+      .some(({value}) => value && value > 0);
 
   return (
     <React.Fragment>

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -1,6 +1,7 @@
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
@@ -84,29 +85,17 @@ describe('DatabaseSpanSummaryPage', () => {
     });
 
     const eventsStatsRequestMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
       body: {
-        'epm()': {
-          data: [
-            [1672531200, [{count: 5}]],
-            [1672542000, [{count: 10}]],
-            [1672552800, [{count: 15}]],
-          ],
-          order: 0,
-          start: 1672531200,
-          end: 1672552800,
-        },
-        'avg(span.self_time)': {
-          data: [
-            [1672531200, [{count: 100}]],
-            [1672542000, [{count: 150}]],
-            [1672552800, [{count: 200}]],
-          ],
-          order: 1,
-          start: 1672531200,
-          end: 1672552800,
-        },
+        timeseries: [
+          TimeSeriesFixture({
+            yAxis: 'epm()',
+          }),
+          TimeSeriesFixture({
+            yAxis: 'avg(span.self_time)',
+          }),
+        ],
       },
     });
 
@@ -254,27 +243,24 @@ describe('DatabaseSpanSummaryPage', () => {
     // EPM Chart
     expect(eventsStatsRequestMock).toHaveBeenNthCalledWith(
       1,
-      `/organizations/${organization.slug}/events-stats/`,
+      `/organizations/${organization.slug}/events-timeseries/`,
       expect.objectContaining({
         method: 'GET',
         query: {
-          cursor: undefined,
           dataset: 'spans',
           sampling: SAMPLING_MODE.NORMAL,
           environment: [],
           excludeOther: 0,
-          field: [],
+          groupBy: undefined,
           interval: '30m',
-          orderby: undefined,
+          sort: undefined,
           partial: 1,
-          per_page: 50,
           project: [],
           query: 'span.group:1756baf8fd19c116',
           referrer: 'api.insights.database.summary-throughput-chart',
           statsPeriod: '10d',
           topEvents: undefined,
-          yAxis: 'epm()',
-          transformAliasToInputFormat: '1',
+          yAxis: ['epm()'],
         },
       })
     );
@@ -282,27 +268,24 @@ describe('DatabaseSpanSummaryPage', () => {
     // Duration Chart
     expect(eventsStatsRequestMock).toHaveBeenNthCalledWith(
       2,
-      `/organizations/${organization.slug}/events-stats/`,
+      `/organizations/${organization.slug}/events-timeseries/`,
       expect.objectContaining({
         method: 'GET',
         query: {
-          cursor: undefined,
           dataset: 'spans',
           sampling: SAMPLING_MODE.NORMAL,
           environment: [],
           excludeOther: 0,
-          field: [],
+          groupBy: undefined,
           interval: '30m',
-          orderby: undefined,
+          sort: undefined,
           partial: 1,
-          per_page: 50,
           project: [],
           query: 'span.group:1756baf8fd19c116',
           referrer: 'api.insights.database.summary-duration-chart',
           statsPeriod: '10d',
           topEvents: undefined,
-          yAxis: 'avg(span.self_time)',
-          transformAliasToInputFormat: '1',
+          yAxis: ['avg(span.self_time)'],
         },
       })
     );

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -88,7 +88,7 @@ describe('DatabaseSpanSummaryPage', () => {
       url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
       body: {
-        timeseries: [
+        timeSeries: [
           TimeSeriesFixture({
             yAxis: 'epm()',
           }),

--- a/tests/js/fixtures/discoverSeries.ts
+++ b/tests/js/fixtures/discoverSeries.ts
@@ -1,6 +1,8 @@
 import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 
-export function TimeSeriesFixture(params: Partial<DiscoverSeries> = {}): DiscoverSeries {
+export function DiscoverSeriesFixture(
+  params: Partial<DiscoverSeries> = {}
+): DiscoverSeries {
   return {
     seriesName: 'avg(span.duration)',
     data: [


### PR DESCRIPTION
First steps to using `/events-timeseries/` endpoint in production!

- Accept `TimeSeries` in `InsightsTimeSeriesWidget`, so we can pass the hook's response data directly to charts
- Remove unnecessary Knip config, since the hook is in actual use now
- Fix incorrectly named fixture (just to clarify)
- Add partial application span hook (just for convenience)
- Use `useFetchEventsTimeSeries` in database module (the bulk of the change)

The change is pretty simple overall, just swapping the hook one-for-one! Some of the parameter names are different, but that's about it. The main change is that the `useFetchSpanTimeSeries` returns an _array_ of `TimeSeries` objects, rathen than an object keyed by the `yAxis`. This means we can just pass the response array directly to the charts. CAVEAT: If the hook is fetching more data than is needed for the charts, the extra data needs to be filtered out! This is not the case for Database module, but it'll be the case for some other ones.

Otherwise, it's basically that:

1. `search` is called `query
2. the aliasing is _always on_, so no need for a parameter