### PR TITLE
fix(tasks) Change usage metric tag

### DIFF
--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -456,7 +456,7 @@ def child_process(
         metrics.incr(
             "taskworker.cogs.usage",
             amount=int(execution_duration * 1000),
-            tags={"app_feature": namespace.app_feature},
+            tags={"feature": namespace.app_feature},
         )
 
         if (


### PR DESCRIPTION
Using `app_feature` results in duplicate tags in saas, as our metrics infrastructure also applies an `app_feature` tag as well.

Refs STREAM-445