### PR TITLE
feat(ai): Add `sentry._internal.segment.contains_gen_ai_spans` attribute to segment span for gen ai traces

### DIFF
--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -73,11 +73,16 @@ class TreeEnricher:
         self._ttid_ts = _timestamp_by_op(spans, "ui.load.initial_display")
         self._ttfd_ts = _timestamp_by_op(spans, "ui.load.full_display")
 
+        self._has_gen_ai_spans = False
         self._span_map: dict[str, list[tuple[int, int]]] = {}
         for span in spans:
+
             if parent_span_id := span.get("parent_span_id"):
                 interval = _span_interval(span)
                 self._span_map.setdefault(parent_span_id, []).append(interval)
+
+            if not self._has_gen_ai_spans and get_span_op(span).startswith("gen_ai."):
+                self._has_gen_ai_spans = True
 
     def _data(self, span: SegmentSpan) -> dict[str, Any]:
         ret = {**span.get("data", {})}
@@ -108,6 +113,8 @@ class TreeEnricher:
             for key, value in shared_tags.items():
                 if ret.get(key) is None:
                     ret[key] = value
+            if self._has_gen_ai_spans and span is self._segment_span:
+                ret["hasGenAISpans"] = True
 
         return ret
 

--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -114,7 +114,7 @@ class TreeEnricher:
                 if ret.get(key) is None:
                     ret[key] = value
             if self._has_gen_ai_spans and span is self._segment_span:
-                ret["sentry._internal.has_gen_ai_spans"] = True
+                ret["sentry._internal.segment.contains_gen_ai_spans"] = True
 
         return ret
 

--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -114,7 +114,7 @@ class TreeEnricher:
                 if ret.get(key) is None:
                     ret[key] = value
             if self._has_gen_ai_spans and span is self._segment_span:
-                ret["hasGenAISpans"] = True
+                ret["sentry._internal.has_gen_ai_spans"] = True
 
         return ret
 

--- a/tests/sentry/spans/consumers/process_segments/test_enrichment.py
+++ b/tests/sentry/spans/consumers/process_segments/test_enrichment.py
@@ -425,6 +425,96 @@ def test_write_tags_for_performance_issue_detection():
     }
 
 
