### PR TITLE
Remove backpressure celery checks

### DIFF
--- a/src/sentry/processing/backpressure/topology.py
+++ b/src/sentry/processing/backpressure/topology.py
@@ -17,25 +17,23 @@ class ProcessingServices(Enum):
 
 
 def get_all_services() -> list[str]:
-    return [item.value for item in ProcessingServices]
+    return [item.value for item in ProcessingServices if item != ProcessingServices.Celery]
 
 
 CONSUMERS = {
     # fallback if no explicit consumer was defined
     "default": get_all_services(),
-    "profiles": [ProcessingServices.Celery.value],
+    "profiles": [],
     # Transactions have been split into their own consumer here,
     # We should consider this for our other consumer types.
     # For example, `ingest-events` does not depend on `attachments-store`.
     "ingest": [
-        ProcessingServices.Celery.value,
         ProcessingServices.AttachmentsStore.value,
         ProcessingServices.ProcessingStore.value,
         ProcessingServices.ProcessingLocks.value,
         ProcessingServices.PostProcessLocks.value,
     ],
     "ingest-transactions": [
-        ProcessingServices.Celery.value,
         ProcessingServices.ProcessingStoreTransactions.value,
         ProcessingServices.ProcessingLocks.value,
         ProcessingServices.PostProcessLocks.value,

--- a/tests/sentry/processing/backpressure/test_checking.py
+++ b/tests/sentry/processing/backpressure/test_checking.py
@@ -28,29 +28,6 @@ EVENTS_MSG = json.dumps(
     {
         "backpressure.checking.enabled": True,
         "backpressure.checking.interval": 5,
-        "backpressure.monitoring.enabled": True,
-        "backpressure.status_ttl": 60,
-    }
-)
-def test_backpressure_unhealthy_profiles() -> None:
-    record_consumer_health(
-        {
-            "celery": Exception("Couldn't check celery"),
-            "attachments-store": [],
-            "processing-store": [],
-            "processing-store-transactions": [],
-            "processing-locks": [],
-            "post-process-locks": [],
-        }
-    )
-    with raises(MessageRejected):
-        process_one_message(consumer_type="profiles", topic="profiles", payload=PROFILES_MSG)
-
-
-@override_options(
-    {
-        "backpressure.checking.enabled": True,
-        "backpressure.checking.interval": 5,
         "backpressure.monitoring.enabled": False,
         "backpressure.status_ttl": 60,
     }
@@ -72,7 +49,6 @@ def test_bad_config() -> None:
 def test_backpressure_healthy_profiles(process_profile_task: MagicMock) -> None:
     record_consumer_health(
         {
-            "celery": [],
             "attachments-store": [],
             "processing-store": [],
             "processing-store-transactions": [],
@@ -96,8 +72,7 @@ def test_backpressure_healthy_profiles(process_profile_task: MagicMock) -> None:
 def test_backpressure_unhealthy_events() -> None:
     record_consumer_health(
         {
-            "celery": Exception("Couldn't check celery"),
-            "attachments-store": [],
+            "attachments-store": Exception("Couldn't check attachments-store"),
             "processing-store": [],
             "processing-store-transactions": [],
             "processing-locks": [],
@@ -120,7 +95,6 @@ def test_backpressure_unhealthy_events() -> None:
 def test_backpressure_healthy_events(preprocess_event: MagicMock) -> None:
     record_consumer_health(
         {
-            "celery": [],
             "attachments-store": [],
             "processing-store": [],
             "processing-store-transactions": [],

--- a/tests/sentry/processing/backpressure/test_monitoring.py
+++ b/tests/sentry/processing/backpressure/test_monitoring.py
@@ -68,7 +68,6 @@ def test_check_redis_health() -> None:
 )
 def test_record_consumer_health() -> None:
     unhealthy_services: MutableMapping[str, UnhealthyReasons] = {
-        "celery": [],
         "attachments-store": [],
         "processing-store": [],
         "processing-store-transactions": [],
@@ -78,7 +77,7 @@ def test_record_consumer_health() -> None:
     record_consumer_health(unhealthy_services)
     assert is_consumer_healthy() is True
 
-    unhealthy_services["celery"] = Exception("Couldn't check celery")
+    unhealthy_services["attachments-store"] = Exception("Couldn't check attachments-store")
     record_consumer_health(unhealthy_services)
     assert is_consumer_healthy() is False
 


### PR DESCRIPTION
We were used to check celery for its health in ingestion.
This is not needed anymore but it caused an incident
Removing celery from the checks of all ingest consumers

ref INC-1392