### PR TITLE
fix(mergedIssues): add title for captureMessage events in merged issues

### DIFF
--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -74,6 +74,8 @@ export function getMessage(
       return '';
     case EventOrGroupType.GENERIC:
       return metadata.value;
+    case EventOrGroupType.DEFAULT:
+      return metadata.title;
     default:
       return culprit || '';
   }

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -74,8 +74,6 @@ export function getMessage(
       return '';
     case EventOrGroupType.GENERIC:
       return metadata.value;
-    case EventOrGroupType.DEFAULT:
-      return metadata.title;
     default:
       return culprit || '';
   }

--- a/static/app/views/issueDetails/groupMerged/mergedItem.tsx
+++ b/static/app/views/issueDetails/groupMerged/mergedItem.tsx
@@ -6,7 +6,6 @@ import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Checkbox} from 'sentry/components/core/checkbox';
 import {Flex} from 'sentry/components/core/layout';
 import {Tooltip} from 'sentry/components/core/tooltip';
-import EventOrGroupTitle from 'sentry/components/eventOrGroupTitle';
 import {IconChevron, IconLink} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Fingerprint} from 'sentry/stores/groupingStore';
@@ -156,7 +155,7 @@ function MergedItem({fingerprint, totalFingerprint}: Props) {
                 style={{marginLeft: space(1)}}
               />
               <EventDetails>
-                <EventOrGroupTitle data={latestEvent} />
+                <Title data-issue-title-primary>{latestEvent.title}</Title>
               </EventDetails>
             </Flex>
           ) : null}
@@ -209,6 +208,11 @@ const EventDetails = styled('div')`
   display: flex;
   justify-content: space-between;
   padding: ${space(1)};
+`;
+
+const Title = styled('span')`
+  position: relative;
+  font-size: ${p => p.theme.fontSize.md};
 `;
 
 export default MergedItem;

--- a/static/app/views/issueDetails/groupMerged/mergedItem.tsx
+++ b/static/app/views/issueDetails/groupMerged/mergedItem.tsx
@@ -6,7 +6,7 @@ import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Checkbox} from 'sentry/components/core/checkbox';
 import {Flex} from 'sentry/components/core/layout';
 import {Tooltip} from 'sentry/components/core/tooltip';
-import EventOrGroupHeader from 'sentry/components/eventOrGroupHeader';
+import EventOrGroupTitle from 'sentry/components/eventOrGroupTitle';
 import {IconChevron, IconLink} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Fingerprint} from 'sentry/stores/groupingStore';
@@ -156,12 +156,7 @@ function MergedItem({fingerprint, totalFingerprint}: Props) {
                 style={{marginLeft: space(1)}}
               />
               <EventDetails>
-                <EventOrGroupHeader
-                  data={latestEvent}
-                  hideIcons
-                  hideLevel
-                  source="merged-item"
-                />
+                <EventOrGroupTitle data={latestEvent} />
               </EventDetails>
             </Flex>
           ) : null}

--- a/static/app/views/issueDetails/groupMerged/mergedItem.tsx
+++ b/static/app/views/issueDetails/groupMerged/mergedItem.tsx
@@ -5,6 +5,7 @@ import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Checkbox} from 'sentry/components/core/checkbox';
 import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {IconChevron, IconLink} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -155,7 +156,9 @@ function MergedItem({fingerprint, totalFingerprint}: Props) {
                 style={{marginLeft: space(1)}}
               />
               <EventDetails>
-                <Title data-issue-title-primary>{latestEvent.title}</Title>
+                <Text size="md" data-issue-title-primary>
+                  {latestEvent.title}
+                </Text>
               </EventDetails>
             </Flex>
           ) : null}
@@ -208,11 +211,6 @@ const EventDetails = styled('div')`
   display: flex;
   justify-content: space-between;
   padding: ${space(1)};
-`;
-
-const Title = styled('span')`
-  position: relative;
-  font-size: ${p => p.theme.fontSize.md};
 `;
 
 export default MergedItem;


### PR DESCRIPTION
fix for #57383

Added `return metadata.title` for `EventGroupOrType.DEFAULT` to fix `captureMessage` issues missing their title in the merged issues tab.

after: 
<img width="745" height="150" alt="Screenshot 2025-09-15 at 10 19 28 AM" src="https://github.com/user-attachments/assets/a82d28bc-2dcb-4b0a-be7b-56481029f9f4" />
before: 
<img width="738" height="157" alt="Screenshot 2025-09-15 at 10 19 12 AM" src="https://github.com/user-attachments/assets/2466c5ab-9c3d-4aca-a7b9-ecfed8c026d0" />

For issue 
<img width="720" height="185" alt="image" src="https://github.com/user-attachments/assets/03a5bea5-7fac-4f58-823e-9603c1e599a7" />


