### PR TITLE
chore(search-bar): Change flow to open operator instead of value

### DIFF
--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -200,7 +200,9 @@ export interface ControlProps
    * won't work correctly.
    */
   trigger?: (
-    props: Omit<React.HTMLAttributes<HTMLElement>, 'children'>,
+    props: Omit<React.HTMLAttributes<HTMLElement>, 'children'> & {
+      ref?: React.Ref<HTMLElement>;
+    },
     isOpen: boolean
   ) => React.ReactNode;
   /**

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -200,8 +200,8 @@ export interface ControlProps
    * won't work correctly.
    */
   trigger?: (
-    props: Omit<React.HTMLAttributes<HTMLElement>, 'children'> & {
-      ref?: React.Ref<HTMLElement>;
+    props: Omit<React.HTMLAttributes<HTMLButtonElement>, 'children'> & {
+      ref?: React.Ref<HTMLButtonElement | null>;
     },
     isOpen: boolean
   ) => React.ReactNode;

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -102,6 +102,7 @@ type UpdateFilterOpAction = {
   op: TermOperator;
   token: TokenResult<Token.FILTER>;
   type: 'UPDATE_FILTER_OP';
+  focusOverride?: FocusOverride;
 };
 
 type UpdateTokenValueAction = {
@@ -213,12 +214,13 @@ function modifyFilterOperator(
     hasWildcardOperators
   );
 
-  if (newQuery === state.query) {
+  if (newQuery === state.query && !action.focusOverride) {
     return state;
   }
 
   return {
     ...state,
+    focusOverride: action.focusOverride ?? null,
     query: newQuery,
     committedQuery: newQuery,
   };

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -356,7 +356,7 @@ describe('SearchQueryBuilder', () => {
       ).not.toBeInTheDocument();
       await userEvent.type(
         screen.getByRole('combobox', {name: 'Add a search term'}),
-        'foo a:b{enter}'
+        'foo a:{enter}b{enter}'
       );
 
       await waitFor(() => expect(mockOnChange).toHaveBeenCalled());
@@ -784,12 +784,15 @@ describe('SearchQueryBuilder', () => {
     });
 
     it('escapes values with spaces and reserved characters', async () => {
-      render(<SearchQueryBuilder {...defaultProps} initialQuery="" />);
+      render(<SearchQueryBuilder {...defaultProps} initialQuery="" />, {
+        organization: {features: ['search-query-builder-input-flow-changes']},
+      });
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
-      await userEvent.type(
-        screen.getByRole('combobox', {name: 'Add a search term'}),
-        'assigned:some" value{enter}'
-      );
+
+      await userEvent.keyboard('assigned:');
+      await userEvent.click(screen.getByRole('option', {name: 'is'}));
+      await userEvent.keyboard('some" value{enter}');
+
       // Value should be surrounded by quotes and escaped
       expect(
         screen.getByRole('row', {name: 'assigned:"some\\" value"'})
@@ -911,23 +914,29 @@ describe('SearchQueryBuilder', () => {
     it('can add an unsupported filter key and value', async () => {
       const mockOnChange = jest.fn();
       render(
-        <SearchQueryBuilder {...defaultProps} onChange={mockOnChange} initialQuery="" />
+        <SearchQueryBuilder {...defaultProps} onChange={mockOnChange} initialQuery="" />,
+        {organization: {features: ['search-query-builder-input-flow-changes']}}
       );
       await userEvent.click(getLastInput());
 
       // Typing "foo", then " a:b" should add the "foo" text followed by a new token "a:b"
       await userEvent.type(
         screen.getByRole('combobox', {name: 'Add a search term'}),
-        'foo a:b{enter}'
+        'foo '
       );
-      expect(screen.getByRole('row', {name: 'foo'})).toBeInTheDocument();
-      expect(screen.getByRole('row', {name: 'a:b'})).toBeInTheDocument();
+
+      await userEvent.keyboard('a:');
+      expect(await screen.findByRole('option', {name: 'is'})).toHaveFocus();
+      await userEvent.keyboard('{enter}');
+      await userEvent.keyboard('b{enter}');
+
+      expect(await screen.findByRole('row', {name: 'foo'})).toBeInTheDocument();
+      expect(await screen.findByRole('row', {name: 'a:b'})).toBeInTheDocument();
 
       await waitFor(() => {
         expect(mockOnChange).toHaveBeenCalledWith('foo a:b', expect.anything());
       });
-
-      expect(mockOnChange).toHaveBeenCalledTimes(1);
+      expect(mockOnChange).toHaveBeenCalledTimes(2);
     });
 
     it('adds default value for filter when typing <filter>:', async () => {
@@ -971,7 +980,9 @@ describe('SearchQueryBuilder', () => {
 
     it('can add a new token by clicking a key suggestion', async () => {
       const mockOnChange = jest.fn();
-      render(<SearchQueryBuilder {...defaultProps} onChange={mockOnChange} />);
+      render(<SearchQueryBuilder {...defaultProps} onChange={mockOnChange} />, {
+        organization: {features: ['search-query-builder-input-flow-changes']},
+      });
 
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
       await userEvent.click(screen.getByRole('option', {name: 'browser.name'}));
@@ -981,13 +992,18 @@ describe('SearchQueryBuilder', () => {
       // onChange should not be called until exiting edit mode
       expect(mockOnChange).not.toHaveBeenCalled();
 
+      // Should have focus on the operator option
+      const operatorOption = await screen.findByRole('option', {name: 'is'});
+      expect(operatorOption).toHaveFocus();
+      await userEvent.click(operatorOption);
+
       await userEvent.click(await screen.findByRole('option', {name: 'Firefox'}));
 
       // New token should have a value
       expect(screen.getByRole('row', {name: 'browser.name:Firefox'})).toBeInTheDocument();
 
       // Now we call onChange
-      expect(mockOnChange).toHaveBeenCalledTimes(1);
+      expect(mockOnChange).toHaveBeenCalledTimes(2);
       expect(mockOnChange).toHaveBeenCalledWith(
         'browser.name:Firefox',
         expect.anything()
@@ -1010,7 +1026,9 @@ describe('SearchQueryBuilder', () => {
     });
 
     it('can add a filter after some free text', async () => {
-      render(<SearchQueryBuilder {...defaultProps} />);
+      render(<SearchQueryBuilder {...defaultProps} />, {
+        organization: {features: ['search-query-builder-input-flow-changes']},
+      });
 
       await userEvent.click(getLastInput());
 
@@ -1021,6 +1039,11 @@ describe('SearchQueryBuilder', () => {
       await userEvent.type(screen.getByRole('combobox'), 'some free text brow');
       await userEvent.click(screen.getByRole('option', {name: 'browser.name'}));
       jest.restoreAllMocks();
+
+      // Should have focus on the operator option
+      const operatorOption = await screen.findByRole('option', {name: 'is'});
+      expect(operatorOption).toHaveFocus();
+      await userEvent.click(operatorOption);
 
       // Filter value should have focus
       expect(await screen.findByLabelText('Edit filter value')).toHaveFocus();
@@ -3515,21 +3538,35 @@ describe('SearchQueryBuilder', () => {
       });
 
       it('focuses on the filter value when user selects an aggregate filter with no arguments', async () => {
-        render(<SearchQueryBuilder {...aggregateDefaultProps} />);
+        render(<SearchQueryBuilder {...aggregateDefaultProps} />, {
+          organization: {features: ['search-query-builder-input-flow-changes']},
+        });
 
         await userEvent.click(getLastInput());
         await userEvent.keyboard('count');
         await userEvent.click(screen.getByRole('option', {name: 'count()'}));
         expect(screen.getByLabelText('count():>100')).toBeInTheDocument();
+
+        const gtOption = screen.getByRole('option', {name: '>'});
+        expect(gtOption).toHaveFocus();
+        await userEvent.click(gtOption);
+
         expect(screen.getByLabelText('Edit filter value')).toHaveFocus();
       });
 
       it('focuses on the filter value when user input looks like an aggregate filter with no arguments', async () => {
-        render(<SearchQueryBuilder {...aggregateDefaultProps} />);
+        render(<SearchQueryBuilder {...aggregateDefaultProps} />, {
+          organization: {features: ['search-query-builder-input-flow-changes']},
+        });
 
         await userEvent.click(getLastInput());
         await userEvent.keyboard('count(');
         expect(screen.getByLabelText('count():>100')).toBeInTheDocument();
+
+        const gtOption = screen.getByRole('option', {name: '>'});
+        expect(gtOption).toHaveFocus();
+        await userEvent.click(gtOption);
+
         expect(screen.getByLabelText('Edit filter value')).toHaveFocus();
       });
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -12,7 +12,7 @@ import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/contex
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderGridItem';
 import {AggregateKey} from 'sentry/components/searchQueryBuilder/tokens/filter/aggregateKey';
 import {FilterKey} from 'sentry/components/searchQueryBuilder/tokens/filter/filterKey';
-import {FilterOperator as FilterOperatorComponent} from 'sentry/components/searchQueryBuilder/tokens/filter/filterOperator';
+import {FilterOperator} from 'sentry/components/searchQueryBuilder/tokens/filter/filterOperator';
 import {UnstyledButton} from 'sentry/components/searchQueryBuilder/tokens/filter/unstyledButton';
 import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/tokens/filter/useFilterButtonProps';
 import {
@@ -169,24 +169,6 @@ function FilterValue({token, state, item, filterRef, onActiveChange}: FilterValu
       <InteractionStateLayer />
       <FilterValueText token={token} />
     </ValueButton>
-  );
-}
-
-interface FilterOperatorProps {
-  item: Node<ParseResultToken>;
-  onOpenChange: (isOpen: boolean) => void;
-  state: ListState<ParseResultToken>;
-  token: TokenResult<Token.FILTER>;
-}
-
-function FilterOperator({token, state, item, onOpenChange}: FilterOperatorProps) {
-  return (
-    <FilterOperatorComponent
-      token={token}
-      state={state}
-      item={item}
-      onOpenChange={onOpenChange}
-    />
   );
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -12,7 +12,7 @@ import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/contex
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderGridItem';
 import {AggregateKey} from 'sentry/components/searchQueryBuilder/tokens/filter/aggregateKey';
 import {FilterKey} from 'sentry/components/searchQueryBuilder/tokens/filter/filterKey';
-import {FilterOperator} from 'sentry/components/searchQueryBuilder/tokens/filter/filterOperator';
+import {FilterOperator as FilterOperatorComponent} from 'sentry/components/searchQueryBuilder/tokens/filter/filterOperator';
 import {UnstyledButton} from 'sentry/components/searchQueryBuilder/tokens/filter/unstyledButton';
 import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/tokens/filter/useFilterButtonProps';
 import {
@@ -170,6 +170,24 @@ function FilterValue({token, state, item, filterRef, onActiveChange}: FilterValu
       <InteractionStateLayer />
       <FilterValueText token={token} />
     </ValueButton>
+  );
+}
+
+interface FilterOperatorProps {
+  item: Node<ParseResultToken>;
+  onOpenChange: (isOpen: boolean) => void;
+  state: ListState<ParseResultToken>;
+  token: TokenResult<Token.FILTER>;
+}
+
+function FilterOperator({token, state, item, onOpenChange}: FilterOperatorProps) {
+  return (
+    <FilterOperatorComponent
+      token={token}
+      state={state}
+      item={item}
+      onOpenChange={onOpenChange}
+    />
   );
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -30,7 +30,6 @@ import {
 import {getKeyName} from 'sentry/components/searchSyntax/utils';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {prettifyTagKey} from 'sentry/utils/fields';
 
@@ -349,7 +348,7 @@ const FilterValueGridCell = styled(BaseGridCell)`
 `;
 
 const ValueButton = styled(UnstyledButton)`
-  padding: 0 ${space(0.25)};
+  padding: 0 ${p => p.theme.space['2xs']};
   color: ${p => p.theme.purple400};
   border-left: 1px solid transparent;
   border-right: 1px solid transparent;
@@ -364,7 +363,7 @@ const ValueButton = styled(UnstyledButton)`
 `;
 
 const ValueEditing = styled('div')`
-  padding: 0 ${space(0.25)};
+  padding: 0 ${p => p.theme.space['2xs']};
   color: ${p => p.theme.purple400};
   border-left: 1px solid transparent;
   border-right: 1px solid transparent;
@@ -378,7 +377,7 @@ const ValueEditing = styled('div')`
 `;
 
 const DeleteButton = styled(UnstyledButton)`
-  padding: 0 ${space(0.75)} 0 ${space(0.5)};
+  padding: 0 ${p => p.theme.space.sm} 0 ${p => p.theme.space.xs};
   border-radius: 0 3px 3px 0;
   color: ${p => p.theme.subText};
   border-left: 1px solid transparent;
@@ -393,7 +392,7 @@ const FilterValueList = styled('div')`
   display: flex;
   align-items: center;
   flex-wrap: nowrap;
-  gap: ${space(0.5)};
+  gap: ${p => p.theme.space.xs};
   max-width: 400px;
 `;
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -270,7 +270,7 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
             aria-label={t('Edit operator for filter: %s', token.key.text)}
             onlyOperator={onlyOperator}
             {...mergeProps(triggerProps, filterButtonProps, focusWithinProps)}
-            ref={mergeRefs(triggerProps.ref, ref) as React.Ref<HTMLButtonElement>}
+            ref={mergeRefs(triggerProps.ref, ref)}
           >
             <InteractionStateLayer />
             {label}

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -260,8 +260,7 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
               if (typeof triggerProps.ref === 'function') {
                 triggerProps.ref(r);
               } else {
-                (triggerProps.ref as React.RefObject<HTMLButtonElement | null>).current =
-                  r;
+                triggerProps.ref.current = r;
               }
 
               if (

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from 'react';
+import {useLayoutEffect, useMemo, useRef, useState, type ReactNode} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {useFocusWithin} from '@react-aria/interactions';
@@ -256,10 +249,6 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
     }
   }, [autoFocus]);
 
-  const resetState = useCallback(() => {
-    setAutoFocus(false);
-  }, []);
-
   return (
     <CompactSelect
       disabled={disabled}
@@ -304,11 +293,11 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
             : undefined,
         });
         initialOpSetting.current = false;
-        resetState();
+        setAutoFocus(false);
       }}
       offset={MENU_OFFSET}
       onInteractOutside={() => {
-        resetState();
+        setAutoFocus(false);
       }}
     />
   );

--- a/static/app/components/searchQueryBuilder/tokens/filter/unstyledButton.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/unstyledButton.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 export function UnstyledButton({
   children,
   ...props
-}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+}: React.ComponentPropsWithRef<'button'>) {
   return (
     <RemovedStylesButton type="button" {...props}>
       {children}

--- a/static/app/components/searchQueryBuilder/tokens/filter/useFilterButtonProps.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/useFilterButtonProps.tsx
@@ -12,7 +12,6 @@ type Props = {
 export function useFilterButtonProps({item, state}: Props) {
   const onFocus = useCallback(() => {
     // Ensure that the state is updated correctly
-    // This is where the focus is set to the filter button
     state.selectionManager.setFocusedKey(item.key);
   }, [item.key, state.selectionManager]);
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/useFilterButtonProps.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/useFilterButtonProps.tsx
@@ -12,6 +12,7 @@ type Props = {
 export function useFilterButtonProps({item, state}: Props) {
   const onFocus = useCallback(() => {
     // Ensure that the state is updated correctly
+    // This is where the focus is set to the filter button
     state.selectionManager.setFocusedKey(item.key);
   }, [item.key, state.selectionManager]);
 

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -137,7 +137,7 @@ function calculateNextFocusForFilter(
   const part =
     definition && definition.kind === FieldKind.FUNCTION && definition.parameters?.length
       ? 'key'
-      : 'value';
+      : 'op';
 
   return {
     itemKey: `${Token.FILTER}:${numPreviousFilterItems}`,

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -34,7 +34,6 @@ import {
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {FieldDefinition} from 'sentry/utils/fields';
 import {FieldKind, FieldValueType} from 'sentry/utils/fields';
@@ -739,8 +738,8 @@ const Row = styled('div')`
     [data-hidden-text='true']::before {
       content: '';
       position: absolute;
-      left: ${space(0.5)};
-      right: ${space(0.5)};
+      left: ${p => p.theme.space.xs};
+      right: ${p => p.theme.space.xs};
       top: 0;
       bottom: 0;
       background-color: ${p => p.theme.gray100};
@@ -756,7 +755,7 @@ const GridCell = styled('div')`
   width: 100%;
 
   input {
-    padding: 0 ${space(0.5)};
+    padding: 0 ${p => p.theme.space.xs};
     min-width: 9px;
     width: 100%;
   }
@@ -772,7 +771,7 @@ const PositionedTooltip = styled(InvalidTokenTooltip)`
 const InvisibleText = styled('div')`
   position: relative;
   color: transparent;
-  padding: 0 ${space(0.5)};
+  padding: 0 ${p => p.theme.space.xs};
   min-width: 9px;
   height: 100%;
 `;

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -16,7 +16,7 @@ export enum QueryInterfaceType {
 
 export type FocusOverride = {
   itemKey: string | 'end';
-  part?: 'value' | 'key';
+  part?: 'value' | 'key' | 'op';
 };
 
 export type FieldDefinitionGetter = (key: string) => FieldDefinition | null;

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -23,7 +23,9 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import AutomationsList from 'sentry/views/automations/list';
 
 describe('AutomationsList', () => {
-  const organization = OrganizationFixture({features: ['workflow-engine-ui']});
+  const organization = OrganizationFixture({
+    features: ['workflow-engine-ui', 'search-query-builder-input-flow-changes'],
+  });
   const project = ProjectFixture({id: '1', slug: 'project-1'});
   const detector = MetricDetectorFixture({
     id: '1',
@@ -175,6 +177,7 @@ describe('AutomationsList', () => {
       // Click through menus to select action:slack
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
       await userEvent.click(await screen.findByRole('option', {name: 'action'}));
+      await userEvent.click(await screen.findByRole('option', {name: 'is'}));
       await userEvent.click(await screen.findByRole('option', {name: 'slack'}));
 
       await screen.findByText('Slack Automation');
@@ -421,6 +424,7 @@ describe('AutomationsList', () => {
       // Click through menus to select action:slack
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
       await userEvent.click(await screen.findByRole('option', {name: 'action'}));
+      await userEvent.click(await screen.findByRole('option', {name: 'is'}));
       await userEvent.click(await screen.findByRole('option', {name: 'slack'}));
 
       // Wait for filtered results to load

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -21,7 +21,8 @@ function renderWithProvider({
   return render(
     <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
       <SpansSearchBar widgetQuery={widgetQuery} onSearch={onSearch} onClose={onClose} />
-    </TraceItemAttributeProvider>
+    </TraceItemAttributeProvider>,
+    {organization: {features: ['search-query-builder-input-flow-changes']}}
   );
 }
 
@@ -126,10 +127,9 @@ describe('SpansSearchBar', () => {
     const searchInput = await screen.findByRole('combobox', {
       name: 'Add a search term',
     });
-    await userEvent.type(searchInput, 'span.op:function');
-
-    // It takes two enters. One to enter the search term, and one to submit the search.
+    await userEvent.type(searchInput, 'span.op:');
     await userEvent.keyboard('{enter}');
+    await userEvent.keyboard('function');
     await userEvent.keyboard('{enter}');
 
     await waitFor(() => {

--- a/static/app/views/detectors/list.spec.tsx
+++ b/static/app/views/detectors/list.spec.tsx
@@ -25,7 +25,7 @@ import DetectorsList from 'sentry/views/detectors/list';
 
 describe('DetectorsList', () => {
   const organization = OrganizationFixture({
-    features: ['workflow-engine-ui'],
+    features: ['workflow-engine-ui', 'search-query-builder-input-flow-changes'],
     access: ['org:write'],
   });
 
@@ -168,6 +168,10 @@ describe('DetectorsList', () => {
       // Click through menus to select type:error
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
       await userEvent.click(await screen.findByRole('option', {name: 'type'}));
+
+      const isOption = await screen.findByRole('option', {name: 'is'});
+      await userEvent.click(isOption);
+
       const options = await screen.findAllByRole('option');
       expect(options).toHaveLength(4);
       expect(options[0]).toHaveTextContent('error');
@@ -200,10 +204,12 @@ describe('DetectorsList', () => {
       const searchInput = await screen.findByRole('combobox', {
         name: 'Add a search term',
       });
-      await userEvent.type(searchInput, 'assignee:test@example.com');
+      await userEvent.type(searchInput, 'assignee:');
 
-      // It takes two enters. One to enter the search term, and one to submit the search.
       await userEvent.keyboard('{enter}');
+
+      await userEvent.keyboard('test@example.com');
+
       await userEvent.keyboard('{enter}');
 
       await screen.findByText('Assigned Detector');
@@ -494,10 +500,9 @@ describe('DetectorsList', () => {
       const searchInput = await screen.findByRole('combobox', {
         name: 'Add a search term',
       });
-      await userEvent.type(searchInput, 'assignee:test@example.com');
-
-      // It takes two enters. One to enter the search term, and one to submit the search.
+      await userEvent.type(searchInput, 'assignee:');
       await userEvent.keyboard('{enter}');
+      await userEvent.keyboard('test@example.com');
       await userEvent.keyboard('{enter}');
 
       // Wait for filtered results to load

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
@@ -25,7 +25,9 @@ jest.mock('sentry/views/issueDetails/utils', () => ({
 }));
 
 describe('EventDetailsHeader', () => {
-  const organization = OrganizationFixture();
+  const organization = OrganizationFixture({
+    features: ['search-query-builder-input-flow-changes'],
+  });
   const project = ProjectFixture({
     environments: ['production', 'staging', 'development'],
   });
@@ -137,7 +139,8 @@ describe('EventDetailsHeader', () => {
 
     const search = await screen.findByPlaceholderText('Filter events\u2026');
     await userEvent.type(search, `${tagKey}:`, {delay: null});
-    await userEvent.keyboard(`${tagValue}{enter}{enter}`, {delay: null});
+    await userEvent.click(screen.getByRole('option', {name: 'is'}));
+    await userEvent.keyboard(`${tagValue}{enter}`, {delay: null});
     await waitFor(() => {
       expect(mockUseNavigate).toHaveBeenCalledWith(
         expect.objectContaining(locationQuery),

--- a/static/app/views/issueDetails/streamline/eventSearch.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventSearch.spec.tsx
@@ -11,7 +11,9 @@ import {EventSearch} from 'sentry/views/issueDetails/streamline/eventSearch';
 const mockHandleSearch = jest.fn();
 
 describe('EventSearch', () => {
-  const organization = OrganizationFixture();
+  const organization = OrganizationFixture({
+    features: ['search-query-builder-input-flow-changes'],
+  });
   const project = ProjectFixture({
     environments: ['production', 'staging', 'developement'],
   });
@@ -47,10 +49,11 @@ describe('EventSearch', () => {
   });
 
   it('handles basic inputs for tags', async () => {
-    render(<EventSearch {...defaultProps} />);
+    render(<EventSearch {...defaultProps} />, {organization});
     const search = screen.getByRole('combobox', {name: 'Add a search term'});
     expect(search).toBeInTheDocument();
     await userEvent.type(search, `${tagKey}:`);
+    await userEvent.click(screen.getByRole('option', {name: 'is'}));
     await userEvent.keyboard(`${tagValue}{enter}{enter}`);
 
     await waitFor(() => {

--- a/static/app/views/issueList/searchBar.spec.tsx
+++ b/static/app/views/issueList/searchBar.spec.tsx
@@ -147,11 +147,14 @@ describe('IssueListSearchBar', () => {
         body: tagValueResponse,
       });
 
-      render(<IssueListSearchBar {...newDefaultProps} />);
+      render(<IssueListSearchBar {...newDefaultProps} />, {
+        organization: {features: ['search-query-builder-input-flow-changes']},
+      });
 
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
       await userEvent.paste(tagKey, {delay: null});
       await userEvent.click(screen.getByRole('option', {name: tagKey}));
+      await userEvent.click(screen.getByRole('option', {name: 'is'}));
       expect(await screen.findByRole('option', {name: tagValue})).toBeInTheDocument();
 
       await waitFor(() => {

--- a/static/app/views/projectDetail/projectFilters.spec.tsx
+++ b/static/app/views/projectDetail/projectFilters.spec.tsx
@@ -27,7 +27,8 @@ describe('ProjectDetail > ProjectFilters', () => {
         onSearch={onSearch}
         tagValueLoader={tagValueLoader}
         relativeDateOptions={{}}
-      />
+      />,
+      {organization: {features: ['search-query-builder-input-flow-changes']}}
     );
 
     await userEvent.click(
@@ -42,6 +43,7 @@ describe('ProjectDetail > ProjectFilters', () => {
     expect(screen.getByRole('option', {name: 'release.version'})).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('option', {name: 'release.version'}));
+    await userEvent.click(screen.getByRole('option', {name: 'is'}));
 
     await screen.findByText('sentry@0.5.3');
   });

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -19,7 +19,9 @@ import {ReleasesDisplayOption} from 'sentry/views/releases/list/releasesDisplayO
 import {ReleasesStatusOption} from 'sentry/views/releases/list/releasesStatusOptions';
 
 describe('ReleasesList', () => {
-  const organization = OrganizationFixture();
+  const organization = OrganizationFixture({
+    features: ['search-query-builder-input-flow-changes'],
+  });
   const projects = [ProjectFixture({features: ['releases']})];
   const semverVersionInfo = {
     buildHash: null,
@@ -543,6 +545,7 @@ describe('ReleasesList', () => {
 
     await userEvent.clear(smartSearchBar);
     await userEvent.click(screen.getByRole('option', {name: 'release.version'}));
+    await userEvent.click(screen.getByRole('option', {name: 'is'}));
 
     expect(await screen.findByText('sentry@0.5.3')).toBeInTheDocument();
   });

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
@@ -60,6 +60,8 @@ function BreadcrumbDropdown({
           crumbLabel={name || route.name}
           menuHasHover={isHovered}
           {...triggerProps}
+          // @ts-expect-error - TODO: Crumb component should be refactored to use a button element instead of a div
+          ref={triggerProps.ref}
         />
       )}
       {...props}


### PR DESCRIPTION
This PR changes the flow for entering values with the search query builder. When typing in a filter now, instead of being taken directly to the value, users are first prompted to select the operator they would like to use for their filter, after selecting they are then prompted to enter their value(s).

Ticket: EXP-498