### PR TITLE
ref(issues): use `RateLimitConfig` instead of deprecated dict

### DIFF
--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -40,6 +40,7 @@ from sentry.models.groupsubscription import GroupSubscriptionManager
 from sentry.models.team import Team
 from sentry.models.userreport import UserReport
 from sentry.plugins.base import plugins
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.sentry_apps.api.serializers.platform_external_issue import (
     PlatformExternalIssueSerializer,
 )
@@ -66,23 +67,25 @@ class GroupDetailsEndpoint(GroupEndpoint):
         "PUT": ApiPublishStatus.PRIVATE,
     }
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=5, window=1),
-            RateLimitCategory.USER: RateLimit(limit=5, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
-        },
-        "PUT": {
-            RateLimitCategory.IP: RateLimit(limit=5, window=1),
-            RateLimitCategory.USER: RateLimit(limit=5, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
-        },
-        "DELETE": {
-            RateLimitCategory.IP: RateLimit(limit=5, window=5),
-            RateLimitCategory.USER: RateLimit(limit=5, window=5),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=5),
-        },
-    }
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=5, window=1),
+                RateLimitCategory.USER: RateLimit(limit=5, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
+            },
+            "PUT": {
+                RateLimitCategory.IP: RateLimit(limit=5, window=1),
+                RateLimitCategory.USER: RateLimit(limit=5, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
+            },
+            "DELETE": {
+                RateLimitCategory.IP: RateLimit(limit=5, window=5),
+                RateLimitCategory.USER: RateLimit(limit=5, window=5),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=5),
+            },
+        }
+    )
 
     def _get_seen_by(self, request: Request, group: Group) -> list[dict[str, Any]]:
         seen_by = list(GroupSeen.objects.filter(group=group).order_by("-last_seen"))

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -36,6 +36,7 @@ from sentry.issues.endpoints.project_event_details import (
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.environment import Environment
 from sentry.models.group import Group
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.search.events.filter import (
     FilterConvertParams,
     convert_search_filter_to_snuba_query,
@@ -122,13 +123,15 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
     }
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=15, window=1),
-            RateLimitCategory.USER: RateLimit(limit=15, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=15, window=1),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=15, window=1),
+                RateLimitCategory.USER: RateLimit(limit=15, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=15, window=1),
+            }
         }
-    }
+    )
 
     @extend_schema(
         operation_id="Retrieve an Issue Event",

--- a/src/sentry/issues/endpoints/group_first_last_release.py
+++ b/src/sentry/issues/endpoints/group_first_last_release.py
@@ -5,6 +5,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.helpers.group_index import get_first_last_release
 from sentry.issues.endpoints.bases.group import GroupEndpoint
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -14,13 +15,15 @@ class GroupFirstLastReleaseEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=5, window=1),
-            RateLimitCategory.USER: RateLimit(limit=5, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=5, window=1),
+                RateLimitCategory.USER: RateLimit(limit=5, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
+            }
         }
