### PR TITLE
feat(prevent): Use GH integration data for TA onboarding

### DIFF
--- a/static/app/views/prevent/tests/onboarding.spec.tsx
+++ b/static/app/views/prevent/tests/onboarding.spec.tsx
@@ -20,6 +20,7 @@ const mockGitHubIntegration = {
     key: 'github',
     name: 'GitHub',
   },
+  externalId: '88888888',
 };
 
 const mockRepositories = [
@@ -42,6 +43,8 @@ describe('TestsOnboardingPage', () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/integrations/',
       body: [mockGitHubIntegration],
+      method: 'GET',
+      match: [MockApiClient.matchQuery({provider_key: 'github', includeConfig: 0})],
     });
 
     MockApiClient.addMockResponse({
@@ -152,7 +155,7 @@ describe('TestsOnboardingPage', () => {
       }
     );
 
-    const githubRadio = screen.getByLabelText('Use GitHub Actions to run my CI');
+    const githubRadio = await screen.findByLabelText('Use GitHub Actions to run my CI');
     expect(githubRadio).not.toBeChecked();
 
     await userEvent.click(githubRadio);
@@ -175,7 +178,7 @@ describe('TestsOnboardingPage', () => {
       }
     );
 
-    const cliRadio = screen.getByLabelText(
+    const cliRadio = await screen.findByLabelText(
       "Use Sentry Prevent's CLI to upload testing reports"
     );
     expect(cliRadio).not.toBeChecked();
@@ -252,20 +255,30 @@ describe('TestsOnboardingPage', () => {
         );
 
         // Change upload permission to Upload Token
-        const uploadTokenRadio = screen.getByLabelText('Use Sentry Prevent Upload Token');
+        const uploadTokenRadio = await screen.findByLabelText(
+          'Use Sentry Prevent Upload Token'
+        );
         await userEvent.click(uploadTokenRadio);
         expect(
-          screen.getByText('Step 1: Output a JUnit XML file in your CI')
+          await screen.findByText('Step 1: Output a JUnit XML file in your CI')
         ).toBeInTheDocument();
         expect(
-          screen.getByText('Step 2: Choose an upload permission')
+          await screen.findByText('Step 2: Choose an upload permission')
         ).toBeInTheDocument();
-        expect(screen.getByLabelText('Use Sentry Prevent Upload Token')).toBeChecked();
-        expect(screen.getByLabelText('Use OpenID Connect (OIDC)')).not.toBeChecked();
-        expect(screen.getByText('Step 2b: Add token as')).toBeInTheDocument();
-        expect(screen.getByText(/^Step 3: Add the script/)).toBeInTheDocument();
-        expect(screen.getByText('Step 4: Run your test suite')).toBeInTheDocument();
-        expect(screen.getByText('Step 5: View results and insights')).toBeInTheDocument();
+        expect(
+          await screen.findByLabelText('Use Sentry Prevent Upload Token')
+        ).toBeChecked();
+        expect(
+          await screen.findByLabelText('Use OpenID Connect (OIDC)')
+        ).not.toBeChecked();
+        expect(await screen.findByText('Step 2b: Add token as')).toBeInTheDocument();
+        expect(await screen.findByText(/^Step 3: Add the script/)).toBeInTheDocument();
+        expect(
+          await screen.findByText('Step 4: Run your test suite')
+        ).toBeInTheDocument();
+        expect(
+          await screen.findByText('Step 5: View results and insights')
+        ).toBeInTheDocument();
 
         // OIDC-specific steps should NOT be present
         expect(
@@ -302,29 +315,31 @@ describe('TestsOnboardingPage', () => {
 
         // Initially should show OIDC steps
         expect(
-          screen.getByText('Step 3: Edit your GitHub Actions workflow')
+          await screen.findByText('Step 3: Edit your GitHub Actions workflow')
         ).toBeInTheDocument();
         expect(screen.queryByText('Step 2b: Add token as')).not.toBeInTheDocument();
         expect(screen.queryByText(/Step 3: Add the script/)).not.toBeInTheDocument();
 
         // Switch to Upload Token
-        const uploadTokenRadio = screen.getByLabelText('Use Sentry Prevent Upload Token');
+        const uploadTokenRadio = await screen.findByLabelText(
+          'Use Sentry Prevent Upload Token'
+        );
         await userEvent.click(uploadTokenRadio);
 
         // Should now show Upload Token steps
         expect(
           screen.queryByText('Step 3: Edit your GitHub Actions workflow')
         ).not.toBeInTheDocument();
-        expect(screen.getByText('Step 2b: Add token as')).toBeInTheDocument();
-        expect(screen.getByText(/Step 3: Add the script/)).toBeInTheDocument();
+        expect(await screen.findByText('Step 2b: Add token as')).toBeInTheDocument();
+        expect(await screen.findByText(/Step 3: Add the script/)).toBeInTheDocument();
 
         // Switch back to OIDC
-        const oidcRadio = screen.getByLabelText('Use OpenID Connect (OIDC)');
+        const oidcRadio = await screen.findByLabelText('Use OpenID Connect (OIDC)');
         await userEvent.click(oidcRadio);
 
         // Should show OIDC steps again
         expect(
-          screen.getByText('Step 3: Edit your GitHub Actions workflow')
+          await screen.findByText('Step 3: Edit your GitHub Actions workflow')
         ).toBeInTheDocument();
         expect(screen.queryByText('Step 2b: Add token as')).not.toBeInTheDocument();
         expect(screen.queryByText(/Step 3: Add the script/)).not.toBeInTheDocument();
@@ -397,35 +412,47 @@ describe('TestsOnboardingPage', () => {
 
         // Should show CLI steps regardless of upload permission
         expect(
-          screen.getByText('Step 1: Output a JUnit XML file in your CI')
+          await screen.findByText('Step 1: Output a JUnit XML file in your CI')
         ).toBeInTheDocument();
-        expect(screen.getByText('Step 2: Add token as')).toBeInTheDocument();
-        expect(screen.getAllByRole('link', {name: 'Sentry Prevent CLI'})).toHaveLength(2);
+        expect(await screen.findByText('Step 2: Add token as')).toBeInTheDocument();
         expect(
-          screen.getByText('Step 3: Install the', {exact: false})
+          await screen.findAllByRole('link', {name: 'Sentry Prevent CLI'})
+        ).toHaveLength(2);
+        expect(
+          await screen.findByText('Step 3: Install the', {exact: false})
         ).toBeInTheDocument();
         expect(
-          screen.getByText('Step 4: Upload this file to Sentry Prevent using the CLI')
+          await screen.findByText(
+            'Step 4: Upload this file to Sentry Prevent using the CLI'
+          )
         ).toBeInTheDocument();
-        expect(screen.getByText('Step 5: Run your test suite')).toBeInTheDocument();
+        expect(
+          await screen.findByText('Step 5: Run your test suite')
+        ).toBeInTheDocument();
         expect(screen.getByText('Step 6: View results and insights')).toBeInTheDocument();
 
         // Switch to GitHub Actions
-        const githubRadio = screen.getByLabelText('Use GitHub Actions to run my CI');
+        const githubRadio = await screen.findByLabelText(
+          'Use GitHub Actions to run my CI'
+        );
         await userEvent.click(githubRadio);
 
         // Should now show GitHub Actions steps
         expect(
-          screen.getByText('Step 1: Output a JUnit XML file in your CI')
+          await screen.findByText('Step 1: Output a JUnit XML file in your CI')
         ).toBeInTheDocument();
         expect(
-          screen.getByText('Step 2: Choose an upload permission')
+          await screen.findByText('Step 2: Choose an upload permission')
         ).toBeInTheDocument();
         expect(
-          screen.getByText('Step 3: Edit your GitHub Actions workflow')
+          await screen.findByText('Step 3: Edit your GitHub Actions workflow')
         ).toBeInTheDocument();
-        expect(screen.getByText('Step 4: Run your test suite')).toBeInTheDocument();
-        expect(screen.getByText('Step 5: View results and insights')).toBeInTheDocument();
+        expect(
+          await screen.findByText('Step 4: Run your test suite')
+        ).toBeInTheDocument();
+        expect(
+          await screen.findByText('Step 5: View results and insights')
+        ).toBeInTheDocument();
 
         // CLI specific steps should NOT be present
         expect(screen.queryByText('Step 2: Add token as')).not.toBeInTheDocument();

--- a/static/app/views/prevent/tests/preOnboarding.tsx
+++ b/static/app/views/prevent/tests/preOnboarding.tsx
@@ -14,33 +14,16 @@ import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import useOrganization from 'sentry/utils/useOrganization';
 
 const INSTRUCTIONS_TEXT = {
-  noOrgs: {
-    header: t('Get Started by installing the GitHub Sentry App'),
-    subtext: t(
-      "You need to install the Sentry App on your GitHub organization as an admin. If you're not an admin, you will need to make sure your GitHub organization admins approve the installation of the Sentry App on GitHub."
-    ),
-    mainCTA: t('Add installation'),
-    mainCTALink: '/settings/integrations/github',
-  },
-  hasOrgs: {
-    header: t('Request Updated Permissions on your Integrated Organization'),
-    subtext: t(
-      "Sentry is requesting updated permissions access to your integrated organization(s). Admin required. If you're not an admin, reach out to your organization's owner to update the Sentry app permissions."
-    ),
-    mainCTA: t('Review permissions'),
-    mainCTALink: '/settings/integrations/github',
-  },
+  header: t('Get Started by installing the GitHub Sentry App'),
+  subtext: t(
+    "You need to install the Sentry App on your GitHub organization as an admin. If you're not an admin, you will need to make sure your GitHub organization admins approve the installation of the Sentry App on GitHub."
+  ),
+  mainCTA: t('Add installation'),
+  mainCTALink: '/settings/integrations/github',
 } as const;
-
-// TODO: this should come from the backend
-const HAS_INTEGRATED_ORGS = false;
 
 export default function TestPreOnboardingPage() {
   const organization = useOrganization();
-  const instructionSet = HAS_INTEGRATED_ORGS
-    ? INSTRUCTIONS_TEXT.hasOrgs
-    : INSTRUCTIONS_TEXT.noOrgs;
-
   const regionData = getRegionDataFromOrganization(organization);
   const isUSStorage = regionData?.name === 'us';
 
@@ -86,11 +69,11 @@ export default function TestPreOnboardingPage() {
       {isUSStorage && (
         <Panel>
           <InstructionsSection>
-            <h2>{instructionSet.header}</h2>
-            <SubtextParagraph>{instructionSet.subtext}</SubtextParagraph>
+            <h2>{INSTRUCTIONS_TEXT.header}</h2>
+            <SubtextParagraph>{INSTRUCTIONS_TEXT.subtext}</SubtextParagraph>
             <ButtonBar>
-              <LinkButton priority="primary" href={instructionSet.mainCTA}>
-                {instructionSet.mainCTA}
+              <LinkButton priority="primary" href={INSTRUCTIONS_TEXT.mainCTA}>
+                {INSTRUCTIONS_TEXT.mainCTA}
               </LinkButton>
               <LinkButton priority="default" href="/settings/integrations/github">
                 Learn more


### PR DESCRIPTION
Original ticket: https://linear.app/getsentry/issue/CCMRG-1440/backend-logic-for-github-app-installation
Closes https://linear.app/getsentry/issue/CCMRG-1636/add-fe-logic-for-sending-to-ta-preonboarding-or-repo-onboarding-steps

We ended up not needing extra Backend changes for this. We can use the /integrations endpoint to grab information about GH app installations for integrated GH orgs to the current user.

- Uses GH app installation info to decide if we should go to preonboarding or onboarding
- Remove placeholder link for managing "repo access" from repo selector
- We also no longer need the 2) section of preonboarding here at https://www.figma.com/design/mSyCX0wCk7e2yItQfiMhaa/GH-1247_MergePlan?node-id=820-5978&t=QKJC4l3y9zJTXis6-1 so I am removing the distinction between "no_org" and "has_orgs".