### PR TITLE
feat(dashboards-limits): Remove frontend feature flags

### DIFF
--- a/static/gsApp/hooks/dashboardsLimit.spec.tsx
+++ b/static/gsApp/hooks/dashboardsLimit.spec.tsx
@@ -15,10 +15,6 @@ import {useDashboardsLimit} from './dashboardsLimit';
 
 const mockOrganization = OrganizationFixture();
 
-const mockOrganizationWithoutFeature = OrganizationFixture({
-  features: [],
-});
-
 describe('useDashboardsLimit', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();

--- a/static/gsApp/hooks/dashboardsLimit.spec.tsx
+++ b/static/gsApp/hooks/dashboardsLimit.spec.tsx
@@ -13,9 +13,7 @@ import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 
 import {useDashboardsLimit} from './dashboardsLimit';
 
-const mockOrganization = OrganizationFixture({
-  features: ['dashboards-plan-limits'],
-});
+const mockOrganization = OrganizationFixture();
 
 const mockOrganizationWithoutFeature = OrganizationFixture({
   features: [],
@@ -25,19 +23,6 @@ describe('useDashboardsLimit', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     SubscriptionStore.init();
-  });
-
-  it('returns no limits when feature flag is disabled', () => {
-    const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
-      organization: mockOrganizationWithoutFeature,
-    });
-
-    expect(result.current).toEqual({
-      hasReachedDashboardLimit: false,
-      dashboardsLimit: 0,
-      isLoading: false,
-      limitMessage: null,
-    });
   });
 
   it('handles unlimited dashboards plan without making dashboards request', async () => {

--- a/static/gsApp/hooks/dashboardsLimit.tsx
+++ b/static/gsApp/hooks/dashboardsLimit.tsx
@@ -41,21 +41,9 @@ export function useDashboardsLimit(): UseDashboardsLimitResult {
       ],
       {
         staleTime: 0,
-        enabled:
-          organization.features.includes('dashboards-plan-limits') &&
-          !isUnlimitedPlan &&
-          dashboardsLimit !== 0,
+        enabled: !isUnlimitedPlan && dashboardsLimit !== 0,
       }
     );
-
-  if (!organization.features.includes('dashboards-plan-limits')) {
-    return {
-      hasReachedDashboardLimit: false,
-      dashboardsLimit: 0,
-      isLoading: false,
-      limitMessage: null,
-    };
-  }
 
   // Add 1 to dashboardsLimit to account for the General dashboard
   const hasReachedDashboardLimit =


### PR DESCRIPTION
Removes the feature flag from the frontend. Because this is gated by the `dashboards-edit` and `dashboards-basic` feature flags, it's pretty much GA'd and ready for removal.