### PR TITLE
fix(checkout v3): Add Default Amount tag + move reserved step

### DIFF
--- a/static/gsApp/views/amCheckout/cart.spec.tsx
+++ b/static/gsApp/views/amCheckout/cart.spec.tsx
@@ -101,6 +101,7 @@ describe('Cart', () => {
     expect(cart).toHaveTextContent('Business Plan');
     expect(cart).toHaveTextContent('Pay-as-you-go spend cap$0-$300/mo');
     expect(cart).toHaveTextContent('Plan Total$89/mo');
+    expect(cart).toHaveTextContent('Default Amount');
     expect(within(cart).getByRole('button', {name: 'Confirm and pay'})).toBeEnabled();
   });
 

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -74,6 +74,7 @@ import CheckoutSuccess from 'getsentry/views/amCheckout/checkoutSuccess';
 import AddBillingDetails from 'getsentry/views/amCheckout/steps/addBillingDetails';
 import AddDataVolume from 'getsentry/views/amCheckout/steps/addDataVolume';
 import AddPaymentMethod from 'getsentry/views/amCheckout/steps/addPaymentMethod';
+import BillingCycle from 'getsentry/views/amCheckout/steps/checkoutV3/billingCycle';
 import BuildYourPlan from 'getsentry/views/amCheckout/steps/checkoutV3/buildYourPlan';
 import ContractSelect from 'getsentry/views/amCheckout/steps/contractSelect';
 import OnDemandBudgetsStep from 'getsentry/views/amCheckout/steps/onDemandBudgets';
