### PR TITLE
fix(aci): update discord action to take targetIdentifier

### DIFF
--- a/static/app/views/automations/components/actions/discord.tsx
+++ b/static/app/views/automations/components/actions/discord.tsx
@@ -1,5 +1,6 @@
 import {Flex} from 'sentry/components/core/layout';
 import {ExternalLink} from 'sentry/components/core/link';
+import {AutomationBuilderInput} from 'sentry/components/workflowEngine/form/automationBuilderInput';
 import {
   OptionalRowLine,
   RowLine,
@@ -12,9 +13,10 @@ import {
   type Action,
   type ActionHandler,
 } from 'sentry/types/workflowEngine/actions';
+import {useActionNodeContext} from 'sentry/views/automations/components/actionNodes';
 import {IntegrationField} from 'sentry/views/automations/components/actions/integrationField';
 import {TagsField} from 'sentry/views/automations/components/actions/tagsField';
-import {TargetDisplayField} from 'sentry/views/automations/components/actions/targetDisplayField';
+import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 
 export function DiscordDetails({
   action,
@@ -45,7 +47,7 @@ export function DiscordNode() {
         {tct('Send a [logo] Discord message to [server] server, to [channel]', {
           logo: ActionMetadata[ActionType.DISCORD]?.icon,
           server: <IntegrationField />,
-          channel: <TargetDisplayField placeholder={t('channel ID or URL')} />,
+          channel: <TargetIdentifierField />,
         })}
       </RowLine>
       <OptionalRowLine>
@@ -62,6 +64,25 @@ export function DiscordNode() {
         )}
       </DismissableInfoAlert>
     </Flex>
+  );
+}
+
+export function TargetIdentifierField() {
+  const {action, actionId, onUpdate} = useActionNodeContext();
+  const {removeError} = useAutomationBuilderErrorContext();
+
+  return (
+    <AutomationBuilderInput
+      name={`${actionId}.config.targetIdentifier`}
+      placeholder={t('channel ID or URL')}
+      value={action.config.targetIdentifier}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+        onUpdate({
+          config: {...action.config, targetIdentifier: e.target.value},
+        });
+        removeError(action.id);
+      }}
+    />
   );
 }
 

--- a/static/app/views/automations/components/actions/discord.tsx
+++ b/static/app/views/automations/components/actions/discord.tsx
@@ -90,7 +90,7 @@ export function validateDiscordAction(action: Action): string | undefined {
   if (!action.integrationId) {
     return t('You must specify a Discord server.');
   }
-  if (!action.config.targetDisplay) {
+  if (!action.config.targetIdentifier) {
     return t('You must specify a channel ID or URL.');
   }
   return undefined;

--- a/static/app/views/automations/components/actions/discord.tsx
+++ b/static/app/views/automations/components/actions/discord.tsx
@@ -67,7 +67,7 @@ export function DiscordNode() {
   );
 }
 
-export function TargetIdentifierField() {
+function TargetIdentifierField() {
   const {action, actionId, onUpdate} = useActionNodeContext();
   const {removeError} = useAutomationBuilderErrorContext();
 

--- a/static/app/views/automations/components/actions/msTeams.tsx
+++ b/static/app/views/automations/components/actions/msTeams.tsx
@@ -21,7 +21,7 @@ export function MSTeamsDetails({
   return tct('Send a [logo] Microsoft Teams notification to [team] team, to [channel]', {
     logo: ActionMetadata[ActionType.MSTEAMS]?.icon,
     team: integrationName,
-    channel: String(action.config.targetIdentifier),
+    channel: action.config.targetDisplay || action.config.targetIdentifier,
   });
 }
 


### PR DESCRIPTION
Discord is different from Slack/MSTeams where it only takes the channel ID/URL (not name), which is saved in targetIdentifier