### PR TITLE
feat(notif-platform): Wire up email provider

### DIFF
--- a/src/sentry/notifications/platform/email/provider.py
+++ b/src/sentry/notifications/platform/email/provider.py
@@ -83,7 +83,7 @@ class EmailNotificationProvider(NotificationProvider[EmailRenderable]):
     @classmethod
     def send(cls, *, target: NotificationTarget, renderable: EmailRenderable) -> None:
         if target.resource_type != NotificationTargetResourceType.EMAIL:
-            raise ValueError(f"Email provider cannot send to {target.resource_type}")
+            raise ValueError(f"EmailNotificationProvider cannot send to {target.resource_type}")
 
         message = renderable
         message.to = [target.resource_id]

--- a/src/sentry/notifications/platform/email/provider.py
+++ b/src/sentry/notifications/platform/email/provider.py
@@ -52,7 +52,7 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
             context=email_context,
         )
         # Required by RFC 2822 (https://www.rfc-editor.org/rfc/rfc2822.html)
-        headers = {"Message-Id": make_msgid(get_from_email_domain())}
+        headers = {"Message-Id": make_msgid(domain=get_from_email_domain())}
         email = EmailMultiAlternatives(
             subject=rendered_template.subject,
             body=txt_body,

--- a/src/sentry/notifications/platform/email/provider.py
+++ b/src/sentry/notifications/platform/email/provider.py
@@ -1,5 +1,7 @@
-from typing import Any
+from django.core.mail import EmailMultiAlternatives
+from django.core.mail.message import make_msgid
 
+from sentry import options
 from sentry.notifications.platform.provider import NotificationProvider
 from sentry.notifications.platform.registry import provider_registry
 from sentry.notifications.platform.renderer import NotificationRenderer
@@ -12,9 +14,15 @@ from sentry.notifications.platform.types import (
     NotificationTargetResourceType,
 )
 from sentry.organizations.services.organization.model import RpcOrganizationSummary
+from sentry.utils.email.address import get_from_email_domain
+from sentry.utils.email.message_builder import inline_css
+from sentry.utils.email.send import send_messages
+from sentry.web.helpers import render_to_string
 
-# TODO(ecosystem): Proper typing for email payloads (HTML + txt)
-type EmailRenderable = Any
+DEFAULT_EMAIL_HTML_PATH = "sentry/emails/platform/default.html"
+DEFAULT_EMAIL_TEXT_PATH = "sentry/emails/platform/default.txt"
+
+type EmailRenderable = EmailMultiAlternatives
 
 
 class EmailRenderer(NotificationRenderer[EmailRenderable]):
@@ -24,7 +32,41 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
     def render[DataT: NotificationData](
         cls, *, data: DataT, rendered_template: NotificationRenderedTemplate
     ) -> EmailRenderable:
-        return {}
+        email_context = {
+            "subject": rendered_template.subject,
+            "body": rendered_template.body,
+            "actions": [(action.label, action.link) for action in rendered_template.actions],
+            "chart_url": rendered_template.chart.url if rendered_template.chart else None,
+            "chart_alt_text": rendered_template.chart.alt_text if rendered_template.chart else None,
+            "footer": rendered_template.footer,
+        }
+
+        html_body = inline_css(
+            render_to_string(
+                template=(rendered_template.email_html_path or DEFAULT_EMAIL_HTML_PATH),
+                context=email_context,
+            )
+        )
+        txt_body = render_to_string(
+            template=(rendered_template.email_text_path or DEFAULT_EMAIL_TEXT_PATH),
+            context=email_context,
+        )
+        # Required by RFC 2822 (https://www.rfc-editor.org/rfc/rfc2822.html)
+        headers = {"Message-Id": make_msgid(get_from_email_domain())}
+        email = EmailMultiAlternatives(
+            subject=rendered_template.subject,
+            body=txt_body,
+            # TODO(ecosystem): Potentially allow templates to configure more attributes of emails
+            from_email=options.get("mail.from"),
+            to=None,
+            cc=None,
+            bcc=None,
+            reply_to=None,
+            # TODO(ecosystem): Ensure we add the List-Unsubscribe header
+            headers=headers,
+        )
+        email.attach_alternative(html_body, "text/html")
+        return email
 
 
 @provider_registry.register(NotificationProviderKey.EMAIL)
@@ -40,4 +82,9 @@ class EmailNotificationProvider(NotificationProvider[EmailRenderable]):
 
     @classmethod
     def send(cls, *, target: NotificationTarget, renderable: EmailRenderable) -> None:
-        pass
+        if target.resource_type != NotificationTargetResourceType.EMAIL:
+            raise ValueError(f"Email provider cannot send to {target.resource_type}")
+
+        message = renderable
+        message.to = [target.resource_id]
+        send_messages([message])

--- a/src/sentry/notifications/platform/sample.py
+++ b/src/sentry/notifications/platform/sample.py
@@ -31,6 +31,20 @@ class ErrorAlertData(NotificationData):
 class ErrorAlertNotificationTemplate(NotificationTemplate[ErrorAlertData]):
     category = NotificationCategory.DEBUG
 
+    @property
+    def example_data(self) -> ErrorAlertData:
+        return ErrorAlertData(
+            error_type="ValueError",
+            error_message="'NoneType' object has no attribute 'get'",
+            project_name="my-app",
+            issue_id="12345",
+            error_count=15,
+            first_seen="2024-01-15 14:30:22 UTC",
+            chart_url="https://example.com/chart",
+            issue_url="https://example.com/issues",
+            assign_url="https://example.com/assign",
+        )
+
     def render(self, data: ErrorAlertData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
             subject=f"{data.error_count} new {data.error_type} errors in {data.project_name}",
@@ -45,28 +59,6 @@ class ErrorAlertNotificationTemplate(NotificationTemplate[ErrorAlertData]):
             ],
             chart=NotificationRenderedImage(
                 url="https://example.com/chart", alt_text="Error occurrence chart"
-            ),
-            footer="This alert was triggered by your error monitoring rules.",
-        )
-
-    def render_example(self) -> NotificationRenderedTemplate:
-        return NotificationRenderedTemplate(
-            subject="15 new ValueError errors in my-app",
-            body=(
-                "A new ValueError error has been detected in my-app with 15 occurrences. "
-                "The error message is: 'NoneType' object has no attribute 'get'. "
-                "This error was first seen at 2024-01-15 14:30:22 UTC and requires immediate attention."
-            ),
-            actions=[
-                NotificationRenderedAction(label="View Issue", link="https://example.com/issues"),
-                NotificationRenderedAction(
-                    label="Assign to Me",
-                    link="https://example.com/assign",
-                ),
-            ],
-            chart=NotificationRenderedImage(
-                url="https://example.com/chart",
-                alt_text="Error occurrence chart",
             ),
             footer="This alert was triggered by your error monitoring rules.",
         )
