### PR TITLE
Remove replay-list-select feature flag from replayTableColumns.tsx

### DIFF
--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -439,9 +439,6 @@ export const ReplaySelectColumn: ReplayTableColumn = {
     replays,
   }) => {
     const organization = useOrganization();
-    if (!organization.features.includes('replay-list-select')) {
-      return null;
-    }
     return (
       <CheckboxHeaderContainer>
         <Checkbox
@@ -477,8 +474,7 @@ export const ReplaySelectColumn: ReplayTableColumn = {
     return (
       <CheckboxClickCapture onClick={e => e.stopPropagation()}>
         <CheckboxCellContainer>
-          {organization.features.includes('replay-list-select') ? (
-            <CheckboxClickTarget htmlFor={`replay-table-select-${replay.id}`}>
+          <CheckboxClickTarget htmlFor={`replay-table-select-${replay.id}`}>
               <Checkbox
                 id={`replay-table-select-${replay.id}`}
                 disabled={isSelected(replay.id) === 'all-selected'}
@@ -488,7 +484,6 @@ export const ReplaySelectColumn: ReplayTableColumn = {
                 }}
               />
             </CheckboxClickTarget>
-          ) : null}
 
           <Tooltip title={t('Unread')} skipWrapper disabled={Boolean(replay.has_viewed)}>
             <UnreadIndicator data-has-viewed={replay.has_viewed} />

--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -438,7 +438,6 @@ export const ReplaySelectColumn: ReplayTableColumn = {
     },
     replays,
   }) => {
-    const organization = useOrganization();
     return (
       <CheckboxHeaderContainer>
         <Checkbox
@@ -466,7 +465,6 @@ export const ReplaySelectColumn: ReplayTableColumn = {
   interactive: true,
   sortKey: undefined,
   Component: ({replay}) => {
-    const organization = useOrganization();
     const {isSelected, toggleSelected} = useListItemCheckboxContext();
     if (replay.is_archived) {
       return null;

--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -475,15 +475,15 @@ export const ReplaySelectColumn: ReplayTableColumn = {
       <CheckboxClickCapture onClick={e => e.stopPropagation()}>
         <CheckboxCellContainer>
           <CheckboxClickTarget htmlFor={`replay-table-select-${replay.id}`}>
-              <Checkbox
-                id={`replay-table-select-${replay.id}`}
-                disabled={isSelected(replay.id) === 'all-selected'}
-                checked={isSelected(replay.id) !== false}
-                onChange={() => {
-                  toggleSelected(replay.id);
-                }}
-              />
-            </CheckboxClickTarget>
+            <Checkbox
+              id={`replay-table-select-${replay.id}`}
+              disabled={isSelected(replay.id) === 'all-selected'}
+              checked={isSelected(replay.id) !== false}
+              onChange={() => {
+                toggleSelected(replay.id);
+              }}
+            />
+          </CheckboxClickTarget>
 
           <Tooltip title={t('Unread')} skipWrapper disabled={Boolean(replay.has_viewed)}>
             <UnreadIndicator data-has-viewed={replay.has_viewed} />


### PR DESCRIPTION
As title says, since replay-list-select has GA value of 100, it can be removed from the replayTableColumns.tsx frontend.

Ticket: https://linear.app/getsentry/issue/REPLAY-656/identify-and-cleanup-any-fully-released-feature-flags-owned-by-team

