### PR TITLE
feat(insights): Adds web vitals seer suggestion issues to web vital meters

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/webVitalMetersWithIssues.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMetersWithIssues.spec.tsx
@@ -52,7 +52,42 @@ describe('WebVitalMetersWithIssues', () => {
       expect.objectContaining({
         query: expect.objectContaining({
           query:
-            'is:unresolved issue.type:[performance_render_blocking_asset_span,performance_uncompressed_assets,performance_http_overhead,performance_consecutive_http,performance_n_plus_one_api_calls,performance_large_http_payload,performance_p95_endpoint_regression]',
+            'is:unresolved issue.type:[web_vitals,performance_render_blocking_asset_span,performance_uncompressed_assets,performance_http_overhead,performance_consecutive_http,performance_n_plus_one_api_calls,performance_large_http_payload,performance_p95_endpoint_regression] !web_vital:[fcp,inp,cls,ttfb]',
+        }),
+      })
+    );
+    expect(issuesMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/issues/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query:
+            'is:unresolved issue.type:[web_vitals,performance_render_blocking_asset_span,performance_uncompressed_assets,performance_http_overhead,performance_consecutive_http,performance_n_plus_one_api_calls,performance_large_http_payload,performance_p95_endpoint_regression] !web_vital:[lcp,inp,cls,ttfb]',
+        }),
+      })
+    );
+    expect(issuesMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/issues/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query:
+            'is:unresolved issue.type:[web_vitals,performance_http_overhead,performance_consecutive_http,performance_n_plus_one_api_calls,performance_large_http_payload,performance_p95_endpoint_regression] !web_vital:[lcp,fcp,cls,ttfb]',
+        }),
+      })
+    );
+    expect(issuesMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/issues/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: 'is:unresolved issue.type:[web_vitals] !web_vital:[lcp,fcp,inp,ttfb]',
+        }),
+      })
+    );
+    expect(issuesMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/issues/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query:
+            'is:unresolved issue.type:[web_vitals,performance_http_overhead] !web_vital:[lcp,fcp,inp,cls]',
         }),
       })
     );

