### PR TITLE
ref(uptime): Remove all usages of ProjectUptimeSubscription

### DIFF
--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -47,7 +47,6 @@ class ProjectDeletionTask(ModelDeletionTask[Project]):
         from sentry.replays.models import ReplayRecordingSegment
         from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
         from sentry.snuba.models import QuerySubscription
-        from sentry.uptime.models import ProjectUptimeSubscription
         from sentry.workflow_engine.models import Detector
 
         relations: list[BaseRelation] = [
@@ -90,7 +89,6 @@ class ProjectDeletionTask(ModelDeletionTask[Project]):
             ProguardArtifactRelease,
             DiscoverSavedQueryProject,
             IncidentProject,
-            ProjectUptimeSubscription,
         ):
             relations.append(ModelRelation(m1, {"project_id": instance.id}, BulkModelDeletionTask))
 

--- a/src/sentry/deletions/defaults/uptime_subscription.py
+++ b/src/sentry/deletions/defaults/uptime_subscription.py
@@ -1,10 +1,34 @@
 from sentry.deletions.base import ModelDeletionTask
-from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
+from sentry.uptime.models import UptimeSubscription
 
 
 class UptimeSubscriptionDeletionTask(ModelDeletionTask[UptimeSubscription]):
     def delete_instance(self, instance: UptimeSubscription) -> None:
-        from sentry.uptime.subscriptions.subscriptions import delete_project_uptime_subscription
+        from sentry import quotas
+        from sentry.constants import DataCategory
+        from sentry.uptime.models import get_detector
+        from sentry.uptime.subscriptions.subscriptions import delete_uptime_subscription
 
-        uptime_monitor = ProjectUptimeSubscription.objects.get(uptime_subscription_id=instance.id)
-        delete_project_uptime_subscription(uptime_monitor)
+        detector = get_detector(instance)
+
+        # XXX: Typically quota updates would be handled by the
+        # delete_uptime_detector function exposed in the
+        # uptime.subscriptions.subscriptions module. However if a Detector is
+        # deleted without using this, we need to still ensure the billing east
+        # is revoked.
+        #
+        # Since the delete_uptime_detector function is already scheduling the
+        # detector for deletion, you may think we could remove the quota
+        # remove_seat call there, since it will happen here. But this would
+        # mean the customers quota is not freed up _immediately_ when the
+        # detector is deleted using that method.
+
+        # TODO(epurkhiser): It's very likely the new Workflow Engine detector
+        # APIs will NOT free up customers seats immediately. We'll probably
+        # need some other hook for this
+
+        # Ensure the billing seat for the parent detector is removed
+        quotas.backend.remove_seat(DataCategory.UPTIME, detector)
+
+        # Ensure the remote subscription is also removed
+        delete_uptime_subscription(instance)

--- a/src/sentry/quotas/types.py
+++ b/src/sentry/quotas/types.py
@@ -1,7 +1,6 @@
 from typing import TypeAlias, Union
 
 from sentry.monitors.models import Monitor
-from sentry.uptime.models import ProjectUptimeSubscription
 from sentry.workflow_engine.models import Detector
 
-SeatObject: TypeAlias = Union[Monitor, ProjectUptimeSubscription, Detector]
+SeatObject: TypeAlias = Union[Monitor, Detector]

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -151,17 +151,14 @@ from sentry.tempest.models import TempestCredentials
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
-from sentry.types.actor import Actor
 from sentry.types.region import Region, get_local_region, get_region_by_name
 from sentry.types.token import AuthTokenType
 from sentry.uptime.models import (
     IntervalSecondsLiteral,
-    ProjectUptimeSubscription,
     UptimeStatus,
     UptimeSubscription,
     UptimeSubscriptionRegion,
 )
-from sentry.uptime.types import UptimeMonitorMode
 from sentry.users.models.identity import Identity, IdentityProvider, IdentityStatus
 from sentry.users.models.user import User
 from sentry.users.models.user_avatar import UserAvatar
@@ -2119,39 +2116,6 @@ class Factories:
             trace_sampling=trace_sampling,
             uptime_status=uptime_status,
             uptime_status_update_date=uptime_status_update_date,
-        )
-
-    @staticmethod
-    def create_project_uptime_subscription(
-        project: Project,
-        env: Environment | None,
-        uptime_subscription: UptimeSubscription,
-        status: int,
-        mode: UptimeMonitorMode,
-        name: str | None,
-        owner: Actor | None,
-        id: int | None,
-    ):
-        if name is None:
-            name = petname.generate().title()
-        owner_team_id = None
-        owner_user_id = None
-        if owner:
-            if owner.is_team:
-                owner_team_id = owner.id
-            elif owner.is_user:
-                owner_user_id = owner.id
-
-        return ProjectUptimeSubscription.objects.create(
-            uptime_subscription=uptime_subscription,
-            project=project,
-            environment=env,
-            status=status,
-            mode=mode,
-            name=name,
-            owner_team_id=owner_team_id,
-            owner_user_id=owner_user_id,
-            pk=id,
         )
 
     @staticmethod

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -889,19 +889,6 @@ class Fixtures:
                 is_triggered=False,
             )
 
