### PR TITLE
chore(nav-cleanup): Remove all usages of enforce-stacked-navigation

### DIFF
--- a/static/app/views/issueList/index.spec.tsx
+++ b/static/app/views/issueList/index.spec.tsx
@@ -12,9 +12,7 @@ describe('IssueListContainer', () => {
     children: <div>Foo</div>,
   };
 
-  const organization = OrganizationFixture({
-    features: ['enforce-stacked-navigation'],
-  });
+  const organization = OrganizationFixture();
 
   const initialRouterConfig = {
     location: {

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
@@ -15,7 +15,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import IssueViewsList from 'sentry/views/issueList/issueViews/issueViewsList/issueViewsList';
 
 const organization = OrganizationFixture({
-  features: ['enforce-stacked-navigation', 'issue-views'],
+  features: ['issue-views'],
 });
 
 describe('IssueViewsList', () => {

--- a/static/app/views/issueList/issueViewsHeader.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeader.spec.tsx
@@ -35,7 +35,6 @@ describe('IssueViewsHeader', () => {
 
   const organization = OrganizationFixture({
     access: ['org:read'],
-    features: ['enforce-stacked-navigation'],
   });
 
   const onIssueViewRouterConfig = {

--- a/static/app/views/nav/index.spec.tsx
+++ b/static/app/views/nav/index.spec.tsx
@@ -35,7 +35,6 @@ const ALL_AVAILABLE_FEATURES = [
   'performance-view',
   'performance-trace-explorer',
   'profiling',
-  'enforce-stacked-navigation',
   'visibility-explore-view',
 ];
 
@@ -440,9 +439,7 @@ describe('Nav', () => {
       });
 
       renderGlobalModal();
-      renderNav({
-        features: ALL_AVAILABLE_FEATURES.concat('enforce-stacked-navigation'),
-      });
+      renderNav();
       await screen.findByRole('navigation', {name: 'Primary Navigation'});
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });

--- a/static/app/views/nav/tour/tour.tsx
+++ b/static/app/views/nav/tour/tour.tsx
@@ -264,15 +264,14 @@ export function useTourModal() {
     {hasSeen: false}
   );
 
-  const enforceStackedNav = organization.features.includes('enforce-stacked-navigation');
   // We don't want to show the tour modal for new users that were forced into the new stacked navigation.
-  const shouldSkipForNewUserEnforcedStackedNav =
-    enforceStackedNav && new Date(user?.dateJoined) > TOUR_MODAL_DATE_THRESHOLD;
+  const shouldSkipTourForNewUsers =
+    new Date(user?.dateJoined) > TOUR_MODAL_DATE_THRESHOLD;
 
   const shouldShowTourModal =
     assistantData?.find(item => item.guide === STACKED_NAVIGATION_TOUR_GUIDE_KEY)
       ?.seen === false &&
-    !shouldSkipForNewUserEnforcedStackedNav &&
+    !shouldSkipTourForNewUsers &&
     !localTourState.hasSeen &&
     !process.env.IS_ACCEPTANCE_TEST;
 


### PR DESCRIPTION
Removes all usages of `enforce-stacked-navigation` so we can remove that flag. Just a single actual usage, the rest are test files.