### PR TITLE
fix(preprod): clear the search URL for blank strings

### DIFF
--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -180,12 +180,12 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
             <InputGroup.Input
               placeholder="Search files"
               value={searchQuery || ''}
-              onChange={e => setSearchQuery(e.target.value)}
+              onChange={e => setSearchQuery(e.target.value || undefined)}
             />
             {searchQuery && (
               <InputGroup.TrailingItems>
                 <Button
-                  onClick={() => setSearchQuery('')}
+                  onClick={() => setSearchQuery(undefined)}
                   aria-label="Clear search"
                   borderless
                   size="zero"


### PR DESCRIPTION
Previously we were left with a dangling `http://dev.getsentry.net:8000/organizations/sentry/preprod/internal/42?search=`, now it properly updates to `http://dev.getsentry.net:8000/organizations/sentry/preprod/internal/42`