### PR TITLE
feat(aci): Pagerduty action validator

### DIFF
--- a/src/sentry/notifications/notification_action/__init__.py
+++ b/src/sentry/notifications/notification_action/__init__.py
@@ -33,6 +33,7 @@ __all__ = [
     "AzureDevOpsActionValidatorHandler",
     "GithubActionValidatorHandler",
     "GithubEnterpriseActionValidatorHandler",
+    "PagerdutyActionValidatorHandler",
 ]
 
 from .action_handler_registry import (
@@ -48,6 +49,7 @@ from .action_validation import (
     JiraActionValidatorHandler,
     JiraServerActionValidatorHandler,
     MSTeamsActionValidatorHandler,
+    PagerdutyActionValidatorHandler,
     SlackActionValidatorHandler,
 )
 from .group_type_notification_registry import IssueAlertRegistryHandler, MetricAlertRegistryHandler

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -515,13 +515,18 @@ class BaseActionValidatorHandler(ABC):
         self.validated_data = validated_data
         self.organization = organization
 
+    def generate_action_form_payload(self) -> dict[str, Any]:
+        return {
+            "data": self.generate_action_form_data(),
+            "integrations": _get_integrations(self.organization, self.provider),
+        }
+
     def clean_data(self) -> dict[str, Any]:
         if self.notify_action_form is None:
             return self.validated_data
 
         notify_action_form = self.notify_action_form(
-            data=self.generate_action_form_payload(),
-            integrations=_get_integrations(self.organization, self.provider),
+            **self.generate_action_form_payload(),
         )
 
         if notify_action_form.is_valid():
@@ -530,7 +535,7 @@ class BaseActionValidatorHandler(ABC):
         raise ValidationError(notify_action_form.errors)
 
     @abstractmethod
-    def generate_action_form_payload(self) -> dict[str, Any]:
+    def generate_action_form_data(self) -> dict[str, Any]:
         # translate validated data from BaseActionValidator to notify action form data
         pass
 

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_pagerduty.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_pagerduty.py
@@ -1,0 +1,91 @@
+from rest_framework.exceptions import ErrorDetail
+
+from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode
+from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
+from sentry.workflow_engine.models import Action
+
+
+class TestPagerDutyActionValidator(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        services = [
+            {
+                "id": 123,
+                "service_name": "moo-deng",
+            },
+            {
+                "id": 321,
+                "service_name": "moo-waan",
+            },
+        ]
+        self.integration, self.org_integration = self.create_provider_integration_for(
+            self.organization,
+            self.user,
+            provider="pagerduty",
+            name="Example PagerDuty",
+            external_id="example-pagerduty",
+            metadata={"services": services},
+        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.org_integration.config["pagerduty_services"] = services
+            self.org_integration.save()
+
+        self.valid_data = {
+            "type": Action.Type.PAGERDUTY,
+            "config": {"targetIdentifier": "123", "targetType": ActionTarget.SPECIFIC.value},
+            "data": {},
+            "integrationId": self.integration.id,
+        }
+
+    def test_validate(self):
+        validator = BaseActionValidator(
+            data=self.valid_data,
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is True
+        validator.save()
+
+    def test_validate__missing_integration_id(self):
+        del self.valid_data["integrationId"]
+        validator = BaseActionValidator(
+            data={**self.valid_data},
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False
+        assert validator.errors == {
+            "nonFieldErrors": [
+                ErrorDetail(
+                    string="Integration ID is required for pagerduty action", code="invalid"
+                )
+            ]
+        }
+
+    def test_validate__invalid_service(self):
+        validator = BaseActionValidator(
+            data={
+                **self.valid_data,
+                "config": {
+                    "targetType": ActionTarget.SPECIFIC.value,
+                    "targetIdentifier": "54321",
+                },
+            },
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False
+        assert validator.errors == {
+            "service": [
+                ErrorDetail(
+                    string="Select a valid choice. 54321 is not one of the available choices.",
+                    code="invalid",
+                )
+            ]
+        }

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -88,7 +88,7 @@ class MockActionHandler(ActionHandler):
 class MockActionValidatorTranslator(BaseActionValidatorHandler):
     notify_action_form = None
 
-    def generate_action_form_payload(self) -> dict[str, Any]:
+    def generate_action_form_data(self) -> dict[str, Any]:
         if not (integration_id := self.validated_data.get("integration_id")):
             raise ValidationError("Integration ID is required for mock action")
 


### PR DESCRIPTION
Pagerduty also passes an extra `service` param to `PagerdutyNotifyServiceForm`, and stores the service id in `target_identifier`.