### PR TITLE
fix(deletions): Deleting group hashes should happen outside the API call

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -14,7 +14,6 @@ from sentry import audit_log, options
 from sentry.api.base import audit_logger
 from sentry.deletions.defaults.group import GROUP_CHUNK_SIZE
 from sentry.deletions.tasks.groups import delete_groups_for_project
-from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphash import GroupHash
 from sentry.models.groupinbox import GroupInbox
@@ -54,8 +53,6 @@ def delete_group_list(
         raise ValueError("All groups must belong to the same project")
 
     group_ids = [g.id for g in group_list]
-    error_ids = [g.id for g in group_list if g.issue_category == GroupCategory.ERROR]
-    non_error_ids = [g.id for g in group_list if g.issue_category != GroupCategory.ERROR]
 
     transaction_id = uuid4().hex
     delete_logger.info(
@@ -75,11 +72,6 @@ def delete_group_list(
             "group_deletion_group_ids": str(group_ids),
         },
     )
-
-    # Removing GroupHash rows prevents new events from associating to the groups
-    # we just deleted.
-    delete_group_hashes(project.id, error_ids, seer_deletion=True)
-    delete_group_hashes(project.id, non_error_ids)
 
     Group.objects.filter(id__in=group_ids).exclude(
         status__in=[GroupStatus.PENDING_DELETION, GroupStatus.DELETION_IN_PROGRESS]

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from sentry import models
+from sentry import models, options
 from sentry.deletions.tasks.nodestore import delete_events_for_groups_from_nodestore_and_eventstore
 from sentry.issues.grouptype import GroupCategory, InvalidGroupTypeError
 from sentry.models.group import Group, GroupStatus
@@ -16,7 +16,6 @@ from sentry.notifications.models.notificationmessage import NotificationMessage
 from sentry.services.eventstore.models import Event
 from sentry.snuba.dataset import Dataset
 from sentry.tasks.delete_seer_grouping_records import may_schedule_task_to_delete_hashes_from_seer
-from sentry.utils import options
 
 from ..base import BaseDeletionTask, BaseRelation, ModelDeletionTask, ModelRelation
 from ..manager import DeletionTaskManager
@@ -179,9 +178,6 @@ class GroupDeletionTask(ModelDeletionTask[Group]):
         error_groups, issue_platform_groups = separate_by_group_category(instance_list)
         error_group_ids = [group.id for group in error_groups]
         issue_platform_group_ids = [group.id for group in issue_platform_groups]
-
-        # Prevent circular import
-        from sentry.api.helpers.group_index.delete import delete_group_hashes
 
         delete_group_hashes(instance_list[0].project_id, error_group_ids, seer_deletion=True)
         delete_group_hashes(instance_list[0].project_id, issue_platform_group_ids)

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1261,7 +1261,8 @@ class DeleteGroupsTest(TestCase):
             GroupHash.objects.create(project=self.project, group=group, hash=hashes[i])
             add_group_to_inbox(group, GroupInboxReason.NEW)
 
-        schedule_tasks_to_delete_groups(request, [self.project], self.organization.id)
+        with self.tasks():
+            schedule_tasks_to_delete_groups(request, [self.project], self.organization.id)
 
         assert (
             len(GroupHash.objects.filter(project_id=self.project.id, group_id__in=group_ids).all())
@@ -1292,7 +1293,8 @@ class DeleteGroupsTest(TestCase):
             GroupHash.objects.create(project=self.project, group=group, hash=hashes[i])
             add_group_to_inbox(group, GroupInboxReason.NEW)
 
-        schedule_tasks_to_delete_groups(request, [self.project], self.organization.id)
+        with self.tasks():
+            schedule_tasks_to_delete_groups(request, [self.project], self.organization.id)
 
         assert (
             len(GroupHash.objects.filter(project_id=self.project.id, group_id__in=group_ids).all())

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -819,10 +819,7 @@ class GroupDeleteTest(APITestCase):
 
         # Deletion was deferred, so it should still exist
         assert Group.objects.get(id=group.id).status == GroupStatus.PENDING_DELETION
-        # BUT the hash should be gone
-        assert not GroupHash.objects.filter(group_id=group.id).exists()
-
-        Group.objects.filter(id=group.id).update(status=GroupStatus.UNRESOLVED)
+        assert GroupHash.objects.filter(group_id=group.id).exists()
 
     def test_delete_and_tasks_run(self) -> None:
         self.login_as(user=self.user)

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -4274,11 +4274,6 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             org = args[0]
         return super().get_response(org, **kwargs)
 
-    def assert_pending_deletion_groups(self, groups: Sequence[Group]) -> None:
-        for group in groups:
-            assert Group.objects.get(id=group.id).status == GroupStatus.PENDING_DELETION
-            assert not GroupHash.objects.filter(group_id=group.id).exists()
-
     def assert_deleted_groups(self, groups: Sequence[Group]) -> None:
         for group in groups:
             assert not Group.objects.filter(id=group.id).exists()
@@ -4433,14 +4428,6 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        response = self.get_success_response(qs_params={"query": ""})
-        assert response.status_code == 204
-        self.assert_pending_deletion_groups(groups)
-
-        # This is needed to put the groups in the unresolved state before also triggering the task
-        Group.objects.filter(id__in=[group.id for group in groups]).update(
-            status=GroupStatus.UNRESOLVED
-        )
         with self.tasks():
             # if query is '' it defaults to is:unresolved
             response = self.get_response(qs_params={"query": ""})


### PR DESCRIPTION
Groups with many group hashes can take long and we should not block the API call but quickly return 204.

Fixes [ID-944](https://linear.app/getsentry/issue/ID-944).