### PR TITLE
feat(dynamic-sampling): Add org effective sample rate endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_sampling_effective_sample_rate.py
+++ b/src/sentry/api/endpoints/organization_sampling_effective_sample_rate.py
@@ -1,0 +1,67 @@
+from datetime import timedelta
+from typing import TypedDict
+
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import OrganizationEndpoint, OrganizationPermission
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.apidocs.constants import RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.dynamic_sampling.tasks.common import get_organization_volume
+from sentry.models.organization import Organization
+
+
+class OrganizationSamplingEffectiveSampleRateResponse(TypedDict):
+    effectiveSampleRate: float | None
+
+
+@region_silo_endpoint
+class OrganizationSamplingEffectiveSampleRateEndpoint(OrganizationEndpoint):
+    """Return the organization's effective sample rate over the last 24h.
+
+    The effective sample rate is computed as indexed / total where:
+    - total = total number of transactions received
+    - indexed = number of transactions kept (indexed)
+    """
+
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    permission_classes = (OrganizationPermission,)
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+
+    @extend_schema(
+        operation_id="Retrieve an Organization's Effective Sample Rate (24h)",
+        tags=["Organizations"],
+        parameters=[GlobalParams.ORG_ID_OR_SLUG],
+        request=None,
+        responses={
+            200: inline_sentry_response_serializer(
+                "OrganizationSamplingEffectiveSampleRateResponse",
+                OrganizationSamplingEffectiveSampleRateResponse,
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(self, request: Request, organization: Organization) -> Response:
+        if not features.has("organizations:dynamic-sampling", organization, actor=request.user):
+            # Maintain parity with previous serializer logic that only exposed
+            # effective sample rate when the org had dynamic sampling enabled.
+            raise ResourceDoesNotExist
+
+        org_volume = get_organization_volume(organization.id, time_interval=timedelta(hours=24))
+        rate: float | None
+        if org_volume is not None and org_volume.indexed is not None and org_volume.total > 0:
+            rate = org_volume.indexed / org_volume.total
+        else:
+            rate = None
+
+        return Response(status=200, data={"effectiveSampleRate": rate})

--- a/src/sentry/api/endpoints/organization_sampling_effective_sample_rate.py
+++ b/src/sentry/api/endpoints/organization_sampling_effective_sample_rate.py
@@ -53,8 +53,6 @@ class OrganizationSamplingEffectiveSampleRateEndpoint(OrganizationEndpoint):
     )
     def get(self, request: Request, organization: Organization) -> Response:
         if not features.has("organizations:dynamic-sampling", organization, actor=request.user):
-            # Maintain parity with previous serializer logic that only exposed
-            # effective sample rate when the org had dynamic sampling enabled.
             raise ResourceDoesNotExist
 
         org_volume = get_organization_volume(organization.id, time_interval=timedelta(hours=24))

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import sentry_sdk
@@ -60,6 +60,7 @@ from sentry.constants import (
     ObjectStatus,
 )
 from sentry.db.models.fields.slug import DEFAULT_SLUG_MAX_LENGTH
+from sentry.dynamic_sampling.tasks.common import get_organization_volume
 from sentry.dynamic_sampling.tasks.helpers.sample_rate import get_org_sample_rate
 from sentry.dynamic_sampling.utils import (
     has_custom_dynamic_sampling,
@@ -513,7 +514,7 @@ class _DetailedOrganizationSerializerResponseOptional(OrganizationSerializerResp
     orgRole: str
     targetSampleRate: float
     samplingMode: str
-    # moved to separate endpoint: OrganizationSamplingEffectiveSampleRateEndpoint
+    effectiveSampleRate: float
     planSampleRate: float
     desiredSampleRate: float
     ingestThroughTrustedRelaysOnly: bool
@@ -777,6 +778,11 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         if access.role is not None:
             context["role"] = access.role  # Deprecated
             context["orgRole"] = access.role
+
+        if features.has("organizations:dynamic-sampling", obj):
+            org_volume = get_organization_volume(obj.id, timedelta(hours=24))
+            if org_volume is not None and org_volume.indexed is not None and org_volume.total > 0:
+                context["effectiveSampleRate"] = org_volume.indexed / org_volume.total
 
         if sample_rate is not None:
             context["planSampleRate"] = sample_rate

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -25,6 +25,9 @@ from sentry.api.endpoints.organization_releases import (
 from sentry.api.endpoints.organization_sampling_admin_metrics import (
     OrganizationDynamicSamplingAdminMetricsEndpoint,
 )
+from sentry.api.endpoints.organization_sampling_effective_sample_rate import (
+    OrganizationSamplingEffectiveSampleRateEndpoint,
+)
 from sentry.api.endpoints.organization_sampling_project_span_counts import (
     OrganizationSamplingProjectSpanCountsEndpoint,
 )
@@ -1586,6 +1589,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/sampling/project-root-counts/$",
         OrganizationSamplingProjectSpanCountsEndpoint.as_view(),
         name="sentry-api-0-organization-sampling-root-counts",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/sampling/effective-sample-rate/$",
+        OrganizationSamplingEffectiveSampleRateEndpoint.as_view(),
+        name="sentry-api-0-organization-sampling-effective-sample-rate",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/sampling/admin-metrics/$",

--- a/tests/sentry/api/endpoints/test_organization_sampling_effective_sample_rate.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_effective_sample_rate.py
@@ -1,0 +1,49 @@
+import pytest
+from django.utils import timezone
+
+from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
+from sentry.testutils.cases import APITestCase, BaseMetricsLayerTestCase
+
+pytestmark = pytest.mark.sentry_metrics
+
+
+class OrganizationSamplingEffectiveSampleRateEndpointTest(APITestCase, BaseMetricsLayerTestCase):
+    endpoint = "sentry-api-0-organization-sampling-effective-sample-rate"
+    method = "GET"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+
+    @property
+    def now(self):
+        # BaseMetricsLayerTestCase expects subclasses to provide a reference time
+        return timezone.now()
+
+    def test_without_feature(self) -> None:
+        self.get_error_response(self.organization.slug, status_code=404)
+
+    def test_get(self) -> None:
+        project = self.create_project(teams=[self.team])
+
+        # Create 3 root transactions in the last minute: 2 dropped, 1 kept → rate = 1/3
+        for decision in ["drop", "drop", "keep"]:
+            self.store_performance_metric(
+                name=TransactionMRI.COUNT_PER_ROOT_PROJECT.value,
+                tags={"transaction": "foo_transaction", "decision": decision},
+                minutes_before_now=1,
+                value=1,
+                project_id=project.id,
+                org_id=self.organization.id,
+            )
+
+        with self.feature("organizations:dynamic-sampling"):
+            response = self.get_success_response(self.organization.slug)
+
+        assert response.data["effectiveSampleRate"] == pytest.approx(1.0 / 3.0, rel=1e-6)
+
+    def test_no_data(self) -> None:
+        with self.feature("organizations:dynamic-sampling"):
+            response = self.get_success_response(self.organization.slug)
+
+        assert response.data == {"effectiveSampleRate": None}


### PR DESCRIPTION
The goal is to move the snuba query fetching effective sample rate out of the detailed org serializer.

It will happen in three steps:
1. Add new endpoint to get information
2. Move UI to new endpoint
3. Remove from organization serializer

part of RTC-1188

route /organizations/:orgId/sampling/effective-sample-rate/