### PR TITLE
feat(checkout v3): New plan feature list

### DIFF
--- a/static/gsApp/views/amCheckout/planFeatures.spec.tsx
+++ b/static/gsApp/views/amCheckout/planFeatures.spec.tsx
@@ -9,6 +9,12 @@ describe('PlanFeatures', () => {
   const businessPlan = PlanDetailsLookupFixture('am3_business')!;
   const planOptions = [freePlan, teamPlan, businessPlan];
 
+  it('renders excess usage warning for business plan', () => {
+    render(<PlanFeatures planOptions={planOptions} activePlan={freePlan} />);
+    expect(screen.getByText("What's included")).toBeInTheDocument();
+    expect(screen.getByText(/Excess usage for/)).toBeInTheDocument();
+  });
+
   it('renders the plan features based on free plan', () => {
     render(<PlanFeatures planOptions={planOptions} activePlan={freePlan} />);
 

--- a/static/gsApp/views/amCheckout/planFeatures.spec.tsx
+++ b/static/gsApp/views/amCheckout/planFeatures.spec.tsx
@@ -1,0 +1,48 @@
+import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import PlanFeatures from 'getsentry/views/amCheckout/planFeatures';
+
+describe('PlanFeatures', () => {
+  const freePlan = PlanDetailsLookupFixture('am3_f')!;
+  const teamPlan = PlanDetailsLookupFixture('am3_team')!;
+  const businessPlan = PlanDetailsLookupFixture('am3_business')!;
+  const planOptions = [freePlan, teamPlan, businessPlan];
+
+  it('renders the plan features based on free plan', () => {
+    render(<PlanFeatures planOptions={planOptions} activePlan={freePlan} />);
+
+    expect(screen.getByText("What's included")).toBeInTheDocument();
+    expect(screen.getByTestId('developer-features-included')).toBeInTheDocument();
+    expect(screen.getByTestId('team-features-excluded')).toBeInTheDocument();
+    expect(screen.getByTestId('business-features-excluded')).toBeInTheDocument();
+  });
+
+  it('renders the plan features based on team plan', () => {
+    render(<PlanFeatures planOptions={planOptions} activePlan={teamPlan} />);
+
+    expect(screen.getByText("What's included")).toBeInTheDocument();
+    expect(screen.getByTestId('developer-features-included')).toBeInTheDocument();
+    expect(screen.getByTestId('team-features-included')).toBeInTheDocument();
+    expect(screen.getByTestId('business-features-excluded')).toBeInTheDocument();
+  });
+
+  it('renders the plan features based on business plan', () => {
+    render(<PlanFeatures planOptions={planOptions} activePlan={businessPlan} />);
+
+    expect(screen.getByText("What's included")).toBeInTheDocument();
+    expect(screen.getByTestId('developer-features-included')).toBeInTheDocument();
+    expect(screen.getByTestId('team-features-included')).toBeInTheDocument();
+    expect(screen.getByTestId('business-features-included')).toBeInTheDocument();
+  });
+
+  it('excludes features that are not in specified plans', () => {
+    render(<PlanFeatures planOptions={planOptions.slice(1)} activePlan={teamPlan} />);
+
+    expect(screen.getByTestId('team-features-included')).toBeInTheDocument();
+    expect(screen.getByTestId('business-features-excluded')).toBeInTheDocument();
+
+    // free plan not included in planOptions
+    expect(screen.queryByTestId('developer-features-excluded')).not.toBeInTheDocument();
+  });
+});

--- a/static/gsApp/views/amCheckout/planFeatures.tsx
+++ b/static/gsApp/views/amCheckout/planFeatures.tsx
@@ -1,0 +1,109 @@
+import {Flex, Grid} from 'sentry/components/core/layout';
+import {Heading, Text} from 'sentry/components/core/text';
+import {IconCheckmark, IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+import type {Plan} from 'getsentry/types';
+
+// TODO(checkout v3): Move features list to backend
+const FEATURES: Array<{features: string[]; plan: string}> = [
+  {
+    plan: 'developer',
+    features: [
+      t('1 user'),
+      t('5k Errors'),
+      t('5GB of Logs'),
+      t('5M Spans'),
+      t('50 Replays'),
+      t('10 custom dashboards'),
+      t('1 Cron Monitor'),
+      t('1 Uptime Monitor'),
+      t('1GB of Attachments'),
+      t('20 metric alerts'),
+    ],
+  },
+  {
+    plan: 'team',
+    features: [
+      t('Unlimited users'),
+      t('50K Errors'),
+      t('Access to UI and Continuous Profiling'),
+      t('Can add event volume to subscription'),
+      t('Third-party integrations'),
+      t('20 custom dashboards'),
+      t('Seer: AI debugging agent (subscription required)'),
+      t('Single Sign-On'),
+      t('Up to 90 day retention'),
+    ],
+  },
+  {
+    plan: 'business',
+    features: [
+      t('Insights (90-day lookback)'),
+      t('Unlimited custom dashboards'),
+      t('Unlimited metric alerts'),
+      t('Advanced quota management'),
+      t('Code Owners support'),
+      t('SAML + SCIM support'),
+      t('BAA'),
+    ],
+  },
+];
+
+function FeatureItem({feature, isIncluded}: {feature: string; isIncluded: boolean}) {
+  return (
+    <Flex gap="sm">
+      {isIncluded ? (
+        <IconCheckmark size="md" color="success" />
+      ) : (
+        <IconClose size="md" color="error" />
+      )}
+      <Text variant={isIncluded ? 'primary' : 'muted'}>{feature}</Text>
+    </Flex>
+  );
+}
+
+function PlanFeatures({
+  planOptions,
+  activePlan,
+}: {
+  activePlan: Plan;
+  planOptions: Plan[];
+}) {
+  const planName = activePlan.name.toLowerCase();
+  const featureList = FEATURES.filter(({plan}) =>
+    planOptions.some(p => p.name.toLowerCase().includes(plan))
+  );
+  const featureListIndex = featureList.findIndex(feature =>
+    planName.includes(feature.plan)
+  );
+  return (
+    <Flex
+      background="primary"
+      padding="2xl"
+      radius="lg"
+      border="primary"
+      gap="sm"
+      direction="column"
+    >
+      <Heading as="h3" size="xl">
+        {t("What's included")}
+      </Heading>
+      <Grid columns={`repeat(${planOptions.length}, 1fr)`} gap="sm">
+        {featureList.map(({plan, features}, index) => {
+          const isIncluded = featureListIndex >= index;
+          const dataTestId = `${plan}-features-${isIncluded ? 'included' : 'excluded'}`;
+          return (
+            <Flex data-test-id={dataTestId} key={plan} direction="column" gap="sm">
+              {features.map(feature => (
+                <FeatureItem key={feature} feature={feature} isIncluded={isIncluded} />
+              ))}
+            </Flex>
+          );
+        })}
+      </Grid>
+    </Flex>
+  );
+}
+
+export default PlanFeatures;

--- a/static/gsApp/views/amCheckout/planFeatures.tsx
+++ b/static/gsApp/views/amCheckout/planFeatures.tsx
@@ -1,9 +1,22 @@
+import styled from '@emotion/styled';
+
 import {Flex, Grid} from 'sentry/components/core/layout';
 import {Heading, Text} from 'sentry/components/core/text';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconCheckmark, IconClose} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
+import type {DataCategory} from 'sentry/types/core';
+import oxfordizeArray from 'sentry/utils/oxfordizeArray';
 
 import type {Plan} from 'getsentry/types';
+import {getSingularCategoryName, listDisplayNames} from 'getsentry/utils/dataCategory';
+import {displayUnitPrice} from 'getsentry/views/amCheckout/utils';
+
+interface PlanFeatureInfo {
+  features: string[];
+  perUnitPriceDiffs: Partial<Record<DataCategory, number>>;
+  plan: Plan;
+}
 
 // TODO(checkout v3): Move features list to backend
 const FEATURES: Array<{features: string[]; plan: string}> = [
@@ -70,13 +83,37 @@ function PlanFeatures({
   activePlan: Plan;
   planOptions: Plan[];
 }) {
-  const planName = activePlan.name.toLowerCase();
-  const featureList = FEATURES.filter(({plan}) =>
-    planOptions.some(p => p.name.toLowerCase().includes(plan))
-  );
-  const featureListIndex = featureList.findIndex(feature =>
-    planName.includes(feature.plan)
-  );
+  const planToFeatures: PlanFeatureInfo[] = [];
+  let activePlanIndex = 0;
+  planOptions.forEach((planOption, index) => {
+    const planName = planOption.name.toLowerCase();
+    const priorPlan = index > 0 ? planOptions[index - 1] : null;
+    const featureList = FEATURES.filter(({plan}) => planName.includes(plan)).flatMap(
+      ({features}) => features
+    );
+    const perUnitPriceDiffs =
+      !priorPlan || priorPlan?.basePrice === 0
+        ? {}
+        : Object.entries(planOption.planCategories).reduce(
+            (acc, [category, eventBuckets]) => {
+              const priorPlanEventBuckets =
+                priorPlan?.planCategories[category as DataCategory];
+              const currentStartingPrice = eventBuckets[1]?.onDemandPrice ?? 0;
+              const priorStartingPrice = priorPlanEventBuckets?.[1]?.onDemandPrice ?? 0;
+              const perUnitPriceDiff = currentStartingPrice - priorStartingPrice;
+              if (perUnitPriceDiff > 0) {
+                acc[category as DataCategory] = perUnitPriceDiff;
+              }
+              return acc;
+            },
+            {} as Partial<Record<DataCategory, number>>
+          );
+    planToFeatures.push({plan: planOption, features: featureList, perUnitPriceDiffs});
+    if (planOption.name.toLowerCase() === activePlan.name.toLowerCase()) {
+      activePlanIndex = index;
+    }
+  });
+
   return (
     <Flex
       background="primary"
@@ -90,14 +127,52 @@ function PlanFeatures({
         {t("What's included")}
       </Heading>
       <Grid columns={`repeat(${planOptions.length}, 1fr)`} gap="sm">
-        {featureList.map(({plan, features}, index) => {
-          const isIncluded = featureListIndex >= index;
-          const dataTestId = `${plan}-features-${isIncluded ? 'included' : 'excluded'}`;
+        {planToFeatures.map(({plan, features, perUnitPriceDiffs}, index) => {
+          const planName = plan.name;
+          const lowerCasePlanName = planName.toLowerCase();
+          const isIncluded = activePlanIndex >= index;
+          const dataTestId = `${lowerCasePlanName}-features-${isIncluded ? 'included' : 'excluded'}`;
           return (
-            <Flex data-test-id={dataTestId} key={plan} direction="column" gap="sm">
+            <Flex
+              data-test-id={dataTestId}
+              key={lowerCasePlanName}
+              direction="column"
+              gap="sm"
+            >
               {features.map(feature => (
                 <FeatureItem key={feature} feature={feature} isIncluded={isIncluded} />
               ))}
+              {Object.keys(perUnitPriceDiffs).length > 0 && (
+                <EventPriceWarning align="center" gap="sm">
+                  <Tooltip
+                    title={tct('Starting at [priceDiffs].', {
+                      priceDiffs: oxfordizeArray(
+                        Object.entries(perUnitPriceDiffs).map(([category, diff]) => {
+                          const formattedDiff = displayUnitPrice({cents: diff});
+                          const formattedCategory = getSingularCategoryName({
+                            plan,
+                            category: category as DataCategory,
+                            capitalize: false,
+                          });
+                          return `+${formattedDiff} / ${formattedCategory}`;
+                        })
+                      ),
+                    })}
+                  >
+                    {/* TODO(checkout v3): verify tooltip copy */}
+                    <Text as="span" size="sm" variant="muted">
+                      {tct('*Excess usage for [categories] costs more on [planName]', {
+                        categories: listDisplayNames({
+                          plan,
+                          categories: Object.keys(perUnitPriceDiffs) as DataCategory[],
+                          shouldTitleCase: true,
+                        }),
+                        planName,
+                      })}
+                    </Text>
+                  </Tooltip>
+                </EventPriceWarning>
+              )}
             </Flex>
           );
         })}
@@ -107,3 +182,10 @@ function PlanFeatures({
 }
 
 export default PlanFeatures;
+
+const EventPriceWarning = styled(Flex)`
+  > span {
+    text-decoration: underline dotted;
+    text-decoration-color: ${p => p.theme.subText};
+  }
+`;

--- a/static/gsApp/views/amCheckout/planFeatures.tsx
+++ b/static/gsApp/views/amCheckout/planFeatures.tsx
@@ -126,7 +126,7 @@ function PlanFeatures({
       <Heading as="h3" size="xl">
         {t("What's included")}
       </Heading>
-      <Grid columns={`repeat(${planOptions.length}, 1fr)`} gap="sm">
+      <Grid columns={{xs: '1fr', sm: `repeat(${planOptions.length}, 1fr)`}} gap="sm">
         {planToFeatures.map(({plan, features, perUnitPriceDiffs}, index) => {
           const planName = plan.name;
           const lowerCasePlanName = planName.toLowerCase();

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.spec.tsx
@@ -6,7 +6,7 @@ import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
-import {resetMockDate, setMockDate, textWithMarkupMatcher} from 'sentry-test/utils';
+import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 import {PlanTier} from 'getsentry/types';
@@ -141,38 +141,6 @@ describe('BuildYourPlan', () => {
       expect(within(businessPlan).getByText('Current')).toBeInTheDocument();
       const teamPlan = screen.getByTestId('plan-option-am3_team');
       expect(within(teamPlan).queryByText('Current')).not.toBeInTheDocument();
-    });
-
-    it('renders targeted features when there is a referrer', async () => {
-      renderCheckout(true, 'upgrade-business-landing.relay');
-
-      const businessPlan = await screen.findByTestId('plan-option-am3_business');
-      const teamPlan = screen.getByTestId('plan-option-am3_team');
-      const warningText = textWithMarkupMatcher(
-        'This plan does not include Advanced server-side filtering'
-      );
-
-      await userEvent.click(businessPlan); // ensure we're on the business plan
-      expect(within(businessPlan).getByRole('radio')).toBeChecked();
-
-      // We don't nudge the user for features if they're already
-      // choosing that plan
-      const advancedFiltering = within(businessPlan)
-        .getByText('Advanced server-side filtering')
-        .closest('div')!;
-      await userEvent.click(businessPlan);
-      expect(
-        within(advancedFiltering).queryByText('Looking for this?')
-      ).not.toBeInTheDocument();
-      expect(within(teamPlan).queryByText(warningText)).not.toBeInTheDocument();
-
-      // Clicking Team shows all the warnings and nudges
-      await userEvent.click(teamPlan);
-      expect(within(teamPlan).getByRole('radio')).toBeChecked();
-      expect(
-        within(advancedFiltering).getByText('Looking for this?')
-      ).toBeInTheDocument();
-      expect(within(teamPlan).getByText(warningText)).toBeInTheDocument();
     });
 
     it('can select plan', async () => {

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.tsx
@@ -113,8 +113,6 @@ function PlanSubstep({
             subscription,
             organization
           );
-          const planIndex = planOptions.indexOf(plan);
-          const priorPlan = planIndex > 0 ? planOptions[planIndex - 1] : undefined;
           const basePrice = utils.formatPrice({cents: plan.basePrice}); // TODO(isabella): confirm discountInfo is no longer used
 
           let planContent = utils.getContentForPlan(plan);
@@ -145,8 +143,6 @@ function PlanSubstep({
               highlightedFeatures={highlightedFeatures}
               planIcon={planIcon}
               shouldShowDefaultPayAsYouGo={shouldShowDefaultPayAsYouGo}
-              shouldShowEventPrice={!!isBizPlanFamily(plan)}
-              priorPlan={priorPlan}
               badge={badge}
             />
           );

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.tsx
@@ -15,10 +15,10 @@ import {
   isBizPlanFamily,
   isDeveloperPlan,
   isNewPayingCustomer,
-  isTeamPlanFamily,
   isTrialPlan,
 } from 'getsentry/utils/billing';
 import BillingCycleSelectCard from 'getsentry/views/amCheckout/billingCycleSelectCard';
+import PlanFeatures from 'getsentry/views/amCheckout/planFeatures';
 import ReserveAdditionalVolume from 'getsentry/views/amCheckout/reserveAdditionalVolume';
 import {getHighlightedFeatures} from 'getsentry/views/amCheckout/steps/planSelect';
 import PlanSelectCard from 'getsentry/views/amCheckout/steps/planSelectCard';
@@ -27,7 +27,6 @@ import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
 import type {
   CheckoutFormData,
   CheckoutV3StepProps,
-  PlanContent,
 } from 'getsentry/views/amCheckout/types';
 import * as utils from 'getsentry/views/amCheckout/utils';
 
@@ -74,17 +73,6 @@ function PlanSubstep({
     // sort by price ascending
     return plans.sort((a, b) => a.basePrice - b.basePrice);
   }, [billingConfig, activePlan.contractInterval]);
-
-  const bizPlanContent: PlanContent = useMemo(() => {
-    const bizPlan = billingConfig.planList.find(p => isBizPlanFamily(p));
-    if (!bizPlan) {
-      return {
-        description: '',
-        features: {},
-      };
-    }
-    return utils.getContentForPlan(bizPlan);
-  }, [billingConfig]);
 
   const getBadge = (plan: Plan): React.ReactNode | undefined => {
     if (
@@ -141,13 +129,6 @@ function PlanSubstep({
             planContent.features.deactivated_member_header = t('Unlimited members');
           }
 
-          let missingFeatures: string[] = [];
-          if (isTeamPlanFamily(plan) && isSelected) {
-            missingFeatures = getHighlightedFeatures(referrer).filter(
-              feature => !planContent.features[feature]
-            );
-          }
-
           const planIcon = getPlanIcon(plan);
           const badge = getBadge(plan);
 
@@ -167,12 +148,11 @@ function PlanSubstep({
               shouldShowEventPrice={!!isBizPlanFamily(plan)}
               priorPlan={priorPlan}
               badge={badge}
-              missingFeatures={missingFeatures}
-              upsellPlanContent={bizPlanContent}
             />
           );
         })}
       </OptionGrid>
+      <PlanFeatures planOptions={planOptions} activePlan={activePlan} />
       <ReserveAdditionalVolume
         activePlan={activePlan}
         formData={formData}


### PR DESCRIPTION
Move list of features out of plan select cards to a separate component which renders checks based on active plan.

<img width="847" height="542" alt="Screenshot 2025-09-11 at 5 29 07 PM" src="https://github.com/user-attachments/assets/932e01fe-c8fc-4ca4-b52f-103ab2d31fb7" />
