### PR TITLE
feat(preprod): Add manual comparison selection and triggering

### DIFF
--- a/static/app/views/preprod/buildComparison/buildComparison.tsx
+++ b/static/app/views/preprod/buildComparison/buildComparison.tsx
@@ -10,9 +10,9 @@ import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import {BuildComparisonHeaderContent} from 'sentry/views/preprod/buildComparison/header/buildComparisonHeaderContent';
+import {BuildCompareHeaderContent} from 'sentry/views/preprod/buildComparison/header/buildCompareHeaderContent';
+import {SizeCompareMainContent} from 'sentry/views/preprod/buildComparison/main/sizeCompareMainContent';
 import {SizeCompareSelectionContent} from 'sentry/views/preprod/buildComparison/main/sizeCompareSelectionContent';
-import {SizeComparisonMainContent} from 'sentry/views/preprod/buildComparison/main/sizeComparisonMainContent';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 
 export default function BuildComparison() {
@@ -73,7 +73,7 @@ export default function BuildComparison() {
   let mainContent = null;
   if (baseArtifactId) {
     // Base artifact provided in URL, show comparison state
-    mainContent = <SizeComparisonMainContent />;
+    mainContent = <SizeCompareMainContent />;
   } else {
     // No base artifact provided in URL, show selection state
     mainContent = (
@@ -85,7 +85,7 @@ export default function BuildComparison() {
     <SentryDocumentTitle title={t('Build comparison')}>
       <Layout.Page>
         <Layout.Header>
-          <BuildComparisonHeaderContent
+          <BuildCompareHeaderContent
             buildDetails={headBuildDetailsQuery.data}
             projectId={projectId}
           />

--- a/static/app/views/preprod/buildComparison/buildComparison.tsx
+++ b/static/app/views/preprod/buildComparison/buildComparison.tsx
@@ -11,6 +11,7 @@ import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildComparisonHeaderContent} from 'sentry/views/preprod/buildComparison/header/buildComparisonHeaderContent';
+import {SizeCompareSelectionContent} from 'sentry/views/preprod/buildComparison/main/sizeCompareSelectionContent';
 import {SizeComparisonMainContent} from 'sentry/views/preprod/buildComparison/main/sizeComparisonMainContent';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 
@@ -73,8 +74,12 @@ export default function BuildComparison() {
   if (baseArtifactId) {
     // Base artifact provided in URL, show comparison state
     mainContent = <SizeComparisonMainContent />;
+  } else {
+    // No base artifact provided in URL, show selection state
+    mainContent = (
+      <SizeCompareSelectionContent headBuildDetails={headBuildDetailsQuery.data} />
+    );
   }
-  // TODO: Support just head selected with list to show comparable builds
 
   return (
     <SentryDocumentTitle title={t('Build comparison')}>

--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -15,12 +15,12 @@ import {
   getReadablePlatformLabel,
 } from 'sentry/views/preprod/utils/labelUtils';
 
-interface BuildComparisonHeaderContentProps {
+interface BuildCompareHeaderContentProps {
   buildDetails: BuildDetailsApiResponse;
   projectId: string;
 }
 
-export function BuildComparisonHeaderContent(props: BuildComparisonHeaderContentProps) {
+export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps) {
   const {buildDetails, projectId} = props;
   const organization = useOrganization();
   const theme = useTheme();

--- a/static/app/views/preprod/buildComparison/header/buildComparisonHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildComparisonHeaderContent.tsx
@@ -6,7 +6,8 @@ import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import {Flex} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import {Heading} from 'sentry/components/core/text/heading';
-import {IconJson} from 'sentry/icons';
+import {IconCode, IconDownload, IconJson} from 'sentry/icons';
+import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {
@@ -71,6 +72,18 @@ export function BuildComparisonHeaderContent(props: BuildComparisonHeaderContent
           </InfoIcon>
           <Text>{buildDetails.app_info.app_id}</Text>
         </Flex>
+        {buildDetails.size_info?.download_size_bytes && (
+          <Flex gap="sm" align="center">
+            <IconDownload size="sm" color="gray300" />
+            <Text>{formatBytesBase10(buildDetails.size_info.download_size_bytes)}</Text>
+          </Flex>
+        )}
+        {buildDetails.size_info?.install_size_bytes && (
+          <Flex gap="sm" align="center">
+            <IconCode size="sm" color="gray300" />
+            <Text>{formatBytesBase10(buildDetails.size_info.install_size_bytes)}</Text>
+          </Flex>
+        )}
       </Flex>
     </Flex>
   );
@@ -80,7 +93,7 @@ const AppIcon = styled('div')`
   width: 24px;
   height: 24px;
   border-radius: 4px;
-  background: #ff6600;
+  background: ${p => p.theme.purple400};
   display: flex;
   align-items: center;
   justify-content: center;

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -24,7 +24,7 @@ import type {
   SizeComparisonApiResponse,
 } from 'sentry/views/preprod/types/appSizeTypes';
 
-export function SizeComparisonMainContent() {
+export function SizeCompareMainContent() {
   const organization = useOrganization();
   const {baseArtifactId, headArtifactId, projectId} = useParams<{
     baseArtifactId: string;

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -9,7 +9,6 @@ import {Flex} from 'sentry/components/core/layout/flex';
 import {Radio} from 'sentry/components/core/radio';
 import {Text} from 'sentry/components/core/text';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {IconBranch} from 'sentry/components/prevent/branchSelector/iconBranch';
 import TimeSince from 'sentry/components/timeSince';
 import {
   IconCalendar,
@@ -21,6 +20,7 @@ import {
   IconLock,
   IconTelescope,
 } from 'sentry/icons';
+import {IconBranch} from 'sentry/icons/iconBranch';
 import {t} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {useApiQuery, useMutation, type UseApiQueryResult} from 'sentry/utils/queryClient';

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -12,6 +12,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconBranch} from 'sentry/components/prevent/branchSelector/iconBranch';
 import {
   IconClose,
+  IconCode,
   IconCommit,
   IconDownload,
   IconFocus,
@@ -287,7 +288,7 @@ function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
           )}
           {installSize && (
             <Flex align="center" gap="xs">
-              <IconDownload size="xs" color="gray300" />
+              <IconCode size="xs" color="gray300" />
               <Text>{formatBytesBase10(installSize)}</Text>
             </Flex>
           )}

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -66,7 +66,6 @@ export function SizeCompareSelectionContent({
     per_page: 25,
     state: BuildDetailsState.PROCESSED,
     app_id: headBuildDetails.app_info?.app_id,
-    build_version: headBuildDetails.app_info?.version,
     // TODO: Add build_configuration when field in API response
   };
 

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -10,7 +10,9 @@ import {Radio} from 'sentry/components/core/radio';
 import {Text} from 'sentry/components/core/text';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconBranch} from 'sentry/components/prevent/branchSelector/iconBranch';
+import TimeSince from 'sentry/components/timeSince';
 import {
+  IconCalendar,
   IconClose,
   IconCode,
   IconCommit,
@@ -66,7 +68,7 @@ export function SizeCompareSelectionContent({
     per_page: 25,
     state: BuildDetailsState.PROCESSED,
     app_id: headBuildDetails.app_info?.app_id,
-    // TODO: Add build_configuration when field in API response
+    build_configuration: headBuildDetails.app_info?.build_configuration,
   };
 
   const buildsQuery: UseApiQueryResult<ListBuildsApiResponse, RequestError> =
@@ -249,6 +251,7 @@ function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
   const prNumber = build.vcs_info?.pr_number;
   const commitHash = build.vcs_info?.head_sha?.substring(0, 7);
   const branchName = build.vcs_info?.head_ref;
+  const dateAdded = build.app_info?.date_added;
   const downloadSize = build.size_info?.download_size_bytes;
   const installSize = build.size_info?.install_size_bytes;
 
@@ -260,10 +263,10 @@ function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
       gap="md"
     >
       <Flex direction="column" gap="sm" flex={1}>
-        <Flex align="center" gap="sm">
+        <Flex align="center" gap="md">
           {(prNumber || branchName) && <IconBranch size="xs" color="gray300" />}
           {prNumber && (
-            <Flex align="center" gap="xs">
+            <Flex align="center" gap="sm">
               <Text>#{prNumber}</Text>
             </Flex>
           )}
@@ -271,22 +274,27 @@ function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
             <BuildItemBranchTag>{build.vcs_info?.head_ref}</BuildItemBranchTag>
           )}
           {commitHash && (
-            <Flex align="center" gap="xs">
+            <Flex align="center" gap="sm">
               <IconCommit size="xs" color="gray300" />
               <Text>{commitHash}</Text>
             </Flex>
           )}
         </Flex>
         <Flex align="center" gap="md">
-          {/* TODO: Add created at when field in API */}
+          {dateAdded && (
+            <Flex align="center" gap="sm">
+              <IconCalendar size="xs" color="gray300" />
+              <TimeSince date={dateAdded} />
+            </Flex>
+          )}
           {downloadSize && (
-            <Flex align="center" gap="xs">
+            <Flex align="center" gap="sm">
               <IconDownload size="xs" color="gray300" />
               <Text>{formatBytesBase10(downloadSize)}</Text>
             </Flex>
           )}
           {installSize && (
-            <Flex align="center" gap="xs">
+            <Flex align="center" gap="sm">
               <IconCode size="xs" color="gray300" />
               <Text>{formatBytesBase10(installSize)}</Text>
             </Flex>

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -1,0 +1,325 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
+import {Stack} from 'sentry/components/core/layout';
+import {Flex} from 'sentry/components/core/layout/flex';
+import {Radio} from 'sentry/components/core/radio';
+import {Text} from 'sentry/components/core/text';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {IconBranch} from 'sentry/components/prevent/branchSelector/iconBranch';
+import {
+  IconClose,
+  IconCommit,
+  IconDownload,
+  IconFocus,
+  IconLock,
+  IconTelescope,
+} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
+import {useApiQuery, useMutation, type UseApiQueryResult} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useApi from 'sentry/utils/useApi';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import {
+  BuildDetailsState,
+  type BuildDetailsApiResponse,
+} from 'sentry/views/preprod/types/buildDetailsTypes';
+import type {ListBuildsApiResponse} from 'sentry/views/preprod/types/listBuildsTypes';
+
+interface SizeCompareSelectionContentProps {
+  headBuildDetails: BuildDetailsApiResponse;
+  baseBuildDetails?: BuildDetailsApiResponse;
+  onBaseBuildClear?: () => void;
+  onBaseBuildSelect?: () => void;
+}
+
+export function SizeCompareSelectionContent({
+  headBuildDetails,
+  baseBuildDetails,
+}: SizeCompareSelectionContentProps) {
+  const organization = useOrganization();
+  const api = useApi({persistInFlight: true});
+  const navigate = useNavigate();
+  const {projectId} = useParams<{
+    projectId: string;
+  }>();
+  const [selectedBaseBuild, setSelectedBaseBuild] = useState<
+    BuildDetailsApiResponse | undefined
+  >(baseBuildDetails);
+
+  const headPrNumber = headBuildDetails.vcs_info?.pr_number;
+  const headSha = headBuildDetails.vcs_info?.head_sha?.substring(0, 7);
+  const headBranchName = headBuildDetails.vcs_info?.head_ref;
+
+  const basePrNumber = selectedBaseBuild?.vcs_info?.pr_number;
+  const baseSha = selectedBaseBuild?.vcs_info?.head_sha?.substring(0, 7);
+  const baseBranchName = selectedBaseBuild?.vcs_info?.head_ref;
+
+  const queryParams: Record<string, any> = {
+    per_page: 25,
+    state: BuildDetailsState.PROCESSED,
+    app_id: headBuildDetails.app_info?.app_id,
+    build_version: headBuildDetails.app_info?.version,
+    // TODO: Add build_configuration when field in API response
+  };
+
+  const buildsQuery: UseApiQueryResult<ListBuildsApiResponse, RequestError> =
+    useApiQuery<ListBuildsApiResponse>(
+      [
+        `/projects/${organization.slug}/${projectId}/preprodartifacts/list-builds/`,
+        {query: queryParams},
+      ],
+      {
+        staleTime: 0,
+        enabled: !!projectId,
+      }
+    );
+
+  const {mutate: triggerComparison, isPending: isComparing} = useMutation<
+    void,
+    RequestError,
+    {baseArtifactId: string; headArtifactId: string}
+  >({
+    mutationFn: ({headArtifactId, baseArtifactId}) => {
+      return api.requestPromise(
+        `/projects/${organization.slug}/${projectId}/preprodartifacts/size-analysis/compare/${headArtifactId}/${baseArtifactId}/`,
+        {
+          method: 'POST',
+        }
+      );
+    },
+    onSuccess: () => {
+      navigate(
+        `/organizations/${organization.slug}/preprod/${projectId}/compare/${headBuildDetails.id}/${selectedBaseBuild?.id}/`
+      );
+    },
+    onError: error => {
+      addErrorMessage(
+        error?.message || t('Failed to trigger comparison. Please try again.')
+      );
+    },
+  });
+
+  return (
+    <Stack gap="xl">
+      <Flex align="center" gap="lg" width="100%" justify="center">
+        <Flex align="center" gap="sm">
+          <IconLock size="xs" locked />
+          <Text bold>{t('Your build:')}</Text>
+          <Text size="sm" variant="accent" bold>
+            {headPrNumber && `#${headPrNumber} `}
+            {headSha && (
+              <Flex align="center" gap="xs">
+                <IconCommit size="xs" />
+                {headSha}
+              </Flex>
+            )}
+          </Text>
+          <BuildBranch>
+            <Text size="sm" variant="muted">
+              {headBranchName}
+            </Text>
+          </BuildBranch>
+        </Flex>
+
+        <Text>{t('vs')}</Text>
+
+        <Flex align="center" gap="sm">
+          {selectedBaseBuild ? (
+            <SelectedBaseBuild align="center" gap="sm">
+              <IconFocus size="xs" color="purple400" />
+              <Text size="sm" variant="accent" bold>
+                {t('Comparison:')}
+              </Text>
+              <Text size="sm" variant="accent" bold>
+                {basePrNumber && `#${basePrNumber} `}
+                {baseSha && (
+                  <Flex align="center" gap="xs">
+                    <IconCommit size="xs" color="purple400" />
+                    {baseSha}
+                  </Flex>
+                )}
+              </Text>
+              <BaseBuildBranch>
+                <Text size="sm" variant="muted">
+                  {baseBranchName}
+                </Text>
+              </BaseBuildBranch>
+              <Button
+                onClick={e => {
+                  e.stopPropagation();
+                  setSelectedBaseBuild(undefined);
+                }}
+                size="zero"
+                priority="transparent"
+                borderless
+                aria-label={t('Clear base build')}
+                icon={<IconClose size="xs" color="purple400" />}
+              />
+            </SelectedBaseBuild>
+          ) : (
+            <SelectBuild>
+              <Text size="sm">{t('Select a build')}</Text>
+            </SelectBuild>
+          )}
+        </Flex>
+
+        <Flex align="center" gap="sm">
+          <Button
+            onClick={() => {
+              if (selectedBaseBuild) {
+                triggerComparison({
+                  baseArtifactId: selectedBaseBuild.id.toString(),
+                  headArtifactId: headBuildDetails.id.toString(),
+                });
+              }
+            }}
+            disabled={!selectedBaseBuild || isComparing}
+            priority="primary"
+            icon={<IconTelescope size="sm" />}
+          >
+            {isComparing ? t('Comparing...') : t('Compare builds')}
+          </Button>
+        </Flex>
+      </Flex>
+
+      {buildsQuery.isLoading && <LoadingIndicator />}
+      {buildsQuery.isError && <Alert type="error">{buildsQuery.error?.message}</Alert>}
+      {buildsQuery.data && (
+        <Stack gap="md">
+          {buildsQuery.data.builds.map(build => {
+            if (build.id === headBuildDetails.id) {
+              return null;
+            }
+
+            return (
+              <BuildItem
+                key={build.id}
+                build={build}
+                isSelected={selectedBaseBuild === build}
+                onSelect={() => setSelectedBaseBuild(build)}
+              />
+            );
+          })}
+        </Stack>
+      )}
+    </Stack>
+  );
+}
+
+const BuildBranch = styled('span')`
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
+  background-color: ${p => p.theme.gray100};
+  border-radius: ${p => p.theme.borderRadius};
+`;
+
+const BaseBuildBranch = styled('span')`
+  padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.sm};
+  background-color: ${p => p.theme.gray100};
+  border-radius: ${p => p.theme.borderRadius};
+`;
+
+const SelectBuild = styled('div')`
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  border-style: dashed;
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
+`;
+
+const SelectedBaseBuild = styled(Flex)`
+  background-color: ${p => p.theme.surface100};
+  border: 1px solid ${p => p.theme.focusBorder};
+  border-radius: ${p => p.theme.borderRadius};
+  padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
+`;
+
+interface BuildItemProps {
+  build: BuildDetailsApiResponse;
+  isSelected: boolean;
+  onSelect: () => void;
+}
+
+function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
+  const prNumber = build.vcs_info?.pr_number;
+  const commitHash = build.vcs_info?.head_sha?.substring(0, 7);
+  const branchName = build.vcs_info?.head_ref;
+  const downloadSize = build.size_info?.download_size_bytes;
+  const installSize = build.size_info?.install_size_bytes;
+
+  return (
+    <BuildItemContainer
+      onClick={onSelect}
+      isSelected={isSelected}
+      align="center"
+      gap="md"
+    >
+      <Flex direction="column" gap="sm" flex={1}>
+        <Flex align="center" gap="sm">
+          {(prNumber || branchName) && <IconBranch size="xs" color="gray300" />}
+          {prNumber && (
+            <Flex align="center" gap="xs">
+              <Text>#{prNumber}</Text>
+            </Flex>
+          )}
+          {branchName && (
+            <BuildItemBranchTag>{build.vcs_info?.head_ref}</BuildItemBranchTag>
+          )}
+          {commitHash && (
+            <Flex align="center" gap="xs">
+              <IconCommit size="xs" color="gray300" />
+              <Text>{commitHash}</Text>
+            </Flex>
+          )}
+        </Flex>
+        <Flex align="center" gap="md">
+          {/* TODO: Add created at when field in API */}
+          {downloadSize && (
+            <Flex align="center" gap="xs">
+              <IconDownload size="xs" color="gray300" />
+              <Text>{formatBytesBase10(downloadSize)}</Text>
+            </Flex>
+          )}
+          {installSize && (
+            <Flex align="center" gap="xs">
+              <IconDownload size="xs" color="gray300" />
+              <Text>{formatBytesBase10(installSize)}</Text>
+            </Flex>
+          )}
+        </Flex>
+      </Flex>
+      <Radio checked={isSelected} onChange={onSelect} />
+    </BuildItemContainer>
+  );
+}
+
+const BuildItemContainer = styled(Flex)<{isSelected: boolean}>`
+  border: 1px solid ${p => (p.isSelected ? p.theme.focusBorder : p.theme.border)};
+  border-radius: ${p => p.theme.borderRadius};
+  padding: ${p => p.theme.space.md};
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${p => p.theme.surface200};
+  }
+
+  ${p =>
+    p.isSelected &&
+    `
+      background-color: ${p.theme.surface100};
+    `}
+`;
+
+const BuildItemBranchTag = styled('span')`
+  padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.sm};
+  background-color: ${p => p.theme.gray100};
+  border-radius: ${p => p.theme.borderRadius};
+  color: ${p => p.theme.purple400};
+  font-size: ${p => p.theme.fontSize.sm};
+  font-weight: ${p => p.theme.fontWeight.normal};
+`;

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -39,7 +39,7 @@ export interface BuildDetailsSizeInfo {
   install_size_bytes: number;
 }
 
-enum BuildDetailsState {
+export enum BuildDetailsState {
   UPLOADING = 0,
   UPLOADED = 1,
   PROCESSED = 3,

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -12,6 +12,7 @@ export interface BuildDetailsApiResponse {
 export interface BuildDetailsAppInfo {
   app_id?: string;
   artifact_type?: BuildDetailsArtifactType;
+  build_configuration?: string;
   build_number?: string;
   date_added?: string;
   date_built?: string;
@@ -19,8 +20,6 @@ export interface BuildDetailsAppInfo {
   name?: string;
   platform?: Platform;
   version?: string;
-  // build_configuration?: string; // Uncomment when available
-  // icon?: string | null; // Uncomment when available
 }
 
 interface BuildDetailsVcsInfo {


### PR DESCRIPTION
Adds manual comparison selection and triggering.

Non-chonk UI states:
<img width="981" height="307" alt="Screenshot 2025-09-16 at 7 42 05 PM" src="https://github.com/user-attachments/assets/08d0f0af-962a-4856-a891-c084b8a74540" />
<img width="988" height="312" alt="Screenshot 2025-09-16 at 7 42 02 PM" src="https://github.com/user-attachments/assets/df5ad805-ac34-4cc8-93a3-3e65871bee87" />



Resolves EME-256, EME-261