### PR TITLE
fix(ourlogs): Fix minimum axis value

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -240,6 +240,7 @@ const DEFAULT_STATS_INFO = {
   yAxisMinInterval: 100,
 };
 const GIGABYTE = 10 ** 9;
+const KILOBYTE = 10 ** 3;
 
 // https://github.com/getsentry/relay/blob/master/relay-base-schema/src/data_category.rs
 export const DATA_CATEGORY_INFO = {
@@ -523,7 +524,7 @@ export const DATA_CATEGORY_INFO = {
     statsInfo: {
       ...DEFAULT_STATS_INFO,
       showExternalStats: true,
-      yAxisMinInterval: 0.5 * GIGABYTE,
+      yAxisMinInterval: 1 * KILOBYTE,
     },
   },
   [DataCategoryExact.SEER_AUTOFIX]: {


### PR DESCRIPTION
### Summary
This fixes minimum axis value for bytes, which should help for users that are just starting since it's nearly impossible to see a few kilobytes of logs to find their failed outcomes otherwise when debugging. The only downside is that some of the rounding in the megabyte / gigabyte range nicely up to 500mb won't happen and it'll land on different yAxis intervals (eg. 1.2GB instead of 1.5GB)

#### Eg.
<img width="536" height="392" alt="Screenshot 2025-09-12 at 4 52 29 PM" src="https://github.com/user-attachments/assets/c3a0cf5a-95b3-48eb-a037-c67ba5bc32b0" />
<img width="507" height="296" alt="Screenshot 2025-09-12 at 4 52 48 PM" src="https://github.com/user-attachments/assets/06c8d858-609a-4068-b092-b124852e63a4" />

