### PR TITLE
ref(search): Remove spaces from wildcard operators

### DIFF
--- a/fixtures/search-syntax/contains_operator.json
+++ b/fixtures/search-syntax/contains_operator.json
@@ -1,13 +1,13 @@
 [
   {
-    "query": "browser.name:containsfirefox",
+    "query": "browser.name:Containsfirefox",
     "result": [
       {"type": "spaces", "value": ""},
       {
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "operator": "contains",
+        "operator": "Contains",
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "value": {"type": "valueText", "value": "firefox", "quoted": false}
       },
@@ -15,14 +15,14 @@
     ]
   },
   {
-    "query": "browser.name:contains[firefox, chrome]",
+    "query": "browser.name:Contains[firefox, chrome]",
     "result": [
       {"type": "spaces", "value": ""},
       {
         "type": "filter",
         "filter": "textIn",
         "negated": false,
-        "operator": "contains",
+        "operator": "Contains",
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "value": {
           "type": "valueTextList",
@@ -42,14 +42,14 @@
     ]
   },
   {
-    "query": "!browser.name:containsfirefox",
+    "query": "!browser.name:Containsfirefox",
     "result": [
       {"type": "spaces", "value": ""},
       {
         "type": "filter",
         "filter": "text",
         "negated": true,
-        "operator": "contains",
+        "operator": "Contains",
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "value": {"type": "valueText", "value": "firefox", "quoted": false}
       },
@@ -57,14 +57,14 @@
     ]
   },
   {
-    "query": "!browser.name:contains[firefox, chrome]",
+    "query": "!browser.name:Contains[firefox, chrome]",
     "result": [
       {"type": "spaces", "value": ""},
       {
         "type": "filter",
         "filter": "textIn",
         "negated": true,
-        "operator": "contains",
+        "operator": "Contains",
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "value": {
           "type": "valueTextList",

--- a/fixtures/search-syntax/ends_with_operator.json
+++ b/fixtures/search-syntax/ends_with_operator.json
@@ -1,13 +1,13 @@
 [
   {
-    "query": "browser.name:ends withfirefox",
+    "query": "browser.name:EndsWithfirefox",
     "result": [
       {"type": "spaces", "value": ""},
       {
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "operator": "ends with",
+        "operator": "EndsWith",
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "value": {"type": "valueText", "value": "firefox", "quoted": false}
       },
@@ -15,14 +15,14 @@
     ]
   },
   {
-    "query": "browser.name:ends with[firefox, chrome]",
+    "query": "browser.name:EndsWith[firefox, chrome]",
     "result": [
       {"type": "spaces", "value": ""},
       {
         "type": "filter",
         "filter": "textIn",
         "negated": false,
-        "operator": "ends with",
+        "operator": "EndsWith",
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "value": {
           "type": "valueTextList",
@@ -42,14 +42,14 @@
     ]
   },
   {
-    "query": "!browser.name:ends withfirefox",
+    "query": "!browser.name:EndsWithfirefox",
     "result": [
       {"type": "spaces", "value": ""},
       {
         "type": "filter",
         "filter": "text",
         "negated": true,
-        "operator": "ends with",
+        "operator": "EndsWith",
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "value": {"type": "valueText", "value": "firefox", "quoted": false}
       },
@@ -57,14 +57,14 @@
     ]
   },
   {
-    "query": "!browser.name:ends with[firefox, chrome]",
+    "query": "!browser.name:EndsWith[firefox, chrome]",
     "result": [
       {"type": "spaces", "value": ""},
       {
         "type": "filter",
         "filter": "textIn",
         "negated": true,
-        "operator": "ends with",
+        "operator": "EndsWith",
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "value": {
           "type": "valueTextList",

--- a/fixtures/search-syntax/starts_with_operator.json
+++ b/fixtures/search-syntax/starts_with_operator.json
@@ -1,13 +1,13 @@
 [
   {
-    "query": "browser.name:starts withfirefox",
+    "query": "browser.name:StartsWithfirefox",
     "result": [
       {"type": "spaces", "value": ""},
       {
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "operator": "starts with",
+        "operator": "StartsWith",
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "value": {"type": "valueText", "value": "firefox", "quoted": false}
       },
@@ -15,14 +15,14 @@
     ]
   },
   {
-    "query": "browser.name:starts with[firefox, chrome]",
+    "query": "browser.name:StartsWith[firefox, chrome]",
     "result": [
       {"type": "spaces", "value": ""},
       {
         "type": "filter",
         "filter": "textIn",
         "negated": false,
-        "operator": "starts with",
+        "operator": "StartsWith",
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "value": {
           "type": "valueTextList",
@@ -42,14 +42,14 @@
     ]
   },
   {
-    "query": "!browser.name:starts withfirefox",
+    "query": "!browser.name:StartsWithfirefox",
     "result": [
       {"type": "spaces", "value": ""},
       {
         "type": "filter",
         "filter": "text",
         "negated": true,
-        "operator": "starts with",
+        "operator": "StartsWith",
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "value": {"type": "valueText", "value": "firefox", "quoted": false}
       },
@@ -57,14 +57,14 @@
     ]
   },
   {
-    "query": "!browser.name:starts with[firefox, chrome]",
+    "query": "!browser.name:StartsWith[firefox, chrome]",
     "result": [
       {"type": "spaces", "value": ""},
       {
         "type": "filter",
         "filter": "textIn",
         "negated": true,
-        "operator": "starts with",
+        "operator": "StartsWith",
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "value": {
           "type": "valueTextList",

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -206,9 +206,9 @@ sep                  = ":"
 negation             = "!"
 # Note: wildcard unicode is defined in src/sentry/search/events/constants.py
 wildcard_unicode     = "\uF00D"
-contains             = "contains"
-starts_with          = "starts with"
-ends_with            = "ends with"
+contains             = "Contains"
+starts_with          = "StartsWith"
+ends_with            = "EndsWith"
 comma                = ","
 spaces               = " "*
 

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -310,9 +310,9 @@ OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt", "=": "exac
 WILDCARD_UNICODE = "\uf00d"
 
 WILDCARD_OPERATOR_MAP = {
-    "contains": f"{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}",
-    "starts_with": f"{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}",
-    "ends_with": f"{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}",
+    "contains": f"{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}",
+    "starts_with": f"{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}",
+    "ends_with": f"{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}",
 }
 
 MAX_SEARCH_RELEASES = 1000

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -450,9 +450,9 @@ closed_bracket = "]"
 sep            = ":"
 negation       = "!"
 wildcard_unicode     = [\uF00D]
-contains             = "contains"
-starts_with          = "starts with"
-ends_with            = "ends with"
+contains             = "Contains"
+starts_with          = "StartsWith"
+ends_with            = "EndsWith"
 comma          = ","
 spaces         = " "* { return tc.tokenSpaces(text()) }
 

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -76,12 +76,12 @@ export enum TermOperator {
   LESS_THAN = '<',
   EQUAL = '=',
   NOT_EQUAL = '!=',
-  CONTAINS = '\uf00dcontains\uf00d',
-  DOES_NOT_CONTAIN = '\uf00ddoes not contain\uf00d',
-  STARTS_WITH = '\uf00dstarts with\uf00d',
-  DOES_NOT_START_WITH = '\uf00ddoes not start with\uf00d',
-  ENDS_WITH = '\uf00dends with\uf00d',
-  DOES_NOT_END_WITH = '\uf00ddoes not end with\uf00d',
+  CONTAINS = '\uf00dContains\uf00d',
+  DOES_NOT_CONTAIN = '\uf00dDoesNotContain\uf00d',
+  STARTS_WITH = '\uf00dStartsWith\uf00d',
+  DOES_NOT_START_WITH = '\uf00dDoesNotStartWith\uf00d',
+  ENDS_WITH = '\uf00dEndsWith\uf00d',
+  DOES_NOT_END_WITH = '\uf00dDoesNotEndWith\uf00d',
 }
 
 /**
@@ -125,9 +125,9 @@ export enum FilterType {
  * Unicode Character: `\uf00d`
  */
 export enum WildcardOperators {
-  CONTAINS = '\uf00dcontains\uf00d',
-  STARTS_WITH = '\uf00dstarts with\uf00d',
-  ENDS_WITH = '\uf00dends with\uf00d',
+  CONTAINS = '\uf00dContains\uf00d',
+  STARTS_WITH = '\uf00dStartsWith\uf00d',
+  ENDS_WITH = '\uf00dEndsWith\uf00d',
 }
 
 export const basicOperators = [TermOperator.DEFAULT, TermOperator.NOT_EQUAL] as const;

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -204,7 +204,7 @@ class ParseSearchQueryTest(SimpleTestCase):
             # expected result value without the wildcard operator, this is because the
             # backend does a translation from the unicode wildcard to the regular
             # asterisk wildcard
-            if "contains" in query or "ends with" in query:
+            if "Contains" in query or "EndsWith" in query:
                 leading_op = "="
                 leading_wildcard_value: str | list[str] | None = None
                 if test_case[1]["filter"] == "text":
@@ -223,7 +223,7 @@ class ParseSearchQueryTest(SimpleTestCase):
                 new_search_value = expected[0].value._replace(raw_value=leading_wildcard_value)
                 expected = [SearchFilter(expected[0].key, leading_op, new_search_value)]
 
-            if "contains" in query or "starts with" in query:
+            if "Contains" in query or "StartsWith" in query:
                 trailing_op = "="
                 trailing_wildcard_value: str | list[str] | None = None
                 if test_case[1]["filter"] == "text":
@@ -1168,67 +1168,67 @@ def test_gen_wildcard_value(value, wildcard_op, expected) -> None:
     [
         # --- contains ---
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}test", "span.op:=^.*test.*$"
+            f"span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}test", "span.op:=^.*test.*$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}*test", "span.op:=^.*\\*test.*$"
+            f"span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}*test", "span.op:=^.*\\*test.*$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}test*", "span.op:=^.*test\\*.*$"
+            f"span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}test*", "span.op:=^.*test\\*.*$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}*test*",
+            f"span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}*test*",
             "span.op:=^.*\\*test\\*.*$",
         ),
         # --- contains quoted text ---
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}"test 1"',
+            f'span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}"test 1"',
             "span.op:=^.*test\\ 1.*$",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}"*test 1"',
+            f'span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}"*test 1"',
             "span.op:=^.*\\*test\\ 1.*$",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}"test 1*"',
+            f'span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}"test 1*"',
             "span.op:=^.*test\\ 1\\*.*$",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}"*test 1*"',
+            f'span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}"*test 1*"',
             "span.op:=^.*\\*test\\ 1\\*.*$",
         ),
         # --- contains text list ---
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}[test, test2]",
+            f"span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}[test, test2]",
             "span.op:[*test*, *test2*]",
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}[*test, *test2]",
+            f"span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}[*test, *test2]",
             "span.op:[*\\*test*, *\\*test2*]",
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}[test*, test2*]",
+            f"span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}[test*, test2*]",
             "span.op:[*test\\**, *test2\\**]",
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}[*test*, *test2*]",
+            f"span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}[*test*, *test2*]",
             "span.op:[*\\*test\\**, *\\*test2\\**]",
         ),
         # --- contains quoted text list ---
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}["test 1", "test 2"]',
+            f'span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}["test 1", "test 2"]',
             "span.op:[*test 1*, *test 2*]",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}["*test 1", "*test 2"]',
+            f'span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}["*test 1", "*test 2"]',
             "span.op:[*\\*test 1*, *\\*test 2*]",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}["test 1*", "test 2*"]',
+            f'span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}["test 1*", "test 2*"]',
             "span.op:[*test 1\\**, *test 2\\**]",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}contains{WILDCARD_UNICODE}["*test 1*", "*test 2*"]',
+            f'span.op:{WILDCARD_UNICODE}Contains{WILDCARD_UNICODE}["*test 1*", "*test 2*"]',
             "span.op:[*\\*test 1\\**, *\\*test 2\\**]",
         ),
     ],
@@ -1244,69 +1244,69 @@ def test_handles_contains_wildcard_op_translations(query, expected) -> None:
 @pytest.mark.parametrize(
     ["query", "expected"],
     [
-        # --- starts with ---
+        # --- StartsWith ---
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}test", "span.op:=^test.*$"
+            f"span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}test", "span.op:=^test.*$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}*test", "span.op:=^\\*test.*$"
+            f"span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}*test", "span.op:=^\\*test.*$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}test*", "span.op:=^test\\*.*$"
+            f"span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}test*", "span.op:=^test\\*.*$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}*test*",
+            f"span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}*test*",
             "span.op:=^\\*test\\*.*$",
         ),
-        # --- starts with quoted text ---
+        # --- StartsWith quoted text ---
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}"test 1"',
+            f'span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}"test 1"',
             "span.op:=^test\\ 1.*$",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}"*test 1"',
+            f'span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}"*test 1"',
             "span.op:=^\\*test\\ 1.*$",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}"test 1*"',
+            f'span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}"test 1*"',
             "span.op:=^test\\ 1\\*.*$",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}"*test 1*"',
