### PR TITLE
ref(feedback): show tooltip on spam mailbox if gen ai features/seer is not set up

### DIFF
--- a/static/app/components/feedback/list/mailboxPicker.tsx
+++ b/static/app/components/feedback/list/mailboxPicker.tsx
@@ -2,11 +2,13 @@ import {useTheme} from '@emotion/react';
 
 import {Badge} from 'sentry/components/core/badge';
 import {Flex} from 'sentry/components/core/layout';
+import {Link} from 'sentry/components/core/link';
 import {SegmentedControl} from 'sentry/components/core/segmentedControl';
 import {Tooltip} from 'sentry/components/core/tooltip';
+import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import type decodeMailbox from 'sentry/components/feedback/decodeMailbox';
 import useMailboxCounts from 'sentry/components/feedback/list/useMailboxCounts';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type Mailbox = ReturnType<typeof decodeMailbox>;
@@ -16,16 +18,39 @@ interface Props {
   value: Mailbox;
 }
 
-const MAILBOXES = [
-  {key: 'unresolved', label: t('Inbox')},
-  {key: 'resolved', label: t('Resolved')},
-  {key: 'ignored', label: t('Spam')},
-];
-
 export default function MailboxPicker({onChange, value}: Props) {
   const organization = useOrganization();
   const {data} = useMailboxCounts({organization});
   const theme = useTheme();
+  const {areAiFeaturesAllowed, setupAcknowledgement} = useOrganizationSeerSetup();
+
+  const hasSpamFeature = organization.features.includes('user-feedback-spam-ingest');
+  const hasAiFeatures = areAiFeaturesAllowed && setupAcknowledgement.orgHasAcknowledged;
+
+  const MAILBOXES = [
+    {key: 'unresolved', label: t('Inbox')},
+    {key: 'resolved', label: t('Resolved')},
+    {
+      key: 'ignored',
+      label: t('Spam'),
+      // only show an AI info tooltip if the org has auto spam detection available,
+      // but not the correct AI flags or seer acknowledgement.
+      tooltip:
+        hasSpamFeature && !hasAiFeatures
+          ? tct(
+              'Generative AI Features and Seer access are required for auto spam detection. Check that [linkGenAI:Generative AI Features] are toggled on, then view the [linkSeer:Seer settings page] for more information.',
+              {
+                linkSeer: <Link to={`/settings/${organization.slug}/seer/`} />,
+                linkGenAI: (
+                  <Link
+                    to={`/settings/${organization.slug}/organization/#hideAiFeatures`}
+                  />
+                ),
+              }
+            )
+          : undefined,
+    },
+  ];
 
   const filteredMailboxes = MAILBOXES;
 
@@ -47,7 +72,13 @@ export default function MailboxPicker({onChange, value}: Props) {
             <SegmentedControl.Item key={mailbox.key} aria-label={mailbox.label}>
               <Tooltip disabled={!count} title={title}>
                 <Flex align="center" gap={theme.isChonk ? 'sm' : '0'}>
-                  {mailbox.label}
+                  {mailbox.tooltip ? (
+                    <Tooltip isHoverable title={mailbox.tooltip}>
+                      {mailbox.label}
+                    </Tooltip>
+                  ) : (
+                    mailbox.label
+                  )}
                   {display ? <Badge type="default">{display}</Badge> : null}
                 </Flex>
               </Tooltip>

--- a/static/app/components/feedback/list/mailboxPicker.tsx
+++ b/static/app/components/feedback/list/mailboxPicker.tsx
@@ -9,6 +9,8 @@ import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrga
 import type decodeMailbox from 'sentry/components/feedback/decodeMailbox';
 import useMailboxCounts from 'sentry/components/feedback/list/useMailboxCounts';
 import {t, tct} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type Mailbox = ReturnType<typeof decodeMailbox>;
@@ -22,8 +24,9 @@ export default function MailboxPicker({onChange, value}: Props) {
   const organization = useOrganization();
   const {data} = useMailboxCounts({organization});
   const theme = useTheme();
-  const {areAiFeaturesAllowed, setupAcknowledgement} = useOrganizationSeerSetup();
+  const {isSelfHosted} = useLegacyStore(ConfigStore);
 
+  const {areAiFeaturesAllowed, setupAcknowledgement} = useOrganizationSeerSetup();
   const hasSpamFeature = organization.features.includes('user-feedback-spam-ingest');
   const hasAiFeatures = areAiFeaturesAllowed && setupAcknowledgement.orgHasAcknowledged;
 
@@ -36,7 +39,7 @@ export default function MailboxPicker({onChange, value}: Props) {
       // only show an AI info tooltip if the org has auto spam detection available,
       // but not the correct AI flags or seer acknowledgement.
       tooltip:
-        hasSpamFeature && !hasAiFeatures
+        hasSpamFeature && !hasAiFeatures && !isSelfHosted
           ? tct(
               'Generative AI Features and Seer access are required for auto spam detection. Check that [linkGenAI:Generative AI Features] are toggled on, then view the [linkSeer:Seer settings page] for more information.',
               {


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-710/spam-detection-should-be-gated-behind-gen-ai-features-and-seer

the tooltip shows up when the org has the spam feature available (`'user-feedback-spam-ingest'` is true) but the org does not have AI feature flags or the seer acknowledgement set up. this will help educate users how to turn spam detection back on, since spam detection may silently stop when we make the backend changes in https://github.com/getsentry/sentry/pull/99608. 

otherwise, if the org doesn't have the spam FF, the mailbox shouldn't be associated with AI (it will just contain manual spam).

https://github.com/user-attachments/assets/78657884-b8a5-4ff9-8db2-ec7395230904

also see: https://github.com/getsentry/sentry/pull/99630

