### PR TITLE
feat(aci): action validation translators

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3077,7 +3077,7 @@ SENTRY_DEFAULT_INTEGRATIONS = (
     "sentry.integrations.vsts_extension.VstsExtensionIntegrationProvider",
     "sentry.integrations.pagerduty.integration.PagerDutyIntegrationProvider",
     "sentry.integrations.vercel.VercelIntegrationProvider",
-    "sentry.integrations.msteams.MsTeamsIntegrationProvider",
+    "sentry.integrations.msteams.integration.MsTeamsIntegrationProvider",
     "sentry.integrations.aws_lambda.AwsLambdaIntegrationProvider",
     "sentry.integrations.discord.DiscordIntegrationProvider",
     "sentry.integrations.opsgenie.OpsgenieIntegrationProvider",

--- a/src/sentry/integrations/discord/actions/issue_alert/form.py
+++ b/src/sentry/integrations/discord/actions/issue_alert/form.py
@@ -68,4 +68,5 @@ class DiscordNotifyServiceForm(forms.Form):
                 )
             except ApiTimeoutError:
                 raise forms.ValidationError("Discord channel lookup timed out")
+
         return cleaned_data

--- a/src/sentry/integrations/discord/actions/issue_alert/form.py
+++ b/src/sentry/integrations/discord/actions/issue_alert/form.py
@@ -68,5 +68,4 @@ class DiscordNotifyServiceForm(forms.Form):
                 )
             except ApiTimeoutError:
                 raise forms.ValidationError("Discord channel lookup timed out")
-
         return cleaned_data

