### PR TITLE
feat(nextjs-insights): Handle replay not available on self-hosted

### DIFF
--- a/static/app/utils/replays/hooks/useDeadRageSelectors.tsx
+++ b/static/app/utils/replays/hooks/useDeadRageSelectors.tsx
@@ -31,7 +31,7 @@ export default function useDeadRageSelectors(params: DeadRageSelectorQueryParams
           },
         },
       ],
-      {staleTime: Infinity}
+      {staleTime: Infinity, enabled: params.enabled}
     );
 
   return {

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -323,6 +323,7 @@ export type ReplayClickElement = {
 export interface DeadRageSelectorQueryParams {
   isWidgetData: boolean;
   cursor?: string | string[] | undefined | null;
+  enabled?: boolean;
   per_page?: number;
   prefix?: string;
   sort?:


### PR DESCRIPTION
### Problem

The dead and rage clicks widget in the nextjs insights page displays a 404 error if the replay feature is not enabled.

### Solution

Check the feature flag and render a missing feature fallback UI instead.
<img width="477" height="313" alt="Screenshot 2025-09-16 at 13 08 16" src="https://github.com/user-attachments/assets/fd13aff7-a5f9-4981-a793-731fa6407005" />
