### PR TITLE
chore(preprod): Create preprod specific endpoint to validate project <> artifact ownership

### DIFF
--- a/src/sentry/preprod/api/bases/preprod_artifact_endpoint.py
+++ b/src/sentry/preprod/api/bases/preprod_artifact_endpoint.py
@@ -1,0 +1,59 @@
+from typing import Any
+
+from rest_framework import status
+from rest_framework.exceptions import APIException
+from rest_framework.request import Request
+
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.preprod.models import PreprodArtifact
+
+
+class HeadPreprodArtifactResourceDoesNotExist(APIException):
+    status_code = status.HTTP_404_NOT_FOUND
+    default_detail = "The requested head preprod artifact does not exist"
+
+
+class BasePreprodArtifactResourceDoesNotExist(APIException):
+    status_code = status.HTTP_404_NOT_FOUND
+    default_detail = "The requested base preprod artifact does not exist"
+
+
+class PreprodArtifactEndpoint(ProjectEndpoint):
+    def convert_args(
+        self,
+        request: Request,
+        *args: Any,
+        **kwargs: Any,
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        args, kwargs = super().convert_args(request, *args, **kwargs)
+
+        head_artifact_id = kwargs.get("head_artifact_id")
+        if head_artifact_id is None:
+            return args, kwargs
+
+        project = kwargs.get("project")
+        if project is None:
+            return args, kwargs
+
+        try:
+            head_artifact = PreprodArtifact.objects.get(id=head_artifact_id)
+            if head_artifact.project_id != project.id:
+                raise HeadPreprodArtifactResourceDoesNotExist
+        except PreprodArtifact.DoesNotExist:
+            raise HeadPreprodArtifactResourceDoesNotExist
+
+        kwargs["head_artifact"] = head_artifact
+
+        base_artifact_id = kwargs.get("base_artifact_id")
+        if base_artifact_id is None:
+            return args, kwargs
+
+        try:
+            base_artifact = PreprodArtifact.objects.get(id=base_artifact_id)
+            if base_artifact.project_id != project.id:
+                raise BasePreprodArtifactResourceDoesNotExist
+        except PreprodArtifact.DoesNotExist:
+            raise BasePreprodArtifactResourceDoesNotExist
+
+        kwargs["base_artifact"] = base_artifact
+        return args, kwargs

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_assemble_generic.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_assemble_generic.py
@@ -97,7 +97,7 @@ class ProjectPreprodArtifactAssembleGenericEndpoint(ProjectEndpoint):
             return True
         return False
 
-    def post(self, request: Request, project, artifact_id) -> Response:
+    def post(self, request: Request, project, head_artifact_id) -> Response:
         """
         Assembles a generic file for a preprod artifact and stores it in the database.
         """
@@ -161,7 +161,7 @@ class ProjectPreprodArtifactAssembleGenericEndpoint(ProjectEndpoint):
                         "project_id": project.id,
                         "checksum": checksum,
                         "chunks": chunks,
-                        "artifact_id": artifact_id,
+                        "artifact_id": head_artifact_id,
                     }
                 )
             elif assemble_type == AssembleType.INSTALLABLE_APP.value:
@@ -175,7 +175,7 @@ class ProjectPreprodArtifactAssembleGenericEndpoint(ProjectEndpoint):
                         "project_id": project.id,
                         "checksum": checksum,
                         "chunks": chunks,
-                        "artifact_id": artifact_id,
+                        "artifact_id": head_artifact_id,
                     }
                 )
             else:

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_install_details.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_install_details.py
@@ -12,8 +12,8 @@ from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.project import ProjectEndpoint
 from sentry.preprod.analytics import PreprodArtifactApiInstallDetailsEvent
+from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactEndpoint
 from sentry.preprod.api.models.project_preprod_build_details_models import (
     platform_from_artifact_type,
 )
@@ -24,59 +24,51 @@ logger = logging.getLogger(__name__)
 
 
 @region_silo_endpoint
-class ProjectPreprodInstallDetailsEndpoint(ProjectEndpoint):
+class ProjectPreprodInstallDetailsEndpoint(PreprodArtifactEndpoint):
     owner = ApiOwner.EMERGE_TOOLS
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
 
