### PR TITLE
feat(crons): Add check-in ID to check-in grid

### DIFF
--- a/static/app/views/insights/crons/components/monitorCheckInsGrid.spec.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckInsGrid.spec.tsx
@@ -249,4 +249,20 @@ describe('CheckInRow', () => {
     render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} />);
     expect(screen.queryByTestId('more-information')).not.toBeInTheDocument();
   });
+
+  it('displays check-in ID and copy button', () => {
+    const checkIn = CheckInFixture({
+      id: 'abcd1234-5678-90ef-ghij-klmnopqrstuv',
+      status: CheckInStatus.OK,
+    });
+
+    render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} />);
+
+    // Check that the short ID is displayed
+    expect(screen.getByText('abcd1234')).toBeInTheDocument();
+
+    // Check that the copy button is present with the correct accessible name
+    const copyButton = screen.getByRole('button', {name: 'Copy Check-In ID'});
+    expect(copyButton).toBeInTheDocument();
+  });
 });

--- a/static/app/views/insights/crons/components/monitorCheckInsGrid.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckInsGrid.tsx
@@ -25,6 +25,7 @@ export function MonitorCheckInsGrid({checkIns, isLoading, project, hasMultiEnv}:
       data={checkIns}
       columnOrder={[
         {key: 'status', width: 120, name: t('Status')},
+        {key: 'checkInId', width: 135, name: t('Check-In ID')},
         {key: 'started', width: 200, name: t('Started')},
         {key: 'completed', width: 240, name: t('Completed')},
         {key: 'duration', width: 150, name: t('Duration')},

--- a/static/app/views/insights/crons/types.tsx
+++ b/static/app/views/insights/crons/types.tsx
@@ -328,6 +328,7 @@ export type CheckInCellKey =
   | 'started'
   | 'completed'
   | 'duration'
+  | 'checkInId'
   | 'issues'
   | 'environment'
   | 'expectedAt';


### PR DESCRIPTION
The table now includes the check-in ID

<img alt="clipboard.png" width="1275" src="https://i.imgur.com/eD6ebi3.png" />