-    }
+    )
 
     def get(self, request: Request, group) -> Response:
         """Get the first and last release for a group.

--- a/src/sentry/issues/endpoints/group_tagkey_details.py
+++ b/src/sentry/issues/endpoints/group_tagkey_details.py
@@ -20,6 +20,7 @@ from sentry.apidocs.parameters import GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.environment import Environment
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.tagstore.types import TagKeySerializer, TagKeySerializerResponse
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -33,13 +34,15 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint):
     owner = ApiOwner.ISSUES
 
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
-            RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1, concurrent_limit=5),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
+                RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1, concurrent_limit=5),
+            }
         }
-    }
+    )
 
     @extend_schema(
         operation_id="Retrieve Tag Details",

--- a/src/sentry/issues/endpoints/group_tagkey_values.py
+++ b/src/sentry/issues/endpoints/group_tagkey_values.py
@@ -21,6 +21,7 @@ from sentry.apidocs.examples.tags_examples import TagsExamples
 from sentry.apidocs.parameters import GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.issues.endpoints.bases.group import GroupEndpoint
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.tagstore.types import TagValueSerializerResponse
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -34,13 +35,15 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
     owner = ApiOwner.ISSUES
 
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=75, window=60, concurrent_limit=5),
-            RateLimitCategory.USER: RateLimit(limit=150, window=60, concurrent_limit=10),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=300, window=60, concurrent_limit=5),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=75, window=60, concurrent_limit=5),
+                RateLimitCategory.USER: RateLimit(limit=150, window=60, concurrent_limit=10),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=300, window=60, concurrent_limit=5),
+            }
         }
-    }
+    )
 
     @extend_schema(
         operation_id="List a Tag's Values for an Issue",

--- a/src/sentry/issues/endpoints/group_tags.py
+++ b/src/sentry/issues/endpoints/group_tags.py
@@ -12,6 +12,7 @@ from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.mobile import get_readable_device_name
 from sentry.api.serializers import serialize
 from sentry.issues.endpoints.bases.group import GroupEndpoint
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.search.utils import DEVICE_CLASS
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -26,13 +27,15 @@ class GroupTagsEndpoint(GroupEndpoint):
     }
 
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
-            RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1, concurrent_limit=5),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
+                RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1, concurrent_limit=5),
+            }
         }
-    }
+    )
 
     def get(self, request: Request, group: Group) -> Response:
 

--- a/src/sentry/issues/endpoints/organization_eventid.py
+++ b/src/sentry/issues/endpoints/organization_eventid.py
@@ -17,6 +17,7 @@ from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.services import eventstore
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.validators import INVALID_ID_DETAILS, is_event_id
@@ -38,13 +39,15 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
     }
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=1, window=1),
-            RateLimitCategory.USER: RateLimit(limit=1, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=1, window=1),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=1, window=1),
+                RateLimitCategory.USER: RateLimit(limit=1, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=1, window=1),
+            }
         }
-    }
+    )
 
     @extend_schema(
         operation_id="Resolve an Event ID",

--- a/src/sentry/issues/endpoints/organization_group_index_stats.py
+++ b/src/sentry/issues/endpoints/organization_group_index_stats.py
@@ -15,6 +15,7 @@ from sentry.exceptions import InvalidParams
 from sentry.issues.endpoints.organization_group_index import ERR_INVALID_STATS_PERIOD
 from sentry.models.group import Group
 from sentry.models.organization import Organization
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -27,13 +28,15 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEndpoint):
     enforce_rate_limit = True
     owner = ApiOwner.ISSUES
 
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=10, window=1),
-            RateLimitCategory.USER: RateLimit(limit=10, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=1),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=10, window=1),
+                RateLimitCategory.USER: RateLimit(limit=10, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=1),
+            }
         }
-    }
+    )
 
     def get(self, request: Request, organization: Organization) -> Response:
         """

--- a/src/sentry/issues/endpoints/organization_issues_count.py
+++ b/src/sentry/issues/endpoints/organization_issues_count.py
@@ -15,6 +15,7 @@ from sentry.exceptions import InvalidParams
 from sentry.issues.issue_search import convert_query_values, parse_search_query
 from sentry.models.organization import Organization
 from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.snuba import discover
 from sentry.snuba.referrer import Referrer
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -32,13 +33,15 @@ class OrganizationIssuesCountEndpoint(OrganizationEndpoint):
     }
     owner = ApiOwner.ISSUES
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=10, window=1),
-            RateLimitCategory.USER: RateLimit(limit=10, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=1),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=10, window=1),
+                RateLimitCategory.USER: RateLimit(limit=10, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=1),
+            }
         }