-    def get(self, request: Request, project, artifact_id) -> HttpResponseBase:
+    def get(self, request: Request, project, head_artifact_id, head_artifact) -> HttpResponseBase:
         try:
             analytics.record(
                 PreprodArtifactApiInstallDetailsEvent(
                     organization_id=project.organization_id,
                     project_id=project.id,
                     user_id=request.user.id,
-                    artifact_id=artifact_id,
+                    artifact_id=head_artifact_id,
                 )
             )
         except Exception as e:
             sentry_sdk.capture_exception(e)
 
-        try:
-            preprod_artifact = PreprodArtifact.objects.get(
-                project=project,
-                id=artifact_id,
-            )
-        except PreprodArtifact.DoesNotExist:
-            return Response({"error": "Preprod artifact not found"}, status=404)
-
         # For iOS apps (XCARCHIVE), check code signature validity
-        if preprod_artifact.artifact_type == PreprodArtifact.ArtifactType.XCARCHIVE:
+        if head_artifact.artifact_type == PreprodArtifact.ArtifactType.XCARCHIVE:
             if (
-                not preprod_artifact.extras
-                or preprod_artifact.extras.get("is_code_signature_valid") is not True
+                not head_artifact.extras
+                or head_artifact.extras.get("is_code_signature_valid") is not True
             ):
                 return JsonResponse(
                     {
                         "is_code_signature_valid": False,
                         "code_signature_errors": (
-                            preprod_artifact.extras.get("code_signature_errors", [])
-                            if preprod_artifact.extras
+                            head_artifact.extras.get("code_signature_errors", [])
+                            if head_artifact.extras
                             else []
                         ),
-                        "platform": platform_from_artifact_type(preprod_artifact.artifact_type),
+                        "platform": platform_from_artifact_type(head_artifact.artifact_type),
                     }
                 )
 
-        if not preprod_artifact.installable_app_file_id:
+        if not head_artifact.installable_app_file_id:
             return Response({"error": "Installable file not available"}, status=404)
 
