### PR TITLE
perf(deletions): Improve group hashes query

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -340,6 +340,13 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_REQUIRED,
 )
 
+# Deletions
+register(
+    "deletions.group-hashes-fetch-batch-size",
+    default=10000,
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Filestore (default)
 register("filestore.backend", default="filesystem", flags=FLAG_NOSTORE)
 register("filestore.options", default={"location": "/tmp/sentry-files"}, flags=FLAG_NOSTORE)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1145,7 +1145,7 @@ register(
     "embeddings-grouping.seer.delete-record-batch-size",
     type=Int,
     default=100,
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
 # Custom model costs mapping for AI Agent Monitoring. Used to map alternative model ids to existing model ids.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -344,7 +344,7 @@ register(
 register(
     "deletions.group-hashes-fetch-batch-size",
     default=10000,
-    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
 # Filestore (default)


### PR DESCRIPTION
This is a follow-up to #98904 

Changes included:
* This brings back the `RangeQuerySetWrapper` for chunking the hashes
* It bumps the batch size to fetch hashes from 100 to 10,000
* It uses `group_id=id` vs `group_id__in=[group_ids]`

This could potentially fix multiple operational errors which are preventing completing many issues including the deletion of projects ([link](https://sentry.sentry.io/issues/?&project=1&query=is%3Aunresolved%20error.type%3AOperationalError%20sentry_grouphash&referrer=issue-list&sort=freq&statsPeriod=24h)). This is because we wrote the code in such a way that it would allow moving further even if we could not delete group hashes (since I assume it could be deleted later on). Unfortunately, when we try to delete the group, project or organization later on the cascading deletion of the org, project or group will fail. Notice this error preventing the deletion of a project:
> canceling statement due to user request SQL: SELECT "sentry_grouphash"."id" FROM "sentry_grouphash" WHERE "sentry_grouphash"."project_id" IN (%s)

<img width="1184" height="559" alt="image" src="https://github.com/user-attachments/assets/7e3f2a23-666f-4ff4-a824-5c953d63529d" />

Fixes [SENTRY-4A7J](https://sentry.sentry.io/issues/6784856737/)