### PR TITLE
feat: add the beta badge to prevent related items

### DIFF
--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -1,6 +1,8 @@
 import {Fragment, useRef} from 'react';
+import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import Hook from 'sentry/components/hook';
 import {
@@ -142,15 +144,18 @@ export function PrimaryNavigationItems() {
         </Feature>
 
         <Feature features={['prevent-ai']}>
-          <SidebarLink
-            to={`/${prefix}/${PREVENT_BASE_URL}/${PREVENT_AI_BASE_URL}/new/`}
-            activeTo={`/${prefix}/${PREVENT_BASE_URL}/`}
-            analyticsKey="prevent"
-            group={PrimaryNavGroup.PREVENT}
-            {...makeNavItemProps(PrimaryNavGroup.PREVENT)}
-          >
-            <IconPrevent />
-          </SidebarLink>
+          <SidebarLinkWithBadge>
+            <SidebarLink
+              to={`/${prefix}/${PREVENT_BASE_URL}/${PREVENT_AI_BASE_URL}/new/`}
+              activeTo={`/${prefix}/${PREVENT_BASE_URL}/`}
+              analyticsKey="prevent"
+              group={PrimaryNavGroup.PREVENT}
+              {...makeNavItemProps(PrimaryNavGroup.PREVENT)}
+            >
+              <IconPrevent />
+            </SidebarLink>
+            <BetaBadge type="beta" />
+          </SidebarLinkWithBadge>
         </Feature>
 
         <SeparatorItem />
@@ -200,3 +205,15 @@ export function PrimaryNavigationItems() {
     </Fragment>
   );
 }
+
+const SidebarLinkWithBadge = styled('div')`
+  position: relative;
+  height: 100%;
+`;
+
+const BetaBadge = styled(FeatureBadge)`
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: 0;
+`;

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import {Container} from 'sentry/components/core/layout';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import Hook from 'sentry/components/hook';
 import {
@@ -144,7 +145,7 @@ export function PrimaryNavigationItems() {
         </Feature>
 
         <Feature features={['prevent-ai']}>
-          <SidebarLinkWithBadge>
+          <Container position="relative" height="100%">
             <SidebarLink
               to={`/${prefix}/${PREVENT_BASE_URL}/${PREVENT_AI_BASE_URL}/new/`}
               activeTo={`/${prefix}/${PREVENT_BASE_URL}/`}
@@ -155,7 +156,7 @@ export function PrimaryNavigationItems() {
               <IconPrevent />
             </SidebarLink>
             <BetaBadge type="beta" />
-          </SidebarLinkWithBadge>
+          </Container>
         </Feature>
 
         <SeparatorItem />
@@ -205,11 +206,6 @@ export function PrimaryNavigationItems() {
     </Fragment>
   );
 }
-
-const SidebarLinkWithBadge = styled('div')`
-  position: relative;
-  height: 100%;
-`;
 
 const BetaBadge = styled(FeatureBadge)`
   position: absolute;

--- a/static/app/views/prevent/tests/testsWrapper.tsx
+++ b/static/app/views/prevent/tests/testsWrapper.tsx
@@ -18,7 +18,7 @@ export default function TestAnalyticsPageWrapper() {
           <HeaderContentBar>
             <Layout.Title>
               {TESTS_PAGE_TITLE}
-              <FeatureBadge type="new" />
+              <FeatureBadge type="beta" />
             </Layout.Title>
           </HeaderContentBar>
         </Layout.HeaderContent>


### PR DESCRIPTION
This PR adds the beta badge to prevent and tests page.

Closes: https://linear.app/getsentry/issue/CCMRG-1650/add-beta-type-feature-badge-on-the-primary-side-nav

<img width="1488" height="816" alt="Screenshot 2025-09-16 at 1 27 42 PM" src="https://github.com/user-attachments/assets/0aefd33f-1de2-4525-ab27-cdf5bbf9c380" />