-        installable_url = get_download_url_for_artifact(preprod_artifact)
+        installable_url = get_download_url_for_artifact(head_artifact)
 
         # Calculate total download count from all InstallablePreprodArtifact instances
         total_download_count = (
-            InstallablePreprodArtifact.objects.filter(preprod_artifact=preprod_artifact).aggregate(
+            InstallablePreprodArtifact.objects.filter(preprod_artifact=head_artifact).aggregate(
                 total_downloads=Sum("download_count")
             )["total_downloads"]
             or 0
@@ -85,26 +77,26 @@ class ProjectPreprodInstallDetailsEndpoint(ProjectEndpoint):
         # Build response based on artifact type
         response_data: dict[str, Any] = {
             "install_url": installable_url,
-            "platform": platform_from_artifact_type(preprod_artifact.artifact_type),
+            "platform": platform_from_artifact_type(head_artifact.artifact_type),
             "download_count": total_download_count,
             "release_notes": (
-                preprod_artifact.extras.get("release_notes") if preprod_artifact.extras else None
+                head_artifact.extras.get("release_notes") if head_artifact.extras else None
             ),
         }
 
         # Only include iOS-specific fields for iOS apps
-        if preprod_artifact.artifact_type == PreprodArtifact.ArtifactType.XCARCHIVE:
+        if head_artifact.artifact_type == PreprodArtifact.ArtifactType.XCARCHIVE:
             response_data.update(
                 {
                     "is_code_signature_valid": True,
                     "profile_name": (
-                        preprod_artifact.extras["profile_name"]
-                        if preprod_artifact.extras and "profile_name" in preprod_artifact.extras
+                        head_artifact.extras["profile_name"]
+                        if head_artifact.extras and "profile_name" in head_artifact.extras
                         else "unknown"
                     ),
                     "codesigning_type": (
-                        preprod_artifact.extras["codesigning_type"]
-                        if preprod_artifact.extras and "codesigning_type" in preprod_artifact.extras
+                        head_artifact.extras["codesigning_type"]
+                        if head_artifact.extras and "codesigning_type" in head_artifact.extras
                         else "unknown"
                     ),
                 }

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -11,9 +11,9 @@ from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.project import ProjectEndpoint
 from sentry.models.release import Release
 from sentry.preprod.analytics import PreprodArtifactApiUpdateEvent
+from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactEndpoint
 from sentry.preprod.authentication import LaunchpadRpcSignatureAuthentication
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
@@ -170,7 +170,7 @@ def find_or_create_release(
 
 
 @region_silo_endpoint
-class ProjectPreprodArtifactUpdateEndpoint(ProjectEndpoint):
+class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
     owner = ApiOwner.EMERGE_TOOLS
     publish_status = {
         "PUT": ApiPublishStatus.PRIVATE,
@@ -185,7 +185,7 @@ class ProjectPreprodArtifactUpdateEndpoint(ProjectEndpoint):
             return True
         return False
 
-    def put(self, request: Request, project, artifact_id) -> Response:
+    def put(self, request: Request, project, head_artifact_id, head_artifact) -> Response:
         """
         Update a preprod artifact with preprocessed data
         ```````````````````````````````````````````````
@@ -197,7 +197,8 @@ class ProjectPreprodArtifactUpdateEndpoint(ProjectEndpoint):
                                           artifact belongs to.
         :pparam string project_id_or_slug: the id or slug of the project the artifact
                                      belongs to.
-        :pparam string artifact_id: the ID of the preprod artifact to update.
+        :pparam string head_artifact_id: the ID of the preprod artifact to update.
+        :pparam object head_artifact: the preprod artifact to update.
         :auth: required
         """
         if not self._is_authorized(request):
@@ -215,56 +216,48 @@ class ProjectPreprodArtifactUpdateEndpoint(ProjectEndpoint):
             return Response({"error": error_message}, status=400)
 
         try:
-            artifact_id_int = int(artifact_id)
+            artifact_id_int = int(head_artifact_id)
             if artifact_id_int <= 0:
                 raise ValueError("ID must be positive")
         except (ValueError, TypeError):
             return Response({"error": "Invalid artifact ID format"}, status=400)
 
-        try:
-            preprod_artifact = PreprodArtifact.objects.get(
-                project=project,
-                id=artifact_id_int,
-            )
-        except PreprodArtifact.DoesNotExist:
-            return Response({"error": f"Preprod artifact {artifact_id} not found"}, status=404)
-
         updated_fields = []
 
         if "date_built" in data:
-            preprod_artifact.date_built = data["date_built"]
+            head_artifact.date_built = data["date_built"]
             updated_fields.append("date_built")
 
         if "artifact_type" in data:
-            preprod_artifact.artifact_type = data["artifact_type"]
+            head_artifact.artifact_type = data["artifact_type"]
             updated_fields.append("artifact_type")
 
         if "error_code" in data:
-            preprod_artifact.error_code = data["error_code"]
+            head_artifact.error_code = data["error_code"]
             updated_fields.append("error_code")
 
         if "error_message" in data:
-            preprod_artifact.error_message = data["error_message"]
+            head_artifact.error_message = data["error_message"]
             updated_fields.append("error_message")
 
         if "error_code" in data or "error_message" in data:
-            preprod_artifact.state = PreprodArtifact.ArtifactState.FAILED
+            head_artifact.state = PreprodArtifact.ArtifactState.FAILED
             updated_fields.append("state")
 
         if "build_version" in data:
-            preprod_artifact.build_version = data["build_version"]
+            head_artifact.build_version = data["build_version"]
             updated_fields.append("build_version")
 
         if "build_number" in data:
-            preprod_artifact.build_number = data["build_number"]
+            head_artifact.build_number = data["build_number"]
             updated_fields.append("build_number")
 
         if "app_id" in data:
-            preprod_artifact.app_id = data["app_id"]
+            head_artifact.app_id = data["app_id"]
             updated_fields.append("app_id")
 
         if "app_name" in data:
-            preprod_artifact.app_name = data["app_name"]
+            head_artifact.app_name = data["app_name"]
             updated_fields.append("app_name")
 
         extras_updates = {}
@@ -272,7 +265,7 @@ class ProjectPreprodArtifactUpdateEndpoint(ProjectEndpoint):
         if "apple_app_info" in data:
             apple_info = data["apple_app_info"]
             if "main_binary_uuid" in apple_info:
-                preprod_artifact.main_binary_identifier = apple_info["main_binary_uuid"]
+                head_artifact.main_binary_identifier = apple_info["main_binary_uuid"]
                 updated_fields.append("main_binary_identifier")
 
             for field in [
@@ -291,17 +284,17 @@ class ProjectPreprodArtifactUpdateEndpoint(ProjectEndpoint):
             extras_updates["dequeued_at"] = data["dequeued_at"]
 
         if extras_updates:
-            if preprod_artifact.extras is None:
-                preprod_artifact.extras = {}
-            preprod_artifact.extras.update(extras_updates)
+            if head_artifact.extras is None:
+                head_artifact.extras = {}
+            head_artifact.extras.update(extras_updates)
             updated_fields.append("extras")
 
         if updated_fields:
-            if preprod_artifact.state != PreprodArtifact.ArtifactState.FAILED:
-                preprod_artifact.state = PreprodArtifact.ArtifactState.PROCESSED
+            if head_artifact.state != PreprodArtifact.ArtifactState.FAILED:
+                head_artifact.state = PreprodArtifact.ArtifactState.PROCESSED
                 updated_fields.append("state")
 
-            preprod_artifact.save(update_fields=updated_fields + ["date_updated"])
+            head_artifact.save(update_fields=updated_fields + ["date_updated"])
 
             create_preprod_status_check_task.apply_async(
                 kwargs={
@@ -310,21 +303,21 @@ class ProjectPreprodArtifactUpdateEndpoint(ProjectEndpoint):
             )
 
         if (
-            preprod_artifact.app_id
-            and preprod_artifact.build_version
-            and preprod_artifact.state == PreprodArtifact.ArtifactState.PROCESSED
+            head_artifact.app_id
+            and head_artifact.build_version
+            and head_artifact.state == PreprodArtifact.ArtifactState.PROCESSED
         ):
             find_or_create_release(
                 project=project,
-                package=preprod_artifact.app_id,
-                version=preprod_artifact.build_version,
-                build_number=preprod_artifact.build_number,
+                package=head_artifact.app_id,
+                version=head_artifact.build_version,
+                build_number=head_artifact.build_number,
             )
 
         return Response(
             {
                 "success": True,
-                "artifactId": artifact_id,
+                "artifactId": head_artifact_id,
                 "updatedFields": updated_fields,
             }
         )

--- a/src/sentry/preprod/api/endpoints/project_preprod_build_details.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_build_details.py
@@ -7,24 +7,23 @@ from sentry import analytics, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.project import ProjectEndpoint
 from sentry.preprod.analytics import PreprodArtifactApiGetBuildDetailsEvent
+from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactEndpoint
 from sentry.preprod.api.models.project_preprod_build_details_models import (
     transform_preprod_artifact_to_build_details,
 )
-from sentry.preprod.models import PreprodArtifact
 
 logger = logging.getLogger(__name__)
 
 
 @region_silo_endpoint
-class ProjectPreprodBuildDetailsEndpoint(ProjectEndpoint):
+class ProjectPreprodBuildDetailsEndpoint(PreprodArtifactEndpoint):
     owner = ApiOwner.EMERGE_TOOLS
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
 
-    def get(self, request: Request, project, artifact_id) -> Response:
+    def get(self, request: Request, project, head_artifact_id, head_artifact) -> Response:
         """
         Get the build details for a preprod artifact
         ````````````````````````````````````````````````````
@@ -35,7 +34,7 @@ class ProjectPreprodBuildDetailsEndpoint(ProjectEndpoint):
                                           artifact belongs to.
         :pparam string project_id_or_slug: the id or slug of the project to retrieve the
                                      artifact from.
-        :pparam string artifact_id: the ID of the preprod artifact to get build details for.
+        :pparam string head_artifact_id: the ID of the preprod artifact to get build details for.
         :auth: required
         """
 
@@ -44,7 +43,7 @@ class ProjectPreprodBuildDetailsEndpoint(ProjectEndpoint):
                 organization_id=project.organization_id,
                 project_id=project.id,
                 user_id=request.user.id,
-                artifact_id=artifact_id,
+                artifact_id=head_artifact_id,
             )
         )
 
@@ -53,13 +52,5 @@ class ProjectPreprodBuildDetailsEndpoint(ProjectEndpoint):
         ):
             return Response({"error": "Feature not enabled"}, status=403)
 
-        try:
-            preprod_artifact = PreprodArtifact.objects.get(
-                project=project,
-                id=artifact_id,
-            )
-        except PreprodArtifact.DoesNotExist:
-            return Response({"error": f"Preprod artifact {artifact_id} not found"}, status=404)
-
-        build_details = transform_preprod_artifact_to_build_details(preprod_artifact)
+        build_details = transform_preprod_artifact_to_build_details(head_artifact)
         return Response(build_details.dict())

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -8,21 +8,17 @@ from sentry import analytics, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.project import ProjectEndpoint
 from sentry.preprod.analytics import (
     PreprodArtifactApiSizeAnalysisCompareGetEvent,
     PreprodArtifactApiSizeAnalysisComparePostEvent,
 )
+from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactEndpoint
 from sentry.preprod.api.models.size_analysis.project_preprod_size_analysis_compare_models import (
     SizeAnalysisCompareGETResponse,
     SizeAnalysisComparePOSTResponse,
     SizeAnalysisComparison,
 )
-from sentry.preprod.models import (
-    PreprodArtifact,
-    PreprodArtifactSizeComparison,
-    PreprodArtifactSizeMetrics,
-)
+from sentry.preprod.models import PreprodArtifactSizeComparison, PreprodArtifactSizeMetrics
 from sentry.preprod.size_analysis.tasks import manual_size_analysis_comparison
 from sentry.preprod.size_analysis.utils import build_size_metrics_map, can_compare_size_metrics
 
@@ -30,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 @region_silo_endpoint
-class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
+class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint):
     owner = ApiOwner.EMERGE_TOOLS
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
@@ -38,7 +34,13 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
     }
 
     def get(
-        self, request: Request, project, head_artifact_id, base_artifact_id
+        self,
+        request: Request,
+        project,
+        head_artifact_id,
+        base_artifact_id,
+        head_artifact,
+        base_artifact,
     ) -> HttpResponseBase:
         """
         Get size analysis comparison results for a preprod artifact
@@ -75,22 +77,11 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
             extra={"head_artifact_id": head_artifact_id, "base_artifact_id": base_artifact_id},
         )
 
-        try:
-            head_preprod_artifact = PreprodArtifact.objects.get(
-                id=head_artifact_id,
-                project=project,
-            )
-        except PreprodArtifact.DoesNotExist:
-            return Response(
-                {"detail": f"Head PreprodArtifact with id {head_artifact_id} does not exist."},
-                status=404,
-            )
-
-        if head_preprod_artifact.project.id != project.id:
+        if head_artifact.project.id != project.id:
             return Response({"error": "Project not found"}, status=404)
 
         head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact_id__in=[head_preprod_artifact.id],
+            preprod_artifact_id__in=[head_artifact.id],
             preprod_artifact__project=project,
         ).select_related("preprod_artifact")
         head_size_metrics = list(head_size_metrics_qs)
@@ -101,22 +92,11 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
                 status=404,
             )
 
-        try:
-            base_preprod_artifact = PreprodArtifact.objects.get(
-                id=base_artifact_id,
-                project=project,
-            )
-        except PreprodArtifact.DoesNotExist:
-            return Response(
-                {"detail": f"Base PreprodArtifact with id {base_artifact_id} does not exist."},
-                status=404,
-            )
-
-        if base_preprod_artifact.project.id != project.id:
+        if base_artifact.project.id != project.id:
             return Response({"error": "Project not found"}, status=404)
 
         base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact_id__in=[base_preprod_artifact.id],
+            preprod_artifact_id__in=[base_artifact.id],
             preprod_artifact__project=project,
         ).select_related("preprod_artifact")
         base_size_metrics = list(base_size_metrics_qs)
@@ -250,7 +230,13 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
         return Response(response.dict())
 
     def post(
-        self, request: Request, project, head_artifact_id, base_artifact_id
+        self,
+        request: Request,
+        project,
+        head_artifact_id,
+        base_artifact_id,
+        head_artifact,
+        base_artifact,
     ) -> HttpResponseBase:
         """
         Trigger size analysis comparison for a preprod artifact
@@ -287,29 +273,8 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
             extra={"head_artifact_id": head_artifact_id, "base_artifact_id": base_artifact_id},
         )
 
-        try:
-            head_preprod_artifact = PreprodArtifact.objects.get(
-                id=head_artifact_id,
-                project=project,
-            )
-        except PreprodArtifact.DoesNotExist:
-            return Response(
-                {"detail": f"Head PreprodArtifact with id {head_artifact_id} does not exist."},
-                status=404,
-            )
-        try:
-            base_preprod_artifact = PreprodArtifact.objects.get(
-                id=base_artifact_id,
-                project=project,
-            )
-        except PreprodArtifact.DoesNotExist:
-            return Response(
-                {"detail": f"Base PreprodArtifact with id {base_artifact_id} does not exist."},
-                status=404,
-            )
-
         head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact_id__in=[head_preprod_artifact.id],
+            preprod_artifact_id__in=[head_artifact.id],
             preprod_artifact__project=project,
         ).select_related("preprod_artifact")
 
