### PR TITLE
bugfix(workflow_engine): Fix issue where detectors were resolving incorrectly

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -391,8 +391,9 @@ class StatefulDetectorHandler(
                 group_data_values[group_key]
             )
 
-            if condition_results is None:
+            if condition_results is None or condition_results.logic_result is False:
                 # Invalid condition result, nothing we can do
+                # Or if we didn't match any conditions in the evaluation
                 continue
 
             if state_data.status == evaluated_priority:

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -119,7 +119,7 @@ class DataCondition(DefaultFieldsModel):
     """
 
     __relocation_scope__ = RelocationScope.Organization
-    __repr__ = sane_repr("type", "condition", "condition_group")
+    __repr__ = sane_repr("type", "comparison", "condition_result", "condition_group_id")
 
     # The comparison is the value that the condition is compared to for the evaluation, this must be a primitive value
     comparison = models.JSONField()

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -201,6 +201,14 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
             condition_result=DetectorPriorityLevel.HIGH,
             condition_group=detector.workflow_condition_group,
         )
+
+        # add a default resolution case
+        self.create_data_condition(
+            type=Condition.LESS_OR_EQUAL,
+            comparison=5,
+            condition_result=DetectorPriorityLevel.OK,
+            condition_group=detector.workflow_condition_group,
+        )
         return detector, data_condition
 
     def build_handler(

--- a/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
@@ -159,7 +159,9 @@ class TestStatefulDetectorHandlerEvaluate(TestCase):
         self.detector.workflow_condition_group = self.create_data_condition_group()
 
         def add_condition(
-            self, val: str | int, result: DetectorPriorityLevel, condition_type: str = "eq"
+            val: str | int,
+            result: DetectorPriorityLevel,
+            condition_type: str = "eq",
         ) -> None:
             self.create_data_condition(
                 type=condition_type,
@@ -192,12 +194,12 @@ class TestStatefulDetectorHandlerEvaluate(TestCase):
         mappings.
         """
         if isinstance(result, DetectorPriorityLevel):
-            result = result.name
+            value = result.name
 
         packet = {
             "id": str(key),
             "dedupe": key,
-            "group_vals": {self.group_key: result},
+            "group_vals": {self.group_key: value},
         }
         return DataPacket(source_id=str(key), packet=packet)
 

--- a/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
@@ -4,7 +4,11 @@ from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.models import DataPacket, Detector
-from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel
+from sentry.workflow_engine.types import (
+    DataConditionResult,
+    DetectorGroupKey,
+    DetectorPriorityLevel,
+)
 from tests.sentry.workflow_engine.handlers.detector.test_base import MockDetectorStateHandler
 
 Level = DetectorPriorityLevel
@@ -185,7 +189,7 @@ class TestStatefulDetectorHandlerEvaluate(TestCase):
             },
         )
 
-    def packet(self, key: int, result: DetectorPriorityLevel | int) -> DataPacket:
+    def packet(self, key: int, result: DataConditionResult | str) -> DataPacket:
         """
         Constructs a test data packet that will evaluate to the
         DetectorPriorityLevel specified for the result parameter.
@@ -193,6 +197,7 @@ class TestStatefulDetectorHandlerEvaluate(TestCase):
         See the `add_condition` to understand the priority level -> group value
         mappings.
         """
+        value = result
         if isinstance(result, DetectorPriorityLevel):
             value = result.name
 


### PR DESCRIPTION
## Description
There's a case where the conditions could look like; `x > 100` and `x <= 50`. When `x = 75`, the detector would resolve because the sentinel value being returned for the new priority is `OK`. 

This updates the checks by ensuring at least 1 condition is met before continuing to see if the detector should be updated. Since we'd need the result from the condition to correctly change the detector state, we can simply check if any condition has been met.