### PR TITLE
chore(nav-cleanup): Move broadcasts component out of old sidebar folder

### DIFF
--- a/static/app/components/sidebar/broadcasts.spec.tsx
+++ b/static/app/components/sidebar/broadcasts.spec.tsx
@@ -3,11 +3,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {BROADCAST_CATEGORIES} from 'sentry/components/sidebar/broadcastPanelItem';
 import {Broadcasts} from 'sentry/components/sidebar/broadcasts';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import type {Broadcast} from 'sentry/types/system';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {BROADCAST_CATEGORIES} from 'sentry/views/nav/primary/whatsNew/item';
 
 jest.mock('sentry/utils/analytics');
 

--- a/static/app/components/sidebar/broadcasts.tsx
+++ b/static/app/components/sidebar/broadcasts.tsx
@@ -1,7 +1,6 @@
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {BroadcastPanelItem} from 'sentry/components/sidebar/broadcastPanelItem';
 import SidebarItem from 'sentry/components/sidebar/sidebarItem';
 import SidebarPanel from 'sentry/components/sidebar/sidebarPanel';
 import SidebarPanelEmpty from 'sentry/components/sidebar/sidebarPanelEmpty';
@@ -12,6 +11,7 @@ import {useApiQuery, useMutation} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
+import {WhatsNewItem} from 'sentry/views/nav/primary/whatsNew/item';
 
 import type {CommonSidebarProps} from './types';
 import {SidebarPanelKey} from './types';
@@ -117,7 +117,7 @@ export function Broadcasts({
             </SidebarPanelEmpty>
           ) : (
             broadcasts.map(item => (
-              <BroadcastPanelItem
+              <WhatsNewItem
                 key={item.id}
                 hasSeen={item.hasSeen}
                 title={item.title}

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -25,7 +25,7 @@ import {PrimaryNavigationHelp} from 'sentry/views/nav/primary/help';
 import {PrimaryNavigationOnboarding} from 'sentry/views/nav/primary/onboarding';
 import {PrimaryNavigationServiceIncidents} from 'sentry/views/nav/primary/serviceIncidents';
 import {useActivateNavGroupOnHover} from 'sentry/views/nav/primary/useActivateNavGroupOnHover';
-import {PrimaryNavigationWhatsNew} from 'sentry/views/nav/primary/whatsNew';
+import {PrimaryNavigationWhatsNew} from 'sentry/views/nav/primary/whatsNew/whatsNew';
 import {NavTourElement, StackedNavigationTour} from 'sentry/views/nav/tour/tour';
 import {NavLayout, PrimaryNavGroup} from 'sentry/views/nav/types';
 import {UserDropdown} from 'sentry/views/nav/userDropdown';

--- a/static/app/views/nav/primary/whatsNew/item.tsx
+++ b/static/app/views/nav/primary/whatsNew/item.tsx
@@ -23,7 +23,7 @@ interface BroadcastPanelItemProps
     'hasSeen' | 'category' | 'title' | 'message' | 'link' | 'mediaUrl'
   > {}
 
-export function BroadcastPanelItem({
+export function WhatsNewItem({
   hasSeen,
   title,
   message,

--- a/static/app/views/nav/primary/whatsNew/whatsNew.spec.tsx
+++ b/static/app/views/nav/primary/whatsNew/whatsNew.spec.tsx
@@ -2,9 +2,9 @@ import {BroadcastFixture} from 'sentry-fixture/broadcast';
 
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {BROADCAST_CATEGORIES} from 'sentry/components/sidebar/broadcastPanelItem';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {PrimaryNavigationWhatsNew} from 'sentry/views/nav/primary/whatsNew';
+import {BROADCAST_CATEGORIES} from 'sentry/views/nav/primary/whatsNew/item';
+import {PrimaryNavigationWhatsNew} from 'sentry/views/nav/primary/whatsNew/whatsNew';
 
 jest.mock('sentry/utils/analytics');
 

--- a/static/app/views/nav/primary/whatsNew/whatsNew.tsx
+++ b/static/app/views/nav/primary/whatsNew/whatsNew.tsx
@@ -2,7 +2,6 @@ import {Fragment, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {BroadcastPanelItem} from 'sentry/components/sidebar/broadcastPanelItem';
 import SidebarPanelEmpty from 'sentry/components/sidebar/sidebarPanelEmpty';
 import {IconBroadcast} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -26,6 +25,7 @@ import {
   PrimaryButtonOverlay,
   usePrimaryButtonOverlay,
 } from 'sentry/views/nav/primary/primaryButtonOverlay';
+import {WhatsNewItem} from 'sentry/views/nav/primary/whatsNew/item';
 import {NavLayout} from 'sentry/views/nav/types';
 
 const MARK_SEEN_DELAY = 1000;
@@ -101,7 +101,7 @@ function WhatsNewContent({unseenPostIds}: {unseenPostIds: string[]}) {
   return (
     <Fragment>
       {broadcasts.map(item => (
-        <BroadcastPanelItem
+        <WhatsNewItem
           key={item.id}
           hasSeen={item.hasSeen}
           title={item.title}


### PR DESCRIPTION
Ref RTC-1154

Need to move out anything currently used from the `/components/sidebar` folder in order to delete it.