### PR TITLE
Use Uncompressed in replacement of Install for Android size status checks

### DIFF
--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -254,6 +254,15 @@ class PreprodArtifact(DefaultFieldsModel):
 
         return results
 
+    def is_android(self) -> bool:
+        return (
+            self.artifact_type == self.ArtifactType.AAB
+            or self.artifact_type == self.ArtifactType.APK
+        )
+
+    def is_ios(self) -> bool:
+        return self.artifact_type == self.ArtifactType.XCARCHIVE
+
     class Meta:
         app_label = "preprod"
         db_table = "sentry_preprodartifact"

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -147,11 +147,12 @@ def _format_processing_summary(
                 f"| {app_id_link} | {version_string} | {_('Processing...')} | - | {_('Processing...')} | - | {_('N/A')} |"
             )
 
+    install_label = _("Uncompressed") if artifact.is_android() else _("Install")
     return _(
-        "| Name | Version | Download | Change | Install | Change | Approval |\n"
+        "| Name | Version | Download | Change | {install_label} | Change | Approval |\n"
         "|------|---------|----------|--------|---------|--------|----------|\n"
         "{table_rows}"
-    ).format(table_rows="\n".join(table_rows))
+    ).format(table_rows="\n".join(table_rows), install_label=install_label)
 
 
 def _format_failure_summary(artifacts: list[PreprodArtifact]) -> str:
@@ -244,11 +245,12 @@ def _format_success_summary(
             f"| {app_id_link} | {version_string} | {download_size} | {download_change} | {install_size} | {install_change} | {_('N/A')} |"
         )
 
+    install_label = _("Uncompressed") if artifact.is_android() else _("Install")
     return _(
-        "| Name | Version | Download | Change | Install | Change | Approval |\n"
+        "| Name | Version | Download | Change | {install_label} | Change | Approval |\n"
         "|------|---------|----------|--------|---------|--------|----------|\n"
         "{table_rows}"
-    ).format(table_rows="\n".join(table_rows))
+    ).format(table_rows="\n".join(table_rows), install_label=install_label)
 
 
 def _get_metric_type_display_name(

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -687,3 +687,65 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         # Count N/A occurrences in the watch line - should be 3 (change columns + approval)
         na_count = watch_line.count("N/A")
         assert na_count >= 2  # At least 2 N/A for the change columns
+
+    def test_android_app_shows_uncompressed_label(self):
+        """Test that Android apps show 'Uncompressed' instead of 'Install' in column header."""
+        # Test Android app
+        android_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.android",
+            build_version="1.0.0",
+            build_number=1,
+            artifact_type=PreprodArtifact.ArtifactType.AAB,
+        )
+
+        android_size_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=android_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=1024 * 1024,  # 1 MB
+            max_download_size=1024 * 1024,
+            min_install_size=2 * 1024 * 1024,  # 2 MB
+            max_install_size=2 * 1024 * 1024,
+        )
+
+        android_size_metrics_map = {android_artifact.id: [android_size_metrics]}
+
+        title, subtitle, android_summary = format_status_check_messages(
+            [android_artifact], android_size_metrics_map, StatusCheckStatus.SUCCESS
+        )
+
+        # Android app should show "Uncompressed" instead of "Install"
+        assert "Uncompressed" in android_summary
+        assert "Install" not in android_summary or android_summary.count("Install") == 0
+
+        # Test iOS app for comparison
+        ios_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.ios",
+            build_version="1.0.0",
+            build_number=1,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+        )
+
+        ios_size_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=ios_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=1024 * 1024,  # 1 MB
+            max_download_size=1024 * 1024,
+            min_install_size=2 * 1024 * 1024,  # 2 MB
+            max_install_size=2 * 1024 * 1024,
+        )
+
+        ios_size_metrics_map = {ios_artifact.id: [ios_size_metrics]}
+
+        title, subtitle, ios_summary = format_status_check_messages(
+            [ios_artifact], ios_size_metrics_map, StatusCheckStatus.SUCCESS
+        )
+
+        # iOS app should show "Install" not "Uncompressed"
+        assert "Install" in ios_summary
+        assert "Uncompressed" not in ios_summary


### PR DESCRIPTION
Android uses uncompressed size, so update "Install" label to be "Uncompressed"

Resolves EME-282