@@ -89,6 +81,19 @@ class DeploymentData(NotificationData):
 class DeploymentNotificationTemplate(NotificationTemplate[DeploymentData]):
     category = NotificationCategory.DEBUG
 
+    @property
+    def example_data(self) -> DeploymentData:
+        return DeploymentData(
+            project_name="my-app",
+            version="v2.1.3",
+            environment="production",
+            deployer="john.doe@acme.com",
+            commit_sha="a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0",
+            commit_message="Fix user authentication bug",
+            deployment_url="https://example.com/deployment",
+            rollback_url="https://example.com/rollback",
+        )
+
     def render(self, data: DeploymentData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
             subject=f"Deployment to {data.environment}: {data.version}",
@@ -102,27 +107,6 @@ class DeploymentNotificationTemplate(NotificationTemplate[DeploymentData]):
                     label="View Deployment", link="https://example.com/deployment"
                 ),
                 NotificationRenderedAction(label="Rollback", link="https://example.com/rollback"),
-            ],
-            footer="Deployment completed at deployment-service",
-        )
-
-    def render_example(self) -> NotificationRenderedTemplate:
-        return NotificationRenderedTemplate(
-            subject="Deployment to production: v2.1.3",
-            body=(
-                "Version v2.1.3 has been successfully deployed to production for project my-app. "
-                "The deployment was initiated by john.doe@acme.com with commit a1b2c3d4: Fix user authentication bug. "
-                "Monitor the deployment status and be ready to rollback if any issues are detected."
-            ),
-            actions=[
-                NotificationRenderedAction(
-                    label="View Deployment",
-                    link="https://example.com/deployment",
-                ),
-                NotificationRenderedAction(
-                    label="Rollback",
-                    link="https://example.com/rollback",
-                ),
             ],
             footer="Deployment completed at deployment-service",
         )
