### PR TITLE
chore(preprod): Return 400 on unsupported VCS provider sent from client

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -11,6 +11,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.debug_files.upload import find_missing_chunks
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.orgauthtoken import is_org_auth_token_auth, update_org_auth_token_last_used
 from sentry.models.project import Project
 from sentry.preprod.analytics import PreprodArtifactApiAssembleEvent
@@ -18,6 +19,14 @@ from sentry.preprod.tasks import assemble_preprod_artifact, create_preprod_artif
 from sentry.preprod.url_utils import get_preprod_artifact_url
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.tasks.assemble import ChunkFileState
+
+SUPPORTED_VCS_PROVIDERS = [
+    IntegrationProviderSlug.GITHUB,
+    IntegrationProviderSlug.GITLAB,
+    IntegrationProviderSlug.GITHUB_ENTERPRISE,
+    IntegrationProviderSlug.BITBUCKET,
+    IntegrationProviderSlug.BITBUCKET_SERVER,
+]
 
 
 def validate_preprod_artifact_schema(request_body: bytes) -> tuple[dict, str | None]:
@@ -112,6 +121,11 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
             data, error_message = validate_preprod_artifact_schema(request.body)
             if error_message:
                 return Response({"error": error_message}, status=400)
+
+            # Support a limited subset of providers
+            provider = data.get("provider")
+            if provider is not None and provider not in SUPPORTED_VCS_PROVIDERS:
+                return Response({"error": "Unsupported provider"}, status=400)
 
             checksum = data.get("checksum")
             chunks = data.get("chunks", [])

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -236,6 +236,16 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         )
         assert response.status_code == 400, response.content
 
+    def test_assemble_json_schema_invalid_provider(self) -> None:
+        """Test that invalid provider is rejected."""
+        response = self.client.post(
+            self.url,
+            data={"checksum": "a" * 40, "chunks": [], "provider": "invalid"},
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+        )
+        assert response.status_code == 400, response.content
+        assert response.data["error"] == "Unsupported provider"
+
     def test_assemble_json_schema_missing_checksum(self) -> None:
         """Test that missing checksum field is rejected."""
         response = self.client.post(


### PR DESCRIPTION
Return a 400 if an unexpected VCS provider is sent from client. Supported VCS providers are a subset of just VCS fields from `IntegrationProviderSlug` ([source](https://github.com/getsentry/sentry/blob/99be2e1985bd99d7779b5233dfc4842a1aae164f/src/sentry/integrations/types.py#L31))