--- a/src/sentry/integrations/messaging/__init__.py
+++ b/src/sentry/integrations/messaging/__init__.py
@@ -5,3 +5,5 @@ The current messaging integrations are Discord, MSTeams, and Slack.
 TODO: Move the packages for individual integrations to be subpackages of this one
       (possibly in coordination with grouping other integrations by purpose)
 """
+
+from .message_builder import *  # noqa: F401,F403

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -13,7 +13,6 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.models.team import Team
-from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notifications.rules import AlertRuleNotification
 from sentry.notifications.utils.links import create_link_to_workflow
@@ -109,6 +108,8 @@ def fetch_environment_name(rule_env: int) -> str | None:
 def get_rule_environment_param_from_rule(
     rule_id: int, rule_environment_id: int | None, organization: Organization, type_id: int
 ) -> dict[str, str]:
+    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
     params = {}
     if should_fire_workflow_actions(organization, type_id):
         if (
@@ -270,6 +271,8 @@ def build_attachment_replay_link(
 
 
 def build_rule_url(rule: Any, group: Group, project: Project) -> str:
+    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
     org_slug = group.organization.slug
     project_slug = project.slug
     if should_fire_workflow_actions(group.organization, group.type):

--- a/src/sentry/integrations/msteams/__init__.py
+++ b/src/sentry/integrations/msteams/__init__.py
@@ -1,22 +1,5 @@
 from sentry.integrations.msteams.spec import MsTeamsMessagingSpec
 
-from .actions.form import *  # noqa: F401,F403
-from .actions.notification import *  # noqa: F401,F403
-from .analytics import *  # noqa: F401,F403
-from .card_builder.base import *  # noqa: F401,F403
-from .card_builder.block import *  # noqa: F401,F403
-from .card_builder.help import *  # noqa: F401,F403
-from .card_builder.identity import *  # noqa: F401,F403
-from .card_builder.installation import *  # noqa: F401,F403
-from .card_builder.notifications import *  # noqa: F401,F403
-from .client import *  # noqa: F401,F403
 from .handlers import MSTeamsActionHandler  # noqa: F401,F403
-from .integration import *  # noqa: F401,F403
-from .link_identity import *  # noqa: F401,F403
-from .notifications import *  # noqa: F401,F403
-from .unlink_identity import *  # noqa: F401,F403
-from .urls import *  # noqa: F401,F403
-from .utils import *  # noqa: F401,F403
-from .webhook import *  # noqa: F401,F403
 
 MsTeamsMessagingSpec().initialize()

--- a/src/sentry/integrations/msteams/actions/form.py
+++ b/src/sentry/integrations/msteams/actions/form.py
@@ -5,6 +5,8 @@ from typing import Any
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
+from sentry.integrations.msteams.utils import find_channel_id
+from sentry.integrations.services.integration.service import integration_service
 from sentry.utils.forms import set_field_choices
 
 
@@ -15,7 +17,6 @@ class MsTeamsNotifyServiceForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         self._team_list = [(i.id, i.name) for i in kwargs.pop("integrations")]
-        self.channel_transformer = kwargs.pop("channel_transformer")
 
         super().__init__(*args, **kwargs)
 
@@ -31,7 +32,13 @@ class MsTeamsNotifyServiceForm(forms.Form):
 
         integration_id = cleaned_data.get("team")
         channel = cleaned_data.get("channel", "")
-        channel_id = self.channel_transformer(integration_id, channel)
+        integration = integration_service.get_integration(
+            integration_id=integration_id,
+        )
+        if not integration:
+            raise forms.ValidationError(_("Team is a required field."), code="invalid")
+
+        channel_id = find_channel_id(integration, channel)
 
         if channel_id is None and integration_id is not None:
             params = {

--- a/src/sentry/integrations/msteams/actions/notification.py
+++ b/src/sentry/integrations/msteams/actions/notification.py
@@ -9,7 +9,6 @@ from sentry.integrations.msteams.card_builder.issues import MSTeamsIssueMessageB
 from sentry.integrations.msteams.client import MsTeamsClient
 from sentry.integrations.msteams.metrics import record_lifecycle_termination_level
 from sentry.integrations.msteams.spec import MsTeamsMessagingSpec
-from sentry.integrations.msteams.utils import get_channel_id
 from sentry.integrations.services.integration import RpcIntegration
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.rules.actions import IntegrationEventAction
@@ -86,9 +85,4 @@ class MsTeamsNotifyServiceAction(IntegrationEventAction):
         )
 
     def get_form_instance(self) -> MsTeamsNotifyServiceForm:
-        return MsTeamsNotifyServiceForm(
-            self.data, integrations=self.get_integrations(), channel_transformer=self.get_channel_id
-        )
-
-    def get_channel_id(self, integration_id, name):
-        return get_channel_id(self.project.organization, integration_id, name)
+        return MsTeamsNotifyServiceForm(self.data, integrations=self.get_integrations())

--- a/src/sentry/integrations/msteams/spec.py
+++ b/src/sentry/integrations/msteams/spec.py
@@ -29,7 +29,7 @@ class MsTeamsMessagingSpec(MessagingIntegrationSpec):
 
     @property
     def integration_provider(self) -> type[IntegrationProvider]:
-        from sentry.integrations.msteams import MsTeamsIntegrationProvider
+        from sentry.integrations.msteams.integration import MsTeamsIntegrationProvider
 
         return MsTeamsIntegrationProvider
 

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -61,18 +61,7 @@ def get_user_conversation_id(integration: Integration | RpcIntegration, user_id:
     return conversation_id
 
 
-def get_channel_id(organization: Organization, integration_id: int, name: str) -> str | None:
-    integrations = integration_service.get_integrations(
-        providers=[IntegrationProviderSlug.MSTEAMS.value],
-        organization_id=organization.id,
-        integration_ids=[integration_id],
-    )
-    if not integrations:
-        return None
-
-    assert len(integrations) == 1, "Found multiple msteams integrations for org!"
-    integration = integrations[0]
-
+def find_channel_id(integration: Integration | RpcIntegration, name: str) -> str | None:
     team_id = integration.external_id
     client = MsTeamsClient(integration)
 
@@ -103,6 +92,21 @@ def get_channel_id(organization: Organization, integration_id: int, name: str) -
         members = client.get_member_list(team_id, continuation_token)
 
     return None
+
+
+def get_channel_id(organization: Organization, integration_id: int, name: str) -> str | None:
+    integrations = integration_service.get_integrations(
+        providers=[IntegrationProviderSlug.MSTEAMS.value],
+        organization_id=organization.id,
+        integration_ids=[integration_id],
+    )
+    if not integrations:
+        return None
+
+    assert len(integrations) == 1, "Found multiple msteams integrations for org!"
+    integration = integrations[0]
+
+    return find_channel_id(integration, name)
 
 
 def send_incident_alert_notification(

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -24,7 +24,7 @@ from sentry.integrations.mixins import NotifyBasicMixin
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.models.organization_integration import OrganizationIntegration
-from sentry.integrations.msteams import MsTeamsClient
+from sentry.integrations.msteams.client import MsTeamsClient
 from sentry.integrations.msteams.metrics import record_lifecycle_termination_level
 from sentry.integrations.msteams.spec import MsTeamsMessagingSpec
 from sentry.integrations.services.integration import (

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -35,7 +35,6 @@ from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.models.rule import Rule
 from sentry.notifications.additional_attachment_manager import get_additional_attachment
-from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.utils.open_period import open_period_start_for_group
 from sentry.rules.actions import IntegrationEventAction
 from sentry.rules.base import CallbackFuture
@@ -436,6 +435,8 @@ class SlackNotifyServiceAction(IntegrationEventAction):
     def after(
         self, event: GroupEvent, notification_uuid: str | None = None
     ) -> Generator[CallbackFuture]:
+        from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
         channel = self.get_option("channel_id")
         tags = set(self.get_tags_list())
 

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -15,7 +15,6 @@ from sentry.integrations.messaging.metrics import (
     MessagingInteractionEvent,
     MessagingInteractionType,
 )
-from sentry.integrations.models.integration import Integration
 from sentry.integrations.repository import get_default_issue_alert_repository
 from sentry.integrations.repository.base import NotificationMessageValidationError
 from sentry.integrations.repository.issue_alert import NewIssueAlertNotificationMessage
@@ -28,7 +27,6 @@ from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageB
 from sentry.integrations.slack.metrics import record_lifecycle_termination_level
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.spec import SlackMessagingSpec
-from sentry.integrations.slack.utils.channel import SlackChannelIdData, get_channel_id
 from sentry.integrations.slack.utils.threads import NotificationActionThreadUtils
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import EventLifecycle
@@ -513,9 +511,4 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         return [s.strip() for s in self.get_option("tags", "").split(",")]
 
     def get_form_instance(self) -> SlackNotifyServiceForm:
-        return SlackNotifyServiceForm(
-            self.data, integrations=self.get_integrations(), channel_transformer=self.get_channel_id
-        )
-
-    def get_channel_id(self, integration: Integration, name: str) -> SlackChannelIdData:
-        return get_channel_id(integration, name)
+        return SlackNotifyServiceForm(self.data, integrations=self.get_integrations())

--- a/src/sentry/notifications/notification_action/__init__.py
+++ b/src/sentry/notifications/notification_action/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "SentryAppActionHandler",
     "SendTestNotification",
     "SlackActionValidatorHandler",
+    "MSTeamsActionValidatorHandler",
 ]
 
 from .action_handler_registry import (
@@ -33,7 +34,7 @@ from .action_handler_registry import (
     SentryAppActionHandler,
     WebhookActionHandler,
 )
-from .action_validation import SlackActionValidatorHandler
+from .action_validation import MSTeamsActionValidatorHandler, SlackActionValidatorHandler
 from .group_type_notification_registry import IssueAlertRegistryHandler, MetricAlertRegistryHandler
 from .grouptype import SendTestNotification
 from .issue_alert_registry import (

--- a/src/sentry/notifications/notification_action/__init__.py
+++ b/src/sentry/notifications/notification_action/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "WebhookActionHandler",
     "SentryAppActionHandler",
     "SendTestNotification",
+    "SlackActionValidatorHandler",
 ]
 
 from .action_handler_registry import (
@@ -32,6 +33,7 @@ from .action_handler_registry import (
     SentryAppActionHandler,
     WebhookActionHandler,
 )
+from .action_validation import SlackActionValidatorHandler
 from .group_type_notification_registry import IssueAlertRegistryHandler, MetricAlertRegistryHandler
 from .grouptype import SendTestNotification
 from .issue_alert_registry import (

--- a/src/sentry/notifications/notification_action/action_handler_registry/common.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/common.py
@@ -12,7 +12,7 @@ MESSAGING_ACTION_CONFIG_SCHEMA = {
             "enum": [ActionTarget.SPECIFIC.value],
         },
     },
-    "required": ["target_identifier", "target_display", "target_type"],
+    "required": ["target_display", "target_type"],
     "additionalProperties": False,
 }
 

--- a/src/sentry/notifications/notification_action/action_validation.py
+++ b/src/sentry/notifications/notification_action/action_validation.py
@@ -4,7 +4,6 @@ from django.core.exceptions import ValidationError
 
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.slack.actions.form import SlackNotifyServiceForm
-from sentry.integrations.slack.utils.channel import get_channel_id as slack_channel_transformer
 from sentry.notifications.notification_action.registry import action_validator_registry
 
 from .types import BaseActionValidatorHandler
@@ -13,7 +12,6 @@ from .types import BaseActionValidatorHandler
 @action_validator_registry.register("slack")
 class SlackActionValidatorHandler(BaseActionValidatorHandler):
     provider = "slack"
-    channel_transformer = slack_channel_transformer
     notify_action_form = SlackNotifyServiceForm
 
     def generate_action_form_payload(self) -> dict[str, Any]:
@@ -25,7 +23,7 @@ class SlackActionValidatorHandler(BaseActionValidatorHandler):
             raise ValidationError(f"Slack integration with id {integration_id} not found")
 
         return {
-            "workspace": integration.name,
+            "workspace": integration_id,
             "channel": self.validated_data["config"]["target_display"],
             "channel_id": self.validated_data["config"].get("target_identifier"),
             "tags": self.validated_data.get("tags"),

--- a/src/sentry/notifications/notification_action/action_validation.py
+++ b/src/sentry/notifications/notification_action/action_validation.py
@@ -3,6 +3,8 @@ from typing import Any
 from django.core.exceptions import ValidationError
 
 from sentry.constants import ObjectStatus
+from sentry.integrations.msteams.actions.form import MsTeamsNotifyServiceForm
+from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.slack.actions.form import SlackNotifyServiceForm
 from sentry.notifications.notification_action.registry import action_validator_registry
@@ -11,26 +13,54 @@ from sentry.workflow_engine.models.action import Action
 from .types import BaseActionValidatorHandler
 
 
+def _get_integration(validated_data: dict[str, Any], provider: str) -> RpcIntegration:
+    if not (integration_id := validated_data.get("integration_id")):
+        raise ValidationError(f"Integration ID is required for {provider} action")
+
+    integration = integration_service.get_integration(
+        integration_id=integration_id, status=ObjectStatus.ACTIVE
+    )
+    if not integration:
+        raise ValidationError(f"{provider} integration with id {integration_id} not found")
+    return integration
+
+
 @action_validator_registry.register(Action.Type.SLACK)
 class SlackActionValidatorHandler(BaseActionValidatorHandler):
     provider = Action.Type.SLACK
     notify_action_form = SlackNotifyServiceForm
 
     def generate_action_form_payload(self) -> dict[str, Any]:
-        if not (integration_id := self.validated_data.get("integration_id")):
-            raise ValidationError("Integration ID is required for Slack action")
-
-        integration = integration_service.get_integration(
-            integration_id=integration_id, status=ObjectStatus.ACTIVE
-        )
-        if not integration:
-            raise ValidationError(f"Slack integration with id {integration_id} not found")
+        integration = _get_integration(self.validated_data, self.provider)
 
         return {
-            "workspace": integration_id,
+            "workspace": integration.id,
             "channel": self.validated_data["config"]["target_display"],
             "channel_id": self.validated_data["config"].get("target_identifier"),
             "tags": self.validated_data["data"].get("tags"),
+        }
+
+    def update_action_data(self, cleaned_data: dict[str, Any]) -> dict[str, Any]:
+        self.validated_data["config"].update(
+            {
+                "target_display": cleaned_data["channel"],
+                "target_identifier": cleaned_data["channel_id"],
+            }
+        )
+        return self.validated_data
+
+
+@action_validator_registry.register(Action.Type.MSTEAMS)
+class MSTeamsActionValidatorHandler(BaseActionValidatorHandler):
+    provider = Action.Type.MSTEAMS
+    notify_action_form = MsTeamsNotifyServiceForm
+
+    def generate_action_form_payload(self) -> dict[str, Any]:
+        integration = _get_integration(self.validated_data, self.provider)
+
+        return {
+            "team": integration.id,
+            "channel": self.validated_data["config"]["target_display"],
         }
 
     def update_action_data(self, cleaned_data: dict[str, Any]) -> dict[str, Any]:

--- a/src/sentry/notifications/notification_action/action_validation.py
+++ b/src/sentry/notifications/notification_action/action_validation.py
@@ -26,7 +26,7 @@ class SlackActionValidatorHandler(BaseActionValidatorHandler):
             "workspace": integration_id,
             "channel": self.validated_data["config"]["target_display"],
             "channel_id": self.validated_data["config"].get("target_identifier"),
-            "tags": self.validated_data.get("tags"),
+            "tags": self.validated_data["data"].get("tags"),
         }
 
     def update_action_data(self, cleaned_data: dict[str, Any]) -> dict[str, Any]:

--- a/src/sentry/notifications/notification_action/action_validation.py
+++ b/src/sentry/notifications/notification_action/action_validation.py
@@ -1,75 +1,17 @@
-from abc import ABC, abstractmethod
-from collections.abc import Callable
 from typing import Any
 
 from django.core.exceptions import ValidationError
-from django.forms import Form
 
-from sentry.constants import ObjectStatus
-from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.slack.actions.form import SlackNotifyServiceForm
 from sentry.integrations.slack.utils.channel import get_channel_id
-from sentry.models.organization import Organization
+from sentry.notifications.notification_action.registry import action_validator_registry
+
+from .types import BaseActionValidatorHandler
 
 
-def clean_validated_action_attrs(
-    attrs: dict[str, Any], organization: Organization
-) -> dict[str, Any]:
-    type = attrs["type"]
-
-    validator_translator = action_validator_translator_mapping.get(type)
-
-    if not validator_translator:
-        raise ValidationError(f"Validator for action type {type} not found")
-
-    return validator_translator(attrs, organization).clean_data()
-
-
-def _get_integrations(organization: Organization, provider: str) -> list[RpcIntegration]:
-    return integration_service.get_integrations(
-        organization_id=organization.id,
-        status=ObjectStatus.ACTIVE,
-        org_integration_status=ObjectStatus.ACTIVE,
-        providers=[provider],
-    )
-
-
-class BaseActionValidatorTranslator(ABC):
-    provider: str
-    notify_action_form: type[Form] | None
-    channel_transformer: Callable[[str, str], str] | None  # passed for Slack and MSTeams
-
-    def __init__(self, validated_data: dict[str, Any], organization: Organization) -> None:
-        self.validated_data = validated_data
-        self.organization = organization
-
-    def clean_data(self) -> dict[str, Any]:
-        if self.notify_action_form is None:
-            return self.validated_data
-
-        notify_action_form = self.notify_action_form(
-            data=self.generate_action_form_payload(),
-            integrations=_get_integrations(self.organization, self.provider),
-            channel_transformer=self.channel_transformer,
-        )
-
-        if notify_action_form.is_valid():
-            return self.update_action_data(notify_action_form.cleaned_data)
-        return self.validated_data
-
-    @abstractmethod
-    def generate_action_form_payload(self) -> dict[str, Any]:
-        # translate validated data from BaseActionValidator to notify action form data
-        pass
-
-    @abstractmethod
-    def update_action_data(self, cleaned_data: dict[str, Any]) -> dict[str, Any]:
-        # update BaseActionValidator data with cleaned notify action form data
-        pass
-
-
-class SlackActionValidatorTranslator(BaseActionValidatorTranslator):
+@action_validator_registry.register("slack")
+class SlackActionValidatorHandler(BaseActionValidatorHandler):
     from sentry.integrations.slack.actions.notification import SlackNotifyServiceAction
 
     provider = "slack"
@@ -99,8 +41,3 @@ class SlackActionValidatorTranslator(BaseActionValidatorTranslator):
             }
         )
         return self.validated_data
-
-
-action_validator_translator_mapping: dict[str, type[BaseActionValidatorTranslator]] = {
-    "slack": SlackActionValidatorTranslator,
-}

--- a/src/sentry/notifications/notification_action/action_validation.py
+++ b/src/sentry/notifications/notification_action/action_validation.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.slack.actions.form import SlackNotifyServiceForm
-from sentry.integrations.slack.utils.channel import get_channel_id
+from sentry.integrations.slack.utils.channel import get_channel_id as slack_channel_transformer
 from sentry.notifications.notification_action.registry import action_validator_registry
 
 from .types import BaseActionValidatorHandler
@@ -12,10 +12,8 @@ from .types import BaseActionValidatorHandler
 
 @action_validator_registry.register("slack")
 class SlackActionValidatorHandler(BaseActionValidatorHandler):
-    from sentry.integrations.slack.actions.notification import SlackNotifyServiceAction
-
     provider = "slack"
-    channel_transformer = get_channel_id
+    channel_transformer = slack_channel_transformer
     notify_action_form = SlackNotifyServiceForm
 
     def generate_action_form_payload(self) -> dict[str, Any]:

--- a/src/sentry/notifications/notification_action/action_validation.py
+++ b/src/sentry/notifications/notification_action/action_validation.py
@@ -1,0 +1,103 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.forms import Form
+
+from sentry.constants import ObjectStatus
+from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.integrations.services.integration.service import integration_service
+from sentry.integrations.slack.actions.form import SlackNotifyServiceForm
+from sentry.integrations.slack.utils.channel import get_channel_id
+from sentry.models.organization import Organization
+
+
+def clean_validated_action_attrs(
+    attrs: dict[str, Any], organization: Organization
+) -> dict[str, Any]:
+    type = attrs["type"]
+
+    validator_translator = action_validator_translator_mapping.get(type)
+
+    if not validator_translator:
+        raise ValidationError(f"Validator for action type {type} not found")
+
+    return validator_translator(attrs, organization).clean_data()
+
+
+def _get_integrations(organization: Organization, provider: str) -> list[RpcIntegration]:
+    return integration_service.get_integrations(
+        organization_id=organization.id,
+        status=ObjectStatus.ACTIVE,
+        org_integration_status=ObjectStatus.ACTIVE,
+        providers=[provider],
+    )
+
+
+class BaseActionValidatorTranslator(ABC):
+    provider: str
+    notify_action_form: type[Form] | None
+
+    def __init__(self, validated_data: dict[str, Any], organization: Organization) -> None:
+        self.validated_data = validated_data
+        self.organization = organization
+
+    def clean_data(self) -> dict[str, Any]:
+        if self.notify_action_form is None:
+            return self.validated_data
+
+        notify_action_form = self.notify_action_form(
+            data=self.generate_action_form_payload(),
+            integrations=_get_integrations(self.organization, self.provider),
+            channel_transformer=get_channel_id,
+        )
+
+        if notify_action_form.is_valid():
+            return self.update_action_data(notify_action_form.cleaned_data)
+        return self.validated_data
+
+    @abstractmethod
+    def generate_action_form_payload(self) -> dict[str, Any]:
+        # translate validated data from BaseActionValidator to notify action form data
+        pass
+
+    @abstractmethod
+    def update_action_data(self, cleaned_data: dict[str, Any]) -> dict[str, Any]:
+        # update BaseActionValidator data with cleaned notify action form data
+        pass
+
+
+class SlackActionValidatorTranslator(BaseActionValidatorTranslator):
+    from sentry.integrations.slack.actions.notification import SlackNotifyServiceAction
+
+    provider = "slack"
+    notify_action_form = SlackNotifyServiceForm
+
+    def generate_action_form_payload(self) -> dict[str, Any]:
+        if not (integration_id := self.validated_data.get("integration_id")):
+            raise ValidationError("Integration ID is required for Slack action")
+
+        integration = integration_service.get_integration(integration_id=integration_id)
+        if not integration:
+            raise ValidationError(f"Slack integration with id {integration_id} not found")
+
+        return {
+            "workspace": integration.name,
+            "channel": self.validated_data["config"]["target_display"],
+            "channel_id": self.validated_data["config"].get("target_identifier"),
+            "tags": self.validated_data.get("tags"),
+        }
+
+    def update_action_data(self, cleaned_data: dict[str, Any]) -> dict[str, Any]:
+        self.validated_data["config"].update(
+            {
+                "target_display": cleaned_data["channel"],
+                "target_identifier": cleaned_data["channel_id"],
+            }
+        )
+        return self.validated_data
+
+
+action_validator_translator_mapping: dict[str, type[BaseActionValidatorTranslator]] = {
+    "slack": SlackActionValidatorTranslator,
+}

--- a/src/sentry/notifications/notification_action/registry.py
+++ b/src/sentry/notifications/notification_action/registry.py
@@ -1,7 +1,13 @@
 from sentry.utils.registry import Registry
 
-from .types import BaseIssueAlertHandler, BaseMetricAlertHandler, LegacyRegistryHandler
+from .types import (
+    BaseActionValidatorHandler,
+    BaseIssueAlertHandler,
+    BaseMetricAlertHandler,
+    LegacyRegistryHandler,
+)
 
 metric_alert_handler_registry = Registry[type[BaseMetricAlertHandler]](enable_reverse_lookup=False)
 issue_alert_handler_registry = Registry[type[BaseIssueAlertHandler]](enable_reverse_lookup=False)
 group_type_notification_registry = Registry[type[LegacyRegistryHandler]]()
+action_validator_registry = Registry[type[BaseActionValidatorHandler]](enable_reverse_lookup=False)

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -3,7 +3,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Collection, Sequence
 from dataclasses import asdict
-from typing import Any, NotRequired, TypedDict
+from typing import Any, NotRequired, Protocol, TypedDict
 
 from sentry import features
 from sentry.constants import ObjectStatus
@@ -15,6 +15,8 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
+from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.integrations.services.integration.service import integration_service
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 from sentry.models.organization import Organization
@@ -478,3 +480,58 @@ class BaseMetricAlertHandler(ABC):
             organization=detector.project.organization,
             project=detector.project,
         )
+
+
+class NotificationActionForm(Protocol):
+    """Protocol for notification action forms since they have various inheritance layers and but all have the same __init__ signature"""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def is_valid(self) -> bool: ...
+
+    @property
+    def cleaned_data(self) -> dict[str, Any]: ...
+
+
+def _get_integrations(organization: Organization, provider: str) -> list[RpcIntegration]:
+    return integration_service.get_integrations(
+        organization_id=organization.id,
+        status=ObjectStatus.ACTIVE,
+        org_integration_status=ObjectStatus.ACTIVE,
+        providers=[provider],
+    )
+
+
+class BaseActionValidatorHandler(ABC):
+    provider: str
+    notify_action_form: type[NotificationActionForm] | None
+    channel_transformer: Callable | None  # passed for Slack and MSTeams
+
+    def __init__(self, validated_data: dict[str, Any], organization: Organization) -> None:
+        self.validated_data = validated_data
+        self.organization = organization
+
+    def clean_data(self) -> dict[str, Any]:
+        if self.notify_action_form is None:
+            return self.validated_data
+
+        # TODO: this is calling an RPC function inside a transaction in WorkflowValidator, need to rework the validator
+        notify_action_form = self.notify_action_form(
+            data=self.generate_action_form_payload(),
+            integrations=_get_integrations(self.organization, self.provider),
+            channel_transformer=self.channel_transformer,
+        )
+
+        if notify_action_form.is_valid():
+            return self.update_action_data(notify_action_form.cleaned_data)
+        return self.validated_data
+
+    @abstractmethod
+    def generate_action_form_payload(self) -> dict[str, Any]:
+        # translate validated data from BaseActionValidator to notify action form data
+        pass
+
+    @abstractmethod
+    def update_action_data(self, cleaned_data: dict[str, Any]) -> dict[str, Any]:
+        # update BaseActionValidator data with cleaned notify action form data
+        pass

--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -31,7 +31,7 @@ class TestActionsValidator(CamelSnakeSerializer):
 
     def validate_actions(self, value):
         for action in value:
-            BaseActionValidator(data=action).is_valid(raise_exception=True)
+            BaseActionValidator(data=action, context=self.context).is_valid(raise_exception=True)
         return value
 
 
@@ -64,7 +64,7 @@ class OrganizationTestFireActionsEndpoint(OrganizationEndpoint):
 
         The actions will be fired against a sample event in the first project of the organization.
         """
