### PR TITLE
ref(grouping): refresh grouphash from database before returning from `create_or_update_grouphash_metadata_if_needed()`

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -155,7 +155,7 @@ def create_or_update_grouphash_metadata_if_needed(
 
         # Handle race condition cases where this event lost the race to create the metadata record
         if not created:
-            grouphash.refresh_from_db(fields=["metadata"])
+            grouphash.refresh_from_db()
 
             logger.info(
                 "grouphash_metadata.creation_race_condition.record_exists",

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -155,6 +155,8 @@ def create_or_update_grouphash_metadata_if_needed(
 
         # Handle race condition cases where this event lost the race to create the metadata record
         if not created:
+            grouphash.refresh_from_db(fields=["metadata"])
+
             logger.info(
                 "grouphash_metadata.creation_race_condition.record_exists",
                 extra={


### PR DESCRIPTION
In `create_or_update_grouphash_metadata_if_needed()` if a `grouphash` loses the race we log it and then return from the function. I think this is causing `grouphash.metadata` to be null in `get_or_create_grouphashes()` which causes the `grouphash_metadata.hash_without_metadata` log. 

Adding the refresh from db function will update the `grouphash` object with the correct metadata even though it lost the race. (similar to #99402)