### PR TITLE
chore(search-bar): Tidy up feature flag quick fix

### DIFF
--- a/static/app/components/deprecatedSmartSearchBar/index.tsx
+++ b/static/app/components/deprecatedSmartSearchBar/index.tsx
@@ -93,7 +93,7 @@ const generateOpAutocompleteGroup = (
 ): AutocompleteGroup => {
   const operatorMap = generateOperatorEntryMap(tagName);
   const operatorItems = validOps
-    .filter(op => isWildcardOperator(op) && !wildcardOperators.includes(op))
+    .filter(op => !(isWildcardOperator(op) && wildcardOperators.includes(op)))
     .map(op => operatorMap[op])
     .filter(defined);
   return {

--- a/static/app/components/deprecatedSmartSearchBar/index.tsx
+++ b/static/app/components/deprecatedSmartSearchBar/index.tsx
@@ -28,6 +28,7 @@ import HighlightQuery from 'sentry/components/searchSyntax/renderer';
 import {
   getKeyName,
   isOperator,
+  isWildcardOperator,
   isWithinToken,
   treeResultLocator,
 } from 'sentry/components/searchSyntax/utils';
@@ -92,7 +93,7 @@ const generateOpAutocompleteGroup = (
 ): AutocompleteGroup => {
   const operatorMap = generateOperatorEntryMap(tagName);
   const operatorItems = validOps
-    .filter(op => !wildcardOperators.includes(op))
+    .filter(op => isWildcardOperator(op) && !wildcardOperators.includes(op))
     .map(op => operatorMap[op])
     .filter(defined);
   return {

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -87,10 +87,11 @@ export function getValidOpsForFilter(
   const allValidTypes = [...new Set([...validTypes, ...interchangeableTypes])];
 
   // Find all valid operations
-  const baseOps = fieldDefinition?.allowComparisonOperators
-    ? allOperators
-    : allValidTypes.flatMap(type => filterTypeConfig[type].validOps);
-  const validOps = new Set<TermOperator>(baseOps);
+  const validOps = new Set<TermOperator>(
+    fieldDefinition?.allowComparisonOperators
+      ? allOperators
+      : allValidTypes.flatMap(type => filterTypeConfig[type].validOps)
+  );
 
   // Conditionally add wildcard operators if:
   // - Feature flag is enabled

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -122,7 +122,7 @@ export enum FilterType {
  * \uf00d unicode character to isolate the wildcard operator from the rest of the string,
  * as this gives us more flexibility down the road to add more operators.
  *
- * Unicode Character: \uf00d
+ * Unicode Character: `\uf00d`
  */
 export enum WildcardOperators {
   CONTAINS = '\uf00dcontains\uf00d',
@@ -130,17 +130,15 @@ export enum WildcardOperators {
   ENDS_WITH = '\uf00dends with\uf00d',
 }
 
-export const allOperators = [
-  TermOperator.DEFAULT,
+export const comparisonOperators = [
   TermOperator.GREATER_THAN_EQUAL,
   TermOperator.LESS_THAN_EQUAL,
   TermOperator.GREATER_THAN,
   TermOperator.LESS_THAN,
   TermOperator.EQUAL,
-  TermOperator.NOT_EQUAL,
 ] as const;
 
-const basicOperators = [TermOperator.DEFAULT, TermOperator.NOT_EQUAL] as const;
+export const basicOperators = [TermOperator.DEFAULT, TermOperator.NOT_EQUAL] as const;
 
 export const wildcardOperators = [
   TermOperator.CONTAINS,
@@ -149,7 +147,7 @@ export const wildcardOperators = [
   TermOperator.DOES_NOT_START_WITH,
   TermOperator.ENDS_WITH,
   TermOperator.DOES_NOT_END_WITH,
-];
+] as const;
 
 /**
  * Map of certain filter types to other filter types with applicable operators
@@ -199,7 +197,7 @@ export const filterTypeConfig = {
   },
   [FilterType.DATE]: {
     validKeys: [Token.KEY_SIMPLE],
-    validOps: allOperators,
+    validOps: [...basicOperators, ...comparisonOperators],
     validValues: [Token.VALUE_ISO_8601_DATE],
     canNegate: false,
   },
@@ -217,19 +215,19 @@ export const filterTypeConfig = {
   },
   [FilterType.DURATION]: {
     validKeys: [Token.KEY_SIMPLE],
-    validOps: allOperators,
+    validOps: [...basicOperators, ...comparisonOperators],
     validValues: [Token.VALUE_DURATION],
     canNegate: true,
   },
   [FilterType.SIZE]: {
     validKeys: [Token.KEY_SIMPLE],
-    validOps: allOperators,
+    validOps: [...basicOperators, ...comparisonOperators],
     validValues: [Token.VALUE_SIZE],
     canNegate: true,
   },
   [FilterType.NUMERIC]: {
     validKeys: [Token.KEY_SIMPLE],
-    validOps: allOperators,
+    validOps: [...basicOperators, ...comparisonOperators],
     validValues: [Token.VALUE_NUMBER],
     canNegate: true,
   },
@@ -247,37 +245,37 @@ export const filterTypeConfig = {
   },
   [FilterType.AGGREGATE_DURATION]: {
     validKeys: [Token.KEY_AGGREGATE],
-    validOps: allOperators,
+    validOps: [...basicOperators, ...comparisonOperators],
     validValues: [Token.VALUE_DURATION],
     canNegate: true,
   },
   [FilterType.AGGREGATE_SIZE]: {
     validKeys: [Token.KEY_AGGREGATE],
-    validOps: allOperators,
+    validOps: [...basicOperators, ...comparisonOperators],
     validValues: [Token.VALUE_SIZE],
     canNegate: true,
   },
   [FilterType.AGGREGATE_NUMERIC]: {
     validKeys: [Token.KEY_AGGREGATE],
-    validOps: allOperators,
+    validOps: [...basicOperators, ...comparisonOperators],
     validValues: [Token.VALUE_NUMBER],
     canNegate: true,
   },
   [FilterType.AGGREGATE_PERCENTAGE]: {
     validKeys: [Token.KEY_AGGREGATE],
-    validOps: allOperators,
+    validOps: [...basicOperators, ...comparisonOperators],
     validValues: [Token.VALUE_PERCENTAGE],
     canNegate: true,
   },
   [FilterType.AGGREGATE_DATE]: {
     validKeys: [Token.KEY_AGGREGATE],
-    validOps: allOperators,
+    validOps: [...basicOperators, ...comparisonOperators],
     validValues: [Token.VALUE_ISO_8601_DATE],
     canNegate: true,
   },
   [FilterType.AGGREGATE_RELATIVE_DATE]: {
     validKeys: [Token.KEY_AGGREGATE],
-    validOps: allOperators,
+    validOps: [...basicOperators, ...comparisonOperators],
     validValues: [Token.VALUE_RELATIVE_DATE],
     canNegate: true,
   },

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -138,12 +138,6 @@ export const allOperators = [
   TermOperator.LESS_THAN,
   TermOperator.EQUAL,
   TermOperator.NOT_EQUAL,
-  TermOperator.CONTAINS,
-  TermOperator.DOES_NOT_CONTAIN,
-  TermOperator.STARTS_WITH,
-  TermOperator.DOES_NOT_START_WITH,
-  TermOperator.ENDS_WITH,
-  TermOperator.DOES_NOT_END_WITH,
 ] as const;
 
 const basicOperators = [TermOperator.DEFAULT, TermOperator.NOT_EQUAL] as const;

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -166,6 +166,14 @@ export const interchangeableFilterOperators = {
   [FilterType.DATE]: [FilterType.SPECIFIC_DATE],
 };
 
+type InterchangeableFilterOperators = keyof typeof interchangeableFilterOperators;
+
+export const isInterchangeableFilterOperator = (
+  type: FilterType
+): type is InterchangeableFilterOperators => {
+  return type in interchangeableFilterOperators;
+};
+
 const textKeys = [
   Token.KEY_SIMPLE,
   Token.KEY_EXPLICIT_TAG,

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -130,6 +130,9 @@ export enum WildcardOperators {
   ENDS_WITH = '\uf00dends with\uf00d',
 }
 
+export const basicOperators = [TermOperator.DEFAULT, TermOperator.NOT_EQUAL] as const;
+export type BasicOperator = (typeof basicOperators)[number];
+
 export const comparisonOperators = [
   TermOperator.GREATER_THAN_EQUAL,
   TermOperator.LESS_THAN_EQUAL,
@@ -137,8 +140,7 @@ export const comparisonOperators = [
   TermOperator.LESS_THAN,
   TermOperator.EQUAL,
 ] as const;
-
-export const basicOperators = [TermOperator.DEFAULT, TermOperator.NOT_EQUAL] as const;
+export type ComparisonOperator = (typeof comparisonOperators)[number];
 
 export const wildcardOperators = [
   TermOperator.CONTAINS,
@@ -148,6 +150,7 @@ export const wildcardOperators = [
   TermOperator.ENDS_WITH,
   TermOperator.DOES_NOT_END_WITH,
 ] as const;
+export type WildcardOperator = (typeof wildcardOperators)[number];
 
 /**
  * Map of certain filter types to other filter types with applicable operators

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -1,6 +1,12 @@
 import type {LocationRange} from 'peggy';
 
-import type {TermOperator, TokenResult} from './parser';
+import type {
+  BasicOperator,
+  ComparisonOperator,
+  TermOperator,
+  TokenResult,
+  WildcardOperator,
+} from './parser';
 import {basicOperators, comparisonOperators, Token, wildcardOperators} from './parser';
 
 /**
@@ -326,17 +332,24 @@ export function isWithinToken(
   return position >= node.location.start.offset && position <= node.location.end.offset;
 }
 
+function isBasicOperator(value: string): value is BasicOperator {
+  // @ts-expect-error - Expected error as basicOperators is a const object
+  return basicOperators.includes(value);
+}
+
+function isComparisonOperator(value: string): value is ComparisonOperator {
+  // @ts-expect-error - Expected error as comparisonOperators is a const object
+  return comparisonOperators.includes(value);
+}
+
+export function isWildcardOperator(value: string): value is WildcardOperator {
+  // @ts-expect-error - Expected error as wildcardOperators is a const object
+  return wildcardOperators.includes(value);
+}
+
 export function isOperator(value: string): value is TermOperator {
   return (
-    // @ts-expect-error - We're checking to see if the value is a valid operator so we're
-    // expecting an error because we're passing in a string.
-    basicOperators.includes(value) ||
-    // @ts-expect-error - We're checking to see if the value is a valid operator so we're
-    // same as above ^^
-    comparisonOperators.includes(value) ||
-    // @ts-expect-error - We're checking to see if the value is a valid operator so we're
-    // same as above ^^
-    wildcardOperators.includes(value)
+    isBasicOperator(value) || isComparisonOperator(value) || isWildcardOperator(value)
   );
 }
 

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -1,7 +1,7 @@
 import type {LocationRange} from 'peggy';
 
 import type {TermOperator, TokenResult} from './parser';
-import {allOperators, Token, wildcardOperators} from './parser';
+import {basicOperators, comparisonOperators, Token, wildcardOperators} from './parser';
 
 /**
  * Used internally within treeResultLocator to stop recursion once we've
@@ -327,9 +327,17 @@ export function isWithinToken(
 }
 
 export function isOperator(value: string): value is TermOperator {
-  // @ts-expect-error - We're checking to see if the value is a valid operator so we're
-  // expecting an error because we're passing in a string.
-  return allOperators.includes(value) || wildcardOperators.includes(value);
+  return (
+    // @ts-expect-error - We're checking to see if the value is a valid operator so we're
+    // expecting an error because we're passing in a string.
+    basicOperators.includes(value) ||
+    // @ts-expect-error - We're checking to see if the value is a valid operator so we're
+    // same as above ^^
+    comparisonOperators.includes(value) ||
+    // @ts-expect-error - We're checking to see if the value is a valid operator so we're
+    // same as above ^^
+    wildcardOperators.includes(value)
+  );
 }
 
 function stringifyTokenFilter(token: TokenResult<Token.FILTER>) {

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -1,7 +1,7 @@
 import type {LocationRange} from 'peggy';
 
 import type {TermOperator, TokenResult} from './parser';
-import {allOperators, Token} from './parser';
+import {allOperators, Token, wildcardOperators} from './parser';
 
 /**
  * Used internally within treeResultLocator to stop recursion once we've
@@ -327,7 +327,9 @@ export function isWithinToken(
 }
 
 export function isOperator(value: string): value is TermOperator {
-  return allOperators.includes(value as TermOperator);
+  // @ts-expect-error - We're checking to see if the value is a valid operator so we're
+  // expecting an error because we're passing in a string.
+  return allOperators.includes(value) || wildcardOperators.includes(value);
 }
 
 function stringifyTokenFilter(token: TokenResult<Token.FILTER>) {

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1961,7 +1961,7 @@ const DEVICE_FIELD_DEFINITION: Record<DeviceFieldKey, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   [FieldKey.DEVICE_SIMULATOR]: {
-    desc: t('Indicates if it occured on a simulator'),
+    desc: t('Indicates if it occurred on a simulator'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.BOOLEAN,
   },
@@ -2510,7 +2510,7 @@ export const DISCOVER_FIELDS = [
   // Meta field that returns total count, usually for equations
   FieldKey.TOTAL_COUNT,
 
-  // Field alises defined in src/sentry/api/event_search.py
+  // Field aliases defined in src/sentry/api/event_search.py
   FieldKey.PROJECT,
   FieldKey.ISSUE,
   FieldKey.USER_DISPLAY,


### PR DESCRIPTION
This PR tidies up the quick fix added in #99329 to get the feature flag functioning properly. This PR also includes some work to tidy up some TS expect-errors, as well as being more conservative adding wildcard operators to different field types.