--- a/static/app/views/insights/browser/webVitals/components/webVitalMetersWithIssues.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMetersWithIssues.tsx
@@ -126,7 +126,7 @@ function VitalMeter({
 
   const headerText = WEB_VITALS_METERS_CONFIG[webVital].name;
   const issueTypes = WEB_VITAL_PERFORMANCE_ISSUES[webVital];
-  const {data: issues} = useWebVitalsIssuesQuery({issueTypes});
+  const {data: issues} = useWebVitalsIssuesQuery({issueTypes, webVital});
   const hasIssues = issues && issues.length > 0;
   const meterBody = (
     <Fragment>
@@ -247,6 +247,7 @@ const getIssuesUrl = ({
 }) => {
   const query = getIssueQueryFilter({
     issueTypes: WEB_VITAL_PERFORMANCE_ISSUES[webVital],
+    webVital,
   });
   return `/organizations/${organization.slug}/issues/?${qs.stringify({
     query,

--- a/static/app/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery.tsx
@@ -2,10 +2,12 @@ import {useCallback} from 'react';
 
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {IssueType, type Group, type ISSUE_TYPE_TO_ISSUE_TITLE} from 'sentry/types/group';
-import {defined} from 'sentry/utils';
 import {useApiQuery, useQueryClient, type ApiQueryKey} from 'sentry/utils/queryClient';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {ORDER} from 'sentry/views/insights/browser/webVitals/components/charts/performanceScoreChart';
+import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
 
 export const POLL_INTERVAL = 1000;
 
@@ -14,17 +16,33 @@ const DEFAULT_ISSUE_TYPES = [IssueType.WEB_VITALS];
 type QueryProps = {
   issueTypes?: Array<keyof typeof ISSUE_TYPE_TO_ISSUE_TITLE>;
   transaction?: string;
+  webVital?: WebVitals;
 };
 
 export function getIssueQueryFilter({
   issueTypes = DEFAULT_ISSUE_TYPES,
+  webVital,
   transaction,
 }: QueryProps) {
-  return `is:unresolved issue.type:[${issueTypes?.join(',')}]${defined(transaction) ? ` transaction:${transaction}` : ''}`;
+  const mutableSearch = MutableSearch.fromQueryObject({
+    is: 'unresolved',
+    'issue.type': `[${issueTypes.join(',')}]`,
+  });
+  if (transaction) {
+    mutableSearch.addFilterValue('transaction', transaction);
+  }
+  if (webVital) {
+    mutableSearch.addFilterValue(
+      '!web_vital',
+      `[${ORDER.filter(v => v !== webVital).join(',')}]`
+    );
+  }
+  return mutableSearch.formatString();
 }
 
 function useWebVitalsIssuesQueryKey({
   issueTypes = DEFAULT_ISSUE_TYPES,
+  webVital,
   transaction,
 }: QueryProps): ApiQueryKey {
   const organization = useOrganization();
@@ -33,7 +51,7 @@ function useWebVitalsIssuesQueryKey({
     `/organizations/${organization.slug}/issues/`,
     {
       query: {
-        query: getIssueQueryFilter({issueTypes, transaction}),
+        query: getIssueQueryFilter({issueTypes, transaction, webVital}),
         project: selection.projects,
         environment: selection.environments,
         ...normalizeDateTimeParams(selection.datetime),
@@ -45,10 +63,11 @@ function useWebVitalsIssuesQueryKey({
 
 export function useInvalidateWebVitalsIssuesQuery({
   issueTypes = DEFAULT_ISSUE_TYPES,
+  webVital,
   transaction,
 }: QueryProps) {
   const queryClient = useQueryClient();
-  const queryKey = useWebVitalsIssuesQueryKey({issueTypes, transaction});
+  const queryKey = useWebVitalsIssuesQueryKey({issueTypes, transaction, webVital});
   return useCallback(() => {
     queryClient.setQueryData(queryKey, undefined);
     queryClient.invalidateQueries({queryKey});
@@ -57,6 +76,7 @@ export function useInvalidateWebVitalsIssuesQuery({
 
 export function useWebVitalsIssuesQuery({
   issueTypes = DEFAULT_ISSUE_TYPES,
+  webVital,
   transaction,
   enabled = true,
   pollInterval,
@@ -66,18 +86,21 @@ export function useWebVitalsIssuesQuery({
   eventIds?: string[];
   pollInterval?: number;
 }) {
-  return useApiQuery<Group[]>(useWebVitalsIssuesQueryKey({issueTypes, transaction}), {
-    staleTime: 0,
-    enabled: Boolean(issueTypes?.length) && enabled,
-    refetchInterval: query => {
-      // Poll until the number of issues in the results array matches the number of expected eventIds.
-      if (!pollInterval || !eventIds) {
-        return false;
-      }
-      const result = query.state.data?.[0];
-      return result && Array.isArray(result) && result.length < eventIds.length
-        ? pollInterval
-        : false;
-    },
-  });
+  return useApiQuery<Group[]>(
+    useWebVitalsIssuesQueryKey({issueTypes, transaction, webVital}),
+    {
+      staleTime: 0,
+      enabled: Boolean(issueTypes?.length) && enabled,
+      refetchInterval: query => {
+        // Poll until the number of issues in the results array matches the number of expected eventIds.
+        if (!pollInterval || !eventIds) {
+          return false;
+        }
+        const result = query.state.data?.[0];
+        return result && Array.isArray(result) && result.length < eventIds.length
+          ? pollInterval
+          : false;
+      },
+    }
+  );
 }

--- a/static/app/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery.tsx
@@ -31,6 +31,9 @@ export function getIssueQueryFilter({
   if (transaction) {
     mutableSearch.addFilterValue('transaction', transaction);
   }
+  // For issue.type:web_vitals, we also want to filter for a specific web_vital tag.
+  // However, the issues api doesn't support OR conditions, so we can't apply a filter to the web_vital tag without it affecting all other filter conditions.
+  // To get around this, we instead filter out all other web_vital tags except the one we want to filter for.
   if (webVital) {
     mutableSearch.addFilterValue(
       '!web_vital',

--- a/static/app/views/insights/browser/webVitals/types.tsx
+++ b/static/app/views/insights/browser/webVitals/types.tsx
@@ -144,6 +144,7 @@ export const WEB_VITAL_PERFORMANCE_ISSUES: Record<
   Array<keyof typeof ISSUE_TYPE_TO_ISSUE_TITLE>
 > = {
   lcp: [
+    'web_vitals',
     'performance_render_blocking_asset_span',
     'performance_uncompressed_assets',
     'performance_http_overhead',
@@ -153,6 +154,7 @@ export const WEB_VITAL_PERFORMANCE_ISSUES: Record<
     'performance_p95_endpoint_regression',
   ],
   fcp: [
+    'web_vitals',
     'performance_render_blocking_asset_span',
     'performance_uncompressed_assets',
     'performance_http_overhead',
@@ -162,12 +164,13 @@ export const WEB_VITAL_PERFORMANCE_ISSUES: Record<
     'performance_p95_endpoint_regression',
   ],
   inp: [
+    'web_vitals',
     'performance_http_overhead',
     'performance_consecutive_http',
     'performance_n_plus_one_api_calls',
     'performance_large_http_payload',
     'performance_p95_endpoint_regression',
   ],
-  cls: [],
-  ttfb: ['performance_http_overhead'],
+  cls: ['web_vitals'],
+  ttfb: ['web_vitals', 'performance_http_overhead'],
 } as const;


### PR DESCRIPTION
Updates Web Vital meters to also query and link to Seer/Autofix Suggestion issues:
<img width="360" height="189" alt="image" src="https://github.com/user-attachments/assets/a1104edf-49af-4724-b3ff-c23e2f931179" />
