### PR TITLE
chore(effective-sample-rate): Use new endpoint for effective sample rate instead of checking the organization

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -102,7 +102,6 @@ export interface Organization extends OrganizationSummary {
     | null;
   defaultSeerScannerAutomation?: boolean;
   desiredSampleRate?: number | null;
-  effectiveSampleRate?: number | null;
   enableSeerCoding?: boolean;
   enableSeerEnhancedAlerts?: boolean;
   enabledConsolePlatforms?: string[];

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -8,7 +8,13 @@ import {
   SubscriptionFixture,
   SubscriptionWithSeerFixture,
 } from 'getsentry-test/fixtures/subscription';
-import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import {DataCategory} from 'sentry/types/core';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
@@ -550,7 +556,7 @@ describe('CustomerOverview', () => {
     });
   });
 
-  it('render dynamic sampling rate for am3 account', () => {
+  it('render dynamic sampling rate for am3 account', async () => {
     const organization = OrganizationFixture({
       features: ['dynamic-sampling'],
       desiredSampleRate: 0.75,
@@ -559,6 +565,11 @@ describe('CustomerOverview', () => {
       organization,
       plan: 'am3_team',
       planTier: PlanTier.AM3,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/sampling/effective-sample-rate/`,
+      body: {effectiveSampleRate: 0.75},
     });
 
     render(
@@ -570,6 +581,64 @@ describe('CustomerOverview', () => {
     );
 
     expect(screen.getByText('Team Plan (am3)')).toBeInTheDocument();
-    expect(screen.getByText('75.00%')).toBeInTheDocument();
+    const term = await screen.findByText('Sample Rate (24h):');
+    const definition = term.nextElementSibling;
+    expect(definition).toBeInTheDocument();
+    if (!definition || !(definition instanceof HTMLElement)) {
+      throw new Error('Sample rate definition not found or not an HTMLElement');
+    }
+    await waitFor(() => expect(definition).toHaveTextContent('75.00%'));
+  });
+
+  it('renders effective sample rate with desired comparison string', async () => {
+    const organization = OrganizationFixture({
+      features: ['dynamic-sampling'],
+      desiredSampleRate: 0.6,
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/sampling/effective-sample-rate/`,
+      body: {effectiveSampleRate: 0.54},
+    });
+
+    render(
+      <CustomerOverview
+        customer={subscription}
+        onAction={jest.fn()}
+        organization={organization}
+      />
+    );
+    await screen.findByText('54.00% instead of 60.00% (~6.00%)');
+  });
+
+  it('renders n/a when effective sample rate is missing', async () => {
+    const organization = OrganizationFixture({
+      features: ['dynamic-sampling'],
+      desiredSampleRate: 0.75,
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/sampling/effective-sample-rate/`,
+      body: {effectiveSampleRate: null},
+    });
+
+    render(
+      <CustomerOverview
+        customer={subscription}
+        onAction={jest.fn()}
+        organization={organization}
+      />
+    );
+
+    const term = await screen.findByText('Sample Rate (24h):');
+    await waitFor(() => {
+      expect(term.nextElementSibling).toHaveTextContent('n/a');
+    });
   });
 });

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -581,13 +581,11 @@ describe('CustomerOverview', () => {
     );
 
     expect(screen.getByText('Team Plan (am3)')).toBeInTheDocument();
-    const term = await screen.findByText('Sample Rate (24h):');
-    const definition = term.nextElementSibling;
-    expect(definition).toBeInTheDocument();
-    if (!definition || !(definition instanceof HTMLElement)) {
-      throw new Error('Sample rate definition not found or not an HTMLElement');
-    }
-    await waitFor(() => expect(definition).toHaveTextContent('75.00%'));
+    await waitFor(() => {
+      const term = screen.getByText('Sample Rate (24h):');
+      const definition = term.nextElementSibling;
+      expect(definition).toHaveTextContent('75.00%');
+    });
   });
 
   it('renders effective sample rate with desired comparison string', async () => {
@@ -636,8 +634,8 @@ describe('CustomerOverview', () => {
       />
     );
 
-    const term = await screen.findByText('Sample Rate (24h):');
     await waitFor(() => {
+      const term = screen.getByText('Sample Rate (24h):');
       expect(term.nextElementSibling).toHaveTextContent('n/a');
     });
   });

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -12,6 +12,7 @@ import {space} from 'sentry/styles/space';
 import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
 import ChangeARRAction from 'admin/components/changeARRAction';
@@ -394,35 +395,52 @@ function isWithinAcceptedMargin(
 }
 
 function DynamicSampling({organization}: {organization: Organization}) {
-  if (organization.features?.includes('dynamic-sampling')) {
-    const effectiveSampleRate = organization.effectiveSampleRate
-      ? organization.effectiveSampleRate * 100
-      : null;
-    const desiredSampleRate = organization.desiredSampleRate
-      ? organization.desiredSampleRate * 100
-      : null;
-    const diffSampleRate =
-      effectiveSampleRate && desiredSampleRate
-        ? Math.abs(effectiveSampleRate - desiredSampleRate)
-        : null;
+  const dynamicSamplingEnabled = organization.features?.includes('dynamic-sampling');
 
-    return (
-      <ThresholdLabel
-        positive={
-          effectiveSampleRate && desiredSampleRate
-            ? isWithinAcceptedMargin(effectiveSampleRate, desiredSampleRate)
-            : false
-        }
-      >
-        {effectiveSampleRate && desiredSampleRate
-          ? `${effectiveSampleRate.toFixed(2)}% instead of ${desiredSampleRate.toFixed(2)}% (~${diffSampleRate?.toFixed(2)}%)`
-          : desiredSampleRate
-            ? `${desiredSampleRate.toFixed(2)}%`
-            : 'n/a'}
-      </ThresholdLabel>
-    );
+  const {data} = useApiQuery<{effectiveSampleRate: number | null}>(
+    [`/organizations/${organization.slug}/sampling/effective-sample-rate/`],
+    {
+      staleTime: Infinity,
+      enabled: dynamicSamplingEnabled,
+    }
+  );
+
+  if (!dynamicSamplingEnabled) {
+    <ThresholdLabel positive={false}>Disabled</ThresholdLabel>;
   }
-  return <ThresholdLabel positive={false}>Disabled</ThresholdLabel>;
+
+  if (!data) {
+    return <ThresholdLabel positive={false}>Loading...</ThresholdLabel>;
+  }
+
+  if (!defined(data.effectiveSampleRate)) {
+    return <ThresholdLabel positive={false}>n/a</ThresholdLabel>;
+  }
+
+  const effectiveSampleRate = data.effectiveSampleRate * 100;
+  const desiredSampleRate = organization.desiredSampleRate
+    ? organization.desiredSampleRate * 100
+    : null;
+  const diffSampleRate =
+    effectiveSampleRate && desiredSampleRate
+      ? Math.abs(effectiveSampleRate - desiredSampleRate)
+      : null;
+
+  return (
+    <ThresholdLabel
+      positive={
+        effectiveSampleRate && desiredSampleRate
+          ? isWithinAcceptedMargin(effectiveSampleRate, desiredSampleRate)
+          : false
+      }
+    >
+      {effectiveSampleRate && desiredSampleRate
+        ? `${effectiveSampleRate.toFixed(2)}% instead of ${desiredSampleRate.toFixed(2)}% (~${diffSampleRate?.toFixed(2)}%)`
+        : desiredSampleRate
+          ? `${desiredSampleRate.toFixed(2)}%`
+          : 'n/a'}
+    </ThresholdLabel>
+  );
 }
 
 function CustomerOverview({customer, onAction, organization}: Props) {

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -406,7 +406,7 @@ function DynamicSampling({organization}: {organization: Organization}) {
   );
 
   if (!dynamicSamplingEnabled) {
-    <ThresholdLabel positive={false}>Disabled</ThresholdLabel>;
+    return <ThresholdLabel positive={false}>Disabled</ThresholdLabel>;
   }
 
   if (!data) {

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -397,7 +397,7 @@ function isWithinAcceptedMargin(
 function DynamicSampling({organization}: {organization: Organization}) {
   const dynamicSamplingEnabled = organization.features?.includes('dynamic-sampling');
 
-  const {data} = useApiQuery<{effectiveSampleRate: number | null}>(
+  const {data, isPending, isError} = useApiQuery<{effectiveSampleRate: number | null}>(
     [`/organizations/${organization.slug}/sampling/effective-sample-rate/`],
     {
       staleTime: Infinity,
@@ -408,8 +408,10 @@ function DynamicSampling({organization}: {organization: Organization}) {
   if (!dynamicSamplingEnabled) {
     return <ThresholdLabel positive={false}>Disabled</ThresholdLabel>;
   }
-
-  if (!data) {
+  if (isError) {
+    return <ThresholdLabel positive={false}>Error loading data</ThresholdLabel>;
+  }
+  if (isPending) {
     return <ThresholdLabel positive={false}>Loading...</ThresholdLabel>;
   }
 


### PR DESCRIPTION
Ref RTC-1188

Depends on https://github.com/getsentry/sentry/pull/99347 and https://github.com/getsentry/sentry/pull/99496 being merged and deployed first. This is the only usage of effective sample rate, so it makes more sense as a separate endpoint than something added to the organization serializer.

This is just an admin view so not doing any special loading states or anything