### PR TITLE
stacktrace: cleanup buttons DE-264

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -406,7 +406,7 @@ const DefaultLine = styled('div')<{
   justify-content: space-between;
   align-items: center;
   background: ${p => (p.isSubFrame ? `${p.theme.surface100}` : `${p.theme.surface200}`)};
-  min-height: 32px;
+  min-height: ${p => (p.theme.isChonk ? '40px' : '38px')};
   word-break: break-word;
   padding: ${space(0.75)} ${space(1.5)};
   font-size: ${p => p.theme.fontSize.sm};

--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -60,8 +60,7 @@ describe('StacktraceLink', () => {
     render(
       <StacktraceLink frame={frame} event={event} line="foo()" disableSetup={false} />
     );
-    const link = await screen.findByRole('link', {name: 'Open this line in GitHub'});
-    expect(link).toBeInTheDocument();
+    const link = await screen.findByRole('button', {name: 'Open this line in GitHub'});
     expect(link).toHaveAttribute('href', 'https://something.io#L233');
   });
 
@@ -155,8 +154,7 @@ describe('StacktraceLink', () => {
       }
     );
 
-    const link = await screen.findByRole('link', {name: 'Open in Codecov'});
-    expect(link).toBeInTheDocument();
+    const link = await screen.findByRole('button', {name: 'Open in Codecov'});
     expect(link).toHaveAttribute(
       'href',
       'https://app.codecov.io/gh/path/to/file.py#L233'
@@ -221,7 +219,7 @@ describe('StacktraceLink', () => {
       }
     );
     expect(
-      await screen.findByRole('link', {name: 'Open this line in GitHub'})
+      await screen.findByRole('button', {name: 'Open this line in GitHub'})
     ).toBeInTheDocument();
     expect(stacktraceCoverageMock).not.toHaveBeenCalled();
   });
