### PR TITLE
only supply the branch param when it exists

### DIFF
--- a/static/app/views/prevent/tests/queries/useGetTestResults.ts
+++ b/static/app/views/prevent/tests/queries/useGetTestResults.ts
@@ -125,7 +125,7 @@ export function useInfiniteTestResults({
                 ],
               sortBy: signedSortBy,
               term,
-              branch,
+              ...(branch ? {branch} : {}),
               ...(mappedFilterBy ? {filterBy: mappedFilterBy} : {}),
               ...(testSuites ? {testSuites} : {}),
               ...(cursor ? {cursor} : {}),

--- a/static/app/views/prevent/tests/queries/useGetTestResults.ts
+++ b/static/app/views/prevent/tests/queries/useGetTestResults.ts
@@ -69,9 +69,17 @@ export function useInfiniteTestResults({
   cursor?: string | null;
   navigation?: 'next' | 'prev';
 }) {
-  const {integratedOrgId, repository, branch, preventPeriod} = usePreventContext();
+  const {
+    integratedOrgId,
+    repository,
+    branch: rawBranch,
+    preventPeriod,
+  } = usePreventContext();
   const organization = useOrganization();
   const [searchParams] = useSearchParams();
+
+  // Normalize branch to undefined when falsy for consistent caching
+  const branch = rawBranch || undefined;
 
   const sortBy = searchParams.get('sort') || '-totalFailCount';
   const signedSortBy = sortValueToSortKey(sortBy);
@@ -125,7 +133,7 @@ export function useInfiniteTestResults({
                 ],
               sortBy: signedSortBy,
               term,
-              ...(branch ? {branch} : {}),
+              branch,
               ...(mappedFilterBy ? {filterBy: mappedFilterBy} : {}),
               ...(testSuites ? {testSuites} : {}),
               ...(cursor ? {cursor} : {}),


### PR DESCRIPTION
Pass the branch param only when it exists, letting all branches to work