### PR TITLE
feat(open periods): Expect open periods to exist

### DIFF
--- a/src/sentry/models/groupopenperiod.py
+++ b/src/sentry/models/groupopenperiod.py
@@ -153,10 +153,7 @@ def get_open_periods_for_group(
 
     if not query_start:
         # use whichever date is more recent to reduce the query range. first_seen could be > 90 days ago
-        query_start = group.first_seen
-        ninety_days_ago = timezone.now() - timedelta(days=90)
-        if group.first_seen > ninety_days_ago:
-            query_start = ninety_days_ago
+        query_start = min(group.first_seen, timezone.now() - timedelta(days=90))
 
     group_open_periods = GroupOpenPeriod.objects.filter(
         group=group, date_started__gte=query_start, id__gte=offset

--- a/src/sentry/models/groupopenperiod.py
+++ b/src/sentry/models/groupopenperiod.py
@@ -12,6 +12,7 @@ from sentry import features
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
+from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 
@@ -124,7 +125,7 @@ def get_open_periods_for_group(
     query_start: datetime | None = None,
     query_end: datetime | None = None,
     limit: int | None = None,
-) -> list[GroupOpenPeriod] | list[None]:
+) -> BaseQuerySet[GroupOpenPeriod] | list[None]:
     if not features.has("organizations:issue-open-periods", group.organization):
         return []
 
@@ -139,7 +140,7 @@ def get_open_periods_for_group(
     if query_end:
         group_open_periods = group_open_periods.filter(date_ended__lte=query_end)
 
-    return [period for period in group_open_periods][:limit]
+    return group_open_periods[:limit]
 
 
 def create_open_period(group: Group, start_time: datetime) -> None:

--- a/src/sentry/models/groupopenperiod.py
+++ b/src/sentry/models/groupopenperiod.py
@@ -152,8 +152,11 @@ def get_open_periods_for_group(
         return []
 
     if not query_start:
-        # use whichever date is more recent to reduce the query range. first_seen could > 90 days ago
-        query_start = not timezone.now() - timedelta(days=90) or group.first_seen
+        # use whichever date is more recent to reduce the query range. first_seen could be > 90 days ago
+        query_start = group.first_seen
+        ninety_days_ago = timezone.now() - timedelta(days=90)
+        if group.first_seen > ninety_days_ago:
+            query_start = ninety_days_ago
 
     group_open_periods = GroupOpenPeriod.objects.filter(
         group=group, date_started__gte=query_start, id__gte=offset

--- a/src/sentry/models/groupopenperiod.py
+++ b/src/sentry/models/groupopenperiod.py
@@ -124,7 +124,7 @@ def get_open_periods_for_group(
     query_start: datetime | None = None,
     query_end: datetime | None = None,
     limit: int | None = None,
-) -> list[GroupOpenPeriod | None]:
+) -> list[GroupOpenPeriod] | list[None]:
     if not features.has("organizations:issue-open-periods", group.organization):
         return []
 
@@ -139,7 +139,7 @@ def get_open_periods_for_group(
     if query_end:
         group_open_periods = group_open_periods.filter(date_ended__lte=query_end)
 
-    return group_open_periods[:limit]
+    return [period for period in group_open_periods][:limit]
 
 
 def create_open_period(group: Group, start_time: datetime) -> None:

--- a/src/sentry/models/groupopenperiod.py
+++ b/src/sentry/models/groupopenperiod.py
@@ -130,16 +130,16 @@ def get_open_periods_for_group(
 
     if not query_start:
         # use whichever date is more recent to reduce the query range. first_seen could be > 90 days ago
-        query_start = min(group.first_seen, timezone.now() - timedelta(days=90))
+        query_start = max(group.first_seen, timezone.now() - timedelta(days=90))
 
     group_open_periods = GroupOpenPeriod.objects.filter(
         group=group,
         date_started__gte=query_start,
-    ).order_by("-date_started")[:limit]
+    ).order_by("-date_started")
     if query_end:
         group_open_periods = group_open_periods.filter(date_ended__lte=query_end)
 
-    return group_open_periods
+    return group_open_periods[:limit]
 
 
 def create_open_period(group: Group, start_time: datetime) -> None:

--- a/src/sentry/workflow_engine/endpoints/organization_open_periods.py
+++ b/src/sentry/workflow_engine/endpoints/organization_open_periods.py
@@ -131,7 +131,8 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
                 status=status.HTTP_200_OK,
             )
         limit = request.GET.get("per_page")
-        limit = int(limit) if limit else limit
+        if limit:
+            limit = int(limit)
 
         open_periods = get_open_periods_for_group(
             group=target_group,

--- a/src/sentry/workflow_engine/endpoints/organization_open_periods.py
+++ b/src/sentry/workflow_engine/endpoints/organization_open_periods.py
@@ -128,7 +128,7 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
         if not target_group:
             return Response(
                 {"detail": "Group not found. Could not query open periods."},
-                status=status.HTTP_200_OK,
+                status=status.HTTP_404_NOT_FOUND,
             )
         limit = None
         per_page = request.GET.get("per_page")

--- a/src/sentry/workflow_engine/endpoints/organization_open_periods.py
+++ b/src/sentry/workflow_engine/endpoints/organization_open_periods.py
@@ -130,9 +130,9 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
                 {"detail": "Group not found. Could not query open periods."},
                 status=status.HTTP_200_OK,
             )
-        limit = request.GET.get("per_page")
-        if limit:
-            limit = int(limit)
+        per_page: str | None = request.GET.get("per_page")
+        if per_page:
+            limit = int(per_page)
 
         open_periods = get_open_periods_for_group(
             group=target_group,

--- a/src/sentry/workflow_engine/endpoints/organization_open_periods.py
+++ b/src/sentry/workflow_engine/endpoints/organization_open_periods.py
@@ -130,7 +130,8 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
                 {"detail": "Group not found. Could not query open periods."},
                 status=status.HTTP_200_OK,
             )
-        per_page: str | None = request.GET.get("per_page")
+        limit = None
+        per_page = request.GET.get("per_page")
         if per_page:
             limit = int(per_page)
 

--- a/src/sentry/workflow_engine/endpoints/organization_open_periods.py
+++ b/src/sentry/workflow_engine/endpoints/organization_open_periods.py
@@ -134,6 +134,7 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
         per_page = request.GET.get("per_page")
         if per_page:
             limit = int(per_page)
+            assert limit > 0
 
         open_periods = get_open_periods_for_group(
             group=target_group,

--- a/src/sentry/workflow_engine/endpoints/organization_open_periods.py
+++ b/src/sentry/workflow_engine/endpoints/organization_open_periods.py
@@ -130,12 +130,14 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
                 {"detail": "Group not found. Could not query open periods."},
                 status=status.HTTP_200_OK,
             )
+        limit = request.GET.get("per_page")
+        limit = int(limit) if limit else limit
 
         open_periods = get_open_periods_for_group(
             group=target_group,
             query_start=start,
             query_end=end,
-            limit=int(request.GET.get("per_page")),
+            limit=limit,
         )
         return self.paginate(
             request=request,

--- a/src/sentry/workflow_engine/endpoints/organization_open_periods.py
+++ b/src/sentry/workflow_engine/endpoints/organization_open_periods.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
-
 from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework import status
 from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -11,7 +10,8 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationDetectorPermission, OrganizationEndpoint
-from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
@@ -20,11 +20,11 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, VisibilityParams
-from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.exceptions import InvalidParams
 from sentry.models.group import Group
-from sentry.models.groupopenperiod import OpenPeriod, get_open_periods_for_group
+from sentry.models.groupopenperiod import get_open_periods_for_group
 from sentry.models.organization import Organization
+from sentry.workflow_engine.endpoints.serializers import GroupOpenPeriodSerializer
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.models.detector_group import DetectorGroup
 
@@ -92,7 +92,7 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
             ),
         ],
         responses={
-            200: inline_sentry_response_serializer("ListOpenPeriods", list[OpenPeriod]),
+            200: GroupOpenPeriodSerializer,
             400: RESPONSE_BAD_REQUEST,
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,
@@ -125,20 +125,22 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
                 else None
             )
         )
-
-        def data_fn(offset: int, limit: int) -> list[OpenPeriod] | list[Any]:
-            if target_group is None:
-                return []
-            return get_open_periods_for_group(
-                group=target_group,
-                query_start=start,
-                query_end=end,
-                offset=offset,
-                limit=limit,
+        if not target_group:
+            return Response(
+                {"detail": "Group not found. Could not query open periods."},
+                status=status.HTTP_200_OK,
             )
 
+        open_periods = get_open_periods_for_group(
+            group=target_group,
+            query_start=start,
+            query_end=end,
+            limit=int(request.GET.get("per_page")),
+        )
         return self.paginate(
             request=request,
-            on_results=lambda results: [result.to_dict() for result in results],
-            paginator=GenericOffsetPaginator(data_fn=data_fn),
+            queryset=open_periods,
+            paginator_cls=OffsetPaginator,
+            on_results=lambda x: serialize(x, request.user),
+            count_hits=True,
         )

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -686,7 +686,7 @@ class DetectorWorkflowSerializer(Serializer):
 
 
 class GroupOpenPeriodResponse(TypedDict):
-    id: int
+    id: str
     start: datetime
     end: datetime | None
     duration: timedelta | None

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -690,8 +690,8 @@ class GroupOpenPeriodResponse(TypedDict):
     start: datetime
     end: datetime | None
     duration: timedelta | None
-    is_open: bool
-    last_checked: datetime
+    isOpen: bool
+    lastChecked: datetime
 
 
 @register(GroupOpenPeriod)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -5,6 +5,12 @@ from django.utils import timezone
 from sentry.incidents.grouptype import MetricIssue
 from sentry.models.activity import Activity
 from sentry.models.group import GroupStatus
+from sentry.models.groupopenperiod import (
+    GroupOpenPeriod,
+    create_open_period,
+    get_open_periods_for_group,
+    update_group_open_period,
+)
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
@@ -77,12 +83,14 @@ class OrganizationOpenPeriodsTest(APITestCase):
         )
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        open_period = response.data[0]
-        assert open_period["start"] == self.group.first_seen
-        assert open_period["end"] is None
-        assert open_period["duration"] is None
-        assert open_period["isOpen"] is True
-        assert open_period["lastChecked"] >= last_checked
+        resp = response.data[0]
+        open_period = GroupOpenPeriod.objects.get(group=self.group)
+        assert resp["id"] == open_period.id
+        assert resp["start"] == self.group.first_seen
+        assert resp["end"] is None
+        assert resp["duration"] is None
+        assert resp["isOpen"] is True
+        assert resp["lastChecked"] >= last_checked
 
     @with_feature("organizations:issue-open-periods")
     def test_open_periods_resolved_group(self) -> None:
@@ -95,115 +103,161 @@ class OrganizationOpenPeriodsTest(APITestCase):
             type=ActivityType.SET_RESOLVED.value,
             datetime=resolved_time,
         )
