### PR TITLE
fix(auth): allow assigning SSO default role to current user's role or below

### DIFF
--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -4,6 +4,7 @@ import logging
 
 from django import forms
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponseRedirect
 from django.http.response import HttpResponse, HttpResponseBadRequest, HttpResponseBase
 from django.urls import reverse
@@ -43,7 +44,7 @@ def auth_provider_settings_form(provider, auth_provider, organization, request):
             organization_id=organization.id, user_id=request.user.id
         )
         if org_member is None:
-            return HttpResponseBadRequest()
+            raise PermissionDenied("User is not a member of the organization")
 
         member_role = roles.get(org_member.role)
         role_choices = [(r.id, r.name) for r in roles.get_all() if member_role.can_manage(r)]

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -96,6 +96,19 @@ class OrganizationAuthSettingsPermissionTest(PermissionTestCase):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
 
+    def test_role_options(self) -> None:
+        manager = self.create_manager_and_attach_identity()
+        self.login_as(manager, organization_id=self.organization.id)
+        with self.feature("organizations:sso-basic"):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+
+            form = resp.context["form"]
+            role_choices = dict(form.fields["default_role"].choices)
+
+            # Verify that the manager can set the default role to manager and below roles
+            assert set(role_choices.keys()) == {"admin", "manager", "member"}
+
     def test_owner_can_load(self) -> None:
         owner = self.create_owner_and_attach_identity()
 


### PR DESCRIPTION
Fixes [VULN-79](https://linear.app/getsentry/issue/VULN-79/privilege-escalation-manager-role-can-gain-owner-privileges-via-sso) and [RTC-1127](https://linear.app/getsentry/issue/RTC-1127/privilege-escalation-manager-role-can-gain-owner-privileges-via-sso#comment-d4155f2f)

[VULN-79]: https://getsentry.atlassian.net/browse/VULN-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