### PR TITLE
chore(dynamic-sampling): add instrumentation for query durations in boost_low_volume_projects grouped by measure

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -411,10 +411,10 @@ def query_project_counts_by_org(
                 query=query.set_offset(offset),
                 tenant_ids={"use_case_id": UseCaseID.TRANSACTIONS.value, "cross_org_query": 1},
             )
-        data = raw_snql_query(
-            request,
-            referrer=Referrer.DYNAMIC_SAMPLING_DISTRIBUTION_FETCH_PROJECTS_WITH_COUNT_PER_ROOT.value,
-        )["data"]
+            data = raw_snql_query(
+                request,
+                referrer=Referrer.DYNAMIC_SAMPLING_DISTRIBUTION_FETCH_PROJECTS_WITH_COUNT_PER_ROOT.value,
+            )["data"]
 
         more_results = len(data) > CHUNK_SIZE
         offset += CHUNK_SIZE

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -403,7 +403,8 @@ def query_project_counts_by_org(
     more_results: bool = True
     while more_results:
         with metrics.timer(
-            "dynamic_sampling.query_project_counts_by_org.query_time", tags={"measure": measure}
+            "dynamic_sampling.query_project_counts_by_org.query_time",
+            tags={"measure": str(measure.value)},
         ):
             request = Request(
                 dataset=Dataset.PerformanceMetrics.value,


### PR DESCRIPTION
- Add a timer to the query execution of the `query_project_counts_per_org` task to figure out if this is limited by the database or some logic in the application
- Add the `@dynamic_sampling_task` decorator to some of the tasks to figure out why we're slower with spans than transactions
Contributes to TET-1147