### PR TITLE
feat: Add limit to Client keys pagination

### DIFF
--- a/src/sentry/core/endpoints/project_keys.py
+++ b/src/sentry/core/endpoints/project_keys.py
@@ -81,6 +81,7 @@ class ProjectKeysEndpoint(ProjectEndpoint):
             request=request,
             queryset=queryset,
             order_by="-id",
+            default_per_page=10,
             on_results=lambda x: serialize(x, request.user, request=request),
         )
 


### PR DESCRIPTION
When users have many client keys, the page loads a long list and the scroll becomes too lengthy. I think showing 10 per page would be a good balance