-        serializer = TestActionsValidator(data=request.data)
+        serializer = TestActionsValidator(data=request.data, context={"organization": organization})
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=HTTP_400_BAD_REQUEST)

--- a/src/sentry/workflow_engine/endpoints/validators/base/action.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/action.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.constants import ObjectStatus
+from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.endpoints.validators.utils import validate_json_schema
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.processors.action import is_action_permitted
@@ -61,16 +62,20 @@ class BaseActionValidator(CamelSnakeSerializer):
             )
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        from sentry.notifications.notification_action.action_validation import (
-            clean_validated_action_attrs,
-        )
+        from sentry.notifications.notification_action.registry import action_validator_registry
 
         attrs = super().validate(attrs)
 
         if not (organization := self.context.get("organization")):
             raise serializers.ValidationError("Organization is required in the context")
 
-        return clean_validated_action_attrs(attrs, organization)
+        try:
+            handler = action_validator_registry.get(attrs["type"])
+        except NoRegistrationExistsError:
+            # TODO: remove try/catch when all existing action types are registered
+            return attrs
+
+        return handler(attrs, organization).clean_data()
 
     def create(self, validated_value: dict[str, Any]) -> Action:
         self._check_action_type(Action.Type(validated_value["type"]))

--- a/src/sentry/workflow_engine/endpoints/validators/base/action.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/action.py
@@ -60,6 +60,18 @@ class BaseActionValidator(CamelSnakeSerializer):
                 f"Organization does not allow this action type: {action_type}"
             )
 
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        from sentry.notifications.notification_action.action_validation import (
+            clean_validated_action_attrs,
+        )
+
+        attrs = super().validate(attrs)
+
+        if not (organization := self.context.get("organization")):
+            raise serializers.ValidationError("Organization is required in the context")
+
+        return clean_validated_action_attrs(attrs, organization)
+
     def create(self, validated_value: dict[str, Any]) -> Action:
         self._check_action_type(Action.Type(validated_value["type"]))
         return Action.objects.create(**validated_value)

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -58,10 +58,16 @@ class WorkflowValidator(CamelSnakeSerializer):
             actions, condition_group = self._split_action_and_condition_group(action_filter)
             BaseDataConditionGroupValidator(data=condition_group).is_valid(raise_exception=True)
 
