### PR TITLE
fix(settings): reference organization directly to check feature flag

### DIFF
--- a/static/app/views/settings/project/projectKeys/list/index.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.tsx
@@ -157,7 +157,6 @@ function ProjectKeys({project}: Props) {
           <KeyRow
             hasWriteAccess={hasAccess}
             key={key.id}
-            orgId={organization.slug}
             projectId={projectId}
             project={project}
             organization={organization}

--- a/static/app/views/settings/project/projectKeys/list/index.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.tsx
@@ -160,6 +160,7 @@ function ProjectKeys({project}: Props) {
             orgId={organization.slug}
             projectId={projectId}
             project={project}
+            organization={organization}
             data={key}
             onToggle={(isActive, data) =>
               handleToggleKeyMutation.mutate({isActive, data})

--- a/static/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/static/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -12,6 +12,7 @@ import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
+import type {Organization} from 'sentry/types/organization';
 import type {Project, ProjectKey} from 'sentry/types/project';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import {useOTelFriendlyUI} from 'sentry/views/performance/otlp/useOTelFriendlyUI';
@@ -24,6 +25,7 @@ type Props = {
   onRemove: (data: ProjectKey) => void;
   onToggle: (isActive: boolean, data: ProjectKey) => void;
   orgId: string;
+  organization: Organization;
   project: Project;
   projectId: string;
 } & Pick<RouteComponentProps, 'routes' | 'location' | 'params'>;
@@ -37,6 +39,7 @@ function KeyRow({
   location,
   params,
   project,
+  organization,
 }: Props) {
   const handleEnable = () => onToggle(true, data);
   const handleDisable = () => onToggle(false, data);
@@ -47,7 +50,7 @@ function KeyRow({
   const isJsPlatform = platform.startsWith('javascript');
   const showOtlpTraces =
     useOTelFriendlyUI() && project.features.includes('relay-otel-endpoint');
-  const showOtlpLogs = project.organization.features.includes('relay-otel-logs-endpoint');
+  const showOtlpLogs = organization.features.includes('relay-otel-logs-endpoint');
 
   return (
     <Panel>

--- a/static/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/static/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -24,7 +24,6 @@ type Props = {
   hasWriteAccess: boolean;
   onRemove: (data: ProjectKey) => void;
   onToggle: (isActive: boolean, data: ProjectKey) => void;
-  orgId: string;
   organization: Organization;
   project: Project;
   projectId: string;


### PR DESCRIPTION
resolves JAVASCRIPT-33CZ

In https://github.com/getsentry/sentry/pull/99313 I added otlp logs to the project settings gated behind a organization feature flag, `relay-otel-logs-endpoint`.

This was accessed with `project.organization.features`, which is problematic. Instead we pass the organization directly down and access it with `organization.features`.

Also removes the `orgId` prop because it's not being used anywhere.