@@ -144,6 +128,19 @@ class SecurityAlertData(NotificationData):
 @template_registry.register(SecurityAlertData.source)
 class SecurityAlertNotificationTemplate(NotificationTemplate[SecurityAlertData]):
     category = NotificationCategory.DEBUG
+
+    @property
+    def example_data(self) -> SecurityAlertData:
+        return SecurityAlertData(
+            alert_type="Suspicious login pattern",
+            severity="critical",
+            project_name="my-app",
+            description="Multiple failed login attempts detected from unusual locations.",
+            affected_users=23,
+            alert_url="https://example.com/security-alert",
+            acknowledge_url="https://example.com/acknowledge",
+            escalate_url="https://example.com/escalate",
+        )
 
     def render(self, data: SecurityAlertData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
@@ -167,31 +164,6 @@ class SecurityAlertNotificationTemplate(NotificationTemplate[SecurityAlertData])
             footer="This is a security alert requiring immediate attention.",
         )
 
-    def render_example(self) -> NotificationRenderedTemplate:
-        return NotificationRenderedTemplate(
-            subject="SECURITY ALERT: Suspicious login pattern in my-app",
-            body=(
-                "A CRITICAL security alert of type Suspicious login pattern has been triggered for project my-app. "
-                "The alert description: Multiple failed login attempts detected from unusual locations. "
-                "This security incident has affected 23 users and requires immediate investigation and response."
-            ),
-            actions=[
-                NotificationRenderedAction(
-                    label="View Alert Details",
-                    link="https://example.com/security-alert",
-                ),
-                NotificationRenderedAction(
-                    label="Acknowledge",
-                    link="https://example.com/acknowledge",
-                ),
-                NotificationRenderedAction(
-                    label="Escalate to Security Team",
-                    link="https://example.com/escalate",
-                ),
-            ],
-            footer="This is a security alert requiring immediate attention.",
-        )
-
 
 @dataclass(frozen=True)
 class PerformanceAlertData(NotificationData):
@@ -207,6 +179,17 @@ class PerformanceAlertData(NotificationData):
 @template_registry.register(PerformanceAlertData.source)
 class PerformanceAlertNotificationTemplate(NotificationTemplate[PerformanceAlertData]):
     category = NotificationCategory.DEBUG
