### PR TITLE
ref(grouping): Refresh grouphash from database before checking for metadata

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1322,6 +1322,7 @@ def assign_event_to_group(
     # `get_or_create_grouphashes`. If it doesn't, perhaps there's a race condition between creation
     # of the metadata and our ability to pull it from the database immediately thereafter.
     for grouphash in [*primary.grouphashes, *secondary.grouphashes]:
+        grouphash.refresh_from_db()
         if not grouphash.metadata:
             logger.warning(
                 "grouphash_metadata.hash_without_metadata",


### PR DESCRIPTION
We are currently collecting a `grouphash_metadata.hash_without_metadata` metric in two places - first when the metadata should have been created, and later once more of the grouping process has happened, to see if race conditions might explain the missing records (and therefore if they would have appeared in the meantime). In order to make this work, we really should go back to the database before doing the second check, so this adds a `refresh_from_db` before collecting the second metric.