### PR TITLE
fix(project-settings): Rate Limit field not saving onBlur and triggering a request even when data hasn’t changed

### DIFF
--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -117,6 +117,7 @@ export function KeySettings({
               params={params}
               data={data}
               disabled={!hasAccess}
+              updateData={updateData}
             />
 
             <Panel>


### PR DESCRIPTION
TL;DR:

- The count field was not saving on onBlur.
- Pressing Enter saved the form but showed no visual feedback.
- Changing the count value, then re-entering the same saved value and triggering onBlur or pressing Enter, still fired a request with unchanged data.

**Before**


https://github.com/user-attachments/assets/6ee3c829-e966-400b-942e-1f6f1f5bc408



**After**

https://github.com/user-attachments/assets/f923cf90-86df-4c19-9ef1-d409050bb9fa





closes https://linear.app/getsentry/issue/TET-660/updating-rate-limit-field-did-not-save-new-values-unless-tabbing-out