### PR TITLE
ref: fix most tests errors with upgraded django-stubs

### DIFF
--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -359,6 +359,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         with self.tasks():
             event = manager.save(self.project.id)
 
+        assert event.group_id is not None
         group = Group.objects.get(id=event.group_id)
         group.status = GroupStatus.RESOLVED
         group.substatus = None
@@ -414,6 +415,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         with self.tasks():
             event = manager.save(self.project.id)
 
+        assert event.group_id is not None
         group = Group.objects.get(id=event.group_id)
         group.status = GroupStatus.RESOLVED
         group.substatus = None
@@ -468,6 +470,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         with self.tasks():
             event = manager.save(self.project.id)
 
+        assert event.group_id is not None
         group = Group.objects.get(id=event.group_id)
         group.status = GroupStatus.RESOLVED
         group.substatus = None
@@ -505,6 +508,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             manager.normalize()
             event = manager.save(self.project.id)
 
+        assert event.group_id is not None
         group = Group.objects.get(id=event.group_id)
         group.status = GroupStatus.RESOLVED
         group.substatus = None
@@ -2219,6 +2223,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         with self.tasks():
             event = manager.save(self.project.id)
 
+        assert event.group_id is not None
         group = Group.objects.get(id=event.group_id)
         tombstone = GroupTombstone.objects.create(
             project_id=group.project_id,

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -109,6 +109,7 @@ class EventManagerGroupingTest(TestCase):
             {"message": "Dogs are great!", "fingerprint": ["maisey"]}, self.project
         )
 
+        assert event1.group_id is not None
         group = Group.objects.get(id=event1.group_id)
 
         assert group.times_seen == 1
@@ -123,6 +124,7 @@ class EventManagerGroupingTest(TestCase):
             {"message": "Adopt don't shop", "fingerprint": ["maisey"]}, self.project
         )
 
+        assert event1.group_id is not None and event2.group_id is not None
         assert event1.group_id == event2.group_id
         group = Group.objects.get(id=event2.group_id)
 
@@ -257,6 +259,7 @@ class PlaceholderTitleTest(TestCase):
             self.project,
         )
 
+        assert event1.group_id is not None
         group = Group.objects.get(id=event1.group_id)
 
         assert group.title == event1.title == "DogsAreNeverAnError: Dogs are great!"
@@ -293,6 +296,7 @@ class PlaceholderTitleTest(TestCase):
                     self.project,
                 )
 
+        assert event1.group_id is not None and event2.group_id is not None
         assert event2.group_id == event1.group_id
 
         # Pull the group again to get updated data
@@ -322,6 +326,9 @@ class PlaceholderTitleTest(TestCase):
             self.project,
         )
 
+        assert event1.group_id is not None
+        assert event2.group_id is not None
+        assert event3.group_id is not None
         assert event3.group_id == event2.group_id == event1.group_id
 
         # Pull the group again to get updated data
@@ -351,6 +358,7 @@ class PlaceholderTitleTest(TestCase):
             self.project,
         )
 
+        assert event1.group_id is not None
         group = Group.objects.get(id=event1.group_id)
 
         assert group.title == event1.title == "DogsAreNeverAnError: Dogs are great!"
@@ -373,6 +381,7 @@ class PlaceholderTitleTest(TestCase):
                 self.project,
             )
 
+        assert event1.group_id is not None and event2.group_id is not None
         assert event2.group_id == event1.group_id
 
         # Pull the group again to get updated data
@@ -398,6 +407,9 @@ class PlaceholderTitleTest(TestCase):
             self.project,
         )
 
+        assert event1.group_id is not None
+        assert event2.group_id is not None
+        assert event3.group_id is not None
         assert event3.group_id == event2.group_id == event1.group_id
 
         # Pull the group again to get updated data

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -398,6 +398,7 @@ class TestEventManagerSeverity(TestCase):
                 )
             ).save(self.project.id)
 
+            assert nope_event.group_id is not None
             group = Group.objects.get(id=nope_event.group_id)
 
             # This first assertion isn't useful in and of itself, but it allows us to prove

--- a/tests/sentry/grouping/test_hashing.py
+++ b/tests/sentry/grouping/test_hashing.py
@@ -75,6 +75,7 @@ class SecondaryGroupingTest(TestCase):
         # Make sure that events did get into same group because of secondary grouping, not because
         # of hashes which come from primary grouping only
         assert not set(event.get_hashes()) & set(event2.get_hashes())  # No overlap
