### PR TITLE
chore(ui): Mark two chart helpers as deprecated

### DIFF
--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -376,4 +376,7 @@ class ChartZoom extends Component<Props> {
   }
 }
 
+/**
+ * @deprecated use useChartZoom instead
+ */
 export default withSentryRouter(ChartZoom);

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -76,6 +76,8 @@ type Props = {
  *
  * This also is very tightly coupled with the Global Selection Header. We can make it more
  * generic if need be in the future.
+ *
+ * @deprecated use useChartZoom instead
  */
 class ChartZoom extends Component<Props> {
   constructor(props: Props) {

--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -98,6 +98,9 @@ type State = {
   releases: ReleaseMetaBasic[] | null;
 };
 
+/**
+ * @deprecated use useReleaseBubbles instead
+ */
 class ReleaseSeries extends Component<ReleaseSeriesProps, State> {
   state: State = {
     releases: null,

--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -332,4 +332,7 @@ class ReleaseSeries extends Component<ReleaseSeriesProps, State> {
   }
 }
 
+/**
+ * @deprecated use useReleaseBubbles instead
+ */
 export default withSentryRouter(withOrganization(withApi(withTheme(ReleaseSeries))));


### PR DESCRIPTION
Both of these have newer hooks.
