### PR TITLE
chore(insights): Remove vestigial `lineStyle` settings in Resources module

### DIFF
--- a/static/app/views/insights/common/components/widgets/resourceSummaryAverageSizeChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/resourceSummaryAverageSizeChartWidget.tsx
@@ -30,14 +30,6 @@ export default function ResourceSummaryAverageSizeChartWidget(
     referrer,
   });
 
-  if (data) {
-    data[`avg(${HTTP_RESPONSE_TRANSFER_SIZE})`].lineStyle = {
-      type: 'dashed',
-    };
-    data[`avg(${HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`].lineStyle = {
-      type: 'dashed',
-    };
-  }
   return (
     <InsightsLineChartWidget
       {...props}


### PR DESCRIPTION
These dashed styles are not in use, and they're not respected! That hasn't been the case in a while. Removing the code. Here's what the chart looks like, it uses colour to distinguish the series:

**e.g.,**
<img width="497" height="236" alt="Screenshot 2025-09-16 at 2 12 07 PM" src="https://github.com/user-attachments/assets/ec980200-3287-4513-b440-078db575d06f" />
