### PR TITLE
fix(typing): Type tests.sentry.integrations.msteams

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -747,7 +747,7 @@ module = [
     "tests.sentry.integrations.jira.utils.*",
     "tests.sentry.integrations.middleware.*",
     "tests.sentry.integrations.models.*",
-    "tests.sentry.integrations.msteams.webhook.*",
+    "tests.sentry.integrations.msteams.*",
     "tests.sentry.integrations.repository.*",
     "tests.sentry.integrations.services.*",
     "tests.sentry.integrations.slack.actions.*",

--- a/tests/sentry/integrations/msteams/notifications/test_resolved.py
+++ b/tests/sentry/integrations/msteams/notifications/test_resolved.py
@@ -57,7 +57,7 @@ class MSTeamsResolvedNotificationTest(MSTeamsActivityNotificationTest):
             == body[3]["columns"][1]["items"][0]["text"]
         )
 
-    def test_resolved_in_release(self, mock_send_card) -> None:
+    def test_resolved_in_release(self, mock_send_card: MagicMock) -> None:
         """
         Test that the card for MS Teams notification is generated correctly when an issue is resolved in a release.
         """

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -5,6 +5,8 @@ import orjson
 import responses
 from django.http import HttpResponse
 from django.urls import reverse
+from requests import PreparedRequest
+from rest_framework.response import Response
 
 from sentry.api.client import ApiClient
 from sentry.integrations.msteams.card_builder.identity import build_linking_card
@@ -69,17 +71,17 @@ class StatusActionTest(APITestCase):
 
     def post_webhook(
         self,
-        action_type="dummy",
-        user_id="g4nd4lf",
-        team_id="f3ll0wsh1p",
-        tenant_id="m17hr4nd1r",
-        conversation_type="channel",
-        channel_id=None,
-        group_id=None,
-        resolve_input=None,
-        archive_input=None,
-        assign_input=None,
-    ):
+        action_type: str = "dummy",
+        user_id: str = "g4nd4lf",
+        team_id: str = "f3ll0wsh1p",
+        tenant_id: str = "m17hr4nd1r",
+        conversation_type: str = "channel",
+        channel_id: str | None = None,
+        group_id: str | None = None,
+        resolve_input: str | None = None,
+        archive_input: str | None = None,
+        assign_input: str | None = None,
+    ) -> Response:
         replyToId = "12345"
 
         channel_data = {"tenant": {"id": tenant_id}}
@@ -126,7 +128,10 @@ class StatusActionTest(APITestCase):
     def test_ask_linking(self, sign: MagicMock, verify: MagicMock) -> None:
         sign.return_value = "signed_parameters"
 
-        def user_conversation_id_callback(request):
+        def user_conversation_id_callback(
+            request: PreparedRequest,
+        ) -> tuple[int, dict[str, str], str]:
+            assert request.body is not None
             payload = orjson.loads(request.body)
             if payload["members"] == [{"id": "s4ur0n"}] and payload["channelData"] == {
                 "tenant": {"id": "7h3_gr347"}

--- a/tests/sentry/integrations/msteams/test_client.py
+++ b/tests/sentry/integrations/msteams/test_client.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from unittest import mock
 from unittest.mock import call, patch
 from urllib.parse import urlencode
@@ -5,6 +6,7 @@ from urllib.parse import urlencode
 import pytest
 import responses
 from django.test import override_settings
+from requests import Request
 
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.msteams.client import MsTeamsClient
@@ -25,7 +27,7 @@ from tests.sentry.integrations.test_helpers import add_control_silo_proxy_respon
 @control_silo_test
 class MsTeamsClientTest(TestCase):
     @pytest.fixture(autouse=True)
-    def _setup_metric_patch(self):
+    def _setup_metric_patch(self) -> Generator[None]:
         with mock.patch("sentry.shared_integrations.client.base.metrics") as self.metrics:
             yield
 
@@ -180,7 +182,7 @@ class MsTeamsClientTest(TestCase):
         assert self.metrics.incr.mock_calls == calls
 
 
-def assert_proxy_request(request, is_proxy=True):
+def assert_proxy_request(request: Request, is_proxy: bool = True) -> None:
     assert (PROXY_BASE_PATH in request.url) == is_proxy
     assert (PROXY_OI_HEADER in request.headers) == is_proxy
     assert (PROXY_SIGNATURE_HEADER in request.headers) == is_proxy

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -33,18 +33,18 @@ class MsTeamsIntegrationTest(IntegrationTestCase):
             "tenant_id": tenant_id,
         }
 
-    def assert_team_installation_post_install(self):
+    def assert_team_installation_post_install(self) -> None:
         integration_url = f"organizations/{self.organization.slug}/alerts/rules/"
         assert integration_url in responses.calls[1].request.body.decode("utf-8")
         assert self.organization.name in responses.calls[1].request.body.decode("utf-8")
 
-    def assert_personal_installation_post_install(self):
+    def assert_personal_installation_post_install(self) -> None:
         integration_url = "/settings/account/notifications"
         request_body = responses.calls[1].request.body.decode("utf-8")
         assert "Personal installation successful" in request_body
         assert integration_url in request_body
 
-    def assert_setup_flow(self, installation_type: str):
+    def assert_setup_flow(self, installation_type: str) -> None:
         responses.reset()
 
         responses.add(

--- a/tests/sentry/integrations/msteams/test_notify_action.py
+++ b/tests/sentry/integrations/msteams/test_notify_action.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import orjson
 import responses
+from django.forms import Form
 
 from sentry.analytics.events.alert_sent import AlertSentEvent
 from sentry.integrations.models.integration import Integration
@@ -39,7 +40,9 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
             },
         )
 
-    def assert_form_valid(self, form, expected_channel_id, expected_channel):
+    def assert_form_valid(
+        self, form: Form, expected_channel_id: str, expected_channel: str
+    ) -> None:
         assert form.is_valid()
         assert form.cleaned_data["channel_id"] == expected_channel_id
         assert form.cleaned_data["channel"] == expected_channel


### PR DESCRIPTION
# Summary
Mostly added types; added a couple assertions where they would've already been throwing errors. We're in test code so running the tests is sufficient for me to feel secure that the assertions won't be problematic.

# Test Plan
```
mypy tests/sentry/integrations/msteams # No errors
pytest tests/sentry/integrations/msteams # 120 passed, 1 skipped, 0 failed
```