### PR TITLE
Add build_configuration to buildDetails appInfo model

### DIFF
--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -16,6 +16,7 @@ class Platform(StrEnum):
 
 
 class BuildDetailsAppInfo(BaseModel):
+    created_at: str | None = None
     app_id: str | None
     name: str | None
     version: str | None
@@ -25,8 +26,7 @@ class BuildDetailsAppInfo(BaseModel):
     artifact_type: PreprodArtifact.ArtifactType | None = None
     platform: Platform | None = None
     is_installable: bool
-    # build_configuration: Optional[str] = None  # Uncomment when available
-    # icon: Optional[str] = None  # Uncomment when available
+    build_configuration: str | None = None
 
 
 class BuildDetailsVcsInfo(BaseModel):
@@ -97,6 +97,9 @@ def transform_preprod_artifact_to_build_details(
             platform_from_artifact_type(artifact.artifact_type) if artifact.artifact_type else None
         ),
         is_installable=is_installable_artifact(artifact),
+        build_configuration=(
+            artifact.build_configuration.name if artifact.build_configuration else None
+        ),
     )
 
     vcs_info = BuildDetailsVcsInfo(

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -16,7 +16,6 @@ class Platform(StrEnum):
 
 
 class BuildDetailsAppInfo(BaseModel):
-    created_at: str | None = None
     app_id: str | None
     name: str | None
     version: str | None

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_list_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_list_builds.py
@@ -420,6 +420,7 @@ class ProjectPreprodListBuildsEndpointTest(APITestCase):
         resp_data = response.json()
         assert len(resp_data["builds"]) == 1
         assert resp_data["builds"][0]["app_info"]["app_id"] == "com.example.configured"
+        assert resp_data["builds"][0]["app_info"]["build_configuration"] == "Release"
 
     # Build version filtering tests
     def test_list_builds_filter_by_build_version(self) -> None:


### PR DESCRIPTION
Adds build_configuration to appInfo model on buildDetails for use with compare. Should also show in the UI in the near future.

Resolves EME-298