### PR TITLE
feat(insights): Pass web vital value to user issue creation endpoint

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
@@ -228,6 +228,15 @@ describe('PageOverviewSidebar', () => {
         <PageOverviewSidebar
           transaction={TRANSACTION_NAME}
           projectScore={{lcpScore: 80}}
+          projectData={[
+            {
+              'p75(measurements.lcp)': 1000,
+              'p75(measurements.cls)': 0.1,
+              'p75(measurements.fcp)': 1800,
+              'p75(measurements.ttfb)': 600,
+              'p75(measurements.inp)': 200,
+            },
+          ]}
         />,
         {organization}
       );
@@ -242,6 +251,7 @@ describe('PageOverviewSidebar', () => {
             issueType: 'web_vitals',
             vital: 'lcp',
             score: 80,
+            value: 1000,
             transaction: TRANSACTION_NAME,
           }),
         })

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -160,6 +160,7 @@ export function PageOverviewSidebar({
 
   const runSeerAnalysis = useRunSeerAnalysis({
     projectScore,
+    projectData: projectData?.[0],
     transaction,
     webVitalTraceSamples,
   });

--- a/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
@@ -2,6 +2,7 @@ import {useCallback} from 'react';
 
 import {IssueType} from 'sentry/types/group';
 import {ORDER} from 'sentry/views/insights/browser/webVitals/components/charts/performanceScoreChart';
+import type {ProjectData} from 'sentry/views/insights/browser/webVitals/components/webVitalMetersWithIssues';
 import {useInvalidateWebVitalsIssuesQuery} from 'sentry/views/insights/browser/webVitals/queries/useWebVitalsIssuesQuery';
 import type {ProjectScore} from 'sentry/views/insights/browser/webVitals/types';
 import {useCreateIssue} from 'sentry/views/insights/browser/webVitals/utils/useCreateIssue';
@@ -21,11 +22,13 @@ type WebVitalTraceSamples = {
 // TODO: Add logic to actually initiate running autofix for each issue. Right now we rely on the project config to automatically run autofix for each issue.
 export function useRunSeerAnalysis({
   projectScore,
+  projectData,
   transaction,
   webVitalTraceSamples,
 }: {
   transaction: string;
   webVitalTraceSamples: WebVitalTraceSamples;
+  projectData?: ProjectData;
   projectScore?: ProjectScore;
 }) {
   const {mutateAsync: createIssueAsync} = useCreateIssue();
@@ -34,7 +37,7 @@ export function useRunSeerAnalysis({
   });
 
   const runSeerAnalysis = useCallback(async (): Promise<string[]> => {
-    if (!projectScore) {
+    if (!projectScore || !projectData) {
       return [];
     }
     const underPerformingWebVitals = ORDER.filter(webVital => {
@@ -47,6 +50,7 @@ export function useRunSeerAnalysis({
           issueType: IssueType.WEB_VITALS,
           vital: webVital,
           score: projectScore[`${webVital}Score`],
+          value: projectData[`p75(measurements.${webVital})`],
           transaction,
           traceId: webVitalTraceSamples[webVital]?.trace,
           timestamp: webVitalTraceSamples[webVital]?.timestamp,
@@ -64,6 +68,7 @@ export function useRunSeerAnalysis({
   }, [
     createIssueAsync,
     projectScore,
+    projectData,
     transaction,
     invalidateWebVitalsIssuesQuery,
     webVitalTraceSamples,


### PR DESCRIPTION
Updates `useRunSeerAnalysis` to also pass the web vital value to the user issue creation endpoint. 

Backend Changes:
https://github.com/getsentry/sentry/pull/99675