### PR TITLE
feat(aci): Translate `tags[sentry:user]` tag

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -13,6 +13,7 @@ import {space} from 'sentry/styles/space';
 import type {MetricDetector, SnubaQuery} from 'sentry/types/workflowEngine/detectors';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useDetectorDateParams} from 'sentry/views/detectors/components/details/metric/utils/useDetectorTimePeriods';
+import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
 import {useIncidentMarkers} from 'sentry/views/detectors/hooks/useIncidentMarkers';
 import {useMetricDetectorSeries} from 'sentry/views/detectors/hooks/useMetricDetectorSeries';
@@ -49,10 +50,11 @@ function MetricDetectorChart({
   const comparisonDelta =
     detectionType === 'percent' ? detector.config.comparisonDelta : undefined;
   const dataset = getDetectorDataset(snubaQuery.dataset, snubaQuery.eventTypes);
+  const datasetConfig = getDatasetConfig(dataset);
   const {series, comparisonSeries, isLoading, error} = useMetricDetectorSeries({
     detectorDataset: dataset,
     dataset: snubaQuery.dataset,
-    aggregate: snubaQuery.aggregate,
+    aggregate: datasetConfig.fromApiAggregate(snubaQuery.aggregate),
     interval: snubaQuery.timeWindow,
     query: snubaQuery.query,
     environment: snubaQuery.environment,

--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -144,7 +144,9 @@ function MetricDetectorDetails({detector}: {detector: MetricDetector}) {
         return (
           <Fragment key={dataSource.id}>
             <DetailItem>{dataSource.queryObj.snubaQuery.environment}</DetailItem>
-            <DetailItem>{dataSource.queryObj.snubaQuery.aggregate}</DetailItem>
+            <DetailItem>
+              {datasetConfig.fromApiAggregate(dataSource.queryObj.snubaQuery.aggregate)}
+            </DetailItem>
             <DetailItem>
               {middleEllipsis(
                 datasetConfig.toSnubaQueryString(dataSource.queryObj.snubaQuery),

--- a/static/app/views/detectors/datasetConfig/errors.tsx
+++ b/static/app/views/detectors/datasetConfig/errors.tsx
@@ -15,6 +15,10 @@ import {
   BASE_INTERVALS,
   getStandardTimePeriodsForInterval,
 } from 'sentry/views/detectors/datasetConfig/utils/timePeriods';
+import {
+  translateAggregateTag,
+  translateAggregateTagBack,
+} from 'sentry/views/detectors/datasetConfig/utils/translateAggregateTag';
 import {FieldValueKind, type FieldValue} from 'sentry/views/discover/table/types';
 
 import type {DetectorDatasetConfig} from './base';
@@ -78,6 +82,7 @@ export const DetectorErrorsConfig: DetectorDatasetConfig<ErrorsSeriesResponse> =
     return getDiscoverSeriesQueryOptions({
       ...options,
       dataset: DetectorErrorsConfig.getDiscoverDataset(),
+      aggregate: translateAggregateTag(options.aggregate),
     });
   },
   getIntervals: ({detectionType}) => {
@@ -90,8 +95,12 @@ export const DetectorErrorsConfig: DetectorDatasetConfig<ErrorsSeriesResponse> =
   transformComparisonSeriesData: data => {
     return [transformEventsStatsComparisonSeries(data)];
   },
-  fromApiAggregate: aggregate => aggregate,
-  toApiAggregate: aggregate => aggregate,
+  fromApiAggregate: aggregate => {
+    return translateAggregateTag(aggregate);
+  },
+  toApiAggregate: aggregate => {
+    return translateAggregateTagBack(aggregate);
+  },
   supportedDetectionTypes: ['static', 'percent', 'dynamic'],
   toSnubaQueryString: snubaQuery => {
     if (!snubaQuery) {

--- a/static/app/views/detectors/datasetConfig/logs.tsx
+++ b/static/app/views/detectors/datasetConfig/logs.tsx
@@ -14,6 +14,10 @@ import {
   getEapTimePeriodsForInterval,
   MetricDetectorInterval,
 } from 'sentry/views/detectors/datasetConfig/utils/timePeriods';
+import {
+  translateAggregateTag,
+  translateAggregateTagBack,
+} from 'sentry/views/detectors/datasetConfig/utils/translateAggregateTag';
 
 import type {DetectorDatasetConfig} from './base';
 
@@ -49,8 +53,12 @@ export const DetectorLogsConfig: DetectorDatasetConfig<LogsSeriesRepsonse> = {
   transformComparisonSeriesData: data => {
     return [transformEventsStatsComparisonSeries(data)];
   },
-  fromApiAggregate: aggregate => aggregate,
-  toApiAggregate: aggregate => aggregate,
+  fromApiAggregate: aggregate => {
+    return translateAggregateTag(aggregate);
+  },
+  toApiAggregate: aggregate => {
+    return translateAggregateTagBack(aggregate);
+  },
   supportedDetectionTypes: ['static', 'percent', 'dynamic'],
   getDiscoverDataset: () => DiscoverDatasets.OURLOGS,
 };

--- a/static/app/views/detectors/datasetConfig/spans.tsx
+++ b/static/app/views/detectors/datasetConfig/spans.tsx
@@ -15,6 +15,10 @@ import {
   getEapTimePeriodsForInterval,
   MetricDetectorInterval,
 } from 'sentry/views/detectors/datasetConfig/utils/timePeriods';
+import {
+  translateAggregateTag,
+  translateAggregateTagBack,
+} from 'sentry/views/detectors/datasetConfig/utils/translateAggregateTag';
 
 import type {DetectorDatasetConfig} from './base';
 
@@ -31,6 +35,7 @@ export const DetectorSpansConfig: DetectorDatasetConfig<SpansSeriesResponse> = {
     return getDiscoverSeriesQueryOptions({
       ...options,
       dataset: DetectorSpansConfig.getDiscoverDataset(),
+      aggregate: translateAggregateTag(options.aggregate),
     });
   },
   getIntervals: ({detectionType}) => {
@@ -64,8 +69,12 @@ export const DetectorSpansConfig: DetectorDatasetConfig<SpansSeriesResponse> = {
   transformComparisonSeriesData: data => {
     return [transformEventsStatsComparisonSeries(data)];
   },
-  fromApiAggregate: aggregate => aggregate,
-  toApiAggregate: aggregate => aggregate,
+  fromApiAggregate: aggregate => {
+    return translateAggregateTag(aggregate);
+  },
+  toApiAggregate: aggregate => {
+    return translateAggregateTagBack(aggregate);
+  },
   supportedDetectionTypes: ['static', 'percent', 'dynamic'],
   getDiscoverDataset: () => DiscoverDatasets.SPANS,
 };

--- a/static/app/views/detectors/datasetConfig/transactions.tsx
+++ b/static/app/views/detectors/datasetConfig/transactions.tsx
@@ -16,6 +16,10 @@ import {
   getStandardTimePeriodsForInterval,
   MetricDetectorTimePeriod,
 } from 'sentry/views/detectors/datasetConfig/utils/timePeriods';
+import {
+  translateAggregateTag,
+  translateAggregateTagBack,
+} from 'sentry/views/detectors/datasetConfig/utils/translateAggregateTag';
 
 import type {DetectorDatasetConfig} from './base';
 import {parseEventTypesFromQuery} from './eventTypes';
@@ -59,6 +63,7 @@ export const DetectorTransactionsConfig: DetectorDatasetConfig<TransactionsSerie
         query,
         statsPeriod: timePeriod,
         dataset: DetectorTransactionsConfig.getDiscoverDataset(),
+        aggregate: translateAggregateTag(options.aggregate),
         ...(isOnDemand && {extra: {useOnDemandMetrics: 'true'}}),
       });
     },
@@ -85,8 +90,12 @@ export const DetectorTransactionsConfig: DetectorDatasetConfig<TransactionsSerie
     transformComparisonSeriesData: data => {
       return [transformEventsStatsComparisonSeries(data)];
     },
-    fromApiAggregate: aggregate => aggregate,
-    toApiAggregate: aggregate => aggregate,
+    fromApiAggregate: aggregate => {
+      return translateAggregateTag(aggregate);
+    },
+    toApiAggregate: aggregate => {
+      return translateAggregateTagBack(aggregate);
+    },
     supportedDetectionTypes: ['static', 'percent', 'dynamic'],
     // TODO: This will need to fall back to the discover dataset if metrics enhanced is not available?
     getDiscoverDataset: () => DiscoverDatasets.METRICS_ENHANCED,

--- a/static/app/views/detectors/datasetConfig/utils/translateAggregateTag.tsx
+++ b/static/app/views/detectors/datasetConfig/utils/translateAggregateTag.tsx
@@ -1,6 +1,6 @@
 export function translateAggregateTag(aggregate: string) {
-  // Translate tags[sentry:user] to user
-  if (aggregate.includes('tags[sentry:user]')) {
+  // Translate count_unique(tags[sentry:user]) to count_unique(user)
+  if (aggregate.includes('(tags[sentry:user])')) {
     return aggregate.replace('tags[sentry:user]', 'user');
   }
 
@@ -8,8 +8,8 @@ export function translateAggregateTag(aggregate: string) {
 }
 
 export function translateAggregateTagBack(aggregate: string) {
-  // Translate user to tags[sentry:user]
-  if (aggregate.includes('user')) {
+  // Translate count_unique(user) to count_unique(tags[sentry:user])
+  if (aggregate.includes('(user)')) {
     return aggregate.replace('user', 'tags[sentry:user]');
   }
 

--- a/static/app/views/detectors/datasetConfig/utils/translateAggregateTag.tsx
+++ b/static/app/views/detectors/datasetConfig/utils/translateAggregateTag.tsx
@@ -1,0 +1,17 @@
+export function translateAggregateTag(aggregate: string) {
+  // Translate tags[sentry:user] to user
+  if (aggregate.includes('tags[sentry:user]')) {
+    return aggregate.replace('tags[sentry:user]', 'user');
+  }
+
+  return aggregate;
+}
+
+export function translateAggregateTagBack(aggregate: string) {
+  // Translate user to tags[sentry:user]
+  if (aggregate.includes('user')) {
+    return aggregate.replace('user', 'tags[sentry:user]');
+  }
+
+  return aggregate;
+}

--- a/static/app/views/detectors/datasetConfig/utils/translateAggregateTag.tsx
+++ b/static/app/views/detectors/datasetConfig/utils/translateAggregateTag.tsx
@@ -1,7 +1,7 @@
 export function translateAggregateTag(aggregate: string) {
   // Translate count_unique(tags[sentry:user]) to count_unique(user)
   if (aggregate.includes('(tags[sentry:user])')) {
-    return aggregate.replace('tags[sentry:user]', 'user');
+    return aggregate.replace('(tags[sentry:user])', '(user)');
   }
 
   return aggregate;
@@ -10,7 +10,7 @@ export function translateAggregateTag(aggregate: string) {
 export function translateAggregateTagBack(aggregate: string) {
   // Translate count_unique(user) to count_unique(tags[sentry:user])
   if (aggregate.includes('(user)')) {
-    return aggregate.replace('user', 'tags[sentry:user]');
+    return aggregate.replace('(user)', '(tags[sentry:user])');
   }
 
   return aggregate;


### PR DESCRIPTION
fixes an issue where the snuba query is saved as tags[sentry:user] but we need to display and query "user"

before
<img width="1174" height="369" alt="image" src="https://github.com/user-attachments/assets/5a663cac-b138-43b2-a95e-22347564517d" />

after
<img width="1142" height="393" alt="image" src="https://github.com/user-attachments/assets/f6b66cd3-0d5f-4d9f-acd6-1e8cd540b402" />
