### PR TITLE
chore(detectors): Set default query injection enabled to `False`

### DIFF
--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -100,7 +100,7 @@ DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS = {
     "http_overhead_detection_enabled": True,
     "transaction_duration_regression_detection_enabled": True,
     "function_duration_regression_detection_enabled": True,
-    "db_query_injection_detection_enabled": True,
+    "db_query_injection_detection_enabled": False,
 }
 
 DEFAULT_PROJECT_PERFORMANCE_GENERAL_SETTINGS = {


### PR DESCRIPTION
for now, we want to allow users to opt into this and have the detectors run, but not run it by default. will set the default to false in this pr, then cleanup some of the other changes (like the noise config) in a future PR. 