### PR TITLE
ref(timeseries): Use `/events-timeseries/` hook in backend Insights landings

### DIFF
--- a/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
@@ -1,6 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {
   render,
@@ -25,6 +26,7 @@ const requestMocks = {
   missRateChart: jest.fn(),
   cacheSamplesMissRateChart: jest.fn(),
   throughputChart: jest.fn(),
+  cacheMissRateError: jest.fn(),
   spanTransactionList: jest.fn(),
   transactionDurations: jest.fn(),
   spanFields: jest.fn(),
@@ -92,27 +94,22 @@ describe('CacheLandingPage', () => {
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
     expect(requestMocks.throughputChart).toHaveBeenCalledWith(
-      `/organizations/${organization.slug}/events-stats/`,
+      `/organizations/${organization.slug}/events-timeseries/`,
       expect.objectContaining({
         method: 'GET',
         query: {
-          cursor: undefined,
           dataset: 'spans',
           sampling: SAMPLING_MODE.NORMAL,
           environment: [],
           excludeOther: 0,
-          field: [],
+          groupBy: undefined,
           interval: '30m',
-          orderby: undefined,
           partial: 1,
-          per_page: 50,
           project: [],
           query: 'span.op:[cache.get_item,cache.get]',
           referrer: 'api.insights.cache.landing-cache-throughput-chart',
           statsPeriod: '10d',
-          topEvents: undefined,
-          yAxis: 'epm()',
-          transformAliasToInputFormat: '1',
+          yAxis: ['epm()'],
         },
       })
     );
@@ -297,25 +294,24 @@ const setRequestMocks = (organization: Organization) => {
   });
 
   requestMocks.missRateChart = MockApiClient.addMockResponse({
-    url: `/organizations/${organization.slug}/events-stats/`,
+    url: `/organizations/${organization.slug}/events-timeseries/`,
     method: 'GET',
     match: [
       MockApiClient.matchQuery({
         referrer: 'api.insights.cache.landing-cache-hit-miss-chart',
+        yAxis: ['cache_miss_rate()'],
       }),
     ],
     body: {
-      data: [
-        [1716379200, [{count: 0.5}]],
-        [1716393600, [{count: 0.75}]],
+      timeSeries: [
+        TimeSeriesFixture({
+          yAxis: 'cache_miss_rate()',
+          values: [
+            {value: 0.5, timestamp: 1716379200000},
+            {value: 0.75, timestamp: 1716393600000},
+          ],
+        }),
       ],
-      meta: {
-        fields: {
-          time: 'date',
-          cache_miss_rate: 'percentage',
-        },
-        units: {},
-      },
     },
   });
 
@@ -343,7 +339,7 @@ const setRequestMocks = (organization: Organization) => {
   });
 
   requestMocks.throughputChart = MockApiClient.addMockResponse({
-    url: `/organizations/${organization.slug}/events-stats/`,
+    url: `/organizations/${organization.slug}/events-timeseries/`,
     method: 'GET',
     match: [
       MockApiClient.matchQuery({
@@ -351,14 +347,37 @@ const setRequestMocks = (organization: Organization) => {
       }),
     ],
     body: {
+      timeSeries: [
+        TimeSeriesFixture({
+          yAxis: 'epm()',
+          values: [
+            {value: 100, timestamp: 1716379200000},
+            {value: 200, timestamp: 1716393600000},
+          ],
+        }),
+      ],
+    },
+  });
+
+  // Mock for the old useSpanSeries call in cache landing page that still uses events-stats
+  requestMocks.cacheMissRateError = MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/events-stats/`,
+    method: 'GET',
+    match: [
+      MockApiClient.matchQuery({
+        referrer: 'api.insights.cache.landing-cache-hit-miss-chart',
+        transformAliasToInputFormat: '1',
+      }),
+    ],
+    body: {
       data: [
-        [1716379200, [{count: 100}]],
-        [1716393600, [{count: 200}]],
+        [1716379200, [{count: 0.5}]],
+        [1716393600, [{count: 0.75}]],
       ],
       meta: {
         fields: {
           time: 'date',
-          epm_14400: 'rate',
+          cache_miss_rate: 'percentage',
         },
         units: {},
       },

--- a/static/app/views/insights/common/components/widgets/cacheMissRateChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/cacheMissRateChartWidget.tsx
@@ -1,9 +1,9 @@
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {Referrer} from 'sentry/views/insights/cache/referrers';
 import {BASE_FILTERS} from 'sentry/views/insights/cache/settings';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
 
@@ -13,14 +13,13 @@ export default function CacheMissRateChartWidget(props: LoadableChartWidgetProps
   const search = MutableSearch.fromQueryObject(BASE_FILTERS);
   const referrer = Referrer.LANDING_CACHE_HIT_MISS_CHART;
 
-  const {isPending, data, error} = useSpanSeries(
+  const {isPending, data, error} = useFetchSpanTimeSeries(
     {
       yAxis: [`${CACHE_MISS_RATE}()`],
-      search,
-      transformAliasToInputFormat: true,
+      query: search,
+      pageFilters: props.pageFilters,
     },
-    referrer,
-    props.pageFilters
+    referrer
   );
 
   // explore/alerts doesn't support `cache_miss_rate`, so this is used as a comparable query
@@ -37,7 +36,7 @@ export default function CacheMissRateChartWidget(props: LoadableChartWidgetProps
       queryInfo={queryInfo}
       id="cacheMissRateChartWidget"
       title={DataTitles[`${CACHE_MISS_RATE}()`]}
-      series={[data[`${CACHE_MISS_RATE}()`]]}
+      timeSeries={data?.timeSeries}
       isLoading={isPending}
       error={error}
     />

--- a/static/app/views/insights/common/components/widgets/cacheThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/cacheThroughputChartWidget.tsx
@@ -1,22 +1,22 @@
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {Referrer} from 'sentry/views/insights/cache/referrers';
 import {BASE_FILTERS} from 'sentry/views/insights/cache/settings';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getThroughputChartTitle} from 'sentry/views/insights/common/views/spans/types';
 
 export default function CacheThroughputChartWidget(props: LoadableChartWidgetProps) {
   const search = MutableSearch.fromQueryObject(BASE_FILTERS);
   const referrer = Referrer.LANDING_CACHE_THROUGHPUT_CHART;
-  const {isPending, data, error} = useSpanSeries(
+
+  const {isPending, data, error} = useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: ['epm()'],
-      transformAliasToInputFormat: true,
+      pageFilters: props.pageFilters,
     },
-    referrer,
-    props.pageFilters
+    referrer
   );
 
   return (
@@ -25,7 +25,7 @@ export default function CacheThroughputChartWidget(props: LoadableChartWidgetPro
       queryInfo={{search, referrer}}
       id="cacheThroughputChartWidget"
       title={getThroughputChartTitle('cache.get_item')}
-      series={[data['epm()']]}
+      timeSeries={data?.timeSeries}
       isLoading={isPending}
       error={error}
     />

--- a/static/app/views/insights/common/components/widgets/httpDomainSummaryDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpDomainSummaryDurationChartWidget.tsx
@@ -1,8 +1,8 @@
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import {useHttpDomainSummaryChartFilter} from 'sentry/views/insights/common/components/widgets/hooks/useHttpDomainSummaryChartFilter';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getDurationChartTitle} from 'sentry/views/insights/common/views/spans/types';
 import {Referrer} from 'sentry/views/insights/http/referrers';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -18,14 +18,13 @@ export default function HttpDomainSummaryDurationChartWidget(
     isPending: isDurationDataLoading,
     data: durationData,
     error: durationError,
-  } = useSpanSeries(
+  } = useFetchSpanTimeSeries(
     {
-      search: MutableSearch.fromQueryObject(chartFilters),
+      query: MutableSearch.fromQueryObject(chartFilters),
       yAxis: [`avg(${SpanFields.SPAN_SELF_TIME})`],
-      transformAliasToInputFormat: true,
+      pageFilters: props.pageFilters,
     },
-    referrer,
-    props.pageFilters
+    referrer
   );
 
   return (
@@ -34,7 +33,7 @@ export default function HttpDomainSummaryDurationChartWidget(
       id="httpDomainSummaryDurationChartWidget"
       title={getDurationChartTitle('http')}
       queryInfo={{search, referrer}}
-      series={[durationData['avg(span.self_time)']]}
+      timeSeries={durationData?.timeSeries}
       isLoading={isDurationDataLoading}
       error={durationError}
     />

--- a/static/app/views/insights/common/components/widgets/httpDomainSummaryResponseCodesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpDomainSummaryResponseCodesChartWidget.tsx
@@ -1,3 +1,4 @@
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -10,7 +11,6 @@ import {BaseChartActionDropdown} from 'sentry/views/insights/common/components/c
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import {useHttpDomainSummaryChartFilter} from 'sentry/views/insights/common/components/widgets/hooks/useHttpDomainSummaryChartFilter';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 import {useAlertsProject} from 'sentry/views/insights/common/utils/useAlertsProject';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
@@ -33,14 +33,13 @@ export default function HttpDomainSummaryResponseCodesChartWidget(
     isPending: isResponseCodeDataLoading,
     data: responseCodeData,
     error: responseCodeError,
-  } = useSpanSeries(
+  } = useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: ['http_response_rate(3)', 'http_response_rate(4)', 'http_response_rate(5)'],
-      transformAliasToInputFormat: true,
+      pageFilters: props.pageFilters,
     },
-    referrer,
-    props.pageFilters
+    referrer
   );
 
   const responseRateField = 'tags[http.response.status_code,number]';
@@ -101,11 +100,7 @@ export default function HttpDomainSummaryResponseCodesChartWidget(
       {...props}
       id="httpDomainSummaryResponseCodesChartWidget"
       title={DataTitles.unsuccessfulHTTPCodes}
-      series={[
-        responseCodeData[`http_response_rate(3)`],
-        responseCodeData[`http_response_rate(4)`],
-        responseCodeData[`http_response_rate(5)`],
-      ]}
+      timeSeries={responseCodeData?.timeSeries}
       extraActions={extraActions}
       aliases={FIELD_ALIASES}
       isLoading={isResponseCodeDataLoading}

--- a/static/app/views/insights/common/components/widgets/httpDomainSummaryThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpDomainSummaryThroughputChartWidget.tsx
@@ -1,8 +1,8 @@
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import {useHttpDomainSummaryChartFilter} from 'sentry/views/insights/common/components/widgets/hooks/useHttpDomainSummaryChartFilter';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getThroughputChartTitle} from 'sentry/views/insights/common/views/spans/types';
 import {Referrer} from 'sentry/views/insights/http/referrers';
 
@@ -17,14 +17,13 @@ export default function HttpDomainSummaryThroughputChartWidget(
     isPending: isThroughputDataLoading,
     data: throughputData,
     error: throughputError,
-  } = useSpanSeries(
+  } = useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: ['epm()'],
-      transformAliasToInputFormat: true,
+      pageFilters: props.pageFilters,
     },
-    Referrer.DOMAIN_SUMMARY_THROUGHPUT_CHART,
-    props.pageFilters
+    Referrer.DOMAIN_SUMMARY_THROUGHPUT_CHART
   );
 
   return (
@@ -33,7 +32,7 @@ export default function HttpDomainSummaryThroughputChartWidget(
       id="httpDomainSummaryThroughputChartWidget"
       title={getThroughputChartTitle('http')}
       queryInfo={{search, referrer}}
-      series={[throughputData['epm()']]}
+      timeSeries={throughputData?.timeSeries}
       isLoading={isThroughputDataLoading}
       error={throughputError}
     />

--- a/static/app/views/insights/common/components/widgets/httpDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpDurationChartWidget.tsx
@@ -1,8 +1,8 @@
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import {useHttpLandingChartFilter} from 'sentry/views/insights/common/components/widgets/hooks/useHttpLandingChartFilter';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getDurationChartTitle} from 'sentry/views/insights/common/views/spans/types';
 import {Referrer} from 'sentry/views/insights/http/referrers';
 
@@ -15,14 +15,13 @@ export default function HttpDurationChartWidget(props: LoadableChartWidgetProps)
     isPending: isDurationDataLoading,
     data: durationData,
     error: durationError,
-  } = useSpanSeries(
+  } = useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: ['avg(span.self_time)'],
-      transformAliasToInputFormat: true,
+      pageFilters: props.pageFilters,
     },
-    referrer,
-    props.pageFilters
+    referrer
   );
 
   return (
@@ -31,7 +30,7 @@ export default function HttpDurationChartWidget(props: LoadableChartWidgetProps)
       queryInfo={{search, referrer}}
       id="httpDurationChartWidget"
       title={getDurationChartTitle('http')}
-      series={[durationData['avg(span.self_time)']]}
+      timeSeries={durationData?.timeSeries}
       isLoading={isDurationDataLoading}
       error={durationError}
     />

--- a/static/app/views/insights/common/components/widgets/httpResponseCodesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpResponseCodesChartWidget.tsx
@@ -1,3 +1,4 @@
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -10,7 +11,6 @@ import {BaseChartActionDropdown} from 'sentry/views/insights/common/components/c
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import {useHttpLandingChartFilter} from 'sentry/views/insights/common/components/widgets/hooks/useHttpLandingChartFilter';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 import {useAlertsProject} from 'sentry/views/insights/common/utils/useAlertsProject';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
@@ -31,14 +31,13 @@ export default function HttpResponseCodesChartWidget(props: LoadableChartWidgetP
     isPending: isResponseCodeDataLoading,
     data: responseCodeData,
     error: responseCodeError,
-  } = useSpanSeries(
+  } = useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: ['http_response_rate(3)', 'http_response_rate(4)', 'http_response_rate(5)'],
-      transformAliasToInputFormat: true,
+      pageFilters: props.pageFilters,
     },
-    referrer,
-    props.pageFilters
+    referrer
   );
 
   const responseRateField = 'tags[http.response.status_code,number]';
@@ -98,13 +97,9 @@ export default function HttpResponseCodesChartWidget(props: LoadableChartWidgetP
     <InsightsLineChartWidget
       {...props}
       id="httpResponseCodesChartWidget"
-      extraActions={extraActions}
       title={DataTitles.unsuccessfulHTTPCodes}
-      series={[
-        responseCodeData[`http_response_rate(3)`],
-        responseCodeData[`http_response_rate(4)`],
-        responseCodeData[`http_response_rate(5)`],
-      ]}
+      timeSeries={responseCodeData?.timeSeries}
+      extraActions={extraActions}
       aliases={FIELD_ALIASES}
       isLoading={isResponseCodeDataLoading}
       error={responseCodeError}

--- a/static/app/views/insights/common/components/widgets/httpThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpThroughputChartWidget.tsx
@@ -1,8 +1,8 @@
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import {useHttpLandingChartFilter} from 'sentry/views/insights/common/components/widgets/hooks/useHttpLandingChartFilter';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getThroughputChartTitle} from 'sentry/views/insights/common/views/spans/types';
 import {Referrer} from 'sentry/views/insights/http/referrers';
 
@@ -16,14 +16,13 @@ export default function HttpThroughputChartWidget(props: LoadableChartWidgetProp
     isPending: isThroughputDataLoading,
     data: throughputData,
     error: throughputError,
-  } = useSpanSeries(
+  } = useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: [yAxis],
-      transformAliasToInputFormat: true,
+      pageFilters: props.pageFilters,
     },
-    referrer,
-    props.pageFilters
+    referrer
   );
 
   return (
@@ -32,7 +31,7 @@ export default function HttpThroughputChartWidget(props: LoadableChartWidgetProp
       queryInfo={{search, referrer}}
       id="httpThroughputChartWidget"
       title={getThroughputChartTitle('http')}
-      series={[throughputData[yAxis]]}
+      timeSeries={throughputData?.timeSeries}
       isLoading={isThroughputDataLoading}
       error={throughputError}
     />

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
@@ -1,5 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {
   render,
@@ -112,7 +113,7 @@ describe('HTTPDomainSummaryPage', () => {
     });
 
     throughputRequestMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
       match: [
         MockApiClient.matchQuery({
@@ -120,23 +121,20 @@ describe('HTTPDomainSummaryPage', () => {
         }),
       ],
       body: {
-        data: [
-          [1699907700, [{count: 7810.2}]],
-          [1699908000, [{count: 1216.8}]],
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'epm()',
+            values: [
+              {value: 7810.2, timestamp: 1699907700000},
+              {value: 1216.8, timestamp: 1699908000000},
+            ],
+          }),
         ],
-        meta: {
-          fields: {
-            'epm()': 'rate',
-          },
-          units: {
-            'epm()': '1/second',
-          },
-        },
       },
     });
 
     durationRequestMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
       match: [
         MockApiClient.matchQuery({
@@ -144,23 +142,20 @@ describe('HTTPDomainSummaryPage', () => {
         }),
       ],
       body: {
-        data: [
-          [1699907700, [{count: 710.2}]],
-          [1699908000, [{count: 116.8}]],
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'avg(span.self_time)',
+            values: [
+              {value: 710.2, timestamp: 1699907700000},
+              {value: 116.8, timestamp: 1699908000000},
+            ],
+          }),
         ],
-        meta: {
-          fields: {
-            'avg(span.duration)': 'rate',
-          },
-          units: {
-            'avg(span.duration)': '1/second',
-          },
-        },
       },
     });
 
     statusRequestMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
       match: [
         MockApiClient.matchQuery({
@@ -168,33 +163,20 @@ describe('HTTPDomainSummaryPage', () => {
         }),
       ],
       body: {
-        'http_response_rate(3)': {
-          data: [[1699908000, [{count: 0.2}]]],
-          meta: {
-            fields: {
-              'http_response_rate(3)': 'percentage',
-            },
-            units: {},
-          },
-        },
-        'http_response_rate(4)': {
-          data: [[1699908000, [{count: 0.1}]]],
-          meta: {
-            fields: {
-              'http_response_rate(4)': 'percentage',
-            },
-            units: {},
-          },
-        },
-        'http_response_rate(5)': {
-          data: [[1699908000, [{count: 0.3}]]],
-          meta: {
-            fields: {
-              'http_response_rate(5)': 'percentage',
-            },
-            units: {},
-          },
-        },
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'http_response_rate(3)',
+            values: [{value: 0.2, timestamp: 1699908000000}],
+          }),
+          TimeSeriesFixture({
+            yAxis: 'http_response_rate(4)',
+            values: [{value: 0.1, timestamp: 1699908000000}],
+          }),
+          TimeSeriesFixture({
+            yAxis: 'http_response_rate(5)',
+            values: [{value: 0.3, timestamp: 1699908000000}],
+          }),
+        ],
       },
     });
   });
@@ -209,27 +191,22 @@ describe('HTTPDomainSummaryPage', () => {
     await waitFor(() => {
       expect(throughputRequestMock).toHaveBeenNthCalledWith(
         1,
-        `/organizations/${organization.slug}/events-stats/`,
+        `/organizations/${organization.slug}/events-timeseries/`,
         expect.objectContaining({
           method: 'GET',
           query: {
-            cursor: undefined,
             dataset: 'spans',
             sampling: SAMPLING_MODE.NORMAL,
             environment: [],
             excludeOther: 0,
-            field: [],
+            groupBy: undefined,
             interval: '30m',
-            orderby: undefined,
             partial: 1,
-            per_page: 50,
             project: [],
             query: 'span.op:http.client span.domain:"\\*.sentry.dev"',
             referrer: 'api.insights.http.domain-summary-throughput-chart',
             statsPeriod: '10d',
-            topEvents: undefined,
-            yAxis: 'epm()',
-            transformAliasToInputFormat: '1',
+            yAxis: ['epm()'],
           },
         })
       );
@@ -237,58 +214,48 @@ describe('HTTPDomainSummaryPage', () => {
 
     expect(durationRequestMock).toHaveBeenNthCalledWith(
       1,
-      `/organizations/${organization.slug}/events-stats/`,
+      `/organizations/${organization.slug}/events-timeseries/`,
       expect.objectContaining({
         method: 'GET',
         query: {
-          cursor: undefined,
           dataset: 'spans',
           sampling: SAMPLING_MODE.NORMAL,
           environment: [],
           excludeOther: 0,
-          field: [],
+          groupBy: undefined,
           interval: '30m',
-          orderby: undefined,
           partial: 1,
-          per_page: 50,
           project: [],
           query: 'span.op:http.client span.domain:"\\*.sentry.dev"',
           referrer: 'api.insights.http.domain-summary-duration-chart',
           statsPeriod: '10d',
-          topEvents: undefined,
-          yAxis: 'avg(span.self_time)',
-          transformAliasToInputFormat: '1',
+          yAxis: ['avg(span.self_time)'],
         },
       })
     );
 
     expect(statusRequestMock).toHaveBeenNthCalledWith(
       1,
-      `/organizations/${organization.slug}/events-stats/`,
+      `/organizations/${organization.slug}/events-timeseries/`,
       expect.objectContaining({
         method: 'GET',
         query: {
-          cursor: undefined,
           dataset: 'spans',
           sampling: SAMPLING_MODE.NORMAL,
           environment: [],
           excludeOther: 0,
-          field: [],
+          groupBy: undefined,
           interval: '30m',
-          orderby: undefined,
           partial: 1,
-          per_page: 50,
           project: [],
           query: 'span.op:http.client span.domain:"\\*.sentry.dev"',
           referrer: 'api.insights.http.domain-summary-response-code-chart',
           statsPeriod: '10d',
-          topEvents: undefined,
           yAxis: [
             'http_response_rate(3)',
             'http_response_rate(4)',
             'http_response_rate(5)',
           ],
-          transformAliasToInputFormat: '1',
         },
       })
     );

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -1,6 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
@@ -165,7 +166,7 @@ describe('HTTPLandingPage', () => {
     });
 
     throughputRequestMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
       match: [
         MockApiClient.matchQuery({
@@ -173,23 +174,20 @@ describe('HTTPLandingPage', () => {
         }),
       ],
       body: {
-        data: [
-          [1699907700, [{count: 7810.2}]],
-          [1699908000, [{count: 1216.8}]],
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'epm()',
+            values: [
+              {value: 7810.2, timestamp: 1699907700000},
+              {value: 1216.8, timestamp: 1699908000000},
+            ],
+          }),
         ],
-        meta: {
-          fields: {
-            'epm()': 'rate',
-          },
-          units: {
-            'epm()': '1/second',
-          },
-        },
       },
     });
 
     durationRequestMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
       match: [
         MockApiClient.matchQuery({
@@ -197,23 +195,20 @@ describe('HTTPLandingPage', () => {
         }),
       ],
       body: {
-        data: [
-          [1699907700, [{count: 710.2}]],
-          [1699908000, [{count: 116.8}]],
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'avg(span.self_time)',
+            values: [
+              {value: 710.2, timestamp: 1699907700000},
+              {value: 1216.8, timestamp: 1699908000000},
+            ],
+          }),
         ],
-        meta: {
-          fields: {
-            'avg(span.duration)': 'duration',
-          },
-          units: {
-            'avg(span.duration)': 'millisecond',
-          },
-        },
       },
     });
 
     statusRequestMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
       match: [
         MockApiClient.matchQuery({
@@ -221,33 +216,20 @@ describe('HTTPLandingPage', () => {
         }),
       ],
       body: {
-        'http_response_rate(3)': {
-          data: [[1699908000, [{count: 0.2}]]],
-          meta: {
-            fields: {
-              'http_response_rate(3)': 'percentage',
-            },
-            units: {},
-          },
-        },
-        'http_response_rate(4)': {
-          data: [[1699908000, [{count: 0.1}]]],
-          meta: {
-            fields: {
-              'http_response_rate(4)': 'percentage',
-            },
-            units: {},
-          },
-        },
-        'http_response_rate(5)': {
-          data: [[1699908000, [{count: 0.3}]]],
-          meta: {
-            fields: {
-              'http_response_rate(5)': 'percentage',
-            },
-            units: {},
-          },
-        },
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'http_response_rate(3)',
+            values: [{value: 0.2, timestamp: 1699908000000}],
+          }),
+          TimeSeriesFixture({
+            yAxis: 'http_response_rate(4)',
+            values: [{value: 0.1, timestamp: 1699908000000}],
+          }),
+          TimeSeriesFixture({
+            yAxis: 'http_response_rate(5)',
+            values: [{value: 0.1, timestamp: 1699908000000}],
+          }),
+        ],
       },
     });
   });
@@ -263,27 +245,22 @@ describe('HTTPLandingPage', () => {
 
     expect(throughputRequestMock).toHaveBeenNthCalledWith(
       1,
-      `/organizations/${organization.slug}/events-stats/`,
+      `/organizations/${organization.slug}/events-timeseries/`,
       expect.objectContaining({
         method: 'GET',
         query: {
-          cursor: undefined,
           dataset: 'spans',
           sampling: SAMPLING_MODE.NORMAL,
           environment: [],
           excludeOther: 0,
-          field: [],
+          groupBy: undefined,
           interval: '30m',
-          orderby: undefined,
           partial: 1,
-          per_page: 50,
           project: [],
           query: 'span.op:http.client',
           referrer: 'api.insights.http.landing-throughput-chart',
           statsPeriod: '10d',
-          topEvents: undefined,
-          yAxis: 'epm()',
-          transformAliasToInputFormat: '1',
+          yAxis: ['epm()'],
         },
       })
     );
@@ -309,58 +286,48 @@ describe('HTTPLandingPage', () => {
 
     expect(durationRequestMock).toHaveBeenNthCalledWith(
       1,
-      `/organizations/${organization.slug}/events-stats/`,
+      `/organizations/${organization.slug}/events-timeseries/`,
       expect.objectContaining({
         method: 'GET',
         query: {
-          cursor: undefined,
           dataset: 'spans',
           sampling: SAMPLING_MODE.NORMAL,
           environment: [],
           excludeOther: 0,
-          field: [],
+          groupBy: undefined,
           interval: '30m',
-          orderby: undefined,
           partial: 1,
-          per_page: 50,
           project: [],
           query: 'span.op:http.client',
           referrer: 'api.insights.http.landing-duration-chart',
           statsPeriod: '10d',
-          topEvents: undefined,
-          yAxis: 'avg(span.self_time)',
-          transformAliasToInputFormat: '1',
+          yAxis: ['avg(span.self_time)'],
         },
       })
     );
 
     expect(statusRequestMock).toHaveBeenNthCalledWith(
       1,
-      `/organizations/${organization.slug}/events-stats/`,
+      `/organizations/${organization.slug}/events-timeseries/`,
       expect.objectContaining({
         method: 'GET',
         query: {
-          cursor: undefined,
           dataset: 'spans',
           sampling: SAMPLING_MODE.NORMAL,
           environment: [],
           excludeOther: 0,
-          field: [],
+          groupBy: undefined,
           interval: '30m',
-          orderby: undefined,
           partial: 1,
-          per_page: 50,
           project: [],
           query: 'span.op:http.client',
           referrer: 'api.insights.http.landing-response-code-chart',
           statsPeriod: '10d',
-          topEvents: undefined,
           yAxis: [
             'http_response_rate(3)',
             'http_response_rate(4)',
             'http_response_rate(5)',
           ],
-          transformAliasToInputFormat: '1',
         },
       })
     );

--- a/static/app/views/insights/queues/charts/latencyChart.spec.tsx
+++ b/static/app/views/insights/queues/charts/latencyChart.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
@@ -23,22 +24,19 @@ describe('latencyChart', () => {
 
   beforeEach(() => {
     eventsStatsMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
       body: {
-        data: [[1739378162, [{count: 1}]]],
-        meta: {
-          fields: {
-            'avg(span.duration)': 'duration',
-            'avg(messaging.message.receive.latency)': 'duration',
-            'epm()': 'rate',
-          },
-          units: {
-            'avg(span.duration)': 'millisecond',
-            'avg(messaging.message.receive.latency)': 'millisecond',
-            'epm()': '1/second',
-          },
-        },
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'avg(messaging.message.receive.latency)',
+            values: [{value: 1, timestamp: 1739378162000}],
+          }),
+          TimeSeriesFixture({
+            yAxis: 'avg(span.duration)',
+            values: [{value: 1, timestamp: 1739378162000}],
+          }),
+        ],
       },
     });
   });
@@ -53,10 +51,10 @@ describe('latencyChart', () => {
     );
     screen.getByText('Average Duration');
     expect(eventsStatsMock).toHaveBeenCalledWith(
-      '/organizations/org-slug/events-stats/',
+      '/organizations/org-slug/events-timeseries/',
       expect.objectContaining({
         query: expect.objectContaining({
-          yAxis: ['avg(span.duration)', 'avg(messaging.message.receive.latency)'],
+          yAxis: ['avg(messaging.message.receive.latency)', 'avg(span.duration)'],
           query: 'span.op:queue.process messaging.destination.name:events',
         }),
       })

--- a/static/app/views/insights/queues/charts/latencyChart.tsx
+++ b/static/app/views/insights/queues/charts/latencyChart.tsx
@@ -1,13 +1,12 @@
-import cloneDeep from 'lodash/cloneDeep';
-
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
-import {defined} from 'sentry/utils';
+import {DurationUnit} from 'sentry/utils/discover/fields';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 // Our loadable chart widgets use this to render, so this import is ok
 // eslint-disable-next-line no-restricted-imports
 import {InsightsAreaChartWidget} from 'sentry/views/insights/common/components/insightsAreaChartWidget';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import type {Referrer} from 'sentry/views/insights/queues/referrers';
 import {FIELD_ALIASES} from 'sentry/views/insights/queues/settings';
 
@@ -29,48 +28,43 @@ export function LatencyChart({id, error, destination, referrer, pageFilters}: Pr
     data,
     isPending,
     error: latencyError,
-  } = useSpanSeries(
+  } = useFetchSpanTimeSeries(
     {
       yAxis: ['avg(span.duration)', 'avg(messaging.message.receive.latency)'],
-      search,
-      transformAliasToInputFormat: true,
+      query: search,
+      pageFilters,
     },
-    referrer,
-    pageFilters
+    referrer
   );
 
-  const messageReceiveLatencySeries = cloneDeep(
-    data['avg(messaging.message.receive.latency)']
-  );
+  const timeSeries = (data?.timeSeries || []).map(
+    (possiblyIncompleteTimeSeries): TimeSeries => {
+      // This is a tricky data issue. If Snuba doesn't find any data for a field,
+      // it doesn't return a unit. If Discover can't guess the type based on the
+      // unit, there's no entry in the meta for the field. If there's no field,
+      // `TimeSeriesWidgetVisualization` dumps that data onto its own "number"
+      // axis, which looks weird. This is a rare case, and I'm hoping that in the
+      // future, backend will be able to determine types most of the time. For
+      // now, I'll add a placeholder.
 
-  if (
-    !isPending &&
-    !error &&
-    defined(messageReceiveLatencySeries.data) &&
-    defined(messageReceiveLatencySeries.meta) &&
-    !defined(
-      messageReceiveLatencySeries.meta?.fields['avg(messaging.message.receive.latency)']
-    )
-  ) {
-    // This is a tricky data issue. If Snuba doesn't find any data for a field,
-    // it doesn't return a unit. If Discover can't guess the type based on the
-    // unit, there's no entry in the meta for the field. If there's no field,
-    // `TimeSeriesWidgetVisualization` dumps that data onto its own "number"
-    // axis, which looks weird. This is a rare case, and I'm hoping that in the
-    // future, backend will be able to determine types most of the time. For
-    // now, backfill the type, since we know it.
-    messageReceiveLatencySeries.meta.fields['avg(messaging.message.receive.latency)'] =
-      'duration';
-    messageReceiveLatencySeries.meta.units['avg(messaging.message.receive.latency)'] =
-      'millisecond';
-  }
+      return {
+        ...possiblyIncompleteTimeSeries,
+        meta: {
+          ...possiblyIncompleteTimeSeries.meta,
+          valueType: possiblyIncompleteTimeSeries.meta.valueType ?? 'duration',
+          valueUnit:
+            possiblyIncompleteTimeSeries.meta.valueUnit ?? DurationUnit.MILLISECOND,
+        },
+      };
+    }
+  );
 
   return (
     <InsightsAreaChartWidget
       id={id}
       queryInfo={{search, referrer}}
       title={t('Average Duration')}
-      series={[messageReceiveLatencySeries, data['avg(span.duration)']]}
+      timeSeries={timeSeries}
       aliases={FIELD_ALIASES}
       error={error ?? latencyError}
       isLoading={isPending}

--- a/static/app/views/insights/queues/charts/latencyChart.tsx
+++ b/static/app/views/insights/queues/charts/latencyChart.tsx
@@ -30,7 +30,7 @@ export function LatencyChart({id, error, destination, referrer, pageFilters}: Pr
     error: latencyError,
   } = useFetchSpanTimeSeries(
     {
-      yAxis: ['avg(span.duration)', 'avg(messaging.message.receive.latency)'],
+      yAxis: ['avg(messaging.message.receive.latency)', 'avg(span.duration)'],
       query: search,
       pageFilters,
     },

--- a/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
@@ -1,6 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
@@ -54,20 +55,19 @@ describe('destinationSummaryPage', () => {
     });
 
     latencyEventsStatsMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
       body: {
-        'avg(span.duration)': {
-          data: [[1739378162, [{count: 1}]]],
-          meta: {
-            fields: {'avg(span.duration)': 'duration'},
-            units: {'avg(span.duration)': 'millisecond'},
-          },
-        },
-        'avg(messaging.message.receive.latency)': {
-          data: [[1739378162, [{count: 1}]]],
-          meta: {fields: {epm: 'rate'}, units: {epm: '1/second'}},
-        },
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'avg(messaging.message.receive.latency)',
+            values: [{value: 1, timestamp: 1739378162000}],
+          }),
+          TimeSeriesFixture({
+            yAxis: 'avg(span.duration)',
+            values: [{value: 1, timestamp: 1739378162000}],
+          }),
+        ],
       },
       match: [
         MockApiClient.matchQuery({
@@ -76,6 +76,7 @@ describe('destinationSummaryPage', () => {
       ],
     });
 
+    // Mock for unchanged throughput chart that still uses events-stats
     throughputEventsStatsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-stats/`,
       method: 'GET',

--- a/static/app/views/insights/queues/views/queuesLandingPage.spec.tsx
+++ b/static/app/views/insights/queues/views/queuesLandingPage.spec.tsx
@@ -1,6 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -54,6 +55,20 @@ describe('queuesLandingPage', () => {
     });
 
     eventsStatsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: {
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'epm()',
+            values: [{value: 1, timestamp: 1739378162000}],
+          }),
+        ],
+      },
+    });
+
+    // Mock for unchanged throughput chart that still uses events-stats
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-stats/`,
       method: 'GET',
       body: {data: []},


### PR DESCRIPTION
Next batch of work in using `/events-timeseries/` endpoint. This is a follow-up to https://github.com/getsentry/sentry/pull/99339, and converts a few more modules: HTTP, Queues, and Caches (but not the sample panels for now).