@@ -295,7 +296,7 @@ class AMCheckout extends Component<Props, State> {
       : OnDemandSpend;
 
     if (isNewCheckout) {
-      return [BuildYourPlan, SetSpendCap];
+      return [BuildYourPlan, SetSpendCap, BillingCycle];
     }
 
     const preAM3Tiers = [PlanTier.AM1, PlanTier.AM2];

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/billingCycle.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/billingCycle.spec.tsx
@@ -1,0 +1,172 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
+
+import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
+import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {resetMockDate, setMockDate} from 'sentry-test/utils';
+
+import SubscriptionStore from 'getsentry/stores/subscriptionStore';
+import {PlanTier} from 'getsentry/types';
+import AMCheckout from 'getsentry/views/amCheckout/';
+
+describe('BillingCycle', () => {
+  const api = new MockApiClient();
+  const organization = OrganizationFixture();
+  const subscription = SubscriptionFixture({organization, plan: 'am3_f'});
+
+  beforeEach(() => {
+    api.clear();
+    setMockDate(new Date('2025-08-13'));
+    MockApiClient.clearMockResponses();
+    SubscriptionStore.set(organization.slug, subscription);
+
+    MockApiClient.addMockResponse({
+      url: `/subscriptions/${organization.slug}/`,
+      method: 'GET',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-config/`,
+      method: 'GET',
+      body: BillingConfigFixture(PlanTier.AM3),
+    });
+    MockApiClient.addMockResponse({
+      method: 'POST',
+      url: '/_experiment/log_exposure/',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/promotions/trigger-check/`,
+      method: 'POST',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/plan-migrations/?applied=0`,
+      method: 'GET',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/subscription/preview/`,
+      method: 'GET',
+      body: {
+        invoiceItems: [],
+      },
+    });
+  });
+
+  afterEach(() => {
+    resetMockDate();
+    organization.features = [];
+  });
+
+  async function assertCycleText({
+    monthlyInfo,
+    yearlyInfo,
+  }: {
+    monthlyInfo: string | RegExp;
+    yearlyInfo: string | RegExp;
+  }) {
+    expect(await screen.findByText('Billing cycle')).toBeInTheDocument();
+
+    const monthlyOption = screen.getByTestId('billing-cycle-option-monthly');
+    expect(within(monthlyOption).getByText('Monthly')).toBeInTheDocument();
+    expect(within(monthlyOption).queryByText('save 10%')).not.toBeInTheDocument();
+    expect(within(monthlyOption).getByText(monthlyInfo)).toBeInTheDocument();
+    expect(within(monthlyOption).getByText('Cancel anytime')).toBeInTheDocument();
+
+    const yearlyOption = screen.getByTestId('billing-cycle-option-annual');
+    expect(within(yearlyOption).getByText('Yearly')).toBeInTheDocument();
+    expect(within(yearlyOption).getByText('save 10%')).toBeInTheDocument();
+    expect(within(yearlyOption).getByText(yearlyInfo)).toBeInTheDocument();
+    expect(
+      within(yearlyOption).getByText("Discount doesn't apply to pay-as-you-go usage")
+    ).toBeInTheDocument();
+  }
+
+  function renderCheckout(isNewCheckout: boolean, referrer?: string) {
+    let location = LocationFixture();
+    if (referrer) {
+      location = LocationFixture({
+        query: {
+          referrer,
+        },
+      });
+    }
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        api={api}
+        onToggleLegacy={jest.fn()}
+        checkoutTier={PlanTier.AM3}
+        isNewCheckout={isNewCheckout}
+        location={location}
+        navigate={jest.fn()}
+      />,
+      {organization}
+    );
+  }
+
+  it('renders for coterm upgrade', async () => {
+    renderCheckout(true);
+    await assertCycleText({
+      monthlyInfo: /Billed monthly starting on August 13/,
+      yearlyInfo: /Billed every 12 months on the 13th of August/,
+    });
+  });
+
+  it('renders for monthly downgrade', async () => {
+    const annualSub = SubscriptionFixture({
+      planDetails: PlanDetailsLookupFixture('am2_business_auf'),
+      contractPeriodStart: '2025-07-16',
+      contractPeriodEnd: '2026-07-15',
+      organization,
+    });
+    SubscriptionStore.set(organization.slug, annualSub);
+    renderCheckout(true);
+    await assertCycleText({
+      monthlyInfo: /Billed monthly starting on July 16/,
+      yearlyInfo: /Billed every 12 months on the 13th of August/, // annual can be applied immediately
+    });
+  });
+
+  it('renders for migrating partner customers', async () => {
+    const partnerSub = SubscriptionFixture({
+      contractInterval: 'annual',
+      sponsoredType: 'FOO',
+      partner: {
+        isActive: true,
+        externalId: 'foo',
+        partnership: {
+          id: 'foo',
+          displayName: 'FOO',
+          supportNote: '',
+        },
+        name: '',
+      },
+      organization,
+    });
+    SubscriptionStore.set(organization.slug, partnerSub);
+    renderCheckout(true);
+    await assertCycleText({
+      monthlyInfo: /Billed monthly starting on your selected start date on submission/,
+      yearlyInfo: /Billed every 12 months from your selected start date on submission/,
+    });
+  });
+
+  it('can select billing cycle', async () => {
+    renderCheckout(true);
+
+    const monthly = await screen.findByRole('radio', {name: 'Monthly billing cycle'});
+    const annual = screen.getByRole('radio', {name: 'Yearly billing cycle'});
+
+    expect(monthly).toBeChecked();
+    expect(annual).not.toBeChecked();
+
+    await userEvent.click(annual);
+    expect(monthly).not.toBeChecked();
+    expect(annual).toBeChecked();
+  });
+});

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/billingCycle.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/billingCycle.tsx
@@ -1,0 +1,93 @@
+import {Fragment, useMemo, useState} from 'react';
+
+import {Flex, Grid} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
+import {t} from 'sentry/locale';
+
+import {ANNUAL} from 'getsentry/constants';
+import BillingCycleSelectCard from 'getsentry/views/amCheckout/billingCycleSelectCard';
+import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
+import type {CheckoutV3StepProps} from 'getsentry/views/amCheckout/types';
+import * as utils from 'getsentry/views/amCheckout/utils';
+
+function BillingCycle({
+  formData,
+  onUpdate,
+  subscription,
+  billingConfig,
+  onEdit,
+  stepNumber,
+}: CheckoutV3StepProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const intervalOptions = useMemo(() => {
+    const basePlan = formData.plan.replace('_auf', '');
+    const plans = billingConfig.planList.filter(({id}) => id.indexOf(basePlan) === 0);
+
+    if (plans.length === 0) {
+      throw new Error('Cannot get billing interval options');
+    }
+
+    return plans;
+  }, [billingConfig, formData.plan]);
+
+  let previousPlanPrice = 0;
+  return (
+    <Flex direction="column" gap="xl">
+      <StepHeader
+        isActive
+        isCompleted={false}
+        onEdit={onEdit}
+        onToggleStep={setIsOpen}
+        isOpen={isOpen}
+        stepNumber={stepNumber}
+        title={t('Billing cycle')}
+        isNewCheckout
+      />
+      {isOpen && (
+        <Fragment>
+          <Text as="div">
+            {t('Additional usage is billed separately, at the start of the next cycle')}
+          </Text>
+          <Grid
+            columns={{xs: '1fr', md: `repeat(${intervalOptions.length}, 1fr)`}}
+            gap="xl"
+          >
+            {intervalOptions.map(plan => {
+              const isSelected = plan.id === formData.plan;
+              const isAnnual = plan.contractInterval === ANNUAL;
+              const priceAfterDiscount = utils.getReservedPriceCents({
+                plan,
+                reserved: formData.reserved,
+                selectedProducts: formData.selectedProducts,
+              });
+              const formattedPriceAfterDiscount = utils.formatPrice({
+                cents: priceAfterDiscount,
+              });
+
+              const priceBeforeDiscount = isAnnual ? previousPlanPrice * 12 : 0;
+              const formattedPriceBeforeDiscount = previousPlanPrice
+                ? utils.formatPrice({cents: priceBeforeDiscount})
+                : '';
+              previousPlanPrice = priceAfterDiscount;
+
+              return (
+                <BillingCycleSelectCard
+                  key={plan.id}
+                  plan={plan}
+                  isSelected={isSelected}
+                  onUpdate={onUpdate}
+                  subscription={subscription}
+                  formattedPriceAfterDiscount={formattedPriceAfterDiscount}
+                  formattedPriceBeforeDiscount={formattedPriceBeforeDiscount}
+                  priceAfterDiscount={priceAfterDiscount}
+                />
+              );
+            })}
+          </Grid>
+        </Fragment>
+      )}
+    </Flex>
+  );
+}
+
+export default BillingCycle;

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.tsx
@@ -9,7 +9,6 @@ import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import getDaysSinceDate from 'sentry/utils/getDaysSinceDate';
 
