### PR TITLE
fix(eco): Handles case where Gitlab default identity is missing

### DIFF
--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -46,7 +46,7 @@ from sentry.pipeline.views.base import PipelineView
 from sentry.pipeline.views.nested import NestedPipelineView
 from sentry.shared_integrations.exceptions import (
     ApiError,
-    IntegrationError,
+    IntegrationConfigurationError,
     IntegrationProviderError,
 )
 from sentry.snuba.referrer import Referrer
@@ -132,8 +132,8 @@ class GitlabIntegration(RepositoryIntegration, GitlabIssuesSpec, CommitContextIn
         try:
             # eagerly populate this just for the error message
             self.default_identity
-        except Identity.DoesNotExist:
-            raise IntegrationError("Identity not found.")
+        except Identity.DoesNotExist as e:
+            raise IntegrationConfigurationError("Identity not found.") from e
         else:
             return GitLabApiClient(self)
 

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -23,6 +23,7 @@ from sentry.shared_integrations.exceptions import (
     ApiForbiddenError,
     ApiRetryError,
     ApiUnauthorized,
+    IntegrationConfigurationError,
     IntegrationError,
 )
 from sentry.users.models.identity import Identity
@@ -225,11 +226,12 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
             scope.set_tag("stacktrace_link.used_version", False)
             try:
                 source_url = self.check_file(repo, filepath, default)
-            except ApiForbiddenError as e:
+            except (ApiForbiddenError, IntegrationConfigurationError) as e:
                 # Similar to the `check_file` implementation, we need to re-raise
                 # for 403 errors as these need to be propagated to the user.
                 lifecycle.record_halt(e)
                 raise
+
             return encode_url(source_url) if source_url else None
 
     def get_codeowner_file(

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -156,7 +156,7 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
             except ApiUnauthorized as e:
                 lifecycle.record_halt(e)
                 return None
-            except ApiForbiddenError as e:
+            except (ApiForbiddenError, IntegrationConfigurationError) as e:
                 lifecycle.record_halt(e)
                 # Need to re-raise since 403 errors will be returned to user via get_link
                 raise


### PR DESCRIPTION
Fixes SENTRY-3ZWV

Handles the case where Gitlab clients fail to be instantiated when the default identity linked to the installation is missing. While not ideal, this case doesn't warrant creating Sentry issues, and can be addressed by reinstalling the integration.