+def test_has_gen_ai_spans_field_when_gen_ai_spans_present():
+    segment_span = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        start_timestamp_precise=1609455600.0,
+        end_timestamp_precise=1609455605.0,
+        span_id="aaaaaaaaaaaaaaaa",
+    )
+
+    spans = [
+        segment_span,
+        build_mock_span(
+            project_id=1,
+            start_timestamp_precise=1609455601.0,
+            end_timestamp_precise=1609455602.0,
+            span_id="bbbbbbbbbbbbbbbb",
+            parent_span_id="aaaaaaaaaaaaaaaa",
+            span_op="gen_ai.chat_completion",
+        ),
+        build_mock_span(
+            project_id=1,
+            start_timestamp_precise=1609455602.0,
+            end_timestamp_precise=1609455603.0,
+            span_id="cccccccccccccccc",
+            parent_span_id="aaaaaaaaaaaaaaaa",
+            span_op="http.client",
+        ),
+    ]
+
+    segment_idx, enriched = TreeEnricher.enrich_spans(spans)
+
+    # Check that the segment span has hasGenAISpans field set to True
+    segment_span_data = enriched[segment_idx]["data"]
+    assert segment_span_data.get("hasGenAISpans") is True
+
+    # Check that non-segment spans don't have the field
+    for i, span in enumerate(enriched):
+        if i != segment_idx:
+            assert "hasGenAISpans" not in span["data"]
+
+
+def test_has_gen_ai_spans_field_not_present_without_gen_ai_spans():
+    segment_span = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        start_timestamp_precise=1609455600.0,
+        end_timestamp_precise=1609455605.0,
+        span_id="aaaaaaaaaaaaaaaa",
+    )
+
+    spans = [
+        segment_span,
+        build_mock_span(
+            project_id=1,
+            start_timestamp_precise=1609455601.0,
+            end_timestamp_precise=1609455602.0,
+            span_id="bbbbbbbbbbbbbbbb",
+            parent_span_id="aaaaaaaaaaaaaaaa",
+            span_op="http.client",
+        ),
+        build_mock_span(
+            project_id=1,
+            start_timestamp_precise=1609455602.0,
+            end_timestamp_precise=1609455603.0,
+            span_id="cccccccccccccccc",
+            parent_span_id="aaaaaaaaaaaaaaaa",
+            span_op="db.query",
+        ),
+        build_mock_span(
+            project_id=1,
+            start_timestamp_precise=1609455603.0,
+            end_timestamp_precise=1609455604.0,
+            span_id="dddddddddddddddd",
+            parent_span_id="aaaaaaaaaaaaaaaa",
+            span_op="resource.script",
+        ),
+    ]
+
+    segment_idx, enriched = TreeEnricher.enrich_spans(spans)
+
+    # Check that the segment span does NOT have hasGenAISpans field
+    assert segment_idx == 0
+    segment_span_data = enriched[segment_idx]["data"]
+    assert "hasGenAISpans" not in segment_span_data
+
+    # Check that no span has the field
+    for span in enriched:
+        assert "hasGenAISpans" not in span["data"]
+
+
 def _mock_performance_issue_span(is_segment, data, **fields):
     return {
         "description": "OrganizationNPlusOne",

--- a/tests/sentry/spans/consumers/process_segments/test_enrichment.py
+++ b/tests/sentry/spans/consumers/process_segments/test_enrichment.py
@@ -456,15 +456,15 @@ def test_has_gen_ai_spans_field_when_gen_ai_spans_present():
 
     segment_idx, enriched = TreeEnricher.enrich_spans(spans)
 
-    # Check that the segment span has sentry._internal.has_gen_ai_spans field set to True
+    # Check that the segment span has sentry._internal.segment.contains_gen_ai_spans field set to True
     assert segment_idx is not None
     segment_span_data = enriched[segment_idx]["data"]
-    assert segment_span_data.get("sentry._internal.has_gen_ai_spans") is True
+    assert segment_span_data.get("sentry._internal.segment.contains_gen_ai_spans") is True
 
     # Check that non-segment spans don't have the field
     for i, span in enumerate(enriched):
         if i != segment_idx:
-            assert "sentry._internal.has_gen_ai_spans" not in span["data"]
+            assert "sentry._internal.segment.contains_gen_ai_spans" not in span["data"]
 
 
 def test_has_gen_ai_spans_field_not_present_without_gen_ai_spans():
@@ -506,14 +506,14 @@ def test_has_gen_ai_spans_field_not_present_without_gen_ai_spans():
 
     segment_idx, enriched = TreeEnricher.enrich_spans(spans)
 
-    # Check that the segment span does NOT have sentry._internal.has_gen_ai_spans field
+    # Check that the segment span does NOT have sentry._internal.segment.contains_gen_ai_spans field
     assert segment_idx == 0
     segment_span_data = enriched[segment_idx]["data"]
-    assert "sentry._internal.has_gen_ai_spans" not in segment_span_data
+    assert "sentry._internal.segment.contains_gen_ai_spans" not in segment_span_data
 
     # Check that no span has the field
     for span in enriched:
-        assert "sentry._internal.has_gen_ai_spans" not in span["data"]
+        assert "sentry._internal.segment.contains_gen_ai_spans" not in span["data"]
 
 
 def _mock_performance_issue_span(is_segment, data, **fields):

--- a/tests/sentry/spans/consumers/process_segments/test_enrichment.py
+++ b/tests/sentry/spans/consumers/process_segments/test_enrichment.py
@@ -457,6 +457,7 @@ def test_has_gen_ai_spans_field_when_gen_ai_spans_present():
     segment_idx, enriched = TreeEnricher.enrich_spans(spans)
 
     # Check that the segment span has hasGenAISpans field set to True
+    assert segment_idx is not None
     segment_span_data = enriched[segment_idx]["data"]
     assert segment_span_data.get("hasGenAISpans") is True
 

--- a/tests/sentry/spans/consumers/process_segments/test_enrichment.py
+++ b/tests/sentry/spans/consumers/process_segments/test_enrichment.py
@@ -456,15 +456,15 @@ def test_has_gen_ai_spans_field_when_gen_ai_spans_present():
 
     segment_idx, enriched = TreeEnricher.enrich_spans(spans)
 
-    # Check that the segment span has hasGenAISpans field set to True
+    # Check that the segment span has sentry._internal.has_gen_ai_spans field set to True
     assert segment_idx is not None
     segment_span_data = enriched[segment_idx]["data"]
-    assert segment_span_data.get("hasGenAISpans") is True
+    assert segment_span_data.get("sentry._internal.has_gen_ai_spans") is True
 
     # Check that non-segment spans don't have the field
     for i, span in enumerate(enriched):
         if i != segment_idx:
-            assert "hasGenAISpans" not in span["data"]
+            assert "sentry._internal.has_gen_ai_spans" not in span["data"]
 
 
 def test_has_gen_ai_spans_field_not_present_without_gen_ai_spans():
@@ -506,14 +506,14 @@ def test_has_gen_ai_spans_field_not_present_without_gen_ai_spans():
 
     segment_idx, enriched = TreeEnricher.enrich_spans(spans)
 
-    # Check that the segment span does NOT have hasGenAISpans field
+    # Check that the segment span does NOT have sentry._internal.has_gen_ai_spans field
     assert segment_idx == 0
     segment_span_data = enriched[segment_idx]["data"]
-    assert "hasGenAISpans" not in segment_span_data
+    assert "sentry._internal.has_gen_ai_spans" not in segment_span_data
 
     # Check that no span has the field
     for span in enriched:
-        assert "hasGenAISpans" not in span["data"]
+        assert "sentry._internal.has_gen_ai_spans" not in span["data"]
 
 
 def _mock_performance_issue_span(is_segment, data, **fields):


### PR DESCRIPTION
Adds a new data attribute to segment span when it detectes that there is at least one gen_ai span in the segment.

This attribute helps populate traffic and duration widgets in AI insights, because it is not possible at the moment do this kind of conditional queries against EAP (return trace when one of the children has...)

Closes [TET-1113: Use Span Buffer to help populate Traffic and Duration widgets](https://linear.app/getsentry/issue/TET-1113/use-span-buffer-to-help-populate-traffic-and-duration-widgets)
