### PR TITLE
chore(ACI): Add log to see if we are ever hitting non-backfilled open periods code

### DIFF
--- a/src/sentry/models/groupopenperiod.py
+++ b/src/sentry/models/groupopenperiod.py
@@ -172,6 +172,7 @@ def get_open_periods_for_group(
     # If there are no open periods in the table, we need to calculate them
     # from the activity log.
     # TODO(snigdha): This is temporary until we have backfilled the GroupOpenPeriod table
+    logger.warning("Open periods not fully backfilled", extra={"group_id": group.id})
 
     if query_start is None or query_end is None:
         query_start = timezone.now() - timedelta(days=90)


### PR DESCRIPTION
Add a log to check if we are ever hitting the code that would run if the open period backfill was not complete. Since the person working on this left we're not completely sure what the state of this is.