### PR TITLE
fix(codecov): Fix sync repos permission check

### DIFF
--- a/src/sentry/codecov/endpoints/sync_repos/sync_repos.py
+++ b/src/sentry/codecov/endpoints/sync_repos/sync_repos.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationPermission
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.parameters import GlobalParams, PreventParams
 from sentry.codecov.base import CodecovEndpoint
@@ -14,6 +15,13 @@ from sentry.codecov.client import CodecovApiClient
 from sentry.codecov.endpoints.sync_repos.query import mutation, query
 from sentry.codecov.endpoints.sync_repos.serializers import SyncReposSerializer
 from sentry.integrations.services.integration.model import RpcIntegration
+
+
+class SyncReposPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read", "org:write", "org:admin"],
+        "POST": ["org:read", "org:write", "org:admin"],
+    }
 
 
 @extend_schema(tags=["Prevent"])
@@ -24,6 +32,7 @@ class SyncReposEndpoint(CodecovEndpoint):
         "POST": ApiPublishStatus.PUBLIC,
         "GET": ApiPublishStatus.PUBLIC,
     }
+    permission_classes = (SyncReposPermission,)
 
     @extend_schema(
         operation_id="Syncs repositories from an integrated org with GitHub",

--- a/tests/sentry/codecov/endpoints/test_sync_repos.py
+++ b/tests/sentry/codecov/endpoints/test_sync_repos.py
@@ -94,3 +94,58 @@ class SyncReposEndpointTest(APITestCase):
 
         mock_capture_exception.assert_called_once()
         mock_logger.assert_called_once()
+
+    @patch("sentry.codecov.endpoints.sync_repos.sync_repos.CodecovApiClient")
+    def test_scope_map_enforcement(self, mock_codecov_client_class) -> None:
+        """Test that the scope map permissions are properly enforced"""
+        # Mock the API response for POST request
+        mock_graphql_response = {
+            "data": {
+                "syncRepos": {
+                    "isSyncing": True,
+                }
+            }
+        }
+
+        mock_codecov_client_instance = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = mock_graphql_response
+        mock_codecov_client_instance.query.return_value = mock_response
+        mock_codecov_client_class.return_value = mock_codecov_client_instance
+
+        # Create a user with only org:read permission
+        user_with_read_only = self.create_user("readonly@test.com")
+        self.create_member(
+            user=user_with_read_only,
+            organization=self.organization,
+            role="member",  # member role has org:read
+        )
+
+        # Create a user with org:write permission
+        user_with_write = self.create_user("write@test.com")
+        self.create_member(
+            user=user_with_write,
+            organization=self.organization,
+            role="admin",  # admin role has org:write
+        )
+
+        # Create a user with no permissions
+        user_without_permissions = self.create_user("noperms@test.com")
+        # Don't add them to the organization
+
+        url = self.reverse_url()
+
+        # Test that user with org:read can access the endpoint
+        self.login_as(user_with_read_only)
+        response = self.client.post(url, data={})
+        assert response.status_code == 200
+
+        # Test that user with org:write can access the endpoint
+        self.login_as(user_with_write)
+        response = self.client.post(url, data={})
+        assert response.status_code == 200
+
+        # Test that user without permissions cannot access the endpoint
+        self.login_as(user_without_permissions)
+        response = self.client.post(url, data={})
+        assert response.status_code == 403


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/99408 - want to do the same thing for Sync Repos endpoint - allow `org:read` sentry user permission to be able to initiate this action

