### PR TITLE
chore(aci): tighten typing of fallthroughType in email Actions

### DIFF
--- a/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
@@ -1,5 +1,6 @@
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
+from sentry.notifications.types import FallthroughChoiceType
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
@@ -29,6 +30,7 @@ class EmailActionHandler(ActionHandler):
             "fallthroughType": {
                 "type": "string",
                 "description": "The fallthrough type for issue owners email notifications",
+                "enum": [*FallthroughChoiceType],
             },
         },
         "additionalProperties": False,

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -225,7 +225,7 @@ ACTION_CHOICES = [
 ]
 
 
-class FallthroughChoiceType(Enum):
+class FallthroughChoiceType(StrEnum):
     ALL_MEMBERS = "AllMembers"
     ACTIVE_MEMBERS = "ActiveMembers"
     NO_ONE = "NoOne"

--- a/tests/sentry/workflow_engine/processors/test_action_deduplication.py
+++ b/tests/sentry/workflow_engine/processors/test_action_deduplication.py
@@ -7,7 +7,10 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.processors.action import get_unique_active_actions
-from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
+from sentry.workflow_engine.typings.notification_action import (
+    FallthroughChoiceType,
+    SentryAppIdentifier,
+)
 
 
 @region_silo_test
@@ -349,7 +352,7 @@ class TestActionDeduplication(TestCase):
                 "target_identifier": "user-123@example.com",
             },
             data={
-                "fallthroughType": "team",
+                "fallthroughType": FallthroughChoiceType.ACTIVE_MEMBERS.value,
             },
         )
 
@@ -359,9 +362,7 @@ class TestActionDeduplication(TestCase):
                 "target_type": ActionTarget.SPECIFIC,
                 "target_identifier": "user-123@example.com",
             },
-            data={
-                "fallthroughType": "none",
-            },
+            data={},
         )
 
         actions_queryset = Action.objects.filter(
@@ -384,7 +385,7 @@ class TestActionDeduplication(TestCase):
                 "target_identifier": "user-123@example.com",
             },
             data={
-                "fallthroughType": "team",
+                "fallthroughType": FallthroughChoiceType.ACTIVE_MEMBERS.value,
             },
         )
 
@@ -395,7 +396,7 @@ class TestActionDeduplication(TestCase):
                 "target_identifier": "user-123@example.com",
             },
             data={
-                "fallthroughType": "team",
+                "fallthroughType": FallthroughChoiceType.ACTIVE_MEMBERS.value,
             },
         )
 

--- a/tests/sentry/workflow_engine/processors/test_action_deduplication.py
+++ b/tests/sentry/workflow_engine/processors/test_action_deduplication.py
@@ -3,14 +3,12 @@ from django.db.models import Value
 
 from sentry.constants import ObjectStatus
 from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.notifications.types import FallthroughChoiceType
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.processors.action import get_unique_active_actions
-from sentry.workflow_engine.typings.notification_action import (
-    FallthroughChoiceType,
-    SentryAppIdentifier,
-)
+from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
 @region_silo_test


### PR DESCRIPTION
We can use an existing enum to define allowed values for fallthroughType