@@ -336,7 +301,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(ProjectEndpoint):
             )
 
         base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact_id__in=[base_preprod_artifact.id],
+            preprod_artifact_id__in=[base_artifact.id],
             preprod_artifact__project=project,
         ).select_related("preprod_artifact")
         if base_size_metrics_qs.count() == 0:

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -49,22 +49,22 @@ preprod_urlpatterns = [
         name="sentry-api-0-project-preprod-list-builds",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/(?P<artifact_id>[^/]+)/size-analysis/$",
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/(?P<head_artifact_id>[^/]+)/size-analysis/$",
         ProjectPreprodArtifactSizeAnalysisDownloadEndpoint.as_view(),
         name="sentry-api-0-project-preprod-artifact-size-analysis-download",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/(?P<artifact_id>[^/]+)/build-details/$",
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/(?P<head_artifact_id>[^/]+)/build-details/$",
         ProjectPreprodBuildDetailsEndpoint.as_view(),
         name="sentry-api-0-project-preprod-artifact-build-details",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/(?P<artifact_id>[^/]+)/install-details/$",
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/(?P<head_artifact_id>[^/]+)/install-details/$",
         ProjectPreprodInstallDetailsEndpoint.as_view(),
         name="sentry-api-0-project-preprod-install-details",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/(?P<artifact_id>[^/]+)/delete/$",
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/(?P<head_artifact_id>[^/]+)/delete/$",
         ProjectPreprodArtifactDeleteEndpoint.as_view(),
         name="sentry-api-0-project-preprod-artifact-delete",
     ),
