### PR TITLE
feat(aci): Move workflow engine scheduling to new task

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1208,6 +1208,12 @@ CELERYBEAT_SCHEDULE_REGION = {
         "schedule": crontab(minute="*/1"),
         "options": {"expires": 10, "queue": "buffers.process_pending_batch"},
     },
+    "flush-delayed-workflows": {
+        "task": "sentry.tasks.process_buffer.schedule_delayed_workflows",
+        # Run every 1 minute
+        "schedule": crontab(minute="*/1"),
+        "options": {"expires": 10, "queue": "workflow_engine.process_workflows"},
+    },
     "sync-options": {
         "task": "sentry.tasks.options.sync_options",
         # Run every 10 seconds
@@ -1632,6 +1638,10 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
     },
     "flush-buffers-batch": {
         "task": "buffer:sentry.tasks.process_buffer.process_pending_batch",
+        "schedule": task_crontab("*/1", "*", "*", "*", "*"),
+    },
+    "flush-delayed-workflows": {
+        "task": "workflow_engine:sentry.tasks.process_buffer.schedule_delayed_workflows",
         "schedule": task_crontab("*/1", "*", "*", "*", "*"),
     },
     "sync-options": {

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3143,6 +3143,12 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "workflow_engine.use_process_pending_batch",
+    type=Bool,
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Restrict uptime issue creation for specific host provider identifiers. Items
 # in this list map to the `host_provider_id` column in the UptimeSubscription

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3143,10 +3143,15 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Control whether delayed workflow engine evaluation is done
+# via the old process_pending_batch task with rules delayed processing, or
+# via the new schedule_delayed_workflows task.
+# NB: These tasks are allowed to run concurrently, so a naive switch here
+# may result in duplicate processing.
 register(
-    "workflow_engine.use_process_pending_batch",
+    "workflow_engine.use_new_scheduling_task",
     type=Bool,
-    default=True,
+    default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/rules/processing/buffer_processing.py
+++ b/src/sentry/rules/processing/buffer_processing.py
@@ -208,13 +208,10 @@ def process_buffer_for_type(processing_type: str, handler: type[DelayedProcessin
 def process_buffer() -> None:
     """
     Process all registered delayed processing types.
-    If workflow_engine.use_process_pending_batch is False, skip delayed_workflow processing
-    to allow it to run in the separate process_delayed_workflows task.
     """
-    use_pending_batch = options.get("workflow_engine.use_process_pending_batch")
-
     for processing_type, handler in delayed_processing_registry.registrations.items():
         # If the config option is disabled and this is delayed_workflow, skip it
+        use_pending_batch = options.get("workflow_engine.use_process_pending_batch")
         if not use_pending_batch and processing_type == "delayed_workflow":
             continue
         process_buffer_for_type(processing_type, handler)

--- a/src/sentry/rules/processing/buffer_processing.py
+++ b/src/sentry/rules/processing/buffer_processing.py
@@ -159,45 +159,62 @@ def process_in_batches(
             )
 
 
-def process_buffer() -> None:
+def process_buffer_for_type(processing_type: str, handler: type[DelayedProcessingBase]) -> None:
+    """
+    Process buffers for a specific processing type and handler.
+    """
     should_emit_logs = options.get("delayed_processing.emit_logs")
 
+    if handler.option and not options.get(handler.option):
+        log_name = f"{processing_type}.disabled"
+        logger.info(log_name, extra={"option": handler.option})
+        return
+
+    buffer = handler.buffer_backend()
+
+    with metrics.timer(f"{processing_type}.process_all_conditions.duration"):
+        # We need to use a very fresh timestamp here; project scores (timestamps) are
+        # updated with each relevant event, and some can be updated every few milliseconds.
+        # The staler this timestamp, the more likely it'll miss some recently updated projects,
+        # and the more likely we'll have frequently updated projects that are never actually
+        # retrieved and processed here.
+        fetch_time = datetime.now(tz=timezone.utc).timestamp()
+        buffer_keys = handler.get_buffer_keys()
+        all_project_ids_and_timestamps = buffer.bulk_get_sorted_set(
+            buffer_keys,
+            min=0,
+            max=fetch_time,
+        )
+
+        if should_emit_logs:
+            log_str = ", ".join(
+                f"{project_id}: {timestamps}"
+                for project_id, timestamps in all_project_ids_and_timestamps.items()
+            )
+            log_name = f"{processing_type}.project_id_list"
+            logger.info(log_name, extra={"project_ids": log_str})
+
+        project_ids = list(all_project_ids_and_timestamps.keys())
+        for project_id in project_ids:
+            process_in_batches(buffer, project_id, processing_type)
+
+        buffer.delete_keys(
+            buffer_keys,
+            min=0,
+            max=fetch_time,
+        )
+
+
+def process_buffer() -> None:
+    """
+    Process all registered delayed processing types.
+    If workflow_engine.use_process_pending_batch is False, skip delayed_workflow processing
+    to allow it to run in the separate process_delayed_workflows task.
+    """
+    use_pending_batch = options.get("workflow_engine.use_process_pending_batch")
+
     for processing_type, handler in delayed_processing_registry.registrations.items():
-        if handler.option and not options.get(handler.option):
-            log_name = f"{processing_type}.disabled"
-            logger.info(log_name, extra={"option": handler.option})
+        # If the config option is disabled and this is delayed_workflow, skip it
+        if not use_pending_batch and processing_type == "delayed_workflow":
             continue
-
-        buffer = handler.buffer_backend()
-
-        with metrics.timer(f"{processing_type}.process_all_conditions.duration"):
-            # We need to use a very fresh timestamp here; project scores (timestamps) are
-            # updated with each relevant event, and some can be updated every few milliseconds.
-            # The staler this timestamp, the more likely it'll miss some recently updated projects,
-            # and the more likely we'll have frequently updated projects that are never actually
-            # retrieved and processed here.
-            fetch_time = datetime.now(tz=timezone.utc).timestamp()
-            buffer_keys = handler.get_buffer_keys()
-            all_project_ids_and_timestamps = buffer.bulk_get_sorted_set(
-                buffer_keys,
-                min=0,
-                max=fetch_time,
-            )
-
-            if should_emit_logs:
-                log_str = ", ".join(
-                    f"{project_id}: {timestamps}"
-                    for project_id, timestamps in all_project_ids_and_timestamps.items()
-                )
-                log_name = f"{processing_type}.project_id_list"
-                logger.info(log_name, extra={"project_ids": log_str})
-
-            project_ids = list(all_project_ids_and_timestamps.keys())
-            for project_id in project_ids:
-                process_in_batches(buffer, project_id, processing_type)
-
-            buffer.delete_keys(
-                buffer_keys,
-                min=0,
-                max=fetch_time,
-            )
+        process_buffer_for_type(processing_type, handler)

--- a/src/sentry/rules/processing/buffer_processing.py
+++ b/src/sentry/rules/processing/buffer_processing.py
@@ -210,8 +210,8 @@ def process_buffer() -> None:
     Process all registered delayed processing types.
     """
     for processing_type, handler in delayed_processing_registry.registrations.items():
-        # If the config option is disabled and this is delayed_workflow, skip it
-        use_pending_batch = options.get("workflow_engine.use_process_pending_batch")
-        if not use_pending_batch and processing_type == "delayed_workflow":
+        # If the new scheduling task is enabled and this is delayed_workflow, skip it
+        use_new_scheduling = options.get("workflow_engine.use_new_scheduling_task")
+        if use_new_scheduling and processing_type == "delayed_workflow":
             continue
         process_buffer_for_type(processing_type, handler)

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -85,8 +85,8 @@ def schedule_delayed_workflows() -> None:
     try:
         with lock.acquire():
             # Only process delayed_workflow type
-            use_pending_batch = options.get("workflow_engine.use_process_pending_batch")
-            if use_pending_batch:
+            use_new_scheduling = options.get("workflow_engine.use_new_scheduling_task")
+            if not use_new_scheduling:
                 logger.info(
                     "Configured to use process_pending_batch for delayed_workflow; exiting."
                 )

--- a/tests/sentry/tasks/test_process_buffer.py
+++ b/tests/sentry/tasks/test_process_buffer.py
@@ -63,8 +63,8 @@ class ScheduleDelayedWorkflowsTest(TestCase):
         mock_process_buffer_for_type: mock.MagicMock,
         mock_options_get: mock.MagicMock,
     ) -> None:
-        # Mock the config option to return False (not using process_pending_batch)
-        mock_options_get.return_value = False
+        # Mock the config option to return True (using new scheduling task)
+        mock_options_get.return_value = True
 
         with self.assertLogs("sentry.tasks.process_buffer", level="WARNING") as logger:
             lock = get_process_lock("schedule_delayed_workflows")
@@ -89,8 +89,8 @@ class ScheduleDelayedWorkflowsTest(TestCase):
         mock_process_buffer_for_type: mock.MagicMock,
         mock_options_get: mock.MagicMock,
     ) -> None:
-        # Mock the config option to return True (using process_pending_batch)
-        mock_options_get.return_value = True
+        # Mock the config option to return False (not using new scheduling task)
+        mock_options_get.return_value = False
 
         with self.assertLogs("sentry.tasks.process_buffer", level="INFO") as logger:
             schedule_delayed_workflows()
@@ -109,8 +109,8 @@ class ScheduleDelayedWorkflowsTest(TestCase):
         mock_process_buffer_for_type: mock.MagicMock,
         mock_options_get: mock.MagicMock,
     ) -> None:
-        # Mock the config option to return False (not using process_pending_batch)
-        mock_options_get.return_value = False
+        # Mock the config option to return True (using new scheduling task)
+        mock_options_get.return_value = True
 
         schedule_delayed_workflows()
 


### PR DESCRIPTION
Creates a new task that (if options allow it) schedules batch workflow processing.

Workflow scheduling and Delayed rule scheduling run on different redis clusters with different client types and
thus some different constraints. We mostly don't want to touch rule processing until we delete it, whereas workflow engine is under active development. By splitting the scheduling, we can make changes for workflow engine without needing to worry about maintaining or modifying rules processing behavior.

The deployment/cutover plans is:
1. Deploy new task, verify it is running and doing nothing.
2. Set up a PR to set `delayed_workflow.rollout` to False and another setting setting it to True and `workflow_engine.use_process_pending_batch` to False.
3. Merge the first PR, then the second immediately after the first is deployed. This should disable the workflow engine publishing, allow it to finish, then re-enable it in the new task.


