### PR TITLE
Double-write and verify objectstore attachments

### DIFF
--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -68,7 +68,9 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
         def stream_attachment():
             filestore_attachment = attachment.getfile()
             objectstore_attachment: IO[bytes] | ContextManager[None] = contextlib.nullcontext()
-            if in_rollout_group("objectstore.double_write.attachments", attachment.project_id):
+            if attachment.blob_path and in_rollout_group(
+                "objectstore.double_write.attachments", attachment.project_id
+            ):
                 # This is a bit ugly admittedly. We have no way to tell whether
                 # an attachment has actually been double-written. We just assume
                 # it was based on the feature flag, which is not the case for all
@@ -78,7 +80,6 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
                     try:
                         # We force the attachment model to use the objectstore backend
                         # by changing its prefix. Its a big hack, but hey why not.
-                        assert attachment.blob_path is not None
                         attachment.blob_path = attachment.blob_path.replace(V1_PREFIX, V2_PREFIX)
                         objectstore_attachment = attachment.getfile()
                         metrics.incr("storage.attachments.double_write.read")
@@ -100,7 +101,6 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
                         except Exception:
                             # If we have encountered one error, clear the objectstore
                             # file, to avoid spamming more errors for all the remaining chunks.
-                            oa.close()
                             oa = None
                             sentry_sdk.capture_exception()
                     yield filestore_chunk

--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -68,7 +68,7 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
         def stream_attachment():
             filestore_attachment = attachment.getfile()
             objectstore_attachment: IO[bytes] | ContextManager[None] = contextlib.nullcontext()
-            if in_rollout_group("objectstore.double_write", attachment.project_id):
+            if in_rollout_group("objectstore.double_write.attachments", attachment.project_id):
                 # This is a bit ugly admittedly. We have no way to tell whether
                 # an attachment has actually been double-written. We just assume
                 # it was based on the feature flag, which is not the case for all
@@ -79,7 +79,7 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
                         # We force the attachment model to use the objectstore backend
                         # by changing its prefix. Its a big hack, but hey why not.
                         assert attachment.blob_path is not None
-                        attachment.blob_path.replace(V1_PREFIX, V2_PREFIX)
+                        attachment.blob_path = attachment.blob_path.replace(V1_PREFIX, V2_PREFIX)
                         objectstore_attachment = attachment.getfile()
                         metrics.incr("storage.attachments.double_write.read")
                     except ClientError as e:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3432,6 +3432,11 @@ register(
 
 # Whether the new objectstore implementation is being used for attachments
 register("objectstore.enable_for.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+# Whether the new objectstore implementation is being used for attachments in a double-write
+# configuration where it writes to the new objectstore alongside the existing filestore.
+# This is mutually exclusive with the above setting.
+register("objectstore.double_write.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 
 # Whether to use 60s granularity for the dynamic sampling query
 register(


### PR DESCRIPTION
This introduces a new deterministic rollout option to double-write attachments to the existing filestore backend, as well as the new objectstore backend.

On the read path, we will then try to read that attachment, and compare the read bytes with the ones from the existing implementation.

The implementation is admittedly very ugly.
Even based on the rollout option, we have no guarantee that an attachment was actually written within the read path. So we just try to read and hope for the best, ignoring and not-found errors.