+            f'span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}"*test 1*"',
             "span.op:=^\\*test\\ 1\\*.*$",
         ),
-        # --- starts with text list ---
+        # --- StartsWith text list ---
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}[test, test2]",
+            f"span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}[test, test2]",
             "span.op:[test*, test2*]",
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}[*test, *test2]",
+            f"span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}[*test, *test2]",
             "span.op:[\\*test*, \\*test2*]",
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}[test*, test2*]",
+            f"span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}[test*, test2*]",
             "span.op:[test\\**, test2\\**]",
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}[*test*, *test2*]",
+            f"span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}[*test*, *test2*]",
             "span.op:[\\*test\\**, \\*test2\\**]",
         ),
-        # --- starts with quoted text list ---
+        # --- StartsWith quoted text list ---
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}["test 1", "test 2"]',
+            f'span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}["test 1", "test 2"]',
             "span.op:[test 1*, test 2*]",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}["*test 1", "*test 2"]',
+            f'span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}["*test 1", "*test 2"]',
             "span.op:[\\*test 1*, \\*test 2*]",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}["test 1*", "test 2*"]',
+            f'span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}["test 1*", "test 2*"]',
             "span.op:[test 1\\**, test 2\\**]",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}starts with{WILDCARD_UNICODE}["*test 1*", "*test 2*"]',
