### PR TITLE
fix(spans-migration): enable transactions tab on deprecation flag

### DIFF
--- a/static/app/views/discover/savedQuery/datasetSelectorTabs.spec.tsx
+++ b/static/app/views/discover/savedQuery/datasetSelectorTabs.spec.tsx
@@ -122,7 +122,7 @@ describe('Discover DatasetSelector', () => {
     );
   });
 
-  it('disables transactions dataset if org has deprecation feature', () => {
+  it('tooltip for transactions dataset if org has deprecation feature', async () => {
     const eventView = new EventView({
       ...EVENT_VIEW_CONSTRUCTOR_PROPS,
       dataset: DiscoverDatasets.ERRORS,
@@ -147,9 +147,11 @@ describe('Discover DatasetSelector', () => {
       }
     );
 
-    expect(screen.getByRole('tab', {name: 'Transactions'})).toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
+    await userEvent.hover(screen.getByRole('tab', {name: 'Transactions'}));
+    expect(
+      await screen.findByText(
+        /Discover\u2192Transactions is going to be merged into Explore\u2192Traces soon/i
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/discover/savedQuery/datasetSelectorTabs.tsx
+++ b/static/app/views/discover/savedQuery/datasetSelectorTabs.tsx
@@ -126,7 +126,6 @@ export function DatasetSelectorTabs(props: Props) {
     {
       value: SavedQueryDatasets.TRANSACTIONS,
       label: DATASET_LABEL_MAP[SavedQueryDatasets.TRANSACTIONS],
-      disabled: deprecatingTransactionsDataset,
       tooltip: deprecatingTransactionsDataset
         ? {
             title: getTransactionDeprecationMessage(tracesUrl),
@@ -171,11 +170,7 @@ export function DatasetSelectorTabs(props: Props) {
     >
       <TabList hideBorder>
         {options.map(option => (
-          <TabList.Item
-            key={option.value}
-            disabled={option.disabled}
-            tooltip={option.tooltip}
-          >
+          <TabList.Item key={option.value} tooltip={option.tooltip}>
             {option.label}
           </TabList.Item>
         ))}


### PR DESCRIPTION
Initially we were disabling the Transactions tab in Discover with the discover deprecation flag but we don't want to disable it anymore because we still need the compare tags view. So i'm enabling the tab but still disabling saving transaction queries.