-import {ANNUAL} from 'getsentry/constants';
 import type {BillingConfig, Plan, PlanTier, Subscription} from 'getsentry/types';
 import {
   getPlanIcon,
@@ -18,7 +17,6 @@ import {
   isNewPayingCustomer,
   isTrialPlan,
 } from 'getsentry/utils/billing';
-import BillingCycleSelectCard from 'getsentry/views/amCheckout/billingCycleSelectCard';
 import PlanFeatures from 'getsentry/views/amCheckout/planFeatures';
 import {getHighlightedFeatures} from 'getsentry/views/amCheckout/steps/planSelect';
 import PlanSelectCard from 'getsentry/views/amCheckout/steps/planSelectCard';
@@ -45,11 +43,6 @@ interface PlanSubstepProps extends BaseSubstepProps {
 }
 
 interface AdditionalProductsSubstepProps extends BaseSubstepProps {}
-
-interface BillingCycleSubstepProps extends BaseSubstepProps {
-  billingConfig: BillingConfig;
-  subscription: Subscription;
-}
 
 function PlanSubstep({
   billingConfig,
@@ -171,69 +164,6 @@ function AdditionalProductsSubstep({
   );
 }
 
-function BillingCycleSubstep({
-  formData,
-  onUpdate,
-  subscription,
-  billingConfig,
-}: BillingCycleSubstepProps) {
-  const intervalOptions = useMemo(() => {
-    const basePlan = formData.plan.replace('_auf', '');
-    const plans = billingConfig.planList.filter(({id}) => id.indexOf(basePlan) === 0);
-
-    if (plans.length === 0) {
-      throw new Error('Cannot get billing interval options');
-    }
-
-    return plans;
-  }, [billingConfig, formData.plan]);
-
-  let previousPlanPrice = 0;
-  return (
-    <Substep>
-      <SubstepHeader>
-        <SubstepTitle>{t('Billing cycle')}</SubstepTitle>
-        <SubstepDescription>
-          {t('Additional usage is billed separately, at the start of the next cycle')}
-        </SubstepDescription>
-      </SubstepHeader>
-      <OptionGrid columns={intervalOptions.length}>
-        {intervalOptions.map(plan => {
-          const isSelected = plan.id === formData.plan;
-          const isAnnual = plan.contractInterval === ANNUAL;
-          const priceAfterDiscount = utils.getReservedPriceCents({
-            plan,
-            reserved: formData.reserved,
-            selectedProducts: formData.selectedProducts,
-          });
-          const formattedPriceAfterDiscount = utils.formatPrice({
-            cents: priceAfterDiscount,
-          });
-
-          const priceBeforeDiscount = isAnnual ? previousPlanPrice * 12 : 0;
-          const formattedPriceBeforeDiscount = previousPlanPrice
-            ? utils.formatPrice({cents: priceBeforeDiscount})
-            : '';
-          previousPlanPrice = priceAfterDiscount;
-
-          return (
-            <BillingCycleSelectCard
-              key={plan.id}
-              plan={plan}
-              isSelected={isSelected}
-              onUpdate={onUpdate}
-              subscription={subscription}
-              formattedPriceAfterDiscount={formattedPriceAfterDiscount}
-              formattedPriceBeforeDiscount={formattedPriceBeforeDiscount}
-              priceAfterDiscount={priceAfterDiscount}
-            />
-          );
-        })}
-      </OptionGrid>
-    </Substep>
-  );
-}
-
 function BuildYourPlan({
   activePlan,
   billingConfig,
@@ -277,13 +207,6 @@ function BuildYourPlan({
             formData={formData}
             onUpdate={onUpdate}
           />
-          <BillingCycleSubstep
-            activePlan={activePlan}
-            formData={formData}
-            onUpdate={onUpdate}
-            subscription={subscription}
-            billingConfig={billingConfig}
-          />
         </Fragment>
       )}
     </BuildYourPlanContainer>
@@ -307,17 +230,6 @@ const SubstepTitle = styled('h2')`
   font-weight: ${p => p.theme.fontWeight.bold};
   margin-top: ${p => p.theme.space['2xl']};
   margin-bottom: 0;
-`;
-
-const SubstepDescription = styled('p')`
-  margin: 0;
-  color: ${p => p.theme.subText};
-`;
-
-const SubstepHeader = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${p => p.theme.space.xs};
 `;
 
 const OptionGrid = styled('div')<{columns: number}>`

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.tsx
@@ -20,7 +20,6 @@ import {
 } from 'getsentry/utils/billing';
 import BillingCycleSelectCard from 'getsentry/views/amCheckout/billingCycleSelectCard';
 import PlanFeatures from 'getsentry/views/amCheckout/planFeatures';
-import ReserveAdditionalVolume from 'getsentry/views/amCheckout/reserveAdditionalVolume';
 import {getHighlightedFeatures} from 'getsentry/views/amCheckout/steps/planSelect';
 import PlanSelectCard from 'getsentry/views/amCheckout/steps/planSelectCard';
 import ProductSelect from 'getsentry/views/amCheckout/steps/productSelect';
@@ -59,7 +58,6 @@ function PlanSubstep({
   subscription,
   organization,
   referrer,
-  checkoutTier,
   onUpdate,
 }: PlanSubstepProps) {
   const planOptions = useMemo(() => {
@@ -149,14 +147,6 @@ function PlanSubstep({
         })}
       </OptionGrid>
       <PlanFeatures planOptions={planOptions} activePlan={activePlan} />
-      <ReserveAdditionalVolume
-        activePlan={activePlan}
-        formData={formData}
-        onUpdate={onUpdate}
-        organization={organization}
-        subscription={subscription}
-        checkoutTier={checkoutTier}
-      />
     </Substep>
   );
 }

--- a/static/gsApp/views/amCheckout/steps/setSpendCap.tsx
+++ b/static/gsApp/views/amCheckout/steps/setSpendCap.tsx
@@ -1,9 +1,11 @@
 import {useCallback, useMemo, useState} from 'react';
 
+import {Flex} from 'sentry/components/core/layout';
 import {capitalize} from 'sentry/utils/string/capitalize';
 
 import type {OnDemandBudgets} from 'getsentry/types';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
+import ReserveAdditionalVolume from 'getsentry/views/amCheckout/reserveAdditionalVolume';
 import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
 import type {SelectableProduct, StepProps} from 'getsentry/views/amCheckout/types';
 import {
@@ -20,6 +22,7 @@ function SetSpendCap({
   onUpdate,
   organization,
   subscription,
+  checkoutTier,
 }: StepProps) {
   const [isOpen, setIsOpen] = useState(true);
   const additionalProducts = useMemo(() => {
@@ -64,28 +67,40 @@ function SetSpendCap({
   );
 
   return (
-    <SpendCapSettings
-      header={
-        <StepHeader
-          title={capitalize(activePlan.budgetTerm)}
-          isActive
-          stepNumber={stepNumber}
-          isCompleted={false}
-          onEdit={onEdit}
-          isOpen={isOpen}
-          onToggleStep={setIsOpen}
-          isNewCheckout
-        />
-      }
-      activePlan={activePlan}
-      onDemandBudgets={
-        formData.onDemandBudget ?? parseOnDemandBudgetsFromSubscription(subscription)
-      }
-      onUpdate={({onDemandBudgets}) => handleBudgetChange({onDemandBudgets})}
-      currentReserved={formData.reserved}
-      additionalProducts={additionalProducts}
-      isOpen={isOpen}
-    />
+    <Flex direction="column" gap="2xl">
+      <SpendCapSettings
+        header={
+          <StepHeader
+            title={capitalize(activePlan.budgetTerm)}
+            isActive
+            stepNumber={stepNumber}
+            isCompleted={false}
+            onEdit={onEdit}
+            isOpen={isOpen}
+            onToggleStep={setIsOpen}
+            isNewCheckout
+          />
+        }
+        activePlan={activePlan}
+        onDemandBudgets={
+          formData.onDemandBudget ?? parseOnDemandBudgetsFromSubscription(subscription)
+        }
+        onUpdate={({onDemandBudgets}) => handleBudgetChange({onDemandBudgets})}
+        currentReserved={formData.reserved}
+        additionalProducts={additionalProducts}
+        isOpen={isOpen}
+        footer={
+          <ReserveAdditionalVolume
+            activePlan={activePlan}
+            formData={formData}
+            onUpdate={onUpdate}
+            organization={organization}
+            subscription={subscription}
+            checkoutTier={checkoutTier}
+          />
+        }
+      />
+    </Flex>
   );
 }
 

--- a/static/gsApp/views/spendCaps/spendCapSettings.tsx
+++ b/static/gsApp/views/spendCaps/spendCapSettings.tsx
@@ -47,6 +47,7 @@ interface SpendCapSettingsProps {
   header: React.ReactNode;
   onDemandBudgets: OnDemandBudgets;
   onUpdate: ({onDemandBudgets}: {onDemandBudgets: OnDemandBudgets}) => void;
+  footer?: React.ReactNode;
   isOpen?: boolean;
 }
 
@@ -593,6 +594,7 @@ function SpendCapSettings({
   currentReserved,
   isOpen,
   additionalProducts,
+  footer,
 }: SpendCapSettingsProps) {
   return (
     <Flex direction="column">
@@ -616,6 +618,7 @@ function SpendCapSettings({
             currentReserved={currentReserved}
             additionalProducts={additionalProducts}
           />
+          {footer}
         </Grid>
       )}
     </Flex>


### PR DESCRIPTION
Adds default amount tag to cart when PAYG is set to the suggested amount for that plan:
<img width="411" height="167" alt="Screenshot 2025-09-17 at 11 17 08 AM" src="https://github.com/user-attachments/assets/3912d797-dfa7-497e-9678-6bdbd27463f0" />

Moves reserved substep from Build your plan step to PAYG step
<img width="1053" height="693" alt="Screenshot 2025-09-17 at 11 17 19 AM" src="https://github.com/user-attachments/assets/48eaf9d0-053d-4777-b2db-f02ece354b6a" />

Changes Billing cycle substep into its own step
<img width="1056" height="313" alt="Screenshot 2025-09-17 at 11 39 24 AM" src="https://github.com/user-attachments/assets/7772b1c5-6dd9-439a-8144-5bebabbea37e" />
