### PR TITLE
fix(typing): Type tests.sentry.release_health

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -806,7 +806,7 @@ module = [
     "tests.sentry.ratelimits.test_leaky_bucket",
     "tests.sentry.receivers.outbox.*",
     "tests.sentry.relay.config.test_metric_extraction",
-    "tests.sentry.release_health.release_monitor.*",
+    "tests.sentry.release_health.*",
     "tests.sentry.relocation.api.*",
     "tests.sentry.replays.lib.*",
     "tests.sentry.replays.tasks.*",

--- a/tests/sentry/release_health/test_metrics_sessions_v2.py
+++ b/tests/sentry/release_health/test_metrics_sessions_v2.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import pytest
 from django.utils import timezone
 from snuba_sdk import Column, Condition, Function, Op
+from snuba_sdk.conditions import ConditionGroup
 
 from sentry.exceptions import InvalidParams
 from sentry.release_health.metrics_sessions_v2 import (
@@ -71,14 +72,18 @@ MOCK_DATETIME = ONE_DAY_AGO.replace(hour=10, minute=0, second=0, microsecond=0)
         ),
     ],
 )
-def test_transform_conditions(input, expected_output, expected_status_filter) -> None:
+def test_transform_conditions(
+    input: ConditionGroup,
+    expected_output: ConditionGroup,
+    expected_status_filter: set[SessionStatus],
+) -> None:
     output, status_filter = _extract_status_filter_from_conditions(input)
     assert output == expected_output
     assert status_filter == expected_status_filter
 
 
 @pytest.mark.parametrize("input", [[Condition(Column("release"), Op.EQ, "foo")]])
-def test_transform_conditions_nochange(input) -> None:
+def test_transform_conditions_nochange(input: ConditionGroup) -> None:
     output, status_filter = _extract_status_filter_from_conditions(input)
     assert input == output
     assert status_filter is None
@@ -102,5 +107,5 @@ def test_transform_conditions_nochange(input) -> None:
         ],
     ],
 )
-def test_transform_conditions_illegal(input) -> None:
+def test_transform_conditions_illegal(input: ConditionGroup) -> None:
     pytest.raises(InvalidParams, _extract_status_filter_from_conditions, input)


### PR DESCRIPTION
Just needed a couple easy-peasy hints.

`mypy` passes; `pytest tests/sentry/release_health/**` passes eventually (3 flaky failures that pass on retry)
