### PR TITLE
feat(notif-platform): Add CLI to send notifications via platform

### DIFF
--- a/src/sentry/notifications/platform/sample.py
+++ b/src/sentry/notifications/platform/sample.py
@@ -30,20 +30,17 @@ class ErrorAlertData(NotificationData):
 @template_registry.register(ErrorAlertData.source)
 class ErrorAlertNotificationTemplate(NotificationTemplate[ErrorAlertData]):
     category = NotificationCategory.DEBUG
-
-    @property
-    def example_data(self) -> ErrorAlertData:
-        return ErrorAlertData(
-            error_type="ValueError",
-            error_message="'NoneType' object has no attribute 'get'",
-            project_name="my-app",
-            issue_id="12345",
-            error_count=15,
-            first_seen="2024-01-15 14:30:22 UTC",
-            chart_url="https://example.com/chart",
-            issue_url="https://example.com/issues",
-            assign_url="https://example.com/assign",
-        )
+    example_data = ErrorAlertData(
+        error_type="ValueError",
+        error_message="'NoneType' object has no attribute 'get'",
+        project_name="my-app",
+        issue_id="12345",
+        error_count=15,
+        first_seen="2024-01-15 14:30:22 UTC",
+        chart_url="https://example.com/chart",
+        issue_url="https://example.com/issues",
+        assign_url="https://example.com/assign",
+    )
 
     def render(self, data: ErrorAlertData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
@@ -82,18 +79,16 @@ class DeploymentData(NotificationData):
 class DeploymentNotificationTemplate(NotificationTemplate[DeploymentData]):
     category = NotificationCategory.DEBUG
 
-    @property
-    def example_data(self) -> DeploymentData:
-        return DeploymentData(
-            project_name="my-app",
-            version="v2.1.3",
-            environment="production",
-            deployer="john.doe@acme.com",
-            commit_sha="a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0",
-            commit_message="Fix user authentication bug",
-            deployment_url="https://example.com/deployment",
-            rollback_url="https://example.com/rollback",
-        )
+    example_data = DeploymentData(
+        project_name="my-app",
+        version="v2.1.3",
+        environment="production",
+        deployer="john.doe@acme.com",
+        commit_sha="a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0",
+        commit_message="Fix user authentication bug",
+        deployment_url="https://example.com/deployment",
+        rollback_url="https://example.com/rollback",
+    )
 
     def render(self, data: DeploymentData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
@@ -129,19 +124,16 @@ class SecurityAlertData(NotificationData):
 @template_registry.register(SecurityAlertData.source)
 class SecurityAlertNotificationTemplate(NotificationTemplate[SecurityAlertData]):
     category = NotificationCategory.DEBUG
-
-    @property
-    def example_data(self) -> SecurityAlertData:
-        return SecurityAlertData(
-            alert_type="Suspicious login pattern",
-            severity="critical",
-            project_name="my-app",
-            description="Multiple failed login attempts detected from unusual locations.",
-            affected_users=23,
-            alert_url="https://example.com/security-alert",
-            acknowledge_url="https://example.com/acknowledge",
-            escalate_url="https://example.com/escalate",
-        )
+    example_data = SecurityAlertData(
+        alert_type="Suspicious login pattern",
+        severity="critical",
+        project_name="my-app",
+        description="Multiple failed login attempts detected from unusual locations.",
+        affected_users=23,
+        alert_url="https://example.com/security-alert",
+        acknowledge_url="https://example.com/acknowledge",
+        escalate_url="https://example.com/escalate",
+    )
 
     def render(self, data: SecurityAlertData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
@@ -180,17 +172,14 @@ class PerformanceAlertData(NotificationData):
 @template_registry.register(PerformanceAlertData.source)
 class PerformanceAlertNotificationTemplate(NotificationTemplate[PerformanceAlertData]):
     category = NotificationCategory.DEBUG
-
-    @property
-    def example_data(self) -> PerformanceAlertData:
-        return PerformanceAlertData(
-            metric_name="API response time",
-            threshold="500ms",
-            current_value="1.2s",
-            project_name="my-app",
-            chart_url="https://example.com/chart",
-            investigation_url="https://example.com/investigate",
-        )
+    example_data = PerformanceAlertData(
+        metric_name="API response time",
+        threshold="500ms",
+        current_value="1.2s",
+        project_name="my-app",
+        chart_url="https://example.com/chart",
+        investigation_url="https://example.com/investigate",
+    )
 
     def render(self, data: PerformanceAlertData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
@@ -225,16 +214,13 @@ class TeamUpdateData(NotificationData):
 @template_registry.register(TeamUpdateData.source)
 class TeamUpdateNotificationTemplate(NotificationTemplate[TeamUpdateData]):
     category = NotificationCategory.DEBUG
-
-    @property
-    def example_data(self) -> TeamUpdateData:
-        return TeamUpdateData(
-            team_name="Engineering",
-            update_type="Weekly Standup Reminder",
-            message="Don't forget about our weekly standup meeting tomorrow at 10 AM. Please prepare your updates on current sprint progress.",
-            author="jane.smith@acme.com",
-            timestamp="2024-01-15 16:45:00 UTC",
-        )
+    example_data = TeamUpdateData(
+        team_name="Engineering",
+        update_type="Weekly Standup Reminder",
+        message="Don't forget about our weekly standup meeting tomorrow at 10 AM. Please prepare your updates on current sprint progress.",
+        author="jane.smith@acme.com",
+        timestamp="2024-01-15 16:45:00 UTC",
+    )
 
     def render(self, data: TeamUpdateData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -173,20 +173,16 @@ class NotificationTemplate[T: NotificationData](abc.ABC):
     The category that a notification belongs to. This will be used to determine which settings a
     user needs to modify to manage receipt of these notifications (if applicable).
     """
+    example_data: T
+    """
+    The example data for this notification.
+    """
 
     @abc.abstractmethod
     def render(self, data: T) -> NotificationRenderedTemplate:
         """
         Produce a rendered template given the notification data. Usually, this will involve
         formatting the data into user-friendly strings of text.
-        """
-        ...
-
-    @property
-    @abc.abstractmethod
-    def example_data(self) -> T:
-        """
-        The example data for this notification.
         """
         ...
 

--- a/src/sentry/runner/commands/notifications.py
+++ b/src/sentry/runner/commands/notifications.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from typing import Any
+
 import click
 
 
@@ -11,13 +13,13 @@ def notifications() -> None:
 
 
 @notifications.group("send")
-def send() -> None:
+def send_cmd() -> None:
     """
     Send debugging notification through a provider.
     """
 
 
-@send.command("email")
+@send_cmd.command("email")
 @click.option(
     "-s",
     "--source",
@@ -65,7 +67,7 @@ def send_email(source: str, target: str) -> None:
     click.echo(f"Example '{source}' email sent to {target}.")
 
 
-@send.command("slack")
+@send_cmd.command("slack")
 def send_slack() -> None:
     """
     Send a Slack notification
@@ -73,7 +75,7 @@ def send_slack() -> None:
     click.echo("Not implemented yet!")
 
 
-@send.command("msteams")
+@send_cmd.command("msteams")
 def send_msteams() -> None:
     """
     Send a Microsoft Teams notification.
@@ -81,7 +83,7 @@ def send_msteams() -> None:
     click.echo("Not implemented yet!")
 
 
-@send.command("discord")
+@send_cmd.command("discord")
 def send_discord() -> None:
     """
     Send a Discord notification.
@@ -90,7 +92,7 @@ def send_discord() -> None:
 
 
 @notifications.command("list")
-def list() -> None:
+def list_cmd() -> None:
     """
     Lists registered notification data.
     """
@@ -99,6 +101,7 @@ def list() -> None:
     configure()
 
     from sentry.notifications.platform.registry import provider_registry, template_registry
+    from sentry.notifications.platform.types import NotificationCategory
 
     click.echo("\nRegistered notification providers:")
     for provider_key, provider_cls in provider_registry.registrations.items():
@@ -107,7 +110,7 @@ def list() -> None:
     click.echo("\nRegistered notification templates:")
     # XXX: For some reason, using a defaultdict(list) here causes the command to interpret
     # the .append() as new arguments, causing an early exit and error.
-    category_to_sources = {}
+    category_to_sources: dict[NotificationCategory, Any] = {}
     for source, template_cls in template_registry.registrations.items():
         category = template_cls.category
         if category not in category_to_sources:

--- a/src/sentry/runner/commands/notifications.py
+++ b/src/sentry/runner/commands/notifications.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+
+import click
+
+
+@click.group()
+def notifications() -> None:
+    """
+    Utilities to debug notifications locally.
+    """
+
+
+@notifications.group("send")
+def send() -> None:
+    """
+    Send debugging notification through a provider.
+    """
+
+
+@send.command("email")
+@click.option(
+    "-s",
+    "--source",
+    help="Registered template source (see `sentry notifications list`)",
+    default="error-alert-service",
+)
+@click.option("-t", "--target", help="Recipient email address", default="user@example.com")
+def send_email(source: str, target: str) -> None:
+    """
+    Send an email notification.
+    Note: Requires configuring SMTP settings in .sentry/config.yml.
+    """
+    from sentry import options
+    from sentry.runner import configure
+
+    configure()
+
+    if options.get("mail.backend") in {"dummy", "console"} or any(
+        options.get(key) is None
+        for key in ["mail.host", "mail.port", "mail.username", "mail.password"]
+    ):
+        click.echo("Unable to send email with current configuration!")
+        click.echo(
+            """Please update .sentry/config.yml:
+  - remove `mail.backend` (if set to 'dummy' or 'console')
+  - set `mail.host`, `mail.port`, `mail.username` and `mail.password`"""
+        )
+        return
+
+    from sentry.notifications.platform.registry import template_registry
+    from sentry.notifications.platform.service import NotificationService
+    from sentry.notifications.platform.target import GenericNotificationTarget
+    from sentry.notifications.platform.types import (
+        NotificationProviderKey,
+        NotificationTargetResourceType,
+    )
+
+    target = GenericNotificationTarget(
+        provider_key=NotificationProviderKey.EMAIL,
+        resource_type=NotificationTargetResourceType.EMAIL,
+        resource_id=target,
+    )
+    template_cls = template_registry.get(source)
+    NotificationService(data=template_cls.example_data).notify(targets=[target])
+
+
+@send.command("slack")
+def send_slack() -> None:
+    """
+    Send a Slack notification
+    """
+    click.echo("Not implemented yet!")
+
+
+@send.command("msteams")
+def send_msteams() -> None:
+    """
+    Send a Microsoft Teams notification.
+    """
+    click.echo("Not implemented yet!")
+
+
+@send.command("discord")
+def send_discord() -> None:
+    """
+    Send a Discord notification.
+    """
+    click.echo("Not implemented yet!")
+
+
+@notifications.command("list")
+def list() -> None:
+    """
+    Lists registered notification data.
+    """
+    from sentry.runner import configure
+
+    configure()
+
+    from sentry.notifications.platform.registry import provider_registry, template_registry
+
+    click.echo("\nRegistered notification providers:")
+    for provider_key, provider_cls in provider_registry.registrations.items():
+        click.echo(f"• key: {provider_key}, class: {provider_cls.__name__}")
+
+    click.echo("\nRegistered notification templates:")
+    # XXX: For some reason, using a defaultdict(list) here causes the command to interpret
+    # the .append() as new arguments, causing an early exit and error.
+    category_to_sources = {}
+    for source, template_cls in template_registry.registrations.items():
+        category = template_cls.category
+        if category not in category_to_sources:
+            category_to_sources[category] = []
+        category_to_sources[category].append({"source": source, "class": template_cls.__name__})
+    for category, sources in category_to_sources.items():
+        click.echo(f"• category: {category}")
+        for source in sources:
+            click.echo(f"  ◦ source: {source['source']}, class: {source['class']}")

--- a/src/sentry/runner/commands/notifications.py
+++ b/src/sentry/runner/commands/notifications.py
@@ -55,13 +55,14 @@ def send_email(source: str, target: str) -> None:
         NotificationTargetResourceType,
     )
 
-    target = GenericNotificationTarget(
+    email_target = GenericNotificationTarget(
         provider_key=NotificationProviderKey.EMAIL,
         resource_type=NotificationTargetResourceType.EMAIL,
         resource_id=target,
     )
     template_cls = template_registry.get(source)
-    NotificationService(data=template_cls.example_data).notify(targets=[target])
+    NotificationService(data=template_cls.example_data).notify(targets=[email_target])
+    click.echo(f"Example '{source}' email sent to {target}.")
 
 
 @send.command("slack")

--- a/src/sentry/runner/main.py
+++ b/src/sentry/runner/main.py
@@ -69,6 +69,7 @@ for cmd in map(
         "sentry.runner.commands.spans.spans",
         "sentry.runner.commands.spans.write_hashes",
         "sentry.runner.commands.llm.llm",
+        "sentry.runner.commands.notifications.notifications",
     ),
 ):
     cli.add_command(cmd)

--- a/src/sentry/testutils/notifications/platform.py
+++ b/src/sentry/testutils/notifications/platform.py
@@ -22,10 +22,7 @@ class MockNotification(NotificationData):
 @template_registry.register(MockNotification.source)
 class MockNotificationTemplate(NotificationTemplate[MockNotification]):
     category = NotificationCategory.DEBUG
-
-    @property
-    def example_data(self) -> MockNotification:
-        return MockNotification(message="This is a mock notification")
+    example_data = MockNotification(message="This is a mock notification")
 
     def render(self, data: MockNotification) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(


### PR DESCRIPTION
Only configuration for now is the source and target, but eventually we could probably allow custom data as well, though the format may have to be a JSON file or something like that.

When we implement the integration providers as well, we'll need to pick an org/integration to use, and ask for a channel ID as well.