@@ -93,7 +93,7 @@ preprod_internal_urlpatterns = [
         name="sentry-admin-preprod-artifact-rerun-analysis",
     ),
     re_path(
-        r"^preprod-artifact/(?P<preprod_artifact_id>[^/]+)/info/$",
+        r"^preprod-artifact/(?P<head_artifact_id>[^/]+)/info/$",
         PreprodArtifactAdminInfoEndpoint.as_view(),
         name="sentry-admin-preprod-artifact-info",
     ),
@@ -103,17 +103,17 @@ preprod_internal_urlpatterns = [
         name="sentry-admin-preprod-artifact-batch-delete",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/(?P<artifact_id>[^/]+)/$",
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/(?P<head_artifact_id>[^/]+)/$",
         ProjectPreprodArtifactDownloadEndpoint.as_view(),
         name="sentry-api-0-project-preprod-artifact-download",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/(?P<artifact_id>[^/]+)/update/$",
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/(?P<head_artifact_id>[^/]+)/update/$",
         ProjectPreprodArtifactUpdateEndpoint.as_view(),
         name="sentry-api-0-project-preprod-artifact-update",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/(?P<artifact_id>[^/]+)/assemble-generic/$",
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/(?P<head_artifact_id>[^/]+)/assemble-generic/$",
         ProjectPreprodArtifactAssembleGenericEndpoint.as_view(),
         name="sentry-api-0-project-preprod-artifact-assemble-generic",
     ),

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
@@ -227,7 +227,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             self.base_artifact.id,
             status_code=404,
         )
