### PR TITLE
ref(timeseries): Use `/events-timeseries/` in Resources module landings

### DIFF
--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
@@ -1,6 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
@@ -251,7 +252,7 @@ const setupMockRequests = (organization: Organization) => {
   });
 
   MockApiClient.addMockResponse({
-    url: `/organizations/${organization.slug}/events-stats/`,
+    url: `/organizations/${organization.slug}/events-timeseries/`,
     method: 'GET',
     match: [
       MockApiClient.matchQuery({
@@ -259,34 +260,14 @@ const setupMockRequests = (organization: Organization) => {
       }),
     ],
     body: {
-      [`${EPM}()`]: {
-        data: [
-          [1699907700, [{count: 7810.2}]],
-          [1699908000, [{count: 1216.8}]],
-        ],
-        meta: {
-          fields: {
-            [`${EPM}()`]: 'rate',
-          },
-          units: {
-            [`${EPM}()`]: '1/second',
-          },
-        },
-      },
-      [`avg(${SPAN_SELF_TIME})`]: {
-        data: [
-          [1699907700, [{count: 1111.2}]],
-          [1699908000, [{count: 2222.8}]],
-        ],
-        meta: {
-          fields: {
-            [`avg(${SPAN_SELF_TIME})`]: 'duration',
-          },
-          units: {
-            [`avg(${SPAN_SELF_TIME})`]: 'millisecond',
-          },
-        },
-      },
+      timeSeries: [
+        TimeSeriesFixture({
+          yAxis: `${EPM}()`,
+        }),
+        TimeSeriesFixture({
+          yAxis: `avg(${SPAN_SELF_TIME})`,
+        }),
+      ],
     },
   });
 

--- a/static/app/views/insights/common/components/widgets/hooks/useResourceLandingSeries.tsx
+++ b/static/app/views/insights/common/components/widgets/hooks/useResourceLandingSeries.tsx
@@ -1,10 +1,10 @@
 import type {PageFilters} from 'sentry/types/core';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {EMPTY_OPTION_VALUE, MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {getResourceTypeFilter} from 'sentry/views/insights/browser/common/queries/useResourcesQuery';
 import {Referrer} from 'sentry/views/insights/browser/resources/referrer';
 import {DEFAULT_RESOURCE_TYPES} from 'sentry/views/insights/browser/resources/settings';
 import {useResourceModuleFilters} from 'sentry/views/insights/browser/resources/utils/useResourceFilters';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import type {ModuleFilters} from 'sentry/views/insights/common/views/spans/types';
 import type {SearchHook} from 'sentry/views/insights/types';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -66,14 +66,13 @@ export function useResourceLandingSeriesSearch(): SearchHook {
 export function useResourceLandingSeries(props: Props) {
   const {search, pageFilters, enabled} = props;
 
-  return useSpanSeries(
+  return useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: ['epm()', `avg(${SPAN_SELF_TIME})`],
-      transformAliasToInputFormat: true,
       enabled,
+      pageFilters,
     },
-    Referrer.RESOURCE_LANDING_SERIES,
-    pageFilters
+    Referrer.RESOURCE_LANDING_SERIES
   );
 }

--- a/static/app/views/insights/common/components/widgets/hooks/useResourceSummarySeries.tsx
+++ b/static/app/views/insights/common/components/widgets/hooks/useResourceSummarySeries.tsx
@@ -1,7 +1,7 @@
 import type {PageFilters} from 'sentry/types/core';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useResourceModuleFilters} from 'sentry/views/insights/browser/resources/utils/useResourceFilters';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import type {SearchHook} from 'sentry/views/insights/types';
 import {SpanFields} from 'sentry/views/insights/types';
 
@@ -43,9 +43,9 @@ export function useResourceSummarySeriesSearch(groupId?: string): SearchHook {
 export function useResourceSummarySeries(props: Props) {
   const {search, pageFilters, enabled, referrer} = props;
 
-  return useSpanSeries(
+  return useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: [
         `epm()`,
         `avg(${SPAN_SELF_TIME})`,
@@ -54,9 +54,8 @@ export function useResourceSummarySeries(props: Props) {
         `avg(${HTTP_RESPONSE_TRANSFER_SIZE})`,
       ],
       enabled,
-      transformAliasToInputFormat: true,
+      pageFilters,
     },
-    referrer,
-    pageFilters
+    referrer
   );
 }

--- a/static/app/views/insights/common/components/widgets/resourceLandingDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/resourceLandingDurationChartWidget.tsx
@@ -22,13 +22,16 @@ export default function ResourceLandingDurationChartWidget(
     pageFilters: props.pageFilters,
   });
 
+  const timeSeries = data?.timeSeries || [];
+  const durationSeries = timeSeries.find(ts => ts.yAxis === `avg(${SPAN_SELF_TIME})`);
+
   return (
     <InsightsLineChartWidget
       {...props}
       queryInfo={{search, referrer, yAxis: [`avg(${SPAN_SELF_TIME})`]}}
       id="resourceLandingDurationChartWidget"
       title={getDurationChartTitle('resource')}
-      series={[data[`avg(${SPAN_SELF_TIME})`]]}
+      timeSeries={durationSeries ? [durationSeries] : []}
       isLoading={isPending}
       error={error}
     />

--- a/static/app/views/insights/common/components/widgets/resourceLandingThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/resourceLandingThroughputChartWidget.tsx
@@ -19,13 +19,16 @@ export default function ResourceLandingThroughputChartWidget(
     enabled,
   });
 
+  const timeSeries = data?.timeSeries || [];
+  const throughputSeries = timeSeries.find(ts => ts.yAxis === 'epm()');
+
   return (
     <InsightsLineChartWidget
       {...props}
-      queryInfo={{search, referrer}}
+      queryInfo={{search, referrer, yAxis: ['epm()']}}
       id="resourceLandingThroughputChartWidget"
       title={getThroughputChartTitle('resource')}
-      series={[data['epm()']]}
+      timeSeries={throughputSeries ? [throughputSeries] : []}
       isLoading={isPending}
       error={error}
     />

--- a/static/app/views/insights/common/components/widgets/resourceSummaryAverageSizeChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/resourceSummaryAverageSizeChartWidget.tsx
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import {useParams} from 'sentry/utils/useParams';
 import {Referrer} from 'sentry/views/insights/browser/resources/referrer';
 import {DATA_TYPE, FIELD_ALIASES} from 'sentry/views/insights/browser/resources/settings';
@@ -30,17 +31,24 @@ export default function ResourceSummaryAverageSizeChartWidget(
     referrer,
   });
 
+  const timeSeries = data?.timeSeries || [];
+  const decodedSeries = timeSeries.find(
+    ts => ts.yAxis === `avg(${HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`
+  );
+  const transferSeries = timeSeries.find(
+    ts => ts.yAxis === `avg(${HTTP_RESPONSE_TRANSFER_SIZE})`
+  );
+  const contentSeries = timeSeries.find(
+    ts => ts.yAxis === `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`
+  );
+
   return (
     <InsightsLineChartWidget
       {...props}
       queryInfo={{search, referrer}}
       id="resourceSummaryAverageSizeChartWidget"
       title={t('Average %s Size', DATA_TYPE)}
-      series={[
-        data?.[`avg(${HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`],
-        data?.[`avg(${HTTP_RESPONSE_TRANSFER_SIZE})`],
-        data?.[`avg(${HTTP_RESPONSE_CONTENT_LENGTH})`],
-      ]}
+      timeSeries={[decodedSeries, transferSeries, contentSeries].filter(defined)}
       aliases={FIELD_ALIASES}
       isLoading={isPending}
       error={error}

--- a/static/app/views/insights/common/components/widgets/resourceSummaryDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/resourceSummaryDurationChartWidget.tsx
@@ -25,13 +25,16 @@ export default function ResourceSummaryDurationChartWidget(
     referrer,
   });
 
+  const timeSeries = data?.timeSeries || [];
+  const durationSeries = timeSeries.find(ts => ts.yAxis === `avg(${SPAN_SELF_TIME})`);
+
   return (
     <InsightsLineChartWidget
       {...props}
       queryInfo={{search, referrer}}
       id="resourceSummaryDurationChartWidget"
       title={getDurationChartTitle('resource')}
-      series={[data?.[`avg(${SPAN_SELF_TIME})`]]}
+      timeSeries={durationSeries ? [durationSeries] : []}
       isLoading={isPending}
       error={error}
     />

--- a/static/app/views/insights/common/components/widgets/resourceSummaryThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/resourceSummaryThroughputChartWidget.tsx
@@ -17,10 +17,13 @@ export default function ResourceSummaryThroughputChartWidget(
 
   const {data, isPending, error} = useResourceSummarySeries({
     search,
-    pageFilters: props.pageFilters,
     enabled,
+    pageFilters: props.pageFilters,
     referrer,
   });
+
+  const timeSeries = data?.timeSeries || [];
+  const throughputSeries = timeSeries.find(ts => ts.yAxis === 'epm()');
 
   return (
     <InsightsLineChartWidget
@@ -28,7 +31,7 @@ export default function ResourceSummaryThroughputChartWidget(
       queryInfo={{search, referrer}}
       id="resourceSummaryThroughputChartWidget"
       title={getThroughputChartTitle('resource')}
-      series={[data?.[`epm()`]]}
+      timeSeries={throughputSeries ? [throughputSeries] : []}
       isLoading={isPending}
       error={error}
     />


### PR DESCRIPTION
Continuing the work on replacing `/events-stats/` with `/events-timeseries/`. This is a smaller chunk, just the Resources module.
