### PR TITLE
fix(flamegraph): Update highlighted frame when clicking calltree

### DIFF
--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -907,6 +907,10 @@ export function useVirtualizedTree<T extends TreeLike>(
     };
   }, [props.scrollContainer, props.rowHeight]);
 
+  const getNodeAtIndex = useCallback((index: number) => {
+    return latestItemsRef.current.find(row => row.key === index)?.item?.node;
+  }, []);
+
   return {
     tree,
     items,
@@ -923,5 +927,6 @@ export function useVirtualizedTree<T extends TreeLike>(
     containerStyles,
     clickedGhostRowRef,
     hoveredGhostRowRef,
+    getNodeAtIndex,
   };
 }


### PR DESCRIPTION
When clicking on a frame in the call tree, we should dispatch the highlighted frame event so the side panel can respond appropriately.

Closes PRO-23