### PR TITLE
fix(search-bar): Fix selecting options with square parenthesis

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -85,6 +85,13 @@ const FILTER_KEYS: TagCollection = {
     kind: FieldKind.FIELD,
     predefined: false,
   },
+  message: {
+    key: 'mesage',
+    name: 'Message',
+    kind: FieldKind.FIELD,
+    predefined: true,
+    values: ['[Filtered]'],
+  },
   custom_tag_name: {
     key: 'custom_tag_name',
     name: 'Custom_Tag_Name',
@@ -1049,6 +1056,20 @@ describe('SearchQueryBuilder', () => {
         name: '!browser.name:""',
       });
       expect(browserNameFilter).toBeInTheDocument();
+    });
+
+    it('selects [Filtered] from dropdown', async () => {
+      render(<SearchQueryBuilder {...defaultProps} />);
+      await userEvent.click(getLastInput());
+
+      await userEvent.type(
+        screen.getByRole('combobox', {name: 'Add a search term'}),
+        'message:'
+      );
+      await userEvent.click(screen.getByRole('option', {name: '[Filtered]'}));
+      expect(
+        await screen.findByRole('row', {name: 'message:"[Filtered]"'})
+      ).toBeInTheDocument();
     });
   });
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -86,7 +86,7 @@ const FILTER_KEYS: TagCollection = {
     predefined: false,
   },
   message: {
-    key: 'mesage',
+    key: 'message',
     name: 'Message',
     kind: FieldKind.FIELD,
     predefined: true,

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -113,14 +113,24 @@ export function getValidOpsForFilter(
   return [...validOps];
 }
 
-export function escapeTagValue(value: string): string {
+interface EscapeTagValueOptions {
+  allowArrayValue?: boolean;
+}
+
+export function escapeTagValue(
+  value: string,
+  options: EscapeTagValueOptions = {}
+): string {
   if (!value) {
     return '';
   }
 
+  const {allowArrayValue = true} = options;
+
   // Wrap in quotes if there is a space or parens
   const shouldEscape =
-    SHOULD_ESCAPE_REGEX.test(value) || (value.startsWith('[') && value.endsWith(']'));
+    SHOULD_ESCAPE_REGEX.test(value) ||
+    (allowArrayValue && value.startsWith('[') && value.endsWith(']'));
   return shouldEscape ? `"${escapeDoubleQuotes(value)}"` : value;
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -119,7 +119,9 @@ export function escapeTagValue(value: string): string {
   }
 
   // Wrap in quotes if there is a space or parens
-  return SHOULD_ESCAPE_REGEX.test(value) ? `"${escapeDoubleQuotes(value)}"` : value;
+  const shouldEscape =
+    SHOULD_ESCAPE_REGEX.test(value) || (value.startsWith('[') && value.endsWith(']'));
+  return shouldEscape ? `"${escapeDoubleQuotes(value)}"` : value;
 }
 
 export function unescapeTagValue(value: string): string {

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -668,7 +668,7 @@ export function SearchQueryBuilderValueCombobox({
             getFilterValueType(token, fieldDefinition),
             selectedValuesUnescaped
               .filter(v => (v.selected ? v.value !== value : true))
-              .map(v => escapeTagValue(v.value))
+              .map(v => escapeTagValue(v.value, {allowArrayValue: false}))
               .join(',')
           );
 


### PR DESCRIPTION
When selecting values surrounded with square parenthesis, it should be treated as a value not as an array.

Closes LOGS-99