### PR TITLE
perf(deletions): Optimize group hash deletions

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -118,6 +118,8 @@ def delete_group_hashes(
             :hashes_batch_size
         ]
         hashes_chunk = list(qs)
+        if not hashes_chunk:
+            return
         try:
             if seer_deletion:
                 # Tell seer to delete grouping records for these groups

--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -112,9 +112,11 @@ def delete_group_hashes(
     group_ids: Sequence[int],
 ) -> None:
     hashes_batch_size = options.get("deletions.group-hashes-batch-size")
+    total_hashes = GroupHash.objects.filter(group_id__in=group_ids).count()
 
-    qs = GroupHash.objects.filter(group_id__in=group_ids).iterator(chunk_size=hashes_batch_size)
-    for hashes_chunk in qs:
+    for i in range(0, total_hashes, hashes_batch_size):
+        qs = GroupHash.objects.filter(group_id__in=group_ids)[i : i + hashes_batch_size]
+        hashes_chunk = list(qs)
         try:
             # Tell seer to delete grouping records for these groups
             # It's low priority to delete the hashes from seer, so we don't want

--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -113,10 +113,12 @@ def delete_group_hashes(
     hashes_batch_size = options.get("deletions.group-hashes-batch-size")
     total_hashes = GroupHash.objects.filter(project_id=project_id, group_id__in=group_ids).count()
 
-    for _ in range(0, total_hashes, hashes_batch_size):
-        qs = GroupHash.objects.filter(project_id=project_id, group_id__in=group_ids)[
-            :hashes_batch_size
-        ]
+    # We multiply by 1.1 to account for the fact that we may have deleted some hashes
+    # since we started the query
+    for _ in range(0, total_hashes * 1.1, hashes_batch_size):
+        qs = GroupHash.objects.filter(project_id=project_id, group_id__in=group_ids).values_list(
+            "id", "hash"
+        )[:hashes_batch_size]
         hashes_chunk = list(qs)
         if not hashes_chunk:
             return

--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -111,8 +111,11 @@ def delete_group_hashes(
     seer_deletion: bool = False,
 ) -> None:
     hashes_batch_size = options.get("deletions.group-hashes-batch-size")
+    total_hashes = GroupHash.objects.filter(project_id=project_id, group_id__in=group_ids).count()
 
-    while True:
+    # We multiply by 1.1 to account for the fact that we may have deleted some hashes
+    # since we started the query
+    for _ in range(0, int(total_hashes * 1.1), hashes_batch_size):
         qs = GroupHash.objects.filter(project_id=project_id, group_id__in=group_ids).values_list(
             "id", "hash"
         )[:hashes_batch_size]

--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -113,9 +113,9 @@ def delete_group_hashes(
     hashes_batch_size = options.get("deletions.group-hashes-batch-size")
     total_hashes = GroupHash.objects.filter(project_id=project_id, group_id__in=group_ids).count()
 
-    for i in range(0, total_hashes, hashes_batch_size):
+    for _ in range(0, total_hashes, hashes_batch_size):
         qs = GroupHash.objects.filter(project_id=project_id, group_id__in=group_ids)[
-            i : i + hashes_batch_size
+            :hashes_batch_size
         ]
         hashes_chunk = list(qs)
         try:

--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -127,6 +127,8 @@ def delete_group_hashes(
         # any network errors to block the deletion of the groups
         hash_values = [gh.hash for gh in group_hashes]
         may_schedule_task_to_delete_hashes_from_seer(project_id, hash_values)
+    except Exception:
+        delete_logger.warning("Error scheduling task to delete hashes from seer")
     finally:
         # IDs are part of the index, so we can use them to delete in batches
         hash_ids = [gh.id for gh in group_hashes]

--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -111,10 +111,12 @@ def delete_group_hashes(
     seer_deletion: bool = False,
 ) -> None:
     hashes_batch_size = options.get("deletions.group-hashes-batch-size")
-    total_hashes = GroupHash.objects.filter(group_id__in=group_ids).count()
+    total_hashes = GroupHash.objects.filter(project_id=project_id, group_id__in=group_ids).count()
 
     for i in range(0, total_hashes, hashes_batch_size):
-        qs = GroupHash.objects.filter(group_id__in=group_ids)[i : i + hashes_batch_size]
+        qs = GroupHash.objects.filter(project_id=project_id, group_id__in=group_ids)[
+            i : i + hashes_batch_size
+        ]
         hashes_chunk = list(qs)
         try:
             if seer_deletion:

--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -78,8 +78,8 @@ def delete_group_list(
 
     # Removing GroupHash rows prevents new events from associating to the groups
     # we just deleted.
-    delete_group_hashes(project.id, error_ids)
-    delete_group_hashes(project.id, non_error_ids, seer_deletion=True)
+    delete_group_hashes(project.id, error_ids, seer_deletion=True)
+    delete_group_hashes(project.id, non_error_ids)
 
     Group.objects.filter(id__in=group_ids).exclude(
         status__in=[GroupStatus.PENDING_DELETION, GroupStatus.DELETION_IN_PROGRESS]

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -174,6 +174,7 @@ class GroupDeletionTask(ModelDeletionTask[Group]):
             except InvalidGroupTypeError:
                 pass
 
+        # Avoid circular import
         from sentry.api.helpers.group_index.delete import delete_group_hashes
 
         delete_group_hashes(instance_list[0].project_id, error_group_ids)

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -16,7 +16,6 @@ from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.notifications.models.notificationmessage import NotificationMessage
 from sentry.services.eventstore.models import Event
 from sentry.snuba.dataset import Dataset
-from sentry.tasks.delete_seer_grouping_records import may_schedule_task_to_delete_hashes_from_seer
 
 from ..base import BaseDeletionTask, BaseRelation, ModelDeletionTask, ModelRelation
 from ..manager import DeletionTaskManager
@@ -174,8 +173,10 @@ class GroupDeletionTask(ModelDeletionTask[Group]):
                     error_group_ids.append(group.id)
             except InvalidGroupTypeError:
                 pass
-        # Tell seer to delete grouping records with these group hashes
-        may_schedule_task_to_delete_hashes_from_seer(error_group_ids)
+
+        from sentry.api.helpers.group_index.delete import delete_group_hashes
+
+        delete_group_hashes(instance_list[0].project_id, error_group_ids)
 
         self._delete_children(instance_list)
 

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -177,7 +177,7 @@ class GroupDeletionTask(ModelDeletionTask[Group]):
         # Avoid circular import
         from sentry.api.helpers.group_index.delete import delete_group_hashes
 
-        delete_group_hashes(instance_list[0].project_id, error_group_ids)
+        delete_group_hashes(instance_list[0].project_id, error_group_ids, seer_deletion=True)
 
         self._delete_children(instance_list)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -342,7 +342,7 @@ register(
 
 # Deletions
 register(
-    "deletions.group-hashes-fetch-batch-size",
+    "deletions.group-hashes-batch-size",
     default=10000,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )


### PR DESCRIPTION
This is a follow-up to #99469 and #98904.

This approach creates a loop to fetch & delete N hashes one iteration a time, thus, always making progress without needing an extra compound index (which is required by `RangeQuerySetWrapper`).

Note: we're trying to avoid adding yet another index.