### PR TITLE
Add build_config handling to size comparison

### DIFF
--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -273,6 +273,11 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
             extra={"head_artifact_id": head_artifact_id, "base_artifact_id": base_artifact_id},
         )
 
+        if head_artifact.build_configuration != base_artifact.build_configuration:
+            return Response(
+                {"error": "Head and base build configurations must be the same."}, status=400
+            )
+
         head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
             preprod_artifact_id__in=[head_artifact.id],
             preprod_artifact__project=project,

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -9,6 +9,7 @@ from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactSizeComparison,
     PreprodArtifactSizeMetrics,
+    PreprodBuildConfiguration,
 )
 from sentry.preprod.size_analysis.tasks import (
     _run_size_analysis_comparison,
@@ -369,6 +370,136 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
             )
 
             # Should not call _run_size_analysis_comparison due to incompatible metrics
+            mock_run_comparison.assert_not_called()
+
+    def test_compare_preprod_artifact_size_analysis_different_build_configurations_as_head(self):
+        """Test compare_preprod_artifact_size_analysis with different build configurations when artifact is head."""
+        # Create commit comparisons
+        head_commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+        base_commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        # Create build configurations
+        debug_config = PreprodBuildConfiguration.objects.create(project=self.project, name="debug")
+        release_config = PreprodBuildConfiguration.objects.create(
+            project=self.project, name="release"
+        )
+
+        # Create artifacts with different build configurations
+        head_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            commit_comparison=head_commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            build_configuration=debug_config,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            commit_comparison=base_commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            build_configuration=release_config,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        with (
+            patch(
+                "sentry.preprod.size_analysis.tasks._run_size_analysis_comparison"
+            ) as mock_run_comparison,
+            patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger,
+        ):
+            compare_preprod_artifact_size_analysis(
+                project_id=self.project.id,
+                org_id=self.organization.id,
+                artifact_id=head_artifact.id,
+            )
+
+            # Should log different build configurations and not run comparison
+            mock_logger.info.assert_called_with(
+                "preprod.size_analysis.compare.artifact_different_build_configurations",
+                extra={"head_artifact_id": head_artifact.id, "base_artifact_id": base_artifact.id},
+            )
+            mock_run_comparison.assert_not_called()
+
+    def test_compare_preprod_artifact_size_analysis_different_build_configurations_as_base(self):
+        """Test compare_preprod_artifact_size_analysis with different build configurations when artifact is base."""
+        # Create commit comparison
+        base_commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+        head_commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="c" * 40,
+            base_sha="a" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        # Create build configurations
+        debug_config = PreprodBuildConfiguration.objects.create(project=self.project, name="debug")
+        release_config = PreprodBuildConfiguration.objects.create(
+            project=self.project, name="release"
+        )
+
+        # Create artifacts with different build configurations
+        base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            commit_comparison=base_commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            build_configuration=debug_config,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        head_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            commit_comparison=head_commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            build_configuration=release_config,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        with (
+            patch(
+                "sentry.preprod.size_analysis.tasks._run_size_analysis_comparison"
+            ) as mock_run_comparison,
+            patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger,
+        ):
+            compare_preprod_artifact_size_analysis(
+                project_id=self.project.id,
+                org_id=self.organization.id,
+                artifact_id=base_artifact.id,
+            )
+
+            # Should log different build configurations and not run comparison
+            mock_logger.info.assert_called_with(
+                "preprod.size_analysis.compare.head_artifact_different_build_configurations",
+                extra={"head_artifact_id": head_artifact.id, "base_artifact_id": base_artifact.id},
+            )
             mock_run_comparison.assert_not_called()
 
 


### PR DESCRIPTION
Adds `build_configuration` handling for comparisons. Also adds an error response to to the compare post endpoint to block invalid compares, but we'll make sure to not allow builds to be compared in the frontend if they can't be, just an extra level of safety

Resolves EME-250