-        assert "Head PreprodArtifact with id 999999 does not exist" in response.data["detail"]
+        assert "The requested head preprod artifact does not exist" in response.data["detail"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_base_artifact_not_found(self):
@@ -239,7 +239,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             999999,
             status_code=404,
         )
-        assert "Base PreprodArtifact with id 999999 does not exist" in response.data["detail"]
+        assert "The requested base preprod artifact does not exist" in response.data["detail"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_head_artifact_wrong_project(self):
@@ -260,10 +260,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             self.base_artifact.id,
             status_code=404,
         )
-        assert (
-            response.data["detail"]
-            == f"Head PreprodArtifact with id {other_artifact.id} does not exist."
-        )
+        assert response.data["detail"] == "The requested head preprod artifact does not exist"
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_base_artifact_wrong_project(self):
@@ -284,10 +281,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             other_artifact.id,
             status_code=404,
         )
-        assert (
-            response.data["detail"]
-            == f"Base PreprodArtifact with id {other_artifact.id} does not exist."
-        )
+        assert response.data["detail"] == "The requested base preprod artifact does not exist"
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_head_artifact_no_size_metrics(self):
@@ -378,7 +372,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             method="post",
             status_code=404,
         )
-        assert "Head PreprodArtifact with id 999999 does not exist" in response.data["detail"]
+        assert "The requested head preprod artifact does not exist" in response.data["detail"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_base_artifact_not_found(self):
@@ -391,7 +385,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             method="post",
             status_code=404,
         )
