### PR TITLE
feat(bug-prediction): Allow exception type string format to be flexible

### DIFF
--- a/src/sentry/seer/fetch_issues/by_error_type.py
+++ b/src/sentry/seer/fetch_issues/by_error_type.py
@@ -15,8 +15,11 @@ def _fetch_issues_from_repo_projects(
     project_ids = [project.id for project in repo_projects.projects]
     date_threshold = datetime.now(tz=UTC) - timedelta(days=num_days_ago)
 
-    # Normalize the search term by removing non-alphanumeric characters and converting to uppercase
-    normalized_exception_type = "".join(c.upper() for c in exception_type if c.isalnum())
+    # Normalize the search term by removing non-ASCII alphanumeric characters and converting to uppercase
+    # This matches the SQL regex [^a-zA-Z0-9] which only keeps ASCII alphanumeric characters
+    normalized_exception_type = "".join(
+        c.upper() for c in exception_type if c.isascii() and c.isalnum()
+    )
 
     # Using raw SQL since data is LegacyTextJSONField which can't be filtered with Django ORM
     query_set = (

--- a/src/sentry/seer/fetch_issues/by_error_type.py
+++ b/src/sentry/seer/fetch_issues/by_error_type.py
@@ -14,11 +14,20 @@ def _fetch_issues_from_repo_projects(
 ) -> list[Group]:
     project_ids = [project.id for project in repo_projects.projects]
     date_threshold = datetime.now(tz=UTC) - timedelta(days=num_days_ago)
+
+    # Normalize the search term by removing non-alphanumeric characters and converting to uppercase
+    normalized_exception_type = "".join(c.upper() for c in exception_type if c.isalnum())
+
     # Using raw SQL since data is LegacyTextJSONField which can't be filtered with Django ORM
     query_set = (
-        Group.objects.annotate(metadata_type=RawSQL("(data::json -> 'metadata' ->> 'type')", []))
+        Group.objects.annotate(
+            metadata_type=RawSQL(
+                "UPPER(REGEXP_REPLACE(data::json -> 'metadata' ->> 'type', '[^a-zA-Z0-9]', '', 'g'))",
+                [],
+            )
+        )
         .filter(
-            metadata_type=exception_type,
+            metadata_type=normalized_exception_type,
             project_id__in=project_ids,
             last_seen__gte=date_threshold,
         )


### PR DESCRIPTION
Make the input to query to get issues by exception type to be case insensitive and ignore non alphanumeric characters.

For example when querying "ReactErrorBoundaryError" previously would not match the issues with "React Error Boundary Error" as the type in the DB
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
