### PR TITLE
feat: Add taskbroker mode that doesn't start workers

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -164,7 +164,8 @@ x-sentry-service-config:
     chartcuterie: [postgres, snuba, chartcuterie, spotlight]
     launchpad: [snuba, postgres, relay, spotlight, launchpad]
     objectstore: [snuba, postgres, relay, spotlight, objectstore]
-    taskbroker:
+    taskbroker: [snuba, postgres, relay, spotlight, taskbroker]
+    taskworker:
       [snuba, postgres, relay, taskbroker, spotlight, taskworker, taskworker-scheduler]
     backend-ci: [snuba, postgres, redis, bigtable, redis-cluster, symbolicator]
     rabbitmq: [postgres, snuba, rabbitmq, spotlight]


### PR DESCRIPTION
Folks often want to use `devserver --workers` and this mode makes that workflow more ergonomic.