### PR TITLE
fix(uptime): Do not show HTTP status if not available

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -137,13 +137,13 @@ function CheckInBodyCell({
     }
     case 'checkStatus': {
       const color = tickStyle(theme)[checkStatus].labelColor ?? theme.textColor;
+      const checkStatusReasonLabel = checkStatusReason
+        ? reasonToText[checkStatusReason](check)
+        : null;
       return (
         <Cell style={{color}}>
           {statusToText[checkStatus]}{' '}
-          {checkStatusReason &&
-            tct('([reason])', {
-              reason: reasonToText[checkStatusReason](check),
-            })}
+          {checkStatusReasonLabel && t('(%s)', checkStatusReasonLabel)}
         </Cell>
       );
     }

--- a/static/app/views/insights/uptime/timelineConfig.tsx
+++ b/static/app/views/insights/uptime/timelineConfig.tsx
@@ -25,7 +25,11 @@ export const reasonToText: Record<
   CheckStatusReason,
   (check: UptimeCheck) => React.ReactNode
 > = {
-  [CheckStatusReason.FAILURE]: check => t('HTTP %s', check.httpStatusCode),
+  [CheckStatusReason.FAILURE]: check =>
+    // TODO(epurkhiser): Not all failures include a HTTP status code, we
+    // should display the `status_reason_description` somewhere (this is not
+    // currently exposed to the frontend)
+    check.httpStatusCode ? t('HTTP %s', check.httpStatusCode) : null,
   [CheckStatusReason.TIMEOUT]: _ => t('Timeout'),
   [CheckStatusReason.DNS_ERROR]: _ => t('DNS Error'),
   [CheckStatusReason.TLS_ERROR]: _ => t('TLS Connection Error'),


### PR DESCRIPTION
Not all Failure sub-status failures are HTTP failures. We should really
probably have had a specific type for HTTP status code failure, and
another type for "unknown" failures

Fixes [NEW-474: Uptime failed status is shown as "null"](https://linear.app/getsentry/issue/NEW-474/uptime-failed-status-is-shown-as-null)