### PR TITLE
feat(preprod): include requested features in Kafka message

### DIFF
--- a/src/sentry/preprod/producer.py
+++ b/src/sentry/preprod/producer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from enum import Enum
 
 from arroyo import Topic as ArroyoTopic
 from arroyo.backends.kafka import KafkaPayload
@@ -14,6 +14,11 @@ from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.kafka_config import get_topic_definition
 
 logger = logging.getLogger(__name__)
+
+
+class PreprodFeature(Enum):
+    SIZE_ANALYSIS = "size_analysis"
+    BUILD_DISTRIBUTION = "build_distribution"
 
 
 def _get_preprod_producer():
@@ -33,13 +38,18 @@ def produce_preprod_artifact_to_kafka(
     project_id: int,
     organization_id: int,
     artifact_id: int,
-    **kwargs: Any,
+    requested_features: list[PreprodFeature] | None = None,
 ) -> None:
+    if requested_features is None:
+        requested_features = [
+            PreprodFeature.SIZE_ANALYSIS,
+            PreprodFeature.BUILD_DISTRIBUTION,
+        ]
     payload_data = {
         "artifact_id": str(artifact_id),
         "project_id": str(project_id),
         "organization_id": str(organization_id),
-        **kwargs,
+        "requested_features": [feature.value for feature in requested_features],
     }
 
     partition_key = f"{project_id}-{artifact_id}".encode()

--- a/src/sentry/preprod/producer.py
+++ b/src/sentry/preprod/producer.py
@@ -41,6 +41,7 @@ def produce_preprod_artifact_to_kafka(
     requested_features: list[PreprodFeature] | None = None,
 ) -> None:
     if requested_features is None:
+        # TODO(preprod): wire up to quota system and remove this default
         requested_features = [
             PreprodFeature.SIZE_ANALYSIS,
             PreprodFeature.BUILD_DISTRIBUTION,

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -133,7 +133,6 @@ def assemble_preprod_artifact(
             project_id=project_id,
             organization_id=org_id,
             artifact_id=artifact_id,
-            **kwargs,
         )
     except Exception as e:
         user_friendly_error_message = "Failed to dispatch preprod artifact event for analysis"


### PR DESCRIPTION
- removes the `kwargs` passing since that is unsafe to do, what if we passed a non-serializable type to the method?
- adds a new field `requested_features` so we can tell launchpad what to run

Resolves EME-84