+        update_group_open_period(
+            group=self.group,
+            new_status=GroupStatus.RESOLVED,
+            resolution_time=resolved_time,
+            resolution_activity=activity,
+        )
 
         response = self.get_success_response(
             *self.get_url_args(), qs_params={"groupId": self.group.id}
         )
+
         assert response.status_code == 200, response.content
-        assert response.data == [
-            {
-                "start": self.group.first_seen,
-                "end": resolved_time,
-                "duration": resolved_time - self.group.first_seen,
-                "isOpen": False,
-                "lastChecked": activity.datetime,
-            }
-        ]
+        resp = response.data[0]
+        open_period = GroupOpenPeriod.objects.get(group=self.group, date_ended=resolved_time)
+        assert resp["id"] == open_period.id
+        assert resp["start"] == self.group.first_seen
+        assert resp["end"] == resolved_time
+        assert resp["duration"] == resolved_time - self.group.first_seen
+        assert resp["isOpen"] is False
+        assert resp["lastChecked"].replace(second=0, microsecond=0) == activity.datetime.replace(
+            second=0, microsecond=0
+        )
 
     @with_feature("organizations:issue-open-periods")
     def test_open_periods_unresolved_group(self) -> None:
         self.group.status = GroupStatus.RESOLVED
         self.group.save()
         resolved_time = timezone.now()
