### PR TITLE
feat(explorer): Add support for tools

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -149,6 +149,8 @@ const BlockContent = styled(MarkedText)`
 
 const ToolsUsed = styled('div')`
   gap: ${space(1)};
+  display: flex;
+  flex-direction: column;
 `;
 
 const UserBlockContent = styled('div')`

--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -1,11 +1,13 @@
 import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 
+import {Text} from 'sentry/components/core/text';
 import {IconChevron} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import {MarkedText} from 'sentry/utils/marked/markedText';
 
 import type {Block} from './types';
+import {getToolsStringFromBlock} from './utils';
 
 interface BlockProps {
   block: Block;
@@ -16,6 +18,8 @@ interface BlockProps {
 }
 
 function BlockComponent({block, isLast, isFocused, onClick, ref}: BlockProps) {
+  const toolsUsed = getToolsStringFromBlock(block);
+
   return (
     <Block ref={ref} isLast={isLast} onClick={onClick}>
       <AnimatePresence>
@@ -27,12 +31,23 @@ function BlockComponent({block, isLast, isFocused, onClick, ref}: BlockProps) {
           {block.message.role === 'user' ? (
             <BlockRow>
               <BlockChevronIcon direction="right" size="sm" />
-              <UserBlockContent>{block.message.content}</UserBlockContent>
+              <UserBlockContent>{block.message.content ?? ''}</UserBlockContent>
             </BlockRow>
           ) : (
             <BlockRow>
               <ResponseDot isLoading={block.loading} />
-              <BlockContent text={block.message.content} />
+              <BlockContentWrapper>
+                {block.message.content && <BlockContent text={block.message.content} />}
+                {toolsUsed.length > 0 && (
+                  <ToolsUsed>
+                    {toolsUsed.map(tool => (
+                      <Text key={tool} size="xs" variant="muted" monospace>
+                        {tool}
+                      </Text>
+                    ))}
+                  </ToolsUsed>
+                )}
+              </BlockContentWrapper>
             </BlockRow>
           )}
           {isFocused && <FocusIndicator />}
@@ -91,12 +106,17 @@ const ResponseDot = styled('div')<{isLoading?: boolean}>`
   `}
 `;
 
+const BlockContentWrapper = styled('div')`
+  padding: ${space(2)};
+`;
+
 const BlockContent = styled(MarkedText)`
   width: 100%;
-  padding: ${space(2)};
   color: ${p => p.theme.textColor};
   white-space: pre-wrap;
   word-wrap: break-word;
+  padding-bottom: 0;
+  margin-bottom: -${space(1)};
 
   p,
   li,
@@ -125,6 +145,10 @@ const BlockContent = styled(MarkedText)`
   h6:first-child {
     margin-top: 0;
   }
+`;
+
+const ToolsUsed = styled('div')`
+  gap: ${space(1)};
 `;
 
 const UserBlockContent = styled('div')`

--- a/static/app/views/seerExplorer/minimizedStrip.tsx
+++ b/static/app/views/seerExplorer/minimizedStrip.tsx
@@ -7,6 +7,7 @@ import {space} from 'sentry/styles/space';
 
 import SlashCommands, {type SlashCommand} from './slashCommands';
 import type {Block} from './types';
+import {getToolsStringFromBlock} from './utils';
 
 interface MinimizedStripProps {
   blocks: Block[];
@@ -39,7 +40,9 @@ function MinimizedStrip({
   const lastAssistantMessage = blocks
     .slice()
     .reverse()
-    .find(block => block.message.role === 'assistant');
+    .find(
+      block => block.message.role === 'assistant' || block.message.role === 'tool_use'
+    );
 
   useEffect(() => {
     if (isInputMode && inputRef.current) {
@@ -189,7 +192,9 @@ function MinimizedStrip({
       return 'Ask Seer anything about your app...';
     }
 
-    const content = lastAssistantMessage.message.content;
+    const content =
+      lastAssistantMessage.message.content ||
+      getToolsStringFromBlock(lastAssistantMessage).join(', ');
     // Remove markdown and limit to one line
     const cleanContent = content
       .replace(/[#*`\n]/g, ' ')

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -3,11 +3,18 @@ export interface Block {
   message: Message;
   timestamp: string;
   loading?: boolean;
+  tool_input?: ToolInput;
+  tool_response?: string;
+}
+
+interface ToolInput {
+  args: Record<string, any>;
+  function: string;
 }
 
 interface Message {
   content: string;
-  role: 'user' | 'assistant';
+  role: 'user' | 'assistant' | 'tool_use';
 }
 
 export type PanelSize = 'max' | 'med' | 'min';

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -3,18 +3,17 @@ export interface Block {
   message: Message;
   timestamp: string;
   loading?: boolean;
-  tool_input?: ToolInput;
-  tool_response?: string;
-}
-
-interface ToolInput {
-  args: Record<string, any>;
-  function: string;
 }
 
 interface Message {
   content: string;
   role: 'user' | 'assistant' | 'tool_use';
+  tool_calls?: ToolCall[];
+}
+
+interface ToolCall {
+  args: string;
+  function: string;
 }
 
 export type PanelSize = 'max' | 'med' | 'min';

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -3,8 +3,8 @@ import type {Block} from './types';
 export function getToolsStringFromBlock(block: Block): string[] {
   // TODO custom displays for each tool
   const tools: string[] = [];
-  if (block.tool_input?.function) {
-    tools.push('Used ' + block.tool_input.function + ' tool');
+  for (const tool of block.message.tool_calls || []) {
+    tools.push('Used ' + tool.function + ' tool');
   }
   return tools;
 }

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -1,0 +1,10 @@
+import type {Block} from './types';
+
+export function getToolsStringFromBlock(block: Block): string[] {
+  // TODO custom displays for each tool
+  const tools: string[] = [];
+  if (block.tool_input?.function) {
+    tools.push('Used ' + block.tool_input.function + ' tool');
+  }
+  return tools;
+}


### PR DESCRIPTION
The UI can now render tool calls and handle multi-turn agent actions. The text we display for tool calls is currently a placeholder and will be modified, along with adding new UI and actions, as I develop real tools in the future.

For simplicity, also removing "optimistic messages"

backend PR: [explorer/agent-tools](https://github.com/getsentry/seer/pull/3355)

<img width="769" height="448" alt="Screenshot 2025-09-15 at 1 37 21 PM" src="https://github.com/user-attachments/assets/de07937d-564e-457d-a15b-69bdec6d1012" />
