### PR TITLE
fix(dashboards): consolidate btn area

### DIFF
--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -9,7 +9,6 @@ import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
-import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import {Hovercard} from 'sentry/components/hovercard';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconAdd, IconDownload, IconEdit, IconStar} from 'sentry/icons';
@@ -197,84 +196,87 @@ function Controls({
     : t('You do not have permission to edit this dashboard');
   return (
     <StyledButtonBar key="controls">
-      <FeedbackWidgetButton />
       <DashboardEditFeature>
         {hasFeature => (
           <Fragment>
             <Feature features="dashboards-import">
-              <Button
-                data-test-id="dashboard-export"
-                onClick={e => {
-                  e.preventDefault();
-                  exportDashboard();
-                }}
-                icon={<IconDownload />}
-                priority="default"
-                size="sm"
-              >
-                {t('Export Dashboard')}
-              </Button>
+              <Tooltip title={t('Export Dashboard')}>
+                <Button
+                  data-test-id="dashboard-export"
+                  aria-label={t('export-dashboard')}
+                  onClick={e => {
+                    e.preventDefault();
+                    exportDashboard();
+                  }}
+                  icon={<IconDownload />}
+                  priority="default"
+                  size="sm"
+                />
+              </Tooltip>
             </Feature>
-            {dashboard.id !== 'default-overview' && (
-              <Button
-                size="sm"
-                aria-label={'dashboards-favourite'}
-                icon={
-                  <IconStar
-                    color={isFavorited ? 'yellow300' : 'gray300'}
-                    isSolid={isFavorited}
-                    aria-label={isFavorited ? t('UnFavorite') : t('Favorite')}
-                    data-test-id={isFavorited ? 'yellow-star' : 'empty-star'}
-                  />
-                }
-                onClick={async () => {
-                  try {
-                    setIsFavorited(!isFavorited);
-                    await updateDashboardFavorite(
-                      api,
-                      queryClient,
-                      organization,
-                      dashboard.id,
-                      !isFavorited
-                    );
-                    trackAnalytics('dashboards_manage.toggle_favorite', {
-                      organization,
-                      dashboard_id: dashboard.id,
-                      favorited: !isFavorited,
-                    });
-                  } catch (error) {
-                    // If the api call fails, revert the state
-                    setIsFavorited(isFavorited);
-                  }
-                }}
-              />
-            )}
             {dashboard.id !== 'default-overview' && (
               <EditAccessSelector
                 dashboard={dashboard}
                 onChangeEditAccess={onChangeEditAccess}
               />
             )}
-            <Button
-              data-test-id="dashboard-edit"
-              onClick={e => {
-                e.preventDefault();
-                onEdit();
-              }}
-              icon={isSaving ? <LoadingIndicator size={14} /> : <IconEdit />}
-              disabled={!hasFeature || hasUnsavedFilters || !hasEditAccess || isSaving}
-              title={
-                isSaving
-                  ? DASHBOARD_SAVING_MESSAGE
-                  : hasEditAccess
-                    ? hasUnsavedFilters && UNSAVED_FILTERS_MESSAGE
-                    : t('You do not have permission to edit this dashboard')
-              }
-              priority="default"
-              size="sm"
-            >
-              {t('Edit Dashboard')}
-            </Button>
+            {dashboard.id !== 'default-overview' && (
+              <Tooltip title={isFavorited ? t('Starred Dashboard') : t('Star Dashboard')}>
+                <Button
+                  size="sm"
+                  aria-label={t('star-dashboard')}
+                  icon={
+                    <IconStar
+                      color={isFavorited ? 'yellow300' : 'gray500'}
+                      isSolid={isFavorited}
+                      aria-label={isFavorited ? t('Unstar') : t('Star')}
+                      data-test-id={isFavorited ? 'yellow-star' : 'empty-star'}
+                    />
+                  }
+                  onClick={async () => {
+                    try {
+                      setIsFavorited(!isFavorited);
+                      await updateDashboardFavorite(
+                        api,
+                        queryClient,
+                        organization,
+                        dashboard.id,
+                        !isFavorited
+                      );
+                      trackAnalytics('dashboards_manage.toggle_favorite', {
+                        organization,
+                        dashboard_id: dashboard.id,
+                        favorited: !isFavorited,
+                      });
+                    } catch (error) {
+                      // If the api call fails, revert the state
+                      setIsFavorited(isFavorited);
+                    }
+                  }}
+                />
+              </Tooltip>
+            )}
+            <Tooltip title={t('Edit Dashboard')}>
+              <Button
+                data-test-id="dashboard-edit"
+                aria-label={t('edit-dashboard')}
+                onClick={e => {
+                  e.preventDefault();
+                  onEdit();
+                }}
+                icon={isSaving ? <LoadingIndicator size={14} /> : <IconEdit />}
+                disabled={!hasFeature || hasUnsavedFilters || !hasEditAccess || isSaving}
+                title={
+                  isSaving
+                    ? DASHBOARD_SAVING_MESSAGE
+                    : hasEditAccess
+                      ? hasUnsavedFilters && UNSAVED_FILTERS_MESSAGE
+                      : t('You do not have permission to edit this dashboard')
+                }
+                priority="default"
+                size="sm"
+              />
+            </Tooltip>
             {hasFeature ? (
               <Tooltip
                 title={tooltipMessage}
@@ -288,7 +290,7 @@ function Controls({
                     'aria-label': t('Add Widget'),
                     size: 'sm',
                     showChevron: true,
-                    icon: <IconAdd isCircled size="sm" />,
+                    icon: <IconAdd size="sm" />,
                     priority: 'primary',
                   }}
                   position="bottom-end"

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -1976,7 +1976,7 @@ describe('Dashboards > Detail', () => {
       await userEvent.click(await screen.findByText('Editors:'));
 
       // selects 'Select All' so everyone has edit access
-      expect(await screen.findByText('Select All')).toBeEnabled();
+      expect(await screen.findByRole('option', {name: 'Select All'})).toBeEnabled();
       expect(await screen.findByRole('option', {name: 'Select All'})).toHaveAttribute(
         'aria-selected',
         'false'
@@ -2063,7 +2063,7 @@ describe('Dashboards > Detail', () => {
       );
       await userEvent.click(await screen.findByText('Editors:'));
 
-      expect(await screen.findByText('Select All')).toBeEnabled();
+      expect(await screen.findByRole('option', {name: 'Select All'})).toBeEnabled();
       expect(await screen.findByRole('option', {name: 'Select All'})).toHaveAttribute(
         'aria-selected',
         'false'

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -486,7 +486,7 @@ describe('Dashboards > Detail', () => {
       await waitFor(() => expect(mockVisit).toHaveBeenCalledTimes(1));
 
       // Enter edit mode.
-      await userEvent.click(screen.getByRole('button', {name: 'Edit Dashboard'}));
+      await userEvent.click(screen.getByRole('button', {name: 'edit-dashboard'}));
 
       // Remove the second and third widgets
       await userEvent.click(
@@ -585,7 +585,7 @@ describe('Dashboards > Detail', () => {
       );
 
       // Enter edit mode.
-      await userEvent.click(await screen.findByRole('button', {name: 'Edit Dashboard'}));
+      await userEvent.click(await screen.findByRole('button', {name: 'edit-dashboard'}));
       expect(await screen.findByRole('button', {name: 'Add Widget'})).toBeInTheDocument();
     });
 
@@ -657,7 +657,7 @@ describe('Dashboards > Detail', () => {
       );
 
       // Enter edit mode.
-      await userEvent.click(await screen.findByRole('button', {name: 'Edit Dashboard'}));
+      await userEvent.click(await screen.findByRole('button', {name: 'edit-dashboard'}));
       expect(screen.queryByRole('button', {name: 'Add widget'})).not.toBeInTheDocument();
     });
 
@@ -773,10 +773,10 @@ describe('Dashboards > Detail', () => {
         }
       );
 
-      await userEvent.click(await screen.findByText('Edit Dashboard'));
+      await userEvent.click(await screen.findByRole('button', {name: 'edit-dashboard'}));
       await userEvent.click(await screen.findByText('Save and Finish'));
 
-      expect(screen.getByText('Edit Dashboard')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'edit-dashboard'})).toBeInTheDocument();
       expect(mockPut).not.toHaveBeenCalled();
     });
 
@@ -826,7 +826,7 @@ describe('Dashboards > Detail', () => {
         }
       );
 
-      await userEvent.click(await screen.findByText('Edit Dashboard'));
+      await userEvent.click(await screen.findByRole('button', {name: 'edit-dashboard'}));
       const widget = (await screen.findByText('First Widget')).closest(
         '.react-grid-item'
       ) as HTMLElement;
@@ -882,7 +882,7 @@ describe('Dashboards > Detail', () => {
         }
       );
 
-      await userEvent.click(await screen.findByText('Edit Dashboard'));
+      await userEvent.click(await screen.findByRole('button', {name: 'edit-dashboard'}));
       await userEvent.click(await screen.findByText('Cancel'));
 
       expect(window.confirm).not.toHaveBeenCalled();
@@ -1476,7 +1476,7 @@ describe('Dashboards > Detail', () => {
       );
     });
 
-    it('disables the Edit Dashboard button when there are unsaved filters', async () => {
+    it('disables the edit-dashboard button when there are unsaved filters', async () => {
       const router = RouterFixture({
         location: {
           ...LocationFixture(),
@@ -1534,7 +1534,7 @@ describe('Dashboards > Detail', () => {
 
       expect(await screen.findByText('Save')).toBeInTheDocument();
       expect(screen.getByTestId('filter-bar-cancel')).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Edit Dashboard'})).toBeDisabled();
+      expect(screen.getByRole('button', {name: 'edit-dashboard'})).toBeDisabled();
     });
 
     it('ignores the order of selection of page filters to render unsaved filters', async () => {
@@ -1875,9 +1875,9 @@ describe('Dashboards > Detail', () => {
         }
       );
 
-      await userEvent.click(await screen.findByText('Edit Access:'));
+      await userEvent.click(await screen.findByText('Editors:'));
       expect(screen.getByText('Creator')).toBeInTheDocument();
-      expect(screen.getByText('All users')).toBeInTheDocument();
+      expect(screen.getByText('Select All')).toBeInTheDocument();
     });
 
     it('creates and updates new permissions for dashboard with no edit perms initialized', async () => {
@@ -1906,16 +1906,16 @@ describe('Dashboards > Detail', () => {
           deprecatedRouterMocks: true,
         }
       );
-      await userEvent.click(await screen.findByText('Edit Access:'));
+      await userEvent.click(await screen.findByText('Editors:'));
 
-      // deselects 'All users' so only creator has edit access
-      expect(await screen.findByText('All users')).toBeEnabled();
-      expect(await screen.findByRole('option', {name: 'All users'})).toHaveAttribute(
+      // deselects 'Select All' so only creator has edit access
+      expect(await screen.findByText('Select All')).toBeEnabled();
+      expect(await screen.findByRole('option', {name: 'Select All'})).toHaveAttribute(
         'aria-selected',
         'true'
       );
-      await userEvent.click(screen.getByRole('option', {name: 'All users'}));
-      expect(await screen.findByRole('option', {name: 'All users'})).toHaveAttribute(
+      await userEvent.click(screen.getByRole('option', {name: 'Select All'}));
+      expect(await screen.findByRole('option', {name: 'Select All'})).toHaveAttribute(
         'aria-selected',
         'false'
       );
@@ -1973,16 +1973,16 @@ describe('Dashboards > Detail', () => {
           deprecatedRouterMocks: true,
         }
       );
-      await userEvent.click(await screen.findByText('Edit Access:'));
+      await userEvent.click(await screen.findByText('Editors:'));
 
-      // selects 'All users' so everyone has edit access
-      expect(await screen.findByText('All users')).toBeEnabled();
-      expect(await screen.findByRole('option', {name: 'All users'})).toHaveAttribute(
+      // selects 'Select All' so everyone has edit access
+      expect(await screen.findByText('Select All')).toBeEnabled();
+      expect(await screen.findByRole('option', {name: 'Select All'})).toHaveAttribute(
         'aria-selected',
         'false'
       );
-      await userEvent.click(screen.getByRole('option', {name: 'All users'}));
-      expect(await screen.findByRole('option', {name: 'All users'})).toHaveAttribute(
+      await userEvent.click(screen.getByRole('option', {name: 'Select All'}));
+      expect(await screen.findByRole('option', {name: 'Select All'})).toHaveAttribute(
         'aria-selected',
         'true'
       );
@@ -2061,10 +2061,10 @@ describe('Dashboards > Detail', () => {
           deprecatedRouterMocks: true,
         }
       );
-      await userEvent.click(await screen.findByText('Edit Access:'));
+      await userEvent.click(await screen.findByText('Editors:'));
 
-      expect(await screen.findByText('All users')).toBeEnabled();
-      expect(await screen.findByRole('option', {name: 'All users'})).toHaveAttribute(
+      expect(await screen.findByText('Select All')).toBeEnabled();
+      expect(await screen.findByRole('option', {name: 'Select All'})).toHaveAttribute(
         'aria-selected',
         'false'
       );
@@ -2136,8 +2136,8 @@ describe('Dashboards > Detail', () => {
         }
       );
 
-      await screen.findByText('Edit Access:');
-      expect(screen.getByRole('button', {name: 'Edit Dashboard'})).toBeDisabled();
+      await screen.findByText('Editors:');
+      expect(screen.getByRole('button', {name: 'edit-dashboard'})).toBeDisabled();
       expect(screen.getByRole('button', {name: 'Add Widget'})).toBeDisabled();
     });
 
@@ -2202,8 +2202,8 @@ describe('Dashboards > Detail', () => {
         }
       );
 
-      await screen.findByText('Edit Access:');
-      expect(screen.getByRole('button', {name: 'Edit Dashboard'})).toBeDisabled();
+      await screen.findByText('Editors:');
+      expect(screen.getByRole('button', {name: 'edit-dashboard'})).toBeDisabled();
       expect(screen.getByRole('button', {name: 'Add Widget'})).toBeDisabled();
       await userEvent.click(await screen.findByLabelText('Widget actions'));
       expect(
@@ -2219,7 +2219,7 @@ describe('Dashboards > Detail', () => {
       );
     });
 
-    it('renders favorite button in unfavorited state', async () => {
+    it('renders favorite button in unstarred state', async () => {
       const router = RouterFixture({
         location: LocationFixture(),
         params: {orgId: 'org-slug', dashboardId: '1'},
@@ -2248,9 +2248,9 @@ describe('Dashboards > Detail', () => {
         }
       );
 
-      const favoriteButton = await screen.findByLabelText('dashboards-favourite');
+      const favoriteButton = await screen.findByLabelText('star-dashboard');
       expect(favoriteButton).toBeInTheDocument();
-      expect(await screen.findByLabelText('Favorite')).toBeInTheDocument();
+      expect(await screen.findByLabelText('Star')).toBeInTheDocument();
     });
 
     it('renders favorite button in favorited state', async () => {
@@ -2282,9 +2282,9 @@ describe('Dashboards > Detail', () => {
         }
       );
 
-      const favoriteButton = await screen.findByLabelText('dashboards-favourite');
+      const favoriteButton = await screen.findByLabelText('star-dashboard');
       expect(favoriteButton).toBeInTheDocument();
-      expect(await screen.findByLabelText('UnFavorite')).toBeInTheDocument();
+      expect(await screen.findByLabelText('Unstar')).toBeInTheDocument();
     });
 
     it('toggles favorite button', async () => {
@@ -2322,12 +2322,12 @@ describe('Dashboards > Detail', () => {
         }
       );
 
-      const favoriteButton = await screen.findByLabelText('dashboards-favourite');
+      const favoriteButton = await screen.findByLabelText('star-dashboard');
       expect(favoriteButton).toBeInTheDocument();
 
-      expect(await screen.findByLabelText('UnFavorite')).toBeInTheDocument();
+      expect(await screen.findByLabelText('Unstar')).toBeInTheDocument();
       await userEvent.click(favoriteButton);
-      expect(await screen.findByLabelText('Favorite')).toBeInTheDocument();
+      expect(await screen.findByLabelText('Star')).toBeInTheDocument();
     });
 
     describe('widget builder redesign', () => {

--- a/static/app/views/dashboards/editAccessSelector.spec.tsx
+++ b/static/app/views/dashboards/editAccessSelector.spec.tsx
@@ -57,14 +57,14 @@ describe('When EditAccessSelector is rendered with no Teams', () => {
   it('renders with creator and everyone options', async () => {
     renderTestComponent();
 
-    await userEvent.click(await screen.findByText('Edit Access:'));
+    await userEvent.click(await screen.findByText('Editors:'));
     expect(screen.getByText('Creator')).toBeInTheDocument();
-    expect(screen.getByText('All users')).toBeInTheDocument();
+    expect(screen.getByText('Select All')).toBeInTheDocument();
   });
 
   it('renders All badge when dashboards has no perms defined', async () => {
     renderTestComponent();
-    await userEvent.click(await screen.findByText('Edit Access:'));
+    await userEvent.click(await screen.findByText('Editors:'));
     expect(screen.getByText('All')).toBeInTheDocument();
   });
 
@@ -76,11 +76,11 @@ describe('When EditAccessSelector is rendered with no Teams', () => {
       permissions: {isEditableByEveryone: true}, // set to true
     });
     renderTestComponent(mockDashboard);
-    await screen.findByText('Edit Access:');
+    await screen.findByText('Editors:');
     expect(screen.getByText('All')).toBeInTheDocument();
   });
 
-  it('renders All badge when All users is selected', async () => {
+  it('renders All badge when Select All is selected', async () => {
     const mockDashboard = DashboardFixture([], {
       id: '1',
       createdBy: UserFixture({id: '1'}),
@@ -88,17 +88,17 @@ describe('When EditAccessSelector is rendered with no Teams', () => {
       permissions: {isEditableByEveryone: false}, // set to false
     });
     renderTestComponent(mockDashboard);
-    await userEvent.click(await screen.findByText('Edit Access:'));
+    await userEvent.click(await screen.findByText('Editors:'));
 
     expect(screen.queryByText('All')).not.toBeInTheDocument();
 
     // Select everyone
-    expect(await screen.findByRole('option', {name: 'All users'})).toHaveAttribute(
+    expect(await screen.findByRole('option', {name: 'Select All'})).toHaveAttribute(
       'aria-selected',
       'false'
     );
-    await userEvent.click(screen.getByRole('option', {name: 'All users'}));
-    expect(await screen.findByRole('option', {name: 'All users'})).toHaveAttribute(
+    await userEvent.click(screen.getByRole('option', {name: 'Select All'}));
+    expect(await screen.findByRole('option', {name: 'Select All'})).toHaveAttribute(
       'aria-selected',
       'true'
     );
@@ -114,7 +114,7 @@ describe('When EditAccessSelector is rendered with no Teams', () => {
       permissions: {isEditableByEveryone: false}, // set to false
     });
     renderTestComponent(mockDashboard);
-    await screen.findByText('Edit Access:');
+    await screen.findByText('Editors:');
     expect(screen.getByText('LI')).toBeInTheDocument(); // dashboard owner's initials
     expect(screen.queryByText('All')).not.toBeInTheDocument();
   });
@@ -178,7 +178,7 @@ describe('When EditAccessSelector is rendered with Teams', () => {
 
   it('renders all teams', async () => {
     renderTestComponent();
-    await userEvent.click(await screen.findByText('Edit Access:'));
+    await userEvent.click(await screen.findByText('Editors:'));
 
     expect(screen.getByText('Teams')).toBeInTheDocument();
     expect(screen.getByText('#team1')).toBeInTheDocument();
@@ -186,7 +186,7 @@ describe('When EditAccessSelector is rendered with Teams', () => {
     expect(screen.getByText('#team3')).toBeInTheDocument();
   });
 
-  it('selects all teams when all users is selected', async () => {
+  it('selects all teams when Select All is selected', async () => {
     const mockDashboard = DashboardFixture([], {
       id: '1',
       createdBy: UserFixture({id: '1'}),
@@ -194,7 +194,7 @@ describe('When EditAccessSelector is rendered with Teams', () => {
       permissions: {isEditableByEveryone: false}, // set to false
     });
     renderTestComponent(mockDashboard);
-    await userEvent.click(await screen.findByText('Edit Access:'));
+    await userEvent.click(await screen.findByText('Editors:'));
 
     expect(await screen.findByRole('option', {name: '#team1'})).toHaveAttribute(
       'aria-selected',
@@ -206,12 +206,12 @@ describe('When EditAccessSelector is rendered with Teams', () => {
     );
 
     // Select everyone
-    expect(await screen.findByRole('option', {name: 'All users'})).toHaveAttribute(
+    expect(await screen.findByRole('option', {name: 'Select All'})).toHaveAttribute(
       'aria-selected',
       'false'
     );
-    await userEvent.click(screen.getByRole('option', {name: 'All users'}));
-    expect(await screen.findByRole('option', {name: 'All users'})).toHaveAttribute(
+    await userEvent.click(screen.getByRole('option', {name: 'Select All'}));
+    expect(await screen.findByRole('option', {name: 'Select All'})).toHaveAttribute(
       'aria-selected',
       'true'
     );
@@ -235,7 +235,7 @@ describe('When EditAccessSelector is rendered with Teams', () => {
     });
     renderTestComponent();
 
-    await userEvent.click(await screen.findByText('Edit Access:'));
+    await userEvent.click(await screen.findByText('Editors:'));
     await userEvent.type(screen.getByPlaceholderText('Search Teams'), 'team2');
 
     expect(screen.getByText('#team2')).toBeInTheDocument();

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -113,10 +113,10 @@ function EditAccessSelector({
       newSelectedValues = ['_creator'];
     } else {
       if (areAllTeamsSelected) {
-        // selecting all teams deselects 'all users'
+        // selecting all teams deselects 'Select All'
         newSelectedValues = ['_creator', '_allUsers', ...teamIds];
       } else {
-        // deselecting any team deselects 'all users'
+        // deselecting any team deselects 'Select All'
         newSelectedValues = newSelectedValues.filter(
           (value: any) => value !== '_allUsers'
         );
@@ -263,17 +263,17 @@ function EditAccessSelector({
       makeCreatorOption(),
       {
         value: '_all_users_section',
+        label: 'Teams',
         options: [
           {
             value: '_allUsers',
-            label: t('All users'),
+            label: t('Select All'),
             disabled: !userCanEditDashboardPermissions,
           },
         ],
       },
       {
         value: '_teams',
-        label: t('Teams'),
         options: sortBy(teamsToRender, listSort).map(makeTeamOption),
         showToggleAllButton: userCanEditDashboardPermissions,
         disabled: !userCanEditDashboardPermissions,
@@ -349,7 +349,7 @@ function EditAccessSelector({
         listOnly
           ? [triggerAvatars]
           : [
-              <LabelContainer key="selector-label">{t('Edit Access:')}</LabelContainer>,
+              <LabelContainer key="selector-label">{t('Editors:')}</LabelContainer>,
               triggerAvatars,
             ]
       }
@@ -373,7 +373,7 @@ function EditAccessSelector({
 
   return (
     <Tooltip
-      title={t('Only the creator of the dashboard can edit permissions')}
+      title={t('Only the creator of this dashboard can manage editor access')}
       disabled={
         userCanEditDashboardPermissions || isMenuOpen || isCollapsedAvatarTooltipOpen
       }

--- a/static/app/views/dashboards/manage/dashboardCard.tsx
+++ b/static/app/views/dashboards/manage/dashboardCard.tsx
@@ -90,13 +90,13 @@ function DashboardCard({
           icon={
             <IconStar
               isSolid={favorited}
-              color={favorited ? 'yellow300' : 'gray300'}
+              color={favorited ? 'yellow300' : 'gray500'}
               size="sm"
-              aria-label={favorited ? t('UnFavorite') : t('Favorite')}
+              aria-label={favorited ? t('Unstar') : t('Star')}
             />
           }
           borderless
-          aria-label={t('Dashboards Favorite')}
+          aria-label={favorited ? t('Starred Dashboard') : t('Star Dashboard')}
           size="xs"
           onClick={async () => {
             try {

--- a/static/app/views/dashboards/manage/dashboardGrid.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.spec.tsx
@@ -299,7 +299,7 @@ describe('Dashboards - DashboardGrid', () => {
     expect(dashboardUpdateMock).not.toHaveBeenCalled();
   });
 
-  it('renders favorite and unfavorite buttons on cards', () => {
+  it('renders star and unstar buttons on cards', () => {
     dashboards = [
       DashboardListItemFixture({
         id: '1',
@@ -330,9 +330,9 @@ describe('Dashboards - DashboardGrid', () => {
       }
     );
 
-    expect(screen.queryAllByLabelText('Dashboards Favorite')).toHaveLength(2);
-    expect(screen.queryAllByLabelText('Favorite')).toHaveLength(1);
-    expect(screen.queryAllByLabelText('UnFavorite')).toHaveLength(1);
+    expect(screen.queryAllByLabelText('Starred Dashboard')).toHaveLength(1);
+    expect(screen.queryAllByLabelText('Star')).toHaveLength(1);
+    expect(screen.queryAllByLabelText('Unstar')).toHaveLength(1);
   });
 
   it('makes PUT requests when favoriting', async () => {
@@ -373,14 +373,14 @@ describe('Dashboards - DashboardGrid', () => {
       }
     );
 
-    expect(screen.queryAllByLabelText('Favorite')).toHaveLength(1);
-    const favoriteButton = screen.queryAllByLabelText('Favorite')[0]!;
+    expect(screen.queryAllByLabelText('Star')).toHaveLength(1);
+    const favoriteButton = screen.queryAllByLabelText('Star')[0]!;
     await userEvent.click(favoriteButton);
 
     await waitFor(() => {
       expect(putMock).toHaveBeenCalled();
     });
 
-    expect(screen.queryAllByLabelText('Favorite')).toHaveLength(0);
+    expect(screen.queryAllByLabelText('Star')).toHaveLength(0);
   });
 });

--- a/static/app/views/dashboards/manage/dashboardTable.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.spec.tsx
@@ -321,11 +321,11 @@ describe('Dashboards - DashboardTable', () => {
       }
     );
 
-    expect(screen.getByLabelText('Favorite Column')).toBeInTheDocument();
-    expect(screen.queryAllByLabelText('Favorite')).toHaveLength(1);
-    expect(screen.queryAllByLabelText('UnFavorite')).toHaveLength(1);
+    expect(screen.getByLabelText('Star Column')).toBeInTheDocument();
+    expect(screen.queryAllByLabelText('Star')).toHaveLength(1);
+    expect(screen.queryAllByLabelText('Unstar')).toHaveLength(1);
 
-    await userEvent.click(screen.queryAllByLabelText('Favorite')[0]!);
-    expect(screen.queryAllByLabelText('UnFavorite')).toHaveLength(2);
+    await userEvent.click(screen.queryAllByLabelText('Star')[0]!);
+    expect(screen.queryAllByLabelText('Unstar')).toHaveLength(2);
   });
 });

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -87,9 +87,9 @@ function FavoriteButton({
       borderless
       icon={
         <IconStar
-          color={favorited ? 'yellow300' : 'gray300'}
+          color={favorited ? 'yellow300' : 'gray500'}
           isSolid={favorited}
-          aria-label={favorited ? t('UnFavorite') : t('Favorite')}
+          aria-label={favorited ? t('Unstar') : t('Star')}
           size="sm"
         />
       }
@@ -337,7 +337,7 @@ function DashboardTable({
               <StyledIconStar
                 color="yellow300"
                 isSolid
-                aria-label={t('Favorite Column')}
+                aria-label={t('Star Column')}
                 key="favorite-header"
               />,
             ];


### PR DESCRIPTION
- Removed give feedback button in favor of the All Dashboards give feedback button
- Simplified edit dashboard button with text to icon
- Changed "Edit Access" to "Editors" 
- Clarified what the editor dropdown is for in the tooltip
- Changed the concept of "Favoriting" to "Starring" to align with navbar
- Added tooltips for all the icon btns 
- Changed "All Users" to "Select All" in the dropdown

**Before:**
<img width="1020" height="113" alt="Screenshot 2025-09-15 at 2 52 24 PM" src="https://github.com/user-attachments/assets/01bf3a4d-3123-4d08-b317-702f498f5d87" />
__________________________
<img width="265" height="117" alt="Screenshot 2025-09-15 at 2 54 00 PM" src="https://github.com/user-attachments/assets/65818cc8-04ad-483e-b423-72088b2e8fd1" />

**After:**
<img width="1049" height="112" alt="Screenshot 2025-09-15 at 2 52 31 PM" src="https://github.com/user-attachments/assets/5e854806-258a-4742-869a-b1b207296696" />
__________________________
<img width="246" height="110" alt="Screenshot 2025-09-15 at 2 53 53 PM" src="https://github.com/user-attachments/assets/2c15dd25-2076-41fb-a380-9ae51699ad50" />