-        Activity.objects.create(
+        resolve_activity = Activity.objects.create(
             group=self.group,
             project=self.group.project,
             type=ActivityType.SET_RESOLVED.value,
             datetime=resolved_time,
         )
+        update_group_open_period(
+            group=self.group,
+            new_status=GroupStatus.RESOLVED,
+            resolution_time=resolved_time,
+            resolution_activity=resolve_activity,
+        )
+        open_period = GroupOpenPeriod.objects.get(group=self.group, date_ended=resolved_time)
 
         unresolved_time = timezone.now()
         self.group.status = GroupStatus.UNRESOLVED
         self.group.save()
-        Activity.objects.create(
+        regression_activity = Activity.objects.create(
             group=self.group,
             project=self.group.project,
             type=ActivityType.SET_REGRESSION.value,
             datetime=unresolved_time,
         )
+        create_open_period(self.group, regression_activity.datetime)
 
         self.group.status = GroupStatus.RESOLVED
         self.group.save()
         second_resolved_time = timezone.now()
-        Activity.objects.create(
+        second_resolve_activity = Activity.objects.create(
             group=self.group,
             project=self.group.project,
             type=ActivityType.SET_RESOLVED.value,
             datetime=second_resolved_time,
+        )
+        update_group_open_period(
+            group=self.group,
+            new_status=GroupStatus.RESOLVED,
+            resolution_time=second_resolved_time,
+            resolution_activity=second_resolve_activity,
+        )
+        open_period2 = GroupOpenPeriod.objects.get(
+            group=self.group, date_ended=second_resolved_time
         )
 
         response = self.get_success_response(
             *self.get_url_args(), qs_params={"groupId": self.group.id}
         )
         assert response.status_code == 200, response.content
-        assert response.data == [
-            {
-                "start": unresolved_time,
-                "end": second_resolved_time,
-                "duration": second_resolved_time - unresolved_time,
-                "isOpen": False,
-                "lastChecked": second_resolved_time,
-            },
-            {
-                "start": self.group.first_seen,
-                "end": resolved_time,
-                "duration": resolved_time - self.group.first_seen,
-                "isOpen": False,
-                "lastChecked": resolved_time,
-            },
-        ]
+        resp = response.data[0]
+        resp2 = response.data[1]
+
+        assert resp["id"] == open_period2.id
+        assert resp["start"] == unresolved_time
+        assert resp["end"] == second_resolved_time
+        assert resp["duration"] == second_resolved_time - unresolved_time
+        assert resp["isOpen"] is False
+        assert resp["lastChecked"].replace(second=0, microsecond=0) == second_resolved_time.replace(
+            second=0, microsecond=0
+        )
+
+        assert resp2["id"] == open_period.id
+        assert resp2["start"] == self.group.first_seen
+        assert resp2["end"] == resolved_time
+        assert resp2["duration"] == resolved_time - self.group.first_seen
+        assert resp2["isOpen"] is False
+        assert resp2["lastChecked"].replace(second=0, microsecond=0) == resolved_time.replace(
+            second=0, microsecond=0
+        )
 
     @with_feature("organizations:issue-open-periods")
     def test_open_periods_limit(self) -> None:
         self.group.status = GroupStatus.RESOLVED
         self.group.save()
         resolved_time = timezone.now()
-        Activity.objects.create(
+        resolve_activity = Activity.objects.create(
             group=self.group,
             project=self.group.project,
             type=ActivityType.SET_RESOLVED.value,
             datetime=resolved_time,
         )
+        update_group_open_period(
+            group=self.group,
+            new_status=GroupStatus.RESOLVED,
+            resolution_time=resolved_time,
+            resolution_activity=resolve_activity,
+        )
+        get_open_periods_for_group(self.group)
 
         unresolved_time = timezone.now()
         self.group.status = GroupStatus.UNRESOLVED
         self.group.save()
-        Activity.objects.create(
+        regression_activity = Activity.objects.create(
             group=self.group,
             project=self.group.project,
             type=ActivityType.SET_REGRESSION.value,
             datetime=unresolved_time,
         )
+        create_open_period(self.group, regression_activity.datetime)
 
         second_resolved_time = timezone.now()
         self.group.status = GroupStatus.RESOLVED
         self.group.save()
-        Activity.objects.create(
+        second_resolve_activity = Activity.objects.create(
             group=self.group,
             project=self.group.project,
             type=ActivityType.SET_RESOLVED.value,
             datetime=second_resolved_time,
         )
+        update_group_open_period(
+            group=self.group,
+            new_status=GroupStatus.RESOLVED,
+            resolution_time=second_resolved_time,
+            resolution_activity=second_resolve_activity,
+        )
+        open_period = GroupOpenPeriod.objects.get(group=self.group, date_ended=second_resolved_time)
 
         response = self.get_success_response(
             *self.get_url_args(), qs_params={"groupId": self.group.id, "per_page": 1}
         )
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert response.data[0] == {
-            "start": unresolved_time,
-            "end": second_resolved_time,
-            "duration": second_resolved_time - unresolved_time,
-            "isOpen": False,
-            "lastChecked": second_resolved_time,
-        }
+        resp = response.data[0]
+        assert resp["id"] == open_period.id
+        assert resp["start"] == unresolved_time
+        assert resp["end"] == second_resolved_time
+        assert resp["duration"] == second_resolved_time - unresolved_time
+        assert resp["isOpen"] is False
+        assert resp["lastChecked"].replace(second=0, microsecond=0) == second_resolved_time.replace(
+            second=0, microsecond=0
+        )

--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.utils import timezone
+from rest_framework import status
 
 from sentry.incidents.grouptype import MetricIssue
 from sentry.models.activity import Activity
@@ -42,10 +43,11 @@ class OrganizationOpenPeriodsTest(APITestCase):
     def test_no_group_link(self) -> None:
         # Create a new detector with no linked group
         detector = self.create_detector()
-        resp = self.get_success_response(
-            self.organization.slug, qs_params={"detectorId": detector.id}
+        resp = self.get_error_response(
+            self.organization.slug,
+            qs_params={"detectorId": detector.id},
+            status_code=status.HTTP_404_NOT_FOUND,
         )
-        assert resp.status_code == 200
         assert resp.data["detail"] == "Group not found. Could not query open periods."
 
     @with_feature("organizations:issue-open-periods")

--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -45,7 +45,8 @@ class OrganizationOpenPeriodsTest(APITestCase):
         resp = self.get_success_response(
             self.organization.slug, qs_params={"detectorId": detector.id}
         )
-        assert resp.data == []
+        assert resp.status_code == 200
+        assert resp.data["detail"] == "Group not found. Could not query open periods."
 
     @with_feature("organizations:issue-open-periods")
     def test_open_period_linked_to_group(self) -> None:
@@ -85,7 +86,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert len(response.data) == 1
         resp = response.data[0]
         open_period = GroupOpenPeriod.objects.get(group=self.group)
-        assert resp["id"] == open_period.id
+        assert resp["id"] == str(open_period.id)
         assert resp["start"] == self.group.first_seen
         assert resp["end"] is None
         assert resp["duration"] is None
@@ -117,7 +118,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert response.status_code == 200, response.content
         resp = response.data[0]
         open_period = GroupOpenPeriod.objects.get(group=self.group, date_ended=resolved_time)
-        assert resp["id"] == open_period.id
+        assert resp["id"] == str(open_period.id)
         assert resp["start"] == self.group.first_seen
         assert resp["end"] == resolved_time
         assert resp["duration"] == resolved_time - self.group.first_seen
@@ -182,7 +183,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
         resp = response.data[0]
         resp2 = response.data[1]
 
-        assert resp["id"] == open_period2.id
+        assert resp["id"] == str(open_period2.id)
         assert resp["start"] == unresolved_time
         assert resp["end"] == second_resolved_time
         assert resp["duration"] == second_resolved_time - unresolved_time
@@ -191,7 +192,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
             second=0, microsecond=0
         )
 
-        assert resp2["id"] == open_period.id
+        assert resp2["id"] == str(open_period.id)
         assert resp2["start"] == self.group.first_seen
         assert resp2["end"] == resolved_time
         assert resp2["duration"] == resolved_time - self.group.first_seen
@@ -253,7 +254,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         resp = response.data[0]
-        assert resp["id"] == open_period.id
+        assert resp["id"] == str(open_period.id)
         assert resp["start"] == unresolved_time
         assert resp["end"] == second_resolved_time
         assert resp["duration"] == second_resolved_time - unresolved_time


### PR DESCRIPTION
Now that we are no longer calling `get_open_periods_for_group` in the `GroupDetailsEndpoint` (https://github.com/getsentry/sentry/pull/99519) we can clean up the code that constructs an open period when there isn't actually a `GroupOpenPeriod` (this code was used before we ran the backfill) to return the objects and serialize them normally. This PR also adds the `id` to the response. A near future PR will add a serializer for `GroupOpenPeriodActivity` and add that to the response as well.