### PR TITLE
feat(cleanup) - Error on `cleanup` on model with no deletion configured

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -154,6 +154,10 @@ def cleanup(
     this can be done with the `--project` or `--organization` flags respectively,
     which accepts a project/organization ID or a string with the form `org/project` where both are slugs.
     """
+    import logging
+
+    logger = logging.getLogger("sentry.cleanup")
+
     if concurrency < 1:
         click.echo("Error: Minimum concurrency is 1", err=True)
         raise click.Abort()
@@ -354,9 +358,6 @@ def cleanup(
         # Exclude models that were legitimately filtered out (silo/router restrictions)
         models_never_attempted = model_list - models_attempted - models_legitimately_filtered
         if models_never_attempted:
-            import logging
-
-            logger = logging.getLogger("sentry.cleanup")
             logger.error(
                 "Models specified with --model were never attempted for deletion, must configure cleanup for this model",
                 extra={

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -358,18 +358,14 @@ def cleanup(
 
             logger = logging.getLogger("sentry.cleanup")
             logger.error(
-                "Models specified with --model were never attempted for deletion",
+                "Models specified with --model were never attempted for deletion, must configure cleanup for this model",
                 extra={
                     "models_never_attempted": sorted(models_never_attempted),
-                    "current_silo_mode": str(SiloMode.get_current_mode()),
                     "legitimately_filtered_models": (
                         sorted(models_legitimately_filtered)
                         if models_legitimately_filtered
                         else None
                     ),
-                    "possible_causes": [
-                        "The model is not in any cleanup processing list",
-                    ],
                 },
             )
 


### PR DESCRIPTION
The current cleanup command receives a list of models, and checks for various different types of deletions to see if the model fits into any of these and runs the one the model is configured for.
However if a model is not added to any of them nothing will happen and the job will just complete silently. It will be up to the caller to notice the model was never picked up by any of these.

Instead this will now send a Sentry Error, raising the visibility of this misconfiguration.