### PR TITLE
ref(releases): Remove existing unused resolution type in_upcoming_release 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,7 @@ lines_between_sections = 1
 known_first_party = "sentry"
 skip = "migrations"
 # feature appears bugged in isort 6.x pycqa/isort#2352
-split_on_trailing_comma = false
+# split_on_trailing_comma setting is no longer supported in isort 6.x
 
 [tool.pytest.ini_options]
 python_files = "test_*.py sentry/testutils/*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,7 @@ lines_between_sections = 1
 known_first_party = "sentry"
 skip = "migrations"
 # feature appears bugged in isort 6.x pycqa/isort#2352
-# split_on_trailing_comma setting is no longer supported in isort 6.x
+split_on_trailing_comma = false
 
 [tool.pytest.ini_options]
 python_files = "test_*.py sentry/testutils/*"

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -389,17 +389,6 @@ def handle_resolve_in_release(
         res_type = GroupResolution.Type.in_next_release
         res_type_str = "in_next_release"
         res_status = GroupResolution.Status.pending
-    elif status_details.get("inUpcomingRelease"):
-        if len(projects) > 1:
-            raise MultipleProjectsError()
-        release = status_details.get("inUpcomingRelease") or most_recent_release(projects[0])
-        activity_type = ActivityType.SET_RESOLVED_IN_RELEASE.value
-        activity_data = {"version": ""}
-
-        new_status_details["inUpcomingRelease"] = True
-        res_type = GroupResolution.Type.in_upcoming_release
-        res_type_str = "in_upcoming_release"
-        res_status = GroupResolution.Status.pending
     elif status_details.get("inRelease"):
         # TODO(jess): We could update validation to check if release
         # applies to multiple projects, but I think we agreed to punt
@@ -761,11 +750,7 @@ def prepare_response(
     # what performance impact this might have & this possibly should be moved else where
     try:
         if len(group_list) == 1:
-            if res_type in (
-                GroupResolution.Type.in_next_release,
-                GroupResolution.Type.in_release,
-                GroupResolution.Type.in_upcoming_release,
-            ):
+            if res_type in (GroupResolution.Type.in_next_release, GroupResolution.Type.in_release):
                 result["activity"] = serialize(
                     Activity.objects.get_activities_for_group(
                         group=group_list[0], num=ACTIVITIES_COUNT

--- a/src/sentry/api/helpers/group_index/validators/status_details.py
+++ b/src/sentry/api/helpers/group_index/validators/status_details.py
@@ -3,14 +3,12 @@ from typing import NotRequired, TypedDict
 from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 
-from sentry import features
 from sentry.api.helpers.group_index.validators.in_commit import InCommitResult, InCommitValidator
 from sentry.models.release import Release
 
 
 class StatusDetailsResult(TypedDict):
     inNextRelease: NotRequired[bool]
-    inUpcomingRelease: NotRequired[bool]
     inRelease: NotRequired[str]
     inCommit: NotRequired[InCommitResult]
     ignoreDuration: NotRequired[int]
@@ -24,9 +22,6 @@ class StatusDetailsResult(TypedDict):
 class StatusDetailsValidator(serializers.Serializer[StatusDetailsResult]):
     inNextRelease = serializers.BooleanField(
         help_text="If true, marks the issue as resolved in the next release."
-    )
-    inUpcomingRelease = serializers.BooleanField(
-        help_text="If true, marks the issue as resolved in the upcoming release."
     )
     inRelease = serializers.CharField(
         help_text=(
@@ -92,20 +87,3 @@ class StatusDetailsValidator(serializers.Serializer[StatusDetailsResult]):
             raise serializers.ValidationError(
                 "No release data present in the system to form a basis for 'Next Release'"
             )
-
-    def validate_inUpcomingRelease(self, value: bool) -> "Release":
-        project = self.context["project"]
-
-        if not features.has("organizations:resolve-in-upcoming-release", project.organization):
-            raise serializers.ValidationError(
-                "Your organization does not have access to this feature."
-            )
-
-        try:
-            return (
-                Release.objects.filter(projects=project, organization_id=project.organization_id)
-                .extra(select={"sort": "COALESCE(date_released, date_added)"})
-                .order_by("-sort")[0]
-            )
-        except IndexError:
-            raise serializers.ValidationError("No release data present in the system.")

--- a/src/sentry/apidocs/examples/issue_examples.py
+++ b/src/sentry/apidocs/examples/issue_examples.py
@@ -132,7 +132,6 @@ MUTATE_ISSUE_RESULT: MutateIssueResponse = {
         "ignoreUserCount": 10,
         "ignoreUserWindow": 60,
         "inNextRelease": False,
-        "inUpcomingRelease": False,
         "inRelease": "1.0.0",
         "inCommit": {
             "commit": "123def456abc",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -350,9 +350,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:replay-list-select", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable version 2 of reprocessing (completely distinct from v1)
     manager.add("organizations:reprocessing-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Enable resolve in upcoming release
-    # TODO(steve): Remove when we remove the feature from the UI
-    manager.add("organizations:resolve-in-upcoming-release", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable revocation of org auth keys when a user renames an org slug
     manager.add("organizations:revoke-org-auth-on-slug-rename", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable detecting SDK crashes during event processing

--- a/src/sentry/models/groupresolution.py
+++ b/src/sentry/models/groupresolution.py
@@ -30,7 +30,6 @@ class GroupResolution(Model):
     class Type:
         in_release = 0
         in_next_release = 1
-        in_upcoming_release = 2
 
     class Status:
         pending = 0
@@ -144,8 +143,7 @@ class GroupResolution(Model):
         # We still fallback to the older model if either current_release_version was not set (
         # i.e. In all resolved cases except for Resolved in Next Release) or if for whatever
         # reason the semver/date checks fail (which should not happen!)
-        # todo(roggenkemper): remove upcoming_release check after we know that no group resolutions have it
-        if res_type in (None, cls.Type.in_next_release, cls.Type.in_upcoming_release):
+        if res_type in (None, cls.Type.in_next_release):
             # Add metric here to ensure that this code branch ever runs given that
             # clear_expired_resolutions changes the type to `in_release` once a Release instance
             # is created

--- a/src/sentry/tasks/clear_expired_resolutions.py
+++ b/src/sentry/tasks/clear_expired_resolutions.py
@@ -26,7 +26,7 @@ def clear_expired_resolutions(release_id):
     the system that any pending resolutions older than the given release can now
     be safely transitioned to resolved.
 
-    This is currently only used for ``in_next_release`` and ``in_upcoming_release`` resolutions.
+    This is currently only used for ``in_next_release`` resolution.
     """
     try:
         release = Release.objects.get(id=release_id)
@@ -35,9 +35,7 @@ def clear_expired_resolutions(release_id):
 
     resolution_list = list(
         GroupResolution.objects.filter(
-            Q(type=GroupResolution.Type.in_next_release)
-            | Q(type__isnull=True)
-            | Q(type=GroupResolution.Type.in_upcoming_release),
+            Q(type=GroupResolution.Type.in_next_release) | Q(type__isnull=True),
             release__projects__in=[p.id for p in release.projects.all()],
             release__date_added__lt=release.date_added,
             status=GroupResolution.Status.pending,

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -34,7 +34,7 @@ from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, SnubaTestCase
-from sentry.testutils.helpers import parse_link_header, with_feature
+from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
@@ -837,83 +837,6 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
         )
         assert activity.data["version"] == ""
-
-    @with_feature("organizations:resolve-in-upcoming-release")
-    def test_set_resolved_in_upcoming_release(self) -> None:
-        release = Release.objects.create(organization_id=self.project.organization_id, version="a")
-        release.add_project(self.project)
-
-        group = self.create_group(status=GroupStatus.UNRESOLVED)
-
-        self.login_as(user=self.user)
-
-        url = f"{self.path}?id={group.id}"
-        response = self.client.put(
-            url,
-            data={"status": "resolved", "statusDetails": {"inUpcomingRelease": True}},
-            format="json",
-        )
-        assert response.status_code == 200
-        assert response.data["status"] == "resolved"
-        assert response.data["statusDetails"]["inUpcomingRelease"]
-        assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
-        assert "activity" in response.data
-
-        group = Group.objects.get(id=group.id)
-        assert group.status == GroupStatus.RESOLVED
-
-        resolution = GroupResolution.objects.get(group=group)
-        assert resolution.release == release
-        assert resolution.type == GroupResolution.Type.in_upcoming_release
-        assert resolution.status == GroupResolution.Status.pending
-        assert resolution.actor_id == self.user.id
-
-        assert GroupSubscription.objects.filter(
-            user_id=self.user.id, group=group, is_active=True
-        ).exists()
-
-        activity = Activity.objects.get(
-            group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
-        )
-        assert activity.data["version"] == ""
-
-    def test_upcoming_release_flag_validation(self) -> None:
-        release = Release.objects.create(organization_id=self.project.organization_id, version="a")
-        release.add_project(self.project)
-
-        group = self.create_group(status=GroupStatus.UNRESOLVED)
-
-        self.login_as(user=self.user)
-
-        url = f"{self.path}?id={group.id}"
-        response = self.client.put(
-            url,
-            data={"status": "resolved", "statusDetails": {"inUpcomingRelease": True}},
-            format="json",
-        )
-        assert response.status_code == 400
-        assert (
-            response.data["statusDetails"]["inUpcomingRelease"][0]
-            == "Your organization does not have access to this feature."
-        )
-
-    @with_feature("organizations:resolve-in-upcoming-release")
-    def test_upcoming_release_release_validation(self) -> None:
-        group = self.create_group(status=GroupStatus.UNRESOLVED)
-
-        self.login_as(user=self.user)
-
-        url = f"{self.path}?id={group.id}"
-        response = self.client.put(
-            url,
-            data={"status": "resolved", "statusDetails": {"inUpcomingRelease": True}},
-            format="json",
-        )
-        assert response.status_code == 400
-        assert (
-            response.data["statusDetails"]["inUpcomingRelease"][0]
-            == "No release data present in the system."
-        )
 
     def test_set_resolved_in_explicit_commit_unreleased(self) -> None:
         repo = self.create_repo(project=self.project, name=self.project.name)


### PR DESCRIPTION
This resolution type is old, not used in the frontend, and there are no plans to roll it out further than the sentry org and the richard-nextjs org. Let's remove it.

There are currently no groups in the sentry org that use this resolution type.

Removal of this resolution type from the frontend: https://github.com/getsentry/sentry/pull/95949