### PR TITLE
fix(dashboards): Reapply has filter only shows aggregates once they are selected

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
@@ -52,7 +52,7 @@ describe('EventsSearchBar', () => {
     );
 
     // Focus the input and type "has:p" to simulate a search for p50
-    const input = await screen.findByRole('combobox');
+    const input = await screen.findByRole('combobox', {name: 'Add a search term'});
     await userEvent.type(input, 'has:p');
 
     // Check that "p50" (a function tag) is NOT in the dropdown
@@ -62,27 +62,17 @@ describe('EventsSearchBar', () => {
     await userEvent.type(input, '{Enter}');
 
     // Check that a selected aggregate is in the dropdown
-    await userEvent.click(
-      await screen.findByRole('button', {name: 'Edit value for filter: has'})
-    );
-    await userEvent.type(
-      await screen.findByRole('combobox', {name: 'Edit filter value'}),
-      'count_uni'
-    );
+    await userEvent.clear(input);
+    await userEvent.type(input, 'count_uni');
 
     listbox = await screen.findByRole('listbox');
-    await within(listbox).findByText('count_unique');
+    await within(listbox).findByText('count_unique(...)');
 
     await userEvent.type(input, '{Enter}');
 
     // Check that a normal tag (e.g. "transaction") IS in the dropdown
-    await userEvent.click(
-      await screen.findByRole('button', {name: 'Edit value for filter: has'})
-    );
-    await userEvent.type(
-      await screen.findByRole('combobox', {name: 'Edit filter value'}),
-      'transact'
-    );
+    await userEvent.clear(input);
+    await userEvent.type(input, 'transact');
 
     listbox = await screen.findByRole('listbox');
     await within(listbox).findByText('transaction');

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
@@ -57,7 +57,7 @@ describe('EventsSearchBar', () => {
 
     // Check that "p50" (a function tag) is NOT in the dropdown
     expect(
-      within(await screen.findByRole('listbox')).queryByText('p50')
+      within(screen.getByRole('listbox')).queryByText('p50')
     ).not.toBeInTheDocument();
   });
 
@@ -90,7 +90,7 @@ describe('EventsSearchBar', () => {
     await userEvent.type(input, 'count_uni');
 
     expect(
-      await within(await screen.findByRole('listbox')).findByText('count_unique(...)')
+      await within(screen.getByRole('listbox')).findByText('count_unique(...)')
     ).toBeInTheDocument();
   });
 
@@ -122,7 +122,10 @@ describe('EventsSearchBar', () => {
     await userEvent.clear(input);
     await userEvent.type(input, 'transact');
 
-    const listbox = await screen.findByRole('listbox');
-    expect(await within(listbox).findByText('transaction')).toBeInTheDocument();
+    expect(
+      await within(screen.getByRole('listbox')).findByRole('option', {
+        name: 'transaction',
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
@@ -56,26 +56,73 @@ describe('EventsSearchBar', () => {
     await userEvent.type(input, 'has:p');
 
     // Check that "p50" (a function tag) is NOT in the dropdown
-    let listbox = await screen.findByRole('listbox');
-    expect(within(listbox).queryByText('p50')).not.toBeInTheDocument();
+    expect(
+      within(await screen.findByRole('listbox')).queryByText('p50')
+    ).not.toBeInTheDocument();
+  });
 
-    await userEvent.type(input, '{Enter}');
+  it('shows the selected aggregate in the dropdown', async () => {
+    render(
+      <EventsSearchBar
+        onClose={jest.fn()}
+        dataset={DiscoverDatasets.TRANSACTIONS}
+        pageFilters={PageFiltersFixture()}
+        widgetQuery={{
+          aggregates: ['count_unique(browser.name)'],
+          columns: [],
+          conditions: '',
+          name: '',
+          orderby: '',
+          fieldAliases: undefined,
+          fields: undefined,
+          isHidden: undefined,
+          onDemand: undefined,
+          selectedAggregate: undefined,
+        }}
+      />,
+      {
+        organization,
+      }
+    );
 
-    // Check that a selected aggregate is in the dropdown
-    await userEvent.clear(input);
+    const input = await screen.findByRole('combobox', {name: 'Add a search term'});
+
     await userEvent.type(input, 'count_uni');
 
-    listbox = await screen.findByRole('listbox');
-    await within(listbox).findByText('count_unique(...)');
+    expect(
+      await within(await screen.findByRole('listbox')).findByText('count_unique(...)')
+    ).toBeInTheDocument();
+  });
 
-    await userEvent.type(input, '{Enter}');
+  it('shows normal tags, e.g. transaction, in the dropdown', async () => {
+    render(
+      <EventsSearchBar
+        onClose={jest.fn()}
+        dataset={DiscoverDatasets.TRANSACTIONS}
+        pageFilters={PageFiltersFixture()}
+        widgetQuery={{
+          aggregates: ['count_unique(browser.name)'],
+          columns: [],
+          conditions: '',
+          name: '',
+          orderby: '',
+          fieldAliases: undefined,
+          fields: undefined,
+          isHidden: undefined,
+          onDemand: undefined,
+          selectedAggregate: undefined,
+        }}
+      />,
+      {
+        organization,
+      }
+    );
 
-    // Check that a normal tag (e.g. "transaction") IS in the dropdown
+    const input = await screen.findByRole('combobox', {name: 'Add a search term'});
     await userEvent.clear(input);
     await userEvent.type(input, 'transact');
 
-    listbox = await screen.findByRole('listbox');
-    await within(listbox).findByText('transaction');
-    await userEvent.type(input, '{Enter}');
+    const listbox = await screen.findByRole('listbox');
+    expect(await within(listbox).findByText('transaction')).toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
@@ -1,6 +1,5 @@
 import type {SearchBarProps} from 'sentry/components/events/searchBar';
 import type {PageFilters} from 'sentry/types/core';
-import {generateAggregateFields} from 'sentry/utils/discover/fields';
 import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -29,7 +28,7 @@ export function EventsSearchBar({
   const {customMeasurements} = useCustomMeasurements();
   const eventView = eventViewFromWidget('', widgetQuery, pageFilters);
   const fields = eventView.hasAggregateField()
-    ? generateAggregateFields(organization, eventView.fields)
+    ? eventView.getAggregateFields()
     : eventView.fields;
 
   return (

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
@@ -1,0 +1,83 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+
+import {SavedSearchType} from 'sentry/types/group';
+import type {Organization} from 'sentry/types/organization';
+import {FieldKind} from 'sentry/utils/fields';
+
+import ResultsSearchQueryBuilder from './resultsSearchQueryBuilder';
+
+function createTestProps(overrides = {}) {
+  return {
+    query: '',
+    onSearch: jest.fn(),
+    onChange: jest.fn(),
+    projectIds: [],
+    supportedTags: {
+      environment: {key: 'environment', name: 'environment', kind: FieldKind.FIELD},
+      p50: {key: 'p50', name: 'p50', kind: FieldKind.FUNCTION},
+      transaction: {key: 'transaction', name: 'transaction', kind: FieldKind.FIELD},
+      user: {key: 'user', name: 'user', kind: FieldKind.FIELD},
+    },
+    recentSearches: SavedSearchType.EVENT,
+    ...overrides,
+  };
+}
+
+describe('ResultsSearchQueryBuilder', () => {
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/recent-searches/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/recent-searches/`,
+      body: [],
+      method: 'POST',
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/tags/`,
+      body: [{key: 'transaction', name: 'transaction', kind: FieldKind.FIELD}],
+    });
+  });
+
+  it('does not show function tags in has: dropdown', async () => {
+    const organization: Organization = OrganizationFixture({
+      features: ['performance-view'],
+    });
+
+    render(
+      <ResultsSearchQueryBuilder
+        {...createTestProps({fields: [{field: 'p50(transaction.duration)'}]})}
+      />,
+      {
+        organization,
+      }
+    );
+
+    // Focus the input and type "has:p" to simulate a search for p50
+    const input = await screen.findByRole('combobox');
+    await userEvent.type(input, 'has:p');
+
+    // Wait for the dropdown to appear
+    let listbox = await screen.findByRole('listbox');
+
+    // Check that "p50" (a function tag) is NOT in the dropdown
+    expect(within(listbox).queryByText('p50')).not.toBeInTheDocument();
+
+    await userEvent.type(input, '{Enter}');
+
+    // Check that a normal tag (e.g. "transaction") IS in the dropdown
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Edit value for filter: has'})
+    );
+    await userEvent.type(
+      await screen.findByRole('combobox', {name: 'Edit filter value'}),
+      'transact'
+    );
+
+    listbox = await screen.findByRole('listbox');
+    await within(listbox).findByText('transaction');
+  });
+});

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
@@ -9,7 +9,9 @@ import {FieldKind} from 'sentry/utils/fields';
 import ResultsSearchQueryBuilder from './resultsSearchQueryBuilder';
 
 describe('ResultsSearchQueryBuilder', () => {
+  let organization: Organization;
   beforeEach(() => {
+    organization = OrganizationFixture();
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/recent-searches/`,
       body: [],
@@ -26,10 +28,6 @@ describe('ResultsSearchQueryBuilder', () => {
   });
 
   it('does not show function tags in has: dropdown', async () => {
-    const organization: Organization = OrganizationFixture({
-      features: ['performance-view'],
-    });
-
     render(
       <ResultsSearchQueryBuilder
         query={''}
@@ -56,21 +54,41 @@ describe('ResultsSearchQueryBuilder', () => {
     await userEvent.type(input, 'has:p');
 
     // Check that "p50" (a function tag) is NOT in the dropdown
-    let listbox = await screen.findByRole('listbox');
-    expect(within(listbox).queryByText('p50')).not.toBeInTheDocument();
+    expect(
+      within(await screen.findByRole('listbox')).queryByText('p50')
+    ).not.toBeInTheDocument();
+  });
 
-    await userEvent.type(input, '{Enter}');
+  it('shows normal tags, e.g. transaction, in the dropdown', async () => {
+    render(
+      <ResultsSearchQueryBuilder
+        query={''}
+        onSearch={jest.fn()}
+        onChange={jest.fn()}
+        projectIds={[]}
+        supportedTags={{
+          environment: {key: 'environment', name: 'environment', kind: FieldKind.FIELD},
+          p50: {key: 'p50', name: 'p50', kind: FieldKind.FUNCTION},
+          transaction: {key: 'transaction', name: 'transaction', kind: FieldKind.FIELD},
+          user: {key: 'user', name: 'user', kind: FieldKind.FIELD},
+        }}
+        recentSearches={SavedSearchType.EVENT}
+        // This fields definition is what caused p50 to appear as a function tag
+        fields={[{field: 'p50(transaction.duration)'}]}
+      />,
+      {
+        organization,
+      }
+    );
 
     // Check that a normal tag (e.g. "transaction") IS in the dropdown
-    await userEvent.click(
-      await screen.findByRole('button', {name: 'Edit value for filter: has'})
-    );
-    await userEvent.type(
-      await screen.findByRole('combobox', {name: 'Edit filter value'}),
-      'transact'
-    );
+    const input = await screen.findByRole('combobox');
+    await userEvent.type(input, 'transact');
 
-    listbox = await screen.findByRole('listbox');
-    await within(listbox).findByText('transaction');
+    expect(
+      await within(await screen.findByRole('listbox')).findByRole('option', {
+        name: 'transaction',
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
@@ -1,0 +1,76 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+
+import {SavedSearchType} from 'sentry/types/group';
+import type {Organization} from 'sentry/types/organization';
+import {FieldKind} from 'sentry/utils/fields';
+
+import ResultsSearchQueryBuilder from './resultsSearchQueryBuilder';
+
+describe('ResultsSearchQueryBuilder', () => {
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/recent-searches/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/recent-searches/`,
+      body: [],
+      method: 'POST',
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/tags/`,
+      body: [{key: 'transaction', name: 'transaction', kind: FieldKind.FIELD}],
+    });
+  });
+
+  it('does not show function tags in has: dropdown', async () => {
+    const organization: Organization = OrganizationFixture({
+      features: ['performance-view'],
+    });
+
+    render(
+      <ResultsSearchQueryBuilder
+        query={''}
+        onSearch={jest.fn()}
+        onChange={jest.fn()}
+        projectIds={[]}
+        supportedTags={{
+          environment: {key: 'environment', name: 'environment', kind: FieldKind.FIELD},
+          p50: {key: 'p50', name: 'p50', kind: FieldKind.FUNCTION},
+          transaction: {key: 'transaction', name: 'transaction', kind: FieldKind.FIELD},
+          user: {key: 'user', name: 'user', kind: FieldKind.FIELD},
+        }}
+        recentSearches={SavedSearchType.EVENT}
+        // This fields definition is what caused p50 to appear as a function tag
+        fields={[{field: 'p50(transaction.duration)'}]}
+      />,
+      {
+        organization,
+      }
+    );
+
+    // Focus the input and type "has:p" to simulate a search for p50
+    const input = await screen.findByRole('combobox');
+    await userEvent.type(input, 'has:p');
+
+    // Check that "p50" (a function tag) is NOT in the dropdown
+    let listbox = await screen.findByRole('listbox');
+    expect(within(listbox).queryByText('p50')).not.toBeInTheDocument();
+
+    await userEvent.type(input, '{Enter}');
+
+    // Check that a normal tag (e.g. "transaction") IS in the dropdown
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Edit value for filter: has'})
+    );
+    await userEvent.type(
+      await screen.findByRole('combobox', {name: 'Edit filter value'}),
+      'transact'
+    );
+
+    listbox = await screen.findByRole('listbox');
+    await within(listbox).findByText('transaction');
+  });
+});

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
@@ -55,7 +55,7 @@ describe('ResultsSearchQueryBuilder', () => {
 
     // Check that "p50" (a function tag) is NOT in the dropdown
     expect(
-      within(await screen.findByRole('listbox')).queryByText('p50')
+      within(screen.getByRole('listbox')).queryByText('p50')
     ).not.toBeInTheDocument();
   });
 
@@ -86,7 +86,7 @@ describe('ResultsSearchQueryBuilder', () => {
     await userEvent.type(input, 'transact');
 
     expect(
-      await within(await screen.findByRole('listbox')).findByRole('option', {
+      await within(screen.getByRole('listbox')).findByRole('option', {
         name: 'transaction',
       })
     ).toBeInTheDocument();

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
@@ -8,23 +8,6 @@ import {FieldKind} from 'sentry/utils/fields';
 
 import ResultsSearchQueryBuilder from './resultsSearchQueryBuilder';
 
-function createTestProps(overrides = {}) {
-  return {
-    query: '',
-    onSearch: jest.fn(),
-    onChange: jest.fn(),
-    projectIds: [],
-    supportedTags: {
-      environment: {key: 'environment', name: 'environment', kind: FieldKind.FIELD},
-      p50: {key: 'p50', name: 'p50', kind: FieldKind.FUNCTION},
-      transaction: {key: 'transaction', name: 'transaction', kind: FieldKind.FIELD},
-      user: {key: 'user', name: 'user', kind: FieldKind.FIELD},
-    },
-    recentSearches: SavedSearchType.EVENT,
-    ...overrides,
-  };
-}
-
 describe('ResultsSearchQueryBuilder', () => {
   beforeEach(() => {
     MockApiClient.addMockResponse({
@@ -49,7 +32,19 @@ describe('ResultsSearchQueryBuilder', () => {
 
     render(
       <ResultsSearchQueryBuilder
-        {...createTestProps({fields: [{field: 'p50(transaction.duration)'}]})}
+        query={''}
+        onSearch={jest.fn()}
+        onChange={jest.fn()}
+        projectIds={[]}
+        supportedTags={{
+          environment: {key: 'environment', name: 'environment', kind: FieldKind.FIELD},
+          p50: {key: 'p50', name: 'p50', kind: FieldKind.FUNCTION},
+          transaction: {key: 'transaction', name: 'transaction', kind: FieldKind.FIELD},
+          user: {key: 'user', name: 'user', kind: FieldKind.FIELD},
+        }}
+        recentSearches={SavedSearchType.EVENT}
+        // This fields definition is what caused p50 to appear as a function tag
+        fields={[{field: 'p50(transaction.duration)'}]}
       />,
       {
         organization,
@@ -60,10 +55,8 @@ describe('ResultsSearchQueryBuilder', () => {
     const input = await screen.findByRole('combobox');
     await userEvent.type(input, 'has:p');
 
-    // Wait for the dropdown to appear
-    let listbox = await screen.findByRole('listbox');
-
     // Check that "p50" (a function tag) is NOT in the dropdown
+    let listbox = await screen.findByRole('listbox');
     expect(within(listbox).queryByText('p50')).not.toBeInTheDocument();
 
     await userEvent.type(input, '{Enter}');

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
@@ -225,13 +225,7 @@ function ResultsSearchQueryBuilder(props: Props) {
 
     Object.assign(combinedTags, filteredTags, STATIC_SEMVER_TAGS, featureFlagTags);
 
-    // Function tags should not be included in the has tag
-    const functionTagKeys = new Set(Object.keys(functionTags));
-    combinedTags.has = getHasTag(
-      Object.fromEntries(
-        Object.entries(combinedTags).filter(([key]) => !functionTagKeys.has(key))
-      )
-    );
+    combinedTags.has = getHasTag(combinedTags);
 
     return combinedTags;
   }, [

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
@@ -225,7 +225,13 @@ function ResultsSearchQueryBuilder(props: Props) {
 
     Object.assign(combinedTags, filteredTags, STATIC_SEMVER_TAGS, featureFlagTags);
 
-    combinedTags.has = getHasTag(combinedTags);
+    // Function tags should not be included in the has tag
+    const functionTagKeys = new Set(Object.keys(functionTags));
+    combinedTags.has = getHasTag(
+      Object.fromEntries(
+        Object.entries(combinedTags).filter(([key]) => !functionTagKeys.has(key))
+      )
+    );
 
     return combinedTags;
   }, [


### PR DESCRIPTION
Take 2 of https://github.com/getsentry/sentry/pull/99579

Had to reapply because it looks like the tests were starting to flake on master. I broke them up a bit more and reduced a few await calls.