### PR TITLE
fix(aci): Make process_workflows_event ignore Group.DoesNotExist

### DIFF
--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -99,7 +99,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
         ),
     ),
 )
-@retry(timeouts=True, exclude=(EventNotFoundError, Group.DoesNotExist))
+@retry(timeouts=True, exclude=EventNotFoundError, ignore=Group.DoesNotExist)
 def process_workflows_event(
     project_id: int,
     event_id: str,


### PR DESCRIPTION
We expect Groups to not exist after they're deleted; we should assume it's intentional and exit quietly.

Fixes SENTRY-4E81.

