### PR TITLE
test(relay): Use GHCR image instead of AR

### DIFF
--- a/src/sentry/testutils/pytest/relay.py
+++ b/src/sentry/testutils/pytest/relay.py
@@ -19,9 +19,7 @@ _log = logging.getLogger(__name__)
 
 
 # This helps the Relay CI to specify the generated Docker build before it is published
-RELAY_TEST_IMAGE = environ.get(
-    "RELAY_TEST_IMAGE", "us-central1-docker.pkg.dev/sentryio/relay/relay:nightly"
-)
+RELAY_TEST_IMAGE = environ.get("RELAY_TEST_IMAGE", "ghcr.io/getsentry/relay:nightly")
 
 
 def _relay_server_container_name() -> str:


### PR DESCRIPTION
In the past we had some issues with downloading the relay image (which we download once per test shard). When talking with dev-infra they brought up that switching the image might help so let's give it a try.

> I think moving them to GHCR would help with these failures
\- https://sentry.slack.com/archives/CTJL7358X/p1757928253382589