+            validated_actions = []
             for action in actions:
-                BaseActionValidator(data=action, context=self.context).is_valid(
-                    raise_exception=True
-                )
+                action_validator = BaseActionValidator(data=action, context=self.context)
+                action_validator.is_valid(raise_exception=True)
+
+                # update because the validated data does not contain "id" for updates
+                action.update(action_validator.validated_data)
+                validated_actions.append(action)
+
+            action_filter["actions"] = validated_actions
 
         return value
 
@@ -91,6 +97,24 @@ class WorkflowValidator(CamelSnakeSerializer):
 
         return serializer.save()
 
+    def _update_or_create_action(
+        self,
+        input_data: dict[str, Any],
+    ) -> Action:
+        # Validating actions hits external APIs. We already validated the data with WorkflowValidator.is_valid().
+        # Avoid re-validating the data by saving the Action directly.
+
+        input_id = input_data.get("id")
+        instance = None
+
+        # Determine if this is an update or create operation
+        if input_id:
+            instance = Action.objects.get(id=input_id)
+            instance.update(**input_data)
+            return instance
+
+        return Action.objects.create(**input_data)
+
     def update_or_create_actions(
         self,
         actions_data: ListInputData,
@@ -100,9 +124,8 @@ class WorkflowValidator(CamelSnakeSerializer):
             actions_data, condition_group.dataconditiongroupaction_set, "action__id"
         )
 
-        validator = BaseActionValidator(context=self.context)
         for action in actions_data:
-            action_instance = self._update_or_create(action, validator, Action)
+            action_instance = self._update_or_create_action(action)
 
             # If this is a new action, associate it to the condition group
             if action.get("id") is None:

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -693,7 +693,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         assert resp.data["actions"][0] == "You must add an action for this alert to fire."
 
     @patch(
-        "sentry.integrations.slack.actions.notification.get_channel_id",
+        "sentry.integrations.slack.actions.form.get_channel_id",
         return_value=SlackChannelIdData("#", None, True),
     )
     @patch.object(find_channel_id_for_rule, "apply_async")

--- a/tests/sentry/integrations/msteams/notifications/test_assigned.py
+++ b/tests/sentry/integrations/msteams/notifications/test_assigned.py
@@ -10,10 +10,10 @@ pytestmark = [requires_snuba]
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsAssignedNotificationTest(MSTeamsActivityNotificationTest):
     def test_assigned(self, mock_send_card: MagicMock) -> None:
         """

--- a/tests/sentry/integrations/msteams/notifications/test_deploy.py
+++ b/tests/sentry/integrations/msteams/notifications/test_deploy.py
@@ -11,10 +11,10 @@ from sentry.types.activity import ActivityType
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsDeployNotificationTest(MSTeamsActivityNotificationTest):
     @skip("Flaky test")
     def test_deploy(self, mock_send_card: MagicMock) -> None:

--- a/tests/sentry/integrations/msteams/notifications/test_escalating.py
+++ b/tests/sentry/integrations/msteams/notifications/test_escalating.py
@@ -10,10 +10,10 @@ pytestmark = [requires_snuba]
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsEscalatingNotificationTest(MSTeamsActivityNotificationTest):
     def test_note(self, mock_send_card: MagicMock) -> None:
         """

--- a/tests/sentry/integrations/msteams/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/msteams/notifications/test_issue_alert.py
@@ -13,10 +13,10 @@ pytestmark = [requires_snuba]
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsIssueAlertNotificationTest(MSTeamsActivityNotificationTest):
     def test_issue_alert_user(self, mock_send_card: MagicMock) -> None:
         """Test that issue alerts are sent to a MS Teams user."""

--- a/tests/sentry/integrations/msteams/notifications/test_note.py
+++ b/tests/sentry/integrations/msteams/notifications/test_note.py
@@ -10,10 +10,10 @@ pytestmark = [requires_snuba]
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsNoteNotificationTest(MSTeamsActivityNotificationTest):
     def test_note(self, mock_send_card: MagicMock) -> None:
         """

--- a/tests/sentry/integrations/msteams/notifications/test_regression.py
+++ b/tests/sentry/integrations/msteams/notifications/test_regression.py
@@ -10,10 +10,10 @@ pytestmark = [requires_snuba]
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsRegressionNotificationTest(MSTeamsActivityNotificationTest):
     def test_regression(self, mock_send_card: MagicMock) -> None:
         """

--- a/tests/sentry/integrations/msteams/notifications/test_resolved.py
+++ b/tests/sentry/integrations/msteams/notifications/test_resolved.py
@@ -13,10 +13,10 @@ pytestmark = [requires_snuba]
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsResolvedNotificationTest(MSTeamsActivityNotificationTest):
     def test_resolved(self, mock_send_card: MagicMock) -> None:
         """

--- a/tests/sentry/integrations/msteams/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/msteams/notifications/test_unassigned.py
@@ -10,10 +10,10 @@ pytestmark = [requires_snuba]
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsUnassignedNotificationTest(MSTeamsActivityNotificationTest):
     def test_unassigned(self, mock_send_card: MagicMock) -> None:
         """

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -5,7 +5,7 @@ import responses
 
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
-from sentry.integrations.msteams import MsTeamsIntegrationProvider
+from sentry.integrations.msteams.integration import MsTeamsIntegrationProvider
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.signing import sign

--- a/tests/sentry/integrations/msteams/test_notifications.py
+++ b/tests/sentry/integrations/msteams/test_notifications.py
@@ -24,7 +24,7 @@ TEST_CARD = {"type": "test_card"}
 
 @control_silo_test
 @patch(
-    "sentry.integrations.msteams.MSTeamsNotificationsMessageBuilder.build_notification_card",
+    "sentry.integrations.msteams.card_builder.notifications.MSTeamsNotificationsMessageBuilder.build_notification_card",
     Mock(return_value=TEST_CARD),
 )
 @patch(
@@ -32,14 +32,14 @@ TEST_CARD = {"type": "test_card"}
     [DummyNotification],
 )
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_member_list",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_member_list",
     Mock(return_value={"members": [{"user": "some_user", "tenantId": "some_tenant_id"}]}),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsNotificationTest(TestCase):
     def _install_msteams_personal(self) -> None:
         self.tenant_id = "50cccd00-7c9c-4b32-8cda-58a084f9334a"
@@ -124,7 +124,7 @@ class MSTeamsNotificationTest(TestCase):
         self._install_msteams_team()
 
         with patch(
-            "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+            "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
         ) as mock_get_user_conversation_id:
             mock_get_user_conversation_id.return_value = "some_conversation_id"
 

--- a/tests/sentry/integrations/msteams/test_notify_action.py
+++ b/tests/sentry/integrations/msteams/test_notify_action.py
@@ -8,7 +8,7 @@ import responses
 
 from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.msteams import MsTeamsNotifyServiceAction
+from sentry.integrations.msteams.actions.notification import MsTeamsNotifyServiceAction
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.testutils.asserts import assert_slo_metric
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase

--- a/tests/sentry/integrations/msteams/webhook/test_ms_teams_events.py
+++ b/tests/sentry/integrations/msteams/webhook/test_ms_teams_events.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from sentry.integrations.msteams import MsTeamsEvents
+from sentry.integrations.msteams.webhook import MsTeamsEvents
 
 
 class TestGetFromValue:

--- a/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_endpoint.py
+++ b/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_endpoint.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 import pytest
 
-from sentry.integrations.msteams import MsTeamsEvents, MsTeamsWebhookEndpoint
+from sentry.integrations.msteams.webhook import MsTeamsEvents, MsTeamsWebhookEndpoint
 
 
 class TestGeTeamInstallationRequestData(TestCase):

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -19,6 +19,7 @@ from sentry.workflow_engine.models import (
     WorkflowDataConditionGroup,
     WorkflowFireHistory,
 )
+from tests.sentry.workflow_engine.test_base import MockActionValidatorTranslator
 
 
 class OrganizationWorkflowAPITestCase(APITestCase):
@@ -492,7 +493,11 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
             "id"
         )
 
