### PR TITLE
fix(cursor-agent): Use the api client for better error logging

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -33,6 +33,7 @@ from sentry.seer.autofix.utils import (
 )
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.shared_integrations.exceptions import ApiError
 
 logger = logging.getLogger(__name__)
 
@@ -367,7 +368,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
 
             try:
                 coding_agent_state = installation.launch(launch_request)
-            except HTTPError:
+            except (HTTPError, ApiError):
                 logger.exception(
                     "coding_agent.repo_launch_error",
                     extra={

--- a/tests/sentry/integrations/cursor/test_client.py
+++ b/tests/sentry/integrations/cursor/test_client.py
@@ -13,7 +13,7 @@ class CursorClientTest(TestCase):
             api_key="test_api_key_123", webhook_secret="test_webhook_secret"
         )
 
-    @patch("requests.post")
+    @patch("sentry.integrations.cursor.client.CursorAgentClient.post")
     def test_launch(self, mock_post):
         from datetime import datetime
 
@@ -23,7 +23,7 @@ class CursorClientTest(TestCase):
 
         # Mock the response
         mock_response = MagicMock()
-        mock_response.json.return_value = {
+        mock_response.json = {
             "id": "test_session_123",
             "name": "Test Session",
             "status": "running",
@@ -60,7 +60,7 @@ class CursorClientTest(TestCase):
         # Verify the API call
         mock_post.assert_called_once()
         call_args = mock_post.call_args
-        assert call_args[0][0] == "https://api.cursor.com/v0/agents"
+        assert call_args[0][0] == "/v0/agents"
 
         # Verify headers
         headers = call_args[1]["headers"]

--- a/tests/sentry/integrations/cursor/test_integration.py
+++ b/tests/sentry/integrations/cursor/test_integration.py
@@ -61,7 +61,7 @@ class CursorIntegrationTest(IntegrationTestCase):
         assert client.api_key == "test_api_key_123"
         assert client.base_url == "https://api.cursor.com"
 
-    @patch("requests.post")
+    @patch("sentry.integrations.cursor.client.CursorAgentClient.post")
     def test_launch(self, mock_post):
         from datetime import datetime
 
@@ -71,7 +71,7 @@ class CursorIntegrationTest(IntegrationTestCase):
 
         # Mock the response
         mock_response = MagicMock()
-        mock_response.json.return_value = {
+        mock_response.json = {
             "id": "test_session_123",
             "name": "Test Session",
             "status": "running",
@@ -128,4 +128,4 @@ class CursorIntegrationTest(IntegrationTestCase):
         # Verify the API call
         mock_post.assert_called_once()
         call_args = mock_post.call_args
-        assert call_args[0][0] == "https://api.cursor.com/v0/agents"
+        assert call_args[0][0] == "/v0/agents"


### PR DESCRIPTION
We weren't actually using the api client that we extend...the `raise_for_status()` we used earlier had really vague errors that were hard to debug.

Ran locally and verified working