### PR TITLE
feat(ACI): Create GroupOpenPeriodsEndpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -279,6 +279,7 @@ from sentry.issues.endpoints import (
     GroupHashesEndpoint,
     GroupNotesDetailsEndpoint,
     GroupNotesEndpoint,
+    GroupOpenPeriodsEndpoint,
     GroupSimilarIssuesEmbeddingsEndpoint,
     GroupSimilarIssuesEndpoint,
     GroupTombstoneDetailsEndpoint,
@@ -838,6 +839,11 @@ def create_group_urls(name_prefix: str) -> list[URLPattern | URLResolver]:
             r"^(?P<issue_id>[^/]+)/hashes/$",
             GroupHashesEndpoint.as_view(),
             name=f"{name_prefix}-group-hashes",
+        ),
+        re_path(
+            r"^(?P<issue_id>[^/]+)/open-periods/$",
+            GroupOpenPeriodsEndpoint.as_view(),
+            name=f"{name_prefix}-open-periods",
         ),
         re_path(
             r"^(?P<issue_id>[^/]+)/reprocessing/$",

--- a/src/sentry/issues/endpoints/__init__.py
+++ b/src/sentry/issues/endpoints/__init__.py
@@ -6,6 +6,7 @@ from .group_events import GroupEventsEndpoint
 from .group_hashes import GroupHashesEndpoint
 from .group_notes import GroupNotesEndpoint
 from .group_notes_details import GroupNotesDetailsEndpoint
+from .group_open_periods import GroupOpenPeriodsEndpoint
 from .group_similar_issues import GroupSimilarIssuesEndpoint
 from .group_similar_issues_embeddings import GroupSimilarIssuesEmbeddingsEndpoint
 from .group_tombstone import GroupTombstoneEndpoint
@@ -46,6 +47,7 @@ __all__ = (
     "GroupHashesEndpoint",
     "GroupNotesDetailsEndpoint",
     "GroupNotesEndpoint",
+    "GroupOpenPeriodsEndpoint",
     "GroupSimilarIssuesEmbeddingsEndpoint",
     "GroupSimilarIssuesEndpoint",
     "GroupTombstoneDetailsEndpoint",

--- a/src/sentry/issues/endpoints/group_open_periods.py
+++ b/src/sentry/issues/endpoints/group_open_periods.py
@@ -23,9 +23,7 @@ class GroupOpenPeriodsEndpoint(GroupEndpoint):
         """
         Retrieve all open periods and their activities for a Group
         """
-
         open_periods = get_open_periods_for_group(group, limit=OPEN_PERIOD_LIMIT)
-        # TODO create a serializer
         # TODO add groupopenperiodactivity data per openperiod once that table exists
         data = {"openPeriods": [open_period.to_dict() for open_period in open_periods]}
         return Response(data)

--- a/src/sentry/issues/endpoints/group_open_periods.py
+++ b/src/sentry/issues/endpoints/group_open_periods.py
@@ -1,0 +1,31 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+
+# from sentry.api.serializers import serialize
+from sentry.issues.endpoints.bases.group import GroupEndpoint
+from sentry.models.group import Group
+from sentry.models.groupopenperiod import get_open_periods_for_group
+
+OPEN_PERIOD_LIMIT = 50
+# ACTIVITY_LIMIT = 50
+
+
+@region_silo_endpoint
+class GroupOpenPeriodsEndpoint(GroupEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+
+    def get(self, request: Request, group: Group) -> Response:
+        """
+        Retrieve all open periods and their activities for a Group
+        """
+
+        open_periods = get_open_periods_for_group(group, limit=OPEN_PERIOD_LIMIT)
+        # TODO create a serializer
+        # TODO add groupopenperiodactivity data per openperiod once that table exists
+        data = {"openPeriods": [open_period.to_dict() for open_period in open_periods]}
+        return Response(data)

--- a/src/sentry/issues/endpoints/group_open_periods.py
+++ b/src/sentry/issues/endpoints/group_open_periods.py
@@ -3,8 +3,6 @@ from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-
-# from sentry.api.serializers import serialize
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.group import Group
 from sentry.models.groupopenperiod import get_open_periods_for_group

--- a/tests/sentry/issues/endpoints/test_group_open_periods.py
+++ b/tests/sentry/issues/endpoints/test_group_open_periods.py
@@ -18,7 +18,7 @@ class GroupOpenPeriodsEndpointEndpointTest(APITestCase):
         assert len(open_periods) == 0
 
     @with_feature("organizations:issue-open-periods")
-    def test_endpoint_with_open_periods(self) -> None:
+    def test_endpoint_with_open_period(self) -> None:
         self.group.type = MetricIssue.type_id
         self.group.save()
 
@@ -33,3 +33,7 @@ class GroupOpenPeriodsEndpointEndpointTest(APITestCase):
         assert open_period["duration"] is None
         assert open_period["isOpen"] is True
         # TODO: assert open_period["lastChecked"] > time
+
+    @with_feature("organizations:issue-open-periods")
+    def test_endpoint_with_multiple_open_periods(self) -> None:
+        pass

--- a/tests/sentry/issues/endpoints/test_group_open_periods.py
+++ b/tests/sentry/issues/endpoints/test_group_open_periods.py
@@ -1,0 +1,35 @@
+from sentry.incidents.grouptype import MetricIssue
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
+
+
+class GroupOpenPeriodsEndpointEndpointTest(APITestCase):
+    def setUp(self):
+        self.url = f"/api/0/issues/{self.group.id}/open-periods/"
+        self.group = self.create_group()
+        self.login_as(user=self.user)
+
+    @with_feature("organizations:issue-open-periods")
+    def test_endpoint_with_no_open_periods(self) -> None:
+        response = self.client.get(self.url, format="json")
+
+        assert response.status_code == 200, response.content
+        open_periods = response.data["openPeriods"]
+        assert len(open_periods) == 0
+
+    @with_feature("organizations:issue-open-periods")
+    def test_endpoint_with_open_periods(self) -> None:
+        self.group.type = MetricIssue.type_id
+        self.group.save()
+
+        response = self.client.get(self.url, format="json")
+
+        assert response.status_code == 200, response.content
+        open_periods = response.data["openPeriods"]
+        assert len(open_periods) == 1
+        open_period = open_periods[0]
+        assert open_period["start"] == self.group.first_seen
+        assert open_period["end"] is None
+        assert open_period["duration"] is None
+        assert open_period["isOpen"] is True
+        # TODO: assert open_period["lastChecked"] > time


### PR DESCRIPTION
Create a simple endpoint to return open periods for a given group. This isn't super useful as is, but after the `GroupOpenPeriodActivity` table is created in https://github.com/getsentry/sentry/pull/99272 we can add the activities to each open period for the response. This will be called by the front end to populate the charts on the metric issue details page to show when open periods happened and at which level they were (warning or critical).