-    def test_create_workflow__with_actions(self) -> None:
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
+    def test_create_workflow__with_actions(self, mock_action_validator: mock.MagicMock) -> None:
         self.valid_workflow["actionFilters"] = [
             {
                 "logicType": "any",

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -427,6 +427,9 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
 
     def setUp(self) -> None:
         super().setUp()
+        self.integration, self.org_integration = self.create_provider_integration_for(
+            provider="slack", organization=self.organization, user=self.user
+        )
         self.valid_workflow = {
             "name": "Test Workflow",
             "enabled": True,
@@ -509,7 +512,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
                             "targetType": 0,
                         },
                         "data": {},
-                        "integrationId": 1,
+                        "integrationId": self.integration.id,
                     },
                 ],
             }

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_msteams.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_msteams.py
@@ -1,0 +1,76 @@
+from unittest import mock
+
+from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
+from sentry.workflow_engine.models import Action
+
+
+class TestMSTeamsActionValidator(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.integration, self.org_integration = self.create_provider_integration_for(
+            provider="msteams", organization=self.organization, user=self.user, name="msteams"
+        )
+
+        self.valid_data = {
+            "type": Action.Type.MSTEAMS,
+            "config": {"targetDisplay": "cathy-sentry", "targetType": ActionTarget.SPECIFIC.value},
+            "data": {},
+            "integrationId": self.integration.id,
+        }
+
+    @mock.patch("sentry.integrations.msteams.actions.form.find_channel_id")
+    def test_validate(self, mock_check_for_channel):
+        mock_check_for_channel.return_value = "C1234567890"
+
+        validator = BaseActionValidator(
+            data=self.valid_data,
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is True
+
+    def test_validate__missing_integration_id(self):
+        del self.valid_data["integrationId"]
+        validator = BaseActionValidator(
+            data={**self.valid_data},
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False
+
+    def test_validate__missing_integration(self):
+        validator = BaseActionValidator(
+            data={**self.valid_data, "integrationId": 123},
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False
+
+    def test_validate__invalid_channel_id(self):
+        validator = BaseActionValidator(
+            data={
+                **self.valid_data,
+                "config": {"targetIdentifier": "C1234567890", "targetDisplay": "asdf"},
+            },
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False
+
+    def test_validate__invalid_channel_name(self):
+        validator = BaseActionValidator(
+            data={
+                **self.valid_data,
+                "config": {"targetDisplay": "asdf"},
+            },
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_slack.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_slack.py
@@ -1,0 +1,45 @@
+from unittest import mock
+
+from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
+from sentry.workflow_engine.models import Action
+
+
+class TestSlackActionValidator(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.integration, self.org_integration = self.create_provider_integration_for(
+            provider="slack", organization=self.organization, user=self.user
+        )
+
+        self.valid_data = {
+            "type": Action.Type.SLACK,
+            "config": {"targetDisplay": "cathy-sentry", "targetType": ActionTarget.SPECIFIC.value},
+            "data": {"tags": "asdf"},
+            "integrationId": self.integration.id,
+        }
+
+    @mock.patch("sentry.integrations.slack.utils.channel.check_for_channel")
+    def test_validate(self, mock_check_for_channel):
+        mock_check_for_channel.return_value = "C1234567890"
+
+        validator = BaseActionValidator(
+            data=self.valid_data,
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is True
+
+    def test_validate__missing_integration_id(self):
+        pass
+
+    def test_validate__missing_integration(self):
+        pass
+
+    def test_validate__invalid_channel_id(self):
+        pass
+
+    def test_validate__invalid_channel_name(self):
+        pass

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_slack.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_slack.py
@@ -1,11 +1,16 @@
 from unittest import mock
 
 from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.notifications.notification_action.action_validation import SlackActionValidatorHandler
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
 from sentry.workflow_engine.models import Action
 
 
+@mock.patch(
+    "sentry.notifications.notification_action.registry.action_validator_registry.get",
+    return_value=SlackActionValidatorHandler,
+)
 class TestSlackActionValidator(TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -21,7 +26,7 @@ class TestSlackActionValidator(TestCase):
         }
 
     @mock.patch("sentry.integrations.slack.utils.channel.check_for_channel")
-    def test_validate(self, mock_check_for_channel):
+    def test_validate(self, mock_check_for_channel, mock_action_validator_get):
         mock_check_for_channel.return_value = "C1234567890"
 
         validator = BaseActionValidator(
@@ -32,14 +37,45 @@ class TestSlackActionValidator(TestCase):
         result = validator.is_valid()
         assert result is True
 
-    def test_validate__missing_integration_id(self):
-        pass
+    def test_validate__missing_integration_id(self, mock_action_validator_get):
+        del self.valid_data["integrationId"]
+        validator = BaseActionValidator(
+            data={**self.valid_data},
+            context={"organization": self.organization},
+        )
 
-    def test_validate__missing_integration(self):
-        pass
+        result = validator.is_valid()
+        assert result is False
 
-    def test_validate__invalid_channel_id(self):
-        pass
+    def test_validate__missing_integration(self, mock_action_validator_get):
+        validator = BaseActionValidator(
+            data={**self.valid_data, "integrationId": 123},
+            context={"organization": self.organization},
+        )
 
-    def test_validate__invalid_channel_name(self):
-        pass
+        result = validator.is_valid()
+        assert result is False
+
+    def test_validate__invalid_channel_id(self, mock_action_validator_get):
+        validator = BaseActionValidator(
+            data={
+                **self.valid_data,
+                "config": {"targetIdentifier": "C1234567890", "targetDisplay": "asdf"},
+            },
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False
+
+    def test_validate__invalid_channel_name(self, mock_action_validator_get):
+        validator = BaseActionValidator(
+            data={
+                **self.valid_data,
+                "config": {"targetDisplay": "asdf"},
+            },
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_slack.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_slack.py
@@ -1,7 +1,11 @@
 from unittest import mock
 
+from django.core.exceptions import ValidationError
+from rest_framework.serializers import ErrorDetail
+
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.shared_integrations.exceptions import DuplicateDisplayNameError
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
 from sentry.workflow_engine.models import Action
@@ -11,7 +15,11 @@ class TestSlackActionValidator(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.integration, self.org_integration = self.create_provider_integration_for(
-            provider="slack", organization=self.organization, user=self.user, name="slack"
+            provider="slack",
+            organization=self.organization,
+            user=self.user,
+            name="slack",
+            metadata={"domain_name": "https://slack.com"},
         )
 
         self.valid_data = {
@@ -22,8 +30,8 @@ class TestSlackActionValidator(TestCase):
         }
 
     @mock.patch("sentry.integrations.slack.actions.form.get_channel_id")
-    def test_validate(self, mock_check_for_channel):
-        mock_check_for_channel.return_value = SlackChannelIdData(
+    def test_validate(self, mock_get_channel_id):
+        mock_get_channel_id.return_value = SlackChannelIdData(
             prefix="#", channel_id="C1234567890", timed_out=False
         )
 
@@ -44,6 +52,11 @@ class TestSlackActionValidator(TestCase):
 
         result = validator.is_valid()
         assert result is False
+        assert validator.errors == {
+            "nonFieldErrors": [
+                ErrorDetail(string="Integration ID is required for slack action", code="invalid")
+            ]
+        }
 
     def test_validate__missing_integration(self):
         validator = BaseActionValidator(
@@ -53,27 +66,53 @@ class TestSlackActionValidator(TestCase):
 
         result = validator.is_valid()
         assert result is False
+        assert validator.errors == {
+            "nonFieldErrors": [
+                ErrorDetail(string="slack integration with id 123 not found", code="invalid")
+            ]
+        }
 
-    def test_validate__invalid_channel_id(self):
+    @mock.patch("sentry.integrations.slack.actions.form.validate_slack_entity_id")
+    def test_validate__invalid_channel_id(self, mock_validate_slack_entity_id):
+        mock_validate_slack_entity_id.side_effect = ValidationError("Invalid channel id")
+
         validator = BaseActionValidator(
             data={
                 **self.valid_data,
-                "config": {"targetIdentifier": "C1234567890", "targetDisplay": "asdf"},
+                "config": {
+                    "targetType": ActionTarget.SPECIFIC.value,
+                    "targetIdentifier": "C1234567890",
+                    "targetDisplay": "asdf",
+                },
             },
             context={"organization": self.organization},
         )
 
         result = validator.is_valid()
         assert result is False
+        assert validator.errors == {
+            "all": [ErrorDetail(string="Slack: Invalid channel id", code="invalid")]
+        }
 
-    def test_validate__invalid_channel_name(self):
+    @mock.patch("sentry.integrations.slack.actions.form.get_channel_id")
+    def test_validate__invalid_channel_name(self, mock_get_channel_id):
+        mock_get_channel_id.side_effect = DuplicateDisplayNameError()
+
         validator = BaseActionValidator(
             data={
                 **self.valid_data,
-                "config": {"targetDisplay": "asdf"},
+                "config": {"targetType": ActionTarget.SPECIFIC.value, "targetDisplay": "asdf"},
             },
             context={"organization": self.organization},
         )
 
         result = validator.is_valid()
         assert result is False
+        assert validator.errors == {
+            "all": [
+                ErrorDetail(
+                    string="Slack: Multiple users were found with display name 'asdf'. Please use your username, found at https://slack.com/account/settings#username.",
+                    code="invalid",
+                )
+            ]
+        }

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_slack.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_slack.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
@@ -10,7 +11,7 @@ class TestSlackActionValidator(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.integration, self.org_integration = self.create_provider_integration_for(
-            provider="slack", organization=self.organization, user=self.user
+            provider="slack", organization=self.organization, user=self.user, name="slack"
         )
 
         self.valid_data = {
@@ -20,9 +21,11 @@ class TestSlackActionValidator(TestCase):
             "integrationId": self.integration.id,
         }
 
-    @mock.patch("sentry.integrations.slack.utils.channel.check_for_channel")
+    @mock.patch("sentry.integrations.slack.actions.form.get_channel_id")
     def test_validate(self, mock_check_for_channel):
-        mock_check_for_channel.return_value = "C1234567890"
+        mock_check_for_channel.return_value = SlackChannelIdData(
+            prefix="#", channel_id="C1234567890", timed_out=False
+        )
 
         validator = BaseActionValidator(
             data=self.valid_data,

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_slack.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_slack.py
@@ -1,16 +1,11 @@
 from unittest import mock
 
 from sentry.notifications.models.notificationaction import ActionTarget
-from sentry.notifications.notification_action.action_validation import SlackActionValidatorHandler
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
 from sentry.workflow_engine.models import Action
 
 
-@mock.patch(
-    "sentry.notifications.notification_action.registry.action_validator_registry.get",
-    return_value=SlackActionValidatorHandler,
-)
 class TestSlackActionValidator(TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -26,7 +21,7 @@ class TestSlackActionValidator(TestCase):
         }
 
     @mock.patch("sentry.integrations.slack.utils.channel.check_for_channel")
-    def test_validate(self, mock_check_for_channel, mock_action_validator_get):
+    def test_validate(self, mock_check_for_channel):
         mock_check_for_channel.return_value = "C1234567890"
 
         validator = BaseActionValidator(
@@ -37,7 +32,7 @@ class TestSlackActionValidator(TestCase):
         result = validator.is_valid()
         assert result is True
 
-    def test_validate__missing_integration_id(self, mock_action_validator_get):
+    def test_validate__missing_integration_id(self):
         del self.valid_data["integrationId"]
         validator = BaseActionValidator(
             data={**self.valid_data},
@@ -47,7 +42,7 @@ class TestSlackActionValidator(TestCase):
         result = validator.is_valid()
         assert result is False
 
-    def test_validate__missing_integration(self, mock_action_validator_get):
+    def test_validate__missing_integration(self):
         validator = BaseActionValidator(
             data={**self.valid_data, "integrationId": 123},
             context={"organization": self.organization},
@@ -56,7 +51,7 @@ class TestSlackActionValidator(TestCase):
         result = validator.is_valid()
         assert result is False
 
-    def test_validate__invalid_channel_id(self, mock_action_validator_get):
+    def test_validate__invalid_channel_id(self):
         validator = BaseActionValidator(
             data={
                 **self.valid_data,
@@ -68,7 +63,7 @@ class TestSlackActionValidator(TestCase):
         result = validator.is_valid()
         assert result is False
 
-    def test_validate__invalid_channel_name(self, mock_action_validator_get):
+    def test_validate__invalid_channel_name(self):
         validator = BaseActionValidator(
             data={
                 **self.valid_data,

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
@@ -3,12 +3,16 @@ from unittest import mock
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
 from sentry.workflow_engine.models import Action
-from tests.sentry.workflow_engine.test_base import MockActionHandler
+from tests.sentry.workflow_engine.test_base import MockActionHandler, MockActionValidatorTranslator
 
 
 @mock.patch(
     "sentry.workflow_engine.registry.action_handler_registry.get",
     return_value=MockActionHandler,
+)
+@mock.patch.dict(
+    "sentry.notifications.notification_action.action_validation.action_validator_translator_mapping",
+    {"slack": MockActionValidatorTranslator},
 )
 class TestBaseActionValidator(TestCase):
     def setUp(self) -> None:

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
@@ -10,9 +10,9 @@ from tests.sentry.workflow_engine.test_base import MockActionHandler, MockAction
     "sentry.workflow_engine.registry.action_handler_registry.get",
     return_value=MockActionHandler,
 )
-@mock.patch.dict(
-    "sentry.notifications.notification_action.action_validation.action_validator_translator_mapping",
-    {"slack": MockActionValidatorTranslator},
+@mock.patch(
+    "sentry.notifications.notification_action.registry.action_validator_registry.get",
+    return_value=MockActionValidatorTranslator,
 )
 class TestBaseActionValidator(TestCase):
     def setUp(self) -> None:
@@ -24,18 +24,23 @@ class TestBaseActionValidator(TestCase):
             "integrationId": 1,
         }
 
-    def test_validate_type(self, mock_action_handler_get: mock.MagicMock) -> None:
+    def test_validate_type(
+        self, mock_action_handler_get: mock.MagicMock, mock_action_validator_get: mock.MagicMock
+    ) -> None:
         validator = BaseActionValidator(
             data={
                 **self.valid_data,
                 "type": Action.Type.SLACK,
             },
+            context={"organization": self.organization},
         )
 
         result = validator.is_valid()
         assert result is True
 
-    def test_validate_type__invalid(self, mock_action_handler_get: mock.MagicMock) -> None:
+    def test_validate_type__invalid(
+        self, mock_action_handler_get: mock.MagicMock, mock_action_validator_get: mock.MagicMock
+    ) -> None:
         validator = BaseActionValidator(
             data={
                 **self.valid_data,
@@ -46,18 +51,23 @@ class TestBaseActionValidator(TestCase):
         result = validator.is_valid()
         assert result is False
 
-    def test_validate_config(self, mock_action_handler_get: mock.MagicMock) -> None:
+    def test_validate_config(
+        self, mock_action_handler_get: mock.MagicMock, mock_action_validator_get: mock.MagicMock
+    ) -> None:
         validator = BaseActionValidator(
             data={
                 **self.valid_data,
                 "config": {"foo": "bar"},
             },
+            context={"organization": self.organization},
         )
 
         result = validator.is_valid()
         assert result is True
 
-    def test_validate_config__invalid(self, mock_action_handler_get: mock.MagicMock) -> None:
+    def test_validate_config__invalid(
+        self, mock_action_handler_get: mock.MagicMock, mock_action_validator_get: mock.MagicMock
+    ) -> None:
         validator = BaseActionValidator(
             data={
                 **self.valid_data,
@@ -68,18 +78,23 @@ class TestBaseActionValidator(TestCase):
         result = validator.is_valid()
         assert result is False
 
-    def test_validate_data(self, mock_action_handler_get: mock.MagicMock) -> None:
+    def test_validate_data(
+        self, mock_action_handler_get: mock.MagicMock, mock_action_validator_get: mock.MagicMock
+    ) -> None:
         validator = BaseActionValidator(
             data={
                 **self.valid_data,
                 "data": {"baz": "foo"},
             },
+            context={"organization": self.organization},
         )
 
         result = validator.is_valid()
         assert result is True
 
-    def test_validate_data__invalid(self, mock_action_handler_get: mock.MagicMock) -> None:
+    def test_validate_data__invalid(
+        self, mock_action_handler_get: mock.MagicMock, mock_action_validator_get: mock.MagicMock
+    ) -> None:
         validator = BaseActionValidator(
             data={
                 **self.valid_data,
@@ -90,7 +105,9 @@ class TestBaseActionValidator(TestCase):
         result = validator.is_valid()
         assert result is False
 
-    def test_validate_type__action_gated(self, mock_action_handler_get: mock.MagicMock) -> None:
+    def test_validate_type__action_gated(
+        self, mock_action_handler_get: mock.MagicMock, mock_action_validator_get: mock.MagicMock
+    ) -> None:
         organization = self.create_organization()
 
         def make_validator() -> BaseActionValidator:

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -16,7 +16,7 @@ from sentry.workflow_engine.models import (
     Workflow,
     WorkflowDataConditionGroup,
 )
-from tests.sentry.workflow_engine.test_base import MockActionHandler
+from tests.sentry.workflow_engine.test_base import MockActionHandler, MockActionValidatorTranslator
 
 
 class TestWorkflowValidator(TestCase):
@@ -47,7 +47,13 @@ class TestWorkflowValidator(TestCase):
         "sentry.workflow_engine.registry.action_handler_registry.get",
         return_value=MockActionHandler,
     )
-    def test_valid_data__with_action_filters(self, mock_action_handler: mock.MagicMock) -> None:
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
+    def test_valid_data__with_action_filters(
+        self, mock_action_handler: mock.MagicMock, mock_action_validator: mock.MagicMock
+    ) -> None:
         self.valid_data["actionFilters"] = [
             {
                 "logicType": "any",
@@ -176,8 +182,12 @@ class TestWorkflowValidatorCreate(TestCase):
         "sentry.workflow_engine.registry.action_handler_registry.get",
         return_value=MockActionHandler,
     )
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
     def test_create__with_actions__creates_workflow_group(
-        self, mock_action_handler: mock.MagicMock
+        self, mock_action_handler: mock.MagicMock, mock_action_validator: mock.MagicMock
     ) -> None:
         self.valid_data["actionFilters"] = [
             {
@@ -208,8 +218,12 @@ class TestWorkflowValidatorCreate(TestCase):
         "sentry.workflow_engine.registry.action_handler_registry.get",
         return_value=MockActionHandler,
     )
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
     def test_create__with_actions__creates_action_group(
-        self, mock_action_handler: mock.MagicMock
+        self, mock_action_handler: mock.MagicMock, mock_action_validator: mock.MagicMock
     ) -> None:
         self.valid_data["actionFilters"] = [
             {
@@ -327,6 +341,10 @@ class TestWorkflowValidatorCreate(TestCase):
                 ]
 
 
+@mock.patch(
+    "sentry.notifications.notification_action.registry.action_validator_registry.get",
+    return_value=MockActionValidatorTranslator,
+)
 class TestWorkflowValidatorUpdate(TestCase):
     def setUp(self) -> None:
         self.context = {
@@ -378,7 +396,11 @@ class TestWorkflowValidatorUpdate(TestCase):
             context=self.context,
         )
 
-        validator.is_valid(raise_exception=True)
+        with mock.patch(
+            "sentry.notifications.notification_action.registry.action_validator_registry.get",
+            return_value=MockActionValidatorTranslator,
+        ):
+            validator.is_valid(raise_exception=True)
         self.workflow = validator.create(validator.validated_data)
         self.context["workflow"] = self.workflow
 
@@ -386,7 +408,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         attrs = serializer.get_attrs([self.workflow], self.user)
         self.valid_saved_data = serializer.serialize(self.workflow, attrs[self.workflow], self.user)
 
-    def test_update_property(self) -> None:
+    def test_update_property(self, mock_action_validator: mock.MagicMock) -> None:
         self.valid_data["name"] = "Update Test"
         validator = WorkflowValidator(data=self.valid_data, context=self.context)
 
@@ -396,7 +418,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         assert workflow.id == self.workflow.id
         assert workflow.name == "Update Test"
 
-    def test_update__remove_trigger_conditions(self) -> None:
+    def test_update__remove_trigger_conditions(self, mock_action_validator: mock.MagicMock) -> None:
         assert self.workflow.when_condition_group
 
         self.valid_saved_data["triggers"] = {
@@ -414,7 +436,9 @@ class TestWorkflowValidatorUpdate(TestCase):
         assert self.workflow.when_condition_group is not None
         assert self.workflow.when_condition_group.conditions.count() == 0
 
-    def test_update__hack_attempt_to_override_different_trigger_condition(self) -> None:
+    def test_update__hack_attempt_to_override_different_trigger_condition(
+        self, mock_action_validator: mock.MagicMock
+    ) -> None:
         fake_dcg = DataConditionGroup.objects.create(
             organization=self.organization,
             logic_type="any",
@@ -432,7 +456,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         with pytest.raises(ValidationError):
             validator.update(self.workflow, validator.validated_data)
 
-    def test_update__remove_action_filter(self) -> None:
+    def test_update__remove_action_filter(self, mock_action_validator: mock.MagicMock) -> None:
         self.valid_saved_data["actionFilters"] = []
 
         validator = WorkflowValidator(data=self.valid_saved_data, context=self.context)
@@ -443,7 +467,7 @@ class TestWorkflowValidatorUpdate(TestCase):
 
         assert self.workflow.workflowdataconditiongroup_set.count() == 0
 
-    def test_update__add_new_filter(self) -> None:
+    def test_update__add_new_filter(self, mock_action_validator: mock.MagicMock) -> None:
         self.valid_saved_data["actionFilters"].append(
             {
                 "actions": [
@@ -492,7 +516,7 @@ class TestWorkflowValidatorUpdate(TestCase):
             "target_type": 0,
         }
 
-    def test_update__remove_one_filter(self) -> None:
+    def test_update__remove_one_filter(self, mock_action_validator: mock.MagicMock) -> None:
         # Configuration for the test
         self.workflow.workflowdataconditiongroup_set.create(
             condition_group=DataConditionGroup.objects.create(
@@ -526,7 +550,7 @@ class TestWorkflowValidatorUpdate(TestCase):
 
         return first_condition
 
-    def test_update__data_condition(self) -> None:
+    def test_update__data_condition(self, mock_action_validator: mock.MagicMock) -> None:
         first_condition = self._get_first_trigger_condition(self.workflow)
         assert first_condition.comparison == 1
 
@@ -542,7 +566,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         first_condition = self._get_first_trigger_condition(self.workflow)
         assert first_condition.comparison == updated_condition["comparison"]
 
-    def test_update__remove_one_data_condition(self) -> None:
+    def test_update__remove_one_data_condition(self, mock_action_validator: mock.MagicMock) -> None:
         # Setup the test
         assert self.workflow.when_condition_group
         assert self.workflow.when_condition_group.conditions.count() == 1
@@ -569,7 +593,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         assert self.workflow.when_condition_group.conditions.count() == 1
         assert self.workflow.when_condition_group.conditions.first() == dc
 
-    def test_update__add_new_action(self) -> None:
+    def test_update__add_new_action(self, mock_action_validator: mock.MagicMock) -> None:
         self.valid_saved_data["actionFilters"][0]["actions"].append(
             {
                 "type": Action.Type.SLACK,
@@ -587,7 +611,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         assert validator.is_valid() is True
         validator.update(self.workflow, validator.validated_data)
 
-    def test_update__modify_action(self) -> None:
+    def test_update__modify_action(self, mock_action_validator: mock.MagicMock) -> None:
         workflow_condition_group = self.workflow.workflowdataconditiongroup_set.first()
         assert workflow_condition_group is not None
         action_condition_group = (
@@ -629,7 +653,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         assert updated_action.id == action.id
         assert updated_action.type == Action.Type.EMAIL
 
-    def test_update__remove_one_action(self) -> None:
+    def test_update__remove_one_action(self, mock_action_validator: mock.MagicMock) -> None:
         workflow_condition_group = self.workflow.workflowdataconditiongroup_set.first()
         assert workflow_condition_group is not None
         new_action = Action.objects.create(
@@ -662,7 +686,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         assert action_condition_group.action.id != new_action.id
         assert action_condition_group.action.type == Action.Type.SLACK
 
-    def test_update__remove_all_actions(self) -> None:
+    def test_update__remove_all_actions(self, mock_action_validator: mock.MagicMock) -> None:
         self.valid_saved_data["actionFilters"][0]["actions"] = []
         validator = WorkflowValidator(data=self.valid_saved_data, context=self.context)
         assert validator.is_valid() is True

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -16,7 +16,7 @@ from sentry.workflow_engine.models import (
     Workflow,
     WorkflowDataConditionGroup,
 )
-from tests.sentry.workflow_engine.test_base import MockActionHandler, MockActionValidatorTranslator
+from tests.sentry.workflow_engine.test_base import MockActionHandler
 
 
 class TestWorkflowValidator(TestCase):
@@ -378,11 +378,7 @@ class TestWorkflowValidatorUpdate(TestCase):
             context=self.context,
         )
 
-        with mock.patch(
-            "sentry.notifications.notification_action.registry.action_validator_registry.get",
-            return_value=MockActionValidatorTranslator,
-        ):
-            validator.is_valid(raise_exception=True)
+        validator.is_valid(raise_exception=True)
         self.workflow = validator.create(validator.validated_data)
         self.context["workflow"] = self.workflow
 

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -16,7 +16,7 @@ from sentry.workflow_engine.models import (
     Workflow,
     WorkflowDataConditionGroup,
 )
-from tests.sentry.workflow_engine.test_base import MockActionHandler
+from tests.sentry.workflow_engine.test_base import MockActionHandler, MockActionValidatorTranslator
 
 
 class TestWorkflowValidator(TestCase):
@@ -47,7 +47,13 @@ class TestWorkflowValidator(TestCase):
         "sentry.workflow_engine.registry.action_handler_registry.get",
         return_value=MockActionHandler,
     )
-    def test_valid_data__with_action_filters(self, mock_action_handler: mock.MagicMock) -> None:
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
+    def test_valid_data__with_action_filters(
+        self, mock_action_handler: mock.MagicMock, mock_action_validator: mock.MagicMock
+    ) -> None:
         self.valid_data["actionFilters"] = [
             {
                 "logicType": "any",
@@ -180,8 +186,12 @@ class TestWorkflowValidatorCreate(TestCase):
         "sentry.workflow_engine.registry.action_handler_registry.get",
         return_value=MockActionHandler,
     )
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
     def test_create__with_actions__creates_workflow_group(
-        self, mock_action_handler: mock.MagicMock
+        self, mock_action_handler: mock.MagicMock, mock_action_validator: mock.MagicMock
     ) -> None:
         self.valid_data["actionFilters"] = [
             {
@@ -212,8 +222,12 @@ class TestWorkflowValidatorCreate(TestCase):
         "sentry.workflow_engine.registry.action_handler_registry.get",
         return_value=MockActionHandler,
     )
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
     def test_create__with_actions__creates_action_group(
-        self, mock_action_handler: mock.MagicMock
+        self, mock_action_handler: mock.MagicMock, mock_action_validator: mock.MagicMock
     ) -> None:
         self.valid_data["actionFilters"] = [
             {
@@ -331,6 +345,10 @@ class TestWorkflowValidatorCreate(TestCase):
                 ]
 
 
+@mock.patch(
+    "sentry.notifications.notification_action.registry.action_validator_registry.get",
+    return_value=MockActionValidatorTranslator,
+)
 class TestWorkflowValidatorUpdate(TestCase):
     def setUp(self) -> None:
         self.context = {
@@ -386,15 +404,20 @@ class TestWorkflowValidatorUpdate(TestCase):
             context=self.context,
         )
 
-        validator.is_valid(raise_exception=True)
-        self.workflow = validator.create(validator.validated_data)
+        with mock.patch(
+            "sentry.notifications.notification_action.registry.action_validator_registry.get",
+            return_value=MockActionValidatorTranslator,
+        ):
+            validator.is_valid(raise_exception=True)
+            self.workflow = validator.create(validator.validated_data)
+
         self.context["workflow"] = self.workflow
 
         serializer = WorkflowSerializer()
         attrs = serializer.get_attrs([self.workflow], self.user)
         self.valid_saved_data = serializer.serialize(self.workflow, attrs[self.workflow], self.user)
 
-    def test_update_property(self) -> None:
+    def test_update_property(self, mock_action_validator: mock.MagicMock) -> None:
         self.valid_data["name"] = "Update Test"
         validator = WorkflowValidator(data=self.valid_data, context=self.context)
 
@@ -404,7 +427,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         assert workflow.id == self.workflow.id
         assert workflow.name == "Update Test"
 
-    def test_update__remove_trigger_conditions(self) -> None:
+    def test_update__remove_trigger_conditions(self, mock_action_validator: mock.MagicMock) -> None:
         assert self.workflow.when_condition_group
 
         self.valid_saved_data["triggers"] = {
@@ -422,7 +445,9 @@ class TestWorkflowValidatorUpdate(TestCase):
         assert self.workflow.when_condition_group is not None
         assert self.workflow.when_condition_group.conditions.count() == 0
 
-    def test_update__hack_attempt_to_override_different_trigger_condition(self) -> None:
+    def test_update__hack_attempt_to_override_different_trigger_condition(
+        self, mock_action_validator: mock.MagicMock
+    ) -> None:
         fake_dcg = DataConditionGroup.objects.create(
             organization=self.organization,
             logic_type="any",
@@ -440,7 +465,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         with pytest.raises(ValidationError):
             validator.update(self.workflow, validator.validated_data)
 
-    def test_update__remove_action_filter(self) -> None:
+    def test_update__remove_action_filter(self, mock_action_validator: mock.MagicMock) -> None:
         self.valid_saved_data["actionFilters"] = []
 
         validator = WorkflowValidator(data=self.valid_saved_data, context=self.context)
@@ -451,7 +476,7 @@ class TestWorkflowValidatorUpdate(TestCase):
 
         assert self.workflow.workflowdataconditiongroup_set.count() == 0
 
-    def test_update__add_new_filter(self) -> None:
+    def test_update__add_new_filter(self, mock_action_validator: mock.MagicMock) -> None:
         self.valid_saved_data["actionFilters"].append(
             {
                 "actions": [
@@ -500,7 +525,7 @@ class TestWorkflowValidatorUpdate(TestCase):
             "target_type": 0,
         }
 
-    def test_update__remove_one_filter(self) -> None:
+    def test_update__remove_one_filter(self, mock_action_validator: mock.MagicMock) -> None:
         # Configuration for the test
         self.workflow.workflowdataconditiongroup_set.create(
             condition_group=DataConditionGroup.objects.create(
@@ -534,7 +559,7 @@ class TestWorkflowValidatorUpdate(TestCase):
 
         return first_condition
 
-    def test_update__data_condition(self) -> None:
+    def test_update__data_condition(self, mock_action_validator: mock.MagicMock) -> None:
         first_condition = self._get_first_trigger_condition(self.workflow)
         assert first_condition.comparison == 1
 
@@ -550,7 +575,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         first_condition = self._get_first_trigger_condition(self.workflow)
         assert first_condition.comparison == updated_condition["comparison"]
 
-    def test_update__remove_one_data_condition(self) -> None:
+    def test_update__remove_one_data_condition(self, mock_action_validator: mock.MagicMock) -> None:
         # Setup the test
         assert self.workflow.when_condition_group
         assert self.workflow.when_condition_group.conditions.count() == 1
@@ -577,7 +602,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         assert self.workflow.when_condition_group.conditions.count() == 1
         assert self.workflow.when_condition_group.conditions.first() == dc
 
-    def test_update__add_new_action(self) -> None:
+    def test_update__add_new_action(self, mock_action_validator: mock.MagicMock) -> None:
         self.valid_saved_data["actionFilters"][0]["actions"].append(
             {
                 "type": Action.Type.SLACK,
@@ -595,7 +620,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         assert validator.is_valid() is True
         validator.update(self.workflow, validator.validated_data)
 
-    def test_update__modify_action(self) -> None:
+    def test_update__modify_action(self, mock_action_validator: mock.MagicMock) -> None:
         workflow_condition_group = self.workflow.workflowdataconditiongroup_set.first()
         assert workflow_condition_group is not None
         action_condition_group = (
@@ -637,7 +662,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         assert updated_action.id == action.id
         assert updated_action.type == Action.Type.EMAIL
 
-    def test_update__remove_one_action(self) -> None:
+    def test_update__remove_one_action(self, mock_action_validator: mock.MagicMock) -> None:
         workflow_condition_group = self.workflow.workflowdataconditiongroup_set.first()
         assert workflow_condition_group is not None
         new_action = Action.objects.create(
@@ -670,7 +695,7 @@ class TestWorkflowValidatorUpdate(TestCase):
         assert action_condition_group.action.id != new_action.id
         assert action_condition_group.action.type == Action.Type.SLACK
 
-    def test_update__remove_all_actions(self) -> None:
+    def test_update__remove_all_actions(self, mock_action_validator: mock.MagicMock) -> None:
         self.valid_saved_data["actionFilters"][0]["actions"] = []
         validator = WorkflowValidator(data=self.valid_saved_data, context=self.context)
         assert validator.is_valid() is True

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -57,7 +57,7 @@ class TestWorkflowValidator(TestCase):
                         "type": Action.Type.SLACK,
                         "config": {"foo": "bar"},
                         "data": {"baz": "bar"},
-                        "integrationId": 1,
+                        "integrationId": self.integration.id,
                     }
                 ],
             }
@@ -81,7 +81,7 @@ class TestWorkflowValidator(TestCase):
                     {
                         "type": Action.Type.SLACK,
                         "config": {},
-                        "integrationId": 1,
+                        "integrationId": self.integration.id,
                     }
                 ],
             }
@@ -112,6 +112,10 @@ class TestWorkflowValidatorCreate(TestCase):
             "organization": self.organization,
             "request": self.make_request(user=self.user),
         }
+
+        self.integration, self.org_integration = self.create_provider_integration_for(
+            provider="slack", organization=self.organization, user=self.user
+        )
 
         self.valid_data = {
             "name": "test",
@@ -186,7 +190,7 @@ class TestWorkflowValidatorCreate(TestCase):
                         "type": Action.Type.SLACK,
                         "config": {"foo": "bar"},
                         "data": {"baz": "bar"},
-                        "integrationId": 1,
+                        "integrationId": self.integration.id,
                     }
                 ],
                 "logicType": "any",
@@ -218,7 +222,7 @@ class TestWorkflowValidatorCreate(TestCase):
                         "type": Action.Type.SLACK,
                         "config": {"foo": "bar"},
                         "data": {"baz": "bar"},
-                        "integrationId": 1,
+                        "integrationId": self.integration.id,
                     }
                 ],
                 "logicType": "any",
@@ -334,6 +338,10 @@ class TestWorkflowValidatorUpdate(TestCase):
             "request": self.make_request(),
         }
 
+        self.integration, self.org_integration = self.create_provider_integration_for(
+            provider="slack", organization=self.organization, user=self.user
+        )
+
         self.action_filters = [
             {
                 "actions": [
@@ -345,7 +353,7 @@ class TestWorkflowValidatorUpdate(TestCase):
                             "target_type": 0,
                         },
                         "data": {},
-                        "integrationId": 1,
+                        "integrationId": self.integration.id,
                     }
                 ],
                 "logicType": "any",
@@ -455,7 +463,7 @@ class TestWorkflowValidatorUpdate(TestCase):
                             "targetType": 0,
                         },
                         "data": {},
-                        "integrationId": 1,
+                        "integrationId": self.integration.id,
                     }
                 ],
                 "logicType": "all",
@@ -579,7 +587,7 @@ class TestWorkflowValidatorUpdate(TestCase):
                     "targetType": 0,
                 },
                 "data": {},
-                "integrationId": 1,
+                "integrationId": self.integration.id,
             }
         )
 

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -12,6 +12,7 @@ from sentry.incidents.utils.types import ProcessedSubscriptionUpdate
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
 from sentry.models.project import Project
+from sentry.notifications.notification_action.action_validation import BaseActionValidatorTranslator
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
@@ -79,6 +80,16 @@ class MockActionHandler(ActionHandler):
         "required": ["baz"],
         "additionalProperties": False,
     }
+
+
+class MockActionValidatorTranslator(BaseActionValidatorTranslator):
+    notify_action_class = None
+
+    def generate_action_form_payload(self, validated_data: dict[str, Any]) -> dict[str, Any]:
+        return validated_data
+
+    def update_action_data(self, cleaned_data: dict[str, Any]) -> dict[str, Any]:
+        return cleaned_data
 
 
 class DataConditionHandlerMixin:

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -12,7 +12,7 @@ from sentry.incidents.utils.types import ProcessedSubscriptionUpdate
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
 from sentry.models.project import Project
-from sentry.notifications.notification_action.action_validation import BaseActionValidatorTranslator
+from sentry.notifications.notification_action.types import BaseActionValidatorHandler
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
@@ -82,14 +82,14 @@ class MockActionHandler(ActionHandler):
     }
 
 
-class MockActionValidatorTranslator(BaseActionValidatorTranslator):
-    notify_action_class = None
+class MockActionValidatorTranslator(BaseActionValidatorHandler):
+    notify_action_form = None
 
-    def generate_action_form_payload(self, validated_data: dict[str, Any]) -> dict[str, Any]:
-        return validated_data
+    def generate_action_form_payload(self) -> dict[str, Any]:
+        return self.validated_data
 
     def update_action_data(self, cleaned_data: dict[str, Any]) -> dict[str, Any]:
-        return cleaned_data
+        return self.validated_data
 
 
 class DataConditionHandlerMixin:


### PR DESCRIPTION
When validating an Action through the API, in addition to making sure the data and config dictionaries have the correct fields and types, we also need to make sure we can actually send a notification with that information.

We can hook into the existing logic that cleans incoming data and hits external APIs to confirm a Slack channel exists, for example. However, the existing logic lives as Django forms and expects the incoming payload to look a certain way which is different than how we're receiving it in the new workflow engine APIs. It also returns the cleaned data in the same legacy format.

This PR introduces a translation layer that:
1. Translates the validated Action data into the legacy data
2. Cleans the legacy data, propagating ValidationErrors upward to prevent saving the workflow if an Action would be invalid
3. Translates the cleaned legacy data back to valid Action data to store in the db