### PR TITLE
ref(useSpans): Expose refetchInterval

### DIFF
--- a/static/app/views/insights/agents/views/onboarding.tsx
+++ b/static/app/views/insights/agents/views/onboarding.tsx
@@ -62,7 +62,7 @@ function useOnboardingProject() {
 
 function useAiSpanWaiter(project: Project) {
   const {selection} = usePageFilters();
-  const [refetchKey, setRefetchKey] = useState(0);
+  const [shouldRefetch, setShouldRefetch] = useState(true);
 
   const request = useSpans(
     {
@@ -71,7 +71,7 @@ function useAiSpanWaiter(project: Project) {
       limit: 1,
       enabled: !!project,
       useQueryOptions: {
-        additonalQueryKey: [`refetch-${refetchKey}`],
+        refetchInterval: shouldRefetch ? 5000 : undefined,
       },
       pageFilters: {
         ...selection,
@@ -89,17 +89,11 @@ function useAiSpanWaiter(project: Project) {
 
   const hasEvents = Boolean(request.data?.length);
 
-  // Create a custom key that changes every 5 seconds to trigger refetch
-  // TODO(aknaus): remove this and add refetchInterval to useEAPSpans
   useEffect(() => {
-    if (hasEvents) return () => {};
-
-    const interval = setInterval(() => {
-      setRefetchKey(prev => prev + 1);
-    }, 5000); // Poll every 5 seconds
-
-    return () => clearInterval(interval);
-  }, [hasEvents]);
+    if (hasEvents && shouldRefetch) {
+      setShouldRefetch(false);
+    }
+  }, [hasEvents, shouldRefetch]);
 
   return request;
 }

--- a/static/app/views/insights/agents/views/overview.tsx
+++ b/static/app/views/insights/agents/views/overview.tsx
@@ -72,7 +72,7 @@ function useShowOnboarding() {
 
 function AgentsOverviewPage() {
   const organization = useOrganization();
-  const showOnboarding = useShowOnboarding();
+  const showOnboarding = true;
   const datePageFilterProps = limitMaxPickableDays(organization);
   const [searchQuery, setSearchQuery] = useLocationSyncedState('query', decodeScalar);
 

--- a/static/app/views/insights/agents/views/overview.tsx
+++ b/static/app/views/insights/agents/views/overview.tsx
@@ -72,7 +72,7 @@ function useShowOnboarding() {
 
 function AgentsOverviewPage() {
   const organization = useOrganization();
-  const showOnboarding = true;
+  const showOnboarding = useShowOnboarding();
   const datePageFilterProps = limitMaxPickableDays(organization);
   const [searchQuery, setSearchQuery] = useLocationSyncedState('query', decodeScalar);
 

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -18,6 +18,7 @@ import type {
 
 interface UseDiscoverQueryOptions {
   additonalQueryKey?: string[];
+  refetchInterval?: number;
 }
 
 interface UseDiscoverOptions<Fields> {
@@ -106,6 +107,7 @@ const useDiscover = <T extends Array<Extract<keyof ResponseType, string>>, Respo
     noPagination,
     samplingMode,
     additionalQueryKey: useQueryOptions?.additonalQueryKey,
+    refetchInterval: useQueryOptions?.refetchInterval,
     keepPreviousData: options.keepPreviousData,
   });
 

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -235,6 +235,7 @@ type WrappedDiscoverQueryProps<T> = {
   limit?: number;
   noPagination?: boolean;
   referrer?: string;
+  refetchInterval?: number;
   samplingMode?: SamplingMode;
 };
 
@@ -252,6 +253,7 @@ function useWrappedDiscoverQueryBase<T>({
   samplingMode,
   pageFiltersReady,
   additionalQueryKey,
+  refetchInterval,
 }: WrappedDiscoverQueryProps<T> & {
   pageFiltersReady: boolean;
 }) {
@@ -287,6 +289,7 @@ function useWrappedDiscoverQueryBase<T>({
       retryDelay: getRetryDelay,
       staleTime: getStaleTimeForEventView(eventView),
       additionalQueryKey,
+      refetchInterval,
       placeholderData: keepPreviousData ? keepPreviousDataFn : undefined,
     },
     queryExtras,

--- a/static/app/views/insights/mcp/views/onboarding.tsx
+++ b/static/app/views/insights/mcp/views/onboarding.tsx
@@ -65,7 +65,7 @@ function useOnboardingProject() {
 
 function useAiSpanWaiter(project: Project) {
   const {selection} = usePageFilters();
-  const [refetchKey, setRefetchKey] = useState(0);
+  const [shouldRefetch, setShouldRefetch] = useState(true);
 
   const request = useSpans(
     {
@@ -74,7 +74,7 @@ function useAiSpanWaiter(project: Project) {
       limit: 1,
       enabled: !!project,
       useQueryOptions: {
-        additonalQueryKey: [`refetch-${refetchKey}`],
+        refetchInterval: shouldRefetch ? 5000 : undefined,
       },
       pageFilters: {
         ...selection,
@@ -92,17 +92,11 @@ function useAiSpanWaiter(project: Project) {
 
   const hasEvents = Boolean(request.data?.length);
 
-  // Create a custom key that changes every 5 seconds to trigger refetch
-  // TODO(aknaus): remove this and add refetchInterval to useEAPSpans
   useEffect(() => {
-    if (hasEvents) return () => {};
-
-    const interval = setInterval(() => {
-      setRefetchKey(prev => prev + 1);
-    }, 5000); // Poll every 5 seconds
-
-    return () => clearInterval(interval);
-  }, [hasEvents]);
+    if (hasEvents && shouldRefetch) {
+      setShouldRefetch(false);
+    }
+  }, [hasEvents, shouldRefetch]);
 
   return request;
 }


### PR DESCRIPTION
Expose the `refetchInterval` query option on `useSpans`.

Ideally, we would allow passing it as a function in the future (as is supported by react query). Though, this is quite hard from a types perspective with all the abstraction layers in-between.