### PR TITLE
ref: Remove todo comment from deprecated field

### DIFF
--- a/static/app/components/deprecatedforms/inputField.tsx
+++ b/static/app/components/deprecatedforms/inputField.tsx
@@ -27,7 +27,7 @@ abstract class InputField<
   getField() {
     return (
       <Input
-        id={this.getId()} // TODO(Priscila): check the reason behind this. We are getting warnings if we have 2 or more fields with the same name, for instance in the DATA PRIVACY RULES
+        id={this.getId()}
         type={this.getType()}
         className="form-control"
         autoComplete={this.props.autoComplete}


### PR DESCRIPTION
The component is deprecated anyway...removing just because 