### PR TITLE
feat(explore): Add setting to disable extrapolation

### DIFF
--- a/static/app/views/explore/components/overChartButtonGroup.tsx
+++ b/static/app/views/explore/components/overChartButtonGroup.tsx
@@ -1,15 +1,13 @@
 import styled from '@emotion/styled';
 
-const OverChartButtonGroup = styled('div')`
+export const OverChartButtonGroup = styled('div')`
   display: flex;
   flex-direction: row;
   gap: ${p => p.theme.space.xs};
   justify-content: space-between;
+  margin-bottom: ${p => p.theme.space.md};
 
   @media (max-width: ${p => p.theme.breakpoints.md}) {
     justify-content: flex-end;
-    margin-bottom: ${p => p.theme.space.md};
   }
 `;
-
-export {OverChartButtonGroup};

--- a/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
@@ -12,7 +12,10 @@ import {isGroupBy} from 'sentry/views/explore/contexts/pageParamsContext/aggrega
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import type {SpansRPCQueryExtras} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useProgressiveQuery} from 'sentry/views/explore/hooks/useProgressiveQuery';
-import {useQueryParamsAggregateFields} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsAggregateFields,
+  useQueryParamsExtrapolate,
+} from 'sentry/views/explore/queryParams/context';
 import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
 
 interface UseExploreAggregatesTableOptions {
@@ -33,6 +36,8 @@ export function useExploreAggregatesTable({
   limit,
   query,
 }: UseExploreAggregatesTableOptions) {
+  const extrapolate = useQueryParamsExtrapolate();
+
   const canTriggerHighAccuracy = useCallback(
     (results: ReturnType<typeof useSpansQuery<any[]>>) => {
       const canGoToHigherAccuracyTier = results.meta?.dataScanned === 'partial';
@@ -46,6 +51,7 @@ export function useExploreAggregatesTable({
     queryHookArgs: {enabled, limit, query},
     queryOptions: {
       canTriggerHighAccuracy,
+      disableExtrapolation: !extrapolate,
     },
   });
 }

--- a/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
@@ -1,37 +1,32 @@
+import type {ReactNode} from 'react';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {PageParamsProvider} from 'sentry/views/explore/contexts/pageParamsContext';
 import {useExploreSpansTable} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 
-jest.mock('sentry/utils/useNavigate');
 jest.mock('sentry/utils/usePageFilters');
 
-describe('useExploreTimeseries', () => {
-  let mockNormalRequestUrl: jest.Mock;
+function Wrapper({children}: {children: ReactNode}) {
+  return (
+    <SpansQueryParamsProvider>
+      <PageParamsProvider>{children}</PageParamsProvider>
+    </SpansQueryParamsProvider>
+  );
+}
 
+describe('useExploreSpansTable', () => {
   beforeEach(() => {
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '14d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [2],
-      },
-    });
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
     jest.clearAllMocks();
   });
 
   it('triggers the high accuracy request when there is no data and a partial scan', async () => {
-    mockNormalRequestUrl = MockApiClient.addMockResponse({
+    const mockNormalRequestUrl = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: {
         data: [],
@@ -56,12 +51,14 @@ describe('useExploreTimeseries', () => {
       ],
       method: 'GET',
     });
-    renderHookWithProviders(() =>
-      useExploreSpansTable({
-        query: 'test value',
-        enabled: true,
-        limit: 10,
-      })
+    renderHookWithProviders(
+      () =>
+        useExploreSpansTable({
+          query: 'test value',
+          enabled: true,
+          limit: 10,
+        }),
+      {additionalWrapper: Wrapper}
     );
 
     expect(mockNormalRequestUrl).toHaveBeenCalledTimes(1);
@@ -90,6 +87,53 @@ describe('useExploreTimeseries', () => {
       '/organizations/org-slug/events/',
       expect.objectContaining({
         query: expect.objectContaining({
+          sampling: SAMPLING_MODE.HIGH_ACCURACY,
+          query: 'test value',
+        }),
+      })
+    );
+  });
+
+  it('disables extrapolation', async () => {
+    const mockNonExtrapolatedRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return (
+            options.query.sampling === SAMPLING_MODE.HIGH_ACCURACY &&
+            options.query.disableAggregateExtrapolation === '1'
+          );
+        },
+      ],
+      method: 'GET',
+    });
+
+    renderHookWithProviders(
+      () =>
+        useExploreSpansTable({
+          query: 'test value',
+          enabled: true,
+          limit: 10,
+        }),
+      {
+        additionalWrapper: Wrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+            query: {
+              extrapolate: '0',
+            },
+          },
+        },
+      }
+    );
+
+    await waitFor(() => expect(mockNonExtrapolatedRequest).toHaveBeenCalledTimes(1));
+    expect(mockNonExtrapolatedRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          disableAggregateExtrapolation: '1',
           sampling: SAMPLING_MODE.HIGH_ACCURACY,
           query: 'test value',
         }),

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -13,6 +13,7 @@ import {
   useProgressiveQuery,
   type SpansRPCQueryExtras,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {useQueryParamsExtrapolate} from 'sentry/views/explore/queryParams/context';
 import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
 
 interface UseExploreSpansTableOptions {
@@ -32,6 +33,8 @@ export function useExploreSpansTable({
   limit,
   query,
 }: UseExploreSpansTableOptions) {
+  const extrapolate = useQueryParamsExtrapolate();
+
   const canTriggerHighAccuracy = useCallback(
     (results: ReturnType<typeof useSpansQuery<any[]>>) => {
       const canGoToHigherAccuracyTier = results.meta?.dataScanned === 'partial';
@@ -40,11 +43,13 @@ export function useExploreSpansTable({
     },
     []
   );
+
   return useProgressiveQuery<typeof useExploreSpansTableImp>({
     queryHookImplementation: useExploreSpansTableImp,
     queryHookArgs: {enabled, limit, query},
     queryOptions: {
       canTriggerHighAccuracy,
+      disableExtrapolation: !extrapolate,
     },
   });
 }

--- a/static/app/views/explore/hooks/useExploreTimeseries.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.tsx
@@ -17,6 +17,7 @@ import {
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
 import {
+  useQueryParamsExtrapolate,
   useQueryParamsGroupBys,
   useQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
@@ -42,6 +43,7 @@ export const useExploreTimeseries = ({
   query: string;
 }) => {
   const visualizes = useQueryParamsVisualizes();
+  const extrapolate = useQueryParamsExtrapolate();
   const topEvents = useTopEvents();
   const isTopN = topEvents ? topEvents > 0 : false;
 
@@ -57,6 +59,7 @@ export const useExploreTimeseries = ({
     queryHookArgs: {query, enabled},
     queryOptions: {
       canTriggerHighAccuracy,
+      disableExtrapolation: !extrapolate,
     },
   });
 };

--- a/static/app/views/explore/logs/logsQueryParams.spec.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.spec.tsx
@@ -16,6 +16,7 @@ function readableQueryParamOptions(
   options: Partial<ReadableQueryParamsOptions> = {}
 ): ReadableQueryParamsOptions {
   return {
+    extrapolate: true,
     mode: Mode.SAMPLES,
     query: '',
     cursor: '',

--- a/static/app/views/explore/logs/logsQueryParams.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.tsx
@@ -66,6 +66,7 @@ export function getReadableQueryParamsFromLocation(
     ) ?? defaultAggregateSortBys(aggregateFields);
 
   return new ReadableQueryParams({
+    extrapolate: true,
     mode,
     query,
 

--- a/static/app/views/explore/logs/logsStateQueryParamsProvider.tsx
+++ b/static/app/views/explore/logs/logsStateQueryParamsProvider.tsx
@@ -37,6 +37,7 @@ export function LogsStateQueryParamsProvider({
 
   const readableQueryParams = useMemo(() => {
     return new ReadableQueryParams({
+      extrapolate: true,
       mode,
       query,
 

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -347,3 +347,19 @@ export function useQueryParamsCursor(): string {
   const queryParams = useQueryParams();
   return queryParams.cursor;
 }
+
+export function useQueryParamsExtrapolate() {
+  const queryParams = useQueryParams();
+  return queryParams.extrapolate;
+}
+
+export function useSetQueryParamsExtrapolate() {
+  const setQueryParams = useSetQueryParams();
+
+  return useCallback(
+    (extrapolate: boolean) => {
+      setQueryParams({extrapolate});
+    },
+    [setQueryParams]
+  );
+}

--- a/static/app/views/explore/queryParams/extrapolate.ts
+++ b/static/app/views/explore/queryParams/extrapolate.ts
@@ -1,0 +1,7 @@
+import type {Location} from 'history';
+
+import {decodeScalar} from 'sentry/utils/queryString';
+
+export function getExtrapolateFromLocation(location: Location, key: string) {
+  return decodeScalar(location.query?.[key], '1') === '1';
+}

--- a/static/app/views/explore/queryParams/managedFields.spec.tsx
+++ b/static/app/views/explore/queryParams/managedFields.spec.tsx
@@ -8,6 +8,7 @@ import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 
 const defaultReadableQueryParamsOptions: ReadableQueryParamsOptions = {
+  extrapolate: true,
   aggregateCursor: '',
   aggregateFields: [{groupBy: ''}, new VisualizeFunction('avg(foo)')],
   aggregateSortBys: [],

--- a/static/app/views/explore/queryParams/readableQueryParams.ts
+++ b/static/app/views/explore/queryParams/readableQueryParams.ts
@@ -11,6 +11,7 @@ export interface ReadableQueryParamsOptions {
   readonly aggregateFields: readonly AggregateField[];
   readonly aggregateSortBys: readonly Sort[];
   readonly cursor: string;
+  readonly extrapolate: boolean;
   readonly fields: string[];
   readonly mode: Mode;
   readonly query: string;
@@ -18,6 +19,7 @@ export interface ReadableQueryParamsOptions {
 }
 
 export class ReadableQueryParams {
+  readonly extrapolate: boolean;
   readonly mode: Mode;
   readonly query: string;
   readonly search: MutableSearch;
@@ -33,6 +35,7 @@ export class ReadableQueryParams {
   readonly visualizes: readonly Visualize[];
 
   constructor(options: ReadableQueryParamsOptions) {
+    this.extrapolate = options.extrapolate;
     this.mode = options.mode;
     this.query = options.query;
     this.search = new MutableSearch(this.query);

--- a/static/app/views/explore/queryParams/writableQueryParams.ts
+++ b/static/app/views/explore/queryParams/writableQueryParams.ts
@@ -7,6 +7,7 @@ export interface WritableQueryParams {
   aggregateFields?: readonly WritableAggregateField[] | null;
   aggregateSortBys?: readonly Sort[] | null;
   cursor?: string | null;
+  extrapolate?: boolean;
   fields?: string[] | null;
   mode?: Mode | null;
   query?: string | null;

--- a/static/app/views/explore/spans/charts/confidenceFooter.spec.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.spec.tsx
@@ -84,4 +84,20 @@ describe('ConfidenceFooter', () => {
       );
     });
   });
+
+  describe('unextrapolated', () => {
+    it('unextrapolated loading', () => {
+      render(<ConfidenceFooter extrapolate={false} />, {wrapper: Wrapper});
+
+      expect(screen.getByTestId('wrapper')).toHaveTextContent('Span Count: \u2026');
+    });
+
+    it('unextrapolated loaded', () => {
+      render(<ConfidenceFooter extrapolate={false} sampleCount={100} />, {
+        wrapper: Wrapper,
+      });
+
+      expect(screen.getByTestId('wrapper')).toHaveTextContent('Span Count: 100');
+    });
+  });
 });

--- a/static/app/views/explore/spans/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.tsx
@@ -10,6 +10,7 @@ import usePrevious from 'sentry/utils/usePrevious';
 type Props = {
   confidence?: Confidence;
   dataScanned?: 'full' | 'partial';
+  extrapolate?: boolean;
   isLoading?: boolean;
   isSampled?: boolean | null;
   sampleCount?: number;
@@ -23,8 +24,24 @@ export function ConfidenceFooter(props: Props) {
   );
 }
 
-function confidenceMessage({sampleCount, confidence, topEvents, isSampled}: Props) {
+function confidenceMessage({
+  extrapolate,
+  sampleCount,
+  confidence,
+  topEvents,
+  isSampled,
+}: Props) {
   const isTopN = defined(topEvents) && topEvents > 1;
+
+  if (defined(extrapolate) && !extrapolate) {
+    if (!defined(sampleCount)) {
+      return t('Span Count: \u2026');
+    }
+    return tct('Span Count: [sampleCountComponent]', {
+      sampleCountComponent: <Count value={sampleCount} />,
+    });
+  }
+
   if (!defined(sampleCount)) {
     return isTopN
       ? t('* Top %s groups extrapolated from \u2026', topEvents)

--- a/static/app/views/explore/spans/charts/index.spec.tsx
+++ b/static/app/views/explore/spans/charts/index.spec.tsx
@@ -21,6 +21,7 @@ describe('ExploreCharts', () => {
       <SpansQueryParamsProvider>
         <PageParamsProvider>
           <ExploreCharts
+            extrapolate
             confidences={[]}
             query={''}
             timeseriesResult={mockTimeseriesResult}

--- a/static/app/views/explore/spans/charts/index.tsx
+++ b/static/app/views/explore/spans/charts/index.tsx
@@ -37,6 +37,7 @@ import type {useSortedTimeSeries} from 'sentry/views/insights/common/queries/use
 
 interface ExploreChartsProps {
   confidences: Confidence[];
+  extrapolate: boolean;
   query: string;
   setVisualizes: (visualizes: BaseVisualize[]) => void;
   timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
@@ -63,6 +64,7 @@ const EXPLORE_CHART_GROUP = 'explore-charts_group';
 
 export function ExploreCharts({
   query,
+  extrapolate,
   timeseriesResult,
   visualizes,
   setVisualizes,
@@ -103,6 +105,7 @@ export function ExploreCharts({
           return (
             <Chart
               key={`${index}`}
+              extrapolate={extrapolate}
               index={index}
               onChartTypeChange={chartType => handleChartTypeChange(index, chartType)}
               onChartVisibilityChange={visible =>
@@ -122,6 +125,7 @@ export function ExploreCharts({
 }
 
 interface ChartProps {
+  extrapolate: boolean;
   index: number;
   onChartTypeChange: (chartType: ChartType) => void;
   onChartVisibilityChange: (visible: boolean) => void;
@@ -133,6 +137,7 @@ interface ChartProps {
 }
 
 function Chart({
+  extrapolate,
   index,
   onChartTypeChange,
   onChartVisibilityChange,
@@ -265,6 +270,7 @@ function Chart({
         Footer={
           visualize.visible && (
             <ConfidenceFooter
+              extrapolate={extrapolate}
               sampleCount={chartInfo.sampleCount}
               isLoading={chartInfo.timeseriesResult?.isPending || false}
               isSampled={chartInfo.isSampled}

--- a/static/app/views/explore/spans/extrapolationEnabledAlert.tsx
+++ b/static/app/views/explore/spans/extrapolationEnabledAlert.tsx
@@ -1,0 +1,30 @@
+import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
+import {t, tct} from 'sentry/locale';
+import {
+  useQueryParamsExtrapolate,
+  useSetQueryParamsExtrapolate,
+} from 'sentry/views/explore/queryParams/context';
+
+export function ExtrapolationEnabledAlert() {
+  const extrapolate = useQueryParamsExtrapolate();
+  const setExtrapolate = useSetQueryParamsExtrapolate();
+
+  if (extrapolate) {
+    return null;
+  }
+
+  return (
+    <Alert.Container>
+      <Alert type="warning">
+        {tct('You have turned off extrapolation. [toggle]', {
+          toggle: (
+            <Button priority="link" onClick={() => setExtrapolate(true)}>
+              {t('Turn it back on')}
+            </Button>
+          ),
+        })}
+      </Alert>
+    </Alert.Container>
+  );
+}

--- a/static/app/views/explore/spans/settingsDropdown.tsx
+++ b/static/app/views/explore/spans/settingsDropdown.tsx
@@ -1,0 +1,48 @@
+import {useMemo} from 'react';
+
+import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
+import {IconSettings} from 'sentry/icons/iconSettings';
+import {t} from 'sentry/locale';
+import {
+  useQueryParamsExtrapolate,
+  useSetQueryParamsExtrapolate,
+} from 'sentry/views/explore/queryParams/context';
+
+export function SettingsDropdown() {
+  const extrapolate = useQueryParamsExtrapolate();
+  const setExtrapolate = useSetQueryParamsExtrapolate();
+
+  const items: MenuItemProps[] = useMemo(() => {
+    const menuItems = [];
+
+    if (extrapolate) {
+      menuItems.push({
+        key: 'disable-extrapolation',
+        textValue: t('Disable Extrapolation'),
+        label: t('Disable Extrapolation'),
+        onAction: () => setExtrapolate(false),
+      });
+    } else {
+      menuItems.push({
+        key: 'enable-extrapolation',
+        textValue: t('Enable Extrapolation'),
+        label: t('Enable Extrapolation'),
+        onAction: () => setExtrapolate(true),
+      });
+    }
+
+    return menuItems;
+  }, [extrapolate, setExtrapolate]);
+
+  return (
+    <DropdownMenu
+      triggerProps={{
+        size: 'xs',
+        showChevron: false,
+        icon: <IconSettings />,
+      }}
+      position="bottom-end"
+      items={items}
+    />
+  );
+}

--- a/static/app/views/explore/spans/spansQueryParams.spec.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.spec.tsx
@@ -18,6 +18,7 @@ function readableQueryParamOptions(
   options: Partial<ReadableQueryParamsOptions> = {}
 ): ReadableQueryParamsOptions {
   return {
+    extrapolate: true,
     mode: Mode.SAMPLES,
     query: '',
     cursor: '',
@@ -49,6 +50,22 @@ describe('getReadableQueryParamsFromLocation', () => {
     const location = locationFixture({});
     const queryParams = getReadableQueryParamsFromLocation(location, organization);
     expect(queryParams).toEqual(new ReadableQueryParams(readableQueryParamOptions()));
+  });
+
+  it('decodes extrapolation on correctly', () => {
+    const location = locationFixture({extrapolate: '1'});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(readableQueryParamOptions({extrapolate: true}))
+    );
+  });
+
+  it('decodes extrapolation off correctly', () => {
+    const location = locationFixture({extrapolate: '0'});
+    const queryParams = getReadableQueryParamsFromLocation(location, organization);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(readableQueryParamOptions({extrapolate: false}))
+    );
   });
 
   it('decodes samples mode correctly', () => {

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -7,6 +7,7 @@ import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateFie
 import {getAggregateFieldsFromLocation} from 'sentry/views/explore/queryParams/aggregateField';
 import {getAggregateSortBysFromLocation} from 'sentry/views/explore/queryParams/aggregateSortBy';
 import {getCursorFromLocation} from 'sentry/views/explore/queryParams/cursor';
+import {getExtrapolateFromLocation} from 'sentry/views/explore/queryParams/extrapolate';
 import {getFieldsFromLocation} from 'sentry/views/explore/queryParams/field';
 import type {GroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {
@@ -36,6 +37,7 @@ const SPANS_AGGREGATE_FIELD_KEY = 'aggregateField';
 const SPANS_GROUP_BY_KEY = 'groupBy';
 const SPANS_VISUALIZATION_KEY = 'visualize';
 const SPANS_AGGREGATE_SORT_KEY = 'aggregateSort';
+const SPANS_EXTRAPOLATE_KEY = 'extrapolate';
 
 export function isDefaultFields(location: Location): boolean {
   return getFieldsFromLocation(location, SPANS_FIELD_KEY) ? false : true;
@@ -45,6 +47,7 @@ export function getReadableQueryParamsFromLocation(
   location: Location,
   organization: Organization
 ): ReadableQueryParams {
+  const extrapolate = getExtrapolateFromLocation(location, SPANS_EXTRAPOLATE_KEY);
   const mode = getModeFromLocation(location, SPANS_MODE_KEY);
   const query = getQueryFromLocation(location, SPANS_QUERY_KEY) ?? '';
 
@@ -64,6 +67,7 @@ export function getReadableQueryParamsFromLocation(
     ) ?? defaultAggregateSortBys(aggregateFields);
 
   return new ReadableQueryParams({
+    extrapolate,
     mode,
     query,
 
@@ -83,6 +87,11 @@ export function getTargetWithReadableQueryParams(
 ): Location {
   const target: Location = {...location, query: {...location.query}};
 
+  updateNullableLocation(
+    target,
+    SPANS_EXTRAPOLATE_KEY,
+    writableQueryParams.extrapolate ? null : '0'
+  );
   updateNullableLocation(target, SPANS_MODE_KEY, writableQueryParams.mode);
 
   updateNullableLocation(target, SPANS_FIELD_KEY, writableQueryParams.fields);

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -1,6 +1,7 @@
 import type {Location} from 'history';
 
 import type {Organization} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {DEFAULT_VISUALIZATION} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
@@ -90,7 +91,11 @@ export function getTargetWithReadableQueryParams(
   updateNullableLocation(
     target,
     SPANS_EXTRAPOLATE_KEY,
-    writableQueryParams.extrapolate ? null : '0'
+    defined(writableQueryParams.extrapolate)
+      ? writableQueryParams.extrapolate
+        ? null
+        : '0'
+      : writableQueryParams.extrapolate
   );
   updateNullableLocation(target, SPANS_MODE_KEY, writableQueryParams.mode);
 

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -66,11 +66,14 @@ import {useExploreTracesTable} from 'sentry/views/explore/hooks/useExploreTraces
 import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
 import {useVisitQuery} from 'sentry/views/explore/hooks/useVisitQuery';
 import {
+  useQueryParamsExtrapolate,
   useQueryParamsMode,
   useQueryParamsVisualizes,
   useSetQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
 import {ExploreCharts} from 'sentry/views/explore/spans/charts';
+import {ExtrapolationEnabledAlert} from 'sentry/views/explore/spans/extrapolationEnabledAlert';
+import {SettingsDropdown} from 'sentry/views/explore/spans/settingsDropdown';
 import {SpansExport} from 'sentry/views/explore/spans/spansExport';
 import {ExploreSpansTour, ExploreSpansTourContext} from 'sentry/views/explore/spans/tour';
 import {ExploreTables} from 'sentry/views/explore/tables';
@@ -406,6 +409,7 @@ function SpanTabContentSection({
   const {selection} = usePageFilters();
   const visualizes = useQueryParamsVisualizes();
   const setVisualizes = useSetQueryParamsVisualizes();
+  const extrapolate = useQueryParamsExtrapolate();
   const [tab, setTab] = useTab();
 
   const query = useExploreQuery();
@@ -511,16 +515,20 @@ function SpanTabContentSection({
         >
           {controlSectionExpanded ? null : t('Advanced')}
         </ChevronButton>
-        <Feature features="organizations:tracing-export-csv">
-          <SpansExport
-            aggregatesTableResult={aggregatesTableResult}
-            spansTableResult={spansTableResult}
-          />
-        </Feature>
+        <ActionButtonsGroup>
+          <Feature features="organizations:tracing-export-csv">
+            <SpansExport
+              aggregatesTableResult={aggregatesTableResult}
+              spansTableResult={spansTableResult}
+            />
+          </Feature>
+          <SettingsDropdown />
+        </ActionButtonsGroup>
       </OverChartButtonGroup>
       {!resultsLoading && !hasResults && (
         <QuotaExceededAlert referrer="spans-explore" traceItemDataset="spans" />
       )}
+      <ExtrapolationEnabledAlert />
       {defined(error) && (
         <Alert.Container>
           <Alert type="error">{error.message}</Alert>
@@ -539,6 +547,7 @@ function SpanTabContentSection({
         <ExploreCharts
           confidences={confidences}
           query={query}
+          extrapolate={extrapolate}
           timeseriesResult={timeseriesResult}
           visualizes={visualizes}
           setVisualizes={setVisualizes}
@@ -655,9 +664,13 @@ const OnboardingContentSection = styled('section')`
   grid-column: 1/3;
 `;
 
+const ActionButtonsGroup = styled('div')`
+  display: flex;
+  gap: ${p => p.theme.space.xs};
+`;
+
 const ChevronButton = withChonk(
   styled(Button)<{expanded: boolean}>`
