### PR TITLE
ref(feedback): check ai flags on backend for spam detection

### DIFF
--- a/src/sentry/feedback/usecases/spam_detection.py
+++ b/src/sentry/feedback/usecases/spam_detection.py
@@ -64,10 +64,10 @@ def trim_response(text):
 
 
 def spam_detection_enabled(project: Project) -> bool:
-    has_spam_feature = features.has(
+    has_spam_enabled = features.has(
         "organizations:user-feedback-spam-ingest", project.organization
     ) and project.get_option("sentry:feedback_ai_spam_detection")
 
     has_ai_enabled = has_seer_access(project.organization)
 
-    return has_spam_feature and has_ai_enabled
+    return has_spam_enabled and has_ai_enabled

--- a/src/sentry/feedback/usecases/spam_detection.py
+++ b/src/sentry/feedback/usecases/spam_detection.py
@@ -3,6 +3,7 @@ import logging
 from sentry import features
 from sentry.llm.usecases import LLMUseCase, complete_prompt
 from sentry.models.project import Project
+from sentry.seer.seer_setup import has_seer_access
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -63,6 +64,10 @@ def trim_response(text):
 
 
 def spam_detection_enabled(project: Project) -> bool:
-    return features.has(
+    has_spam_feature = features.has(
         "organizations:user-feedback-spam-ingest", project.organization
     ) and project.get_option("sentry:feedback_ai_spam_detection")
+
+    has_ai_enabled = has_seer_access(project.organization)
+
+    return has_spam_feature and has_ai_enabled

--- a/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
@@ -21,7 +21,6 @@ from sentry.feedback.usecases.label_generation import (
     MAX_AI_LABELS,
     MAX_AI_LABELS_JSON_LENGTH,
 )
-from sentry.feedback.usecases.spam_detection import spam_detection_enabled
 from sentry.models.group import Group, GroupStatus
 from sentry.signals import first_feedback_received, first_new_feedback_received
 from sentry.testutils.helpers import Feature
@@ -525,7 +524,10 @@ def test_create_feedback_spam_detection_produce_to_kafka(
     expected_result,
     expected_evidence_display,
 ):
-    with patch(spam_detection_enabled, return_value=enabled):
+    with patch(
+        "sentry.feedback.usecases.ingest.create_feedback.spam_detection_enabled",
+        return_value=enabled,
+    ):
         event = mock_feedback_event(default_project.id, message=input_message)
 
         mock_openai = Mock()


### PR DESCRIPTION
relates to https://linear.app/getsentry/issue/REPLAY-710/spam-detection-should-be-gated-behind-gen-ai-features-and-seer