### PR TITLE
feat(uptime): Switch to detectorQuery APIs

### DIFF
--- a/static/app/actionCreators/uptime.tsx
+++ b/static/app/actionCreators/uptime.tsx
@@ -8,20 +8,23 @@ import {
 import type {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import type {UptimeRule} from 'sentry/views/alerts/rules/uptime/types';
 
 export async function updateUptimeRule(
   api: Client,
   org: Organization,
-  uptimeRule: UptimeRule,
+  project: Project,
+  detector: UptimeDetector,
   data: Partial<UptimeRule>
 ): Promise<UptimeRule | null> {
   addLoadingMessage();
 
   try {
     const resp = await api.requestPromise(
-      `/projects/${org.slug}/${uptimeRule.projectSlug}/uptime/${uptimeRule.id}/`,
+      `/projects/${org.slug}/${project.slug}/uptime/${detector.id}/`,
       {
         method: 'PUT',
         data,

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1552,14 +1552,12 @@ function buildRoutes(): RouteObject[] {
             {
               path: ':projectId/:detectorId/details/',
               component: make(() => import('sentry/views/alerts/rules/uptime/details')),
-              deprecatedRouteProps: true,
             },
             {
               path: 'existing-or-create/',
               component: make(
                 () => import('sentry/views/alerts/rules/uptime/existingOrCreate')
               ),
-              deprecatedRouteProps: true,
             },
           ],
         },

--- a/static/app/views/alerts/rules/uptime/details.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/details.spec.tsx
@@ -1,13 +1,22 @@
-import {UptimeRuleFixture} from 'sentry-fixture/uptimeRule';
+import {UptimeDetectorFixture} from 'sentry-fixture/detectors';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 import {UptimeSummaryFixture} from 'sentry-fixture/uptimeSummary';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import UptimeAlertDetails from './details';
 
 describe('UptimeAlertDetails', () => {
-  const {organization, project, routerProps} = initializeOrg();
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+
+  const getInitialRouterConfig = (detectorId: string) => ({
+    location: {
+      pathname: `/organizations/${organization.slug}/alerts/rules/uptime/${project.slug}/${detectorId}/details/`,
+    },
+    route: '/organizations/:orgId/alerts/rules/uptime/:projectId/:detectorId/details/',
+  });
 
   beforeEach(() => {
     MockApiClient.addMockResponse({
@@ -19,50 +28,44 @@ describe('UptimeAlertDetails', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/?limit=1&project=2&query=issue.type%3Auptime_domain_failure%20title%3A%22Downtime%20detected%20for%20https%3A%2F%2Fsentry.io%2F%22`,
+      url: `/organizations/org-slug/issues/?limit=1&project=2&query=issue.type%3Auptime_domain_failure%20title%3A%22Downtime%20detected%20for%20https%3A%2F%2Fexample.com%22`,
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/uptime/1/checks/`,
+      url: `/projects/${organization.slug}/${project.slug}/uptime/3/checks/`,
       body: [],
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/uptime-summary/',
       body: {
-        '1': UptimeSummaryFixture(),
+        '3': UptimeSummaryFixture(),
       },
     });
   });
 
   it('renders', async () => {
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/uptime/1/`,
-      body: UptimeRuleFixture({name: 'Uptime Test Rule'}),
+      url: `/organizations/${organization.slug}/detectors/3/`,
+      body: UptimeDetectorFixture({name: 'Uptime Test Rule'}),
     });
 
-    render(
-      <UptimeAlertDetails
-        {...routerProps}
-        params={{...routerProps.params, detectorId: '1'}}
-      />,
-      {organization}
-    );
+    render(<UptimeAlertDetails />, {
+      organization,
+      initialRouterConfig: getInitialRouterConfig('3'),
+    });
     expect(await screen.findByText('Uptime Test Rule')).toBeInTheDocument();
   });
 
   it('shows a message for invalid uptime alert', async () => {
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/uptime/2/`,
+      url: `/organizations/${organization.slug}/detectors/2/`,
       statusCode: 404,
     });
 
-    render(
-      <UptimeAlertDetails
-        {...routerProps}
-        params={{...routerProps.params, detectorId: '2'}}
-      />,
-      {organization}
-    );
+    render(<UptimeAlertDetails />, {
+      organization,
+      initialRouterConfig: getInitialRouterConfig('2'),
+    });
     expect(
       await screen.findByText('The uptime alert rule you were looking for was not found.')
     ).toBeInTheDocument();
@@ -70,27 +73,24 @@ describe('UptimeAlertDetails', () => {
 
   it('disables and enables the rule', async () => {
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/uptime/2/`,
+      url: `/organizations/${organization.slug}/detectors/2/`,
       statusCode: 404,
     });
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/uptime/1/`,
-      body: UptimeRuleFixture({name: 'Uptime Test Rule'}),
+      url: `/organizations/${organization.slug}/detectors/3/`,
+      body: UptimeDetectorFixture({name: 'Uptime Test Rule'}),
     });
 
-    render(
-      <UptimeAlertDetails
-        {...routerProps}
-        params={{...routerProps.params, detectorId: '1'}}
-      />,
-      {organization}
-    );
+    render(<UptimeAlertDetails />, {
+      organization,
+      initialRouterConfig: getInitialRouterConfig('3'),
+    });
     await screen.findByText('Uptime Test Rule');
 
     const disableMock = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/uptime/1/`,
+      url: `/projects/${organization.slug}/${project.slug}/uptime/3/`,
       method: 'PUT',
-      body: UptimeRuleFixture({name: 'Uptime Test Rule', status: 'disabled'}),
+      body: UptimeDetectorFixture({name: 'Uptime Test Rule', enabled: false}),
     });
 
     const disableButtons = await screen.findAllByRole('button', {
@@ -104,9 +104,9 @@ describe('UptimeAlertDetails', () => {
     );
 
     const enableMock = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/uptime/1/`,
+      url: `/projects/${organization.slug}/${project.slug}/uptime/3/`,
       method: 'PUT',
-      body: UptimeRuleFixture({name: 'Uptime Test Rule', status: 'active'}),
+      body: UptimeDetectorFixture({name: 'Uptime Test Rule', enabled: true}),
     });
 
     // Button now re-enables the monitor

--- a/static/app/views/alerts/rules/uptime/details.tsx
+++ b/static/app/views/alerts/rules/uptime/details.tsx
@@ -19,43 +19,41 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconEdit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import {useQueryClient} from 'sentry/utils/queryClient';
+import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
+import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
-import {useUptimeMonitorSummaries} from 'sentry/views/insights/uptime/utils/useUptimeMonitorSummary';
 import {
-  setUptimeRuleData,
-  useUptimeRule,
-} from 'sentry/views/insights/uptime/utils/useUptimeRule';
+  makeDetectorDetailsQueryKey,
+  useDetectorQuery,
+} from 'sentry/views/detectors/hooks';
+import {useUptimeMonitorSummaries} from 'sentry/views/insights/uptime/utils/useUptimeMonitorSummary';
 
 import {UptimeDetailsSidebar} from './detailsSidebar';
 import {DetailsTimeline} from './detailsTimeline';
 import {StatusToggleButton} from './statusToggleButton';
-import {CheckStatus, type CheckStatusBucket, type UptimeRule} from './types';
+import {CheckStatus, type CheckStatusBucket} from './types';
 import {UptimeChecksTable} from './uptimeChecksTable';
 import {UptimeIssues} from './uptimeIssues';
 
-interface UptimeAlertDetailsProps
-  extends RouteComponentProps<{detectorId: string; projectId: string}> {}
+export default function UptimeAlertDetails() {
+  const {detectorId, projectId} = useParams<{detectorId: string; projectId: string}>();
 
-export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
   const api = useApi();
   const organization = useOrganization();
   const queryClient = useQueryClient();
-
-  const {projectId, detectorId} = params;
 
   const {projects, fetching: loadingProject} = useProjects({slugs: [projectId]});
   const project = projects.find(({slug}) => slug === projectId);
 
   const {
-    data: uptimeRule,
+    data: detector,
     isPending,
     isError,
-  } = useUptimeRule({projectSlug: projectId, detectorId});
+  } = useDetectorQuery<UptimeDetector>(detectorId);
 
   const {data: uptimeSummaries} = useUptimeMonitorSummaries({detectorIds: [detectorId]});
   const summary = uptimeSummaries?.[detectorId];
@@ -95,18 +93,25 @@ export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
     );
   }
 
-  const handleUpdate = async (data: Partial<UptimeRule>) => {
-    const resp = await updateUptimeRule(api, organization, uptimeRule, data);
+  const toggleStatus = async ({enabled}: Partial<UptimeDetector>) => {
+    // XXX(epurkhiser): We're not yet able to use the detector APIs to enable /
+    // disable uptime monitors. The detector APIs are not yet connected to
+    // billing or remote uptime subscription updates, so we need to continue
+    // using the legacy uptime rule APIs.
+    const resp = await updateUptimeRule(api, organization, project, detector, {
+      status: enabled ? 'active' : 'disabled',
+    });
 
     if (resp !== null) {
-      setUptimeRuleData({
+      setApiQueryData<UptimeDetector>(
         queryClient,
-        organizationSlug: organization.slug,
-        projectSlug: projectId,
-        uptimeRule: resp,
-      });
+        makeDetectorDetailsQueryKey({orgSlug: organization.slug, detectorId}),
+        prev => Object.assign({}, prev, {enabled})
+      );
     }
   };
+
+  const uptimeSub = detector.dataSources[0].queryObj;
 
   const canEdit = hasEveryAccess(['alerts:write'], {organization, project});
   const permissionTooltipText = tct(
@@ -116,7 +121,7 @@ export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
 
   return (
     <Layout.Page>
-      <SentryDocumentTitle title={`${uptimeRule.name} — Alerts`} />
+      <SentryDocumentTitle title={`${detector.name} — Alerts`} />
       <Layout.Header>
         <Layout.HeaderContent>
           <Breadcrumbs
@@ -140,14 +145,14 @@ export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
               hideName
               avatarProps={{hasTooltip: true, tooltip: project.slug}}
             />
-            {uptimeRule.name}
+            {detector.name}
           </Layout.Title>
         </Layout.HeaderContent>
         <Layout.HeaderActions>
           <ButtonBar>
             <StatusToggleButton
-              uptimeRule={uptimeRule}
-              onToggleStatus={status => handleUpdate({status})}
+              uptimeDetector={detector}
+              onToggleStatus={data => toggleStatus(data)}
               size="sm"
               disabled={!canEdit}
               {...(canEdit ? {} : {title: permissionTooltipText})}
@@ -172,15 +177,15 @@ export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
           <StyledPageFilterBar condensed>
             <DatePageFilter />
           </StyledPageFilterBar>
-          {uptimeRule.status === 'disabled' && (
+          {!detector.enabled && (
             <Alert.Container>
               <Alert
                 type="muted"
                 trailingItems={
                   <StatusToggleButton
-                    uptimeRule={uptimeRule}
+                    uptimeDetector={detector}
                     size="xs"
-                    onToggleStatus={status => handleUpdate({status})}
+                    onToggleStatus={data => toggleStatus(data)}
                   >
                     {t('Enable')}
                   </StatusToggleButton>
@@ -190,19 +195,19 @@ export default function UptimeAlertDetails({params}: UptimeAlertDetailsProps) {
               </Alert>
             </Alert.Container>
           )}
-          <DetailsTimeline uptimeRule={uptimeRule} onStatsLoaded={checkHasUnknown} />
-          <UptimeIssues project={project} uptimeRule={uptimeRule} />
+          <DetailsTimeline uptimeDetector={detector} onStatsLoaded={checkHasUnknown} />
+          <UptimeIssues project={project} uptimeDetector={detector} />
           <SectionHeading>{t('Checks List')}</SectionHeading>
           <UptimeChecksTable
-            detectorId={uptimeRule.id}
-            projectSlug={uptimeRule.projectSlug}
-            traceSampling={uptimeRule.traceSampling}
+            detectorId={detector.id}
+            projectSlug={project.slug}
+            traceSampling={uptimeSub.traceSampling}
           />
         </Layout.Main>
         <Layout.Side>
           <UptimeDetailsSidebar
             summary={summary}
-            uptimeRule={uptimeRule}
+            uptimeDetector={detector}
             showMissedLegend={showMissedLegend}
           />
         </Layout.Side>

--- a/static/app/views/alerts/rules/uptime/detailsSidebar.tsx
+++ b/static/app/views/alerts/rules/uptime/detailsSidebar.tsx
@@ -12,35 +12,32 @@ import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {CheckIndicator} from 'sentry/views/alerts/rules/uptime/checkIndicator';
-import {
-  CheckStatus,
-  type UptimeRule,
-  type UptimeSummary,
-} from 'sentry/views/alerts/rules/uptime/types';
+import {CheckStatus, type UptimeSummary} from 'sentry/views/alerts/rules/uptime/types';
 import {UptimeDuration} from 'sentry/views/insights/uptime/components/duration';
 import {UptimePercent} from 'sentry/views/insights/uptime/components/percent';
 import {statusToText} from 'sentry/views/insights/uptime/timelineConfig';
 
 interface UptimeDetailsSidebarProps {
   showMissedLegend: boolean;
-  uptimeRule: UptimeRule;
+  uptimeDetector: UptimeDetector;
   summary?: UptimeSummary;
 }
 
 export function UptimeDetailsSidebar({
   summary,
-  uptimeRule,
+  uptimeDetector,
   showMissedLegend,
 }: UptimeDetailsSidebarProps) {
+  const uptimeSub = uptimeDetector.dataSources[0].queryObj;
+
   return (
     <Fragment>
       <MonitorUrlContainer>
         <SectionHeading>{t('Checked URL')}</SectionHeading>
-        <CodeSnippet
-          hideCopyButton
-        >{`${uptimeRule.method} ${uptimeRule.url}`}</CodeSnippet>
+        <CodeSnippet hideCopyButton>{`${uptimeSub.method} ${uptimeSub.url}`}</CodeSnippet>
       </MonitorUrlContainer>
       <Grid
         columns={summary && summary.avgDurationUs !== null ? '2fr 1fr 1fr' : '1fr 1fr'}
@@ -162,17 +159,24 @@ export function UptimeDetailsSidebar({
       <KeyValueTable>
         <KeyValueTableRow
           keyName={t('Check Interval')}
-          value={t('Every %s', getDuration(uptimeRule.intervalSeconds))}
+          value={t('Every %s', getDuration(uptimeSub.intervalSeconds))}
         />
         <KeyValueTableRow
           keyName={t('Timeout')}
-          value={t('After %s', getDuration(uptimeRule.timeoutMs / 1000, 2))}
+          value={t('After %s', getDuration(uptimeSub.timeoutMs / 1000, 2))}
         />
-        <KeyValueTableRow keyName={t('Environment')} value={uptimeRule.environment} />
+        <KeyValueTableRow
+          keyName={t('Environment')}
+          value={uptimeDetector.config.environment}
+        />
         <KeyValueTableRow
           keyName={t('Owner')}
           value={
-            uptimeRule.owner ? <ActorAvatar actor={uptimeRule.owner} /> : t('Unassigned')
+            uptimeDetector.owner ? (
+              <ActorAvatar actor={uptimeDetector.owner} />
+            ) : (
+              t('Unassigned')
+            )
           }
         />
       </KeyValueTable>

--- a/static/app/views/alerts/rules/uptime/detailsTimeline.tsx
+++ b/static/app/views/alerts/rules/uptime/detailsTimeline.tsx
@@ -7,23 +7,24 @@ import {
 } from 'sentry/components/checkInTimeline/gridLines';
 import {useTimeWindowConfig} from 'sentry/components/checkInTimeline/hooks/useTimeWindowConfig';
 import Panel from 'sentry/components/panels/panel';
+import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import {OverviewRow} from 'sentry/views/insights/uptime/components/overviewTimeline/overviewRow';
 import {useUptimeMonitorStats} from 'sentry/views/insights/uptime/utils/useUptimeMonitorStats';
 
-import type {CheckStatusBucket, UptimeRule} from './types';
+import type {CheckStatusBucket} from './types';
 
 interface Props {
   /**
    * Called when stats have been loaded for this timeline.
    */
   onStatsLoaded: (stats: CheckStatusBucket[]) => void;
-  uptimeRule: UptimeRule;
+  uptimeDetector: UptimeDetector;
 }
 
-export function DetailsTimeline({uptimeRule, onStatsLoaded}: Props) {
-  const {id} = uptimeRule;
+export function DetailsTimeline({uptimeDetector, onStatsLoaded}: Props) {
+  const {id} = uptimeDetector;
   const elementRef = useRef<HTMLDivElement>(null);
   const {width: containerWidth} = useDimensions<HTMLDivElement>({elementRef});
   const timelineWidth = useDebouncedValue(containerWidth, 500);
@@ -31,7 +32,7 @@ export function DetailsTimeline({uptimeRule, onStatsLoaded}: Props) {
   const timeWindowConfig = useTimeWindowConfig({timelineWidth});
 
   const {data: uptimeStats} = useUptimeMonitorStats({
-    detectorIds: [String(uptimeRule.id)],
+    detectorIds: [String(uptimeDetector.id)],
     timeWindowConfig,
   });
 
@@ -55,9 +56,9 @@ export function DetailsTimeline({uptimeRule, onStatsLoaded}: Props) {
         cursorOverlayAnchorOffset={10}
       />
       <OverviewRow
-        uptimeRule={uptimeRule}
+        uptimeDetector={uptimeDetector}
         timeWindowConfig={timeWindowConfig}
-        singleRuleView
+        single
       />
     </Panel>
   );

--- a/static/app/views/alerts/rules/uptime/statusToggleButton.tsx
+++ b/static/app/views/alerts/rules/uptime/statusToggleButton.tsx
@@ -2,28 +2,23 @@ import type {ButtonProps} from 'sentry/components/core/button';
 import {Button} from 'sentry/components/core/button';
 import {IconPause, IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {ObjectStatus} from 'sentry/types/core';
-
-import type {UptimeRule} from './types';
+import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 
 interface StatusToggleButtonProps extends Omit<ButtonProps, 'onClick'> {
-  onToggleStatus: (status: ObjectStatus) => Promise<void>;
-  uptimeRule: UptimeRule;
+  onToggleStatus: (opts: {enabled: boolean}) => Promise<void>;
+  uptimeDetector: UptimeDetector;
 }
 
 export function StatusToggleButton({
-  uptimeRule,
+  uptimeDetector: {enabled},
   onToggleStatus,
   ...props
 }: StatusToggleButtonProps) {
-  const {status} = uptimeRule;
-  const isDisabled = status === 'disabled';
+  const Icon = enabled ? IconPause : IconPlay;
 
-  const Icon = isDisabled ? IconPlay : IconPause;
-
-  const label = isDisabled
-    ? t('Enable this uptime rule')
-    : t('Disable this uptime rule and stop performing checks');
+  const label = enabled
+    ? t('Disable this uptime rule and stop performing checks')
+    : t('Enable this uptime rule');
 
   return (
     <Button
@@ -31,9 +26,9 @@ export function StatusToggleButton({
       aria-label={label}
       title={label}
       onClick={async () => {
-        await onToggleStatus(isDisabled ? 'active' : 'disabled');
+        await onToggleStatus({enabled: !enabled});
         // TODO(epurkhiser): We'll need a hook here to trigger subscription
-        // refesh in getsentry when toggling uptime monitors since it will
+        // refresh in getsentry when toggling uptime monitors since it will
         // consume quota.
       }}
       {...props}

--- a/static/app/views/alerts/rules/uptime/uptimeIssues.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeIssues.tsx
@@ -5,19 +5,18 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import {t} from 'sentry/locale';
 import {IssueType} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
-
-import type {UptimeRule} from './types';
+import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 
 interface Props {
   project: Project;
-  uptimeRule: UptimeRule;
+  uptimeDetector: UptimeDetector;
 }
 
-export function UptimeIssues({project, uptimeRule}: Props) {
+export function UptimeIssues({project, uptimeDetector}: Props) {
   // TODO(epurkhiser): We need a better way to query for uptime issues, using
   // the title is brittle and means when the user changes the URL we'll have to
   // wait for a new event before the issue matches again.
-  const query = `issue.type:${IssueType.UPTIME_DOMAIN_FAILURE} title:"Downtime detected for ${uptimeRule.url}"`;
+  const query = `issue.type:${IssueType.UPTIME_DOMAIN_FAILURE} title:"Downtime detected for ${uptimeDetector.dataSources[0].queryObj.url}"`;
 
   const emptyMessage = () => {
     return (

--- a/static/app/views/detectors/hooks/index.ts
+++ b/static/app/views/detectors/hooks/index.ts
@@ -115,7 +115,7 @@ export function useUpdateDetector<T extends Detector = Detector>() {
   });
 }
 
-const makeDetectorDetailsQueryKey = ({
+export const makeDetectorDetailsQueryKey = ({
   orgSlug,
   detectorId,
 }: {

--- a/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
@@ -11,18 +11,18 @@ import {useTimeWindowConfig} from 'sentry/components/checkInTimeline/hooks/useTi
 import Panel from 'sentry/components/panels/panel';
 import {Sticky} from 'sentry/components/sticky';
 import {space} from 'sentry/styles/space';
+import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useDimensions} from 'sentry/utils/useDimensions';
-import type {UptimeRule} from 'sentry/views/alerts/rules/uptime/types';
 import {useUptimeMonitorSummaries} from 'sentry/views/insights/uptime/utils/useUptimeMonitorSummary';
 
 import {OverviewRow} from './overviewRow';
 
 interface Props {
-  uptimeRules: UptimeRule[];
+  uptimeDetectors: UptimeDetector[];
 }
 
-export function OverviewTimeline({uptimeRules}: Props) {
+export function OverviewTimeline({uptimeDetectors}: Props) {
   const elementRef = useRef<HTMLDivElement>(null);
   const {width: containerWidth} = useDimensions<HTMLDivElement>({elementRef});
   const timelineWidth = useDebouncedValue(containerWidth, 500);
@@ -31,7 +31,7 @@ export function OverviewTimeline({uptimeRules}: Props) {
   const dateNavigation = useDateNavigation();
 
   const {data: summaries} = useUptimeMonitorSummaries({
-    detectorIds: uptimeRules.map(rule => rule.id),
+    detectorIds: uptimeDetectors.map(detector => detector.id),
     timeWindowConfig,
   });
 
@@ -67,12 +67,12 @@ export function OverviewTimeline({uptimeRules}: Props) {
         cursorOverlayAnchorOffset={10}
       />
       <UptimeAlertRow>
-        {uptimeRules.map(uptimeRule => (
+        {uptimeDetectors.map(detector => (
           <OverviewRow
-            key={uptimeRule.id}
+            key={detector.id}
             timeWindowConfig={timeWindowConfig}
-            uptimeRule={uptimeRule}
-            summary={summaries?.[uptimeRule.id] ?? null}
+            uptimeDetector={detector}
+            summary={summaries?.[detector.id] ?? null}
           />
         ))}
       </UptimeAlertRow>

--- a/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
@@ -17,12 +17,13 @@ import {IconClock, IconStats, IconTimer, IconUser} from 'sentry/icons';
 import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
+import useProjectFromId from 'sentry/utils/useProjectFromId';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
-import type {UptimeRule, UptimeSummary} from 'sentry/views/alerts/rules/uptime/types';
+import type {UptimeSummary} from 'sentry/views/alerts/rules/uptime/types';
 import {UptimeDuration} from 'sentry/views/insights/uptime/components/duration';
 import {UptimePercent} from 'sentry/views/insights/uptime/components/percent';
 import {
@@ -34,49 +35,45 @@ import {useUptimeMonitorStats} from 'sentry/views/insights/uptime/utils/useUptim
 
 interface Props {
   timeWindowConfig: TimeWindowConfig;
-  uptimeRule: UptimeRule;
+  uptimeDetector: UptimeDetector;
   /**
-   * Whether only one uptime rule is being rendered in a larger view with this
-   * component. turns off things like zebra striping, hover effect, and showing
-   * rule name.
+   * Whether only one uptime detector is being rendered in a larger view with
+   * this component. turns off things like zebra striping, hover effect, and
+   * showing detector name.
    */
-  singleRuleView?: boolean;
+  single?: boolean;
   summary?: UptimeSummary | null;
 }
 
-export function OverviewRow({
-  summary,
-  uptimeRule,
-  timeWindowConfig,
-  singleRuleView,
-}: Props) {
+export function OverviewRow({summary, uptimeDetector, timeWindowConfig, single}: Props) {
   const organization = useOrganization();
-  const project = useProjectFromSlug({
-    organization,
-    projectSlug: uptimeRule.projectSlug,
+  const project = useProjectFromId({
+    project_id: uptimeDetector.projectId,
   });
 
   const location = useLocation();
   const query = pick(location.query, ['start', 'end', 'statsPeriod', 'environment']);
 
   const {data: uptimeStats, isPending} = useUptimeMonitorStats({
-    detectorIds: [uptimeRule.id],
+    detectorIds: [uptimeDetector.id],
     timeWindowConfig,
   });
 
   const detailsPath = makeAlertsPathname({
-    path: `/rules/uptime/${uptimeRule.projectSlug}/${uptimeRule.id}/details/`,
+    path: `/rules/uptime/${project?.slug}/${uptimeDetector.id}/details/`,
     organization,
   });
 
-  const ruleDetails = singleRuleView ? null : (
+  const subscription = uptimeDetector.dataSources[0].queryObj;
+
+  const ruleDetails = single ? null : (
     <DetailsLink to={{pathname: detailsPath, query}}>
-      <Name>{uptimeRule.name}</Name>
+      <Name>{uptimeDetector.name}</Name>
       <Details>
         <DetailsLine>
           {project && <ProjectBadge project={project} avatarSize={12} disableLink />}
-          {uptimeRule.owner ? (
-            <ActorBadge actor={uptimeRule.owner} avatarSize={12} />
+          {uptimeDetector.owner ? (
+            <ActorBadge actor={uptimeDetector.owner} avatarSize={12} />
           ) : (
             <Flex gap="xs" align="center">
               <IconUser size="xs" />
@@ -87,7 +84,7 @@ export function OverviewRow({
         <DetailsLine>
           <Flex gap="xs" align="center">
             <IconTimer />
-            {t('Checked every %s', getDuration(uptimeRule.intervalSeconds))}
+            {t('Checked every %s', getDuration(subscription.intervalSeconds))}
           </Flex>
           {summary === undefined ? null : summary === null ? (
             <Fragment>
@@ -115,16 +112,16 @@ export function OverviewRow({
             </Fragment>
           )}
         </DetailsLine>
-        <div>{uptimeRule.status === 'disabled' && <Tag>{t('Disabled')}</Tag>}</div>
+        <div>{!uptimeDetector.enabled && <Tag>{t('Disabled')}</Tag>}</div>
       </Details>
     </DetailsLink>
   );
 
   return (
     <TimelineRow
-      key={uptimeRule.id}
-      singleRuleView={singleRuleView}
-      as={singleRuleView ? 'div' : 'li'}
+      key={uptimeDetector.id}
+      singleRuleView={single}
+      as={single ? 'div' : 'li'}
     >
       {ruleDetails}
       <TimelineContainer>
@@ -132,7 +129,7 @@ export function OverviewRow({
           <CheckInPlaceholder />
         ) : (
           <CheckInTimeline
-            bucketedData={uptimeStats?.[uptimeRule.id] ?? []}
+            bucketedData={uptimeStats?.[uptimeDetector.id] ?? []}
             statusLabel={statusToText}
             statusStyle={tickStyle}
             statusPrecedent={checkStatusPrecedent}

--- a/static/app/views/insights/uptime/utils/useUptimeRule.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeRule.tsx
@@ -1,8 +1,6 @@
 import {
-  setApiQueryData,
   useApiQuery,
   type ApiQueryKey,
-  type QueryClient,
   type UseApiQueryOptions,
 } from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -23,23 +21,4 @@ export function useUptimeRule(
     `/projects/${organization.slug}/${projectSlug}/uptime/${detectorId}/`,
   ];
   return useApiQuery<UptimeRule>(queryKey, {staleTime: 0, ...options});
-}
-
-interface SetUptimeRuleDataOptions {
-  organizationSlug: string;
-  projectSlug: string;
-  queryClient: QueryClient;
-  uptimeRule: UptimeRule;
-}
-
-export function setUptimeRuleData({
-  queryClient,
-  organizationSlug,
-  projectSlug,
-  uptimeRule,
-}: SetUptimeRuleDataOptions) {
-  const queryKey: ApiQueryKey = [
-    `/projects/${organizationSlug}/${projectSlug}/uptime/${uptimeRule.id}/`,
-  ];
-  setApiQueryData(queryClient, queryKey, uptimeRule);
 }

--- a/static/app/views/insights/uptime/views/overview.spec.tsx
+++ b/static/app/views/insights/uptime/views/overview.spec.tsx
@@ -1,8 +1,8 @@
+import {UptimeDetectorFixture} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TeamFixture} from 'sentry-fixture/team';
-import {UptimeRuleFixture} from 'sentry-fixture/uptimeRule';
 import {UptimeSummaryFixture} from 'sentry-fixture/uptimeSummary';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
@@ -23,12 +23,12 @@ describe('Uptime Overview', () => {
     OrganizationStore.init();
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/uptime/',
+      url: '/organizations/org-slug/detectors/',
       body: [
-        UptimeRuleFixture({
+        UptimeDetectorFixture({
           id: '123',
           name: 'Test Monitor',
-          projectSlug: project.slug,
+          projectId: project.id,
           owner: undefined,
         }),
       ],

--- a/static/app/views/insights/uptime/views/overview.tsx
+++ b/static/app/views/insights/uptime/views/overview.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
-import * as qs from 'query-string';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
@@ -12,20 +11,17 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
-import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import Pagination from 'sentry/components/pagination';
 import Panel from 'sentry/components/panels/panel';
-import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconAdd} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {type UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -34,8 +30,8 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
-import type {UptimeRule} from 'sentry/views/alerts/rules/uptime/types';
-import {OwnerFilter} from 'sentry/views/insights/crons/components/ownerFilter';
+import {DetectorSearch} from 'sentry/views/detectors/components/detectorSearch';
+import {useDetectorsQuery} from 'sentry/views/detectors/hooks';
 import {OverviewTimeline} from 'sentry/views/insights/uptime/components/overviewTimeline';
 import {MODULE_DESCRIPTION, MODULE_DOC_LINK} from 'sentry/views/insights/uptime/settings';
 
@@ -46,44 +42,20 @@ export default function UptimeOverview() {
   const project = decodeList(location.query?.project);
   const {projects} = useProjects();
 
-  function makeQueryKey() {
-    const {query, environment, owner, cursor, sort, asc} = location.query;
-    return [
-      `/organizations/${organization.slug}/uptime/`,
-      {
-        query: {
-          cursor,
-          query,
-          project,
-          environment,
-          owner,
-          includeNew: true,
-          per_page: 20,
-          sort,
-          asc,
-        },
-      },
-    ] as const;
-  }
-
   const {
-    data: uptimeRules,
+    data: detectors,
     getResponseHeader: uptimeListHeaders,
     isPending,
-  } = useApiQuery<UptimeRule[]>(makeQueryKey(), {staleTime: 0});
+  } = useDetectorsQuery<UptimeDetector>({
+    query: `type:uptime ${location.query.query}`,
+    cursor: decodeScalar(location.query.cursor),
+    projects: project.map(Number),
+  });
 
   useRouteAnalyticsEventNames('uptime.page_viewed', 'Uptime: Page Viewed');
-  useRouteAnalyticsParams({empty_state: !uptimeRules || uptimeRules.length === 0});
+  useRouteAnalyticsParams({empty_state: !detectors || detectors.length === 0});
 
   const uptimeListPageLinks = uptimeListHeaders?.('Link');
-
-  const handleSearch = (query: string) => {
-    const currentQuery = {...location.query, cursor: undefined};
-    navigate({
-      pathname: location.pathname,
-      query: normalizeDateTimeParams({...currentQuery, query}),
-    });
-  };
 
   const canCreateAlert =
     hasEveryAccess(['alerts:write'], {organization}) ||
@@ -127,34 +99,30 @@ export default function UptimeOverview() {
       <Layout.Body>
         <Layout.Main fullWidth>
           <Filters>
-            <OwnerFilter
-              selectedOwners={decodeList(location.query.owner)}
-              onChangeFilter={owner => {
+            <PageFilterBar>
+              <ProjectPageFilter resetParamsOnChange={['cursor']} />
+              <DatePageFilter />
+            </PageFilterBar>
+            <DetectorSearch
+              initialQuery=""
+              placeholder={t('Filter uptime monitors')}
+              excludeKeys={['type']}
+              onSearch={query => {
                 navigate(
                   {
                     ...location,
-                    query: {...location.query, owner, cursor: undefined},
+                    query: {...location.query, query, cursor: undefined},
                   },
                   {replace: true}
                 );
               }}
             />
-            <PageFilterBar>
-              <ProjectPageFilter resetParamsOnChange={['cursor']} />
-              <EnvironmentPageFilter resetParamsOnChange={['cursor']} />
-              <DatePageFilter />
-            </PageFilterBar>
-            <SearchBar
-              query={decodeScalar(qs.parse(location.search)?.query, '')}
-              placeholder={t('Search by name or slug')}
-              onSearch={handleSearch}
-            />
           </Filters>
           {isPending ? (
             <LoadingIndicator />
-          ) : uptimeRules?.length ? (
+          ) : detectors?.length ? (
             <Fragment>
-              <OverviewTimeline uptimeRules={uptimeRules} />
+              <OverviewTimeline uptimeDetectors={detectors} />
               {uptimeListPageLinks && <Pagination pageLinks={uptimeListPageLinks} />}
             </Fragment>
           ) : (

--- a/static/app/views/issueDetails/groupUptimeChecks.spec.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.spec.tsx
@@ -1,10 +1,10 @@
+import {UptimeDetectorFixture} from 'sentry-fixture/detectors';
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {UptimeCheckFixture} from 'sentry-fixture/uptimeCheck';
-import {UptimeRuleFixture} from 'sentry-fixture/uptimeRule';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -48,8 +48,8 @@ describe('GroupUptimeChecks', () => {
       body: event,
     });
     MockApiClient.addMockResponse({
-      url: `/projects/org-slug/project-slug/uptime/123/`,
-      body: UptimeRuleFixture(),
+      url: `/organizations/${organization.slug}/detectors/123/`,
+      body: UptimeDetectorFixture({id: '123'}),
     });
     PageFiltersStore.onInitializeUrlState(
       {

--- a/static/app/views/issueDetails/groupUptimeChecks.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.tsx
@@ -2,14 +2,15 @@ import {usePageFilterDates} from 'sentry/components/checkInTimeline/hooks/useMon
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
+import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {UptimeChecksGrid} from 'sentry/views/alerts/rules/uptime/uptimeChecksGrid';
+import {useDetectorQuery} from 'sentry/views/detectors/hooks';
 import {useUptimeChecks} from 'sentry/views/insights/uptime/utils/useUptimeChecks';
-import {useUptimeRule} from 'sentry/views/insights/uptime/utils/useUptimeRule';
 import {EventListTable} from 'sentry/views/issueDetails/streamline/eventListTable';
 import {useUptimeIssueDetectorId} from 'sentry/views/issueDetails/streamline/issueUptimeCheckTimeline';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
@@ -31,13 +32,9 @@ export default function GroupUptimeChecks() {
   const canFetchUptimeChecks =
     Boolean(organization.slug) && Boolean(group?.project.slug) && Boolean(detectorId);
 
-  const {data: uptimeRule} = useUptimeRule(
-    {
-      projectSlug: group?.project.slug ?? '',
-      detectorId: detectorId ?? '',
-    },
-    {enabled: canFetchUptimeChecks}
-  );
+  const {data: uptimeDetector} = useDetectorQuery<UptimeDetector>(detectorId ?? '', {
+    enabled: canFetchUptimeChecks,
+  });
 
   const {data: uptimeChecks, getResponseHeader} = useUptimeChecks(
     {
@@ -56,7 +53,7 @@ export default function GroupUptimeChecks() {
     return <LoadingError onRetry={refetchGroup} />;
   }
 
-  if (isGroupPending || uptimeChecks === undefined || uptimeRule === undefined) {
+  if (isGroupPending || uptimeChecks === undefined || uptimeDetector === undefined) {
     return <LoadingIndicator />;
   }
 
@@ -77,7 +74,7 @@ export default function GroupUptimeChecks() {
       }}
     >
       <UptimeChecksGrid
-        traceSampling={uptimeRule.traceSampling}
+        traceSampling={uptimeDetector.dataSources[0].queryObj.traceSampling}
         uptimeChecks={uptimeChecks}
       />
     </EventListTable>


### PR DESCRIPTION
- Uses useDetectorsQuery for the uptime overview listing
- Usees useDetectorQuery for detctor details + uptime issue checks view

Some care had to be made to ensure enable / disable functionality still correctly works, since the detector APIs do not yet correctly handle lifecycle functionality for when an uptime monitor is enabled/disabled.