### PR TITLE
fix(aci milestone 3): address dual -> single processing edge case

### DIFF
--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -229,6 +229,7 @@ def incident_attachment_info(
         title_link_params["notification_uuid"] = notification_uuid
 
     from sentry.incidents.grouptype import MetricIssue
+    from sentry.incidents.models import Incident
 
     # TODO(iamrajjoshi): This will need to be updated once we plan out Metric Alerts rollout
     if should_fire_workflow_actions(organization, MetricIssue.type_id):
@@ -250,7 +251,6 @@ def incident_attachment_info(
             workflow_engine_params["alert"] = str(open_period_incident.incident_identifier)
         except IncidentGroupOpenPeriod.DoesNotExist as e:
             sentry_sdk.capture_exception(e)
-            # Swallowing the error here since this model isn't being written to just yet
 
         title_link = build_title_link(alert_rule_id, organization, workflow_engine_params)
 

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -229,7 +229,6 @@ def incident_attachment_info(
         title_link_params["notification_uuid"] = notification_uuid
 
     from sentry.incidents.grouptype import MetricIssue
-    from sentry.incidents.models import Incident
 
     # TODO(iamrajjoshi): This will need to be updated once we plan out Metric Alerts rollout
     if should_fire_workflow_actions(organization, MetricIssue.type_id):

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -93,6 +93,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             substatus=new_substatus,
             activity_type=activity_type,
             activity_data=status_change.get("activity_data"),
+            detector_id=status_change.get("detector_id"),
         )
         remove_group_from_inbox(group, action=GroupInboxRemoveAction.IGNORED)
         kick_off_status_syncs.apply_async(
@@ -131,6 +132,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             activity_type=activity_type,
             from_substatus=group.substatus,
             activity_data=status_change.get("activity_data"),
+            detector_id=status_change.get("detector_id"),
         )
         add_group_to_inbox(group, group_inbox_reason)
         kick_off_status_syncs.apply_async(

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -68,6 +68,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             substatus=new_substatus,
             activity_type=activity_type,
             activity_data=status_change.get("activity_data"),
+            detector_id=status_change.get("detector_id"),
         )
         remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED)
         kick_off_status_syncs.apply_async(

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -530,7 +530,7 @@ class GroupManager(BaseManager["Group"]):
                         "Call to update metric issue status missing detector ID",
                         extra={"group_id": group.id},
                     )
-                    return
+                    continue
                 update_incident_based_on_open_period_status_change(group, status, detector_id)
 
     def from_share_id(self, share_id: str) -> Group:

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -444,6 +444,7 @@ class GroupManager(BaseManager["Group"]):
         activity_data: Mapping[str, Any] | None = None,
         send_activity_notification: bool = True,
         from_substatus: int | None = None,
+        detector_id: int | None = None,
     ) -> None:
         """For each groups, update status to `status` and create an Activity."""
         from sentry.incidents.grouptype import MetricIssue
@@ -524,7 +525,13 @@ class GroupManager(BaseManager["Group"]):
 
             # TODO (aci cleanup): remove this once we've deprecated the incident model
             if group.type == MetricIssue.type_id:
-                update_incident_based_on_open_period_status_change(group, status)
+                if detector_id is None:
+                    logger.error(
+                        "Call to update metric issue status missing detector ID",
+                        extra={"group_id": group.id},
+                    )
+                    return
+                update_incident_based_on_open_period_status_change(group, status, detector_id)
 
     def from_share_id(self, share_id: str) -> Group:
         if not share_id or len(share_id) != 32:

--- a/src/sentry/workflow_engine/models/incident_groupopenperiod.py
+++ b/src/sentry/workflow_engine/models/incident_groupopenperiod.py
@@ -108,7 +108,7 @@ class IncidentGroupOpenPeriod(DefaultFieldsModel):
             calculate_event_date_from_update_date,
         )
 
-        # XXX: there's a small chance that an open incident exists already if single processing
+        # XXX: there's a chance that an open incident exists already if single processing
         # is enabled for an organization in the middle of an active incident. See if such
         # an incident exists, and associate it with the open period if so.
         open_incident = (
@@ -117,6 +117,23 @@ class IncidentGroupOpenPeriod(DefaultFieldsModel):
             .first()
         )
         if open_incident is not None:
+            # if a new occurrence came in, that means we need to update the priority of the incident
+            priority = (
+                occurrence.priority
+                if occurrence.priority is not None
+                else DetectorPriorityLevel.HIGH
+            )
+            severity = (
+                IncidentStatus.CRITICAL
+                if priority == DetectorPriorityLevel.HIGH
+                else IncidentStatus.WARNING
+            )  # this assumes that LOW isn't used for metric issues
+
+            update_incident_status(
+                open_incident,
+                severity,
+                status_method=IncidentStatusMethod.RULE_TRIGGERED,
+            )
             return open_incident
 
         # Extract query subscription id from evidence_data
@@ -143,7 +160,7 @@ class IncidentGroupOpenPeriod(DefaultFieldsModel):
         )
         # XXX: if this is the very first open period, or if the priority didn't change from the last priority on the last open period,
         # manually add the first incident status change activity because the group never changed priority
-        # if the priority changed, then the call to update_incident_status in update_priority will be a no-op.
+        # if the priority changed, then the call to update_incident_status in update_priority will be a no-op
         priority = (
             occurrence.priority if occurrence.priority is not None else DetectorPriorityLevel.HIGH
         )
@@ -225,16 +242,14 @@ def update_incident_activity_based_on_group_activity(
         # This could happen because the priority changed when opening the period, but
         # the priority change came before relationship creation. This isn't a problem—we create the
         # relationship with the new priority in create_from_occurrence() anyway.
-        #
-        # it could also happen (very rarely) if single processing was turned on during an active incident
-        # we should account for this case and create the correct relationship if this happens
-        # I don't know if we can get the alert rule here, though... in that case let's move the
-        # priority update in the create_incident_for_open_period method to also account for
-        # already open incidents that were just not linked
-        open_incident = (
-            Incident.objects.filter(alert_rule__id=alert_rule.id, date_ended=None)
-            .order_by("-date_started")
-            .first()
+
+        # we could also hit this case if there are outstanding open incidents when switching to single
+        # processing. Again, create_from_occurrence() will handle any status changes we need.
+        logger.info(
+            "No IncidentGroupOpenPeriod relationship found when updating IncidentActivity table",
+            extra={
+                "open_period_id": open_period.id,
+            },
         )
         return
 
@@ -252,6 +267,7 @@ def update_incident_activity_based_on_group_activity(
 def update_incident_based_on_open_period_status_change(
     group: Group,
     new_status: int,
+    detector_id: int,
 ) -> None:
     from sentry.incidents.logic import update_incident_status
     from sentry.incidents.models.incident import Incident, IncidentStatus, IncidentStatusMethod
@@ -274,20 +290,25 @@ def update_incident_based_on_open_period_status_change(
 
     except IncidentGroupOpenPeriod.DoesNotExist:
         # check if single processing was turned on while there was an active incident
-        # how do we get the alert rule? there's no link to it from the group ;_;
+        alert_rule_id = AlertRuleDetector.objects.get(detector_id=detector_id).alert_rule_id
         open_incident = (
-            Incident.objects.filter(alert_rule__id=alert_rule.id, date_ended=None)
+            Incident.objects.filter(alert_rule__id=alert_rule_id, date_ended=None)
             .order_by("-date_started")
             .first()
         )
+        if open_incident is not None:
+            IncidentGroupOpenPeriod.create_relationship(
+                incident=open_incident, open_period=open_period
+            )
+        else:
+            logger.exception(
+                "No IncidentGroupOpenPeriod relationship and no outstanding incident",
+                extra={
+                    "open_period_id": open_period.id,
+                },
+            )
+            return
 
-        logger.warning(
-            "No IncidentGroupOpenPeriod relationship found",
-            extra={
-                "open_period_id": open_period.id,
-            },
-        )
-        return
     if incident.subscription_id is not None:
         subscription = QuerySubscription.objects.select_related("snuba_query").get(
             id=int(incident.subscription_id)

--- a/src/sentry/workflow_engine/models/incident_groupopenperiod.py
+++ b/src/sentry/workflow_engine/models/incident_groupopenperiod.py
@@ -112,7 +112,7 @@ class IncidentGroupOpenPeriod(DefaultFieldsModel):
         # is enabled for an organization in the middle of an active incident. See if such
         # an incident exists, and associate it with the open period if so.
         open_incident = (
-            Incident.objects.filter(alert_rule__id=alert_rule.id, date_ended=None)
+            Incident.objects.filter(alert_rule__id=alert_rule.id, date_closed=None)
             .order_by("-date_started")
             .first()
         )
@@ -292,14 +292,13 @@ def update_incident_based_on_open_period_status_change(
         # check if single processing was turned on while there was an active incident
         alert_rule_id = AlertRuleDetector.objects.get(detector_id=detector_id).alert_rule_id
         open_incident = (
-            Incident.objects.filter(alert_rule__id=alert_rule_id, date_ended=None)
+            Incident.objects.filter(alert_rule__id=alert_rule_id, date_closed=None)
             .order_by("-date_started")
             .first()
         )
         if open_incident is not None:
-            IncidentGroupOpenPeriod.create_relationship(
-                incident=open_incident, open_period=open_period
-            )
+            incident = open_incident
+            IncidentGroupOpenPeriod.create_relationship(incident=incident, open_period=open_period)
         else:
             logger.exception(
                 "No IncidentGroupOpenPeriod relationship and no outstanding incident",

--- a/tests/sentry/issues/test_ingest_incident_integration.py
+++ b/tests/sentry/issues/test_ingest_incident_integration.py
@@ -227,3 +227,8 @@ class IncidentGroupOpenPeriodIntegrationTest(TestCase):
         assert item.incident_id == incident.id
         activity = IncidentActivity.objects.filter(incident_id=incident.id)
         assert len(activity) == 4  # detected, created, priority change, close
+
+        last_activity_entry = activity[3]
+        assert last_activity_entry.type == 2
+        assert last_activity_entry.previous_value == str(IncidentStatus.CRITICAL.value)
+        assert last_activity_entry.value == str(IncidentStatus.CLOSED.value)

--- a/tests/sentry/issues/test_ingest_incident_integration.py
+++ b/tests/sentry/issues/test_ingest_incident_integration.py
@@ -66,7 +66,7 @@ class IncidentGroupOpenPeriodIntegrationTest(TestCase):
                 "project_id": self.project.id,
                 "new_status": GroupStatus.RESOLVED,
                 "new_substatus": None,
-                "detector_id": None,
+                "detector_id": self.detector.id,
                 "activity_data": {"test": "test"},
             }
 
@@ -167,5 +167,63 @@ class IncidentGroupOpenPeriodIntegrationTest(TestCase):
         assert open_period.date_ended is not None
         item = IncidentGroupOpenPeriod.objects.get(group_open_period=open_period)
         incident = Incident.objects.get(id=item.incident_id)
+        activity = IncidentActivity.objects.filter(incident_id=incident.id)
+        assert len(activity) == 4  # detected, created, priority change, close
+
+    def test_can_update_outstanding_incident_priority(self) -> None:
+        """Test that we link and update an incident that was opened before the org started single processing"""
+        _, group_info = self.save_issue_occurrence()
+        group = group_info.group
+        assert group is not None
+
+        assert GroupOpenPeriod.objects.filter(group=group, project=self.project).exists()
+
+        open_period = GroupOpenPeriod.objects.get(group=group, project=self.project)
+
+        dummy_relationship = IncidentGroupOpenPeriod.objects.get(group_open_period=open_period)
+        incident = Incident.objects.get(id=dummy_relationship.incident_id)
+
+        # this is a little hacky, but to emulate dual processing -> single processing I will
+        # just delete the IGOP relationship
+        IncidentGroupOpenPeriod.objects.all().delete()
+
+        _, group_info = self.save_issue_occurrence(priority=DetectorPriorityLevel.MEDIUM)
+        group = group_info.group
+        assert group is not None
+
+        item = IncidentGroupOpenPeriod.objects.get(group_open_period=open_period)
+        assert item.incident_id == incident.id
+        activity = IncidentActivity.objects.filter(incident_id=incident.id)
+
+        assert len(activity) == 4
+        last_activity_entry = activity[3]
+        assert last_activity_entry.type == 2
+        assert last_activity_entry.value == str(IncidentStatus.WARNING.value)
+        assert last_activity_entry.previous_value == str(IncidentStatus.CRITICAL.value)
+
+    def test_can_resolve_outstanding_incident(self) -> None:
+        """Test that we link and update an incident that was opened before the org started single processing on resolution"""
+        _, group_info = self.save_issue_occurrence()
+        group = group_info.group
+        assert group is not None
+
+        assert GroupOpenPeriod.objects.filter(group=group, project=self.project).exists()
+
+        open_period = GroupOpenPeriod.objects.get(group=group, project=self.project)
+
+        dummy_relationship = IncidentGroupOpenPeriod.objects.get(group_open_period=open_period)
+        incident = Incident.objects.get(id=dummy_relationship.incident_id)
+
+        # this is a little hacky, but to emulate dual processing -> single processing I will
+        # just delete the IGOP relationship
+        IncidentGroupOpenPeriod.objects.all().delete()
+
+        with self.tasks():
+            update_status(group, self.mock_status_change_message)
+
+        open_period = GroupOpenPeriod.objects.get(group=group)
+        assert open_period.date_ended is not None
+        item = IncidentGroupOpenPeriod.objects.get(group_open_period=open_period)
+        assert item.incident_id == incident.id
         activity = IncidentActivity.objects.filter(incident_id=incident.id)
         assert len(activity) == 4  # detected, created, priority change, close

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -240,8 +240,13 @@ class TestProcessWorkflowActivity(TestCase):
         mock_filter_actions.assert_called_once_with({self.action_group}, expected_event_data)
 
     @with_feature("organizations:workflow-engine-single-process-metric-issues")
+    @mock.patch(
+        "sentry.workflow_engine.models.incident_groupopenperiod.update_incident_based_on_open_period_status_change"
+    )  # rollout code that is independently tested
     @mock.patch("sentry.workflow_engine.tasks.workflows.metrics.incr")
-    def test__e2e__issue_plat_to_processed(self, mock_incr: mock.MagicMock) -> None:
+    def test__e2e__issue_plat_to_processed(
+        self, mock_incr: mock.MagicMock, mock_update_igop: mock.MagicMock
+    ) -> None:
         self.message = StatusChangeMessageData(
             id="test-id",
             fingerprint=["group-1"],
@@ -282,9 +287,15 @@ class TestProcessWorkflowActivity(TestCase):
     @with_feature("organizations:workflow-engine-single-process-metric-issues")
     @with_feature("organizations:workflow-engine-process-metric-issue-workflows")
     @mock.patch("sentry.issues.status_change_consumer.get_group_from_fingerprint")
+    @mock.patch(
+        "sentry.workflow_engine.models.incident_groupopenperiod.update_incident_based_on_open_period_status_change"
+    )  # rollout code that is independently tested
     @mock.patch("sentry.workflow_engine.tasks.workflows.metrics.incr")
     def test__e2e__issue_plat_to_processed_activity_data_is_set(
-        self, mock_incr: mock.MagicMock, mock_get_group_from_fingerprint: mock.MagicMock
+        self,
+        mock_incr: mock.MagicMock,
+        mock_update_igop: mock.MagicMock,
+        mock_get_group_from_fingerprint: mock.MagicMock,
     ) -> None:
         mock_get_group_from_fingerprint.return_value = self.group
 


### PR DESCRIPTION
Address the edge case where we turn on single processing while there is an active incident (this incident would not have an IGOP relationship).

If the issue's priority is being updated, then we will create the relationship and update the incident's priority in `create_from_occurrence()`. If the issue is being resolved, then we'll use the detector id from the status change message to fetch the relevant open incident, then create the relationship and close the incident.