### PR TITLE
ref(replay): add replay gen ai tooltip

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeer/askSeerOption.tsx
+++ b/static/app/components/searchQueryBuilder/askSeer/askSeerOption.tsx
@@ -65,7 +65,7 @@ export function AskSeerOption<T>({state}: {state: ComboBoxState<T>}) {
       <AskSeerLabel {...labelProps}>
         <Tooltip
           title={tct(
-            'The assistant requires Generative AI which is subject to our [dataProcessingPolicy:data processing policy].',
+            'The assistant requires Generative AI, which is subject to our [dataProcessingPolicy:data processing policy].',
             {
               dataProcessingPolicy: (
                 <ExternalLink

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -7,7 +7,6 @@ import replayEmptyState from 'sentry-images/spot/replays-empty-state.svg';
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {Badge} from 'sentry/components/core/badge';
 import {Button} from 'sentry/components/core/button';
-import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
 import {ExternalLink} from 'sentry/components/core/link';
 import {Text} from 'sentry/components/core/text';
@@ -60,7 +59,9 @@ export default function Ai() {
 
   // the org doesn't have the replay summaries ff, or
   // hideAiFeatures is true (settings "Show Generative AI Features" toggle is off), or
-  // org does not have the gen-ai-features ff
+  // org does not have the gen-ai-features ff.
+  // the tab should be hidden for all these cases, but the user can still access
+  // the tab content via the url.
   if (!organization.features.includes('replay-ai-summaries') || !areAiFeaturesAllowed) {
     return (
       <Wrapper data-test-id="replay-details-ai-summary-tab">

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -24,7 +24,6 @@ function getReplayTabs({
   isVideoReplay: boolean;
   organization: Organization;
 }): Record<TabKey, ReactNode> {
-  // For video replays, we hide the memory tab (not applicable for mobile)
   return {
     [TabKey.AI]:
       organization.features.includes('replay-ai-summaries') &&


### PR DESCRIPTION
- closes https://linear.app/getsentry/issue/REPLAY-705/improvement-qol-streamline-consent-flow-for-ai-replay-summaries
- seer access is implicitly given when user clicks on the summary tab, assuming the org has generative ai features enabled
- if no generative ai features are enabled for the org, the user will not see the summary tab.

previously, we were directing the user to settings if the seer acknowledgement was not acknowledged, which is an extra step that we don't want -- could be confusing since that page is also coupled with purchasing seer, but replay ai summaries is currently not a paid feature.

### new flow for an org with generative ai settings turned on:

https://github.com/user-attachments/assets/b0392963-8ba3-4c5f-afca-47f5b8da6239

### HIDE AI FEATURES is true (aka "show generative ai features" in settings is toggled off)

https://github.com/user-attachments/assets/e33637cf-44a7-4a92-9118-836623906039


