### PR TITLE
fix(coding-agents): Fix tag stretching

### DIFF
--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -125,9 +125,11 @@ function CodingAgentCard({codingAgentState, repo}: CodingAgentCardProps) {
                 <Content>
                   <CardHeader>
                     <AgentTitle>{codingAgentState.name}</AgentTitle>
-                    <Tag type={getTagType(codingAgentState.status)}>
-                      {getStatusText(codingAgentState.status)}
-                    </Tag>
+                    <div>
+                      <Tag type={getTagType(codingAgentState.status)}>
+                        {getStatusText(codingAgentState.status)}
+                      </Tag>
+                    </div>
                   </CardHeader>
 
                   <CardContent>


### PR DESCRIPTION
you do need this div

Before:
<img width="1738" height="798" alt="CleanShot 2025-09-16 at 16 34 49@2x" src="https://github.com/user-attachments/assets/2cca5c5a-0fa7-426b-b731-d41bff0ed417" />
After:
<img width="2594" height="734" alt="CleanShot 2025-09-16 at 16 34 32@2x" src="https://github.com/user-attachments/assets/b27e17fa-7abe-493d-9e9a-9d6b6341a680" />
