### PR TITLE
fix(ourlogs): Allow replay id on trace logs

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_logs.py
+++ b/src/sentry/api/endpoints/organization_trace_logs.py
@@ -55,6 +55,7 @@ class OrganizationTraceLogsEndpoint(OrganizationEventsV2EndpointBase):
         self,
         snuba_params: SnubaParams,
         trace_ids: list[str],
+        replay_id: str | None,
         orderby: list[str],
         additional_query: str | None,
         offset: int,
@@ -80,12 +81,26 @@ class OrganizationTraceLogsEndpoint(OrganizationEventsV2EndpointBase):
                     f"{stripped_orderby} must be one of {','.join(sorted(required_keys))}"
                 )
 
-        # Create the query based on the trace ids
-        base_query = (
-            f"{constants.TRACE_ALIAS}:{trace_ids[0]}"
-            if len(trace_ids) == 1
-            else f"{constants.TRACE_ALIAS}:[{','.join(trace_ids)}]"
-        )
+        base_query_parts = []
+
+        # Create the query based on trace id and/or replay id
+        if trace_ids:
+            trace_query = (
+                f"{constants.TRACE_ALIAS}:{trace_ids[0]}"
+                if len(trace_ids) == 1
+                else f"{constants.TRACE_ALIAS}:[{','.join(trace_ids)}]"
+            )
+            base_query_parts.append(trace_query)
+
+        if replay_id:
+            replay_query = f"replay_id:{replay_id}"
+            base_query_parts.append(replay_query)
+
+        if len(base_query_parts) > 1:
+            base_query = f"({' OR '.join(base_query_parts)})"
+        else:
+            base_query = base_query_parts[0]
+
         if additional_query is not None:
             query = f"{base_query} and {additional_query}"
         else:
@@ -112,11 +127,17 @@ class OrganizationTraceLogsEndpoint(OrganizationEventsV2EndpointBase):
             return Response(status=404)
 
         trace_ids = request.GET.getlist("traceId", [])
+        replay_id = request.GET.get("replayId")
+
         for trace_id in trace_ids:
             if not is_event_id(trace_id):
                 raise ParseError(INVALID_ID_DETAILS.format(trace_id))
-        if len(trace_ids) == 0:
-            raise ParseError("Need to pass at least one traceId")
+
+        if replay_id and not is_event_id(replay_id):
+            raise ParseError(INVALID_ID_DETAILS.format(replay_id))
+
+        if len(trace_ids) == 0 and not replay_id:
+            raise ParseError("Need to pass at least one traceId or replayId")
 
         orderby = request.GET.getlist("sort", ["-timestamp", "-timestamp_precise"])
         additional_query = request.GET.get("query")
@@ -126,7 +147,7 @@ class OrganizationTraceLogsEndpoint(OrganizationEventsV2EndpointBase):
         def data_fn(offset: int, limit: int) -> EventsResponse:
             with handle_query_errors():
                 return self.query_logs_data(
-                    snuba_params, trace_ids, orderby, additional_query, offset, limit
+                    snuba_params, trace_ids, replay_id, orderby, additional_query, offset, limit
                 )
 
         return self.paginate(

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3291,6 +3291,7 @@ class SpanTestCase(BaseTestCase):
 class _OptionalOurLogData(TypedDict, total=False):
     body: str
     trace_id: str
+    replay_id: str
     severity_text: str
     severity_number: int
     trace_flags: int

--- a/tests/snuba/api/endpoints/test_organization_trace_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_logs.py
@@ -349,3 +349,43 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
             f"-{constants.TIMESTAMP_ALIAS}",
             f"-{constants.TIMESTAMP_PRECISE_ALIAS}",
         ]
+
+    def test_trace_and_replay_id_combined(self) -> None:
+        trace_id = "1" * 32
+        replay_id = "2" * 32
+        self.store_ourlogs(
+            [
+                self.create_ourlog(
+                    {"body": "trace_log", "trace_id": trace_id},
+                    timestamp=self.ten_mins_ago,
+                ),
+                self.create_ourlog(
+                    {"body": "replay_log", "sentry.replay_id": replay_id},
+                    timestamp=self.eleven_mins_ago,
+                ),
+                self.create_ourlog(
+                    {"body": "other_log", "trace_id": "3" * 32},
+                    timestamp=self.ten_mins_ago,
+                ),
+            ]
+        )
+
+        response = self.client.get(
+            self.url,
+            data={"traceId": trace_id, "replayId": replay_id},
+            format="json",
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 2
+        messages = {log["message"] for log in data}
+        assert messages == {"trace_log", "replay_log"}
+
+    def test_no_trace_or_replay_id(self) -> None:
+        response = self.client.get(
+            self.url,
+            data={},
+            format="json",
+        )
+        assert response.status_code == 400, response.content
+        assert "Need to pass at least one traceId or replayId" in response.data["detail"]

--- a/tests/snuba/api/endpoints/test_organization_trace_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_logs.py
@@ -436,7 +436,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
         )
         response = self.client.get(
             self.url,
-            data={},
+            data={"project": self.project.id},
             format="json",
         )
         assert response.status_code == 400, response.content

--- a/tests/snuba/api/endpoints/test_organization_trace_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_logs.py
@@ -350,6 +350,50 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
             f"-{constants.TIMESTAMP_PRECISE_ALIAS}",
         ]
 
+    def test_replay_id_simple(self) -> None:
+        replay_id = "1" * 32
+        self.store_ourlogs(
+            [
+                self.create_ourlog(
+                    {"body": "foo", "replay_id": replay_id},
+                    timestamp=self.ten_mins_ago,
+                ),
+                self.create_ourlog(
+                    {"body": "bar", "replay_id": "2" * 32},
+                    timestamp=self.ten_mins_ago,
+                ),
+            ]
+        )
+
+        response = self.client.get(
+            self.url,
+            data={"replayId": replay_id},
+            format="json",
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        log_data = data[0]
+        assert log_data["project.id"] == self.project.id
+        assert log_data["message"] == "foo"
+
+    def test_replay_id_invalid(self) -> None:
+        self.store_ourlogs(
+            [
+                self.create_ourlog(
+                    {"body": "foo", "replay_id": "1" * 32},
+                    timestamp=self.ten_mins_ago,
+                ),
+            ]
+        )
+        for replay_id in ["1" * 16, "test"]:
+            response = self.client.get(
+                self.url,
+                data={"replayId": replay_id},
+                format="json",
+            )
+            assert response.status_code == 400, response.content
+
     def test_trace_and_replay_id_combined(self) -> None:
         trace_id = "1" * 32
         replay_id = "2" * 32
@@ -360,7 +404,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
                     timestamp=self.ten_mins_ago,
                 ),
                 self.create_ourlog(
-                    {"body": "replay_log", "sentry.replay_id": replay_id},
+                    {"body": "replay_log", "replay_id": replay_id},
                     timestamp=self.eleven_mins_ago,
                 ),
                 self.create_ourlog(
@@ -382,6 +426,14 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
         assert messages == {"trace_log", "replay_log"}
 
     def test_no_trace_or_replay_id(self) -> None:
+        self.store_ourlogs(
+            [
+                self.create_ourlog(
+                    {"body": "foo", "trace_id": "1" * 32},
+                    timestamp=self.ten_mins_ago,
+                ),
+            ]
+        )
         response = self.client.get(
             self.url,
             data={},


### PR DESCRIPTION
### Summary
Trace logs is also used in the replays tab, in which case we may want to send replay id OR trace id (or both if we want to try to get backend traces on top of the frontend logs attached to the replay id).

