### PR TITLE
feat(prevent): Redirect between TA onboard vs tests

### DIFF
--- a/static/app/views/prevent/tests/onboarding.spec.tsx
+++ b/static/app/views/prevent/tests/onboarding.spec.tsx
@@ -39,6 +39,11 @@ const mockRepositories = [
   },
 ];
 
+const mockRepoData = {
+  testAnalyticsEnabled: false,
+  uploadToken: 'test-token',
+};
+
 describe('TestsOnboardingPage', () => {
   beforeEach(() => {
     MockApiClient.addMockResponse({
@@ -62,6 +67,11 @@ describe('TestsOnboardingPage', () => {
       body: {
         isSyncing: false,
       },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/prevent/owner/123/repository/test-repo/`,
+      body: mockRepoData,
     });
   });
 
@@ -362,25 +372,43 @@ describe('TestsOnboardingPage', () => {
             },
           }
         );
-        expect(
-          await screen.findByText('Step 1: Output a JUnit XML file in your CI')
-        ).toBeInTheDocument();
-        expect(await screen.findByText('Step 2: Add token as')).toBeInTheDocument();
-        expect(screen.getAllByRole('link', {name: 'Sentry Prevent CLI'})).toHaveLength(2);
-        expect(
-          await screen.findByText('Step 3: Install the', {exact: false})
-        ).toBeInTheDocument();
-        expect(
-          await screen.findByText(
-            'Step 4: Upload this file to Sentry Prevent using the CLI'
-          )
-        ).toBeInTheDocument();
-        expect(
-          await screen.findByText('Step 5: Run your test suite')
-        ).toBeInTheDocument();
-        expect(
-          await screen.findByText('Step 6: View results and insights')
-        ).toBeInTheDocument();
+        await Promise.all([
+          waitFor(() =>
+            expect(
+              screen.getByText('Step 1: Output a JUnit XML file in your CI')
+            ).toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(
+              screen.getByText('Step 2: Add token as', {exact: false})
+            ).toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(
+              screen.getAllByRole('link', {name: 'Sentry Prevent CLI'})
+            ).toHaveLength(2)
+          ),
+
+          waitFor(() =>
+            expect(
+              screen.getByText('Step 3: Install the', {exact: false})
+            ).toBeInTheDocument()
+          ),
+
+          waitFor(() =>
+            expect(
+              screen.getByText('Step 4: Upload this file to Sentry Prevent using the CLI')
+            ).toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(screen.getByText('Step 5: Run your test suite')).toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(
+              screen.getByText('Step 6: View results and insights')
+            ).toBeInTheDocument()
+          ),
+        ]);
 
         // GitHub Actions specific steps should NOT be present
         expect(
@@ -412,25 +440,41 @@ describe('TestsOnboardingPage', () => {
         );
 
         // Should show CLI steps regardless of upload permission
-        expect(
-          await screen.findByText('Step 1: Output a JUnit XML file in your CI')
-        ).toBeInTheDocument();
-        expect(await screen.findByText('Step 2: Add token as')).toBeInTheDocument();
-        expect(
-          await screen.findAllByRole('link', {name: 'Sentry Prevent CLI'})
-        ).toHaveLength(2);
-        expect(
-          await screen.findByText('Step 3: Install the', {exact: false})
-        ).toBeInTheDocument();
-        expect(
-          await screen.findByText(
-            'Step 4: Upload this file to Sentry Prevent using the CLI'
-          )
-        ).toBeInTheDocument();
-        expect(
-          await screen.findByText('Step 5: Run your test suite')
-        ).toBeInTheDocument();
-        expect(screen.getByText('Step 6: View results and insights')).toBeInTheDocument();
+        await Promise.all([
+          waitFor(() =>
+            expect(
+              screen.getByText('Step 1: Output a JUnit XML file in your CI')
+            ).toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(
+              screen.getByText('Step 2: Add token as', {exact: false})
+            ).toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(
+              screen.getAllByRole('link', {name: 'Sentry Prevent CLI'})
+            ).toHaveLength(2)
+          ),
+          waitFor(() =>
+            expect(
+              screen.getByText('Step 3: Install the', {exact: false})
+            ).toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(
+              screen.getByText('Step 4: Upload this file to Sentry Prevent using the CLI')
+            ).toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(screen.getByText('Step 5: Run your test suite')).toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(
+              screen.getByText('Step 6: View results and insights')
+            ).toBeInTheDocument()
+          ),
+        ]);
 
         // Switch to GitHub Actions
         const githubRadio = await screen.findByLabelText(
@@ -439,35 +483,200 @@ describe('TestsOnboardingPage', () => {
         await userEvent.click(githubRadio);
 
         // Should now show GitHub Actions steps
-        expect(
-          await screen.findByText('Step 1: Output a JUnit XML file in your CI')
-        ).toBeInTheDocument();
-        expect(
-          await screen.findByText('Step 2: Choose an upload permission')
-        ).toBeInTheDocument();
-        expect(
-          await screen.findByText('Step 3: Edit your GitHub Actions workflow')
-        ).toBeInTheDocument();
-        expect(
-          await screen.findByText('Step 4: Run your test suite')
-        ).toBeInTheDocument();
-        expect(
-          await screen.findByText('Step 5: View results and insights')
-        ).toBeInTheDocument();
+        await Promise.all([
+          waitFor(() =>
+            expect(
+              screen.getByText('Step 1: Output a JUnit XML file in your CI')
+            ).toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(
+              screen.getByText('Step 2: Choose an upload permission')
+            ).toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(
+              screen.getByText('Step 3: Edit your GitHub Actions workflow')
+            ).toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(screen.getByText('Step 4: Run your test suite')).toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(
+              screen.getByText('Step 5: View results and insights')
+            ).toBeInTheDocument()
+          ),
 
-        // CLI specific steps should NOT be present
-        expect(screen.queryByText('Step 2: Add token as')).not.toBeInTheDocument();
-        expect(
-          screen.queryByRole('link', {name: 'Sentry Prevent CLI'})
-        ).not.toBeInTheDocument();
-        expect(screen.queryByText('Step 3: Install the')).not.toBeInTheDocument();
-        expect(
-          screen.queryByText('Step 4: Upload this file to Sentry Prevent using the CLI')
-        ).not.toBeInTheDocument();
-        expect(
-          screen.queryByText('Step 6: View results and insights')
-        ).not.toBeInTheDocument();
+          // CLI specific steps should NOT be present
+          waitFor(() =>
+            expect(screen.queryByText('Step 2: Add token as')).not.toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(
+              screen.queryByRole('link', {name: 'Sentry Prevent CLI'})
+            ).not.toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(screen.queryByText('Step 3: Install the')).not.toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(
+              screen.queryByText(
+                'Step 4: Upload this file to Sentry Prevent using the CLI'
+              )
+            ).not.toBeInTheDocument()
+          ),
+          waitFor(() =>
+            expect(
+              screen.queryByText('Step 6: View results and insights')
+            ).not.toBeInTheDocument()
+          ),
+        ]);
       });
+    });
+  });
+
+  describe('Token Generation', () => {
+    it('generates repository token and shows token after clicking generate button', async () => {
+      // Mock repo data without token initially
+      const mockRepoDataWithoutToken = {
+        testAnalyticsEnabled: false,
+        uploadToken: null,
+      };
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/prevent/owner/123/repository/test-repo/`,
+        body: mockRepoDataWithoutToken,
+      });
+
+      // Mock the regenerate token API call
+      const regenerateTokenMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/prevent/owner/123/repository/test-repo/token/regenerate/',
+        method: 'POST',
+        body: {
+          token: 'new-generated-token-12345',
+        },
+      });
+
+      render(
+        <PreventContext.Provider value={mockPreventContext}>
+          <TestsOnboardingPage />
+        </PreventContext.Provider>,
+        {
+          initialRouterConfig: {
+            location: {
+              pathname: '/prevent/tests/new',
+              query: {opt: 'githubAction'},
+            },
+          },
+        }
+      );
+
+      // Change upload permission to Upload Token to show the AddUploadTokenStep
+      const uploadTokenRadio = await screen.findByLabelText(
+        'Use Sentry Prevent Upload Token'
+      );
+      await userEvent.click(uploadTokenRadio);
+
+      await screen.findByText('Step 2b: Add token as');
+
+      // Initially should show generate button
+      expect(
+        screen.getByRole('button', {name: 'Generate Repository Token'})
+      ).toBeInTheDocument();
+
+      // Should not show token initially
+      expect(screen.queryByText('SENTRY_PREVENT_TOKEN')).not.toBeInTheDocument();
+
+      // Mock the updated repo data with token after regeneration
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/prevent/owner/123/repository/test-repo/`,
+        body: {
+          ...mockRepoDataWithoutToken,
+          uploadToken: 'new-generated-token-12345',
+        },
+      });
+
+      // Click the generate button
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Generate Repository Token'})
+      );
+
+      // Wait for the API call to complete
+      await waitFor(() => {
+        expect(regenerateTokenMock).toHaveBeenCalledWith(
+          '/organizations/org-slug/prevent/owner/123/repository/test-repo/token/regenerate/',
+          expect.objectContaining({
+            method: 'POST',
+          })
+        );
+      });
+
+      // token should now be showing
+      expect(await screen.findByText('SENTRY_PREVENT_TOKEN')).toBeInTheDocument();
+      expect(screen.getByText('new-generated-token-12345')).toBeInTheDocument();
+    });
+  });
+
+  describe('Regenerate Token', () => {
+    it('show existing token and regenerates token on button click', async () => {
+      const mockRepoDataWithToken = {
+        testAnalyticsEnabled: false,
+        uploadToken: 'old-generated-token-12345',
+      };
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/prevent/owner/123/repository/test-repo/`,
+        body: mockRepoDataWithToken,
+      });
+
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/prevent/owner/123/repository/test-repo/token/regenerate/',
+        method: 'POST',
+        body: {
+          token: 'new-generated-token-12345',
+        },
+      });
+
+      render(
+        <PreventContext.Provider value={mockPreventContext}>
+          <TestsOnboardingPage />
+        </PreventContext.Provider>,
+        {
+          initialRouterConfig: {
+            location: {
+              pathname: '/prevent/tests/new',
+              query: {opt: 'githubAction'},
+            },
+          },
+        }
+      );
+
+      const uploadTokenRadio = await screen.findByLabelText(
+        'Use Sentry Prevent Upload Token'
+      );
+      await userEvent.click(uploadTokenRadio);
+
+      await screen.findByText('Step 2b: Add token as');
+
+      expect(screen.getByRole('button', {name: 'Regenerate'})).toBeInTheDocument();
+
+      expect(await screen.findByText('SENTRY_PREVENT_TOKEN')).toBeInTheDocument();
+      expect(await screen.findByText('old-generated-token-12345')).toBeInTheDocument();
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/prevent/owner/123/repository/test-repo/`,
+        body: {
+          ...mockRepoDataWithToken,
+          uploadToken: 'new-generated-token-12345',
+        },
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'Regenerate'}));
+
+      expect(await screen.findByText('SENTRY_PREVENT_TOKEN')).toBeInTheDocument();
+      expect(screen.getByText('new-generated-token-12345')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/prevent/tests/onboarding.tsx
+++ b/static/app/views/prevent/tests/onboarding.tsx
@@ -99,13 +99,7 @@ export default function TestsOnboardingPage() {
 
   const uploadPermissionUploadTokenSteps = (
     <Fragment>
-      {/* this component currently only rendered when repository and integratedOrgId are defined */}
-      <AddUploadTokenStep
-        step="2b"
-        repoData={repoData}
-        repository={repository!}
-        integratedOrgId={integratedOrgId!}
-      />
+      <AddUploadTokenStep step="2b" />
       <AddScriptToYamlStep step="3" />
       <RunTestSuiteStep step="4" />
       <ViewResultsInsightsStep step="5" />
@@ -129,13 +123,7 @@ export default function TestsOnboardingPage() {
   const cliSteps = (
     <Fragment>
       <OutputCoverageFileStep step="1" />
-      {/* this component currently only rendered when repository and integratedOrgId are defined */}
-      <AddUploadTokenStep
-        step="2"
-        repoData={repoData}
-        repository={repository!}
-        integratedOrgId={integratedOrgId!}
-      />
+      <AddUploadTokenStep step="2" />
       <InstallPreventCLIStep step="3" />
       <UploadFileCLIStep previousStep="3" step="4" />
       <RunTestSuiteStep step="5" />

--- a/static/app/views/prevent/tests/onboarding.tsx
+++ b/static/app/views/prevent/tests/onboarding.tsx
@@ -44,6 +44,7 @@ export default function TestsOnboardingPage() {
   const navigate = useNavigate();
   const organization = useOrganization();
   const {integratedOrgId, repository} = usePreventContext();
+  const {data: repoData, isSuccess} = useRepo();
   const opt = searchParams.get('opt');
 
   const theme = useTheme();
@@ -57,12 +58,6 @@ export default function TestsOnboardingPage() {
   );
   const [selectedUploadPermission, setSelectedUploadPermission] =
     useState<UploadPermission>(UploadPermission.OIDC);
-
-  const {data: repoData, isSuccess} = useRepo({
-    organizationSlug: organization.slug,
-    integratedOrgId,
-    repository,
-  });
 
   useEffect(() => {
     if (repoData?.testAnalyticsEnabled && isSuccess) {

--- a/static/app/views/prevent/tests/onboarding.tsx
+++ b/static/app/views/prevent/tests/onboarding.tsx
@@ -58,17 +58,17 @@ export default function TestsOnboardingPage() {
   const [selectedUploadPermission, setSelectedUploadPermission] =
     useState<UploadPermission>(UploadPermission.OIDC);
 
-  const {data: repoData} = useRepo({
+  const {data: repoData, isSuccess} = useRepo({
     organizationSlug: organization.slug,
     integratedOrgId,
     repository,
   });
 
   useEffect(() => {
-    if (repoData?.testAnalyticsEnabled) {
+    if (repoData?.testAnalyticsEnabled && isSuccess) {
       navigate('/prevent/tests');
     }
-  }, [repoData?.testAnalyticsEnabled, navigate]);
+  }, [repoData?.testAnalyticsEnabled, navigate, isSuccess]);
 
   const {data: integrations = [], isPending} = useApiQuery<OrganizationIntegration[]>(
     [

--- a/static/app/views/prevent/tests/onboardingSteps/addUploadTokenStep.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/addUploadTokenStep.tsx
@@ -9,30 +9,25 @@ import {CodeSnippet} from 'sentry/components/codeSnippet';
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
 import {ExternalLink} from 'sentry/components/core/link';
+import {usePreventContext} from 'sentry/components/prevent/context/preventContext';
 import {integratedOrgIdToDomainName} from 'sentry/components/prevent/utils';
 import {t, tct} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {OnboardingStep} from 'sentry/views/prevent/tests/onboardingSteps/onboardingStep';
 import {useGetActiveIntegratedOrgs} from 'sentry/views/prevent/tests/queries/useGetActiveIntegratedOrgs';
-import type {Repository} from 'sentry/views/prevent/tests/queries/useRepo';
+import {useRepo} from 'sentry/views/prevent/tests/queries/useRepo';
 import {useRegenerateRepositoryToken} from 'sentry/views/prevent/tokens/repoTokenTable/hooks/useRegenerateRepositoryToken';
 
 interface AddUploadTokenStepProps {
-  integratedOrgId: string;
-  repository: string;
   step: string;
-  repoData?: Repository;
 }
 
-export function AddUploadTokenStep({
-  repoData,
-  step,
-  repository,
-  integratedOrgId,
-}: AddUploadTokenStepProps) {
+export function AddUploadTokenStep({step}: AddUploadTokenStepProps) {
   const organization = useOrganization();
   const theme = useTheme();
   const isDarkMode = theme.type === 'dark';
+  const {integratedOrgId, repository} = usePreventContext();
+  const {data: repoData} = useRepo();
 
   const {data: integrations = []} = useGetActiveIntegratedOrgs({organization});
   const githubOrgDomain = integratedOrgIdToDomainName(integratedOrgId, integrations);
@@ -75,21 +70,23 @@ export function AddUploadTokenStep({
                     {repoData.uploadToken}
                   </RightPaddedCodeSnippet>
                 </Flex>
-                <Button
-                  priority="default"
-                  onClick={() => {
-                    regenerateToken({
-                      orgSlug: organization.slug,
-                      integratedOrgId,
-                      repository,
-                    });
-                  }}
-                >
-                  {t('Regenerate')}
-                </Button>
+                {integratedOrgId && repository ? (
+                  <Button
+                    priority="default"
+                    onClick={() => {
+                      regenerateToken({
+                        orgSlug: organization.slug,
+                        integratedOrgId,
+                        repository,
+                      });
+                    }}
+                  >
+                    {t('Regenerate')}
+                  </Button>
+                ) : null}
               </Flex>
             </Fragment>
-          ) : (
+          ) : integratedOrgId && repository ? (
             <Button
               priority="primary"
               onClick={() => {
@@ -102,7 +99,7 @@ export function AddUploadTokenStep({
             >
               {t('Generate Repository Token')}
             </Button>
-          )}
+          ) : null}
         </OnboardingStep.Content>
       </OnboardingStep.Body>
       <OnboardingStep.ExpandableDropdown

--- a/static/app/views/prevent/tests/queries/useGetTestResults.ts
+++ b/static/app/views/prevent/tests/queries/useGetTestResults.ts
@@ -209,3 +209,5 @@ export function useInfiniteTestResults({
     ...rest,
   };
 }
+
+export type UseInfiniteTestResultsResult = ReturnType<typeof useInfiniteTestResults>;

--- a/static/app/views/prevent/tests/queries/useGetTestResults.ts
+++ b/static/app/views/prevent/tests/queries/useGetTestResults.ts
@@ -209,5 +209,3 @@ export function useInfiniteTestResults({
     ...rest,
   };
 }
-
-export type UseInfiniteTestResultsResult = ReturnType<typeof useInfiniteTestResults>;

--- a/static/app/views/prevent/tests/queries/useRepo.spec.tsx
+++ b/static/app/views/prevent/tests/queries/useRepo.spec.tsx
@@ -3,10 +3,19 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {PreventContext} from 'sentry/components/prevent/context/preventContext';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import {useRepo} from './useRepo';
+
+const mockPreventContext = {
+  integratedOrgId: 'org123',
+  repository: 'test-repo',
+  branch: 'main',
+  preventPeriod: '30d',
+  changeContextValue: jest.fn(),
+};
 
 describe('useRepo', () => {
   beforeEach(() => {
@@ -27,19 +36,15 @@ describe('useRepo', () => {
 
     const wrapper = ({children}: {children: React.ReactNode}) => (
       <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext value={organization}>{children}</OrganizationContext>
+        <OrganizationContext value={organization}>
+          <PreventContext.Provider value={mockPreventContext}>
+            {children}
+          </PreventContext.Provider>
+        </OrganizationContext>
       </QueryClientProvider>
     );
 
-    const {result} = renderHook(
-      () =>
-        useRepo({
-          organizationSlug: organization.slug,
-          integratedOrgId: 'org123',
-          repository: 'test-repo',
-        }),
-      {wrapper}
-    );
+    const {result} = renderHook(() => useRepo(), {wrapper});
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
@@ -61,19 +66,15 @@ describe('useRepo', () => {
 
     const wrapper = ({children}: {children: React.ReactNode}) => (
       <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext value={organization}>{children}</OrganizationContext>
+        <OrganizationContext value={organization}>
+          <PreventContext.Provider value={mockPreventContext}>
+            {children}
+          </PreventContext.Provider>
+        </OrganizationContext>
       </QueryClientProvider>
     );
 
-    const {result} = renderHook(
-      () =>
-        useRepo({
-          organizationSlug: organization.slug,
-          integratedOrgId: 'org123',
-          repository: 'test-repo',
-        }),
-      {wrapper}
-    );
+    const {result} = renderHook(() => useRepo(), {wrapper});
 
     await waitFor(() => {
       expect(result.current.isError).toBe(true);

--- a/static/app/views/prevent/tests/queries/useRepo.spec.tsx
+++ b/static/app/views/prevent/tests/queries/useRepo.spec.tsx
@@ -1,0 +1,85 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+import {useRepo} from './useRepo';
+
+describe('useRepo', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('fetches repository data successfully', async () => {
+    const organization = OrganizationFixture({slug: 'test-org'});
+    const mockRepoData = {
+      testAnalyticsEnabled: true,
+      uploadToken: 'test-token-123',
+    };
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/prevent/owner/org123/repository/test-repo/`,
+      body: mockRepoData,
+    });
+
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
+      </QueryClientProvider>
+    );
+
+    const {result} = renderHook(
+      () =>
+        useRepo({
+          organizationSlug: organization.slug,
+          integratedOrgId: 'org123',
+          repository: 'test-repo',
+        }),
+      {wrapper}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockRepoData);
+    expect(result.current.data?.testAnalyticsEnabled).toBe(true);
+    expect(result.current.data?.uploadToken).toBe('test-token-123');
+  });
+
+  it('handles API errors gracefully', async () => {
+    const organization = OrganizationFixture({slug: 'test-org'});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/prevent/owner/org123/repository/test-repo/`,
+      statusCode: 404,
+      body: {detail: 'Repository not found'},
+    });
+
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
+      </QueryClientProvider>
+    );
+
+    const {result} = renderHook(
+      () =>
+        useRepo({
+          organizationSlug: organization.slug,
+          integratedOrgId: 'org123',
+          repository: 'test-repo',
+        }),
+      {wrapper}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/static/app/views/prevent/tests/queries/useRepo.tsx
+++ b/static/app/views/prevent/tests/queries/useRepo.tsx
@@ -1,0 +1,28 @@
+import {useApiQuery} from 'sentry/utils/queryClient';
+import type {UseApiQueryResult} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+
+export interface Repository {
+  testAnalyticsEnabled: boolean;
+  uploadToken?: string;
+}
+
+export function useRepo({
+  organizationSlug,
+  integratedOrgId,
+  repository,
+}: {
+  integratedOrgId?: string;
+  organizationSlug?: string;
+  repository?: string;
+}): UseApiQueryResult<Repository, RequestError> {
+  return useApiQuery<Repository>(
+    [
+      `/organizations/${organizationSlug}/prevent/owner/${integratedOrgId}/repository/${repository}/`,
+    ],
+    {
+      staleTime: 0,
+      enabled: Boolean(organizationSlug && integratedOrgId && repository),
+    }
+  );
+}

--- a/static/app/views/prevent/tests/queries/useRepo.tsx
+++ b/static/app/views/prevent/tests/queries/useRepo.tsx
@@ -19,7 +19,7 @@ export function useRepo(): UseApiQueryResult<Repository, RequestError> {
       `/organizations/${organizationSlug}/prevent/owner/${integratedOrgId}/repository/${repository}/`,
     ],
     {
-      staleTime: 0,
+      staleTime: 30_000,
       enabled: Boolean(organizationSlug && integratedOrgId && repository),
     }
   );

--- a/static/app/views/prevent/tests/queries/useRepo.tsx
+++ b/static/app/views/prevent/tests/queries/useRepo.tsx
@@ -4,7 +4,7 @@ import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export interface Repository {
+interface Repository {
   testAnalyticsEnabled: boolean;
   uploadToken?: string;
 }

--- a/static/app/views/prevent/tests/queries/useRepo.tsx
+++ b/static/app/views/prevent/tests/queries/useRepo.tsx
@@ -1,21 +1,19 @@
+import {usePreventContext} from 'sentry/components/prevent/context/preventContext';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
+import useOrganization from 'sentry/utils/useOrganization';
 
 export interface Repository {
   testAnalyticsEnabled: boolean;
   uploadToken?: string;
 }
 
-export function useRepo({
-  organizationSlug,
-  integratedOrgId,
-  repository,
-}: {
-  integratedOrgId?: string;
-  organizationSlug?: string;
-  repository?: string;
-}): UseApiQueryResult<Repository, RequestError> {
+export function useRepo(): UseApiQueryResult<Repository, RequestError> {
+  const organization = useOrganization();
+  const {integratedOrgId, repository} = usePreventContext();
+  const organizationSlug = organization.slug;
+
   return useApiQuery<Repository>(
     [
       `/organizations/${organizationSlug}/prevent/owner/${integratedOrgId}/repository/${repository}/`,

--- a/static/app/views/prevent/tests/tests.spec.tsx
+++ b/static/app/views/prevent/tests/tests.spec.tsx
@@ -73,6 +73,11 @@ const mockIntegrations = [
   {name: 'integration-2', id: '2', status: 'active'},
 ];
 
+const mockRepoData = {
+  testAnalyticsEnabled: true,
+  uploadToken: 'test-token',
+};
+
 const mockApiCall = () => {
   MockApiClient.addMockResponse({
     url: `/organizations/org-slug/prevent/owner/123/repository/some-repository/test-results/`,
@@ -121,6 +126,11 @@ const mockApiCall = () => {
     body: {
       isSyncing: false,
     },
+  });
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/prevent/owner/123/repository/some-repository/',
+    method: 'GET',
+    body: mockRepoData,
   });
 };
 

--- a/static/app/views/prevent/tests/tests.tsx
+++ b/static/app/views/prevent/tests/tests.tsx
@@ -15,8 +15,10 @@ import {decodeSorts} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useInfiniteTestResults} from 'sentry/views/prevent/tests/queries/useGetTestResults';
-import type {UseInfiniteTestResultsResult} from 'sentry/views/prevent/tests/queries/useGetTestResults';
+import {
+  useInfiniteTestResults,
+  type UseInfiniteTestResultsResult,
+} from 'sentry/views/prevent/tests/queries/useGetTestResults';
 import {useRepo} from 'sentry/views/prevent/tests/queries/useRepo';
 import {DEFAULT_SORT} from 'sentry/views/prevent/tests/settings';
 import {Summaries} from 'sentry/views/prevent/tests/summaries/summaries';

--- a/static/app/views/prevent/tests/tests.tsx
+++ b/static/app/views/prevent/tests/tests.tsx
@@ -14,7 +14,6 @@ import {t} from 'sentry/locale';
 import {decodeSorts} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import useOrganization from 'sentry/utils/useOrganization';
 import {
   useInfiniteTestResults,
   type UseInfiniteTestResultsResult,
@@ -63,15 +62,7 @@ export default function TestsPage() {
         </PageFilterBar>
         {shouldDisplayTestSuiteDropdown && <TestSuiteDropdown />}
       </ControlsContainer>
-      {shouldDisplayContent ? (
-        <Content
-          integratedOrgId={integratedOrgId}
-          repository={repository}
-          response={response}
-        />
-      ) : (
-        <EmptySelectorsMessage />
-      )}
+      {shouldDisplayContent ? <Content response={response} /> : <EmptySelectorsMessage />}
     </LayoutGap>
   );
 }
@@ -82,22 +73,14 @@ const LayoutGap = styled('div')`
 `;
 
 interface TestResultsContentData {
-  integratedOrgId: string;
-  repository: string;
   response: UseInfiniteTestResultsResult;
 }
 
-function Content({response, integratedOrgId, repository}: TestResultsContentData) {
+function Content({response}: TestResultsContentData) {
   const location = useLocation();
   const navigate = useNavigate();
-  const organization = useOrganization();
   const {branch: selectedBranch} = usePreventContext();
-
-  const {data: repoData, isSuccess} = useRepo({
-    organizationSlug: organization.slug,
-    integratedOrgId,
-    repository,
-  });
+  const {data: repoData, isSuccess} = useRepo();
 
   useEffect(() => {
     if (!repoData?.testAnalyticsEnabled && isSuccess) {

--- a/static/app/views/prevent/tokens/repoTokenTable/hooks/useRegenerateRepositoryToken.tsx
+++ b/static/app/views/prevent/tokens/repoTokenTable/hooks/useRegenerateRepositoryToken.tsx
@@ -32,6 +32,12 @@ export function useRegenerateRepositoryToken() {
           `/organizations/${variables.orgSlug}/prevent/owner/${variables.integratedOrgId}/repositories/tokens/`,
         ],
       });
+      // Invalidate the specific repository query
+      queryClient.invalidateQueries({
+        queryKey: [
+          `/organizations/${variables.orgSlug}/prevent/owner/${variables.integratedOrgId}/repository/${variables.repository}/`,
+        ],
+      });
     },
     onError: () => {
       addErrorMessage('Failed to regenerate token.');


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/CCMRG-1613/ta-redirection-for-onboarding-vs-test-results-page

- Uses new single repository API call to get `testAnalyticsEnabled` field and handles accordingly. If value is false, they should be sent to onboarding. If value is true, they should be on test results page.
- Grabs token for repo to display in onboarding and allows user to generate/regenerate token from onboarding steps.