### PR TITLE
Introduce an option to avoid double-counting metrics

### DIFF
--- a/tests/sentry/metrics/test_dualwrite.py
+++ b/tests/sentry/metrics/test_dualwrite.py
@@ -11,7 +11,7 @@ def test_dualwrite_distribution(distribution, timing):
     backend = DualWriteMetricsBackend(
         primary_backend="sentry.metrics.datadog.DatadogMetricsBackend",
         secondary_backend="sentry.metrics.precise_dogstatsd.PreciseDogStatsdMetricsBackend",
-        allow_prefixes=["foo"],
+        distribution_prefixes=["foo"],
     )
 
     backend.distribution("foo", 100, tags={"some": "stuff"}, unit="byte")


### PR DESCRIPTION
The `DualWriteMetricsBackend` is currently emitting the same metric to both configured backends. This is not an issue for distributions, but leads to double-counting for counters.

This PR avoids this problem by introducing an option for what to do about counters, which defaults to only send those to the secondary backend.