### PR TITLE
fix(replays): Calculate layout based on new nav sizing

### DIFF
--- a/static/app/utils/replays/hooks/useReplayLayout.tsx
+++ b/static/app/utils/replays/hooks/useReplayLayout.tsx
@@ -1,11 +1,15 @@
 import {useCallback} from 'react';
 import {useTheme} from '@emotion/react';
 
-import PreferencesStore from 'sentry/stores/preferencesStore';
-import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useUrlParams from 'sentry/utils/url/useUrlParams';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
+import {
+  NAV_SIDEBAR_SECONDARY_WIDTH_LOCAL_STORAGE_KEY,
+  SECONDARY_SIDEBAR_WIDTH,
+} from 'sentry/views/nav/constants';
+import {useNavContext} from 'sentry/views/nav/context';
 import {getDefaultLayout} from 'sentry/views/replays/detail/layout/utils';
 
 export enum LayoutKey {
@@ -69,8 +73,13 @@ function isLayout(val: string): val is LayoutKey {
 
 function useReplayLayout() {
   const theme = useTheme();
-  const collapsed = !!useLegacyStore(PreferencesStore).collapsed;
-  const defaultLayout = getDefaultLayout(collapsed, theme);
+  const {isCollapsed} = useNavContext();
+  const [secondarySidebarWidth] = useSyncedLocalStorageState(
+    NAV_SIDEBAR_SECONDARY_WIDTH_LOCAL_STORAGE_KEY,
+    SECONDARY_SIDEBAR_WIDTH
+  );
+  const defaultLayout = getDefaultLayout(isCollapsed, theme, secondarySidebarWidth);
+
   const organization = useOrganization();
 
   const {getParamValue, setParamValue} = useUrlParams('l_page', defaultLayout);

--- a/static/app/views/nav/constants.tsx
+++ b/static/app/views/nav/constants.tsx
@@ -1,3 +1,4 @@
+export const NAV_SIDEBAR_SECONDARY_WIDTH_LOCAL_STORAGE_KEY = 'secondary-sidebar-width';
 export const NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY = 'navigation-sidebar-is-collapsed';
 export const NAV_PRIMARY_LINK_DATA_ATTRIBUTE = 'data-primary-navigation-link';
 export const NAV_SECONDARY_SIDEBAR_DATA_ATTRIBUTE = 'data-secondary-navigation-sidebar';

--- a/static/app/views/nav/sidebar.tsx
+++ b/static/app/views/nav/sidebar.tsx
@@ -12,7 +12,11 @@ import {chonkStyled} from 'sentry/utils/theme/theme.chonk';
 import {withChonk} from 'sentry/utils/theme/withChonk';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
-import {PRIMARY_SIDEBAR_WIDTH, SECONDARY_SIDEBAR_WIDTH} from 'sentry/views/nav/constants';
+import {
+  NAV_SIDEBAR_SECONDARY_WIDTH_LOCAL_STORAGE_KEY,
+  PRIMARY_SIDEBAR_WIDTH,
+  SECONDARY_SIDEBAR_WIDTH,
+} from 'sentry/views/nav/constants';
 import {useNavContext} from 'sentry/views/nav/context';
 import {OrgDropdown} from 'sentry/views/nav/orgDropdown';
 import {PrimaryNavigationItems} from 'sentry/views/nav/primary/index';
@@ -39,7 +43,7 @@ export function Sidebar() {
   const {isOpen} = useCollapsedNav();
 
   const [secondarySidebarWidth] = useSyncedLocalStorageState(
-    'secondary-sidebar-width',
+    NAV_SIDEBAR_SECONDARY_WIDTH_LOCAL_STORAGE_KEY,
     SECONDARY_SIDEBAR_WIDTH
   );
 

--- a/static/app/views/replays/detail/layout/utils.tsx
+++ b/static/app/views/replays/detail/layout/utils.tsx
@@ -1,18 +1,18 @@
 import type {Theme} from '@emotion/react';
 
-import {
-  SIDEBAR_COLLAPSED_WIDTH,
-  SIDEBAR_EXPANDED_WIDTH,
-} from 'sentry/components/sidebar/constants';
 import {LayoutKey} from 'sentry/utils/replays/hooks/useReplayLayout';
+import {PRIMARY_SIDEBAR_WIDTH} from 'sentry/views/nav/constants';
 
-export const getDefaultLayout = (collapsed: boolean, theme: Theme): LayoutKey => {
+export const getDefaultLayout = (
+  collapsed: boolean,
+  theme: Theme,
+  secondarySidebarWidth: number
+): LayoutKey => {
   const {innerWidth, innerHeight} = window;
 
-  const sidebarWidth = parseInt(
-    collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_EXPANDED_WIDTH,
-    10
-  );
+  const sidebarWidth = collapsed
+    ? PRIMARY_SIDEBAR_WIDTH
+    : PRIMARY_SIDEBAR_WIDTH + secondarySidebarWidth;
 
   const mediumScreenWidth = parseInt(theme.breakpoints.md, 10);
 


### PR DESCRIPTION
Ref RTC-1154

As I was removing all the old nav sidebar code, I saw that this depended on the old sidebar widths. This PR updates the code so that it uses the new nav widths instead.

It might be better if this measured the page content instead so that it's not coupled to the nav code, but this unblocks the deleting of the old sidebar for now