### PR TITLE
chore(api-docs): Explain that the create project endpoint may require the team:admin scope

### DIFF
--- a/src/sentry/core/endpoints/team_projects.py
+++ b/src/sentry/core/endpoints/team_projects.py
@@ -193,11 +193,12 @@ class TeamProjectsEndpoint(TeamEndpoint):
             409: OpenApiResponse(description="A project with this slug already exists."),
         },
         examples=ProjectExamples.CREATE_PROJECT,
+        description="""Create a new project bound to a team.
+
+        Note: If your organization has disabled member project creation, the `org:write` or `team:admin` scope is required.
+        """,
     )
     def post(self, request: Request, team: Team) -> Response:
-        """
-        Create a new project bound to a team.
-        """
         from sentry.core.endpoints.organization_projects_experiment import (
             DISABLED_FEATURE_ERROR_STRING,
         )


### PR DESCRIPTION
Closes RTC-1209

<img width="922" height="409" alt="CleanShot 2025-09-17 at 10 13 18" src="https://github.com/user-attachments/assets/da0c6cf8-a1be-4a1b-a526-9aee736d953d" />
