### PR TITLE
feat(detectors): Update `concurrency_threshold` and add logging to N+1 API Call detector 

### DIFF
--- a/src/sentry/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
+++ b/src/sentry/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from collections import defaultdict
 from datetime import timedelta
@@ -176,6 +177,8 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
             )
 
         parent_span_id = last_span.get("parent_span_id")
+        if self.stored_problems.get(fingerprint):
+            logging.info("Multiple N+1 API Call Problems for Fingerprint")
         self.stored_problems[fingerprint] = PerformanceProblem(
             fingerprint=fingerprint,
             op=last_span["op"],

--- a/src/sentry/performance_issues/performance_detection.py
+++ b/src/sentry/performance_issues/performance_detection.py
@@ -286,7 +286,7 @@ def get_detection_settings(project_id: int | None = None) -> dict[DetectorType, 
         },
         DetectorType.EXPERIMENTAL_N_PLUS_ONE_API_CALLS: {
             "total_duration": settings["n_plus_one_api_calls_total_duration_threshold"],  # ms
-            "concurrency_threshold": 10,  # ms
+            "concurrency_threshold": 15,  # ms
             "count": 5,
             "allowed_span_ops": ["http.client"],
             "detection_enabled": settings["n_plus_one_api_calls_detection_enabled"],


### PR DESCRIPTION
this pr makes two changes to the experimental N+1 API Call detector:
1) updates the concurrency threshold to 15ms from 10ms. when auditing issues noticed that this threshold was breached quite often (but only by a few ms) for cases that I think we should still register as problems. bumping us up to 15ms gives a chance to see if we are producing better results we an increased threshold, which we can revert if the results aren't what we want. 
2) right now the fingerprint is based on the url. there are some cases where we could be detecting 2 sets of problems on the same url in the same transaction, but only are saving one. i want to see how big of a problem this is before we try to think of a solution. 