### PR TITLE
ref(ACI): Clean up tests to reuse base methods

### DIFF
--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -67,11 +67,14 @@ class TestHandler(BaseMetricAlertHandler):
 @with_feature("organizations:issue-open-periods")
 class MetricAlertHandlerBase(BaseWorkflowTest):
     def create_models(self):
-
         self.workflow, self.detector, _, _ = self.create_detector_and_workflow()
-        self.snuba_query, self.subscription, self.data_source, _ = (
-            self.create_test_query_data_source(detector=self.detector)
+        self.snuba_query = self.create_snuba_query()
+        self.subscription = self.create_snuba_query_subscription(snuba_query_id=self.snuba_query.id)
+        self.data_source = self.create_data_source(
+            organization=self.organization,
+            source_id=str(self.subscription.id),
         )
+        self.create_data_source_detector(data_source=self.data_source, detector=self.detector)
 
         self.alert_rule = self.create_alert_rule()
         self.create_alert_rule_detector(detector=self.detector, alert_rule_id=self.alert_rule.id)

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -1,7 +1,7 @@
 import uuid
 from collections.abc import Mapping
 from dataclasses import asdict
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any
 from unittest import mock
 
@@ -22,7 +22,6 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
@@ -37,9 +36,7 @@ from sentry.seer.anomaly_detection.types import (
     AnomalyDetectionThresholdType,
 )
 from sentry.services.eventstore.models import GroupEvent
-from sentry.snuba.dataset import Dataset
-from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
-from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
+from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
@@ -70,46 +67,14 @@ class TestHandler(BaseMetricAlertHandler):
 @with_feature("organizations:issue-open-periods")
 class MetricAlertHandlerBase(BaseWorkflowTest):
     def create_models(self):
-        self.project = self.create_project()
-        self.detector = self.create_detector(
-            project=self.project,
-            config={"detection_type": "static", "threshold_period": 1},
-            type="metric_issue",
-        )
 
-        with self.tasks():
-            self.snuba_query = create_snuba_query(
-                query_type=SnubaQuery.Type.ERROR,
-                dataset=Dataset.Events,
-                query="hello",
-                aggregate="count()",
-                time_window=timedelta(minutes=1),
-                resolution=timedelta(minutes=1),
-                environment=self.environment,
-                event_types=[SnubaQueryEventType.EventType.ERROR],
-            )
-            self.query_subscription = create_snuba_subscription(
-                project=self.project,
-                subscription_type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
-                snuba_query=self.snuba_query,
-            )
-        self.data_source = self.create_data_source(
-            organization=self.organization, source_id=self.query_subscription.id
+        self.workflow, self.detector, _, _ = self.create_detector_and_workflow()
+        self.snuba_query, self.subscription, self.data_source, _ = (
+            self.create_test_query_data_source(detector=self.detector)
         )
-        self.create_data_source_detector(data_source=self.data_source, detector=self.detector)
-        self.workflow = self.create_workflow(environment=self.environment)
-
-        self.snuba_query = self.create_snuba_query()
 
         self.alert_rule = self.create_alert_rule()
         self.create_alert_rule_detector(detector=self.detector, alert_rule_id=self.alert_rule.id)
-
-        self.subscription = self.create_snuba_query_subscription(snuba_query_id=self.snuba_query.id)
-
-        self.data_source = self.create_data_source(
-            organization=self.organization,
-            source_id=self.subscription.id,
-        )
 
         self.evidence_data = MetricIssueEvidenceData(
             value=123.45,

--- a/tests/sentry/workflow_engine/processors/test_data_packet.py
+++ b/tests/sentry/workflow_engine/processors/test_data_packet.py
@@ -12,7 +12,7 @@ class TestProcessDataPacket(BaseWorkflowTest):
             self.create_detector_and_workflow()
         )
 
-        self.data_source, self.data_packet = self.create_test_query_data_source(self.detector)
+        _, _, self.data_source, self.data_packet = self.create_test_query_data_source(self.detector)
 
     def test_single_data_packet(self) -> None:
         results = process_data_packet(self.data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)

--- a/tests/sentry/workflow_engine/processors/test_data_sources.py
+++ b/tests/sentry/workflow_engine/processors/test_data_sources.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-from sentry.snuba.models import SnubaQuery
 from sentry.workflow_engine.models import DataPacket
 from sentry.workflow_engine.processors.data_source import process_data_source
 from sentry.workflow_engine.registry import data_source_type_registry
@@ -8,16 +7,6 @@ from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
 class TestProcessDataSources(BaseWorkflowTest):
-    def create_snuba_query(self, **kwargs):
-        return SnubaQuery.objects.create(
-            type=SnubaQuery.Type.ERROR.value,
-            dataset="events",
-            aggregate="count()",
-            time_window=60,
-            resolution=60,
-            **kwargs,
-        )
-
     def setUp(self) -> None:
         # check that test_base registers the data_source_type_registry
         assert isinstance(data_source_type_registry.get("test"), mock.Mock)

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -271,7 +271,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
 
             self.create_data_condition(
                 condition_group=detector.workflow_condition_group,
-                type=Condition.EQUAL,
+                type=Condition.GREATER,
                 condition_result=DetectorPriorityLevel.HIGH,
                 comparison=1,
             )

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -225,7 +225,9 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
 
         return workflow, detector, detector_workflow, workflow_triggers
 
-    def create_test_query_data_source(self, detector: Detector) -> tuple[DataSource, DataPacket]:
+    def create_test_query_data_source(
+        self, detector: Detector
+    ) -> tuple[SnubaQuery, QuerySubscription, DataSource, DataPacket]:
         """
         Create a DataSource and DataPacket for testing; this will create a QuerySubscriptionUpdate and link it to a data_source.
 
@@ -280,7 +282,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
             packet=subscription_update,
         )
 
-        return data_source, data_packet
+        return snuba_query, query_subscription, data_source, data_packet
 
     def create_workflow_action(
         self,

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -271,7 +271,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
 
             self.create_data_condition(
                 condition_group=detector.workflow_condition_group,
-                type=Condition.GREATER,
+                type=Condition.EQUAL,
                 condition_result=DetectorPriorityLevel.HIGH,
                 comparison=1,
             )

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -53,6 +53,7 @@ class BaseWorkflowIntegrationTest(BaseWorkflowTest):
         )
         self.detector.workflow_condition_group = detector_conditions
         self.detector.save()
+        _, _, self.data_source, self.data_packet = self.create_test_query_data_source(self.detector)
 
         self.action_group, self.action = self.create_workflow_action(workflow=self.workflow)
         self.event = self.store_event(data={}, project_id=self.project.id)
@@ -101,8 +102,6 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
         """
         This test ensures that a data_source can create the correct event in Issue Platform
         """
-        self.data_source, self.data_packet = self.create_test_query_data_source(self.detector)
-
         with mock.patch(
             "sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka"
         ) as mock_producer:
@@ -117,8 +116,6 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
 
     @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_workflow_engine__data_source__different_type(self) -> None:
-        self.data_source, self.data_packet = self.create_test_query_data_source(self.detector)
-
         with mock.patch(
             "sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka"
         ) as mock_producer:
@@ -131,7 +128,6 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
 
     @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_workflow_engine__data_source__no_detectors(self) -> None:
-        self.data_source, self.data_packet = self.create_test_query_data_source(self.detector)
         self.detector.delete()
 
         with mock.patch(


### PR DESCRIPTION
Refactor some tests as I noticed they were redefining things or unnecessarily creating objects we have methods to create. 