### PR TITLE
Fix separator export in fold section

### DIFF
--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -204,10 +204,10 @@ export function FoldSection({
   );
 }
 
-export const SectionDivider = styled((props: SeparatorProps) => (
+export const SectionDivider = styled(({orientation, margin, ...props}: SeparatorProps) => (
   <Separator
-    orientation={props.orientation || 'horizontal'}
-    margin={props.margin || 'lg 0'}
+    orientation={orientation || 'horizontal'}
+    margin={margin || 'lg 0'}
     {...props}
   />
 ))`

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -10,7 +10,7 @@ import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
 
 import {Disclosure} from 'sentry/components/core/disclosure';
-import {Separator} from 'sentry/components/core/separator';
+import {Separator as CoreSeparator} from 'sentry/components/core/separator';
 import {Text} from 'sentry/components/core/text';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {t} from 'sentry/locale';
@@ -204,7 +204,13 @@ export function FoldSection({
   );
 }
 
-export const SectionDivider = styled(Separator)`
+export const Separator = styled(
+  (props: {orientation?: string; margin?: string; [key: string]: any}) => (
+    <CoreSeparator orientation={props.orientation || "horizontal"} margin={props.margin || "lg 0"} />
+  )
+)``;
+
+export const SectionDivider = styled(CoreSeparator)`
   &:last-child {
     display: none;
   }

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -205,8 +205,11 @@ export function FoldSection({
 }
 
 export const Separator = styled(
-  (props: {orientation?: string; margin?: string; [key: string]: any}) => (
-    <CoreSeparator orientation={props.orientation || "horizontal"} margin={props.margin || "lg 0"} />
+  (props: {[key: string]: any; margin?: string; orientation?: string}) => (
+    <CoreSeparator
+      orientation={props.orientation || 'horizontal'}
+      margin={props.margin || 'lg 0'}
+    />
   )
 )``;
 

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -10,10 +10,7 @@ import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
 
 import {Disclosure} from 'sentry/components/core/disclosure';
-import {
-  Separator as CoreSeparator,
-  type SeparatorProps,
-} from 'sentry/components/core/separator';
+import {Separator, type SeparatorProps} from 'sentry/components/core/separator';
 import {Text} from 'sentry/components/core/text';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {t} from 'sentry/locale';
@@ -202,13 +199,13 @@ export function FoldSection({
           <ErrorBoundary mini>{expanded ? children : null}</ErrorBoundary>
         </Disclosure.Content>
       </DisclosureWithScrollMargin>
-      <Separator orientation="horizontal" margin="lg 0" />
+      <SectionDivider orientation="horizontal" margin="lg 0" />
     </Fragment>
   );
 }
 
-export const Separator = styled((props: SeparatorProps) => (
-  <CoreSeparator
+export const SectionDivider = styled((props: SeparatorProps) => (
+  <Separator
     orientation={props.orientation || 'horizontal'}
     margin={props.margin || 'lg 0'}
     {...props}

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -204,13 +204,15 @@ export function FoldSection({
   );
 }
 
-export const SectionDivider = styled(({orientation, margin, ...props}: SeparatorProps) => (
-  <Separator
-    orientation={orientation || 'horizontal'}
-    margin={margin || 'lg 0'}
-    {...props}
-  />
-))`
+export const SectionDivider = styled(
+  ({orientation, margin, ...props}: SeparatorProps) => (
+    <Separator
+      orientation={orientation || 'horizontal'}
+      margin={margin || 'lg 0'}
+      {...props}
+    />
+  )
+)`
   &:last-child {
     display: none;
   }

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -10,7 +10,10 @@ import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
 
 import {Disclosure} from 'sentry/components/core/disclosure';
-import {Separator as CoreSeparator, type SeparatorProps} from 'sentry/components/core/separator';
+import {
+  Separator as CoreSeparator,
+  type SeparatorProps,
+} from 'sentry/components/core/separator';
 import {Text} from 'sentry/components/core/text';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {t} from 'sentry/locale';
@@ -204,15 +207,13 @@ export function FoldSection({
   );
 }
 
-export const Separator = styled(
-  (props: SeparatorProps) => (
-    <CoreSeparator
-      orientation={props.orientation || 'horizontal'}
-      margin={props.margin || 'lg 0'}
-      {...props}
-    />
-  )
-)`
+export const Separator = styled((props: SeparatorProps) => (
+  <CoreSeparator
+    orientation={props.orientation || 'horizontal'}
+    margin={props.margin || 'lg 0'}
+    {...props}
+  />
+))`
   &:last-child {
     display: none;
   }

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -10,7 +10,7 @@ import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
 
 import {Disclosure} from 'sentry/components/core/disclosure';
-import {Separator as CoreSeparator} from 'sentry/components/core/separator';
+import {Separator as CoreSeparator, type SeparatorProps} from 'sentry/components/core/separator';
 import {Text} from 'sentry/components/core/text';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {t} from 'sentry/locale';
@@ -199,21 +199,20 @@ export function FoldSection({
           <ErrorBoundary mini>{expanded ? children : null}</ErrorBoundary>
         </Disclosure.Content>
       </DisclosureWithScrollMargin>
-      <SectionDivider orientation="horizontal" margin="lg 0" />
+      <Separator orientation="horizontal" margin="lg 0" />
     </Fragment>
   );
 }
 
 export const Separator = styled(
-  (props: {[key: string]: any; margin?: string; orientation?: string}) => (
+  (props: SeparatorProps) => (
     <CoreSeparator
       orientation={props.orientation || 'horizontal'}
       margin={props.margin || 'lg 0'}
+      {...props}
     />
   )
-)``;
-
-export const SectionDivider = styled(CoreSeparator)`
+)`
   &:last-child {
     display: none;
   }


### PR DESCRIPTION
The margin was only applied to the Separator used in the FoldSection component, and not the exported one.