### PR TITLE
ref(replay): decide error/feedback chapter highlighting from frontend

### DIFF
--- a/static/app/views/replays/detail/ai/chapterList.tsx
+++ b/static/app/views/replays/detail/ai/chapterList.tsx
@@ -47,11 +47,13 @@ export function ChapterList({timeRanges}: Props) {
           error,
           feedback,
           breadcrumbs:
-            replay?.getSummaryChapterFrames().filter(
-              breadcrumb =>
-                breadcrumb.timestampMs >= period_start &&
-                breadcrumb.timestampMs <= period_end // should be exclusive (<) ?
-            ) ?? [],
+            replay
+              ?.getSummaryChapterFrames()
+              .filter(
+                breadcrumb =>
+                  breadcrumb.timestampMs >= period_start &&
+                  breadcrumb.timestampMs <= period_end
+              ) ?? [],
         }))
         .sort((a, b) => a.start - b.start),
     [timeRanges, replay]

--- a/static/app/views/replays/detail/ai/chapterList.tsx
+++ b/static/app/views/replays/detail/ai/chapterList.tsx
@@ -15,6 +15,7 @@ import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import {useReplayReader} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
 import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import type {ReplayFrame} from 'sentry/utils/replays/types';
+import {isErrorFrame, isFeedbackFrame} from 'sentry/utils/replays/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {TimeRanges} from 'sentry/views/replays/detail/ai/utils';
@@ -46,13 +47,11 @@ export function ChapterList({timeRanges}: Props) {
           error,
           feedback,
           breadcrumbs:
-            replay
-              ?.getSummaryChapterFrames()
-              .filter(
-                breadcrumb =>
-                  breadcrumb.timestampMs >= period_start &&
-                  breadcrumb.timestampMs <= period_end
-              ) ?? [],
+            replay?.getSummaryChapterFrames().filter(
+              breadcrumb =>
+                breadcrumb.timestampMs >= period_start &&
+                breadcrumb.timestampMs <= period_end // should be exclusive (<) ?
+            ) ?? [],
         }))
         .sort((a, b) => a.start - b.start),
     [timeRanges, replay]
@@ -70,7 +69,7 @@ export function ChapterList({timeRanges}: Props) {
 
   return (
     <ChaptersList>
-      {chapterData.map(({title, start, end, breadcrumbs, error, feedback}, i) => (
+      {chapterData.map(({title, start, end, breadcrumbs}, i) => (
         <ChapterRow
           key={i}
           title={title}
@@ -78,8 +77,6 @@ export function ChapterList({timeRanges}: Props) {
           end={end}
           breadcrumbs={breadcrumbs}
           onClickChapterTimestamp={onClickChapterTimestamp}
-          error={error}
-          feedback={feedback}
         />
       ))}
     </ChaptersList>
@@ -93,13 +90,9 @@ function ChapterRow({
   breadcrumbs,
   onClickChapterTimestamp,
   className,
-  error,
-  feedback,
 }: {
   breadcrumbs: ReplayFrame[];
   end: number;
-  error: boolean;
-  feedback: boolean;
   onClickChapterTimestamp: (event: React.MouseEvent<Element>, start: number) => void;
   start: number;
   title: string;
@@ -119,10 +112,13 @@ function ChapterRow({
   const hasOccurred = currentTime >= startOffset;
   const isBeforeHover = currentHoverTime === undefined || currentHoverTime >= startOffset;
 
+  const isError = breadcrumbs.some(isErrorFrame);
+  const isFeedback = !isError && breadcrumbs.some(isFeedbackFrame);
+
   return (
     <ChapterWrapper
-      data-has-error={Boolean(error)}
-      data-has-feedback={Boolean(feedback)}
+      data-is-error={isError}
+      data-is-feedback={isFeedback}
       className={classNames(className, {
         beforeCurrentTime: hasOccurred,
         afterCurrentTime: !hasOccurred,
@@ -137,19 +133,19 @@ function ChapterRow({
       <Chapter
         onClick={() =>
           trackAnalytics('replay.ai-summary.chapter-clicked', {
-            chapter_type: error ? 'error' : feedback ? 'feedback' : undefined,
+            chapter_type: isError ? 'error' : isFeedback ? 'feedback' : undefined,
             organization,
           })
         }
       >
         <ChapterIconWrapper>
-          {error ? (
+          {isError ? (
             isOpen || isHovered ? (
               <ChapterIconArrow direction="right" size="xs" color="red300" />
             ) : (
               <IconFire size="xs" color="red300" />
             )
-          ) : feedback ? (
+          ) : isFeedback ? (
             isOpen || isHovered ? (
               <ChapterIconArrow direction="right" size="xs" color="pink300" />
             ) : (
@@ -290,13 +286,13 @@ const ChapterWrapper = styled('details')`
     border-top: 1px solid ${p => p.theme.backgroundSecondary};
   }
 
-  [data-has-feedback='true'] {
+  [data-is-feedback='true'] {
     &:hover {
       border-top: 1px solid ${p => p.theme.pink100};
     }
   }
 
-  [data-has-error='true'] {
+  [data-is-error='true'] {
     &:hover {
       border-top: 1px solid ${p => p.theme.red100};
     }
@@ -337,7 +333,7 @@ const Chapter = styled('summary')`
     display: none;
   }
 
-  [data-has-feedback='true'] & {
+  [data-is-feedback='true'] & {
     color: ${p => p.theme.pink300};
 
     &:hover {
@@ -345,7 +341,7 @@ const Chapter = styled('summary')`
     }
   }
 
-  [data-has-error='true'] & {
+  [data-is-error='true'] & {
     color: ${p => p.theme.red300};
 
     &:hover {


### PR DESCRIPTION
Part of [REPLAY-625: \[Bug\] LLM still thinks console/network or other non-error logs are errors](https://linear.app/getsentry/issue/REPLAY-625/bug-llm-still-thinks-consolenetwork-or-other-non-error-logs-are-errors)

These fields should be removed from the LLM output as we can deterministically compute them from the frontend frames. This PR stops reading them from the API response, then they can be safely removed