### PR TITLE
fix(modal): Show the error message returned from the server when inviting members fails

### DIFF
--- a/static/app/components/modals/inviteMembersModal/inviteMembersFooter.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteMembersFooter.tsx
@@ -1,9 +1,7 @@
-import styled from '@emotion/styled';
-
+import {Flex} from 'sentry/components/core/layout';
 import InviteButton from 'sentry/components/modals/inviteMembersModal/inviteButton';
 import {useInviteMembersContext} from 'sentry/components/modals/inviteMembersModal/inviteMembersContext';
 import InviteStatusMessage from 'sentry/components/modals/inviteMembersModal/inviteStatusMessage';
-import {space} from 'sentry/styles/space';
 
 interface Props {
   canSend: boolean;
@@ -32,7 +30,7 @@ export default function InviteMembersFooter({canSend}: Props) {
   };
 
   return (
-    <FooterContent>
+    <Flex gap="md" align="center" justify="between" flex="1">
       <div>
         <InviteStatusMessage data-test-id="invite-status-message" />
       </div>
@@ -48,14 +46,6 @@ export default function InviteMembersFooter({canSend}: Props) {
           sendInvites();
         }}
       />
-    </FooterContent>
+    </Flex>
   );
 }
-
-const FooterContent = styled('div')`
-  display: flex;
-  gap: ${space(1)};
-  align-items: center;
-  justify-content: space-between;
-  flex: 1;
-`;

--- a/static/app/components/modals/inviteMembersModal/inviteStatusMessage.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteStatusMessage.tsx
@@ -1,10 +1,9 @@
-import styled from '@emotion/styled';
-
+import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {useInviteMembersContext} from 'sentry/components/modals/inviteMembersModal/inviteMembersContext';
 import {IconCheckmark, IconWarning} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 
 interface InviteCountProps {
   count: number;
@@ -13,11 +12,11 @@ interface InviteCountProps {
 
 function InviteCount({count, isRequest}: InviteCountProps) {
   return (
-    <BoldCount>
+    <Text bold>
       {isRequest
         ? tn('%s invite request', '%s invite requests', count)
         : tn('%s invite', '%s invites', count)}
-    </BoldCount>
+    </Text>
   );
 }
 
@@ -38,20 +37,20 @@ function CountMessage({sentCount, errorCount, isRequest}: CountMessageProps) {
   return (
     <div>
       {sentCount > 0 && (
-        <StatusMessage status="success" isNewInviteModal>
+        <Flex gap="md" align="center">
           <IconCheckmark size="sm" color="successText" />
           <span role="alert" aria-label={t('Sent Invites')}>
             {tct('[invites] sent.', tctComponents)}
           </span>
-        </StatusMessage>
+        </Flex>
       )}
       {errorCount > 0 && (
-        <StatusMessage status="error" isNewInviteModal>
+        <Flex gap="md" align="center">
           <IconWarning size="sm" color="errorText" />
           <span role="alert" aria-label={t('Failed Invites')}>
             {tct('[failedInvites] failed to send.', tctComponents)}
           </span>
-        </StatusMessage>
+        </Flex>
       )}
     </div>
   );
@@ -61,12 +60,12 @@ export default function InviteStatusMessage() {
   const {complete, inviteStatus, sendingInvites, willInvite} = useInviteMembersContext();
   if (sendingInvites) {
     return (
-      <StatusMessage>
+      <Flex gap="md" align="center">
         <LoadingIndicator mini relative size={16} />
         {willInvite
           ? t('Sending organization invitations\u2026')
           : t('Sending invite requests\u2026')}
-      </StatusMessage>
+      </Flex>
     );
   }
 
@@ -86,20 +85,3 @@ export default function InviteStatusMessage() {
 
   return null;
 }
-
-export const StatusMessage = styled('div')<{
-  isNewInviteModal?: boolean;
-  status?: 'success' | 'error';
-}>`
-  display: flex;
-  gap: ${space(1)};
-  align-items: center;
-  font-size: ${p => p.theme.fontSize.md};
-  color: ${p =>
-    p.status === 'error' && !p.isNewInviteModal ? p.theme.errorText : p.theme.textColor};
-`;
-
-const BoldCount = styled('div')`
-  display: inline;
-  font-weight: bold;
-`;

--- a/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
+++ b/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
@@ -142,7 +142,12 @@ export default function useInviteModal({organization, initialData, source}: Prop
           : false;
 
         const orgLevelError = errorResponse?.organization;
-        const error = orgLevelError || emailError || t('Could not invite user');
+        const error =
+          orgLevelError ||
+          emailError ||
+          (errorResponse?.detail
+            ? t('Could not invite user. %s', errorResponse?.detail)
+            : t('Could not invite user.'));
 
         setState(prev => ({
           ...prev,

--- a/static/app/components/modals/inviteMissingMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.tsx
@@ -6,9 +6,9 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Checkbox} from 'sentry/components/core/checkbox';
+import {Flex} from 'sentry/components/core/layout';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {StatusMessage} from 'sentry/components/modals/inviteMembersModal/inviteStatusMessage';
 import type {InviteStatus} from 'sentry/components/modals/inviteMembersModal/types';
 import type {MissingMemberInvite} from 'sentry/components/modals/inviteMissingMembersModal/types';
 import type {InviteModalRenderFunc} from 'sentry/components/modals/memberInviteModalCustomization';
@@ -109,10 +109,10 @@ export function InviteMissingMembersModal({
   const renderStatusMessage = () => {
     if (sendingInvites) {
       return (
-        <StatusMessage>
+        <Flex gap="md" align="center">
           <LoadingIndicator mini relative size={16} />
           {t('Sending organization invitations\u2026')}
-        </StatusMessage>
+        </Flex>
       );
     }
 
@@ -128,14 +128,14 @@ export function InviteMissingMembersModal({
       };
 
       return (
-        <StatusMessage status="success">
+        <Flex gap="md" align="center">
           <IconCheckmark size="sm" />
           <span>
             {errorCount > 0
               ? tct('Sent [invites], [failed] failed to send.', tctComponents)
               : tct('Sent [invites]', tctComponents)}
           </span>
-        </StatusMessage>
+        </Flex>
       );
     }
 


### PR DESCRIPTION
So, when inviting members we actually send out N requests, one for each email address that's in the list. This made it tough to show one error message in the modal :(

So instead of showing one, I put each error response from the server into the tooltip of the email address. It's not my favorite, but it's slightly better.

Also, i updated some UI components as i was going along. 

<img width="879" height="392" alt="Screenshot 2025-09-12 at 2 21 11 PM" src="https://github.com/user-attachments/assets/3937cce8-e681-47bf-913f-41f516f8c9e2" />


Related to ENG-5522