### PR TITLE
fix(typing): Type tests.sentry.data_export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -722,7 +722,7 @@ module = [
     "tests.sentry.auth_v2.endpoints.*",
     "tests.sentry.celery.*",
     "tests.sentry.charts.*",
-    "tests.sentry.data_export.processors.*",
+    "tests.sentry.data_export.*",
     "tests.sentry.data_secrecy.*",
     "tests.sentry.debug.utils.*",
     "tests.sentry.deletions.tasks.test_groups",

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -24,7 +24,9 @@ class DataExportTest(APITestCase):
         self.create_member(user=self.user, organization=self.org, teams=[self.team])
         self.login_as(user=self.user)
 
-    def make_payload(self, payload_type, extras=None, overwrite=False):
+    def make_payload(
+        self, payload_type: str, extras: dict[str, Any] | None = None, overwrite: bool = False
+    ) -> dict[str, Any]:
         payload: dict[str, Any] = {}
         if payload_type == "issue":
             payload = {

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -334,7 +334,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
     @patch("sentry.data_export.tasks.MAX_BATCH_SIZE", 35)
     @patch("sentry.data_export.tasks.MAX_FILE_SIZE", 55)
     @patch("sentry.data_export.models.ExportedData.email_success")
-    def test_discover_export_file_too_large(self, emailer) -> None:
+    def test_discover_export_file_too_large(self, emailer: MagicMock) -> None:
         de = ExportedData.objects.create(
             user_id=self.user.id,
             organization=self.org,
@@ -623,7 +623,7 @@ class AssembleDownloadLargeTest(TestCase, SnubaTestCase):
 
     @patch("sentry.data_export.tasks.MAX_BATCH_SIZE", 200)
     @patch("sentry.data_export.models.ExportedData.email_success")
-    def test_discover_large_batch(self, emailer) -> None:
+    def test_discover_large_batch(self, emailer: MagicMock) -> None:
         """
         Each row in this export requires exactly 13 bytes, with batch_size=3 and
         MAX_BATCH_SIZE=200, this means that each batch can export 6 batch fragments,


### PR DESCRIPTION
Just a few missing type hints, nothing special.

`mypy tests/sentry/data_export` passes.
