### PR TITLE
fix(prevent): Expose TA enabled field instead of activated

### DIFF
--- a/src/sentry/codecov/endpoints/repository/query.py
+++ b/src/sentry/codecov/endpoints/repository/query.py
@@ -7,8 +7,7 @@ query = """query GetRepo(
       __typename
       ... on Repository {
           uploadToken
-          activated
-          active
+          testAnalyticsEnabled
         }
       ... on NotFoundError {
         message

--- a/src/sentry/codecov/endpoints/repository/serializers.py
+++ b/src/sentry/codecov/endpoints/repository/serializers.py
@@ -12,8 +12,7 @@ class RepositorySerializer(serializers.Serializer):
     """
 
     uploadToken = serializers.CharField(allow_null=True)
-    activated = serializers.BooleanField()
-    active = serializers.BooleanField()
+    testAnalyticsEnabled = serializers.BooleanField()
 
     def to_representation(self, graphql_response):
         """

--- a/tests/sentry/codecov/endpoints/test_repository.py
+++ b/tests/sentry/codecov/endpoints/test_repository.py
@@ -12,8 +12,7 @@ mock_graphql_response_success: dict[str, Any] = {
         "owner": {
             "repository": {
                 "uploadToken": "token123",
-                "activated": True,
-                "active": True,
+                "testAnalyticsEnabled": True,
             }
         }
     }
@@ -96,8 +95,7 @@ class RepositoryEndpointTest(APITestCase):
 
         assert response.status_code == 200
         assert response.data["uploadToken"] == "token123"
-        assert response.data["activated"] is True
-        assert response.data["active"] is True
+        assert response.data["testAnalyticsEnabled"] is True
 
         serializer_fields = set(RepositorySerializer().fields.keys())
         response_keys = set(response.data.keys())


### PR DESCRIPTION
We need this field from `Repository` instead for dictating whether we should be showing onboarding or available test analytics results for a specific repository.

The previous fields were added in https://github.com/getsentry/sentry/pull/99230