### PR TITLE
feat(overwatch): Adds new RPC service to check for user Prevent consent for multiple organizations

### DIFF
--- a/src/sentry/overwatch_webhooks/overwatch_consent/impl.py
+++ b/src/sentry/overwatch_webhooks/overwatch_consent/impl.py
@@ -10,7 +10,7 @@ from sentry.overwatch_webhooks.overwatch_consent.service import OverwatchConsent
 
 
 class DatabaseBackedOverwatchConsentService(OverwatchConsentService):
-    def get_organization_prevent_consent_status(
+    def get_organization_consent_status(
         self, *, organization_ids: list[int], region_name: str
     ) -> dict[int, RpcOrganizationConsentStatus]:
         """

--- a/src/sentry/overwatch_webhooks/overwatch_consent/impl.py
+++ b/src/sentry/overwatch_webhooks/overwatch_consent/impl.py
@@ -25,7 +25,9 @@ class DatabaseBackedOverwatchConsentService(OverwatchConsentService):
         result: dict[int, RpcOrganizationConsentStatus] = {}
 
         for org in organizations:
-            hide_ai_features = org.get_option("sentry:hide_ai_features", HIDE_AI_FEATURES_DEFAULT)
+            hide_ai_features = bool(
+                org.get_option("sentry:hide_ai_features", HIDE_AI_FEATURES_DEFAULT)
+            )
             pr_review_test_generation_enabled = bool(
                 org.get_option(
                     "sentry:enable_pr_review_test_generation",

--- a/src/sentry/overwatch_webhooks/overwatch_consent/impl.py
+++ b/src/sentry/overwatch_webhooks/overwatch_consent/impl.py
@@ -1,0 +1,42 @@
+# Please do not use
+#     from __future__ import annotations
+# in modules such as this one where hybrid cloud data models or service classes are
+# defined, because we want to reflect on type annotations and avoid forward references.
+
+from sentry.constants import ENABLE_PR_REVIEW_TEST_GENERATION_DEFAULT, HIDE_AI_FEATURES_DEFAULT
+from sentry.models.organization import Organization
+from sentry.overwatch_webhooks.overwatch_consent.model import RpcOrganizationConsentStatus
+from sentry.overwatch_webhooks.overwatch_consent.service import OverwatchConsentService
+
+
+class DatabaseBackedOverwatchConsentService(OverwatchConsentService):
+    def get_organization_prevent_consent_status(
+        self, *, organization_ids: list[int], region_name: str
+    ) -> dict[int, RpcOrganizationConsentStatus]:
+        """
+        Get consent status for multiple organizations in a region.
+
+        Consent is determined by the combination of 2 different organization option values:
+        - sentry:hide_ai_features should be False (default)
+        - sentry:enable_pr_review_test_generation should be True (default is False)
+        """
+        organizations = Organization.objects.filter(id__in=organization_ids)
+
+        result: dict[int, RpcOrganizationConsentStatus] = {}
+
+        for org in organizations:
+            hide_ai_features = org.get_option("sentry:hide_ai_features", HIDE_AI_FEATURES_DEFAULT)
+            pr_review_test_generation_enabled = bool(
+                org.get_option(
+                    "sentry:enable_pr_review_test_generation",
+                    ENABLE_PR_REVIEW_TEST_GENERATION_DEFAULT,
+                )
+            )
+            has_consent = not hide_ai_features and pr_review_test_generation_enabled
+
+            result[org.id] = RpcOrganizationConsentStatus(
+                organization_id=org.id,
+                has_consent=has_consent,
+            )
+
+        return result

--- a/src/sentry/overwatch_webhooks/overwatch_consent/model.py
+++ b/src/sentry/overwatch_webhooks/overwatch_consent/model.py
@@ -1,0 +1,15 @@
+# Please do not use
+#     from __future__ import annotations
+# in modules such as this one where hybrid cloud data models or service classes are
+# defined, because we want to reflect on type annotations and avoid forward references.
+
+from sentry.hybridcloud.rpc import RpcModel
+
+
+class RpcOrganizationConsentStatus(RpcModel):
+    """
+    Represents consent status for an organization.
+    """
+
+    organization_id: int
+    has_consent: bool

--- a/src/sentry/overwatch_webhooks/overwatch_consent/service.py
+++ b/src/sentry/overwatch_webhooks/overwatch_consent/service.py
@@ -25,7 +25,7 @@ class OverwatchConsentService(RpcService):
 
     @regional_rpc_method(resolve=ByRegionName())
     @abstractmethod
-    def get_organization_prevent_consent_status(
+    def get_organization_consent_status(
         self, *, organization_ids: list[int], region_name: str
     ) -> dict[int, RpcOrganizationConsentStatus]:
         """

--- a/src/sentry/overwatch_webhooks/overwatch_consent/service.py
+++ b/src/sentry/overwatch_webhooks/overwatch_consent/service.py
@@ -1,0 +1,41 @@
+# Please do not use
+#     from __future__ import annotations
+# in modules such as this one where hybrid cloud data models or service classes are
+# defined, because we want to reflect on type annotations and avoid forward references.
+
+from abc import abstractmethod
+
+from sentry.hybridcloud.rpc.resolvers import ByRegionName
+from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
+from sentry.overwatch_webhooks.overwatch_consent.model import RpcOrganizationConsentStatus
+from sentry.silo.base import SiloMode
+
+
+class OverwatchConsentService(RpcService):
+    key = "overwatch_consent"
+    local_mode = SiloMode.REGION
+
+    @classmethod
+    def get_local_implementation(cls) -> RpcService:
+        from sentry.overwatch_webhooks.overwatch_consent.impl import (
+            DatabaseBackedOverwatchConsentService,
+        )
+
+        return DatabaseBackedOverwatchConsentService()
+
+    @regional_rpc_method(resolve=ByRegionName())
+    @abstractmethod
+    def get_organization_prevent_consent_status(
+        self, *, organization_ids: list[int], region_name: str
+    ) -> dict[int, RpcOrganizationConsentStatus]:
+        """
+        Get consent status for multiple organizations in a region.
+
+        :param organization_ids: List of organization IDs to check
+        :param region_name: The region name
+        :return: Dictionary mapping organization ID to consent status
+        """
+        pass
+
+
+overwatch_consent_service = OverwatchConsentService.create_delegation()

--- a/tests/sentry/overwatch_webhooks/overwatch_consent/test_service.py
+++ b/tests/sentry/overwatch_webhooks/overwatch_consent/test_service.py
@@ -13,10 +13,10 @@ class OverwatchConsentServiceTest(TestCase):
             for key, value in options.items():
                 OrganizationOption.objects.set_value(org, key, value)
 
-    def test_get_organization_prevent_consent_status_delegation(self):
+    def test_get_organization_consent_status_delegation(self):
         org = self.create_organization()
 
-        result = overwatch_consent_service.get_organization_prevent_consent_status(
+        result = overwatch_consent_service.get_organization_consent_status(
             organization_ids=[org.id], region_name="us"
         )
 
@@ -26,7 +26,7 @@ class OverwatchConsentServiceTest(TestCase):
         assert result[org.id].organization_id == org.id
         assert isinstance(result[org.id].has_consent, bool)
 
-    def test_get_organization_prevent_consent_status_multiple_orgs(self):
+    def test_get_organization_consent_status_multiple_orgs(self):
         org1 = self.create_organization()
         org2 = self.create_organization()
 
@@ -38,7 +38,7 @@ class OverwatchConsentServiceTest(TestCase):
             org2, {"sentry:hide_ai_features": True, "sentry:enable_pr_review_test_generation": True}
         )
 
-        result = overwatch_consent_service.get_organization_prevent_consent_status(
+        result = overwatch_consent_service.get_organization_consent_status(
             organization_ids=[org1.id, org2.id], region_name="us"
         )
 
@@ -50,23 +50,23 @@ class OverwatchConsentServiceTest(TestCase):
         assert result[org2.id].organization_id == org2.id
         assert result[org2.id].has_consent is False
 
-    def test_get_organization_prevent_consent_status_empty_list(self):
-        result = overwatch_consent_service.get_organization_prevent_consent_status(
+    def test_get_organization_consent_status_empty_list(self):
+        result = overwatch_consent_service.get_organization_consent_status(
             organization_ids=[], region_name="us"
         )
 
         assert result == {}
 
-    def test_get_organization_prevent_consent_status_nonexistent_org(self):
+    def test_get_organization_consent_status_nonexistent_org(self):
         nonexistent_id = 999999
 
-        result = overwatch_consent_service.get_organization_prevent_consent_status(
+        result = overwatch_consent_service.get_organization_consent_status(
             organization_ids=[nonexistent_id], region_name="us"
         )
 
         assert result == {}
 
-    def test_get_organization_prevent_consent_status_mixed_existing_nonexistent(self):
+    def test_get_organization_consent_status_mixed_existing_nonexistent(self):
         org = self.create_organization()
         self._add_organization_options(
             org, {"sentry:hide_ai_features": False, "sentry:enable_pr_review_test_generation": True}
@@ -74,7 +74,7 @@ class OverwatchConsentServiceTest(TestCase):
 
         nonexistent_id = 999999
 
-        result = overwatch_consent_service.get_organization_prevent_consent_status(
+        result = overwatch_consent_service.get_organization_consent_status(
             organization_ids=[org.id, nonexistent_id], region_name="us"
         )
 

--- a/tests/sentry/overwatch_webhooks/overwatch_consent/test_service.py
+++ b/tests/sentry/overwatch_webhooks/overwatch_consent/test_service.py
@@ -1,0 +1,85 @@
+from sentry.models.options import OrganizationOption
+from sentry.models.organization import Organization
+from sentry.overwatch_webhooks.overwatch_consent.model import RpcOrganizationConsentStatus
+from sentry.overwatch_webhooks.overwatch_consent.service import overwatch_consent_service
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode_of, create_test_regions
+
+
+@all_silo_test(regions=create_test_regions("us"))
+class OverwatchConsentServiceTest(TestCase):
+    def _add_organization_options(self, org: Organization, options: dict[str, bool]):
+        with assume_test_silo_mode_of(OrganizationOption):
+            for key, value in options.items():
+                OrganizationOption.objects.set_value(org, key, value)
+
+    def test_get_organization_prevent_consent_status_delegation(self):
+        org = self.create_organization()
+
+        result = overwatch_consent_service.get_organization_prevent_consent_status(
+            organization_ids=[org.id], region_name="us"
+        )
+
+        assert isinstance(result, dict)
+        assert org.id in result
+        assert isinstance(result[org.id], RpcOrganizationConsentStatus)
+        assert result[org.id].organization_id == org.id
+        assert isinstance(result[org.id].has_consent, bool)
+
+    def test_get_organization_prevent_consent_status_multiple_orgs(self):
+        org1 = self.create_organization()
+        org2 = self.create_organization()
+
+        self._add_organization_options(
+            org1,
+            {"sentry:hide_ai_features": False, "sentry:enable_pr_review_test_generation": True},
+        )
+        self._add_organization_options(
+            org2, {"sentry:hide_ai_features": True, "sentry:enable_pr_review_test_generation": True}
+        )
+
+        result = overwatch_consent_service.get_organization_prevent_consent_status(
+            organization_ids=[org1.id, org2.id], region_name="us"
+        )
+
+        assert len(result) == 2
+        assert org1.id in result
+        assert org2.id in result
+        assert result[org1.id].organization_id == org1.id
+        assert result[org1.id].has_consent is True
+        assert result[org2.id].organization_id == org2.id
+        assert result[org2.id].has_consent is False
+
+    def test_get_organization_prevent_consent_status_empty_list(self):
+        result = overwatch_consent_service.get_organization_prevent_consent_status(
+            organization_ids=[], region_name="us"
+        )
+
+        assert result == {}
+
+    def test_get_organization_prevent_consent_status_nonexistent_org(self):
+        nonexistent_id = 999999
+
+        result = overwatch_consent_service.get_organization_prevent_consent_status(
+            organization_ids=[nonexistent_id], region_name="us"
+        )
+
+        assert result == {}
+
+    def test_get_organization_prevent_consent_status_mixed_existing_nonexistent(self):
+        org = self.create_organization()
+        self._add_organization_options(
+            org, {"sentry:hide_ai_features": False, "sentry:enable_pr_review_test_generation": True}
+        )
+
+        nonexistent_id = 999999
+
+        result = overwatch_consent_service.get_organization_prevent_consent_status(
+            organization_ids=[org.id, nonexistent_id], region_name="us"
+        )
+
+        assert len(result) == 1
+        assert org.id in result
+        assert nonexistent_id not in result
+        assert result[org.id].organization_id == org.id
+        assert result[org.id].has_consent is True


### PR DESCRIPTION
Adds a new service called `OverwatchConsentService` which is used as a region-specific RPC to query Organization-level consent for test generation features. This is meant to replace the code [here](https://github.com/getsentry/sentry/blob/d511e8eea020bdb4b423590cb69772bddfb80551/src/sentry/seer/endpoints/seer_rpc.py#L229), which was previously performing consent checks.

This will be used by #99389 to conditionally forward webhooks on behalf of Overwatch, for all integration installations with the proper consent.
