### PR TITLE
fix(agents-insights): model cost format

### DIFF
--- a/static/app/views/insights/agents/components/modelsTable.tsx
+++ b/static/app/views/insights/agents/components/modelsTable.tsx
@@ -144,7 +144,7 @@ export function ModelsTable() {
       requests: span['count()'] ?? 0,
       avg: span['avg(span.duration)'] ?? 0,
       p95: span['p95(span.duration)'] ?? 0,
-      cost: Number(span['sum(gen_ai.usage.total_cost)']),
+      cost: span['sum(gen_ai.usage.total_cost)'],
       errors: span['count_if(span.status,equals,unknown)'] ?? 0,
       inputTokens: Number(span['sum(gen_ai.usage.input_tokens)']),
       inputCachedTokens: Number(span['sum(gen_ai.usage.input_tokens.cached)']),

--- a/static/app/views/insights/agents/utils/formatLLMCosts.tsx
+++ b/static/app/views/insights/agents/utils/formatLLMCosts.tsx
@@ -1,6 +1,9 @@
 import {formatDollars} from 'sentry/utils/formatters';
 
-export function formatLLMCosts(cost: string | number) {
+export function formatLLMCosts(cost: string | number | null) {
+  if (cost === null) {
+    return '\u2014';
+  }
   let number = Number(cost);
   // TODO: remove this hotfix for bug on BE that results in costs sometimes being multiplied by 1000000
   if (number > 10000) {


### PR DESCRIPTION
closes [TET-1138: Show `-` cost when cost == 0 in Agent Monitoring / Models view](https://linear.app/getsentry/issue/TET-1138/show-cost-when-cost-==-0-in-agent-monitoring-models-view)