+            f'span.op:{WILDCARD_UNICODE}StartsWith{WILDCARD_UNICODE}["*test 1*", "*test 2*"]',
             "span.op:[\\*test 1\\**, \\*test 2\\**]",
         ),
     ],
@@ -1322,69 +1322,69 @@ def test_handles_starts_with_wildcard_op_translations(query, expected) -> None:
 @pytest.mark.parametrize(
     ["query", "expected"],
     [
-        # --- ends with ---
+        # --- EndsWith ---
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}test", "span.op:=^.*test$"
+            f"span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}test", "span.op:=^.*test$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}*test", "span.op:=^.*\\*test$"
+            f"span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}*test", "span.op:=^.*\\*test$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}test*", "span.op:=^.*test\\*$"
+            f"span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}test*", "span.op:=^.*test\\*$"
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}*test*",
+            f"span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}*test*",
             "span.op:=^.*\\*test\\*$",
         ),
-        # --- ends with quoted text ---
+        # --- EndsWith quoted text ---
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}"test 1"',
+            f'span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}"test 1"',
             "span.op:=^.*test\\ 1$",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}"*test 1"',
+            f'span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}"*test 1"',
             "span.op:=^.*\\*test\\ 1$",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}"test 1*"',
+            f'span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}"test 1*"',
             "span.op:=^.*test\\ 1\\*$",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}"*test 1*"',
