### PR TITLE
feat(uptime): Add thresholds to config

### DIFF
--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -55,6 +55,8 @@ from sentry.types.actor import Actor
 from sentry.uptime.models import UptimeStatus, UptimeSubscription, UptimeSubscriptionRegion
 from sentry.uptime.types import (
     DATA_SOURCE_UPTIME_SUBSCRIPTION,
+    DEFAULT_DOWNTIME_THRESHOLD,
+    DEFAULT_RECOVERY_THRESHOLD,
     GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
     UptimeMonitorMode,
 )
@@ -813,6 +815,8 @@ class Fixtures:
         uptime_status=UptimeStatus.OK,
         uptime_status_update_date: datetime | None = None,
         id: int | None = None,
+        recovery_threshold: int | None = None,
+        downtime_threshold: int | None = None,
     ) -> Detector:
         if project is None:
             project = self.project
@@ -867,6 +871,16 @@ class Fixtures:
             config={
                 "environment": env_name,
                 "mode": mode,
+                "recovery_threshold": (
+                    recovery_threshold
+                    if recovery_threshold is not None
+                    else DEFAULT_RECOVERY_THRESHOLD
+                ),
+                "downtime_threshold": (
+                    downtime_threshold
+                    if downtime_threshold is not None
+                    else DEFAULT_DOWNTIME_THRESHOLD
+                ),
             },
             workflow_condition_group=condition_group,
         )

--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -308,6 +308,16 @@ class UptimeDomainCheckFailure(GroupType):
                     "enum": [mode.value for mode in UptimeMonitorMode],
                 },
                 "environment": {"type": ["string", "null"]},
+                "recovery_threshold": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of consecutive successful checks required to mark monitor as recovered",
+                },
+                "downtime_threshold": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of consecutive failed checks required to mark monitor as down",
+                },
             },
             "additionalProperties": False,
         },

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -33,6 +33,8 @@ from sentry.uptime.subscriptions.tasks import (
 )
 from sentry.uptime.types import (
     DATA_SOURCE_UPTIME_SUBSCRIPTION,
+    DEFAULT_DOWNTIME_THRESHOLD,
+    DEFAULT_RECOVERY_THRESHOLD,
     GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
     UptimeMonitorMode,
 )
@@ -45,6 +47,7 @@ from sentry.workflow_engine.models.data_condition_group import DataConditionGrou
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
 logger = logging.getLogger(__name__)
+
 
 UPTIME_SUBSCRIPTION_TYPE = "uptime_monitor"
 MAX_AUTO_SUBSCRIPTIONS_PER_ORG = 1
@@ -187,6 +190,8 @@ def create_uptime_detector(
     owner: Actor | None = None,
     trace_sampling: bool = False,
     override_manual_org_limit: bool = False,
+    recovery_threshold: int = DEFAULT_RECOVERY_THRESHOLD,
+    downtime_threshold: int = DEFAULT_DOWNTIME_THRESHOLD,
 ) -> Detector:
     """
     Creates an UptimeSubscription and associated Detector
@@ -272,6 +277,8 @@ def create_uptime_detector(
             config={
                 "environment": env,
                 "mode": mode,
+                "recovery_threshold": recovery_threshold,
+                "downtime_threshold": downtime_threshold,
             },
             workflow_condition_group=condition_group,
         )
@@ -316,6 +323,8 @@ def update_uptime_detector(
     status: int = ObjectStatus.ACTIVE,
     mode: UptimeMonitorMode = UptimeMonitorMode.MANUAL,
     ensure_assignment: bool = False,
+    recovery_threshold: int | NotSet = NOT_SET,
+    downtime_threshold: int | NotSet = NOT_SET,
 ):
     """
     Updates a uptime detector and its associated uptime subscription.
@@ -363,6 +372,18 @@ def update_uptime_detector(
             config={
                 "mode": mode,
                 "environment": env.name if env else None,
+                "recovery_threshold": default_if_not_set(
+                    # TODO: Remove DEFAULT_RECOVERY_THRESHOLD fallback after
+                    # backfill migration ensures all configs have this value
+                    detector.config.get("recovery_threshold", DEFAULT_RECOVERY_THRESHOLD),
+                    recovery_threshold,
+                ),
+                "downtime_threshold": default_if_not_set(
+                    # TODO: Remove DEFAULT_DOWNTIME_THRESHOLD fallback after
+                    # backfill migration ensures all configs have this value
+                    detector.config.get("downtime_threshold", DEFAULT_DOWNTIME_THRESHOLD),
+                    downtime_threshold,
+                ),
             },
         )
 

--- a/src/sentry/uptime/types.py
+++ b/src/sentry/uptime/types.py
@@ -18,6 +18,16 @@ GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE = "uptime_domain_failure"
 The GroupType slug for UptimeDomainCheckFailure GroupTypes.
 """
 
+DEFAULT_RECOVERY_THRESHOLD = 1
+"""
+Default number of consecutive successful checks required to mark monitor as recovered.
+"""
+
+DEFAULT_DOWNTIME_THRESHOLD = 3
+"""
+Default number of consecutive failed checks required to mark monitor as down.
+"""
+
 RegionScheduleMode = Literal["round_robin"]
 """
 Defines how we'll schedule checks based on other active regions.


### PR DESCRIPTION
Add configurable recovery and downtime thresholds for uptime monitors

- Add recovery_threshold and downtime_threshold fields to uptime
  detector config schema

- Update validator to accept optional threshold parameters with defaults
  (recovery: 1, downtime: 3)

- Modify create/update detector functions to store threshold values in
  config

- Add threshold constants to uptime/types.py to avoid circular imports

- Update tests to verify default and custom threshold values work
  correctly

- Add TODO comments for cleanup after backfill migration runs

This allows users to customize how many consecutive successes (recovery)
or failures (downtime) are needed before changing monitor state, instead
of using hardcoded global values.

Part of [NEW-302: Configurable downtime and recovery thresholds for uptime](https://linear.app/getsentry/issue/NEW-302/configurable-downtime-and-recovery-thresholds-for-uptime)