@@ -247,8 +245,7 @@ describe('StacktraceLink', () => {
         disableSetup={false}
       />
     );
-    const link = await screen.findByRole('link', {name: 'GitHub'});
-    expect(link).toBeInTheDocument();
+    const link = await screen.findByRole('button', {name: 'GitHub'});
     expect(link).toHaveAttribute(
       'href',
       'https://www.github.com/username/path/to/file.py#L100'
@@ -264,8 +261,7 @@ describe('StacktraceLink', () => {
       <StacktraceLink frame={frame} event={event} line="foo()" disableSetup={false} />
     );
 
-    const link = await screen.findByRole('link', {name: 'Open this line in GitHub'});
-    expect(link).toBeInTheDocument();
+    const link = await screen.findByRole('button', {name: 'Open this line in GitHub'});
     expect(link).toHaveAttribute('href', 'https://something.io#L233');
     // The link is an icon with aira label
     expect(link).toHaveTextContent('');

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -1,17 +1,16 @@
 import {useEffect, useMemo, useState} from 'react';
-import {css, keyframes} from '@emotion/react';
-import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
-import {ExternalLink} from 'sentry/components/core/link';
+import {LinkButton, type LinkButtonProps} from 'sentry/components/core/button/linkButton';
+import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {useStacktraceCoverage} from 'sentry/components/events/interfaces/frame/useStacktraceCoverage';
 import {hasFileExtension} from 'sentry/components/events/interfaces/frame/utils';
 import Placeholder from 'sentry/components/placeholder';
 import {IconCopy, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Event, Frame} from 'sentry/types/event';
 import type {StacktraceLinkResult} from 'sentry/types/integrations';
 import {CodecovStatusCode} from 'sentry/types/integrations';
@@ -43,118 +42,8 @@ const supportedStacktracePlatforms: PlatformKey[] = [
   'ruby',
   'scala',
 ];
+
 const scmProviders = ['github', 'gitlab', 'bitbucket'];
-
-function shouldShowCodecovFeatures(
-  organization: Organization,
-  match: StacktraceLinkResult,
-  codecovStatus: CodecovStatusCode
-) {
-  const validStatus = codecovStatus && codecovStatus !== CodecovStatusCode.NO_INTEGRATION;
-
-  return (
-    organization.codecovAccess && validStatus && match.config?.provider.key === 'github'
-  );
-}
-
-interface CodecovLinkProps {
-  event: Event;
-  organization: Organization;
-  coverageUrl?: string;
-  status?: CodecovStatusCode;
-}
-
-function CodecovLink({
-  coverageUrl,
-  status = CodecovStatusCode.COVERAGE_EXISTS,
-  organization,
-  event,
-}: CodecovLinkProps) {
-  if (status === CodecovStatusCode.NO_COVERAGE_DATA) {
-    return (
-      <CodecovWarning>
-        {t('Code Coverage not found')}
-        <IconWarning size="xs" color="errorText" />
-      </CodecovWarning>
-    );
-  }
-
-  if (status !== CodecovStatusCode.COVERAGE_EXISTS || !coverageUrl) {
-    return null;
-  }
-
-  const onOpenCodecovLink = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    trackAnalytics('integrations.stacktrace_codecov_link_clicked', {
-      view: 'stacktrace_issue_details',
-      organization,
-      group_id: event.groupID ? parseInt(event.groupID, 10) : -1,
-      ...getAnalyticsDataForEvent(event),
-    });
-  };
-
-  return (
-    <OpenInLink
-      href={coverageUrl}
-      openInNewTab
-      onClick={onOpenCodecovLink}
-      aria-label={t('Open in Codecov')}
-    >
-      <Tooltip title={t('Open in Codecov')} skipWrapper>
-        <StyledIconWrapper>{getIntegrationIcon('codecov', 'sm')}</StyledIconWrapper>
-      </Tooltip>
-    </OpenInLink>
-  );
-}
-
-interface CopyFrameLinkProps {
-  event: Event;
-  frame: Frame;
-  shouldFadeIn?: boolean;
-}
-
-function CopyFrameLink({event, frame, shouldFadeIn = false}: CopyFrameLinkProps) {
-  const filePath =
-    frame.filename && frame.lineNo !== null
-      ? `${frame.filename}:${frame.lineNo}`
-      : frame.filename || '';
-
-  const {onClick: handleCopyPath} = useCopyToClipboard({
-    text: filePath,
-    successMessage: t('File path copied to clipboard'),
-    errorMessage: t('Failed to copy file path'),
-  });
-
-  const handleClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    handleCopyPath();
-  };
-
-  const ButtonComponent = shouldFadeIn ? FadeInButton : Button;
-
-  // Don't render if there's no valid file path to copy
-  if (!filePath) {
-    return null;
-  }
-
-  return (
-    <Tooltip title={t('Copy file path')} skipWrapper>
-      <ButtonComponent
-        size="zero"
-        priority="transparent"
-        aria-label={t('Copy file path')}
-        icon={<IconCopy size="xs" />}
-        onClick={handleClick}
-        analyticsEventKey="stacktrace_link_copy_file_path"
-        analyticsEventName="Stacktrace Link Copy File Path"
-        analyticsParams={{
-          group_id: event.groupID ? parseInt(event.groupID, 10) : -1,
-          ...getAnalyticsDataForEvent(event),
-        }}
-      />
-    </Tooltip>
-  );
-}
 
 interface StacktraceLinkProps {
   /**
@@ -172,27 +61,28 @@ interface StacktraceLinkProps {
 export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLinkProps) {
   const organization = useOrganization();
   const {projects} = useProjects();
-  const validFilePath = hasFileExtension(frame.absPath || frame.filename || '');
-  // TODO: Currently we only support GitHub links. Implement support for other source code providers.
-  // Related comment: https://github.com/getsentry/sentry/pull/62596#discussion_r1443025242
-  const hasGithubSourceLink = (frame.sourceLink || '').startsWith(
-    'https://www.github.com/'
-  );
-  const [shouldStartQuery, setShouldStartQuery] = useState(false);
   const project = useMemo(
     () => projects.find(p => p.id === event.projectID),
     [projects, event]
   );
 
+  const validFilePath = hasFileExtension(frame.absPath || frame.filename || '');
+  const [shouldStartQuery, setShouldStartQuery] = useState(false);
+
+  // The stacktrace link is rendered on hover
+  // Delay the query until the mouse hovers the frame for more than 50ms
   useEffect(() => {
-    // The stacktrace link is rendered on hover
-    // Delay the query until the mouse hovers the frame for more than 50ms
     const timer = setTimeout(() => {
       setShouldStartQuery(true);
-    }, 50); // Delay of 50ms
+    }, 50);
     return () => timer && clearTimeout(timer);
   }, []);
 
+  // TODO: Currently we only support GitHub links. Implement support for other source code providers.
+  // Related comment: https://github.com/getsentry/sentry/pull/62596#discussion_r1443025242
+  const hasGithubSourceLink = (frame.sourceLink || '').startsWith(
+    'https://www.github.com/'
+  );
   const isQueryEnabled = hasGithubSourceLink
     ? false
     : shouldStartQuery && validFilePath && frame.inApp;
@@ -276,10 +166,6 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
     }
   };
 
-  const handleSubmit = () => {
-    refetch();
-  };
-
   if (!validFilePath) {
     return null;
   }
@@ -291,24 +177,21 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
       <StacktraceLinkWrapper>
         <CopyFrameLink event={event} frame={frame} />
         <Tooltip title={t('Open this line in GitHub')} skipWrapper>
-          <OpenInLink
+          <ProviderLink
             onClick={e => onOpenLink(e, frame.sourceLink)}
             href={frame.sourceLink}
-            openInNewTab
             aria-label={t('GitHub')}
-          >
-            <StyledIconWrapper>{getIntegrationIcon('github', 'sm')}</StyledIconWrapper>
-          </OpenInLink>
+            icon={getIntegrationIcon('github', DEFAULT_ICON_SIZE)}
+          />
         </Tooltip>
       </StacktraceLinkWrapper>
     );
   }
 
   if ((isPending && isQueryEnabled) || !match) {
-    const placeholderWidth = coverageEnabled ? '40px' : '14px';
     return (
       <StacktraceLinkWrapper>
-        <Placeholder height="14px" width={placeholderWidth} />
+        <Placeholder height="14px" width={coverageEnabled ? '40px' : '14px'} />
       </StacktraceLinkWrapper>
     );
   }
@@ -318,23 +201,19 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
     const label = t('Open this line in %s', match.config.provider.name);
     return (
       <StacktraceLinkWrapper>
-        <CopyFrameLink event={event} frame={frame} shouldFadeIn />
-        <OpenInLink
-          onClick={onOpenLink}
-          href={getIntegrationSourceUrl(
-            match.config.provider.key,
-            match.sourceUrl,
-            frame.lineNo
-          )}
-          openInNewTab
-          aria-label={label}
-        >
-          <Tooltip title={label} skipWrapper>
-            <StyledIconWrapper>
-              {getIntegrationIcon(match.config.provider.key, 'sm')}
-            </StyledIconWrapper>
-          </Tooltip>
-        </OpenInLink>
+        <CopyFrameLink event={event} frame={frame} />
+        <Tooltip title={label} skipWrapper>
+          <ProviderLink
+            onClick={onOpenLink}
+            href={getIntegrationSourceUrl(
+              match.config.provider.key,
+              match.sourceUrl,
+              frame.lineNo
+            )}
+            aria-label={label}
+            icon={getIntegrationIcon(match.config.provider.key, DEFAULT_ICON_SIZE)}
+          />
+        </Tooltip>
         {coverageEnabled && isLoadingCoverage ? (
           <Placeholder height="14px" width="14px" />
         ) : coverage &&
@@ -367,11 +246,13 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
   ) {
     return (
       <StacktraceLinkWrapper>
-        <CopyFrameLink event={event} frame={frame} shouldFadeIn />
+        <CopyFrameLink event={event} frame={frame} />
         <Tooltip title={t('GitHub')} skipWrapper>
-          <OpenInLink onClick={onOpenLink} href={frame.sourceLink} openInNewTab>
-            <StyledIconWrapper>{getIntegrationIcon('github', 'sm')}</StyledIconWrapper>
-          </OpenInLink>
+          <ProviderLink
+            onClick={onOpenLink}
+            href={frame.sourceLink}
+            icon={getIntegrationIcon('github', DEFAULT_ICON_SIZE)}
+          />
         </Tooltip>
         {coverageEnabled && isLoadingCoverage ? (
           <Placeholder height="14px" width="14px" />
@@ -400,13 +281,16 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
     );
     return (
       <StacktraceLinkWrapper>
-        <CopyFrameLink event={event} frame={frame} shouldFadeIn />
-        <FixMappingButton
-          type="button"
-          priority="link"
+        <CopyFrameLink event={event} frame={frame} />
+        <Button
+          size={DEFAULT_BUTTON_SIZE}
+          priority="transparent"
           icon={
             sourceCodeProviders.length === 1
-              ? getIntegrationIcon(sourceCodeProviders[0]!.provider.key, 'sm')
+              ? getIntegrationIcon(
+                  sourceCodeProviders[0]!.provider.key,
+                  DEFAULT_ICON_SIZE
+                )
               : undefined
           }
           onClick={e => {
@@ -426,7 +310,7 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
             );
             openModal(deps => (
               <StacktraceLinkModal
-                onSubmit={handleSubmit}
+                onSubmit={refetch}
                 filename={filename}
                 module={frame.module ?? undefined}
                 absPath={frame.absPath ?? undefined}
@@ -440,7 +324,7 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
           }}
         >
           {t('Set up Code Mapping')}
-        </FixMappingButton>
+        </Button>
       </StacktraceLinkWrapper>
     );
   }
@@ -448,57 +332,124 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
   return null;
 }
 
-const fadeIn = keyframes`
-  from { opacity: 0; }
-  to { opacity: 1; }
-`;
+function shouldShowCodecovFeatures(
+  organization: Organization,
+  match: StacktraceLinkResult,
+  codecovStatus: CodecovStatusCode
+) {
+  return (
+    codecovStatus &&
+    codecovStatus !== CodecovStatusCode.NO_INTEGRATION &&
+    organization.codecovAccess &&
+    match.config?.provider.key === 'github'
+  );
+}
 
-const StacktraceLinkWrapper = styled('div')`
-  display: flex;
-  gap: ${space(1)};
-  align-items: center;
-  color: ${p => p.theme.subText};
-  font-family: ${p => p.theme.text.family};
-  padding: 0 ${space(1)};
-`;
+// This should never have been set, as the icons inside buttons already auto adjust
+// depending on the button size, however the reason it cannot be removed is that the icon
+// function initializes a default argument for the icon size to md, meaning we cannot simply remove it.
+const DEFAULT_ICON_SIZE = 'xs';
+const DEFAULT_BUTTON_SIZE = 'xs';
 
-const FixMappingButton = styled(Button)`
-  color: ${p => p.theme.subText};
-  font-weight: 400;
-  font-size: ${p => p.theme.fontSize.sm};
-  &:hover {
-    color: ${p => p.theme.textColor};
+interface CodecovLinkProps {
+  event: Event;
+  organization: Organization;
+  coverageUrl?: string;
+  status?: CodecovStatusCode;
+}
+
+function CodecovLink({
+  coverageUrl,
+  status = CodecovStatusCode.COVERAGE_EXISTS,
+  organization,
+  event,
+}: CodecovLinkProps) {
+  if (status === CodecovStatusCode.NO_COVERAGE_DATA) {
+    return (
+      <Flex align="center" gap="sm">
+        <Text variant="danger">{t('Code Coverage not found')}</Text>
+        <IconWarning size={DEFAULT_ICON_SIZE} color="errorText" />
+      </Flex>
+    );
   }
-`;
 
-const StyledIconWrapper = styled('span')`
-  color: inherit;
-  line-height: 0;
-`;
-
-const LinkStyles = css`
-  display: flex;
-  align-items: center;
-  gap: ${space(0.75)};
-`;
-
-const OpenInLink = styled(ExternalLink)`
-  ${LinkStyles}
-  color: ${p => p.theme.subText};
-  animation: ${fadeIn} 0.2s ease-in-out forwards;
-  &:hover {
-    color: ${p => p.theme.textColor};
+  if (status !== CodecovStatusCode.COVERAGE_EXISTS || !coverageUrl) {
+    return null;
   }
-`;
 
-const CodecovWarning = styled('div')`
-  display: flex;
-  color: ${p => p.theme.errorText};
-  gap: ${space(0.75)};
-  align-items: center;
-`;
+  const onOpenCodecovLink = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    trackAnalytics('integrations.stacktrace_codecov_link_clicked', {
+      view: 'stacktrace_issue_details',
+      organization,
+      group_id: event.groupID ? parseInt(event.groupID, 10) : -1,
+      ...getAnalyticsDataForEvent(event),
+    });
+  };
 
-const FadeInButton = styled(Button)`
-  animation: ${fadeIn} 0.2s ease-in-out forwards;
-  color: ${p => p.theme.subText};
-`;
+  return (
+    <Tooltip title={t('Open in Codecov')} skipWrapper>
+      <ProviderLink
+        href={coverageUrl}
+        onClick={onOpenCodecovLink}
+        aria-label={t('Open in Codecov')}
+        icon={getIntegrationIcon('codecov', DEFAULT_ICON_SIZE)}
+      />
+    </Tooltip>
+  );
+}
+interface CopyFrameLinkProps {
+  event: Event;
+  frame: Frame;
+}
+
+function CopyFrameLink({event, frame}: CopyFrameLinkProps) {
+  const filePath =
+    frame.filename && frame.lineNo !== null
+      ? `${frame.filename}:${frame.lineNo}`
+      : frame.filename || '';
+
+  const {onClick: handleCopyPath} = useCopyToClipboard({
+    text: filePath,
+    successMessage: t('File path copied to clipboard'),
+    errorMessage: t('Failed to copy file path'),
+  });
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    handleCopyPath();
+  };
+
+  // Don't render if there's no valid file path to copy
+  if (!filePath) {
+    return null;
+  }
+
+  return (
+    <Tooltip title={t('Copy file path')} skipWrapper>
+      <Button
+        size={DEFAULT_BUTTON_SIZE}
+        priority="transparent"
+        aria-label={t('Copy file path')}
+        icon={<IconCopy />}
+        onClick={handleClick}
+        analyticsEventKey="stacktrace_link_copy_file_path"
+        analyticsEventName="Stacktrace Link Copy File Path"
+        analyticsParams={{
+          group_id: event.groupID ? parseInt(event.groupID, 10) : -1,
+          ...getAnalyticsDataForEvent(event),
+        }}
+      />
+    </Tooltip>
+  );
+}
+
+function StacktraceLinkWrapper({children}: {children: React.ReactNode}) {
+  return <Flex align="center">{children}</Flex>;
+}
+
+function ProviderLink(props: LinkButtonProps) {
+  return (
+    <LinkButton size={DEFAULT_BUTTON_SIZE} priority="transparent" external {...props} />
+  );
+}

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -1,4 +1,6 @@
 import {useEffect, useMemo, useState} from 'react';
+import {keyframes} from '@emotion/react';
+import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
@@ -444,8 +446,22 @@ function CopyFrameLink({event, frame}: CopyFrameLinkProps) {
   );
 }
 
+const fadeIn = keyframes`
+from { opacity: 0; }
+to { opacity: 1; }
+`;
+
+const FadeInStacktraceLinkWrapper = styled(Flex)`
+  a,
+  button {
+    animation: ${fadeIn} 0.2s ease-in-out forwards;
+  }
+`;
+
 function StacktraceLinkWrapper({children}: {children: React.ReactNode}) {
-  return <Flex align="center">{children}</Flex>;
+  return (
+    <FadeInStacktraceLinkWrapper align="center">{children}</FadeInStacktraceLinkWrapper>
+  );
 }
 
 function ProviderLink(props: LinkButtonProps) {


### PR DESCRIPTION
This PR cleans up the StackTraceLinks such that they use the buttons of same sizes

Notable changes:
 - The stacktrace rows are higher, this is because the buttons that are displayed have larger hit boxes and hovering would otherwise cause an annoying flicker. Imo, this is an improvement, as the hitbox of the old buttons was quite small
<img width="248" height="90" alt="CleanShot 2025-09-12 at 16 25 53@2x" src="https://github.com/user-attachments/assets/2f55d2b4-fb50-453d-99a0-78d75119cf80" />

- The icon sizes are now the same size (we were overriding the icon size that is otherwise set by the button)
- The hover effect with faded background is now the same on all of the buttons - previously only the copy button did this
- Codecov functionality was moved to the bottom of the file so that the stacktrace component is at the top

Couple screenshots of the codecov failed state that are usually not visible:
<img width="928" height="336" alt="CleanShot 2025-09-12 at 16 11 06@2x" src="https://github.com/user-attachments/assets/15a4d118-8c67-47fd-91d8-1e65ff065599" />
