### PR TITLE
feat(aci): add warning banner for automations with disabled actions

### DIFF
--- a/static/app/components/workflowEngine/gridCell/titleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/titleCell.tsx
@@ -37,7 +37,7 @@ export function TitleCell({
         {warning && (
           <Fragment>
             &mdash;
-            <Tooltip title={warning.message}>
+            <Tooltip title={warning.message} skipWrapper>
               <Flex gap="sm" align="center">
                 {warning.color === 'danger' && <Text variant="danger">Invalid</Text>}
                 <IconWarning color={warning.color} />

--- a/static/app/views/automations/components/actions/azureDevOps.tsx
+++ b/static/app/views/automations/components/actions/azureDevOps.tsx
@@ -1,5 +1,5 @@
 import {ActionMetadata} from 'sentry/components/workflowEngine/ui/actionMetadata';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Action, ActionHandler} from 'sentry/types/workflowEngine/actions';
 import {ActionType} from 'sentry/types/workflowEngine/actions';
 import {IntegrationField} from 'sentry/views/automations/components/actions/integrationField';
@@ -13,8 +13,7 @@ export function AzureDevOpsDetails({
   handler: ActionHandler;
 }) {
   const integrationName =
-    handler.integrations?.find(i => i.id === action.integrationId)?.name ||
-    action.integrationId;
+    handler.integrations?.find(i => i.id === action.integrationId)?.name || t('unknown');
 
   return tct('Create an [logo] Azure DevOps work item in [integration]', {
     logo: ActionMetadata[ActionType.AZURE_DEVOPS]?.icon,

--- a/static/app/views/automations/components/actions/discord.tsx
+++ b/static/app/views/automations/components/actions/discord.tsx
@@ -24,8 +24,7 @@ export function DiscordDetails({
   handler: ActionHandler;
 }) {
   const integrationName =
-    handler.integrations?.find(i => i.id === action.integrationId)?.name ||
-    action.integrationId;
+    handler.integrations?.find(i => i.id === action.integrationId)?.name || t('unknown');
   const tags = String(action.data.tags);
 
   return tct(

--- a/static/app/views/automations/components/actions/github.tsx
+++ b/static/app/views/automations/components/actions/github.tsx
@@ -1,5 +1,5 @@
 import {ActionMetadata} from 'sentry/components/workflowEngine/ui/actionMetadata';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Action, ActionHandler} from 'sentry/types/workflowEngine/actions';
 import {ActionType} from 'sentry/types/workflowEngine/actions';
 import {IntegrationField} from 'sentry/views/automations/components/actions/integrationField';
@@ -13,8 +13,7 @@ export function GithubDetails({
   handler: ActionHandler;
 }) {
   const integrationName =
-    handler.integrations?.find(i => i.id === action.integrationId)?.name ||
-    action.integrationId;
+    handler.integrations?.find(i => i.id === action.integrationId)?.name || t('unknown');
 
   return tct('Create a [logo] GitHub issue in [integration]', {
     logo: ActionMetadata[ActionType.GITHUB]?.icon,

--- a/static/app/views/automations/components/actions/githubEnterprise.tsx
+++ b/static/app/views/automations/components/actions/githubEnterprise.tsx
@@ -1,5 +1,5 @@
 import {ActionMetadata} from 'sentry/components/workflowEngine/ui/actionMetadata';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Action, ActionHandler} from 'sentry/types/workflowEngine/actions';
 import {ActionType} from 'sentry/types/workflowEngine/actions';
 import {IntegrationField} from 'sentry/views/automations/components/actions/integrationField';
@@ -13,8 +13,7 @@ export function GithubEnterpriseDetails({
   handler: ActionHandler;
 }) {
   const integrationName =
-    handler.integrations?.find(i => i.id === action.integrationId)?.name ||
-    action.integrationId;
+    handler.integrations?.find(i => i.id === action.integrationId)?.name || t('unknown');
 
   return tct('Create a [logo] GitHub Enterprise issue in [integration]', {
     logo: ActionMetadata[ActionType.GITHUB_ENTERPRISE]?.icon,

--- a/static/app/views/automations/components/actions/jira.tsx
+++ b/static/app/views/automations/components/actions/jira.tsx
@@ -1,5 +1,5 @@
 import {ActionMetadata} from 'sentry/components/workflowEngine/ui/actionMetadata';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Action, ActionHandler} from 'sentry/types/workflowEngine/actions';
 import {ActionType} from 'sentry/types/workflowEngine/actions';
 import {IntegrationField} from 'sentry/views/automations/components/actions/integrationField';
@@ -7,8 +7,7 @@ import {TicketActionSettingsButton} from 'sentry/views/automations/components/ac
 
 export function JiraDetails({action, handler}: {action: Action; handler: ActionHandler}) {
   const integrationName =
-    handler.integrations?.find(i => i.id === action.integrationId)?.name ||
-    action.integrationId;
+    handler.integrations?.find(i => i.id === action.integrationId)?.name || t('unknown');
 
   return tct('Create a [logo] Jira issue in [integration]', {
     logo: ActionMetadata[ActionType.JIRA]?.icon,

--- a/static/app/views/automations/components/actions/jiraServer.tsx
+++ b/static/app/views/automations/components/actions/jiraServer.tsx
@@ -1,5 +1,5 @@
 import {ActionMetadata} from 'sentry/components/workflowEngine/ui/actionMetadata';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Action, ActionHandler} from 'sentry/types/workflowEngine/actions';
 import {ActionType} from 'sentry/types/workflowEngine/actions';
 import {IntegrationField} from 'sentry/views/automations/components/actions/integrationField';
@@ -13,8 +13,7 @@ export function JiraServerDetails({
   handler: ActionHandler;
 }) {
   const integrationName =
-    handler.integrations?.find(i => i.id === action.integrationId)?.name ||
-    action.integrationId;
+    handler.integrations?.find(i => i.id === action.integrationId)?.name || t('unknown');
 
   return tct('Create a [logo] Jira Server issue in [integration]', {
     logo: ActionMetadata[ActionType.JIRA_SERVER]?.icon,

--- a/static/app/views/automations/components/actions/msTeams.tsx
+++ b/static/app/views/automations/components/actions/msTeams.tsx
@@ -16,8 +16,7 @@ export function MSTeamsDetails({
   handler: ActionHandler;
 }) {
   const integrationName =
-    handler.integrations?.find(i => i.id === action.integrationId)?.name ||
-    action.integrationId;
+    handler.integrations?.find(i => i.id === action.integrationId)?.name || t('unknown');
 
   return tct('Send a [logo] Microsoft Teams notification to [team] team, to [channel]', {
     logo: ActionMetadata[ActionType.MSTEAMS]?.icon,

--- a/static/app/views/automations/components/actions/opsgenie.tsx
+++ b/static/app/views/automations/components/actions/opsgenie.tsx
@@ -26,7 +26,7 @@ export function OpsgenieDetails({
     'Send a [logo] Opsgenie notification to [account] and team [team] with [priority] priority',
     {
       logo: ActionMetadata[ActionType.OPSGENIE]?.icon,
-      account: integration?.name || action.integrationId,
+      account: integration?.name || t('unknown'),
       team: service?.name || action.config.targetIdentifier,
       priority: String(action.data.priority),
     }

--- a/static/app/views/automations/components/actions/pagerduty.tsx
+++ b/static/app/views/automations/components/actions/pagerduty.tsx
@@ -26,8 +26,8 @@ export function PagerdutyDetails({
     'Send a [logo] PagerDuty notification to [account] and service [service] with [severity] severity',
     {
       logo: ActionMetadata[ActionType.PAGERDUTY]?.icon,
-      account: integration?.name || action.integrationId,
-      service: service?.name || action.config.targetIdentifier,
+      account: integration?.name || t('unknown'),
+      service: service?.name || t('unknown'),
       severity: String(action.data.priority),
     }
   );

--- a/static/app/views/automations/components/actions/slack.tsx
+++ b/static/app/views/automations/components/actions/slack.tsx
@@ -23,8 +23,7 @@ export function SlackDetails({
   handler: ActionHandler;
 }) {
   const integrationName =
-    handler.integrations?.find(i => i.id === action.integrationId)?.name ||
-    action.integrationId;
+    handler.integrations?.find(i => i.id === action.integrationId)?.name || t('unknown');
 
   return tct(
     'Send a [logo] Slack message to [workspace] workspace, to [channel][tagsAndNotes]',

--- a/static/app/views/automations/components/conditionsPanel.tsx
+++ b/static/app/views/automations/components/conditionsPanel.tsx
@@ -141,7 +141,7 @@ function ActionDetails({action, handler}: ActionDetailsProps) {
 
   return (
     <Fragment>
-      {action.status === 'active' && (
+      {action.status === 'disabled' && (
         <IconPadding>
           <IconWarning color="danger" />
         </IconPadding>

--- a/static/app/views/automations/components/conditionsPanel.tsx
+++ b/static/app/views/automations/components/conditionsPanel.tsx
@@ -1,10 +1,11 @@
+import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import Placeholder from 'sentry/components/placeholder';
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
+import {IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {
   ActionType,
   SentryAppIdentifier,
@@ -138,21 +139,30 @@ function ActionDetails({action, handler}: ActionDetailsProps) {
   const node = actionNodesMap.get(action.type);
   const Component = node?.details;
 
-  if (!Component || !handler) {
-    return <span>{node?.label}</span>;
-  }
-
-  return <Component action={action} handler={handler} />;
+  return (
+    <Fragment>
+      {action.status === 'active' && (
+        <IconPadding>
+          <IconWarning color="danger" />
+        </IconPadding>
+      )}
+      {!Component || !handler ? (
+        <span>{node?.label}</span>
+      ) : (
+        <Component action={action} handler={handler} />
+      )}
+    </Fragment>
+  );
 }
 
 const Panel = styled('div')`
   display: flex;
   flex-direction: column;
-  gap: ${space(1.5)};
+  gap: ${p => p.theme.space.lg};
   background-color: ${p => p.theme.backgroundSecondary};
   border: 1px solid ${p => p.theme.translucentBorder};
   border-radius: ${p => p.theme.borderRadius};
-  padding: ${space(1.5)};
+  padding: ${p => p.theme.space.lg};
   word-break: break-word;
 `;
 
@@ -163,15 +173,21 @@ const ConditionGroupHeader = styled('div')`
 const ConditionGroupWrapper = styled('div')<{showDivider?: boolean}>`
   display: flex;
   flex-direction: column;
-  gap: ${space(1)};
+  gap: ${p => p.theme.space.md};
   color: ${p => p.theme.subText};
 
   ${p =>
     p.showDivider &&
     css`
-      padding-top: ${space(1.5)};
+      padding-top: ${p.theme.space.lg};
       border-top: 1px solid ${p.theme.translucentBorder};
     `}
+`;
+
+const IconPadding = styled('span')`
+  padding-right: ${p => p.theme.space.sm};
+  height: 100%;
+  vertical-align: middle;
 `;
 
 export default ConditionsPanel;

--- a/static/app/views/automations/detail.spec.tsx
+++ b/static/app/views/automations/detail.spec.tsx
@@ -1,0 +1,212 @@
+import {
+  ActionFilterFixture,
+  ActionFixture,
+  AutomationFixture,
+} from 'sentry-fixture/automations';
+import {MetricDetectorFixture} from 'sentry-fixture/detectors';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import AutomationDetail from 'sentry/views/automations/detail';
+
+describe('AutomationDetail', () => {
+  const organization = OrganizationFixture({features: ['workflow-engine-ui']});
+  const automation = AutomationFixture({
+    id: '123',
+    name: 'Test Automation',
+    detectorIds: ['1', '2'],
+  });
+  const user = UserFixture({id: '1', name: 'John Doe', email: 'john@example.com'});
+  const detectors = [
+    MetricDetectorFixture({id: '1', name: 'CPU Usage Monitor', projectId: '1'}),
+    MetricDetectorFixture({id: '2', name: 'Memory Usage Monitor', projectId: '2'}),
+  ];
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/1/',
+      body: user,
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/123/',
+      body: automation,
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      body: detectors,
+      match: [MockApiClient.matchQuery({id: ['1', '2']})],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/123/stats/',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/123/group-history/',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/available-actions/`,
+      method: 'GET',
+      body: [],
+    });
+  });
+
+  it('displays automation details correctly', async () => {
+    render(<AutomationDetail />, {
+      organization,
+      initialRouterConfig: {
+        route: '/automations/:automationId/',
+        location: {pathname: '/automations/123/'},
+      },
+    });
+
+    expect(
+      await screen.findByRole('heading', {name: 'Test Automation'})
+    ).toBeInTheDocument();
+
+    // Check sidebar sections
+    expect(screen.getByRole('heading', {name: 'Last Triggered'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Environment'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Action Interval'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Conditions'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Details'})).toBeInTheDocument();
+  });
+
+  it('can enable a disabled automation', async () => {
+    const disabledAutomation = AutomationFixture({
+      ...automation,
+      enabled: false,
+    });
+
+    const updateRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/123/',
+      method: 'PUT',
+      body: {...disabledAutomation, enabled: false},
+    });
+
+    render(<AutomationDetail />, {
+      organization,
+      initialRouterConfig: {
+        route: '/automations/:automationId/',
+        location: {pathname: '/automations/123/'},
+      },
+    });
+
+    const enableButton = await screen.findByRole('button', {name: 'Disable'});
+    await userEvent.click(enableButton);
+
+    await waitFor(() => {
+      expect(updateRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/workflows/123/',
+        expect.objectContaining({
+          data: {
+            id: '123',
+            name: 'Test Automation',
+            enabled: false,
+          },
+        })
+      );
+    });
+
+    expect(screen.getByText('Enable')).toBeInTheDocument();
+  });
+
+  describe('Action warnings', () => {
+    it('displays warning when automation has no actions', async () => {
+      const automationWithWarning = AutomationFixture({
+        ...automation,
+        actionFilters: [ActionFilterFixture({actions: []})],
+      });
+
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/workflows/123/',
+        body: automationWithWarning,
+      });
+
+      render(<AutomationDetail />, {
+        organization,
+        initialRouterConfig: {
+          route: '/automations/:automationId/',
+          location: {pathname: '/automations/123/'},
+        },
+      });
+
+      await screen.findByRole('heading', {name: 'Test Automation'});
+
+      expect(
+        screen.getByText('You must add an action for this automation to run.')
+      ).toBeInTheDocument();
+    });
+
+    it('displays warning all actions are invalid', async () => {
+      const automationWithWarning = AutomationFixture({
+        ...automation,
+        actionFilters: [
+          ActionFilterFixture({
+            actions: [ActionFixture({status: 'disabled'})],
+          }),
+        ],
+      });
+
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/workflows/123/',
+        body: automationWithWarning,
+      });
+
+      render(<AutomationDetail />, {
+        organization,
+        initialRouterConfig: {
+          route: '/automations/:automationId/',
+          location: {pathname: '/automations/123/'},
+        },
+      });
+
+      await screen.findByRole('heading', {name: 'Test Automation'});
+
+      expect(
+        screen.getByText(
+          'Automation is invalid because no actions can run. Actions need to be reconfigured.'
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('displays warning some actions are invalid', async () => {
+      const automationWithWarning = AutomationFixture({
+        ...automation,
+        actionFilters: [
+          ActionFilterFixture({
+            actions: [ActionFixture(), ActionFixture({status: 'disabled'})],
+          }),
+        ],
+      });
+
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/workflows/123/',
+        body: automationWithWarning,
+      });
+
+      render(<AutomationDetail />, {
+        organization,
+        initialRouterConfig: {
+          route: '/automations/:automationId/',
+          location: {pathname: '/automations/123/'},
+        },
+      });
+
+      await screen.findByRole('heading', {name: 'Test Automation'});
+
+      expect(
+        screen.getByText('One or more actions need to be reconfigured in order to run.')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/automations/detail.spec.tsx
+++ b/static/app/views/automations/detail.spec.tsx
@@ -81,7 +81,7 @@ describe('AutomationDetail', () => {
     expect(screen.getByRole('heading', {name: 'Details'})).toBeInTheDocument();
   });
 
-  it('can enable a disabled automation', async () => {
+  it('can disable an enabled automation', async () => {
     const disabledAutomation = AutomationFixture({
       ...automation,
       enabled: false,

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -2,6 +2,7 @@ import {Fragment, useCallback} from 'react';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
+import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
@@ -33,6 +34,7 @@ import {AutomationStatsChart} from 'sentry/views/automations/components/automati
 import ConditionsPanel from 'sentry/views/automations/components/conditionsPanel';
 import ConnectedMonitorsList from 'sentry/views/automations/components/connectedMonitorsList';
 import {useAutomationQuery, useUpdateAutomation} from 'sentry/views/automations/hooks';
+import {getAutomationActionsWarning} from 'sentry/views/automations/hooks/utils';
 import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
 import {useDetectorsQuery} from 'sentry/views/detectors/hooks';
 
@@ -64,6 +66,8 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
   const {selection} = usePageFilters();
   const {start, end, period, utc} = selection.datetime;
 
+  const warning = getAutomationActionsWarning(automation);
+
   return (
     <SentryDocumentTitle title={automation.name} noSuffix>
       <DetailLayout>
@@ -86,6 +90,11 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
         </DetailLayout.Header>
         <DetailLayout.Body>
           <DetailLayout.Main>
+            {warning && (
+              <Alert type={warning.color === 'warning' ? 'warning' : 'error'}>
+                {warning.message}
+              </Alert>
+            )}
             <PageFiltersContainer>
               <DatePageFilter />
               <ErrorBoundary>


### PR DESCRIPTION
follow up to https://github.com/getsentry/sentry/pull/99269

now that actions have a status, we can flag disabled actions on the automation details page

as of now, actions are only disabled when the integration is uninstalled (therefore the action is considered misconfigured since the integration installation no longer exists)

example banner (when there are no actions):
<img width="857" height="209" alt="Screenshot 2025-09-12 at 2 21 23 PM" src="https://github.com/user-attachments/assets/c45d8f25-63e5-4c23-b82b-df4373021f53" />

example of disabled action:
<img width="291" height="80" alt="Screenshot 2025-09-12 at 2 28 55 PM" src="https://github.com/user-attachments/assets/c42b483c-bd19-4e21-ba85-2761e7aa547f" />
