### PR TITLE
fix(stats): remove indexed spans special case

### DIFF
--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -32,7 +32,6 @@ import {
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {hasDynamicSamplingCustomFeature} from 'sentry/utils/dynamicSampling/features';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import HeaderTabs from 'sentry/views/organizationStats/header';
@@ -81,17 +80,6 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
 
     const categories = Object.values(DATA_CATEGORY_INFO);
     const info = categories.find(c => c.plural === dataCategoryPlural);
-
-    if (
-      info?.name === DataCategoryExact.SPAN &&
-      this.props.organization.features.includes('spans-usage-tracking') &&
-      !hasDynamicSamplingCustomFeature(this.props.organization)
-    ) {
-      return {
-        ...info,
-        name: DataCategoryExact.SPAN_INDEXED,
-      };
-    }
 
     // Default to errors
     return info ?? DATA_CATEGORY_INFO.error;


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/BIL-1575/fix-broken-toggle-for-show-client-discarded-data

We query for `dataCategory.name` in the org stats endpoint https://github.com/getsentry/sentry/blob/629d6c23fc32b93af2da43243a30cb10a903a604/static/app/views/organizationStats/usageStatsProjects.tsx#L92
So spans stats have been showing indexed spans stats