### PR TITLE
fix(aci): Move schedule_delayed_workflows into workflow_engine

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1209,7 +1209,7 @@ CELERYBEAT_SCHEDULE_REGION = {
         "options": {"expires": 10, "queue": "buffers.process_pending_batch"},
     },
     "flush-delayed-workflows": {
-        "task": "sentry.tasks.process_buffer.schedule_delayed_workflows",
+        "task": "sentry.workflow_engine.tasks.workflows.schedule_delayed_workflows",
         # Run every 1 minute
         "schedule": crontab(minute="*/1"),
         "options": {"expires": 10, "queue": "workflow_engine.process_workflows"},
@@ -1641,7 +1641,7 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "schedule": task_crontab("*/1", "*", "*", "*", "*"),
     },
     "flush-delayed-workflows": {
-        "task": "workflow_engine:sentry.tasks.process_buffer.schedule_delayed_workflows",
+        "task": "workflow_engine:sentry.workflow_engine.tasks.workflows.schedule_delayed_workflows",
         "schedule": task_crontab("*/1", "*", "*", "*", "*"),
     },
     "sync-options": {

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -4,7 +4,6 @@ from typing import Any
 import sentry_sdk
 from django.apps import apps
 
-from sentry import options
 from sentry.db.models.base import Model
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker import namespaces
@@ -74,26 +73,10 @@ def process_pending_batch() -> None:
     ),
 )
 def schedule_delayed_workflows() -> None:
