### PR TITLE
fix(codecov): Fix regenerate token permission check

### DIFF
--- a/src/sentry/codecov/endpoints/repository_token_regenerate/repository_token_regenerate.py
+++ b/src/sentry/codecov/endpoints/repository_token_regenerate/repository_token_regenerate.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationPermission
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.parameters import GlobalParams, PreventParams
 from sentry.codecov.base import CodecovEndpoint
@@ -16,6 +17,13 @@ from sentry.codecov.endpoints.repository_token_regenerate.serializers import (
 from sentry.integrations.services.integration.model import RpcIntegration
 
 
+class RepositoryTokenRegeneratePermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read", "org:write", "org:admin"],
+        "POST": ["org:read", "org:write", "org:admin"],
+    }
+
+
 @extend_schema(tags=["Prevent"])
 @region_silo_endpoint
 class RepositoryTokenRegenerateEndpoint(CodecovEndpoint):
@@ -23,6 +31,7 @@ class RepositoryTokenRegenerateEndpoint(CodecovEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.PUBLIC,
     }
+    permission_classes = (RepositoryTokenRegeneratePermission,)
 
     @extend_schema(
         operation_id="Regenerates a repository upload token and returns the new token",


### PR DESCRIPTION
Codecov requires a token for each github repo to send data to Codecov. We have a UI page in Sentry to allow regenerating that token. We want this operation available to all Sentry users in an org (`org:read` permission).
This PR fixes the fact that `OrganizationPermission` by default only allows POST by `org:write` and `org:admin`, but we want this endpoint to allow `org:read`. This approach follows a similar pattern to [this PR](https://github.com/getsentry/sentry/commit/0551bcca487040373873e84caeb7bfc1ddad89c4#diff-951afca1345842d06c9db6a68c10c20b76a99ce9dbda792a2d37e3b24084fc23).

**Other Info:**

Regenerate Token api at `https://us.sentry.io/api/0/organizations/codecov/prevent/owner/301769/repository/testagain/token/regenerate/` forwards the http request from Sentry UI frontend over to Codecov api backend (graphQL). Auth in between sentry backend and codecov backend is a signed JWT with metadata on the org.

The `RegenerateTokenEndpoint` inherits from CodecovEndpoint → OrganizationEndpoint, and therefore uses the `OrganizationPermission`. By default, OrganizationPermission requires at least org:write permission for any POST requests ([code here](https://github.com/getsentry/sentry/blob/c68a74b7d246b57f6537e857dc19d391b676ddf2/src/sentry/api/bases/organization.py#L50)). See PR [here](https://github.com/getsentry/sentry/pull/95368) where this was set up.

So this PR updates the permissions for just this endpoint. It overrides the default behavior to allow POST requests from users with only org:read, while still inheriting the rest of the protections from OrganizationEndpoint.


Closes https://linear.app/getsentry/issue/CCMRG-1639

