### PR TITLE
feat(replay): add dropdown to change timestamp pref on replay index

### DIFF
--- a/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
+++ b/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/core/button';
 import {CompositeSelect} from 'sentry/components/core/compactSelect/composite';
 import {Flex} from 'sentry/components/core/layout';
+import {REPLAY_TIMESTAMP_OPTIONS} from 'sentry/components/replays/preferences/replayPreferences';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -10,8 +11,6 @@ import formatDuration from 'sentry/utils/duration/formatDuration';
 import {useReplayPrefs} from 'sentry/utils/replays/playback/providers/replayPreferencesContext';
 import {useReplayReader} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
-
-export const timestampOptions: Array<'relative' | 'absolute'> = ['relative', 'absolute'];
 
 export default function ReplayPreferenceDropdown({
   speedOptions,
@@ -93,7 +92,7 @@ export default function ReplayPreferenceDropdown({
         label={t('Timestamps')}
         value={prefs.timestampType}
         onChange={opt => setPrefs({timestampType: opt.value})}
-        options={timestampOptions.map(option => ({
+        options={REPLAY_TIMESTAMP_OPTIONS.map(option => ({
           label: `${toTitleCase(option)}`,
           value: option,
         }))}

--- a/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
+++ b/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
@@ -11,7 +11,7 @@ import {useReplayPrefs} from 'sentry/utils/replays/playback/providers/replayPref
 import {useReplayReader} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
-const timestampOptions: Array<'relative' | 'absolute'> = ['relative', 'absolute'];
+export const timestampOptions: Array<'relative' | 'absolute'> = ['relative', 'absolute'];
 
 export default function ReplayPreferenceDropdown({
   speedOptions,

--- a/static/app/components/replays/preferences/replayPreferences.tsx
+++ b/static/app/components/replays/preferences/replayPreferences.tsx
@@ -57,3 +57,8 @@ export const LocalStorageReplayPreferences: PrefsStrategy = {
     localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(prefs));
   },
 };
+
+export const REPLAY_TIMESTAMP_OPTIONS: Array<'relative' | 'absolute'> = [
+  'relative',
+  'absolute',
+];

--- a/static/app/views/replays/list/replayIndexTable.tsx
+++ b/static/app/views/replays/list/replayIndexTable.tsx
@@ -8,7 +8,7 @@ import {
   JetpackComposePiiNotice,
   useNeedsJetpackComposePiiNotice,
 } from 'sentry/components/replays/jetpackComposePiiNotice';
-import {timestampOptions} from 'sentry/components/replays/preferences/replayPreferenceDropdown';
+import {REPLAY_TIMESTAMP_OPTIONS} from 'sentry/components/replays/preferences/replayPreferences';
 import ReplayTable from 'sentry/components/replays/table/replayTable';
 import useReplayTableSort from 'sentry/components/replays/table/useReplayTableSort';
 import {IconSettings} from 'sentry/icons';
@@ -104,7 +104,7 @@ export default function ReplayIndexTable({
             {
               key: t('Timestamps'),
               label: t('Timestamps'),
-              options: timestampOptions.map(option => ({
+              options: REPLAY_TIMESTAMP_OPTIONS.map(option => ({
                 label: `${toTitleCase(option)}`,
                 value: option,
                 key: option,

--- a/static/app/views/replays/list/replayIndexTable.tsx
+++ b/static/app/views/replays/list/replayIndexTable.tsx
@@ -2,22 +2,27 @@ import {Fragment, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
+import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {Flex} from 'sentry/components/core/layout/flex';
 import {
   JetpackComposePiiNotice,
   useNeedsJetpackComposePiiNotice,
 } from 'sentry/components/replays/jetpackComposePiiNotice';
+import {timestampOptions} from 'sentry/components/replays/preferences/replayPreferenceDropdown';
 import ReplayTable from 'sentry/components/replays/table/replayTable';
 import useReplayTableSort from 'sentry/components/replays/table/useReplayTableSort';
+import {IconSettings} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {ListItemCheckboxProvider} from 'sentry/utils/list/useListItemCheckboxState';
 import {useQueryClient, type ApiQueryKey} from 'sentry/utils/queryClient';
 import {useHaveSelectedProjectsSentAnyReplayEvents} from 'sentry/utils/replays/hooks/useReplayOnboarding';
+import {useReplayPrefs} from 'sentry/utils/replays/playback/providers/replayPreferencesContext';
 import {
   MIN_DEAD_RAGE_CLICK_SDK,
   MIN_REPLAY_CLICK_SDK,
 } from 'sentry/utils/replays/sdkVersions';
 import type RequestError from 'sentry/utils/requestError/requestError';
+import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
@@ -47,6 +52,7 @@ export default function ReplayIndexTable({
   replays,
 }: Props) {
   const queryClient = useQueryClient();
+  const [prefs, setPrefs] = useReplayPrefs();
 
   const {
     selection: {projects},
@@ -85,7 +91,7 @@ export default function ReplayIndexTable({
 
   return (
     <Fragment>
-      <Flex gap="xl" wrap="wrap">
+      <Flex gap="md" wrap="wrap">
         <ReplaysFilters />
         <ReplaysSearch />
         {showDeadRageClickCards ? (
@@ -93,6 +99,28 @@ export default function ReplayIndexTable({
             {widgetIsOpen ? t('Hide Widgets') : t('Show Widgets')}
           </Button>
         ) : null}
+        <CompactSelect
+          options={[
+            {
+              key: t('Timestamps'),
+              label: t('Timestamps'),
+              options: timestampOptions.map(option => ({
+                label: `${toTitleCase(option)}`,
+                value: option,
+                key: option,
+              })),
+            },
+          ]}
+          trigger={triggerProps => (
+            <Button
+              {...triggerProps}
+              icon={<IconSettings />}
+              aria-label={t('Configure timestamp settings')}
+            />
+          )}
+          value={prefs.timestampType}
+          onChange={opt => setPrefs({timestampType: opt.value})}
+        />
       </Flex>
       {projects.length === 1 ? (
         <BulkDeleteAlert


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-664/ability-to-toggle-relativeabsolute-directly-from-session-replay-index

https://github.com/user-attachments/assets/120b28c0-2805-4fef-a90c-a212d17633b8

