### PR TITLE
fix(js): Directly access process.env.NODE_ENV

### DIFF
--- a/static/app/components/frontendVersionContext.spec.tsx
+++ b/static/app/components/frontendVersionContext.spec.tsx
@@ -5,13 +5,12 @@ import ConfigStore from 'sentry/stores/configStore';
 
 import {FrontendVersionProvider, useFrontendVersion} from './frontendVersionContext';
 
-// Mock constants to control test environment, the FrontendVersionProvider ony
-// does anything in production SAAS.
 jest.mock('sentry/constants', () => ({
   __esModule: true,
   DEPLOY_PREVIEW_CONFIG: undefined,
-  NODE_ENV: 'production',
 }));
+
+const originalNodeEnv = process.env.NODE_ENV;
 
 function TestComponent() {
   const {state, deployedVersion, runningVersion} = useFrontendVersion();
@@ -29,10 +28,12 @@ describe('FrontendVersionProvider', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     ConfigStore.set('sentryMode', 'SAAS');
+    process.env.NODE_ENV = 'production';
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
+    process.env.NODE_ENV = originalNodeEnv;
   });
 
   it('provides state="current" when server version matches current version', async () => {
@@ -133,7 +134,7 @@ describe('FrontendVersionProvider', () => {
   });
 
   it('provides state="disabled" when NODE_ENV is not production', async () => {
-    jest.mocked(constants).NODE_ENV = 'development';
+    process.env.NODE_ENV = 'development';
 
     MockApiClient.addMockResponse({
       url: '/internal/frontend-version/',

--- a/static/app/components/frontendVersionContext.tsx
+++ b/static/app/components/frontendVersionContext.tsx
@@ -1,6 +1,6 @@
 import {createContext, useContext} from 'react';
 
-import {DEPLOY_PREVIEW_CONFIG, NODE_ENV} from 'sentry/constants';
+import {DEPLOY_PREVIEW_CONFIG} from 'sentry/constants';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -78,7 +78,7 @@ export function FrontendVersionProvider({children, force, releaseVersion}: Props
     //
     // We only make stale version assessments when the frontend is running a
     // production build.
-    NODE_ENV === 'production' &&
+    process.env.NODE_ENV === 'production' &&
     //
     // We do not make stale version assessments when running deployment
     // previews, these are inherinetly a differning version from what is


### PR DESCRIPTION
For some unknown reason importing from the constants file is causing
this to come back as a object of the module's exports