+            f'span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}"*test 1*"',
             "span.op:=^.*\\*test\\ 1\\*$",
         ),
-        # --- ends with text list ---
+        # --- EndsWith text list ---
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}[test, test2]",
+            f"span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}[test, test2]",
             "span.op:[*test, *test2]",
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}[*test, *test2]",
+            f"span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}[*test, *test2]",
             "span.op:[*\\*test, *\\*test2]",
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}[test*, test2*]",
+            f"span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}[test*, test2*]",
             "span.op:[*test\\*, *test2\\*]",
         ),
         pytest.param(
-            f"span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}[*test*, *test2*]",
+            f"span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}[*test*, *test2*]",
             "span.op:[*\\*test\\*, *\\*test2\\*]",
         ),
-        # --- ends with quoted text list ---
+        # --- EndsWith quoted text list ---
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}["test 1", "test 2"]',
+            f'span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}["test 1", "test 2"]',
             "span.op:[*test 1, *test 2]",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}["*test 1", "*test 2"]',
+            f'span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}["*test 1", "*test 2"]',
             "span.op:[*\\*test 1, *\\*test 2]",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}["test 1*", "test 2*"]',
+            f'span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}["test 1*", "test 2*"]',
             "span.op:[*test 1\\*, *test 2\\*]",
         ),
         pytest.param(
-            f'span.op:{WILDCARD_UNICODE}ends with{WILDCARD_UNICODE}["*test 1*", "*test 2*"]',
+            f'span.op:{WILDCARD_UNICODE}EndsWith{WILDCARD_UNICODE}["*test 1*", "*test 2*"]',
             "span.op:[*\\*test 1\\*, *\\*test 2\\*]",
         ),
     ],


### PR DESCRIPTION
Quickly removing the spaces from the wildcard operators to deal spacing issues when splitting a query into tokens.

Ticket: EXP-516, EXP-515