### PR TITLE
perf(group_index): Prevent total hashes query from timing out

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -216,19 +216,17 @@ def delete_group_hashes(
     seer_deletion: bool = False,
 ) -> None:
     hashes_batch_size = options.get("deletions.group-hashes-batch-size")
-    total_hashes = GroupHash.objects.filter(project_id=project_id, group_id__in=group_ids).count()
-
-    # Early return if there are no hashes to delete
-    if total_hashes == 0:
-        return
 
     # Validate batch size to ensure it's at least 1 to avoid ValueError in range()
     hashes_batch_size = max(1, hashes_batch_size)
 
-    # We multiply by 1.1 to account for the fact that we may have deleted some hashes
-    # since we started the query. Ensure we always process at least one batch if there are hashes.
-    max_iterations = max(1, int(total_hashes * 1.1))
-    for _ in range(0, max_iterations, hashes_batch_size):
+    # Set a reasonable upper bound on iterations to prevent infinite loops.
+    # This replaces the expensive COUNT(*) query that was causing database timeouts.
+    # The loop will naturally terminate when no more hashes are found.
+    max_iterations = 10000
+    iterations = 0
+
+    while iterations < max_iterations:
         qs = GroupHash.objects.filter(project_id=project_id, group_id__in=group_ids).values_list(
             "id", "hash"
         )[:hashes_batch_size]
@@ -247,6 +245,8 @@ def delete_group_hashes(
         finally:
             hash_ids = [gh[0] for gh in hashes_chunk]
             GroupHash.objects.filter(id__in=hash_ids).delete()
+
+        iterations += 1
 
 
 def separate_by_group_category(instance_list: Sequence[Group]) -> tuple[list[Group], list[Group]]:


### PR DESCRIPTION
This is an issue when a delete is attempted for many groups with large number of group hashes.

- Replaces the expensive `COUNT(*)` query with a loop that iterates until no more hashes are found.
- Adds a reasonable upper bound on iterations to prevent infinite loops.
- Improves performance by avoiding database timeouts when deleting GroupHashes.

Fixes [SENTRY-54W8](https://sentry.io/organizations/sentry/issues/6882831878/).