### PR TITLE
fix(deletions): Fix stuck project & org deletions

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -215,6 +215,9 @@ def delete_group_hashes(
     group_ids: Sequence[int],
     seer_deletion: bool = False,
 ) -> None:
+    if not group_ids:
+        return
+
     hashes_batch_size = options.get("deletions.group-hashes-batch-size")
 
     # Validate batch size to ensure it's at least 1 to avoid ValueError in range()

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -238,8 +238,10 @@ def delete_group_hashes(
     iterations = 0
 
     while iterations < max_iterations:
-        qs = GroupHash.objects.filter(project_id=project_id, group_id__in=group_ids)
-        hashes_chunk = list(qs.values_list("id", "hash")[:hashes_batch_size])
+        qs = GroupHash.objects.filter(project_id=project_id, group_id__in=group_ids).values_list(
+            "id", "hash"
+        )[:hashes_batch_size]
+        hashes_chunk = list(qs)
         if not hashes_chunk:
             break
         try:

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -227,10 +227,10 @@ def delete_group_hashes(
     iterations = 0
 
     while iterations < max_iterations:
-        qs = GroupHash.objects.filter(project_id=project_id, group_id__in=group_ids).values_list(
-            "id", "hash"
-        )[:hashes_batch_size]
-        hashes_chunk = list(qs)
+        qs = GroupHash.objects.filter(project_id=project_id)
+        if group_ids:
+            qs = qs.filter(group_id__in=group_ids)
+        hashes_chunk = list(qs.values_list("id", "hash")[:hashes_batch_size])
         if not hashes_chunk:
             break
         try:

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -754,9 +754,9 @@ class Project(Model):
         # There are projects being blocked from deletion because they have GroupHash objects
         # that are preventing the project from being deleted.
         try:
-            from sentry.deletions.defaults.group import delete_group_hashes
+            from sentry.deletions.defaults.group import delete_project_group_hashes
 
-            delete_group_hashes(project_id=self.id, group_ids=[])
+            delete_project_group_hashes(project_id=self.id)
         except Exception:
             logger.warning("Failed to delete group hashes for project %s", self.id)
 

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -50,6 +50,8 @@ from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.retries import TimedRetryPolicy
 from sentry.utils.snowflake import save_with_snowflake_id, snowflake_id_model
 
+logger = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
     from sentry.models.options.project_option import ProjectOptionManager
     from sentry.models.options.project_template_option import ProjectTemplateOptionManager
@@ -748,6 +750,15 @@ class Project(Model):
     def delete(self, *args, **kwargs):
         # There is no foreign key relationship so we have to manually cascade.
         notifications_service.remove_notification_settings_for_project(project_id=self.id)
+
+        # There are projects being blocked from deletion because they have GroupHash objects
+        # that are preventing the project from being deleted.
+        try:
+            from sentry.deletions.defaults.group import delete_group_hashes
+
+            delete_group_hashes(project_id=self.id, group_ids=[])
+        except Exception:
+            logger.warning("Failed to delete group hashes for project %s", self.id)
 
         with outbox_context(transaction.atomic(router.db_for_write(Project))):
             Project.outbox_for_update(self.id, self.organization_id).save()


### PR DESCRIPTION
There are some projects which we are attempting to delete, however, when their associated group hashes are attempted to being removed, we fail to do so because there's too many.

We have a ticket to investigate why the custom deletion tasks are not working as expected (We don't see Group & GroupHash deletions happening in the breadcrumbs).

Once we get to delete the Project's instance, Django's cascading deletion is used (rather than our custom tasks) and the query to select the group hashes times out.

Some performance issues have been addressed to ensure the group hashes are deleted before we attempt to delete the project (#99478, #99469, #98912 and #98904), however, these scheduled deletions keep trying the same projects again and again.

You can use this query to see scheduled deletions stuck:
```
select
  *
from
  sentry_regionscheduleddeletion
where
  model_name in ('Project', 'Organization')
  and date_scheduled < '2025-09-15 12:00:00+00:00'
order by
  date_scheduled;
```

Fixes [SENTRY-4A7H](https://sentry.sentry.io/issues/6784855129/)