### PR TITLE
fix(eco): Records halt for ApiForbidden errors in get_stacktrace_link

### DIFF
--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -223,7 +223,13 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
                     return encode_url(source_url)
 
             scope.set_tag("stacktrace_link.used_version", False)
-            source_url = self.check_file(repo, filepath, default)
+            try:
+                source_url = self.check_file(repo, filepath, default)
+            except ApiForbiddenError as e:
+                # Similar to the `check_file` implementation, we need to re-raise
+                # for 403 errors as these need to be propagated to the user.
+                lifecycle.record_halt(e)
+                raise
             return encode_url(source_url) if source_url else None
 
     def get_codeowner_file(


### PR DESCRIPTION
Handles `ApiForbidden` exceptions in the `get_stacktrace_link` implementation, similar to `check_file`. These exceptions still need to be propagated up to the user for visibility, but are resulting in a ton of noise in our monitors when an org revokes an API token.
