### PR TITLE
fix(aci): Fix detector: filter in issue search

### DIFF
--- a/src/sentry/issues/issue_search.py
+++ b/src/sentry/issues/issue_search.py
@@ -258,6 +258,16 @@ def convert_seer_actionability_value(
     return results
 
 
+def convert_detector_value(
+    value: Iterable[str],
+    projects: Sequence[Project],
+    user: User,
+    environments: Sequence[Environment] | None,
+) -> list[str]:
+    """Convert detector ID(s) to a list of strings for consistent handling"""
+    return list(value)
+
+
 value_converters: Mapping[str, ValueConverter] = {
     "assigned_or_suggested": convert_actor_or_none_value,
     "assigned_to": convert_actor_or_none_value,
@@ -273,6 +283,7 @@ value_converters: Mapping[str, ValueConverter] = {
     "device.class": convert_device_class_value,
     "substatus": convert_substatus_value,
     "issue.seer_actionability": convert_seer_actionability_value,
+    "detector": convert_detector_value,
 }
 
 

--- a/tests/sentry/issues/test_issue_search.py
+++ b/tests/sentry/issues/test_issue_search.py
@@ -347,6 +347,13 @@ class ConvertSeerActionabilityValueTest(TestCase):
             convert_query_values(filters, [self.project], self.user, None)
 
 
+class ConvertDetectorValueTest(TestCase):
+    def test_valid(self) -> None:
+        filters = [SearchFilter(SearchKey("detector"), "=", SearchValue("412345"))]
+        result = convert_query_values(filters, [self.project], self.user, None)
+        assert result[0].value.raw_value == ["412345"]
+
+
 class ConvertActorOrNoneValueTest(TestCase):
     def test_user(self) -> None:
         assert convert_actor_or_none_value(


### PR DESCRIPTION
Search filters can have list or scalar values.
The previous tests for detector filtering used list values, and the filter code did also, but when parsed from a 'detector:$ID' query, it'd be a str, and in Python a str is also a Sequence[str], so the `in_()` expression in the ORM code quietly worked.

This adds a list converter for 'detector', along with ample testing and an assertion to ensure we don't step on this rake again.


Fixes ACI-464.
