### PR TITLE
chore(issue-details): Cleanup chained exceptions UI 

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -355,7 +355,7 @@ export function Content({
   }
 
   return (
-    <div>
+    <ChainedExceptionsContainer>
       {hasChainedExceptions && (
         <Fragment>
           <p>
@@ -363,11 +363,11 @@ export function Content({
               numExceptions: values.length,
             })}
           </p>
-          <SectionDivider orientation="horizontal" />
+          <StyledSectionDivider orientation="horizontal" />
         </Fragment>
       )}
       {children}
-    </div>
+    </ChainedExceptionsContainer>
   );
 }
 
@@ -386,6 +386,10 @@ const Title = styled('h5')`
   word-break: break-word;
 `;
 
+const ChainedExceptionsContainer = styled('div')`
+  margin-bottom: ${p => p.theme.space.lg};
+`;
+
 const ShowRelatedExceptionsButton = styled(Button)`
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSize.sm};
@@ -399,4 +403,8 @@ const StyledFoldSection = styled(FoldSection)`
     margin-left: ${p => p.theme.space.xl};
     margin-right: ${p => p.theme.space.xl};
   }
+`;
+
+const StyledSectionDivider = styled(SectionDivider)`
+  margin-bottom: ${p => p.theme.space.lg};
 `;

--- a/static/app/components/events/interfaces/exception.tsx
+++ b/static/app/components/events/interfaces/exception.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import styled from '@emotion/styled';
 
 import {CommitRow} from 'sentry/components/commitRow';
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -109,7 +110,7 @@ export function Exception({
             {hasStreamlinedUI && group && (
               <Fragment>
                 {data.values && data.values.length > 1 && (
-                  <SectionDivider orientation="horizontal" />
+                  <StyledSectionDivider orientation="horizontal" />
                 )}
                 <ErrorBoundary
                   mini
@@ -130,3 +131,7 @@ export function Exception({
     </StacktraceContext>
   );
 }
+
+const StyledSectionDivider = styled(SectionDivider)`
+  margin-bottom: ${p => p.theme.space.lg};
+`;


### PR DESCRIPTION
fixes a few margin issues in the chained exceptions ui 

before: 
<img width="222" height="271" alt="Screenshot 2025-09-15 at 1 26 05 PM" src="https://github.com/user-attachments/assets/e9b3907e-af01-4067-9869-f995cbf45eee" />

after: 
<img width="217" height="306" alt="Screenshot 2025-09-15 at 1 25 58 PM" src="https://github.com/user-attachments/assets/6378d38e-f3f8-4042-82ff-abb96425ecb7" />