-        # TODO(epurkhiser): Dual create a ProjectUptimeSubscription as well,
-        # can be removed once we completely remove ProjectUptimeSubscription
-        Factories.create_project_uptime_subscription(
-            project,
-            env,
-            uptime_subscription,
-            status,
-            mode,
-            name,
-            Actor.from_object(owner) if owner else None,
-            id,
-        )
-
         return detector
 
     @pytest.fixture(autouse=True)

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -343,17 +343,8 @@ def get_uptime_subscription(detector: Detector) -> UptimeSubscription:
     return UptimeSubscription.objects.get_from_cache(id=int(data_source.source_id))
 
 
-def get_project_subscription(detector: Detector) -> ProjectUptimeSubscription:
-    """
-    Given a detector get the matching project subscription
-    """
-    data_source = detector.data_sources.first()
-    assert data_source
-    return ProjectUptimeSubscription.objects.get(uptime_subscription_id=int(data_source.source_id))
-
-
 def get_audit_log_data(detector: Detector):
-    """Get audit log data from a detector instead of a ProjectUptimeSubscription instance."""
+    """Get audit log data from a detector."""
     uptime_subscription = get_uptime_subscription(detector)
 
     owner_user_id = None

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -17,12 +17,9 @@ from sentry.types.actor import Actor
 from sentry.uptime.detectors.url_extraction import extract_domain_parts
 from sentry.uptime.grouptype import UptimeDomainCheckFailure, resolve_uptime_issue
 from sentry.uptime.models import (
-    ProjectUptimeSubscription,
     UptimeStatus,
     UptimeSubscription,
     UptimeSubscriptionRegion,
-    get_detector,
-    get_project_subscription,
     get_uptime_subscription,
     load_regions_for_uptime_subscription,
 )
