### PR TITLE
fix(discover): Update project converter to accept wild card search filter values

### DIFF
--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -70,7 +70,7 @@ def release_filter_converter(
 
 
 def matches_slug_pattern(slug_pattern: str, slug: str) -> bool:
-    return re.match(slug_pattern, slug)
+    return bool(re.match(slug_pattern, slug))
 
 
 def matches_slug_patterns(slug_patterns: list[str], slug: str) -> bool:

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -7399,3 +7399,15 @@ class OrganizationEventsUptimeDatasetEndpointTest(
                 "trace_id": trace_id,
             }
         ]
+
+    def test_project_slug_converter(self) -> None:
+        self.store_event(self.transaction_data, self.project.id)
+        response = self.do_request(
+            {
+                "field": ["project.name"],
+                "query": "project:ba*",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        assert response.data["data"][0]["project.name"] == self.project.slug


### PR DESCRIPTION
Searching for `project:ba*` doesn't work because `project_slug_converter` previously only used exact string comparison. Updates so that we always use glob matching instead (this should be fine because at most it's just iterated over the list of projects. If it causes performance issues, we can optimize).