+
+    @property
+    def example_data(self) -> PerformanceAlertData:
+        return PerformanceAlertData(
+            metric_name="API response time",
+            threshold="500ms",
+            current_value="1.2s",
+            project_name="my-app",
+            chart_url="https://example.com/chart",
+            investigation_url="https://example.com/investigate",
+        )
 
     def render(self, data: PerformanceAlertData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
@@ -226,26 +209,6 @@ class PerformanceAlertNotificationTemplate(NotificationTemplate[PerformanceAlert
             ),
         )
 
-    def render_example(self) -> NotificationRenderedTemplate:
-        return NotificationRenderedTemplate(
-            subject="Performance Alert: API response time threshold exceeded",
-            body=(
-                "Performance alert triggered for API response time in project my-app. "
-                "The current value of 1.2s exceeds the threshold of 500ms. "
-                "Immediate investigation is recommended to identify and resolve the performance degradation."
-            ),
-            actions=[
-                NotificationRenderedAction(
-                    label="Investigate Performance",
-                    link="https://example.com/investigate",
-                )
-            ],
-            chart=NotificationRenderedImage(
-                url="https://example.com/chart",
-                alt_text="Performance metrics chart",
-            ),
-        )
-
 
 @dataclass(frozen=True)
 class TeamUpdateData(NotificationData):
@@ -261,6 +224,16 @@ class TeamUpdateData(NotificationData):
 class TeamUpdateNotificationTemplate(NotificationTemplate[TeamUpdateData]):
     category = NotificationCategory.DEBUG
 
+    @property
+    def example_data(self) -> TeamUpdateData:
+        return TeamUpdateData(
+            team_name="Engineering",
+            update_type="Weekly Standup Reminder",
+            message="Don't forget about our weekly standup meeting tomorrow at 10 AM. Please prepare your updates on current sprint progress.",
+            author="jane.smith@acme.com",
+            timestamp="2024-01-15 16:45:00 UTC",
+        )
+
     def render(self, data: TeamUpdateData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
             subject=f"Team Update: {data.update_type}",
@@ -268,17 +241,6 @@ class TeamUpdateNotificationTemplate(NotificationTemplate[TeamUpdateData]):
                 f"Team {data.team_name} has posted a {data.update_type} update. "
                 f"Message: {data.message} "
                 f"Posted by {data.author} at {data.timestamp}."
-            ),
-            footer="This is an informational update from your team.",
-        )
-
-    def render_example(self) -> NotificationRenderedTemplate:
-        return NotificationRenderedTemplate(
-            subject="Team Update: Weekly Standup Reminder",
-            body=(
-                "Team Engineering has posted a Weekly Standup Reminder update. "
-                "Message: Don't forget about our weekly standup meeting tomorrow at 10 AM. Please prepare your updates on current sprint progress. "
-                "Posted by jane.smith@acme.com at 2024-01-15 16:45:00 UTC."
             ),
             footer="This is an informational update from your team.",
         )

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -182,9 +182,17 @@ class NotificationTemplate[T: NotificationData](abc.ABC):
         """
         ...
 
+    @property
     @abc.abstractmethod
+    def example_data(self) -> T:
+        """
+        The example data for this notification.
+        """
+        ...
+
     def render_example(self) -> NotificationRenderedTemplate:
         """
         Used to produce a debugging example rendered template for this notification. This
         implementation should be pure, and not populate with any live data.
         """
+        return self.render(data=self.example_data)

--- a/src/sentry/templates/sentry/emails/platform/default.html
+++ b/src/sentry/templates/sentry/emails/platform/default.html
@@ -1,0 +1,57 @@
+{% load sentry_helpers %} {% load sentry_assets %}
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    {% include "sentry/emails/email-styles.html" %}
+  </head>
+  <body class="{% block bodyclass %}{% endblock %}">
+    <table class="main">
+      <tr>
+        <td>
+          <div class="header">
+            <div class="container">
+              <h1>
+                <a href="{% absolute_uri %}"
+                  ><img
+                    src="{% absolute_asset_url 'sentry' 'images/email/sentry_logo_full.png' %}"
+                    width="125px"
+                    height="29px"
+                    alt="Sentry"
+                /></a>
+              </h1>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <div class="container">
+            <div class="inner">
+              <h3>{{subject}}</h3>
+              <p>{{body}}</p>
+              {% if actions %}
+                <p>
+                  {% for action_label, action_link in actions %}
+                  <a class="btn btn-default" href="{{action_link}}">{{action_label}}</a>
+                  {% endfor %}
+                </p>
+              {% endif %}
+              {% if chart_url %}
+              <img src="{{chart_url}}" alt="{{chart_alt_text}}" />
+              {% endif %}
+            </div>
+          </div>
+          {% if footer %}
+          <div class="container">
+            <div class="footer">
+              <p>{{footer}}</p>
+            </div>
+          </div>
+          {% endif %}
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/src/sentry/templates/sentry/emails/platform/default.txt
+++ b/src/sentry/templates/sentry/emails/platform/default.txt
@@ -1,0 +1,10 @@
+{{subject}}
+
+{{body}}
+{% if actions %}{% for action_label, action_link in actions %}
+* {{ action_label }}: {{ action_link }}
+{% endfor %}{% endif %}
+{% if chart_alt_text %}{{chart_alt_text}}:{% endif %}
+{% if chart_url %}{{chart_url}}{% endif %}
+
+{% if footer %}{{footer}}{% endif %}

--- a/src/sentry/testutils/notifications/platform.py
+++ b/src/sentry/testutils/notifications/platform.py
@@ -23,6 +23,10 @@ class MockNotification(NotificationData):
 class MockNotificationTemplate(NotificationTemplate[MockNotification]):
     category = NotificationCategory.DEBUG
 
+    @property
+    def example_data(self) -> MockNotification:
+        return MockNotification(message="This is a mock notification")
+
     def render(self, data: MockNotification) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
             subject="Mock Notification",
@@ -30,25 +34,11 @@ class MockNotificationTemplate(NotificationTemplate[MockNotification]):
             actions=[
                 NotificationRenderedAction(label="Visit Sentry", link="https://www.sentry.io")
             ],
-            footer="This is a mock footer",
             chart=NotificationRenderedImage(
                 url="https://raw.githubusercontent.com/knobiknows/all-the-bufo/main/all-the-bufo/bufo-pog.png",
                 alt_text="Bufo Pog",
             ),
-        )
-
-    def render_example(self) -> NotificationRenderedTemplate:
-        return NotificationRenderedTemplate(
-            subject="Mock Notification",
-            body="This is a mock notification",
-            actions=[
-                NotificationRenderedAction(label="Visit Sentry", link="https://www.sentry.io")
-            ],
             footer="This is a mock footer",
-            chart=NotificationRenderedImage(
-                url="https://raw.githubusercontent.com/knobiknows/all-the-bufo/main/all-the-bufo/bufo-pog.png",
-                alt_text="Bufo Pog",
-            ),
         )
 
 

--- a/tests/sentry/notifications/platform/email/test_provider.py
+++ b/tests/sentry/notifications/platform/email/test_provider.py
@@ -34,6 +34,10 @@ class EmailRendererTest(TestCase):
         assert content_type == "text/html"
         text_content = email.body
 
+        # Helping the type checker
+        assert self.rendered_template.chart is not None
+        assert self.rendered_template.footer is not None
+
         for element in [
             self.rendered_template.subject,
             self.rendered_template.body,
@@ -43,8 +47,8 @@ class EmailRendererTest(TestCase):
             self.rendered_template.chart.alt_text,
             self.rendered_template.footer,
         ]:
-            assert element in text_content
-            assert element in html_content
+            assert element in str(text_content)
+            assert element in str(html_content)
 
 
 class EmailNotificationProviderTest(TestCase):
@@ -68,7 +72,7 @@ class EmailNotificationProviderTest(TestCase):
         assert EmailNotificationProvider.is_available(organization=self.organization) is True
 
     @mock.patch("sentry.notifications.platform.email.provider.send_messages")
-    def test_send(self, mock_send_messages) -> None:
+    def test_send(self, mock_send_messages: mock.MagicMock) -> None:
         email = EmailRenderer.render(data=self.data, rendered_template=self.rendered_template)
         EmailNotificationProvider.send(target=self.target, renderable=email)
         mock_send_messages.assert_called_once()

--- a/tests/sentry/notifications/platform/email/test_provider.py
+++ b/tests/sentry/notifications/platform/email/test_provider.py
@@ -1,7 +1,12 @@
-from sentry.notifications.platform.email.provider import EmailNotificationProvider
-from sentry.notifications.platform.target import GenericNotificationTarget
+from unittest import mock
+
+import pytest
+from django.core.mail import EmailMultiAlternatives
+
+from sentry import options
+from sentry.notifications.platform.email.provider import EmailNotificationProvider, EmailRenderer
+from sentry.notifications.platform.target import GenericNotificationTarget, prepare_targets
 from sentry.notifications.platform.types import (
-    NotificationCategory,
     NotificationProviderKey,
     NotificationTargetResourceType,
 )
@@ -10,23 +15,72 @@ from sentry.testutils.notifications.platform import MockNotification, MockNotifi
 
 
 class EmailRendererTest(TestCase):
-    def test_default_renderer(self) -> None:
-        data = MockNotification(message="test")
-        template = MockNotificationTemplate()
-        rendered_template = template.render(data)
-        renderer = EmailNotificationProvider.get_renderer(
-            data=data, category=NotificationCategory.DEBUG
-        )
-        assert renderer.render(data=data, rendered_template=rendered_template) == {}
+    def setUp(self) -> None:
+        self.data = MockNotification(message="test message")
+        self.template = MockNotificationTemplate()
+        self.rendered_template = self.template.render(self.data)
+
+    def test_render(self) -> None:
+        email = EmailRenderer.render(data=self.data, rendered_template=self.rendered_template)
+
+        assert isinstance(email, EmailMultiAlternatives)
+        assert email.subject == self.rendered_template.subject
+        assert email.from_email == options.get("mail.from")
+        assert len(email.to) == 0
+        assert "Message-Id" in email.extra_headers
+
+        [html_alternative] = email.alternatives
+        [html_content, content_type] = html_alternative
+        assert content_type == "text/html"
+        text_content = email.body
+
+        for element in [
+            self.rendered_template.subject,
+            self.rendered_template.body,
+            self.rendered_template.actions[0].label,
+            self.rendered_template.actions[0].link,
+            self.rendered_template.chart.url,
+            self.rendered_template.chart.alt_text,
+            self.rendered_template.footer,
+        ]:
+            assert element in text_content
+            assert element in html_content
 
 
 class EmailNotificationProviderTest(TestCase):
-    def test_basic_fields(self) -> None:
-        provider = EmailNotificationProvider()
-        assert provider.key == NotificationProviderKey.EMAIL
-        assert provider.target_class == GenericNotificationTarget
-        assert provider.target_resource_types == [NotificationTargetResourceType.EMAIL]
+    def setUp(self) -> None:
+        self.provider = EmailNotificationProvider()
+        self.data = MockNotification(message="test message")
+        self.rendered_template = MockNotificationTemplate().render(self.data)
+        self.email = "test@example.com"
+        self.target = GenericNotificationTarget(
+            provider_key=NotificationProviderKey.EMAIL,
+            resource_type=NotificationTargetResourceType.EMAIL,
+            resource_id=self.email,
+        )
+        prepare_targets([self.target])
 
-    def test_is_available(self) -> None:
+    def test_provider_configuration(self) -> None:
+        assert self.provider.key == NotificationProviderKey.EMAIL
+        assert self.provider.target_class == GenericNotificationTarget
+        assert self.provider.target_resource_types == [NotificationTargetResourceType.EMAIL]
         assert EmailNotificationProvider.is_available() is True
         assert EmailNotificationProvider.is_available(organization=self.organization) is True
+
+    @mock.patch("sentry.notifications.platform.email.provider.send_messages")
+    def test_send(self, mock_send_messages) -> None:
+        email = EmailRenderer.render(data=self.data, rendered_template=self.rendered_template)
+        EmailNotificationProvider.send(target=self.target, renderable=email)
+        mock_send_messages.assert_called_once()
+        [sent_message] = mock_send_messages.call_args[0][0]
+        assert sent_message.to == [self.email]
+
+    def test_send_with_invalid_resource_type(self) -> None:
+        target = GenericNotificationTarget(
+            provider_key=NotificationProviderKey.EMAIL,
+            resource_type=NotificationTargetResourceType.CHANNEL,
+            resource_id="C01234567890",
+        )
+        email = EmailRenderer.render(data=self.data, rendered_template=self.rendered_template)
+        with pytest.raises(ValueError, match="EmailNotificationProvider cannot send to channel"):
+            EmailNotificationProvider.send(target=target, renderable=email)


### PR DESCRIPTION
It'll use a custom email path if provided, but also enables a default email.
Also refactored the examples to just display data.

<img width="733" height="505" alt="image" src="https://github.com/user-attachments/assets/f116fc27-2fd0-4818-ac39-dee445896f6e" />

<img width="847" height="365" alt="image" src="https://github.com/user-attachments/assets/af560762-47a5-459b-80fd-ed9e331ad3e1" />