@@ -192,7 +189,7 @@ def create_uptime_detector(
     override_manual_org_limit: bool = False,
 ) -> Detector:
     """
-    Creates an UptimeSubscription and associated ProjectUptimeSubscription
+    Creates an UptimeSubscription and associated Detector
     """
     if mode == UptimeMonitorMode.MANUAL:
         manual_subscription_count = Detector.objects.filter(
@@ -225,7 +222,6 @@ def create_uptime_detector(
             router.db_for_write(DataConditionGroup),
             router.db_for_write(DataSourceDetector),
             router.db_for_write(Detector),
-            router.db_for_write(ProjectUptimeSubscription),
         )
     ):
         uptime_subscription = create_uptime_subscription(
@@ -281,16 +277,6 @@ def create_uptime_detector(
         )
         DataSourceDetector.objects.create(data_source=data_source, detector=detector)
 
-        uptime_monitor = ProjectUptimeSubscription.objects.create(
-            project=project,
-            environment=environment,
-            uptime_subscription=uptime_subscription,
-            mode=mode.value,
-            name=name,
-            owner_user_id=owner_user_id,
-            owner_team_id=owner_team_id,
-        )
-
         # Don't consume a seat if we're still in onboarding mode
         if mode != UptimeMonitorMode.AUTO_DETECTED_ONBOARDING:
             # Update status. This may have the side effect of removing or creating a
@@ -308,9 +294,8 @@ def create_uptime_detector(
                 case ObjectStatus.DISABLED:
                     disable_uptime_detector(detector)
 
-    # ProjectUptimeSubscription may have been updated as part of
+    # Detector may have been updated as part of
     # {enable,disable}_uptime_detector
-    uptime_monitor.refresh_from_db()
     detector.refresh_from_db()
 
     return detector
@@ -333,12 +318,11 @@ def update_uptime_detector(
     ensure_assignment: bool = False,
 ):
     """
-    Links a project to an uptime subscription so that it can process results.
+    Updates a uptime detector and its associated uptime subscription.
     """
     with atomic_transaction(
         using=(
             router.db_for_write(UptimeSubscription),
-            router.db_for_write(ProjectUptimeSubscription),
             router.db_for_write(Detector),
         )
     ):
@@ -355,9 +339,8 @@ def update_uptime_detector(
             trace_sampling=trace_sampling,
         )
 
-        uptime_monitor = get_project_subscription(detector)
-        owner_user_id = uptime_monitor.owner_user_id
-        owner_team_id = uptime_monitor.owner_team_id
+        owner_user_id = detector.owner_user_id
+        owner_team_id = detector.owner_team_id
         if owner and owner is not NOT_SET:
             if owner.is_user:
                 owner_user_id = owner.id
@@ -366,17 +349,15 @@ def update_uptime_detector(
                 owner_team_id = owner.id
                 owner_user_id = None
 
-        env = default_if_not_set(uptime_monitor.environment, environment)
-        uptime_monitor.update(
-            environment=env,
-            name=default_if_not_set(uptime_monitor.name, name),
-            mode=mode,
-            owner_user_id=owner_user_id,
-            owner_team_id=owner_team_id,
-        )
+        current_env = detector.config.get("environment")
+        if current_env:
+            current_env_obj = Environment.get_or_create(detector.project, current_env)
+        else:
+            current_env_obj = None
+        env = default_if_not_set(current_env_obj, environment)
 
         detector.update(
-            name=default_if_not_set(uptime_monitor.name, name),
+            name=default_if_not_set(detector.name, name),
             owner_user_id=owner_user_id,
             owner_team_id=owner_team_id,
             config={
@@ -403,21 +384,18 @@ def update_uptime_detector(
 
 def disable_uptime_detector(detector: Detector, skip_quotas: bool = False):
     """
-    Disables a uptime detector. The associated ProjectUptimeSubscription will also be disabled,
-    and if the UptimeSubscription no longer has any active ProjectUptimeSubscriptions, it will
-    also be disabled.
+    Disables a uptime detector. If the UptimeSubscription no longer has any active
+    detectors, it will also be disabled.
     """
     with atomic_transaction(
         using=(
             router.db_for_write(UptimeSubscription),
-            router.db_for_write(ProjectUptimeSubscription),
             router.db_for_write(Detector),
         )
     ):
-        uptime_monitor = get_project_subscription(detector)
-        uptime_subscription: UptimeSubscription = uptime_monitor.uptime_subscription
+        uptime_subscription: UptimeSubscription = get_uptime_subscription(detector)
 
-        if uptime_monitor.status == ObjectStatus.DISABLED and not detector.enabled:
+        if not detector.enabled:
             return
 
         if uptime_subscription.uptime_status == UptimeStatus.FAILED:
@@ -428,16 +406,17 @@ def disable_uptime_detector(detector: Detector, skip_quotas: bool = False):
         # from a good state
         uptime_subscription.update(uptime_status=UptimeStatus.OK)
 
-        uptime_monitor.update(status=ObjectStatus.DISABLED)
         detector.update(enabled=False)
 
         if not skip_quotas:
             quotas.backend.disable_seat(DataCategory.UPTIME, detector)
 
-        # Are there any other project subscriptions associated to the subscription
-        # that are NOT disabled?
-        has_active_subscription = uptime_subscription.projectuptimesubscription_set.exclude(
-            status=ObjectStatus.DISABLED
+        # Are there any other detectors associated to the subscription
+        # that are still enabled?
+        has_active_subscription = Detector.objects.filter(
+            data_sources__source_id=str(uptime_subscription.id),
+            enabled=True,
+            status=ObjectStatus.ACTIVE,
         ).exists()
 
         # All project subscriptions are disabled, we can disable the subscription
@@ -461,13 +440,7 @@ def enable_uptime_detector(
     By default if the monitor is already marked as ACTIVE this function is a
     no-op. Pass `ensure_assignment=True` to force seat assignment.
     """
-    uptime_monitor = get_project_subscription(detector)
-
-    if (
-        not ensure_assignment
-        and uptime_monitor.status != ObjectStatus.DISABLED
-        and detector.enabled
-    ):
+    if not ensure_assignment and detector.enabled:
         return
 
     if not skip_quotas:
@@ -483,8 +456,7 @@ def enable_uptime_detector(
             disable_uptime_detector(detector)
             raise UptimeMonitorNoSeatAvailable(None)
 
-    uptime_subscription: UptimeSubscription = uptime_monitor.uptime_subscription
-    uptime_monitor.update(status=ObjectStatus.ACTIVE)
+    uptime_subscription: UptimeSubscription = get_uptime_subscription(detector)
     detector.update(enabled=True)
 
     # The subscription was disabled, it can be re-activated now
@@ -494,26 +466,23 @@ def enable_uptime_detector(
 
 
 def delete_uptime_detector(detector: Detector):
-    uptime_monitor = get_project_subscription(detector)
-    delete_project_uptime_subscription(uptime_monitor)
+    uptime_subscription = get_uptime_subscription(detector)
+    quotas.backend.remove_seat(DataCategory.UPTIME, detector)
     detector.update(status=ObjectStatus.PENDING_DELETION)
     RegionScheduledDeletion.schedule(detector, days=0)
-
-
-def delete_project_uptime_subscription(uptime_monitor: ProjectUptimeSubscription):
-    uptime_subscription: UptimeSubscription = uptime_monitor.uptime_subscription
-    detector = get_detector(uptime_monitor.uptime_subscription)
-    quotas.backend.remove_seat(DataCategory.UPTIME, detector)
-    uptime_monitor.delete()
     remove_uptime_subscription_if_unused(uptime_subscription)
 
 
 def remove_uptime_subscription_if_unused(uptime_subscription: UptimeSubscription):
     """
-    Determines if an uptime subscription is no longer used by any `ProjectUptimeSubscriptions` and removes it if so
+    Determines if an uptime subscription is no longer used by any detectors and removes it if so
     """
     # If the uptime subscription is no longer used, we also remove it.
-    if not uptime_subscription.projectuptimesubscription_set.exists():
+    has_active_detectors = Detector.objects.filter(
+        data_sources__source_id=str(uptime_subscription.id),
+        status=ObjectStatus.ACTIVE,
+    ).exists()
+    if not has_active_detectors:
         delete_uptime_subscription(uptime_subscription)
 
 

--- a/tests/sentry/deletions/test_detector.py
+++ b/tests/sentry/deletions/test_detector.py
@@ -5,12 +5,7 @@ from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.grouptype import MetricIssue
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
-from sentry.uptime.models import (
-    ProjectUptimeSubscription,
-    UptimeSubscription,
-    get_project_subscription,
-    get_uptime_subscription,
-)
+from sentry.uptime.models import UptimeSubscription, get_uptime_subscription
 from sentry.workflow_engine.models import (
     DataCondition,
     DataConditionGroup,
@@ -131,7 +126,6 @@ class DeleteDetectorTest(BaseWorkflowTest, HybridCloudTestMixin):
     def test_delete_uptime_detector(self) -> None:
         detector = self.create_uptime_detector()
         uptime_sub = get_uptime_subscription(detector)
-        proj_sub = get_project_subscription(detector)
         self.ScheduledDeletion.schedule(instance=detector, days=0)
 
         with self.tasks():
@@ -139,7 +133,5 @@ class DeleteDetectorTest(BaseWorkflowTest, HybridCloudTestMixin):
 
         with pytest.raises(Detector.DoesNotExist):
             detector.refresh_from_db()
-        with pytest.raises(ProjectUptimeSubscription.DoesNotExist):
-            proj_sub.refresh_from_db()
         with pytest.raises(UptimeSubscription.DoesNotExist):
             uptime_sub.refresh_from_db()

--- a/tests/sentry/deletions/test_project.py
+++ b/tests/sentry/deletions/test_project.py
@@ -1,3 +1,6 @@
+from unittest import mock
+
+from sentry.constants import DataCategory
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.incidents.models.incident import Incident
@@ -35,7 +38,7 @@ from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
-from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
+from sentry.uptime.models import UptimeSubscription, get_uptime_subscription
 from sentry.workflow_engine.models import (
     DataCondition,
     DataConditionGroup,
@@ -221,23 +224,11 @@ class DeleteProjectTest(BaseWorkflowTest, TransactionTestCase, HybridCloudTestMi
         )
         assert len(events) == 0
 
-    def test_delete_with_uptime_monitors(self) -> None:
+    @mock.patch("sentry.quotas.backend.remove_seat")
+    def test_delete_with_uptime_monitors(self, mock_remove_seat) -> None:
         project = self.create_project(name="test")
-
-        # Create uptime subscription
-        uptime_subscription = UptimeSubscription.objects.create(
-            url="https://example.com",
-            url_domain="example",
-            url_domain_suffix="com",
-            interval_seconds=60,
-            timeout_ms=5000,
-            method="GET",
-        )
-
-        # Create project uptime subscription
-        project_uptime_subscription = ProjectUptimeSubscription.objects.create(
-            project=project, uptime_subscription=uptime_subscription, name="Test Monitor"
-        )
+        detector = self.create_uptime_detector(project=project)
+        uptime_subscription = get_uptime_subscription(detector)
 
         self.ScheduledDeletion.schedule(instance=project, days=0)
 
@@ -245,9 +236,9 @@ class DeleteProjectTest(BaseWorkflowTest, TransactionTestCase, HybridCloudTestMi
             run_scheduled_deletions()
 
         assert not Project.objects.filter(id=project.id).exists()
-        assert not ProjectUptimeSubscription.objects.filter(
-            id=project_uptime_subscription.id
-        ).exists()
+        assert not Detector.objects.filter(id=detector.id).exists()
+        assert not UptimeSubscription.objects.filter(id=uptime_subscription.id).exists()
+        mock_remove_seat.assert_called_with(DataCategory.UPTIME, detector)
 
 
 class DeleteWorkflowEngineModelsTest(DeleteProjectTest):

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -24,7 +24,7 @@ from sentry.conf.types import kafka_definition
 from sentry.conf.types.kafka_definition import Topic as KafkaTopic
 from sentry.conf.types.kafka_definition import get_topic_codec
 from sentry.conf.types.uptime import UptimeRegionConfig
-from sentry.constants import DataCategory
+from sentry.constants import DataCategory, ObjectStatus
 from sentry.models.group import Group, GroupStatus
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.helpers.datetime import freeze_time
@@ -44,13 +44,7 @@ from sentry.uptime.detectors.result_handler import (
 )
 from sentry.uptime.detectors.tasks import is_failed_url
 from sentry.uptime.grouptype import UptimeDomainCheckFailure, build_detector_fingerprint_component
-from sentry.uptime.models import (
-    ProjectUptimeSubscription,
-    UptimeStatus,
-    UptimeSubscription,
-    UptimeSubscriptionRegion,
-    get_project_subscription,
-)
+from sentry.uptime.models import UptimeStatus, UptimeSubscription, UptimeSubscriptionRegion
 from sentry.uptime.types import IncidentStatus, UptimeMonitorMode
 from sentry.utils import json
 from tests.sentry.uptime.subscriptions.test_tasks import ConfigPusherTestMixin
@@ -75,7 +69,6 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             uptime_subscription=self.subscription,
             owner=self.user,
         )
-        self.project_subscription = get_project_subscription(self.detector)
 
     def send_result(
         self, result: CheckResult, consumer: ProcessingStrategy[KafkaPayload] | None = None
@@ -518,7 +511,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             "organizations:uptime",
             "organizations:uptime-create-issues",
         ]
-        self.project_subscription.update(mode=UptimeMonitorMode.AUTO_DETECTED_ONBOARDING)
+        # Update detector mode configuration
         self.detector.update(
             config={
                 **self.detector.config,
@@ -626,18 +619,15 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
         with pytest.raises(UptimeSubscription.DoesNotExist):
             self.subscription.refresh_from_db()
-        with pytest.raises(ProjectUptimeSubscription.DoesNotExist):
-            self.project_subscription.refresh_from_db()
+        # Detector should be marked for pending deletion when subscription is removed
+        self.detector.refresh_from_db()
+        assert self.detector.status == ObjectStatus.PENDING_DELETION
 
     def test_onboarding_success_ongoing(self) -> None:
         features = [
             "organizations:uptime",
             "organizations:uptime-create-issues",
         ]
-        self.project_subscription.update(
-            mode=UptimeMonitorMode.AUTO_DETECTED_ONBOARDING,
-            date_added=datetime.now(timezone.utc) - timedelta(minutes=5),
-        )
         self.detector.update(
             config={
                 **self.detector.config,
@@ -686,11 +676,6 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             "organizations:uptime",
             "organizations:uptime-create-issues",
         ]
-        self.project_subscription.update(
-            mode=UptimeMonitorMode.AUTO_DETECTED_ONBOARDING,
-            date_added=datetime.now(timezone.utc)
-            - (ONBOARDING_MONITOR_PERIOD + timedelta(minutes=5)),
-        )
         self.detector.update(
             config={
                 **self.detector.config,
@@ -750,8 +735,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
 
-        self.project_subscription.refresh_from_db()
-        assert self.project_subscription.mode == UptimeMonitorMode.AUTO_DETECTED_ACTIVE
+        self.detector.refresh_from_db()
+        assert self.detector.config["mode"] == UptimeMonitorMode.AUTO_DETECTED_ACTIVE.value
         self.subscription.refresh_from_db()
         assert self.subscription.interval_seconds == int(
             AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL.total_seconds()

--- a/tests/sentry/uptime/detectors/test_ranking.py
+++ b/tests/sentry/uptime/detectors/test_ranking.py
@@ -17,7 +17,6 @@ from sentry.uptime.detectors.ranking import (
     should_detect_for_organization,
     should_detect_for_project,
 )
-from sentry.uptime.models import get_project_subscription
 
 
 class AddBaseUrlToRankTest(UptimeTestCase):
@@ -205,6 +204,5 @@ class ShouldDetectForOrgTest(UptimeTestCase):
         assert should_detect_for_organization(self.organization)
         detector = self.create_uptime_detector()
         assert not should_detect_for_organization(self.organization)
-        get_project_subscription(detector).delete()
         detector.delete()
         assert should_detect_for_organization(self.organization)

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -15,11 +15,9 @@ from sentry.testutils.skips import requires_kafka
 from sentry.types.actor import Actor
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.uptime.models import (
-    ProjectUptimeSubscription,
     UptimeStatus,
     UptimeSubscription,
     UptimeSubscriptionRegion,
-    get_project_subscription,
     get_uptime_subscription,
 )
 from sentry.uptime.subscriptions.subscriptions import (
@@ -203,13 +201,10 @@ class CreateUptimeDetectorTest(UptimeTestCase):
             timeout_ms=1000,
             mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         )
-        assert ProjectUptimeSubscription.objects.filter(
-            project=self.project,
-            uptime_subscription__url="https://sentry.io",
-            uptime_subscription__interval_seconds=3600,
-            uptime_subscription__timeout_ms=1000,
-            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
-        ).exists()
+        uptime_subscription = get_uptime_subscription(detector)
+        assert uptime_subscription.url == "https://sentry.io"
+        assert uptime_subscription.interval_seconds == 3600
+        assert uptime_subscription.timeout_ms == 1000
 
         assert detector.config["mode"] == UptimeMonitorMode.AUTO_DETECTED_ACTIVE.value
         assert detector.config["environment"] == self.environment.name
@@ -235,16 +230,13 @@ class CreateUptimeDetectorTest(UptimeTestCase):
             mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         )
 
-        assert (
-            ProjectUptimeSubscription.objects.filter(
-                project=self.project,
-                uptime_subscription__url="https://sentry.io",
-                uptime_subscription__interval_seconds=3600,
-                uptime_subscription__timeout_ms=1000,
-                mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
-            ).count()
-            == 2
+        # Both detectors should exist and use different uptime subscriptions
+        detectors = Detector.objects.filter(
+            project=self.project,
+            type=UptimeDomainCheckFailure.slug,
+            config__mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE.value,
         )
+        assert detectors.count() == 2
 
     def test_max_proj_subs(self) -> None:
         with mock.patch(
@@ -418,9 +410,8 @@ class CreateUptimeDetectorTest(UptimeTestCase):
         # Monitor created but is not enabled due to no seat assignment
         assert not detector.enabled
 
-        proj_sub = get_project_subscription(detector)
-        assert proj_sub.status == ObjectStatus.DISABLED
-        assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
+        uptime_subscription = get_uptime_subscription(detector)
+        assert uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
 
     def test_create_manual_removes_onboarding(self) -> None:
         assert self.organization.update_option("sentry:uptime_autodetection", True)
@@ -456,7 +447,7 @@ class CreateUptimeDetectorTest(UptimeTestCase):
             detector.refresh_from_db()
 
 
-class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
+class UpdateUptimeDetectorTest(UptimeTestCase):
     def test(self) -> None:
         with self.tasks():
             detector = create_uptime_detector(
@@ -467,8 +458,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 timeout_ms=1000,
                 mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
             )
-            proj_sub = get_project_subscription(detector)
-            prev_uptime_subscription = proj_sub.uptime_subscription
+            prev_uptime_subscription = get_uptime_subscription(detector)
             prev_uptime_subscription.refresh_from_db()
             prev_subscription_id = prev_uptime_subscription.subscription_id
             update_uptime_detector(
@@ -486,11 +476,10 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
             )
 
         detector.refresh_from_db()
-        proj_sub.refresh_from_db()
-        assert proj_sub.name == "New name"
-        assert proj_sub.owner_user_id == self.user.id
-        assert proj_sub.owner_team_id is None
-        assert proj_sub.mode == UptimeMonitorMode.MANUAL
+        assert detector.name == "New name"
+        assert detector.owner_user_id == self.user.id
+        assert detector.owner_team_id is None
+        assert detector.config["mode"] == UptimeMonitorMode.MANUAL
         prev_uptime_subscription.refresh_from_db()
         assert prev_uptime_subscription.url == "https://santry.io"
         assert prev_uptime_subscription.interval_seconds == 60
@@ -500,8 +489,8 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
         assert prev_uptime_subscription.body == "a body"
         assert prev_uptime_subscription.subscription_id == prev_subscription_id
 
-        assert detector.name == "New name"
-        assert detector.owner_user_id == self.user.id
+        # Detector fields should be updated
+        assert detector.config["environment"] == self.environment.name
 
     def test_already_exists(self) -> None:
         with self.tasks():
@@ -513,7 +502,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 timeout_ms=1000,
                 mode=UptimeMonitorMode.MANUAL,
             )
-            proj_sub = get_project_subscription(detector)
+            uptime_subscription = get_uptime_subscription(detector)
             other_detector = create_uptime_detector(
                 self.project,
                 self.environment,
@@ -522,42 +511,36 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 timeout_ms=1000,
                 mode=UptimeMonitorMode.MANUAL,
             )
-            other_proj_sub = get_project_subscription(other_detector)
+            other_uptime_subscription = get_uptime_subscription(other_detector)
 
             update_uptime_detector(
                 detector,
                 environment=self.environment,
-                url=proj_sub.uptime_subscription.url,
-                interval_seconds=other_proj_sub.uptime_subscription.interval_seconds,
+                url=uptime_subscription.url,
+                interval_seconds=other_uptime_subscription.interval_seconds,
                 timeout_ms=1000,
-                method=other_proj_sub.uptime_subscription.method,
-                headers=other_proj_sub.uptime_subscription.headers,
-                body=other_proj_sub.uptime_subscription.body,
-                name=other_proj_sub.name,
-                owner=other_proj_sub.owner,
-                trace_sampling=other_proj_sub.uptime_subscription.trace_sampling,
+                method=other_uptime_subscription.method,
+                headers=other_uptime_subscription.headers,
+                body=other_uptime_subscription.body,
+                name=other_detector.name,
+                owner=other_detector.owner,
+                trace_sampling=other_uptime_subscription.trace_sampling,
             )
 
-        assert (
-            ProjectUptimeSubscription.objects.filter(
-                project=self.project,
-                uptime_subscription__url="https://sentry.io",
-                uptime_subscription__interval_seconds=3600,
-                uptime_subscription__timeout_ms=1000,
-                mode=UptimeMonitorMode.MANUAL,
-            ).count()
-            == 1
+        # Verify that we still have both detectors after the update
+        sentry_detectors = Detector.objects.filter(
+            project=self.project,
+            data_sources__source_id=str(uptime_subscription.id),
+            config__mode=UptimeMonitorMode.MANUAL.value,
         )
-        assert (
-            ProjectUptimeSubscription.objects.filter(
-                project=self.project,
-                uptime_subscription__url="https://santry.io",
-                uptime_subscription__interval_seconds=3600,
-                uptime_subscription__timeout_ms=1000,
-                mode=UptimeMonitorMode.MANUAL,
-            ).count()
-            == 1
+        assert sentry_detectors.count() == 1
+
+        santry_detectors = Detector.objects.filter(
+            project=self.project,
+            data_sources__source_id=str(other_uptime_subscription.id),
+            config__mode=UptimeMonitorMode.MANUAL.value,
         )
+        assert santry_detectors.count() == 1
 
     @mock.patch("sentry.uptime.subscriptions.subscriptions.disable_uptime_detector")
     def test_status_disable(self, mock_disable_uptime_detector: mock.MagicMock) -> None:
@@ -616,7 +599,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
         mock_enable_uptime_detector.assert_called_with(mock.ANY, ensure_assignment=True)
 
 
-class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
+class DeleteUptimeDetectorTest(UptimeTestCase):
     @mock.patch("sentry.quotas.backend.remove_seat")
     def test_other_subscriptions(self, mock_remove_seat: mock.MagicMock) -> None:
         other_project = self.create_project()
@@ -636,22 +619,20 @@ class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
             timeout_ms=1000,
             mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         )
-        proj_sub = get_project_subscription(detector)
-        other_sub = get_project_subscription(other_detector)
+        uptime_subscription = get_uptime_subscription(detector)
+        other_uptime_subscription = get_uptime_subscription(other_detector)
 
-        assert proj_sub.uptime_subscription_id != other_sub.uptime_subscription_id
+        assert uptime_subscription.id != other_uptime_subscription.id
 
         with self.tasks():
             delete_uptime_detector(detector)
             run_scheduled_deletions()
 
-        with pytest.raises(ProjectUptimeSubscription.DoesNotExist):
-            proj_sub.refresh_from_db()
-
+        # Detector should be deleted
         with pytest.raises(Detector.DoesNotExist):
             detector.refresh_from_db()
 
-        assert UptimeSubscription.objects.filter(id=other_sub.uptime_subscription_id).exists()
+        assert UptimeSubscription.objects.filter(id=other_uptime_subscription.id).exists()
         mock_remove_seat.assert_called_with(DataCategory.UPTIME, detector)
 
     @mock.patch("sentry.quotas.backend.remove_seat")
@@ -664,16 +645,17 @@ class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
             timeout_ms=1000,
             mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         )
-        proj_sub = get_project_subscription(detector)
+        uptime_subscription = get_uptime_subscription(detector)
         with self.tasks():
             delete_uptime_detector(detector)
             run_scheduled_deletions()
 
-        with pytest.raises(ProjectUptimeSubscription.DoesNotExist):
-            proj_sub.refresh_from_db()
+        # Detector should be deleted
+        with pytest.raises(Detector.DoesNotExist):
+            detector.refresh_from_db()
 
         with pytest.raises(UptimeSubscription.DoesNotExist):
-            proj_sub.uptime_subscription.refresh_from_db()
+            uptime_subscription.refresh_from_db()
         mock_remove_seat.assert_called_with(DataCategory.UPTIME, detector)
 
 
@@ -748,7 +730,7 @@ class GetAutoMonitoredSubscriptionsForProjectTest(UptimeTestCase):
         assert get_auto_monitored_detectors_for_project(other_project) == []
 
 
-class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
+class DisableUptimeDetectorTest(UptimeTestCase):
     @mock.patch("sentry.quotas.backend.disable_seat")
     def test(self, mock_disable_seat: mock.MagicMock) -> None:
         detector = create_uptime_detector(
@@ -759,14 +741,13 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
             timeout_ms=1000,
             mode=UptimeMonitorMode.MANUAL,
         )
-        proj_sub = get_project_subscription(detector)
+        uptime_subscription = get_uptime_subscription(detector)
 
         with self.tasks():
             disable_uptime_detector(detector)
 
-        proj_sub.refresh_from_db()
-        assert proj_sub.status == ObjectStatus.DISABLED
-        assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
+        uptime_subscription.refresh_from_db()
+        assert uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
         mock_disable_seat.assert_called_with(DataCategory.UPTIME, detector)
 
         detector.refresh_from_db()
@@ -787,18 +768,17 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
                 timeout_ms=1000,
                 mode=UptimeMonitorMode.MANUAL,
             )
-            proj_sub = get_project_subscription(detector)
+            uptime_subscription = get_uptime_subscription(detector)
 
             # XXX(epurkhiser): This should actually be looking at the detector state
-            proj_sub.uptime_subscription.update(uptime_status=UptimeStatus.FAILED)
+            uptime_subscription.update(uptime_status=UptimeStatus.FAILED)
 
             disable_uptime_detector(detector)
             mock_resolve_uptime_issue.assert_called_with(detector)
 
-        proj_sub.refresh_from_db()
-        assert proj_sub.status == ObjectStatus.DISABLED
-        assert proj_sub.uptime_subscription.uptime_status == UptimeStatus.OK
-        assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
+        uptime_subscription.refresh_from_db()
+        assert uptime_subscription.uptime_status == UptimeStatus.OK
+        assert uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
         mock_disable_seat.assert_called_with(DataCategory.UPTIME, detector)
 
         detector.refresh_from_db()
@@ -814,9 +794,7 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
             timeout_ms=1000,
             mode=UptimeMonitorMode.MANUAL,
         )
-        proj_sub = get_project_subscription(detector)
-
-        proj_sub.update(status=ObjectStatus.DISABLED)
+        # Manually disable the detector first
         detector.update(enabled=False)
 
         disable_uptime_detector(detector)
@@ -833,21 +811,20 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
             timeout_ms=1000,
             mode=UptimeMonitorMode.MANUAL,
         )
-        proj_sub = get_project_subscription(detector)
+        uptime_subscription = get_uptime_subscription(detector)
 
         with self.tasks():
             disable_uptime_detector(detector, skip_quotas=True)
 
-        proj_sub.refresh_from_db()
-        assert proj_sub.status == ObjectStatus.DISABLED
-        assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
+        uptime_subscription.refresh_from_db()
+        assert uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
         mock_disable_seat.assert_not_called()
 
         detector.refresh_from_db()
         assert not detector.enabled
 
 
-class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
+class EnableUptimeDetectorTest(UptimeTestCase):
     @mock.patch(
         "sentry.quotas.backend.assign_seat",
         return_value=Outcome.ACCEPTED,
@@ -870,7 +847,7 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
                 timeout_ms=1000,
                 mode=UptimeMonitorMode.MANUAL,
             )
-            proj_sub = get_project_subscription(detector)
+            uptime_subscription = get_uptime_subscription(detector)
 
         # Calling enable_uptime_detector on an already enabled
         # monitor does nothing
@@ -880,21 +857,20 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
         detector.refresh_from_db()
 
         # Manually mark the monitor and subscription as disabled
-        proj_sub.update(status=ObjectStatus.DISABLED)
         detector.update(enabled=False)
         detector.refresh_from_db()
 
-        proj_sub.uptime_subscription.update(status=UptimeSubscription.Status.DISABLED.value)
-        proj_sub.refresh_from_db()
-        proj_sub.uptime_subscription.refresh_from_db()
+        uptime_subscription.update(status=UptimeSubscription.Status.DISABLED.value)
+        uptime_subscription.refresh_from_db()
+        uptime_subscription.refresh_from_db()
 
         # Enabling the subscription marks the subscription as active again
         with self.tasks():
             enable_uptime_detector(detector)
 
-        proj_sub.refresh_from_db()
-        assert proj_sub.status == ObjectStatus.ACTIVE
-        assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.ACTIVE.value
+        uptime_subscription.refresh_from_db()
+        assert detector.enabled
+        assert uptime_subscription.status == UptimeSubscription.Status.ACTIVE.value
 
         # Seat assignment was called
         mock_check_assign_seat.assert_called_with(DataCategory.UPTIME, detector)
@@ -925,7 +901,7 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
                 timeout_ms=1000,
                 mode=UptimeMonitorMode.MANUAL,
             )
-            proj_sub = get_project_subscription(detector)
+            uptime_subscription = get_uptime_subscription(detector)
 
         # We'll be unable to assign a seat
         with self.tasks(), raises(UptimeMonitorNoSeatAvailable) as exc_info:
@@ -934,9 +910,9 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
         assert exc_info.value.result is not None
         assert exc_info.value.result.reason == "Testing"
 
-        proj_sub.refresh_from_db()
-        assert proj_sub.status == ObjectStatus.DISABLED
-        assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
+        uptime_subscription.refresh_from_db()
+        assert not detector.enabled
+        assert uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
 
         detector.refresh_from_db()
         assert not detector.enabled
@@ -954,10 +930,9 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
             timeout_ms=1000,
             mode=UptimeMonitorMode.MANUAL,
         )
-        proj_sub = get_project_subscription(detector)
 
         assert detector.enabled
-        assert proj_sub.status == ObjectStatus.ACTIVE
+        assert detector.enabled
 
         enable_uptime_detector(detector)
 
@@ -987,24 +962,23 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
                 timeout_ms=1000,
                 mode=UptimeMonitorMode.MANUAL,
             )
-            proj_sub = get_project_subscription(detector)
+        uptime_subscription = get_uptime_subscription(detector)
 
         # Manually mark the monitor and subscription as disabled
-        proj_sub.update(status=ObjectStatus.DISABLED)
         detector.update(enabled=False)
         detector.refresh_from_db()
 
-        proj_sub.uptime_subscription.update(status=UptimeSubscription.Status.DISABLED.value)
-        proj_sub.refresh_from_db()
-        proj_sub.uptime_subscription.refresh_from_db()
+        uptime_subscription.update(status=UptimeSubscription.Status.DISABLED.value)
+        uptime_subscription.refresh_from_db()
+        uptime_subscription.refresh_from_db()
 
         # Enabling the subscription marks the subscription as active again
         with self.tasks():
             enable_uptime_detector(detector, skip_quotas=True)
 
-        proj_sub.refresh_from_db()
-        assert proj_sub.status == ObjectStatus.ACTIVE
-        assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.ACTIVE.value
+        uptime_subscription.refresh_from_db()
+        assert detector.enabled
+        assert uptime_subscription.status == UptimeSubscription.Status.ACTIVE.value
 
         mock_check_assign_seat.assert_not_called()
         mock_assign_seat.assert_not_called()


### PR DESCRIPTION
Part of [NEW-438: Clean up dual writing for uptime](https://linear.app/getsentry/issue/NEW-438/clean-up-dual-writing-for-uptime)