### PR TITLE
Remove Flag user-feedback-ai-categorization Flag Usage in Sentry

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -496,8 +496,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:use-case-insensitive-codeowners", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:user-feedback-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable label generation at ingest time for user feedbacks
-    manager.add("organizations:user-feedback-ai-categorization", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the backend endpoint and frontend for categorizing user feedbacks
     manager.add("organizations:user-feedback-ai-categorization-features", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable AI-powered title generation for user feedback

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -358,9 +358,7 @@ def create_feedback_issue(
     )
 
     # Generating labels using Seer, which will later be used to categorize feedbacks
-    if should_query_seer and features.has(
-        "organizations:user-feedback-ai-categorization", project.organization
-    ):
+    if should_query_seer:
         try:
             labels = generate_labels(feedback_message, project.organization_id)
             # This will rarely happen unless the user writes a really long feedback message

--- a/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
@@ -1009,9 +1009,7 @@ def test_create_feedback_adds_ai_labels(
         mock_generate_labels,
     ):
 
-        create_feedback_issue(
-            event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-        )
+        create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
     assert mock_produce_occurrence_to_kafka.call_count == 1
     produced_event = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]
@@ -1046,9 +1044,7 @@ def test_create_feedback_handles_label_generation_errors(
         mock_generate_labels,
     ):
         # This should not raise an exception and should still create the feedback
-        create_feedback_issue(
-            event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-        )
+        create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
     # Verify that the feedback was still created successfully
     assert mock_produce_occurrence_to_kafka.call_count == 1
@@ -1068,9 +1064,7 @@ def test_create_feedback_truncates_ai_labels_max_list_length(
     """Test that create_feedback_issue truncates AI labels when more than MAX_AI_LABELS are returned. If the list of labels is longer than MAX_AI_LABELS_JSON_LENGTH characters, the list is truncated in this test to match the intended behaviour."""
     mock_has_seer_access.return_value = True
     event = mock_feedback_event(default_project.id)
-    event["contexts"]["feedback"][
-        "message"
-    ] = "This is a very complex feedback with many issues"
+    event["contexts"]["feedback"]["message"] = "This is a very complex feedback with many issues"
 
     alphabet = "abcdefghijklmnopqrstuvwxyz"
 
@@ -1083,9 +1077,7 @@ def test_create_feedback_truncates_ai_labels_max_list_length(
         "sentry.feedback.usecases.ingest.create_feedback.generate_labels",
         mock_generate_labels,
     ):
-        create_feedback_issue(
-            event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-        )
+        create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
     assert mock_produce_occurrence_to_kafka.call_count == 1
 
@@ -1104,9 +1096,7 @@ def test_create_feedback_truncates_ai_labels_max_list_length(
     ai_labels = [
         value for key, value in tags.items() if key.startswith(f"{AI_LABEL_TAG_PREFIX}.label.")
     ]
-    assert (
-        len(ai_labels) == labels_list_length
-    ), "Should be truncated to exactly labels_list_length"
+    assert len(ai_labels) == labels_list_length, "Should be truncated to exactly labels_list_length"
 
     for i in range(labels_list_length):
         assert tags[f"{AI_LABEL_TAG_PREFIX}.label.{i}"] == expected_labels[i]
@@ -1126,9 +1116,7 @@ def test_create_feedback_truncates_ai_labels_max_json_length(
     mock_has_seer_access.return_value = True
     event = mock_feedback_event(default_project.id)
 
-    event["contexts"]["feedback"][
-        "message"
-    ] = "This is a very complex feedback with many issues"
+    event["contexts"]["feedback"]["message"] = "This is a very complex feedback with many issues"
 
     # The serialized list of labels should be longer than MAX_AI_LABELS_JSON_LENGTH characters, so we should only take the first item
     def mock_generate_labels(*args, **kwargs):
@@ -1138,9 +1126,7 @@ def test_create_feedback_truncates_ai_labels_max_json_length(
         "sentry.feedback.usecases.ingest.create_feedback.generate_labels",
         mock_generate_labels,
     ):
-        create_feedback_issue(
-            event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-        )
+        create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
     assert mock_produce_occurrence_to_kafka.call_count == 1
 

--- a/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
@@ -997,40 +997,35 @@ def test_create_feedback_adds_ai_labels(
 ) -> None:
     """Test that create_feedback_issue adds AI labels to tags when label generation succeeds."""
     mock_has_seer_access.return_value = True
-    with Feature(
-        {
-            "organizations:user-feedback-ai-categorization": True,
-        }
+    event = mock_feedback_event(default_project.id)
+    event["contexts"]["feedback"]["message"] = "The login button is broken and the UI is slow"
+
+    # This assumes that the maximum number of labels allowed is greater than 3
+    def mock_generate_labels(*args, **kwargs):
+        return ["User Interface", "Authentication", "Performance"]
+
+    with patch(
+        "sentry.feedback.usecases.ingest.create_feedback.generate_labels",
+        mock_generate_labels,
     ):
-        event = mock_feedback_event(default_project.id)
-        event["contexts"]["feedback"]["message"] = "The login button is broken and the UI is slow"
 
-        # This assumes that the maximum number of labels allowed is greater than 3
-        def mock_generate_labels(*args, **kwargs):
-            return ["User Interface", "Authentication", "Performance"]
+        create_feedback_issue(
+            event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+        )
 
-        with patch(
-            "sentry.feedback.usecases.ingest.create_feedback.generate_labels",
-            mock_generate_labels,
-        ):
+    assert mock_produce_occurrence_to_kafka.call_count == 1
+    produced_event = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]
+    tags = produced_event["tags"]
 
-            create_feedback_issue(
-                event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
+    ai_labels = [
+        value for key, value in tags.items() if key.startswith(f"{AI_LABEL_TAG_PREFIX}.label.")
+    ]
 
-        assert mock_produce_occurrence_to_kafka.call_count == 1
-        produced_event = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]
-        tags = produced_event["tags"]
+    expected_labels = ["Authentication", "Performance", "User Interface"]
 
-        ai_labels = [
-            value for key, value in tags.items() if key.startswith(f"{AI_LABEL_TAG_PREFIX}.label.")
-        ]
-
-        expected_labels = ["Authentication", "Performance", "User Interface"]
-
-        assert len(ai_labels) == 3
-        assert set(ai_labels) == set(expected_labels)
-        assert tags[f"{AI_LABEL_TAG_PREFIX}.labels"] == json.dumps(expected_labels)
+    assert len(ai_labels) == 3
+    assert set(ai_labels) == set(expected_labels)
+    assert tags[f"{AI_LABEL_TAG_PREFIX}.labels"] == json.dumps(expected_labels)
 
 
 @django_db_all
@@ -1039,36 +1034,31 @@ def test_create_feedback_handles_label_generation_errors(
 ) -> None:
     """Test that create_feedback_issue continues to work even when generate_labels raises an error."""
     mock_has_seer_access.return_value = True
-    with Feature(
-        {
-            "organizations:user-feedback-ai-categorization": True,
-        }
+    event = mock_feedback_event(default_project.id)
+    event["contexts"]["feedback"]["message"] = "This is a valid feedback message"
+
+    # Mock generate_labels to raise an exception
+    def mock_generate_labels(*args, **kwargs):
+        raise Exception("Label generation failed")
+
+    with patch(
+        "sentry.feedback.usecases.ingest.create_feedback.generate_labels",
+        mock_generate_labels,
     ):
-        event = mock_feedback_event(default_project.id)
-        event["contexts"]["feedback"]["message"] = "This is a valid feedback message"
+        # This should not raise an exception and should still create the feedback
+        create_feedback_issue(
+            event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+        )
 
-        # Mock generate_labels to raise an exception
-        def mock_generate_labels(*args, **kwargs):
-            raise Exception("Label generation failed")
+    # Verify that the feedback was still created successfully
+    assert mock_produce_occurrence_to_kafka.call_count == 1
 
-        with patch(
-            "sentry.feedback.usecases.ingest.create_feedback.generate_labels",
-            mock_generate_labels,
-        ):
-            # This should not raise an exception and should still create the feedback
-            create_feedback_issue(
-                event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
+    produced_event = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]
+    tags = produced_event["tags"]
 
-        # Verify that the feedback was still created successfully
-        assert mock_produce_occurrence_to_kafka.call_count == 1
-
-        produced_event = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]
-        tags = produced_event["tags"]
-
-        ai_labels = [tag for tag in tags.keys() if tag.startswith(f"{AI_LABEL_TAG_PREFIX}.label.")]
-        assert len(ai_labels) == 0
-        assert f"{AI_LABEL_TAG_PREFIX}.labels" not in tags
+    ai_labels = [tag for tag in tags.keys() if tag.startswith(f"{AI_LABEL_TAG_PREFIX}.label.")]
+    assert len(ai_labels) == 0
+    assert f"{AI_LABEL_TAG_PREFIX}.labels" not in tags
 
 
 @django_db_all
@@ -1077,60 +1067,55 @@ def test_create_feedback_truncates_ai_labels_max_list_length(
 ) -> None:
     """Test that create_feedback_issue truncates AI labels when more than MAX_AI_LABELS are returned. If the list of labels is longer than MAX_AI_LABELS_JSON_LENGTH characters, the list is truncated in this test to match the intended behaviour."""
     mock_has_seer_access.return_value = True
-    with Feature(
-        {
-            "organizations:user-feedback-ai-categorization": True,
-        }
+    event = mock_feedback_event(default_project.id)
+    event["contexts"]["feedback"][
+        "message"
+    ] = "This is a very complex feedback with many issues"
+
+    alphabet = "abcdefghijklmnopqrstuvwxyz"
+
+    # Mock generate_labels to return more than MAX_AI_LABELS labels
+    # The labels should be sorted alphabetically, so don't store numbers, instead use letters
+    def mock_generate_labels(*args, **kwargs):
+        return [f"{alphabet[i]}" for i in range(MAX_AI_LABELS + 5)]
+
+    with patch(
+        "sentry.feedback.usecases.ingest.create_feedback.generate_labels",
+        mock_generate_labels,
     ):
-        event = mock_feedback_event(default_project.id)
-        event["contexts"]["feedback"][
-            "message"
-        ] = "This is a very complex feedback with many issues"
+        create_feedback_issue(
+            event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+        )
 
-        alphabet = "abcdefghijklmnopqrstuvwxyz"
+    assert mock_produce_occurrence_to_kafka.call_count == 1
 
-        # Mock generate_labels to return more than MAX_AI_LABELS labels
-        # The labels should be sorted alphabetically, so don't store numbers, instead use letters
-        def mock_generate_labels(*args, **kwargs):
-            return [f"{alphabet[i]}" for i in range(MAX_AI_LABELS + 5)]
+    # Don't use ai_labels since we don't rely on dict order
+    expected_labels = [f"{alphabet[i]}" for i in range(MAX_AI_LABELS)]
 
-        with patch(
-            "sentry.feedback.usecases.ingest.create_feedback.generate_labels",
-            mock_generate_labels,
-        ):
-            create_feedback_issue(
-                event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
+    # Truncate the labels so the serialized list is within the allowed length
+    while len(json.dumps(expected_labels)) > MAX_AI_LABELS_JSON_LENGTH:
+        expected_labels.pop()
 
-        assert mock_produce_occurrence_to_kafka.call_count == 1
+    labels_list_length = min(len(expected_labels), MAX_AI_LABELS)
 
-        # Don't use ai_labels since we don't rely on dict order
-        expected_labels = [f"{alphabet[i]}" for i in range(MAX_AI_LABELS)]
+    produced_event = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]
+    tags = produced_event["tags"]
 
-        # Truncate the labels so the serialized list is within the allowed length
-        while len(json.dumps(expected_labels)) > MAX_AI_LABELS_JSON_LENGTH:
-            expected_labels.pop()
+    ai_labels = [
+        value for key, value in tags.items() if key.startswith(f"{AI_LABEL_TAG_PREFIX}.label.")
+    ]
+    assert (
+        len(ai_labels) == labels_list_length
+    ), "Should be truncated to exactly labels_list_length"
 
-        labels_list_length = min(len(expected_labels), MAX_AI_LABELS)
+    for i in range(labels_list_length):
+        assert tags[f"{AI_LABEL_TAG_PREFIX}.label.{i}"] == expected_labels[i]
 
-        produced_event = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]
-        tags = produced_event["tags"]
+    assert tags[f"{AI_LABEL_TAG_PREFIX}.labels"] == json.dumps(expected_labels)
 
-        ai_labels = [
-            value for key, value in tags.items() if key.startswith(f"{AI_LABEL_TAG_PREFIX}.label.")
-        ]
-        assert (
-            len(ai_labels) == labels_list_length
-        ), "Should be truncated to exactly labels_list_length"
-
-        for i in range(labels_list_length):
-            assert tags[f"{AI_LABEL_TAG_PREFIX}.label.{i}"] == expected_labels[i]
-
-        assert tags[f"{AI_LABEL_TAG_PREFIX}.labels"] == json.dumps(expected_labels)
-
-        # Verify that labels beyond labels_list_length are not present
-        for i in range(labels_list_length, labels_list_length + 5):
-            assert f"{AI_LABEL_TAG_PREFIX}.label.{i}" not in tags
+    # Verify that labels beyond labels_list_length are not present
+    for i in range(labels_list_length, labels_list_length + 5):
+        assert f"{AI_LABEL_TAG_PREFIX}.label.{i}" not in tags
 
 
 @django_db_all
@@ -1139,40 +1124,35 @@ def test_create_feedback_truncates_ai_labels_max_json_length(
 ) -> None:
     """Test that create_feedback_issue truncates AI labels when the serialized list of labels is longer than MAX_AI_LABELS_JSON_LENGTH characters."""
     mock_has_seer_access.return_value = True
-    with Feature(
-        {
-            "organizations:user-feedback-ai-categorization": True,
-        }
+    event = mock_feedback_event(default_project.id)
+
+    event["contexts"]["feedback"][
+        "message"
+    ] = "This is a very complex feedback with many issues"
+
+    # The serialized list of labels should be longer than MAX_AI_LABELS_JSON_LENGTH characters, so we should only take the first item
+    def mock_generate_labels(*args, **kwargs):
+        return ["a" * (MAX_AI_LABELS_JSON_LENGTH - 50)] * 100
+
+    with patch(
+        "sentry.feedback.usecases.ingest.create_feedback.generate_labels",
+        mock_generate_labels,
     ):
-        event = mock_feedback_event(default_project.id)
-
-        event["contexts"]["feedback"][
-            "message"
-        ] = "This is a very complex feedback with many issues"
-
-        # The serialized list of labels should be longer than MAX_AI_LABELS_JSON_LENGTH characters, so we should only take the first item
-        def mock_generate_labels(*args, **kwargs):
-            return ["a" * (MAX_AI_LABELS_JSON_LENGTH - 50)] * 100
-
-        with patch(
-            "sentry.feedback.usecases.ingest.create_feedback.generate_labels",
-            mock_generate_labels,
-        ):
-            create_feedback_issue(
-                event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
-            )
-
-        assert mock_produce_occurrence_to_kafka.call_count == 1
-
-        produced_event = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]
-        tags = produced_event["tags"]
-
-        ai_labels = [
-            value for key, value in tags.items() if key.startswith(f"{AI_LABEL_TAG_PREFIX}.label.")
-        ]
-
-        assert len(ai_labels) == 1
-        assert tags[f"{AI_LABEL_TAG_PREFIX}.label.0"] == "a" * (MAX_AI_LABELS_JSON_LENGTH - 50)
-        assert tags[f"{AI_LABEL_TAG_PREFIX}.labels"] == json.dumps(
-            ["a" * (MAX_AI_LABELS_JSON_LENGTH - 50)]
+        create_feedback_issue(
+            event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
         )
+
+    assert mock_produce_occurrence_to_kafka.call_count == 1
+
+    produced_event = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]
+    tags = produced_event["tags"]
+
+    ai_labels = [
+        value for key, value in tags.items() if key.startswith(f"{AI_LABEL_TAG_PREFIX}.label.")
+    ]
+
+    assert len(ai_labels) == 1
+    assert tags[f"{AI_LABEL_TAG_PREFIX}.label.0"] == "a" * (MAX_AI_LABELS_JSON_LENGTH - 50)
+    assert tags[f"{AI_LABEL_TAG_PREFIX}.labels"] == json.dumps(
+        ["a" * (MAX_AI_LABELS_JSON_LENGTH - 50)]
+    )


### PR DESCRIPTION
The GA value of organizations:user-feedback-ai-categorization is 100 in [flagpole.yaml,](https://github.com/getsentry/sentry-options-automator/blob/main/options/default/flagpole.yaml) but the flag is still being used in the sentry codebase.

Ticket: https://linear.app/getsentry/issue/REPLAY-656/identify-and-cleanup-any-fully-released-feature-flags-owned-by-team

