### PR TITLE
ref(replay): summaries - handle dataset errors separately

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -230,16 +230,16 @@ class ProjectReplaySummaryEndpoint(ProjectEndpoint):
             trace_connected_error_ids = {x["id"] for x in trace_connected_errors}
 
             # Fetch directly linked errors, if they weren't returned by the trace query.
-            replay_errors = fetch_error_details(
+            direct_errors = fetch_error_details(
                 project_id=project.id,
                 error_ids=[x for x in error_ids if x not in trace_connected_error_ids],
             )
 
-            error_events = replay_errors + trace_connected_errors
+            error_events = direct_errors + trace_connected_errors
 
             metrics.distribution(
                 "replays.endpoints.project_replay_summary.direct_errors",
-                value=len(replay_errors),
+                value=len(direct_errors),
             )
             metrics.distribution(
                 "replays.endpoints.project_replay_summary.trace_connected_errors",

--- a/src/sentry/replays/usecases/summarize.py
+++ b/src/sentry/replays/usecases/summarize.py
@@ -117,7 +117,7 @@ def fetch_trace_connected_errors(
         )
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        error_query_results = []
+        error_query_results = {"data": []}
 
     # Query for issuePlatform dataset
     try:
@@ -139,7 +139,7 @@ def fetch_trace_connected_errors(
         )
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        issue_query_results = []
+        issue_query_results = {"data": []}
 
     # Process results and convert to EventDict objects
     events = []

--- a/src/sentry/replays/usecases/summarize.py
+++ b/src/sentry/replays/usecases/summarize.py
@@ -80,26 +80,26 @@ def fetch_trace_connected_errors(
     end: datetime | None,
     limit: int,
 ) -> list[EventDict]:
-    """Fetch error details given trace IDs and return a list of EventDict objects."""
+    """Fetch same-trace events from both errors and issuePlatform datasets."""
+    if not trace_ids:
+        return []
+
+    # Get projects in the organization that the user has access to
+    org_projects = list(
+        Project.objects.filter(organization=project.organization, status=ObjectStatus.ACTIVE)
+    )
+
+    snuba_params = SnubaParams(
+        projects=org_projects,
+        start=start,
+        end=end,
+        organization=project.organization,
+    )
+
+    trace_ids_query = f"trace:[{','.join(trace_ids)}]"
+
+    # Query for errors dataset
     try:
-        if not trace_ids:
-            return []
-
-        # Get projects in the organization that the user has access to
-        org_projects = list(
-            Project.objects.filter(organization=project.organization, status=ObjectStatus.ACTIVE)
-        )
-
-        snuba_params = SnubaParams(
-            projects=org_projects,
-            start=start,
-            end=end,
-            organization=project.organization,
-        )
-
-        trace_ids_query = f"trace:[{','.join(trace_ids)}]"
-
-        # Query for errors dataset
         error_query_results = query_trace_connected_events(
             dataset_label="errors",
             selected_columns=[
@@ -115,8 +115,12 @@ def fetch_trace_connected_errors(
             limit=limit,
             referrer=Referrer.API_REPLAY_SUMMARIZE_BREADCRUMBS.value,
         )
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
+        error_query_results = []
 
-        # Query for issuePlatform dataset
+    # Query for issuePlatform dataset
+    try:
         issue_query_results = query_trace_connected_events(
             dataset_label="issuePlatform",
             selected_columns=[
@@ -133,61 +137,60 @@ def fetch_trace_connected_errors(
             limit=limit,
             referrer=Referrer.API_REPLAY_SUMMARIZE_BREADCRUMBS.value,
         )
-
-        # Process results and convert to EventDict objects
-        error_events = []
-
-        # Process error query results
-        for event in error_query_results["data"]:
-            timestamp = _parse_iso_timestamp_to_ms(
-                event.get("timestamp_ms")
-            ) or _parse_iso_timestamp_to_ms(event.get("timestamp"))
-            message = event.get("message", "")
-
-            if timestamp:
-                error_events.append(
-                    EventDict(
-                        category="error",
-                        id=event.get("id"),
-                        title=event.get("title", ""),
-                        timestamp=timestamp,
-                        message=message,
-                    )
-                )
-
-        # Process issuePlatform query results
-        for event in issue_query_results["data"]:
-            timestamp = _parse_iso_timestamp_to_ms(
-                event.get("timestamp_ms")
-            ) or _parse_iso_timestamp_to_ms(event.get("timestamp"))
-            message = event.get("subtitle", "") or event.get("message", "")
-
-            if event.get("occurrence_type_id") == FeedbackGroup.type_id:
-                category = "feedback"
-            else:
-                category = "error"
-
-            # NOTE: The issuePlatform dataset query can return feedback.
-            # We also fetch feedback from nodestore in fetch_feedback_details
-            # for feedback breadcrumbs.
-            # We avoid creating duplicate feedback logs
-            # by filtering for unique feedback IDs during log generation.
-            if timestamp:
-                error_events.append(
-                    EventDict(
-                        category=category,
-                        id=event.get("event_id"),
-                        title=event.get("title", ""),
-                        timestamp=timestamp,
-                        message=message,
-                    )
-                )
-
-        return error_events
-
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        return []
+        issue_query_results = []
+
+    # Process results and convert to EventDict objects
+    events = []
+
+    # Process error query results
+    for event in error_query_results["data"]:
+        timestamp = _parse_iso_timestamp_to_ms(
+            event.get("timestamp_ms")
+        ) or _parse_iso_timestamp_to_ms(event.get("timestamp"))
+        message = event.get("message", "")
+
+        if timestamp:
+            events.append(
+                EventDict(
+                    category="error",
+                    id=event.get("id"),
+                    title=event.get("title", ""),
+                    timestamp=timestamp,
+                    message=message,
+                )
+            )
+
+    # Process issuePlatform query results
+    for event in issue_query_results["data"]:
+        timestamp = _parse_iso_timestamp_to_ms(
+            event.get("timestamp_ms")
+        ) or _parse_iso_timestamp_to_ms(event.get("timestamp"))
+        message = event.get("subtitle", "") or event.get("message", "")
+
+        if event.get("occurrence_type_id") == FeedbackGroup.type_id:
+            category = "feedback"
+        else:
+            category = "error"
+
+        # NOTE: The issuePlatform dataset query can return feedback.
+        # We also fetch feedback from nodestore in fetch_feedback_details
+        # for feedback breadcrumbs.
+        # We avoid creating duplicate feedback logs
+        # by filtering for unique feedback IDs during log generation.
+        if timestamp:
+            events.append(
+                EventDict(
+                    category=category,
+                    id=event.get("event_id"),
+                    title=event.get("title", ""),
+                    timestamp=timestamp,
+                    message=message,
+                )
+            )
+
+    return events
 
 
 @sentry_sdk.trace

--- a/tests/sentry/replays/endpoints/test_project_replay_summary.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_summary.py
@@ -221,7 +221,7 @@ class ProjectReplaySummaryTestCase(
         trace_id = uuid.uuid4().hex
         span_id = "1" + uuid.uuid4().hex[:15]
 
-        # Create a direct error event that is also trace connected.
+        # Create a direct error event that is not trace connected.
         direct_event_id = uuid.uuid4().hex
         direct_error_timestamp = now.timestamp() - 2
         self.store_event(
@@ -240,7 +240,7 @@ class ProjectReplaySummaryTestCase(
                     "replay": {"replay_id": self.replay_id},
                     "trace": {
                         "type": "trace",
-                        "trace_id": trace_id,
+                        "trace_id": uuid.uuid4().hex,
                         "span_id": span_id,
                     },
                 },


### PR DESCRIPTION
Handle snuba query errors separately so if one dataset fails, we still get results from the other.
Also updates a test to test both direct and trace conn