### PR TITLE
fix(reprocessing): Avoid reprocessing of group that is being reprocessed to

### DIFF
--- a/src/sentry/issues/endpoints/group_reprocessing.py
+++ b/src/sentry/issues/endpoints/group_reprocessing.py
@@ -37,8 +37,7 @@ class GroupReprocessingEndpoint(GroupEndpoint):
         parent = (
             Activity.objects.annotate(new_group_id=RawSQL("(data::json ->> 'newGroupId')", []))
             .filter(type=ActivityType.REPROCESS.value, new_group_id=str(group.id))
-            .order_by("-datetime")
-            .first()
+            .first()  # There should only be one activity
         )
         if parent and not is_group_finished(parent.group_id):
             return self.respond(

--- a/src/sentry/issues/endpoints/group_reprocessing.py
+++ b/src/sentry/issues/endpoints/group_reprocessing.py
@@ -1,10 +1,14 @@
+from django.db.models.expressions import RawSQL
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.issues.endpoints.bases.group import GroupEndpoint
+from sentry.models.activity import Activity
+from sentry.reprocessing2 import is_group_finished
 from sentry.tasks.reprocessing2 import reprocess_group
+from sentry.types.activity import ActivityType
 
 
 @region_silo_endpoint
@@ -20,11 +24,29 @@ class GroupReprocessingEndpoint(GroupEndpoint):
 
         This endpoint triggers reprocessing for all events in a group.
 
+        Returns a 409 if the group itself is currently on the receiving-end
+        of a reprocessing.
+
         :pparam string issue_id: the numeric ID of the issue to reprocess. The
             reprocessed events will be assigned to a new numeric ID. See comments
             in sentry.reprocessing2.
         :auth: required
         """
+
+        # Using raw SQL since data is LegacyTextJSONField which can't be filtered with Django ORM
+        parent = (
+            Activity.objects.annotate(new_group_id=RawSQL("(data::json ->> 'newGroupId')", []))
+            .filter(type=ActivityType.REPROCESS.value, new_group_id=str(group.id))
+            .order_by("-datetime")
+            .first()
+        )
+        if parent and not is_group_finished(parent.group_id):
+            return self.respond(
+                {
+                    "error": "group is part of an ongoing reprocessing",
+                },
+                status=409,
+            )
 
         max_events = request.data.get("maxEvents")
         if max_events:

--- a/tests/sentry/issues/endpoints/test_group_reprocessing.py
+++ b/tests/sentry/issues/endpoints/test_group_reprocessing.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from sentry.models.activity import Activity
+from sentry.models.group import Group
 from sentry.testutils.cases import APITestCase
 from sentry.types.activity import ActivityType
 
@@ -17,7 +18,7 @@ class GroupReprocessingEndpointTest(APITestCase):
     def _url(self, group_id: int) -> str:
         return f"/api/0/issues/{group_id}/reprocessing/"
 
-    def _create_reprocess_activity(self, old_group, new_group, event_count=10):
+    def _create_reprocess_activity(self, old_group: Group, new_group: Group, event_count: int = 10):
         return Activity.objects.create(
             project=self.project,
             group_id=old_group.id,

--- a/tests/sentry/issues/endpoints/test_group_reprocessing.py
+++ b/tests/sentry/issues/endpoints/test_group_reprocessing.py
@@ -18,7 +18,9 @@ class GroupReprocessingEndpointTest(APITestCase):
     def _url(self, group_id: int) -> str:
         return f"/api/0/issues/{group_id}/reprocessing/"
 
-    def _create_reprocess_activity(self, old_group: Group, new_group: Group, event_count: int = 10):
+    def _create_reprocess_activity(
+        self, old_group: Group, new_group: Group, event_count: int = 10
+    ) -> Activity:
         return Activity.objects.create(
             project=self.project,
             group_id=old_group.id,

--- a/tests/sentry/issues/endpoints/test_group_reprocessing.py
+++ b/tests/sentry/issues/endpoints/test_group_reprocessing.py
@@ -1,0 +1,63 @@
+from unittest.mock import patch
+
+from sentry.models.activity import Activity
+from sentry.testutils.cases import APITestCase
+from sentry.types.activity import ActivityType
+
+
+class GroupReprocessingEndpointTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.org = self.create_organization()
+        self.project = self.create_project(organization=self.org)
+        self.user = self.create_user()
+        self.create_member(user=self.user, organization=self.org, role="owner")
+        self.login_as(self.user)
+
+    def _url(self, group_id: int) -> str:
+        return f"/api/0/issues/{group_id}/reprocessing/"
+
+    def _create_reprocess_activity(self, old_group, new_group, event_count=10):
+        return Activity.objects.create(
+            project=self.project,
+            group_id=old_group.id,
+            type=ActivityType.REPROCESS.value,
+            data={
+                "oldGroupId": old_group.id,
+                "newGroupId": new_group.id,
+                "eventCount": event_count,
+            },
+        )
+
+    def test_allows_when_no_parent(self) -> None:
+        lone_group = self.create_group(project=self.project)
+
+        resp = self.client.post(self._url(lone_group.id), data={"remainingEvents": "keep"})
+
+        assert resp.status_code == 200
+
+    def test_allows_when_parent_finished(self) -> None:
+        old_group = self.create_group(project=self.project)
+        new_group = self.create_group(project=self.project)
+
+        self._create_reprocess_activity(old_group, new_group)
+
+        with patch(
+            "sentry.issues.endpoints.group_reprocessing.is_group_finished", return_value=True
+        ):
+            resp = self.client.post(self._url(new_group.id), data={"remainingEvents": "keep"})
+
+        assert resp.status_code == 200
+
+    def test_blocks_when_parent_in_progress(self) -> None:
+        old_group = self.create_group(project=self.project)
+        new_group = self.create_group(project=self.project)
+
+        self._create_reprocess_activity(old_group, new_group)
+
+        with patch(
+            "sentry.issues.endpoints.group_reprocessing.is_group_finished", return_value=False
+        ):
+            resp = self.client.post(self._url(new_group.id), data={"remainingEvents": "keep"})
+
+        assert resp.status_code == 409


### PR DESCRIPTION
Adds logic that checks whether the group is currently involved in a reprocessing activity. If that is the case don't trigger the reprocessing on the group since it can have funky side effects.

Fix: https://linear.app/getsentry/issue/INGEST-157/reprocessing-while-reprocessing-breaks-reprocessing