### PR TITLE
perf(aci): Avoid unnecessary organization db load

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -225,9 +225,10 @@ def evaluate_workflow_triggers(
         else:
             if evaluation:
                 triggered_workflows.add(workflow)
+                organization = event_data.group.project.organization
                 if features.has(
                     "organizations:workflow-engine-metric-alert-dual-processing-logs",
-                    workflow.organization,
+                    organization,
                 ):
                     try:
                         detector_workflow = DetectorWorkflow.objects.get(workflow_id=workflow.id)
@@ -236,7 +237,7 @@ def evaluate_workflow_triggers(
                             extra={
                                 "workflow_id": workflow.id,
                                 "detector_id": detector_workflow.detector_id,
-                                "organization_id": workflow.organization.id,
+                                "organization_id": organization.id,
                                 "project_id": event_data.group.project.id,
                                 "group_type": event_data.group.type,
                             },

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -352,7 +352,7 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             self.detector,
             self.detector_workflow,
             self.workflow_triggers,
-        ) = self.create_detector_and_workflow()
+        ) = self.create_detector_and_workflow(organization=self.organization)
 
         occurrence = self.build_occurrence(evidence_data={"detector_id": self.detector.id})
         self.group, self.event, self.group_event = self.create_group_event(


### PR DESCRIPTION
Loading workflow.organization is convenient, but requires a db query in most current cases. We could annotate workflow to avoid it, but it's better practice to use fields from WorkflowEventData, which should basically never require a query once populated.
