### PR TITLE
fix(flamegraph): Aggregate flamegraph average duration typo

### DIFF
--- a/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
@@ -74,12 +74,9 @@ function makeSortFunction(
           a: VirtualizedTreeNode<FlamegraphFrame>,
           b: VirtualizedTreeNode<FlamegraphFrame>
         ) => {
-          const avgA = a.node.frame.averageCallDuration;
-          const avgB = b.node.frame.averageCallDuration;
-          if (defined(avgA) && defined(avgB)) {
-            return avgB - avgA;
-          }
-          return b.node.node.aggregate_duration_ns - a.node.node.aggregate_duration_ns;
+          const avgA = a.node.frame.averageCallDuration || 0;
+          const avgB = b.node.frame.averageCallDuration || 0;
+          return avgB - avgA;
         }
       : (
           a: VirtualizedTreeNode<FlamegraphFrame>,
@@ -87,10 +84,7 @@ function makeSortFunction(
         ) => {
           const avgA = a.node.frame.averageCallDuration || 0;
           const avgB = b.node.frame.averageCallDuration || 0;
-          if (defined(avgA) && defined(avgB)) {
-            return avgA - avgB;
-          }
-          return a.node.node.aggregate_duration_ns - b.node.node.aggregate_duration_ns;
+          return avgA - avgB;
         };
   }
 

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
@@ -74,9 +74,12 @@ function makeSortFunction(
           a: VirtualizedTreeNode<FlamegraphFrame>,
           b: VirtualizedTreeNode<FlamegraphFrame>
         ) => {
-          const avgA = a.node.frame.averageCallDuration || 0;
-          const avgB = b.node.frame.averageCallDuration || 0;
-          return avgB - avgA;
+          const avgA = a.node.frame.averageCallDuration;
+          const avgB = b.node.frame.averageCallDuration;
+          if (defined(avgA) && defined(avgB)) {
+            return avgB - avgA;
+          }
+          return b.node.node.aggregate_duration_ns - a.node.node.aggregate_duration_ns;
         }
       : (
           a: VirtualizedTreeNode<FlamegraphFrame>,
@@ -84,7 +87,10 @@ function makeSortFunction(
         ) => {
           const avgA = a.node.frame.averageCallDuration || 0;
           const avgB = b.node.frame.averageCallDuration || 0;
-          return avgA - avgB;
+          if (defined(avgA) && defined(avgB)) {
+            return avgA - avgB;
+          }
+          return a.node.node.aggregate_duration_ns - b.node.node.aggregate_duration_ns;
         };
   }
 
@@ -253,6 +259,7 @@ export function AggregateFlamegraphTreeTable({
                   abbreviation
                 />
               }
+              showAvg
               avgWeight={
                 defined(r.item.node.frame.averageCallDuration) ? (
                   <PerformanceDuration

--- a/static/app/components/profiling/flamegraph/callTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/callTreeTable.tsx
@@ -79,10 +79,6 @@ export const CallTreeTable = styled('div')`
     padding-right: ${space(1)};
     justify-content: flex-end;
 
-    &:nth-child(2) {
-      padding-right: 0;
-    }
-
     &:focus {
       outline: none;
     }
@@ -91,7 +87,7 @@ export const CallTreeTable = styled('div')`
   .${CallTreeTableClassNames.FRAME_CELL} {
     display: flex;
     align-items: center;
-    padding: 0 ${space(1)};
+    padding-left: ${space(1)};
     white-space: nowrap;
 
     &:focus {


### PR DESCRIPTION
Missed the `showAvg` option on call trees.