### PR TITLE
feat(insights): Update create Web Vitals issue endpoint to also accept vital value

### DIFF
--- a/src/sentry/issues/endpoints/project_user_issue.py
+++ b/src/sentry/issues/endpoints/project_user_issue.py
@@ -106,6 +106,7 @@ class WebVitalsUserIssueFormatter(BaseUserIssueFormatter):
             "transaction": transaction,
             "web_vital": vital,
             "score": str(self.data.get("score")),
+            vital: str(self.data.get("value", "")),
         }
 
     def get_evidence(self) -> tuple[dict, list[IssueEvidence]]:
@@ -113,11 +114,13 @@ class WebVitalsUserIssueFormatter(BaseUserIssueFormatter):
         score = self.data.get("score")
         transaction = self.data.get("transaction", "")
         trace_id = self.data.get("traceId")
+        vital_value = self.data.get("value")
 
         evidence_data = {
             "transaction": transaction,
             "vital": vital,
             "score": score,
+            vital: vital_value,
         }
 
         evidence_display = [
@@ -134,6 +137,11 @@ class WebVitalsUserIssueFormatter(BaseUserIssueFormatter):
             IssueEvidence(
                 name="Score",
                 value=str(score),
+                important=True,
+            ),
+            IssueEvidence(
+                name=vital.upper(),
+                value=str(vital_value),
                 important=True,
             ),
         ]
@@ -166,6 +174,7 @@ class ProjectUserIssueRequestSerializer(serializers.Serializer):
 class WebVitalsIssueDataSerializer(ProjectUserIssueRequestSerializer):
     score = serializers.IntegerField(required=True, min_value=0, max_value=100)
     vital = serializers.ChoiceField(required=True, choices=["lcp", "fcp", "cls", "inp", "ttfb"])
+    value = serializers.IntegerField(required=True)
 
 
 class ProjectUserIssuePermission(ProjectPermission):

--- a/tests/sentry/issues/endpoints/test_project_user_issue.py
+++ b/tests/sentry/issues/endpoints/test_project_user_issue.py
@@ -38,6 +38,7 @@ class ProjectUserIssueEndpointTest(APITestCase):
             "transaction": "/test-transaction",
             "issueType": WebVitalsGroup.slug,
             "score": 75,
+            "value": 1000,
             "vital": "lcp",
             "traceId": "1234567890",
             "timestamp": "2025-01-01T00:00:00Z",
@@ -73,6 +74,7 @@ class ProjectUserIssueEndpointTest(APITestCase):
             "vital": "lcp",
             "score": 75,
             "trace_id": "1234567890",
+            "lcp": 1000,
         }
 
         # Verify event data
@@ -85,6 +87,7 @@ class ProjectUserIssueEndpointTest(APITestCase):
             "transaction": "/test-transaction",
             "web_vital": "lcp",
             "score": "75",
+            "lcp": "1000",
         }
         assert event_data["contexts"] == {
             "trace": {
@@ -133,6 +136,7 @@ class ProjectUserIssueEndpointTest(APITestCase):
             "issueType": WebVitalsGroup.slug,
             "score": 150,
             "vital": "invalid_vital",
+            "value": 1000,
         }
 
         response = self.get_error_response(
@@ -153,6 +157,7 @@ class ProjectUserIssueEndpointTest(APITestCase):
             "issueType": WebVitalsGroup.slug,
             "score": 75,
             "vital": "lcp",
+            "value": 1000,
         }
 
         with patch(


### PR DESCRIPTION
Updates the `project_user_issue` endpoint to also accept a vital `value`, which is added to tags and evidence for Seer usage.

Frontend Changes:
https://github.com/getsentry/sentry/pull/99688