### PR TITLE
fix(workflow_engine): Use WorkflowEventContext to get detector info

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -232,11 +232,12 @@ def evaluate_workflow_triggers(
                 ):
                     try:
                         detector = WorkflowEventContext.get().detector
+                        detector_id = detector.id if detector else None
                         logger.info(
                             "workflow_engine.process_workflows.workflow_triggered",
                             extra={
                                 "workflow_id": workflow.id,
-                                "detector_id": detector.id,
+                                "detector_id": detector_id,
                                 "organization_id": organization.id,
                                 "project_id": event_data.group.project.id,
                                 "group_type": event_data.group.type,

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -231,12 +231,12 @@ def evaluate_workflow_triggers(
                     organization,
                 ):
                     try:
-                        detector_workflow = DetectorWorkflow.objects.get(workflow_id=workflow.id)
+                        detector = WorkflowEventContext.get().detector
                         logger.info(
                             "workflow_engine.process_workflows.workflow_triggered",
                             extra={
                                 "workflow_id": workflow.id,
-                                "detector_id": detector_workflow.detector_id,
+                                "detector_id": detector.id,
                                 "organization_id": organization.id,
                                 "project_id": event_data.group.project.id,
                                 "group_type": event_data.group.type,

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -27,6 +27,10 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.workflow_fire_history import WorkflowFireHistory
+from sentry.workflow_engine.processors.contexts.workflow_event_context import (
+    WorkflowEventContext,
+    WorkflowEventContextData,
+)
 from sentry.workflow_engine.processors.data_condition_group import get_data_conditions_for_group
 from sentry.workflow_engine.processors.workflow import (
     DelayedWorkflowItem,
@@ -370,6 +374,11 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
     @patch("sentry.workflow_engine.processors.workflow.logger")
     def test_logs_triggered_workflows(self, mock_logger: MagicMock) -> None:
+        WorkflowEventContext.set(
+            WorkflowEventContextData(
+                detector=self.detector,
+            )
+        )
         evaluate_workflow_triggers({self.workflow}, self.event_data, self.event_start_time)
         mock_logger.info.assert_called_once_with(
             "workflow_engine.process_workflows.workflow_triggered",


### PR DESCRIPTION
# Description
Rather than make a query for the detector information, we can grab it from the shared context.

This also fixes an issue where `.get` was throwing an error because of a workflow being reused.