-    }
+    )
 
     def _count(
         self, request: Request, query, organization, projects, environments, extra_query_kwargs=None

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -17,6 +17,7 @@ from sentry.api.serializers.models.event import IssueEventSerializerResponse
 from sentry.api.utils import get_date_range_from_params
 from sentry.exceptions import InvalidParams
 from sentry.models.project import Project
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -91,13 +92,15 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
 
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=5, window=1),
-            RateLimitCategory.USER: RateLimit(limit=5, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
-        },
-    }
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=5, window=1),
+                RateLimitCategory.USER: RateLimit(limit=5, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
+            },
+        }
+    )
 
     def get(self, request: Request, project: Project, event_id: str) -> Response:
         """

--- a/src/sentry/issues/endpoints/project_events.py
+++ b/src/sentry/issues/endpoints/project_events.py
@@ -18,6 +18,7 @@ from sentry.apidocs.parameters import CursorQueryParam, EventParams, GlobalParam
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.exceptions import InvalidParams
 from sentry.models.project import Project
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.services import eventstore
 from sentry.snuba.events import Columns
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -31,13 +32,15 @@ class ProjectEventsEndpoint(ProjectEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
     }
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=60, window=60, concurrent_limit=1),
-            RateLimitCategory.USER: RateLimit(limit=60, window=60, concurrent_limit=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=60, window=60, concurrent_limit=2),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=60, window=60, concurrent_limit=1),
+                RateLimitCategory.USER: RateLimit(limit=60, window=60, concurrent_limit=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=60, window=60, concurrent_limit=2),
+            }
         }
-    }
+    )
 
     @extend_schema(
         operation_id="List a Project's Error Events",

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -26,6 +26,7 @@ from sentry.models.environment import Environment
 from sentry.models.group import QUERY_STATUS_LOOKUP, Group, GroupStatus
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.search.events.constants import EQUALITY_OPERATORS
 from sentry.signals import advanced_search
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -47,13 +48,15 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
     permission_classes = (ProjectEventPermission,)
     enforce_rate_limit = True
 
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=5, window=1),
-            RateLimitCategory.USER: RateLimit(limit=5, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=5, window=1),
+                RateLimitCategory.USER: RateLimit(limit=5, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
+            }
         }
-    }
+    )
 
     @track_slo_response("workflow")
     def get(self, request: Request, project: Project) -> Response:

--- a/src/sentry/issues/endpoints/project_group_stats.py
+++ b/src/sentry/issues/endpoints/project_group_stats.py
@@ -11,6 +11,7 @@ from sentry.api.helpers.environments import get_environment_id
 from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.project import Project
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.tsdb.base import TSDBModel
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -22,13 +23,15 @@ class ProjectGroupStatsEndpoint(ProjectEndpoint, StatsMixin):
         "GET": ApiPublishStatus.PRIVATE,
     }
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=20, window=1),
-            RateLimitCategory.USER: RateLimit(limit=20, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=20, window=1),
+                RateLimitCategory.USER: RateLimit(limit=20, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1),
+            }
         }
-    }
+    )
 
     def get(self, request: Request, project: Project) -> Response:
         try:

--- a/src/sentry/issues/endpoints/related_issues.py
+++ b/src/sentry/issues/endpoints/related_issues.py
@@ -9,6 +9,7 @@ from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.related.same_root_cause import same_root_cause_analysis
 from sentry.issues.related.trace_connected import trace_connected_analysis
 from sentry.models.group import Group
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -23,13 +24,15 @@ class RelatedIssuesEndpoint(GroupEndpoint):
     owner = ApiOwner.ISSUES
     publish_status = {"GET": ApiPublishStatus.EXPERIMENTAL}
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=15, window=5),
-            RateLimitCategory.USER: RateLimit(limit=15, window=5),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=15, window=1),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=15, window=5),
+                RateLimitCategory.USER: RateLimit(limit=15, window=5),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=15, window=1),
+            }
         }
-    }
+    )
 
     # We get a Group object since the endpoint is /issues/{issue_id}/related-issues
     def get(self, request: Request, group: Group) -> Response:


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/99484, removing the deprecated rate limit config so we can move to only using `RateLimitConfig`.