### PR TITLE
fix(dynamic-sampling): Replace new badge with alpha badge

### DIFF
--- a/static/app/views/settings/dynamicSampling/index.tsx
+++ b/static/app/views/settings/dynamicSampling/index.tsx
@@ -71,7 +71,7 @@ export default function DynamicSamplingSettings() {
         title={
           <Fragment>
             {t('Dynamic Sampling')}
-            <FeatureBadge type="new" />
+            <FeatureBadge type="alpha" />
           </Fragment>
         }
         action={

--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -130,7 +130,7 @@ export function getOrganizationNavigationConfiguration({
           path: `${organizationSettingsPathPrefix}/dynamic-sampling/`,
           title: t('Dynamic Sampling'),
           description: t('Manage your sampling rate'),
-          badge: () => 'new',
+          badge: () => 'alpha',
           show: ({organization}) =>
             !!organization && hasDynamicSamplingCustomFeature(organization),
         },


### PR DESCRIPTION
**Before**
<img width="1621" height="743" alt="image" src="https://github.com/user-attachments/assets/444bccf0-1378-4918-8608-bd185227021a" />


**After**
<img width="1933" height="954" alt="Screenshot 2025-09-15 at 14 03 58" src="https://github.com/user-attachments/assets/c6fd4112-9071-47fe-88b0-817d13037990" />

closes https://linear.app/getsentry/issue/TET-1088/dynamic-sampling-badge-mismatch-alphanew
