### PR TITLE
feat(flamegraph): Cycle through flamegraph search results with enter

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
@@ -410,10 +410,10 @@ function FlamegraphSearch({
 
   const handleKeyDown = useCallback(
     (evt: React.KeyboardEvent<HTMLInputElement>) => {
-      if (evt.key === 'ArrowDown') {
+      if (evt.key === 'ArrowDown' || (!evt.shiftKey && evt.key === 'Enter')) {
         evt.preventDefault();
         onNextSearchClick();
-      } else if (evt.key === 'ArrowUp') {
+      } else if (evt.key === 'ArrowUp' || (evt.shiftKey && evt.key === 'Enter')) {
         evt.preventDefault();
         onPreviousSearchClick();
       }

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch.tsx
@@ -76,7 +76,10 @@ export function flamegraphSearchReducer(
       };
     }
     case 'set search results': {
-      return {...state, index: null, highlightFrames: null, ...action.payload};
+      const frames = action.payload.results.frames;
+      const spans = action.payload.results.spans;
+      const index = frames.size + spans.size > 0 ? 0 : null;
+      return {...state, index, highlightFrames: null, ...action.payload};
     }
     case 'set search index position': {
       return {...state, index: action.payload};


### PR DESCRIPTION
This 2 things:
1. Always focus on the first results when the search results change
2. Let users cycle through them using Enter/Shift+Enter instead of just Up/Down