### PR TITLE
chore: Update datetime method to clean up noisy log

### DIFF
--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -190,7 +190,7 @@ def outside_retention_with_modified_start(
 
     # Need to support timezone-aware and naive datetimes since
     # Snuba API only deals in naive UTC
-    now = datetime.now(UTC) if start.tzinfo else datetime.utcnow()
+    now = datetime.now(UTC) if start.tzinfo else datetime.now(UTC).replace(tzinfo=None)
     start = max(start, now - timedelta(days=retention))
 
     return start > end, start


### PR DESCRIPTION
While looking through GCP logs, I see this noisy log showing up a ton:

```
/usr/src/sentry/src/sentry/utils/dates.py:193: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```

lets address it