+        assert event.group_id is not None
         assert event.group_id == event2.group_id
 
         group = Group.objects.get(id=event.group_id)

--- a/tests/sentry/incidents/test_metric_issue_post_process.py
+++ b/tests/sentry/incidents/test_metric_issue_post_process.py
@@ -126,7 +126,7 @@ class MetricIssueIntegrationTest(BaseWorkflowTest, BaseMetricIssueTest):
         event = eventstore.backend.get_event_by_id(
             occurrence.project_id, stored_occurrence.event_id
         )
-        assert event
+        assert event and event.group_id
         return Group.objects.get(id=event.group_id)
 
     def test_simple(self, mock_trigger: MagicMock) -> None:

--- a/tests/sentry/integrations/gitlab/tasks/test_open_pr_comment.py
+++ b/tests/sentry/integrations/gitlab/tasks/test_open_pr_comment.py
@@ -1,3 +1,4 @@
+from typing import TypedDict
 from unittest.mock import patch
 
 import pytest
@@ -23,6 +24,13 @@ from sentry.utils import json
 from tests.sentry.integrations.gitlab.tasks.test_pr_comment import GitlabCommentTestCase
 
 pytestmark = [requires_snuba]
+
+
+class _GroupDict(TypedDict):
+    group_id: int
+    event_count: int
+    function_name: str
+
 
 DIFFS = {
     "pure_addition": """diff --git a/test.py b/test.py
@@ -369,7 +377,7 @@ class TestOpenPRCommentWorkflow(GitlabCommentTestCase):
             for i in range(6)
         ][0].group.id
 
-        self.groups = [
+        self.groups: list[_GroupDict] = [
             {
                 "group_id": g.id,
                 "event_count": 1000 * (i + 1),

--- a/tests/sentry/models/test_projectcounter.py
+++ b/tests/sentry/models/test_projectcounter.py
@@ -42,6 +42,7 @@ def create_existing_group(project, message):
         group_creation_spy, group_creation_results = patches
 
         event = save_new_event({"message": message}, project)
+        assert event.group_id is not None
         group = Group.objects.get(id=event.group_id)
 
         assert (

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -383,6 +383,7 @@ class ActivityNotificationTest(APITestCase):
             with self.tasks():
                 event = manager.save(self.project.id)
 
+            assert event.group_id is not None
             group = Group.objects.get(id=event.group_id)
             group.status = GroupStatus.RESOLVED
             group.substatus = None

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -165,8 +165,8 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             member = OrganizationMember.objects.get(organization=organization, user_id=user.id)
 
-            assert getattr(member.flags, "sso:linked")
-            assert not getattr(member.flags, "sso:invalid")
+            assert member.flags["sso:linked"]
+            assert not member.flags["sso:invalid"]
 
     def create_org_and_auth_provider(self, provider_name="dummy"):
         self.user.update(is_managed=True)
@@ -286,7 +286,8 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
             om = OrganizationMember.objects.get(id=om.id)
 
         # No more linked members, users are not managed either.
-        assert not getattr(om.flags, "sso:linked")
+        assert om.user_id is not None
+        assert not om.flags["sso:linked"]
         assert not User.objects.get(id=om.user_id).is_managed
 
         # Replica record should be removed too
@@ -408,7 +409,8 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             om = OrganizationMember.objects.get(id=om.id)
 
-        assert not getattr(om.flags, "sso:linked")
+        assert om.user_id is not None
+        assert not om.flags["sso:linked"]
         assert not User.objects.get(id=om.user_id).is_managed
 
         assert len(mail.outbox)
@@ -424,7 +426,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         self.create_om_and_link_sso(organization)
         path = reverse("sentry-organization-auth-provider-settings", args=[organization.slug])
 
-        assert not getattr(auth_provider.flags, "allow_unlinked")
+        assert not auth_provider.flags.allow_unlinked
         assert organization.default_role == "member"
         self.login_as(self.user, organization_id=organization.id)
 
@@ -436,7 +438,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         assert resp.status_code == 200
 
         auth_provider = AuthProvider.objects.get(organization_id=organization.id)
-        assert getattr(auth_provider.flags, "allow_unlinked")
+        assert auth_provider.flags.allow_unlinked
 
         with assume_test_silo_mode(SiloMode.REGION):
             organization = Organization.objects.get(id=organization.id)
@@ -456,7 +458,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         self.create_om_and_link_sso(organization)
         path = reverse("sentry-organization-auth-provider-settings", args=[organization.slug])
 
-        assert not getattr(auth_provider.flags, "allow_unlinked")
+        assert not auth_provider.flags.allow_unlinked
         assert organization.default_role == "member"
         self.login_as(self.user, organization_id=organization.id)
 
@@ -468,7 +470,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         assert resp.status_code == 200
 
         auth_provider = AuthProvider.objects.get(organization_id=organization.id)
-        assert getattr(auth_provider.flags, "allow_unlinked")
+        assert auth_provider.flags.allow_unlinked
         with assume_test_silo_mode(SiloMode.REGION):
             organization = Organization.objects.get(id=organization.id)
             assert organization.default_role == "member"
@@ -487,7 +489,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         self.create_om_and_link_sso(organization)
         path = reverse("sentry-organization-auth-provider-settings", args=[organization.slug])
 
-        assert not getattr(auth_provider.flags, "allow_unlinked")
+        assert not auth_provider.flags.allow_unlinked
         assert organization.default_role == "member"
         self.login_as(self.user, organization_id=organization.id)
 
@@ -499,7 +501,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         assert resp.status_code == 200
 
         auth_provider = AuthProvider.objects.get(organization_id=organization.id)
-        assert not getattr(auth_provider.flags, "allow_unlinked")
+        assert not auth_provider.flags.allow_unlinked
         with assume_test_silo_mode(SiloMode.REGION):
             organization = Organization.objects.get(id=organization.id)
             assert organization.default_role == "owner"
@@ -517,7 +519,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         self.create_om_and_link_sso(organization)
         path = reverse("sentry-organization-auth-provider-settings", args=[organization.slug])
 
-        assert not getattr(auth_provider.flags, "allow_unlinked")
+        assert not auth_provider.flags.allow_unlinked
         assert organization.default_role == "member"
         self.login_as(self.user, organization_id=organization.id)
 
@@ -529,7 +531,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         assert resp.status_code == 200
 
         auth_provider = AuthProvider.objects.get(organization_id=organization.id)
-        assert not getattr(auth_provider.flags, "allow_unlinked")
+        assert not auth_provider.flags.allow_unlinked
         with assume_test_silo_mode(SiloMode.REGION):
             organization = Organization.objects.get(id=organization.id)
             assert organization.default_role == "member"
@@ -543,7 +545,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         self.create_om_and_link_sso(organization)
         path = reverse("sentry-organization-auth-provider-settings", args=[organization.slug])
 
-        assert not getattr(auth_provider.flags, "allow_unlinked")
+        assert not auth_provider.flags.allow_unlinked
         assert organization.default_role == "member"
         self.login_as(self.user, organization_id=organization.id)
 
@@ -561,7 +563,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         assert resp.status_code == 200
 
         auth_provider = AuthProvider.objects.get(organization_id=organization.id)
-        assert getattr(auth_provider.flags, "scim_enabled")
+        assert auth_provider.flags.scim_enabled
         assert auth_provider.get_scim_token() is not None
 
         org_member = organization_service.get_organization_by_id(id=auth_provider.organization_id)
@@ -605,7 +607,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
         assert resp.status_code == 200
         auth_provider = AuthProvider.objects.get(organization_id=organization.id)
 
-        assert not getattr(auth_provider.flags, "scim_enabled")
+        assert not auth_provider.flags.scim_enabled
         org_member = organization_service.get_organization_by_id(id=auth_provider.organization_id)
         assert org_member is not None
         assert get_scim_url(auth_provider, org_member.organization) is None
@@ -663,7 +665,7 @@ class OrganizationAuthSettingsSAML2Test(AuthProviderTestCase):
         self.create_om_and_link_sso(organization)
         path = reverse("sentry-organization-auth-provider-settings", args=[organization.slug])
 
-        assert not getattr(auth_provider, "config")
+        assert not auth_provider.config
         self.login_as(self.user, organization_id=organization.id)
 
         with self.feature("organizations:sso-basic"), outbox_runner():
@@ -682,7 +684,7 @@ class OrganizationAuthSettingsSAML2Test(AuthProviderTestCase):
         auth_provider = AuthProvider.objects.get(
             organization_id=organization.id, id=auth_provider.id
         )
-        assert getattr(auth_provider, "config") == {
+        assert auth_provider.config == {
             "idp": {
                 "x509cert": "bar_x509_cert",
             }


### PR DESCRIPTION
new django-stubs notices that `id` cannot be looked up with `None`

<!-- Describe your PR here. -->