### PR TITLE
feat(aci): Remove use of group.openPeriods

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -936,7 +936,6 @@ export interface BaseGroup {
   integrationIssues?: ExternalIssue[];
   latestEvent?: Event;
   latestEventHasAttachments?: boolean;
-  openPeriods?: GroupOpenPeriod[] | null;
   owners?: SuggestedOwner[] | null;
   seerAutofixLastTriggered?: string | null;
   seerFixabilityScore?: number | null;

--- a/static/app/views/issueDetails/metricIssues/metricIssuesSection.tsx
+++ b/static/app/views/issueDetails/metricIssues/metricIssuesSection.tsx
@@ -10,6 +10,7 @@ import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {extractEventTypeFilterFromRule} from 'sentry/views/alerts/rules/metric/utils/getEventTypeFilter';
 import {isCrashFreeAlert} from 'sentry/views/alerts/rules/metric/utils/isCrashFreeAlert';
 import {useMetricRule} from 'sentry/views/alerts/rules/metric/utils/useMetricRule';
+import {useOpenPeriods} from 'sentry/views/detectors/hooks/useOpenPeriods';
 import {
   useMetricIssueAlertId,
   useMetricTimePeriod,
@@ -45,7 +46,8 @@ export function MetricIssuesSection({
       enabled: !!ruleId,
     }
   );
-  const timePeriod = useMetricTimePeriod({openPeriod: group.openPeriods?.[0]});
+  const {data: openPeriods} = useOpenPeriods({groupId: group.id});
+  const timePeriod = useMetricTimePeriod({openPeriod: openPeriods?.[0]});
 
   if (!rule || !timePeriod) {
     return null;

--- a/static/app/views/issueDetails/streamline/sidebar/firstLastSeenSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/firstLastSeenSection.tsx
@@ -11,6 +11,7 @@ import type {Release} from 'sentry/types/release';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useOpenPeriods} from 'sentry/views/detectors/hooks/useOpenPeriods';
 import {useFetchAllEnvsGroupData} from 'sentry/views/issueDetails/groupSidebar';
 import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
@@ -33,9 +34,13 @@ export default function FirstLastSeenSection({group}: {group: Group}) {
     }
   );
   const environments = useEnvironmentsFromUrl();
+  const {data: openPeriods} = useOpenPeriods(
+    {groupId: group.id},
+    {enabled: issueTypeConfig.useOpenPeriodChecks}
+  );
 
   const lastSeen = issueTypeConfig.useOpenPeriodChecks
-    ? (group.openPeriods?.[0]?.lastChecked ?? group.lastSeen)
+    ? (openPeriods?.[0]?.lastChecked ?? group.lastSeen)
     : group.lastSeen;
 
   const shortEnvironmentLabel =


### PR DESCRIPTION
This was removed from the api in #99519
