### PR TITLE
feat(dashboards-limits): Remove backend feature flags

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -327,15 +327,13 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         if not features.has("organizations:dashboards-edit", organization, actor=request.user):
             return Response(status=404)
 
-        if features.has("organizations:dashboards-plan-limits", organization, actor=request.user):
-            dashboard_count = Dashboard.objects.filter(organization=organization).count()
-            dashboard_limit = quotas.backend.get_dashboard_limit(organization.id)
-
-            if dashboard_limit >= 0 and dashboard_count >= dashboard_limit:
-                return Response(
-                    f"You may not exceed {dashboard_limit} dashboards on your current plan.",
-                    status=400,
-                )
+        dashboard_count = Dashboard.objects.filter(organization=organization).count()
+        dashboard_limit = quotas.backend.get_dashboard_limit(organization.id)
+        if dashboard_limit >= 0 and dashboard_count >= dashboard_limit:
+            return Response(
+                f"You may not exceed {dashboard_limit} dashboards on your current plan.",
+                status=400,
+            )
 
         serializer = DashboardSerializer(
             data=request.data,

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -106,8 +106,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-mep", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable metrics enhanced performance for AM2+ customers as they transition from AM2 to AM3
     manager.add("organizations:dashboards-metrics-transition", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable dashboard limits by plan type
-    manager.add("organizations:dashboards-plan-limits", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable starred dashboards with reordering
     manager.add("organizations:dashboards-starred-reordering", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the dashboard widget builder redesign UI

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -1881,14 +1881,12 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
     @patch("sentry.quotas.backend.get_dashboard_limit")
     def test_dashboard_limit_prevents_creation(self, mock_get_dashboard_limit) -> None:
         mock_get_dashboard_limit.return_value = 1
-        with self.feature("organizations:dashboards-plan-limits"):
-            response = self.do_request("post", self.url, data={"title": "New Dashboard w/ Limit"})
+        response = self.do_request("post", self.url, data={"title": "New Dashboard w/ Limit"})
         assert response.status_code == 400
         assert response.data == "You may not exceed 1 dashboards on your current plan."
 
         mock_get_dashboard_limit.return_value = 5
-        with self.feature("organizations:dashboards-plan-limits"):
-            response = self.do_request("post", self.url, data={"title": "New Dashboard w/ Limit"})
+        response = self.do_request("post", self.url, data={"title": "New Dashboard w/ Limit"})
         assert response.status_code == 201
 
     def test_prebuilt_dashboard_is_shown_when_favorites_pinned_and_no_dashboards(self) -> None:


### PR DESCRIPTION
Removes the backend feature flags. To be merged after #99683.

dashboard limits are now GA'd and currently applied for any users with `dashboards-edit` and `dashboard-basic`. Since those flags guard these endpoints, we can just remove this flag and rely on those larger feature ones.