### PR TITLE
chore(grouping): Fix grouping info snapshot source

### DIFF
--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/actix.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.121587+00:00'
+created: '2025-09-11T21:20:19.623079+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/android_anr.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.190365+00:00'
+created: '2025-09-11T21:20:19.678855+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/aspnetcore.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.222809+00:00'
+created: '2025-09-11T21:20:19.699428+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.255249+00:00'
+created: '2025-09-11T21:20:19.718058+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/bugly.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.298185+00:00'
+created: '2025-09-11T21:20:19.738658+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.373923+00:00'
+created: '2025-09-11T21:20:19.780253+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.344378+00:00'
+created: '2025-09-11T21:20:19.760978+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-10T21:59:26.081057+00:00'
+created: '2025-09-11T21:20:19.801457+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/checksum_no_regex_match.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.443715+00:00'
+created: '2025-09-11T21:20:19.819288+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "hashed_checksum": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/checksum_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/checksum_regex_match.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.478485+00:00'
+created: '2025-09-11T21:20:19.836961+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "checksum": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.510845+00:00'
+created: '2025-09-11T21:20:19.855667+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/connection_error.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.547357+00:00'
+created: '2025-09-11T21:20:19.876198+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.574833+00:00'
+created: '2025-09-11T21:20:19.908323+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.616373+00:00'
+created: '2025-09-11T21:20:19.948949+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.941137+00:00'
+created: '2025-09-11T21:20:20.320093+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_img_src.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_img_src.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.642293+00:00'
+created: '2025-09-11T21:20:19.977707+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.666479+00:00'
+created: '2025-09-11T21:20:20.023787+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_data_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_data_uri.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.695165+00:00'
+created: '2025-09-11T21:20:20.086630+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.729032+00:00'
+created: '2025-09-11T21:20:20.118899+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.791403+00:00'
+created: '2025-09-11T21:20:20.159463+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_uri.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.827860+00:00'
+created: '2025-09-11T21:20:20.211727+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_style_src_elem.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_style_src_elem.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.873615+00:00'
+created: '2025-09-11T21:20:20.282621+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.063437+00:00'
+created: '2025-09-11T21:20:20.400309+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:03.996477+00:00'
+created: '2025-09-11T21:20:20.364759+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.110492+00:00'
+created: '2025-09-11T21:20:20.526178+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/empty.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/empty.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.147902+00:00'
+created: '2025-09-11T21:20:20.559036+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "fallback": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-10T21:59:26.474607+00:00'
+created: '2025-09-11T21:20:20.592789+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.249615+00:00'
+created: '2025-09-11T21:20:20.699956+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.210353+00:00'
+created: '2025-09-11T21:20:20.633877+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.231817+00:00'
+created: '2025-09-11T21:20:20.662562+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.269765+00:00'
+created: '2025-09-11T21:20:20.737096+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.311494+00:00'
+created: '2025-09-11T21:20:20.791731+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.290017+00:00'
+created: '2025-09-11T21:20:20.767705+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.332987+00:00'
+created: '2025-09-11T21:20:20.826050+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.353311+00:00'
+created: '2025-09-11T21:20:20.854389+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.372528+00:00'
+created: '2025-09-11T21:20:20.876266+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.393316+00:00'
+created: '2025-09-11T21:20:20.897011+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.414622+00:00'
+created: '2025-09-11T21:20:20.920031+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.435978+00:00'
+created: '2025-09-11T21:20:20.941233+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_exception.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_exception.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.454477+00:00'
+created: '2025-09-11T21:20:20.978125+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.475647+00:00'
+created: '2025-09-11T21:20:21.002821+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.493425+00:00'
+created: '2025-09-11T21:20:21.038220+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.537104+00:00'
+created: '2025-09-11T21:20:21.109738+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.515873+00:00'
+created: '2025-09-11T21:20:21.064848+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.555801+00:00'
+created: '2025-09-11T21:20:21.146804+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.598068+00:00'
+created: '2025-09-11T21:20:21.224729+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.577361+00:00'
+created: '2025-09-11T21:20:21.183704+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.617435+00:00'
+created: '2025-09-11T21:20:21.256033+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_type.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_type.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.636359+00:00'
+created: '2025-09-11T21:20:21.283940+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_value.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_value.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.653260+00:00'
+created: '2025-09-11T21:20:21.324014+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/expectct.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/expectct.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.756592+00:00'
+created: '2025-09-11T21:20:21.476182+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.776082+00:00'
+created: '2025-09-11T21:20:21.502094+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.794619+00:00'
+created: '2025-09-11T21:20:21.531883+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_empty_list.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.821242+00:00'
+created: '2025-09-11T21:20:21.561442+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.839039+00:00'
+created: '2025-09-11T21:20:21.585921+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.856107+00:00'
+created: '2025-09-11T21:20:21.613494+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.874158+00:00'
+created: '2025-09-11T21:20:21.636905+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.891919+00:00'
+created: '2025-09-11T21:20:21.657724+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.911012+00:00'
+created: '2025-09-11T21:20:21.679117+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.928834+00:00'
+created: '2025-09-11T21:20:21.702591+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.946945+00:00'
+created: '2025-09-11T21:20:21.725160+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.965061+00:00'
+created: '2025-09-11T21:20:21.745617+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:04.987153+00:00'
+created: '2025-09-11T21:20:21.765332+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.017146+00:00'
+created: '2025-09-11T21:20:21.784262+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.040493+00:00'
+created: '2025-09-11T21:20:21.803737+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.064835+00:00'
+created: '2025-09-11T21:20:21.835746+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.089971+00:00'
+created: '2025-09-11T21:20:21.865120+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.111521+00:00'
+created: '2025-09-11T21:20:21.895134+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.133271+00:00'
+created: '2025-09-11T21:20:21.924130+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.153770+00:00'
+created: '2025-09-11T21:20:21.946226+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.216166+00:00'
+created: '2025-09-11T21:20:22.016831+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.176823+00:00'
+created: '2025-09-11T21:20:21.971131+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.197100+00:00'
+created: '2025-09-11T21:20:21.992577+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.260146+00:00'
+created: '2025-09-11T21:20:22.059412+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.236804+00:00'
+created: '2025-09-11T21:20:22.037191+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.280064+00:00'
+created: '2025-09-11T21:20:22.079401+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.299912+00:00'
+created: '2025-09-11T21:20:22.102275+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.318813+00:00'
+created: '2025-09-11T21:20:22.125429+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.338201+00:00'
+created: '2025-09-11T21:20:22.148344+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.376054+00:00'
+created: '2025-09-11T21:20:22.192599+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.356697+00:00'
+created: '2025-09-11T21:20:22.169909+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.395465+00:00'
+created: '2025-09-11T21:20:22.215155+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.415013+00:00'
+created: '2025-09-11T21:20:22.235904+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.435071+00:00'
+created: '2025-09-11T21:20:22.259052+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.474699+00:00'
+created: '2025-09-11T21:20:22.333873+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.454650+00:00'
+created: '2025-09-11T21:20:22.296092+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.494675+00:00'
+created: '2025-09-11T21:20:22.365740+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.514039+00:00'
+created: '2025-09-11T21:20:22.398495+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.534206+00:00'
+created: '2025-09-11T21:20:22.431152+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.552405+00:00'
+created: '2025-09-11T21:20:22.458104+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.573605+00:00'
+created: '2025-09-11T21:20:22.497625+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.593847+00:00'
+created: '2025-09-11T21:20:22.523117+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.615771+00:00'
+created: '2025-09-11T21:20:22.552958+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.635739+00:00'
+created: '2025-09-11T21:20:22.577784+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.657446+00:00'
+created: '2025-09-11T21:20:22.600961+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.678080+00:00'
+created: '2025-09-11T21:20:22.626523+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.698928+00:00'
+created: '2025-09-11T21:20:22.649517+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.718353+00:00'
+created: '2025-09-11T21:20:22.672705+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.745703+00:00'
+created: '2025-09-11T21:20:22.698657+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.781117+00:00'
+created: '2025-09-11T21:20:22.724219+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.812036+00:00'
+created: '2025-09-11T21:20:22.749885+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.836638+00:00'
+created: '2025-09-11T21:20:22.772318+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.865325+00:00'
+created: '2025-09-11T21:20:22.796852+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.893006+00:00'
+created: '2025-09-11T21:20:22.821255+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.919379+00:00'
+created: '2025-09-11T21:20:22.846681+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hpkp.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hpkp.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:05.943855+00:00'
+created: '2025-09-11T21:20:22.872529+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.056004+00:00'
+created: '2025-09-11T21:20:22.895467+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.101286+00:00'
+created: '2025-09-11T21:20:22.921511+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.123953+00:00'
+created: '2025-09-11T21:20:22.946438+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.145312+00:00'
+created: '2025-09-11T21:20:22.966498+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.167256+00:00'
+created: '2025-09-11T21:20:22.987371+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.193216+00:00'
+created: '2025-09-11T21:20:23.053377+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.219043+00:00'
+created: '2025-09-11T21:20:23.088397+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.242519+00:00'
+created: '2025-09-11T21:20:23.121797+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.280884+00:00'
+created: '2025-09-11T21:20:23.181013+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.262323+00:00'
+created: '2025-09-11T21:20:23.157765+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.299300+00:00'
+created: '2025-09-11T21:20:23.203271+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_message.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.336505+00:00'
+created: '2025-09-11T21:20:23.244353+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_message_parameterization.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.319521+00:00'
+created: '2025-09-11T21:20:23.223992+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.354909+00:00'
+created: '2025-09-11T21:20:23.264782+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.373083+00:00'
+created: '2025-09-11T21:20:23.286350+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.391915+00:00'
+created: '2025-09-11T21:20:23.309781+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.410190+00:00'
+created: '2025-09-11T21:20:23.333413+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.428710+00:00'
+created: '2025-09-11T21:20:23.362533+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.447968+00:00'
+created: '2025-09-11T21:20:23.383414+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.466824+00:00'
+created: '2025-09-11T21:20:23.404445+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.486248+00:00'
+created: '2025-09-11T21:20:23.426864+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.507150+00:00'
+created: '2025-09-11T21:20:23.449522+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.528730+00:00'
+created: '2025-09-11T21:20:23.469432+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.551618+00:00'
+created: '2025-09-11T21:20:23.492197+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.575408+00:00'
+created: '2025-09-11T21:20:23.514076+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.621291+00:00'
+created: '2025-09-11T21:20:23.558784+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel_anonymous.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.596045+00:00'
+created: '2025-09-11T21:20:23.534562+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/logentry_prefers_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/logentry_prefers_message.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.641726+00:00'
+created: '2025-09-11T21:20:23.579619+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/logentry_uses_formatted.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/logentry_uses_formatted.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.663403+00:00'
+created: '2025-09-11T21:20:23.600117+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.686328+00:00'
+created: '2025-09-11T21:20:23.624352+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.711667+00:00'
+created: '2025-09-11T21:20:23.650767+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.733666+00:00'
+created: '2025-09-11T21:20:23.677336+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_prefers_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_prefers_message.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.755204+00:00'
+created: '2025-09-11T21:20:23.696907+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_uses_formatted.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_uses_formatted.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.774980+00:00'
+created: '2025-09-11T21:20:23.715952+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_with_key_pair_values.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.795747+00:00'
+created: '2025-09-11T21:20:23.736536+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.821656+00:00'
+created: '2025-09-11T21:20:23.758213+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.843505+00:00'
+created: '2025-09-11T21:20:23.777244+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.865168+00:00'
+created: '2025-09-11T21:20:23.796922+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.886447+00:00'
+created: '2025-09-11T21:20:23.816378+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.908371+00:00'
+created: '2025-09-11T21:20:23.836373+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.928993+00:00'
+created: '2025-09-11T21:20:23.857853+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.948574+00:00'
+created: '2025-09-11T21:20:23.879965+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_no_filenames.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.968739+00:00'
+created: '2025-09-11T21:20:23.900918+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:06.988409+00:00'
+created: '2025-09-11T21:20:23.921748+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.007549+00:00'
+created: '2025-09-11T21:20:23.942563+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_with_function_name.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.026341+00:00'
+created: '2025-09-11T21:20:23.965661+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.044978+00:00'
+created: '2025-09-11T21:20:23.987902+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.062527+00:00'
+created: '2025-09-11T21:20:24.008054+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.081698+00:00'
+created: '2025-09-11T21:20:24.029252+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.100554+00:00'
+created: '2025-09-11T21:20:24.051435+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.119242+00:00'
+created: '2025-09-11T21:20:24.072095+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.138541+00:00'
+created: '2025-09-11T21:20:24.092895+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.202352+00:00'
+created: '2025-09-11T21:20:24.183052+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.159102+00:00'
+created: '2025-09-11T21:20:24.121057+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.181295+00:00'
+created: '2025-09-11T21:20:24.151372+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_native.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.226690+00:00'
+created: '2025-09-11T21:20:24.235942+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_cocoa.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.247609+00:00'
+created: '2025-09-11T21:20:24.267341+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.272874+00:00'
+created: '2025-09-11T21:20:24.301922+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.294940+00:00'
+created: '2025-09-11T21:20:24.322551+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_discards_seemingly_useless_stack.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_discards_seemingly_useless_stack.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.316067+00:00'
+created: '2025-09-11T21:20:24.348654+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.336639+00:00'
+created: '2025-09-11T21:20:24.372958+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_group_different_js_errors.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_group_different_js_errors.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.356779+00:00'
+created: '2025-09-11T21:20:24.394684+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.378004+00:00'
+created: '2025-09-11T21:20:24.418050+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.398941+00:00'
+created: '2025-09-11T21:20:24.443358+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.424325+00:00'
+created: '2025-09-11T21:20:24.469372+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.445902+00:00'
+created: '2025-09-11T21:20:24.500540+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.467972+00:00'
+created: '2025-09-11T21:20:24.522057+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.489762+00:00'
+created: '2025-09-11T21:20:24.547655+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.511071+00:00'
+created: '2025-09-11T21:20:24.571254+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.533523+00:00'
+created: '2025-09-11T21:20:24.595423+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/template_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/template_compute_hashes.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.554008+00:00'
+created: '2025-09-11T21:20:24.615416+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "default": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.573795+00:00'
+created: '2025-09-11T21:20:24.634807+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_no_hash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_no_hash.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.597402+00:00'
+created: '2025-09-11T21:20:24.655707+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unity.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.617596+00:00'
+created: '2025-09-11T21:20:24.676192+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.639315+00:00'
+created: '2025-09-11T21:20:24.699407+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.659950+00:00'
+created: '2025-09-11T21:20:24.722143+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.683550+00:00'
+created: '2025-09-11T21:20:24.744750+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.709157+00:00'
+created: '2025-09-11T21:20:24.768626+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.734048+00:00'
+created: '2025-09-11T21:20:24.791309+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2025-09-08T19:48:07.757092+00:00'
+created: '2025-09-11T21:20:24.813399+00:00'
 creator: sentry
-source: tests/sentry/grouping/test_grouping_inputs.py
+source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "app": {


### PR DESCRIPTION
When I was working on adding grouping info snapshot tests, I changed the name of the test file and forgot to run the snapshots again, so they all are listed as having the old filename as their source. To reduce noise in future PRs, this updates them all to point to the new filename.