### PR TITLE
feat: Auto-select platform if search matches 100%

### DIFF
--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -159,13 +159,18 @@ function PlatformPicker({
     });
   }, [filter, category, availablePlatforms, showOther, categories]);
 
-  const latestValuesRef = useRef({filter, platformList, source, organization});
+  const latestValuesRef = useRef({
+    filter,
+    platformList,
+    source,
+    organization,
+  });
 
   useEffect(() => {
     latestValuesRef.current = {filter, platformList, source, organization};
   });
 
-  const debounceLogSearch = useRef(
+  const debounceSearch = useRef(
     debounce(() => {
       const {
         filter: currentFilter,
@@ -173,14 +178,30 @@ function PlatformPicker({
         source: currentSource,
         organization: currentOrganization,
       } = latestValuesRef.current;
-      if (currentFilter) {
-        trackAnalytics('growth.platformpicker_search', {
-          search: currentFilter.toLowerCase(),
-          num_results: currentPlatformList.length,
-          source: currentSource,
-          organization: currentOrganization ?? null,
-        });
+
+      if (!currentFilter) {
+        return;
       }
+      trackAnalytics('growth.platformpicker_search', {
+        search: currentFilter.toLowerCase(),
+        num_results: currentPlatformList.length,
+        source: currentSource,
+        organization: currentOrganization ?? null,
+      });
+
+      if (!visibleSelection) {
+        return;
+      }
+
+      const fullPlatformMatch = currentPlatformList.find(
+        platformItem => platformItem.name.toLowerCase() === currentFilter.toLowerCase()
+      );
+
+      if (!fullPlatformMatch) {
+        return;
+      }
+
+      setPlatform({...fullPlatformMatch, category});
     }, DEFAULT_DEBOUNCE_DURATION)
   ).current;
 
@@ -214,7 +235,7 @@ function PlatformPicker({
             placeholder={t('Filter Platforms')}
             onChange={val => {
               setFilter(val);
-              debounceLogSearch();
+              debounceSearch();
             }}
           />
         )}

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -164,10 +164,11 @@ function PlatformPicker({
     platformList,
     source,
     organization,
+    category,
   });
 
   useEffect(() => {
-    latestValuesRef.current = {filter, platformList, source, organization};
+    latestValuesRef.current = {filter, platformList, source, organization, category};
   });
 
   const debounceSearch = useRef(
@@ -177,6 +178,7 @@ function PlatformPicker({
         platformList: currentPlatformList,
         source: currentSource,
         organization: currentOrganization,
+        category: currentCategory,
       } = latestValuesRef.current;
 
       if (!currentFilter) {
@@ -201,7 +203,7 @@ function PlatformPicker({
         return;
       }
 
-      setPlatform({...fullPlatformMatch, category});
+      setPlatform({...fullPlatformMatch, category: currentCategory});
     }, DEFAULT_DEBOUNCE_DURATION)
   ).current;
 


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/TET-1137/select-platform-if-string-is-100percent-match

**Preview**

https://github.com/user-attachments/assets/8379c255-1621-4e16-9227-57a3f53171f0



**Notes**

- When mimicking the Python search example in the main onboarding, it feels nice to have the platform highlighted - even if it isn’t explicitly selected. That said, I’m not sure if this might confuse users, since the highlight often implies the platform is already chosen. Just my two cents - what’s your opinion? If we all agree, I can implement that in a follow-up

- Currently, we’re using a hack in the project creation with key={category}  in the <PlatformPicker / > as a prop ([see](https://github.com/getsentry/sentry/blob/06d028f636e3b9d163a013cbb665e47b94b9452a/static/app/views/projectInstall/createProject.tsx#L505)), so that when navigating back in the flow, the correct category is re-selected. With the new changes, however, there’s a bug: for example, if I type python → the platform gets selected → the category is updated, sometimes the search gets completely wiped out. Since we have a lot of little issues with the categories, I am wondering if we should persist it in the URL. In this current implementation no category is updated based on a 100% matched search 