### PR TITLE
ref(releases): fix issue count on release index & other spots

### DIFF
--- a/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
+++ b/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
@@ -97,7 +97,7 @@ export default function useOrganizationReleases({
               : '',
             crash_free_sessions: release.projects[0]?.healthData?.crashFreeSessions ?? 0,
             sessions: release.projects[0]?.healthData?.totalSessions ?? 0,
-            error_count: release.projects[0]?.newGroups ?? 0,
+            error_count: release.newGroups ?? 0,
             project_id: release.projects[0]?.id ?? 0,
             adoption: release.projects[0]?.healthData?.adoption ?? 0,
             status: release.status,

--- a/static/app/views/releases/drawer/releasesDrawerTable.tsx
+++ b/static/app/views/releases/drawer/releasesDrawerTable.tsx
@@ -94,7 +94,7 @@ export function ReleasesDrawerTable({
     project: d.projects[0]!,
     release: d.version,
     date: d.dateCreated,
-    error_count: d.projects[0]?.newGroups ?? 0,
+    error_count: d.newGroups ?? 0,
     project_id: d.projects[0]?.id ?? 0,
   }));
 

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -88,6 +88,7 @@ function ReleaseCard({
     dateCreated,
     versionInfo,
     adoptionStages,
+    newGroups,
     projects,
   } = release;
 
@@ -267,6 +268,7 @@ function ReleaseCard({
                   location={location}
                   organization={organization}
                   project={project}
+                  newGroups={newGroups}
                   releaseVersion={version}
                   showPlaceholders={showHealthPlaceholders}
                   showReleaseAdoptionStages={showReleaseAdoptionStages}

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -65,6 +65,7 @@ type Props = {
   index: number;
   isTopRelease: boolean;
   location: Location;
+  newGroups: number;
   organization: Organization;
   project: ReleaseProject;
   releaseVersion: string;
@@ -85,9 +86,10 @@ function ReleaseCardProjectRow({
   releaseVersion,
   showPlaceholders,
   showReleaseAdoptionStages,
+  newGroups,
 }: Props) {
   const theme = useTheme();
-  const {id, newGroups} = project;
+  const {id} = project;
 
   const crashCount = getHealthData.getCrashCount(
     releaseVersion,

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -31,7 +31,7 @@ function getReplayTabs({
       areAiFeaturesAllowed &&
       !isVideoReplay ? (
         <Flex align="center" gap="sm">
-          {t('Summary')}
+          {t('AI Summary')}
           <Tooltip
             title={t(
               'This feature is experimental! Try it out and let us know what you think. No promises!'


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-706/release-newgroups-count-is-sometimes-incorrect
closes https://linear.app/getsentry/issue/REPLAY-151/release-overview-new-issues-counter-doesnt-filter-when-selecting
closes https://linear.app/getsentry/issue/REPLAY-139/new-issues-in-release-showing-up-unexpectedly-in-the-team-plan

i believe all the issues above were relating to an incorrect issue count value in the release row, leading to confusion about the actual count of new issues for that release.

the `newGroups` value returned by the `/releases/` endpoint is correct; however, the frontend on the releases index was mistakenly using the project's `newGroups` field.  The project's `newGroups` field is the sum of all the new issues for that project -- hence why they're all the same  in the photo below. we should instead be using the count from the release itself.

i also fixed 2 other spots where we were relying on the project `newGroups` field in insights mobile session health page & on release drawer.

before:
<img width="1084" height="376" alt="SCR-20250915-nxra" src="https://github.com/user-attachments/assets/2f2044b7-4cb2-49e1-b2fb-437589bf0212" />

<img width="1272" height="514" alt="SCR-20250915-oech" src="https://github.com/user-attachments/assets/d6b7d321-c91b-4221-a673-bdc2656c40a5" />


after:
<img width="1080" height="346" alt="SCR-20250915-nxnn" src="https://github.com/user-attachments/assets/a72f03fd-e478-4e22-a6c8-217958674cfc" />

<img width="1267" height="564" alt="SCR-20250915-ocyn" src="https://github.com/user-attachments/assets/65364c90-f9de-459a-af16-82ab1313fdd8" />
