### PR TITLE
fix(logs): Ensure subtrees arent overwritten

### DIFF
--- a/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
@@ -126,7 +126,7 @@ function addToAttributeTree(
   if (hasInvalidBranchCount || hasInvalidBranchSequence) {
     tree[attribute.attribute_key] = {
       value: attribute.attribute_value,
-      subtree: {},
+      subtree: tree[attribute.attribute_key]?.subtree ?? {},
       meta,
       originalAttribute,
     };


### PR DESCRIPTION
If attributes are written in the wrong order, the subtree gets overwritten.

Closes LOGS-281