### PR TITLE
fix(dashboards-tables): Pass query condition in explore URL

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
@@ -3,7 +3,10 @@ import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
 import {DisplayType} from 'sentry/views/dashboards/types';
-import {getWidgetExploreUrl} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
+import {
+  getWidgetExploreUrl,
+  getWidgetTableRowExploreUrlFunction,
+} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 
 describe('getWidgetExploreUrl', () => {
   const organization = OrganizationFixture();
@@ -333,6 +336,52 @@ describe('getWidgetExploreUrl', () => {
         ['statsPeriod', '14d'],
         ['visualize', JSON.stringify({chartType: 1, yAxes: ['avg(span.duration)']})],
         ['referrer', 'test-referrer'],
+      ],
+    });
+  });
+});
+
+describe('getWidgetTableRowExploreUrlFunction', () => {
+  const organization = OrganizationFixture();
+  const selection = PageFiltersFixture();
+
+  it('uses the filter conditions from the widget to generate the trace URL', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      queries: [
+        {
+          fields: ['browser.name'],
+          aggregates: ['avg(span.duration)'],
+          columns: ['span.description'],
+          conditions: 'span.description:test',
+          orderby: '-avg(span.duration)',
+          name: '',
+        },
+      ],
+    });
+
+    const urlGenerator = getWidgetTableRowExploreUrlFunction(
+      selection,
+      widget,
+      organization
+    );
+    const url = urlGenerator({
+      'browser.name': 'Chrome',
+    });
+
+    expectUrl(url).toMatch({
+      path: '/organizations/org-slug/explore/traces/',
+      params: [
+        ['field', 'browser.name'],
+        ['groupBy', 'browser.name'],
+        ['interval', '30m'],
+        ['mode', 'samples'],
+        // span.description:test is carried over from the widget query conditions
+        ['query', 'span.description:test browser.name:Chrome'],
+        ['referrer', 'api.dashboards.tablewidget.row'],
+        ['sort', '-span.duration'],
+        ['statsPeriod', '14d'],
+        ['visualize', JSON.stringify({chartType: 1, yAxes: ['avg(span.duration)']})],
       ],
     });
   });

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -462,7 +462,7 @@ export function getWidgetTableRowExploreUrlFunction(
       );
     }
 
-    const query = new MutableSearch('');
+    const query = new MutableSearch(widget.queries[0]?.conditions ?? '');
     fields.map(field => {
       const value = dataRow[field];
       if (!defined(value)) {


### PR DESCRIPTION
Filter conditions for the table widget were being ignored when clicking "View span samples" from a cell action. This sets the conditions as the base starting point for mutable search where the other fields will be added on top of these.