### PR TITLE
fix treemap tooltip

### DIFF
--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -42,6 +42,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
         borderColor,
         borderWidth: 6,
         gapWidth: 2,
+        gapColor: 'transparent',
       },
       label: {
         fontSize: 12,
@@ -189,7 +190,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
   const tooltip: TooltipOption = {
     trigger: 'item',
     borderWidth: 0,
-    backgroundColor: theme.white,
+    backgroundColor: theme.background,
     hideDelay: 0,
     transitionDuration: 0,
     padding: 12,


### PR DESCRIPTION
fix tooltip on light mode. Regardless of light or dark mode, tooltip background is always white atm, so using dark text

OLD
<img width="234" height="143" alt="image" src="https://github.com/user-attachments/assets/b4b3a069-b945-4d5e-a115-13b065f3c938" />

NEW
<img width="232" height="123" alt="image" src="https://github.com/user-attachments/assets/7f3059fb-b798-4431-8066-7a054c4ae30f" />


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
