### PR TITLE
fix(profiling): Remove go from profiling platforms

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -399,7 +399,6 @@ export const profiling: PlatformKey[] = [
   'dotnet-winforms',
   'dotnet-wpf',
   'flutter',
-  'go',
   'javascript',
   'javascript-angular',
   'javascript-astro',

--- a/static/app/views/profiling/onboarding.tsx
+++ b/static/app/views/profiling/onboarding.tsx
@@ -274,16 +274,7 @@ export function Onboarding() {
               {project: project.slug}
             )}
           </p>
-          <LinkButton
-            size="sm"
-            href={
-              // TODO(aknaus): Go does not have profiling docs yet, so we redirect to the general profiling docs. Remove this once Go has docs.
-              currentPlatform.id === 'go'
-                ? 'https://docs.sentry.io/product/profiling/getting-started/'
-                : `${currentPlatform.link}/profiling/`
-            }
-            external
-          >
+          <LinkButton size="sm" href={`${currentPlatform.link}/profiling/`} external>
             {t('Go to Documentation')}
           </LinkButton>
         </DescriptionWrapper>


### PR DESCRIPTION
Remove `go` from profiling platforms as the profiling support got unshipped a while ago.

This change affects the in-product profiling onboarding.
Instead of linking to a generic docs page we now display that profiling is not available for Go.