-    """
-    Schedule delayed workflow buffers in a batch.
-    """
-    from sentry.rules.processing.buffer_processing import process_buffer_for_type
-    from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflow
-
-    lock = get_process_lock("schedule_delayed_workflows")
-
-    try:
-        with lock.acquire():
-            # Only process delayed_workflow type
-            use_new_scheduling = options.get("workflow_engine.use_new_scheduling_task")
-            if not use_new_scheduling:
-                logger.info(
-                    "Configured to use process_pending_batch for delayed_workflow; exiting."
-                )
-                return
-            process_buffer_for_type("delayed_workflow", DelayedWorkflow)
-    except UnableToAcquireLock as error:
-        logger.warning("schedule_delayed_workflows.fail", extra={"error": error})
+    # NOTE: This task was moved to the workflow_engine.tasks.workflows module, and this
+    # definition only remains to avoid noise as we transition.
+    # This should be safe to delete shortly after it is merged.
+    pass
 
 
 @instrumented_task(

--- a/tests/sentry/tasks/test_process_buffer.py
+++ b/tests/sentry/tasks/test_process_buffer.py
@@ -8,7 +8,6 @@ from sentry.tasks.process_buffer import (
     process_incr,
     process_pending,
     process_pending_batch,
-    schedule_delayed_workflows,
 )
 from sentry.testutils.cases import TestCase
 
@@ -51,71 +50,3 @@ class ProcessPendingBatchTest(TestCase):
         with self.assertNoLogs("sentry.tasks.process_buffer", level="WARNING"):
             process_pending_batch()
             assert len(mock_process_buffer.mock_calls) == 1
-
-
-class ScheduleDelayedWorkflowsTest(TestCase):
-    @mock.patch("sentry.options.get")
-    @mock.patch("sentry.rules.processing.buffer_processing.process_buffer_for_type")
-    @mock.patch("sentry.workflow_engine.tasks.delayed_workflows.DelayedWorkflow")
-    def test_schedule_delayed_workflows_locked_out(
-        self,
-        mock_delayed_workflow: mock.MagicMock,
-        mock_process_buffer_for_type: mock.MagicMock,
-        mock_options_get: mock.MagicMock,
-    ) -> None:
-        # Mock the config option to return True (using new scheduling task)
-        mock_options_get.return_value = True
-
-        with self.assertLogs("sentry.tasks.process_buffer", level="WARNING") as logger:
-            lock = get_process_lock("schedule_delayed_workflows")
-            with lock.acquire():
-                schedule_delayed_workflows()
-                self.assertEqual(len(logger.output), 1)
-                assert len(mock_process_buffer_for_type.mock_calls) == 0
-
-        with self.assertNoLogs("sentry.tasks.process_buffer", level="WARNING"):
-            schedule_delayed_workflows()
-            assert len(mock_process_buffer_for_type.mock_calls) == 1
-            mock_process_buffer_for_type.assert_called_with(
-                "delayed_workflow", mock_delayed_workflow
-            )
-
-    @mock.patch("sentry.options.get")
-    @mock.patch("sentry.rules.processing.buffer_processing.process_buffer_for_type")
-    @mock.patch("sentry.workflow_engine.tasks.delayed_workflows.DelayedWorkflow")
-    def test_schedule_delayed_workflows_config_option_true(
-        self,
-        mock_delayed_workflow: mock.MagicMock,
-        mock_process_buffer_for_type: mock.MagicMock,
-        mock_options_get: mock.MagicMock,
-    ) -> None:
-        # Mock the config option to return False (not using new scheduling task)
-        mock_options_get.return_value = False
-
-        with self.assertLogs("sentry.tasks.process_buffer", level="INFO") as logger:
-            schedule_delayed_workflows()
-            # Should log and exit without calling process_buffer_for_type
-            assert len(mock_process_buffer_for_type.mock_calls) == 0
-            assert any(
-                "Configured to use process_pending_batch" in output for output in logger.output
-            )
-
-    @mock.patch("sentry.options.get")
-    @mock.patch("sentry.rules.processing.buffer_processing.process_buffer_for_type")
-    @mock.patch("sentry.workflow_engine.tasks.delayed_workflows.DelayedWorkflow")
-    def test_schedule_delayed_workflows_normal_operation(
-        self,
-        mock_delayed_workflow: mock.MagicMock,
-        mock_process_buffer_for_type: mock.MagicMock,
-        mock_options_get: mock.MagicMock,
-    ) -> None:
-        # Mock the config option to return True (using new scheduling task)
-        mock_options_get.return_value = True
-
-        schedule_delayed_workflows()
-
-        # Should only process delayed_workflow
-        assert len(mock_process_buffer_for_type.mock_calls) == 1
-        mock_process_buffer_for_type.assert_called_once_with(
-            "delayed_workflow", mock_delayed_workflow
-        )

--- a/tests/sentry/workflow_engine/tasks/test_workflows.py
+++ b/tests/sentry/workflow_engine/tasks/test_workflows.py
@@ -1,0 +1,77 @@
+from unittest import mock
+
+from sentry.locks import locks
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.tasks.workflows import schedule_delayed_workflows
+
+
+class ScheduleDelayedWorkflowsTest(TestCase):
+    @mock.patch("sentry.options.get")
+    @mock.patch("sentry.rules.processing.buffer_processing.process_buffer_for_type")
+    @mock.patch("sentry.workflow_engine.tasks.delayed_workflows.DelayedWorkflow")
+    def test_schedule_delayed_workflows_locked_out(
+        self,
+        mock_delayed_workflow: mock.MagicMock,
+        mock_process_buffer_for_type: mock.MagicMock,
+        mock_options_get: mock.MagicMock,
+    ) -> None:
+        # Mock the config option to return True (using new scheduling task)
+        mock_options_get.return_value = True
+
+        with self.assertLogs("sentry.workflow_engine.tasks.workflows", level="WARNING") as logger:
+            lock = locks.get(
+                "workflow_engine:schedule_delayed_workflows",
+                duration=60,
+                name="schedule_delayed_workflows",
+            )
+            with lock.acquire():
+                schedule_delayed_workflows()
+                self.assertEqual(len(logger.output), 1)
+                assert len(mock_process_buffer_for_type.mock_calls) == 0
+
+        with self.assertNoLogs("sentry.workflow_engine.tasks.workflows", level="WARNING"):
+            schedule_delayed_workflows()
+            assert len(mock_process_buffer_for_type.mock_calls) == 1
+            mock_process_buffer_for_type.assert_called_with(
+                "delayed_workflow", mock_delayed_workflow
+            )
+
+    @mock.patch("sentry.options.get")
+    @mock.patch("sentry.rules.processing.buffer_processing.process_buffer_for_type")
+    @mock.patch("sentry.workflow_engine.tasks.delayed_workflows.DelayedWorkflow")
+    def test_schedule_delayed_workflows_config_option_false(
+        self,
+        mock_delayed_workflow: mock.MagicMock,
+        mock_process_buffer_for_type: mock.MagicMock,
+        mock_options_get: mock.MagicMock,
+    ) -> None:
+        # Mock the config option to return False (not using new scheduling task)
+        mock_options_get.return_value = False
+
+        with self.assertLogs("sentry.workflow_engine.tasks.workflows", level="INFO") as logger:
+            schedule_delayed_workflows()
+            # Should log and exit without calling process_buffer_for_type
+            assert len(mock_process_buffer_for_type.mock_calls) == 0
+            assert any(
+                "Configured to use process_pending_batch" in output for output in logger.output
+            )
+
+    @mock.patch("sentry.options.get")
+    @mock.patch("sentry.rules.processing.buffer_processing.process_buffer_for_type")
+    @mock.patch("sentry.workflow_engine.tasks.delayed_workflows.DelayedWorkflow")
+    def test_schedule_delayed_workflows_normal_operation(
+        self,
+        mock_delayed_workflow: mock.MagicMock,
+        mock_process_buffer_for_type: mock.MagicMock,
+        mock_options_get: mock.MagicMock,
+    ) -> None:
+        # Mock the config option to return True (using new scheduling task)
+        mock_options_get.return_value = True
+
+        schedule_delayed_workflows()
+
+        # Should only process delayed_workflow
+        assert len(mock_process_buffer_for_type.mock_calls) == 1
+        mock_process_buffer_for_type.assert_called_once_with(
+            "delayed_workflow", mock_delayed_workflow
+        )


### PR DESCRIPTION
It was originally colocated with the task it was replacing for clarity, but long-term we really want it to be namespaced with our other tasks, so this adds it where we want it and leaves a stub of the previous ones to ensure a noiseless transition.
