### PR TITLE
feat(insights): save enviornment and date selection in storage namespace

### DIFF
--- a/static/app/actionCreators/pageFilters.spec.tsx
+++ b/static/app/actionCreators/pageFilters.spec.tsx
@@ -433,10 +433,77 @@ describe('PageFilters ActionCreators', () => {
       pageFilterStorageMock.mockRestore();
     });
 
-    it('retrieves filters from a separate key when storageNamespace is provided', () => {
-      const starfishKey = `global-selection:starfish:${organization.slug}`;
+    it('uses global datetime with storageNamespace', () => {
+      const storageNamespace = 'insights:frontend';
+      const insightsKey = `global-selection:${storageNamespace}:${organization.slug}`;
+      const globalKey = `global-selection:${organization.slug}`;
       localStorage.setItem(
-        starfishKey,
+        insightsKey,
+        JSON.stringify({
+          environments: [],
+          projects: [],
+          pinnedFilters: ['datetime'],
+          start: null,
+          end: null,
+          period: '14d',
+          utc: null,
+        })
+      );
+
+      localStorage.setItem(
+        globalKey,
+        JSON.stringify({
+          environments: [],
+          projects: [],
+          pinnedFilters: ['datetime'],
+          start: null,
+          end: null,
+          period: '30d',
+          utc: null,
+        })
+      );
+
+      initializeUrlState({
+        organization,
+        queryParams: {},
+        router,
+        memberProjects: projects,
+        nonMemberProjects: [],
+        shouldEnforceSingleProject: false,
+        storageNamespace,
+      });
+      expect(localStorage.getItem).toHaveBeenCalledWith(insightsKey);
+      expect(localStorage.getItem).toHaveBeenCalledWith(globalKey);
+
+      expect(PageFiltersStore.onInitializeUrlState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          environments: [],
+          projects: [],
+          datetime: {
+            period: '30d',
+            start: null,
+            end: null,
+            utc: null,
+          },
+        }),
+        new Set(['datetime']),
+        true
+      );
+      expect(router.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            environment: [],
+            project: [],
+            statsPeriod: '30d',
+          },
+        })
+      );
+    });
+
+    it('retrieves filters from a separate key when storageNamespace is provided', () => {
+      const insightsKey = `global-selection:insights:${organization.slug}`;
+      localStorage.setItem(
+        insightsKey,
         JSON.stringify({
           environments: [],
           projects: [1],
@@ -451,10 +518,10 @@ describe('PageFilters ActionCreators', () => {
         memberProjects: projects,
         nonMemberProjects: [],
         shouldEnforceSingleProject: false,
-        storageNamespace: 'starfish',
+        storageNamespace: 'insights',
       });
 
-      expect(localStorage.getItem).toHaveBeenCalledWith(starfishKey);
+      expect(localStorage.getItem).toHaveBeenCalledWith(insightsKey);
       expect(PageFiltersStore.onInitializeUrlState).toHaveBeenCalledWith(
         expect.objectContaining({
           environments: [],

--- a/static/app/actionCreators/pageFilters.spec.tsx
+++ b/static/app/actionCreators/pageFilters.spec.tsx
@@ -433,6 +433,61 @@ describe('PageFilters ActionCreators', () => {
       pageFilterStorageMock.mockRestore();
     });
 
+    it('fallbacks to global state with storageNamespace empty', () => {
+      const storageNamespace = 'insights:frontend';
+      const insightsKey = `global-selection:${storageNamespace}:${organization.slug}`;
+      const globalKey = `global-selection:${organization.slug}`;
+
+      localStorage.setItem(
+        globalKey,
+        JSON.stringify({
+          environments: [],
+          projects: [1],
+          pinnedFilters: ['datetime', 'projects', 'environments'],
+          start: null,
+          end: null,
+          period: '30d',
+          utc: null,
+        })
+      );
+
+      initializeUrlState({
+        organization,
+        queryParams: {},
+        router,
+        memberProjects: projects,
+        nonMemberProjects: [],
+        shouldEnforceSingleProject: false,
+        storageNamespace,
+      });
+      expect(localStorage.getItem).toHaveBeenCalledWith(insightsKey);
+      expect(localStorage.getItem).toHaveBeenCalledWith(globalKey);
+
+      expect(PageFiltersStore.onInitializeUrlState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          environments: [],
+          projects: [1],
+          datetime: {
+            period: '30d',
+            start: null,
+            end: null,
+            utc: null,
+          },
+        }),
+        new Set(['datetime', 'projects', 'environments']),
+        true
+      );
+      expect(router.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            environment: [],
+            project: ['1'],
+            statsPeriod: '30d',
+          },
+        })
+      );
+    });
+
     it('uses global datetime with storageNamespace', () => {
       const storageNamespace = 'insights:frontend';
       const insightsKey = `global-selection:${storageNamespace}:${organization.slug}`;

--- a/static/app/components/organizations/datePageFilter.tsx
+++ b/static/app/components/organizations/datePageFilter.tsx
@@ -27,7 +27,6 @@ export function DatePageFilter({
   menuWidth,
   triggerProps = {},
   resetParamsOnChange,
-  storageNamespace,
   ...selectProps
 }: DatePageFilterProps) {
   const router = useRouter();
@@ -53,7 +52,6 @@ export function DatePageFilter({
         updateDateTime(newTimePeriod, router, {
           save: true,
           resetParams: resetParamsOnChange,
-          storageNamespace,
         });
       }}
       menuTitle={menuTitle ?? t('Filter Time Range')}

--- a/static/app/components/organizations/environmentPageFilter/index.tsx
+++ b/static/app/components/organizations/environmentPageFilter/index.tsx
@@ -21,7 +21,7 @@ import {
   type EnvironmentPageFilterTriggerProps,
 } from './trigger';
 
-interface EnvironmentPageFilterProps
+export interface EnvironmentPageFilterProps
   extends Partial<
     Omit<
       HybridFilterProps<string>,
@@ -64,6 +64,7 @@ export function EnvironmentPageFilter({
   resetParamsOnChange,
   footerMessage,
   triggerProps = {},
+  storageNamespace,
   ...selectProps
 }: EnvironmentPageFilterProps) {
   const router = useRouter();
@@ -136,9 +137,17 @@ export function EnvironmentPageFilter({
       updateEnvironments(newValue, router, {
         save: true,
         resetParams: resetParamsOnChange,
+        storageNamespace,
       });
     },
-    [envPageFilterValue, resetParamsOnChange, router, organization, onChange]
+    [
+      envPageFilterValue,
+      resetParamsOnChange,
+      router,
+      organization,
+      onChange,
+      storageNamespace,
+    ]
   );
 
   const onToggle = useCallback(

--- a/static/app/components/organizations/hybridFilter.tsx
+++ b/static/app/components/organizations/hybridFilter.tsx
@@ -68,6 +68,7 @@ export interface HybridFilterProps<Value extends SelectKey>
    */
   onStagedValueChange?: (selected: Value[]) => void;
   onToggle?: (selected: Value[]) => void;
+  storageNamespace?: string;
 }
 
 /**

--- a/static/app/components/organizations/pageFilters/persistence.tsx
+++ b/static/app/components/organizations/pageFilters/persistence.tsx
@@ -105,17 +105,21 @@ export function getPageFilterStorage(orgSlug: string, storageNamespace = '') {
   const localStorageKey = makeLocalStorageKey(
     storageNamespace.length > 0 ? `${storageNamespace}:${orgSlug}` : orgSlug
   );
+  const globalSelectionKey = makeLocalStorageKey(orgSlug);
 
   const value = localStorage.getItem(localStorageKey);
+  const globalSelectionValue = localStorage.getItem(globalSelectionKey);
 
-  if (!value) {
+  if (!value || !globalSelectionValue) {
     return null;
   }
 
   let decoded: StoredObject;
+  let decodedGlobalSelection: StoredObject;
 
   try {
     decoded = JSON.parse(value);
+    decodedGlobalSelection = JSON.parse(globalSelectionValue);
   } catch (err) {
     // use default if invalid
     Sentry.captureException(err);
@@ -124,16 +128,22 @@ export function getPageFilterStorage(orgSlug: string, storageNamespace = '') {
     return null;
   }
 
-  const {projects, environments, start, end, period, utc, pinnedFilters} = decoded;
+  const {projects, environments, pinnedFilters} = decoded;
+  const {
+    start: globalStart,
+    end: globalEnd,
+    period: globalPeriod,
+    utc: globalUtc,
+  } = decodedGlobalSelection;
 
   const state = getStateFromQuery(
     {
       project: projects.map(String),
       environment: environments,
-      start,
-      end,
-      period,
-      utc,
+      start: globalStart,
+      end: globalEnd,
+      period: globalPeriod,
+      utc: globalUtc,
     },
     {allowAbsoluteDatetime: true}
   );

--- a/static/app/components/organizations/pageFilters/persistence.tsx
+++ b/static/app/components/organizations/pageFilters/persistence.tsx
@@ -105,46 +105,23 @@ export function getPageFilterStorage(orgSlug: string, storageNamespace = '') {
   const globalSelectionValue = decodePageFilter(orgSlug);
   const storageNamespaceValue = decodePageFilter(`${storageNamespace}:${orgSlug}`);
 
-  const hasStorageNamespace = storageNamespaceValue && storageNamespace.length > 0;
+  const {projects, environments, pinnedFilters} = {
+    ...globalSelectionValue,
+    ...storageNamespaceValue,
+  };
+  const state = getStateFromQuery(
+    {
+      project: projects?.map(String),
+      environment: environments,
+      start: globalSelectionValue?.start,
+      end: globalSelectionValue?.end,
+      period: globalSelectionValue?.period,
+      utc: globalSelectionValue?.utc,
+    },
+    {allowAbsoluteDatetime: true}
+  );
 
-  if (!globalSelectionValue && hasStorageNamespace) {
-    const state = getStateFromQuery(
-      {
-        project: storageNamespaceValue.projects.map(String),
-        environment: storageNamespaceValue.environments,
-      },
-      {allowAbsoluteDatetime: true}
-    );
-    return {state, pinnedFilters: new Set(storageNamespaceValue.pinnedFilters)};
-  }
-  if (globalSelectionValue) {
-    // storageNamespace only applies to project/environment selection
-    const projects = hasStorageNamespace
-      ? storageNamespaceValue.projects
-      : globalSelectionValue.projects;
-    const environments = hasStorageNamespace
-      ? storageNamespaceValue.environments
-      : globalSelectionValue.environments;
-    const pinnedFilters = hasStorageNamespace
-      ? storageNamespaceValue.pinnedFilters
-      : globalSelectionValue.pinnedFilters;
-
-    const {start, end, period, utc} = globalSelectionValue;
-
-    const state = getStateFromQuery(
-      {
-        project: projects.map(String),
-        environment: environments,
-        start,
-        end,
-        period,
-        utc,
-      },
-      {allowAbsoluteDatetime: true}
-    );
-    return {state, pinnedFilters: new Set(pinnedFilters)};
-  }
-  return null;
+  return {state, pinnedFilters: new Set(pinnedFilters)};
 }
 
 function decodePageFilter(key: string): StoredObject | null {

--- a/static/app/components/timeRangeSelector/index.tsx
+++ b/static/app/components/timeRangeSelector/index.tsx
@@ -133,10 +133,6 @@ export interface TimeRangeSelectorProps
    */
   start?: DateString;
   /**
-   * Optional prefix for the storage key, for areas of the app that need separate pagefilters (i.e Starfish)
-   */
-  storageNamespace?: string;
-  /**
    * Default initial value for using UTC
    */
   utc?: boolean | null;

--- a/static/app/views/insights/agents/views/overview.tsx
+++ b/static/app/views/insights/agents/views/overview.tsx
@@ -6,7 +6,6 @@ import {SegmentedControl} from 'sentry/components/core/segmentedControl';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {
   EAPSpanSearchQueryBuilder,
@@ -44,6 +43,7 @@ import {AIInsightsFeature} from 'sentry/views/insights/agents/utils/features';
 import {Referrer} from 'sentry/views/insights/agents/utils/referrers';
 import {Onboarding} from 'sentry/views/insights/agents/views/onboarding';
 import {TwoColumnWidgetGrid, WidgetGrid} from 'sentry/views/insights/agents/views/styles';
+import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/components/enviornmentSelector';
 import {ModuleFeature} from 'sentry/views/insights/common/components/moduleFeature';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
@@ -174,7 +174,7 @@ function AgentsOverviewPage() {
                 <ToolRibbon>
                   <PageFilterBar condensed>
                     <InsightsProjectSelector />
-                    <EnvironmentPageFilter />
+                    <InsightsEnvironmentSelector />
                     <DatePageFilter {...datePageFilterProps} />
                   </PageFilterBar>
                   {!showOnboarding && (

--- a/static/app/views/insights/common/components/enviornmentSelector.tsx
+++ b/static/app/views/insights/common/components/enviornmentSelector.tsx
@@ -1,0 +1,15 @@
+import {
+  EnvironmentPageFilter,
+  type EnvironmentPageFilterProps,
+} from 'sentry/components/organizations/environmentPageFilter';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+
+type Props = Omit<EnvironmentPageFilterProps, 'storageNamespace'>;
+
+export function InsightsEnvironmentSelector(props: Props) {
+  const {view} = useDomainViewFilters();
+
+  const storageNamespace = view;
+
+  return <EnvironmentPageFilter {...props} storageNamespace={storageNamespace} />;
+}

--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -1,11 +1,11 @@
 import {Fragment, useEffect, useState} from 'react';
 
 import {Tooltip} from 'sentry/components/core/tooltip';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {SECOND} from 'sentry/utils/formatters';
 import useProjects from 'sentry/utils/useProjects';
+import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/components/enviornmentSelector';
 import {InsightsModuleDatePageFilter} from 'sentry/views/insights/common/components/insightsModuleDatePageFilter';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {useHasFirstSpan} from 'sentry/views/insights/common/queries/useHasFirstSpan';
@@ -77,7 +77,7 @@ export function ModulePageFilterBar({
       <div>
         <PageFilterBar condensed>
           {!disableProjectFilter && <InsightsProjectSelector />}
-          <EnvironmentPageFilter />
+          <InsightsEnvironmentSelector />
           <InsightsModuleDatePageFilter />
         </PageFilterBar>
       </div>

--- a/static/app/views/insights/mcp/views/overview.tsx
+++ b/static/app/views/insights/mcp/views/overview.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {SegmentedControl} from 'sentry/components/core/segmentedControl';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {
   EAPSpanSearchQueryBuilder,
@@ -28,6 +27,7 @@ import {TraceItemDataset} from 'sentry/views/explore/types';
 import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 import {useLocationSyncedState} from 'sentry/views/insights/agents/hooks/useLocationSyncedState';
 import {McpInsightsFeature} from 'sentry/views/insights/agents/utils/features';
+import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/components/enviornmentSelector';
 import {ModuleFeature} from 'sentry/views/insights/common/components/moduleFeature';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
@@ -215,7 +215,7 @@ function McpOverviewPage() {
                 <ToolRibbon>
                   <PageFilterBar condensed>
                     <InsightsProjectSelector />
-                    <EnvironmentPageFilter />
+                    <InsightsEnvironmentSelector />
                     <DatePageFilter {...datePageFilterProps} />
                   </PageFilterBar>
                   {!showOnboarding && (

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -6,7 +6,6 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {TabbedCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {t} from 'sentry/locale';
@@ -15,6 +14,7 @@ import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pa
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/components/enviornmentSelector';
 import {ModuleFeature} from 'sentry/views/insights/common/components/moduleFeature';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
@@ -273,7 +273,7 @@ function ScreensLandingPage() {
                 <Container>
                   <PageFilterBar condensed>
                     <InsightsProjectSelector onChange={handleProjectChange} />
-                    <EnvironmentPageFilter />
+                    <InsightsEnvironmentSelector />
                     <DatePageFilter />
                   </PageFilterBar>
                 </Container>

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -5,7 +5,6 @@ import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -19,6 +18,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/components/enviornmentSelector';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
@@ -202,7 +202,7 @@ function EAPBackendOverviewPage() {
               <ToolRibbon>
                 <PageFilterBar condensed>
                   <InsightsProjectSelector />
-                  <EnvironmentPageFilter />
+                  <InsightsEnvironmentSelector />
                   <DatePageFilter />
                 </PageFilterBar>
                 {!showOnboarding && (

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -7,7 +7,6 @@ import {CompactSelect} from 'sentry/components/core/compactSelect';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -21,6 +20,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/components/enviornmentSelector';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {OverviewIssuesWidget} from 'sentry/views/insights/common/components/overviewIssuesWidget';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
@@ -148,7 +148,7 @@ function FrontendOverviewPage() {
               <ToolRibbon>
                 <PageFilterBar condensed>
                   <InsightsProjectSelector />
-                  <EnvironmentPageFilter />
+                  <InsightsEnvironmentSelector />
                   <DatePageFilter />
                 </PageFilterBar>
                 {!showOnboarding && (

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -4,7 +4,6 @@ import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
@@ -22,6 +21,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/components/enviornmentSelector';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
@@ -230,7 +230,7 @@ function EAPMobileOverviewPage() {
               <ToolRibbon>
                 <PageFilterBar condensed>
                   <InsightsProjectSelector />
-                  <EnvironmentPageFilter />
+                  <InsightsEnvironmentSelector />
                   <DatePageFilter />
                 </PageFilterBar>
                 {!showOnboarding && (

--- a/static/app/views/insights/pages/platform/shared/layout.tsx
+++ b/static/app/views/insights/pages/platform/shared/layout.tsx
@@ -4,12 +4,12 @@ import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/components/enviornmentSelector';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
@@ -70,7 +70,7 @@ export function PlatformLandingPageLayout({
               <ToolRibbon>
                 <PageFilterBar condensed>
                   <InsightsProjectSelector />
-                  <EnvironmentPageFilter />
+                  <InsightsEnvironmentSelector />
                   <DatePageFilter />
                 </PageFilterBar>
                 {!showOnboarding && (


### PR DESCRIPTION
There's a bug when you refresh the insights pages (for example /insights/frontend/) and remove the query params so that we rely on the local storage state, only the project selection persists, the date and environment reset to the default (all environments + 14 days). This PR fixes this issue
1. Add `storageNamespace` logic to the environment selector, that way we store the selected environment per domain (frontend/backend/mobile), just as we do with the project.
2. Introduce and use `InsightsEnviornmentSelector`, this is a wrapper around the regular enviornment selector, but automatically adds the storageNamespace.
3. Update `storageNamespace` to not apply to the the date selection, we always use the global date selection from local storage. And the datepicker updates the global date selection as well so that it persists between pages.