### PR TITLE
perf(aci): Cache Group lookup for process_workflows/trigger_action

### DIFF
--- a/src/sentry/workflow_engine/tasks/utils.py
+++ b/src/sentry/workflow_engine/tasks/utils.py
@@ -82,8 +82,8 @@ def build_workflow_event_data_from_event(
         raise EventNotFoundError(event_id, project_id)
 
     occurrence = IssueOccurrence.fetch(occurrence_id, project_id) if occurrence_id else None
-    # TODO(iamrajjoshi): Should we use get_from_cache here?
-    group = Group.objects.get(id=group_id)
+
+    group = Group.objects.get_from_cache(id=group_id)
     group_event = GroupEvent.from_event(event, group)
     group_event.occurrence = occurrence
 


### PR DESCRIPTION
For process_workflows_event, querying for Group is one of the primary required queries.
It's frequently very fast (~1ms), but at times we've observed it taking 100ms or more. Perhaps more significantly, querying for Group by ID is the most common query the app does, and we're part of htat.
Given that this task runs after post_process, which does read Group through the cache, the Group we're processing should nearly always be in the cache, so here we expect a very high hit rate, a significant reduction in query volume to the database, and improvement in some of our wost case task latency.
