### PR TITLE
feat(cursor-agent): allow updating the api key

### DIFF
--- a/src/sentry/integrations/cursor/integration.py
+++ b/src/sentry/integrations/cursor/integration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from typing import Any
 
 from django import forms
@@ -134,7 +134,7 @@ class CursorAgentIntegration(CodingAgentIntegration):
             }
         ]
 
-    def update_organization_config(self, data: dict[str, Any]) -> None:
+    def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
         api_key = data.get("api_key")
         if not api_key:
             raise IntegrationError("API key is required")

--- a/src/sentry/integrations/cursor/integration.py
+++ b/src/sentry/integrations/cursor/integration.py
@@ -21,6 +21,7 @@ from sentry.integrations.coding_agent.integration import (
 from sentry.integrations.cursor.client import CursorAgentClient
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.apitoken import generate_token
 from sentry.shared_integrations.exceptions import IntegrationError
@@ -121,6 +122,31 @@ class CursorAgentIntegrationProvider(CodingAgentIntegrationProvider):
 
 
 class CursorAgentIntegration(CodingAgentIntegration):
+    def get_organization_config(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "api_key",
+                "type": "secret",
+                "label": _("Cursor API Key"),
+                "help": _("Update the API key used by Cursor Background Agents."),
+                "required": True,
+                "placeholder": "***********************",
+            }
+        ]
+
+    def update_organization_config(self, data: dict[str, Any]) -> None:
+        api_key = data.get("api_key")
+        if not api_key:
+            raise IntegrationError("API key is required")
+
+        # Persist on the Integration metadata since this key is global per installation
+        metadata = dict(self.model.metadata or {})
+        metadata["api_key"] = api_key
+        integration_service.update_integration(integration_id=self.model.id, metadata=metadata)
+
+        # Do not store API key in org config; clear any submitted value
+        super().update_organization_config({})
+
     def get_client(self):
         return CursorAgentClient(
             api_key=self.api_key,

--- a/tests/sentry/integrations/cursor/test_integration.py
+++ b/tests/sentry/integrations/cursor/test_integration.py
@@ -155,9 +155,7 @@ class CursorIntegrationTest(IntegrationTestCase):
         assert integration.metadata["api_key"] == "new_secret_key"
 
         # OrganizationIntegration config should remain empty (no secret stored there)
-        from sentry.integrations.models.organization_integration import (
-            OrganizationIntegration,
-        )
+        from sentry.integrations.models.organization_integration import OrganizationIntegration
 
         with assume_test_silo_mode_of(OrganizationIntegration):
             org_integration = OrganizationIntegration.objects.get(

--- a/tests/sentry/integrations/cursor/test_integration.py
+++ b/tests/sentry/integrations/cursor/test_integration.py
@@ -7,6 +7,7 @@ import pytest
 from sentry.integrations.cursor.integration import CursorAgentIntegrationProvider
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils.cases import IntegrationTestCase
+from sentry.testutils.silo import assume_test_silo_mode_of
 
 
 class CursorIntegrationTest(IntegrationTestCase):
@@ -129,3 +130,57 @@ class CursorIntegrationTest(IntegrationTestCase):
         mock_post.assert_called_once()
         call_args = mock_post.call_args
         assert call_args[0][0] == "/v0/agents"
+
+    def test_update_organization_config_persists_api_key_and_clears_org_config(self):
+        # Create a Cursor integration linked to this organization
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor",
+            name="Cursor Agent",
+            external_id="cursor",
+            metadata={
+                "api_key": "old_key",
+                "domain_name": "cursor.sh",
+                "webhook_secret": "secret123",
+            },
+        )
+
+        installation = integration.get_installation(organization_id=self.organization.id)
+
+        # Call update with a new API key
+        installation.update_organization_config({"api_key": "new_secret_key"})
+
+        # Metadata should be updated on the Integration
+        integration.refresh_from_db()
+        assert integration.metadata["api_key"] == "new_secret_key"
+
+        # OrganizationIntegration config should remain empty (no secret stored there)
+        from sentry.integrations.models.organization_integration import (
+            OrganizationIntegration,
+        )
+
+        with assume_test_silo_mode_of(OrganizationIntegration):
+            org_integration = OrganizationIntegration.objects.get(
+                integration_id=integration.id, organization_id=self.organization.id
+            )
+            assert org_integration.config == {}
+
+    def test_update_organization_config_missing_api_key_raises(self):
+        # Create a Cursor integration linked to this organization
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor",
+            name="Cursor Agent",
+            external_id="cursor",
+            metadata={
+                "api_key": "present_key",
+                "domain_name": "cursor.sh",
+                "webhook_secret": "secret123",
+            },
+        )
+
+        installation = integration.get_installation(organization_id=self.organization.id)
+
+        # Missing api_key should raise
+        with pytest.raises(IntegrationError, match="API key is required"):
+            installation.update_organization_config({})


### PR DESCRIPTION
Implements the configuration screen for the Cursor Agent, this way users can change the API key without a full uninstall.

<img width="2960" height="558" alt="CleanShot 2025-09-16 at 15 10 11@2x" src="https://github.com/user-attachments/assets/e1a80e97-cc76-4edb-8fdc-d25636dd09d4" />
