### PR TITLE
perf(aci): Batch data condition list fetches

### DIFF
--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -92,7 +92,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         return {"name": self.name}
 
     def evaluate_trigger_conditions(
-        self, event_data: WorkflowEventData
+        self, event_data: WorkflowEventData, when_data_conditions: list[DataCondition] | None = None
     ) -> tuple[bool, list[DataCondition]]:
         """
         Evaluate the conditions for the workflow trigger and return if the evaluation was successful.
@@ -118,7 +118,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
             )
             return False, []
         group_evaluation, remaining_conditions = process_data_condition_group(
-            group, workflow_event_data
+            group, workflow_event_data, when_data_conditions
         )
         return group_evaluation.logic_result, remaining_conditions
 

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -166,6 +166,7 @@ def evaluate_data_conditions(
 def process_data_condition_group(
     group: DataConditionGroup,
     value: T,
+    data_conditions_for_group: list[DataCondition] | None = None,
 ) -> DataConditionGroupResult:
     condition_results: list[ProcessedDataCondition] = []
 
@@ -180,7 +181,9 @@ def process_data_condition_group(
 
     # Check if conditions are already prefetched before using cache
     all_conditions: list[DataCondition]
-    if (
+    if data_conditions_for_group is not None:
+        all_conditions = data_conditions_for_group
+    elif (
         hasattr(group, "_prefetched_objects_cache")
         and "conditions" in group._prefetched_objects_cache
     ):

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -439,8 +439,10 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
     @patch.object(get_data_conditions_for_group, "batch")
     def test_batched_data_condition_lookup_is_used(self, mock_batch):
         """Test that batch lookup is used when evaluating multiple workflows."""
-        workflow_two, _, _, triggers_two = self.create_detector_and_workflow(name_prefix="two")
+        workflow_two, _, _, _ = self.create_detector_and_workflow(name_prefix="two")
 
+        assert self.workflow.when_condition_group
+        assert workflow_two.when_condition_group
         # Mock the batch method to return the expected data
         mock_batch.return_value = [
             list(self.workflow.when_condition_group.conditions.all()),


### PR DESCRIPTION
In process_workflows_event, we frequently have hundreds of DataConditionGroups being processed, each with their own list of DataConditions. In slower cases, a majority of the execution time is spent fetching DataConditions one by one.
By batch fetching when we have a full list to be iterated, we can turn hundreds of cache round trips to just a couple and hopefully improve performance significantly enough to justify the additional interface complexity.