-        assert "Base PreprodArtifact with id 999999 does not exist" in response.data["detail"]
+        assert "The requested base preprod artifact does not exist" in response.data["detail"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_head_artifact_no_size_metrics(self):

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_delete.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_delete.py
@@ -79,14 +79,21 @@ class ProjectPreprodArtifactDeleteTest(APITestCase):
             status_code=404,
         )
 
-        assert "not found" in response.data["error"].lower()
+        assert "The requested head preprod artifact does not exist" in response.data["detail"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": False})
     def test_delete_artifact_feature_disabled(self):
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            app_name="test_artifact",
+            app_id="com.test.app",
+            build_version="1.0.0",
+            build_number=1,
+        )
         response = self.get_error_response(
             self.organization.slug,
             self.project.slug,
-            "1",
+            artifact.id,
             status_code=403,
         )
 

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_download.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_download.py
@@ -49,7 +49,7 @@ class ProjectPreprodArtifactDownloadEndpointTest(TestCase):
         response = self.client.get(url, **headers)
 
         assert response.status_code == 404
-        assert "not found" in response.json()["error"]
+        assert "The requested head preprod artifact does not exist" in response.json()["detail"]
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_download_preprod_artifact_no_file(self) -> None:

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -117,7 +117,7 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
     def test_update_preprod_artifact_not_found(self) -> None:
         response = self._make_request({"artifact_type": 1}, artifact_id=999999)
         assert response.status_code == 404
-        assert "not found" in response.json()["error"]
+        assert "The requested head preprod artifact does not exist" in response.json()["detail"]
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_update_preprod_artifact_invalid_json(self) -> None:

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
@@ -81,7 +81,7 @@ class ProjectPreprodBuildDetailsEndpointTest(APITestCase):
             url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
         )
         assert response.status_code == 404
-        assert "not found" in response.json()["error"]
+        assert "The requested head preprod artifact does not exist" in response.json()["detail"]
 
     def test_get_build_details_feature_flag_disabled(self) -> None:
         with self.feature({"organizations:preprod-frontend-routes": False}):


### PR DESCRIPTION
Right now in the preprod artifact endpoints, we validate that the project in question is owned by the requesting user, but we rely on the specific queries for artifact data in each endpoint including the project_id. If they don't any user could specify an artifact_id of any other org and the query would succeed.

This is an attempt to first validate that the artifact_id in question belongs to the validated project_id