-    margin-bottom: ${space(1)};
     display: none;
 
     @media (min-width: ${p => p.theme.breakpoints.md}) {
@@ -674,7 +687,6 @@ const ChevronButton = withChonk(
       `}
   `,
   chonkStyled(Button)<{expanded: boolean}>`
-    margin-bottom: ${space(1)};
     display: none;
 
     @media (min-width: ${p => p.theme.breakpoints.md}) {

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -39,6 +39,7 @@ import type {SpanFields, SpanFunctions} from 'sentry/views/insights/types';
 type SeriesMap = Record<string, TimeSeries[]>;
 
 interface Options<Fields> {
+  disableAggregateExtrapolation?: string;
   enabled?: boolean;
   fields?: string[];
   interval?: string;
@@ -70,6 +71,7 @@ export const useSortedTimeSeries = <
     overriddenRoute,
     enabled,
     samplingMode,
+    disableAggregateExtrapolation,
   } = options;
 
   const pageFilters = usePageFilters();
@@ -114,6 +116,7 @@ export const useSortedTimeSeries = <
       orderby: eventView.sorts?.[0] ? encodeSort(eventView.sorts?.[0]) : undefined,
       interval: eventView.interval,
       sampling: samplingMode,
+      disableAggregateExtrapolation,
       // Timeseries requests do not support cursors, overwrite it to undefined so
       // pagination does not cause extra requests
       cursor: undefined,

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -109,6 +109,7 @@ function useSpansQueryBase<T>({
     cursor,
     allowAggregateConditions,
     samplingMode: queryExtras?.samplingMode,
+    disableAggregateExtrapolation: queryExtras?.disableAggregateExtrapolation,
   });
 
   if (trackResponseAnalytics) {
@@ -227,6 +228,7 @@ type WrappedDiscoverQueryProps<T> = {
   additionalQueryKey?: string[];
   allowAggregateConditions?: boolean;
   cursor?: string;
+  disableAggregateExtrapolation?: string;
   enabled?: boolean;
   initialData?: T;
   keepPreviousData?: boolean;
@@ -246,6 +248,7 @@ function useWrappedDiscoverQueryBase<T>({
   cursor,
   noPagination,
   allowAggregateConditions,
+  disableAggregateExtrapolation,
   samplingMode,
   pageFiltersReady,
   additionalQueryKey,
@@ -256,8 +259,14 @@ function useWrappedDiscoverQueryBase<T>({
   const organization = useOrganization();
 
   const queryExtras: Record<string, string> = {};
-  if (eventView.dataset === DiscoverDatasets.SPANS && samplingMode) {
-    queryExtras.sampling = samplingMode;
+  if (eventView.dataset === DiscoverDatasets.SPANS) {
+    if (samplingMode) {
+      queryExtras.sampling = samplingMode;
+    }
+
+    if (disableAggregateExtrapolation) {
+      queryExtras.disableAggregateExtrapolation = '1';
+    }
   }
 
   if (allowAggregateConditions !== undefined) {


### PR DESCRIPTION
This adds a settings button to the explore page that has options to
enable/disable extrapolation for the page. It does not persist across sessions
so each fresh visit to the explore page starts with extrapolation enabled.

Re-applies #99164