### PR TITLE
feat(aci): MSTeams action validator

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3077,7 +3077,7 @@ SENTRY_DEFAULT_INTEGRATIONS = (
     "sentry.integrations.vsts_extension.VstsExtensionIntegrationProvider",
     "sentry.integrations.pagerduty.integration.PagerDutyIntegrationProvider",
     "sentry.integrations.vercel.VercelIntegrationProvider",
-    "sentry.integrations.msteams.MsTeamsIntegrationProvider",
+    "sentry.integrations.msteams.integration.MsTeamsIntegrationProvider",
     "sentry.integrations.aws_lambda.AwsLambdaIntegrationProvider",
     "sentry.integrations.discord.DiscordIntegrationProvider",
     "sentry.integrations.opsgenie.OpsgenieIntegrationProvider",

--- a/src/sentry/integrations/messaging/__init__.py
+++ b/src/sentry/integrations/messaging/__init__.py
@@ -5,3 +5,5 @@ The current messaging integrations are Discord, MSTeams, and Slack.
 TODO: Move the packages for individual integrations to be subpackages of this one
       (possibly in coordination with grouping other integrations by purpose)
 """
+
+from .message_builder import *  # noqa: F401,F403

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -13,7 +13,6 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.models.team import Team
-from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notifications.rules import AlertRuleNotification
 from sentry.notifications.utils.links import create_link_to_workflow
@@ -109,6 +108,8 @@ def fetch_environment_name(rule_env: int) -> str | None:
 def get_rule_environment_param_from_rule(
     rule_id: int, rule_environment_id: int | None, organization: Organization, type_id: int
 ) -> dict[str, str]:
+    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
     params = {}
     if should_fire_workflow_actions(organization, type_id):
         if (
@@ -270,6 +271,8 @@ def build_attachment_replay_link(
 
 
 def build_rule_url(rule: Any, group: Group, project: Project) -> str:
+    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
     org_slug = group.organization.slug
     project_slug = project.slug
     if should_fire_workflow_actions(group.organization, group.type):

--- a/src/sentry/integrations/msteams/__init__.py
+++ b/src/sentry/integrations/msteams/__init__.py
@@ -1,22 +1,5 @@
 from sentry.integrations.msteams.spec import MsTeamsMessagingSpec
 
-from .actions.form import *  # noqa: F401,F403
-from .actions.notification import *  # noqa: F401,F403
-from .analytics import *  # noqa: F401,F403
-from .card_builder.base import *  # noqa: F401,F403
-from .card_builder.block import *  # noqa: F401,F403
-from .card_builder.help import *  # noqa: F401,F403
-from .card_builder.identity import *  # noqa: F401,F403
-from .card_builder.installation import *  # noqa: F401,F403
-from .card_builder.notifications import *  # noqa: F401,F403
-from .client import *  # noqa: F401,F403
 from .handlers import MSTeamsActionHandler  # noqa: F401,F403
-from .integration import *  # noqa: F401,F403
-from .link_identity import *  # noqa: F401,F403
-from .notifications import *  # noqa: F401,F403
-from .unlink_identity import *  # noqa: F401,F403
-from .urls import *  # noqa: F401,F403
-from .utils import *  # noqa: F401,F403
-from .webhook import *  # noqa: F401,F403
 
 MsTeamsMessagingSpec().initialize()

--- a/src/sentry/integrations/msteams/actions/form.py
+++ b/src/sentry/integrations/msteams/actions/form.py
@@ -5,6 +5,8 @@ from typing import Any
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
+from sentry.integrations.msteams.utils import find_channel_id
+from sentry.integrations.services.integration.service import integration_service
 from sentry.utils.forms import set_field_choices
 
 
@@ -15,7 +17,6 @@ class MsTeamsNotifyServiceForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         self._team_list = [(i.id, i.name) for i in kwargs.pop("integrations")]
-        self.channel_transformer = kwargs.pop("channel_transformer")
 
         super().__init__(*args, **kwargs)
 
@@ -31,7 +32,13 @@ class MsTeamsNotifyServiceForm(forms.Form):
 
         integration_id = cleaned_data.get("team")
         channel = cleaned_data.get("channel", "")
-        channel_id = self.channel_transformer(integration_id, channel)
+        integration = integration_service.get_integration(
+            integration_id=integration_id,
+        )
+        if not integration:
+            raise forms.ValidationError(_("Team is a required field."), code="invalid")
+
+        channel_id = find_channel_id(integration, channel)
 
         if channel_id is None and integration_id is not None:
             params = {

--- a/src/sentry/integrations/msteams/actions/notification.py
+++ b/src/sentry/integrations/msteams/actions/notification.py
@@ -9,7 +9,6 @@ from sentry.integrations.msteams.card_builder.issues import MSTeamsIssueMessageB
 from sentry.integrations.msteams.client import MsTeamsClient
 from sentry.integrations.msteams.metrics import record_lifecycle_termination_level
 from sentry.integrations.msteams.spec import MsTeamsMessagingSpec
-from sentry.integrations.msteams.utils import get_channel_id
 from sentry.integrations.services.integration import RpcIntegration
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.rules.actions import IntegrationEventAction
@@ -86,9 +85,4 @@ class MsTeamsNotifyServiceAction(IntegrationEventAction):
         )
 
     def get_form_instance(self) -> MsTeamsNotifyServiceForm:
-        return MsTeamsNotifyServiceForm(
-            self.data, integrations=self.get_integrations(), channel_transformer=self.get_channel_id
-        )
-
-    def get_channel_id(self, integration_id, name):
-        return get_channel_id(self.project.organization, integration_id, name)
+        return MsTeamsNotifyServiceForm(self.data, integrations=self.get_integrations())

--- a/src/sentry/integrations/msteams/spec.py
+++ b/src/sentry/integrations/msteams/spec.py
@@ -29,7 +29,7 @@ class MsTeamsMessagingSpec(MessagingIntegrationSpec):
 
     @property
     def integration_provider(self) -> type[IntegrationProvider]:
-        from sentry.integrations.msteams import MsTeamsIntegrationProvider
+        from sentry.integrations.msteams.integration import MsTeamsIntegrationProvider
 
         return MsTeamsIntegrationProvider
 

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -61,18 +61,7 @@ def get_user_conversation_id(integration: Integration | RpcIntegration, user_id:
     return conversation_id
 
 
-def get_channel_id(organization: Organization, integration_id: int, name: str) -> str | None:
-    integrations = integration_service.get_integrations(
-        providers=[IntegrationProviderSlug.MSTEAMS.value],
-        organization_id=organization.id,
-        integration_ids=[integration_id],
-    )
-    if not integrations:
-        return None
-
-    assert len(integrations) == 1, "Found multiple msteams integrations for org!"
-    integration = integrations[0]
-
+def find_channel_id(integration: Integration | RpcIntegration, name: str) -> str | None:
     team_id = integration.external_id
     client = MsTeamsClient(integration)
 
@@ -103,6 +92,21 @@ def get_channel_id(organization: Organization, integration_id: int, name: str) -
         members = client.get_member_list(team_id, continuation_token)
 
     return None
+
+
+def get_channel_id(organization: Organization, integration_id: int, name: str) -> str | None:
+    integrations = integration_service.get_integrations(
+        providers=[IntegrationProviderSlug.MSTEAMS.value],
+        organization_id=organization.id,
+        integration_ids=[integration_id],
+    )
+    if not integrations:
+        return None
+
+    assert len(integrations) == 1, "Found multiple msteams integrations for org!"
+    integration = integrations[0]
+
+    return find_channel_id(integration, name)
 
 
 def send_incident_alert_notification(

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -24,7 +24,7 @@ from sentry.integrations.mixins import NotifyBasicMixin
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.models.organization_integration import OrganizationIntegration
-from sentry.integrations.msteams import MsTeamsClient
+from sentry.integrations.msteams.client import MsTeamsClient
 from sentry.integrations.msteams.metrics import record_lifecycle_termination_level
 from sentry.integrations.msteams.spec import MsTeamsMessagingSpec
 from sentry.integrations.services.integration import (

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -35,7 +35,6 @@ from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.models.rule import Rule
 from sentry.notifications.additional_attachment_manager import get_additional_attachment
-from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.utils.open_period import open_period_start_for_group
 from sentry.rules.actions import IntegrationEventAction
 from sentry.rules.base import CallbackFuture
@@ -436,6 +435,8 @@ class SlackNotifyServiceAction(IntegrationEventAction):
     def after(
         self, event: GroupEvent, notification_uuid: str | None = None
     ) -> Generator[CallbackFuture]:
+        from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
         channel = self.get_option("channel_id")
         tags = set(self.get_tags_list())
 

--- a/src/sentry/notifications/notification_action/__init__.py
+++ b/src/sentry/notifications/notification_action/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "SentryAppActionHandler",
     "SendTestNotification",
     "SlackActionValidatorHandler",
+    "MSTeamsActionValidatorHandler",
 ]
 
 from .action_handler_registry import (
@@ -33,7 +34,7 @@ from .action_handler_registry import (
     SentryAppActionHandler,
     WebhookActionHandler,
 )
-from .action_validation import SlackActionValidatorHandler
+from .action_validation import MSTeamsActionValidatorHandler, SlackActionValidatorHandler
 from .group_type_notification_registry import IssueAlertRegistryHandler, MetricAlertRegistryHandler
 from .grouptype import SendTestNotification
 from .issue_alert_registry import (

--- a/src/sentry/notifications/notification_action/action_validation.py
+++ b/src/sentry/notifications/notification_action/action_validation.py
@@ -3,6 +3,8 @@ from typing import Any
 from django.core.exceptions import ValidationError
 
 from sentry.constants import ObjectStatus
+from sentry.integrations.msteams.actions.form import MsTeamsNotifyServiceForm
+from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.slack.actions.form import SlackNotifyServiceForm
 from sentry.notifications.notification_action.registry import action_validator_registry
@@ -11,26 +13,52 @@ from sentry.workflow_engine.models.action import Action
 from .types import BaseActionValidatorHandler
 
 
+def _get_integration(validated_data: dict[str, Any], provider: str) -> RpcIntegration:
+    if not (integration_id := validated_data.get("integration_id")):
+        raise ValidationError(f"Integration ID is required for {provider} action")
+
+    integration = integration_service.get_integration(integration_id=integration_id)
+    if not integration:
+        raise ValidationError(f"{provider} integration with id {integration_id} not found")
+    return integration
+
+
 @action_validator_registry.register(Action.Type.SLACK)
 class SlackActionValidatorHandler(BaseActionValidatorHandler):
     provider = Action.Type.SLACK
     notify_action_form = SlackNotifyServiceForm
 
     def generate_action_form_payload(self) -> dict[str, Any]:
-        if not (integration_id := self.validated_data.get("integration_id")):
-            raise ValidationError("Integration ID is required for Slack action")
-
-        integration = integration_service.get_integration(
-            integration_id=integration_id, status=ObjectStatus.ACTIVE
-        )
-        if not integration:
-            raise ValidationError(f"Slack integration with id {integration_id} not found")
+        integration = _get_integration(self.validated_data, self.provider)
 
         return {
-            "workspace": integration_id,
+            "workspace": integration.id,
             "channel": self.validated_data["config"]["target_display"],
             "channel_id": self.validated_data["config"].get("target_identifier"),
             "tags": self.validated_data["data"].get("tags"),
+        }
+
+    def update_action_data(self, cleaned_data: dict[str, Any]) -> dict[str, Any]:
+        self.validated_data["config"].update(
+            {
+                "target_display": cleaned_data["channel"],
+                "target_identifier": cleaned_data["channel_id"],
+            }
+        )
+        return self.validated_data
+
+
+@action_validator_registry.register(Action.Type.MSTEAMS)
+class MSTeamsActionValidatorHandler(BaseActionValidatorHandler):
+    provider = Action.Type.MSTEAMS
+    notify_action_form = MsTeamsNotifyServiceForm
+
+    def generate_action_form_payload(self) -> dict[str, Any]:
+        integration = _get_integration(self.validated_data, self.provider)
+
+        return {
+            "team": integration.id,
+            "channel": self.validated_data["config"]["target_display"],
         }
 
     def update_action_data(self, cleaned_data: dict[str, Any]) -> dict[str, Any]:

--- a/src/sentry/notifications/notification_action/action_validation.py
+++ b/src/sentry/notifications/notification_action/action_validation.py
@@ -17,7 +17,9 @@ def _get_integration(validated_data: dict[str, Any], provider: str) -> RpcIntegr
     if not (integration_id := validated_data.get("integration_id")):
         raise ValidationError(f"Integration ID is required for {provider} action")
 
-    integration = integration_service.get_integration(integration_id=integration_id)
+    integration = integration_service.get_integration(
+        integration_id=integration_id, status=ObjectStatus.ACTIVE
+    )
     if not integration:
         raise ValidationError(f"{provider} integration with id {integration_id} not found")
     return integration

--- a/tests/sentry/integrations/msteams/notifications/test_assigned.py
+++ b/tests/sentry/integrations/msteams/notifications/test_assigned.py
@@ -10,10 +10,10 @@ pytestmark = [requires_snuba]
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsAssignedNotificationTest(MSTeamsActivityNotificationTest):
     def test_assigned(self, mock_send_card: MagicMock) -> None:
         """

--- a/tests/sentry/integrations/msteams/notifications/test_deploy.py
+++ b/tests/sentry/integrations/msteams/notifications/test_deploy.py
@@ -11,10 +11,10 @@ from sentry.types.activity import ActivityType
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsDeployNotificationTest(MSTeamsActivityNotificationTest):
     @skip("Flaky test")
     def test_deploy(self, mock_send_card: MagicMock) -> None:

--- a/tests/sentry/integrations/msteams/notifications/test_escalating.py
+++ b/tests/sentry/integrations/msteams/notifications/test_escalating.py
@@ -10,10 +10,10 @@ pytestmark = [requires_snuba]
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsEscalatingNotificationTest(MSTeamsActivityNotificationTest):
     def test_note(self, mock_send_card: MagicMock) -> None:
         """

--- a/tests/sentry/integrations/msteams/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/msteams/notifications/test_issue_alert.py
@@ -13,10 +13,10 @@ pytestmark = [requires_snuba]
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsIssueAlertNotificationTest(MSTeamsActivityNotificationTest):
     def test_issue_alert_user(self, mock_send_card: MagicMock) -> None:
         """Test that issue alerts are sent to a MS Teams user."""

--- a/tests/sentry/integrations/msteams/notifications/test_note.py
+++ b/tests/sentry/integrations/msteams/notifications/test_note.py
@@ -10,10 +10,10 @@ pytestmark = [requires_snuba]
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsNoteNotificationTest(MSTeamsActivityNotificationTest):
     def test_note(self, mock_send_card: MagicMock) -> None:
         """

--- a/tests/sentry/integrations/msteams/notifications/test_regression.py
+++ b/tests/sentry/integrations/msteams/notifications/test_regression.py
@@ -10,10 +10,10 @@ pytestmark = [requires_snuba]
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsRegressionNotificationTest(MSTeamsActivityNotificationTest):
     def test_regression(self, mock_send_card: MagicMock) -> None:
         """

--- a/tests/sentry/integrations/msteams/notifications/test_resolved.py
+++ b/tests/sentry/integrations/msteams/notifications/test_resolved.py
@@ -13,10 +13,10 @@ pytestmark = [requires_snuba]
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsResolvedNotificationTest(MSTeamsActivityNotificationTest):
     def test_resolved(self, mock_send_card: MagicMock) -> None:
         """

--- a/tests/sentry/integrations/msteams/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/msteams/notifications/test_unassigned.py
@@ -10,10 +10,10 @@ pytestmark = [requires_snuba]
 
 
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsUnassignedNotificationTest(MSTeamsActivityNotificationTest):
     def test_unassigned(self, mock_send_card: MagicMock) -> None:
         """

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -5,7 +5,7 @@ import responses
 
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
-from sentry.integrations.msteams import MsTeamsIntegrationProvider
+from sentry.integrations.msteams.integration import MsTeamsIntegrationProvider
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.signing import sign

--- a/tests/sentry/integrations/msteams/test_notifications.py
+++ b/tests/sentry/integrations/msteams/test_notifications.py
@@ -32,14 +32,14 @@ TEST_CARD = {"type": "test_card"}
     [DummyNotification],
 )
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
     Mock(return_value="some_conversation_id"),
 )
 @patch(
-    "sentry.integrations.msteams.MsTeamsClientABC.get_member_list",
+    "sentry.integrations.msteams.client.MsTeamsClientABC.get_member_list",
     Mock(return_value={"members": [{"user": "some_user", "tenantId": "some_tenant_id"}]}),
 )
-@patch("sentry.integrations.msteams.MsTeamsClientABC.send_card")
+@patch("sentry.integrations.msteams.client.MsTeamsClientABC.send_card")
 class MSTeamsNotificationTest(TestCase):
     def _install_msteams_personal(self) -> None:
         self.tenant_id = "50cccd00-7c9c-4b32-8cda-58a084f9334a"
@@ -124,7 +124,7 @@ class MSTeamsNotificationTest(TestCase):
         self._install_msteams_team()
 
         with patch(
-            "sentry.integrations.msteams.MsTeamsClientABC.get_user_conversation_id",
+            "sentry.integrations.msteams.client.MsTeamsClientABC.get_user_conversation_id",
         ) as mock_get_user_conversation_id:
             mock_get_user_conversation_id.return_value = "some_conversation_id"
 

--- a/tests/sentry/integrations/msteams/test_notifications.py
+++ b/tests/sentry/integrations/msteams/test_notifications.py
@@ -24,7 +24,7 @@ TEST_CARD = {"type": "test_card"}
 
 @control_silo_test
 @patch(
-    "sentry.integrations.msteams.MSTeamsNotificationsMessageBuilder.build_notification_card",
+    "sentry.integrations.msteams.card_builder.notifications.MSTeamsNotificationsMessageBuilder.build_notification_card",
     Mock(return_value=TEST_CARD),
 )
 @patch(

--- a/tests/sentry/integrations/msteams/test_notify_action.py
+++ b/tests/sentry/integrations/msteams/test_notify_action.py
@@ -8,7 +8,7 @@ import responses
 
 from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.msteams import MsTeamsNotifyServiceAction
+from sentry.integrations.msteams.actions.notification import MsTeamsNotifyServiceAction
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.testutils.asserts import assert_slo_metric
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase

--- a/tests/sentry/integrations/msteams/webhook/test_ms_teams_events.py
+++ b/tests/sentry/integrations/msteams/webhook/test_ms_teams_events.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from sentry.integrations.msteams import MsTeamsEvents
+from sentry.integrations.msteams.webhook import MsTeamsEvents
 
 
 class TestGetFromValue:

--- a/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_endpoint.py
+++ b/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_endpoint.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 import pytest
 
-from sentry.integrations.msteams import MsTeamsEvents, MsTeamsWebhookEndpoint
+from sentry.integrations.msteams.webhook import MsTeamsEvents, MsTeamsWebhookEndpoint
 
 
 class TestGeTeamInstallationRequestData(TestCase):

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_msteams.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_msteams.py
@@ -1,0 +1,76 @@
+from unittest import mock
+
+from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
+from sentry.workflow_engine.models import Action
+
+
+class TestMSTeamsActionValidator(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.integration, self.org_integration = self.create_provider_integration_for(
+            provider="msteams", organization=self.organization, user=self.user, name="msteams"
+        )
+
+        self.valid_data = {
+            "type": Action.Type.MSTEAMS,
+            "config": {"targetDisplay": "cathy-sentry", "targetType": ActionTarget.SPECIFIC.value},
+            "data": {},
+            "integrationId": self.integration.id,
+        }
+
+    @mock.patch("sentry.integrations.msteams.actions.form.find_channel_id")
+    def test_validate(self, mock_check_for_channel):
+        mock_check_for_channel.return_value = "C1234567890"
+
+        validator = BaseActionValidator(
+            data=self.valid_data,
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is True
+
+    def test_validate__missing_integration_id(self):
+        del self.valid_data["integrationId"]
+        validator = BaseActionValidator(
+            data={**self.valid_data},
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False
+
+    def test_validate__missing_integration(self):
+        validator = BaseActionValidator(
+            data={**self.valid_data, "integrationId": 123},
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False
+
+    def test_validate__invalid_channel_id(self):
+        validator = BaseActionValidator(
+            data={
+                **self.valid_data,
+                "config": {"targetIdentifier": "C1234567890", "targetDisplay": "asdf"},
+            },
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False
+
+    def test_validate__invalid_channel_name(self):
+        validator = BaseActionValidator(
+            data={
+                **self.valid_data,
+                "config": {"targetDisplay": "asdf"},
+            },
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False


### PR DESCRIPTION
Merge into https://github.com/getsentry/sentry/pull/99433 because both MSTeams and Slack use the same config schema, so we should have both action validators ready together when we make `target_identifier` optional on the config schema. The action validators will populate `target_identifier` for the `Action`'s config for saving.