### PR TITLE
fix(timeseries): Handle missing groupby

### DIFF
--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -237,6 +237,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
 
         if top_events > 0:
             raw_groupby = self.get_field_list(organization, request, param_name="groupBy")
+            if len(raw_groupby) == 0:
+                raise ParseError("groupBy is a required parameter when doing topEvents")
             if "timestamp" in raw_groupby:
                 raise ParseError("Cannot group by timestamp")
             if dataset in RPC_DATASETS:

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -912,6 +912,22 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert response.status_code == 200, response.content
 
+    def test_top_events_without_groupby(self) -> None:
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": ["count()"],
+                "orderby": ["-count()"],
+                "topEvents": 5,
+                "dataset": "spans",
+            },
+        )
+
+        assert response.status_code == 400, response.content
+        assert "groupBy is a required" in response.data["detail"]
+
     def test_count_extrapolation(self) -> None:
         event_counts = [6, 0, 6, 3, 0, 3]
         spans = []


### PR DESCRIPTION
- Fixes SENTRY-4MGS
- This ensures that we throw a parse error if a top events query is made without a groupby
- Closes DAIN-918