### PR TITLE
chore(detectors): Reset noise config limit for query injection issues 

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -538,7 +538,7 @@ class QueryInjectionVulnerabilityGroupType(PerformanceGroupTypeDefaults, GroupTy
     category_v2 = GroupCategory.DB_QUERY.value
     enable_auto_resolve = False
     enable_escalation_detection = False
-    noise_config = NoiseConfig(ignore_limit=10000)
+    noise_config = NoiseConfig(ignore_limit=10)
     default_priority = PriorityLevel.MEDIUM
 
 


### PR DESCRIPTION
now that users need to opt-in, we can reset the noise config to a more reasonable level. was originally raised to prevent new issues while we investigated.