### PR TITLE
feat(crons): Switch occurrence fingerprint generation to be consistent for a monitor environment

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -592,6 +592,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enables CMD+K supercharged (omni search)
     manager.add("organizations:cmd-k-supercharged", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
+    # Enables using a consistent occurrence fingerprint for a given MonitorEnvironment
+    manager.add("organizations:crons-consistent-fingerprint", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
+
     # NOTE: Don't add features down here! Add them to their specific group and sort
     #       them alphabetically! The order features are registered is not important.
 

--- a/src/sentry/monitors/logic/incidents.py
+++ b/src/sentry/monitors/logic/incidents.py
@@ -6,10 +6,11 @@ from datetime import datetime, timedelta
 
 from django.utils import timezone
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.analytics.events.cron_monitor_broken_status_recovery import (
     CronMonitorBrokenStatusRecovery,
 )
+from sentry.models.organization import Organization
 from sentry.monitors.logic.incident_occurrence import (
     dispatch_incident_occurrence,
     resolve_incident_group,
@@ -88,6 +89,11 @@ def try_incident_threshold(
 
         starting_checkin = previous_checkins[0]
 
+        optional_defaults = {}
+        organization = Organization.objects.get(id=monitor_env.monitor.organization_id)
+        if features.has("organizations:crons-consistent-fingerprint", organization):
+            optional_defaults["grouphash"] = monitor_env.build_occurrence_fingerprint()
+
         incident: MonitorIncident | None
         incident, _ = MonitorIncident.objects.get_or_create(
             monitor_environment=monitor_env,
@@ -96,6 +102,7 @@ def try_incident_threshold(
                 "monitor": monitor_env.monitor,
                 "starting_checkin_id": starting_checkin.id,
                 "starting_timestamp": starting_checkin.date_added,
+                **optional_defaults,
             },
         )
 

--- a/src/sentry/monitors/logic/incidents.py
+++ b/src/sentry/monitors/logic/incidents.py
@@ -10,6 +10,7 @@ from sentry import analytics, features
 from sentry.analytics.events.cron_monitor_broken_status_recovery import (
     CronMonitorBrokenStatusRecovery,
 )
+from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.models.organization import Organization
 from sentry.monitors.logic.incident_occurrence import (
     dispatch_incident_occurrence,
@@ -90,7 +91,8 @@ def try_incident_threshold(
         starting_checkin = previous_checkins[0]
 
         optional_defaults = {}
-        organization = Organization.objects.get(id=monitor_env.monitor.organization_id)
+        with in_test_hide_transaction_boundary():
+            organization = Organization.objects.get(id=monitor_env.monitor.organization_id)
         if features.has("organizations:crons-consistent-fingerprint", organization):
             optional_defaults["grouphash"] = monitor_env.build_occurrence_fingerprint()
 

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -710,6 +710,9 @@ class MonitorEnvironment(Model):
         except MonitorIncident.DoesNotExist:
             return None
 
+    def build_occurrence_fingerprint(self) -> str:
+        return f"crons:{self.id}"
+
 
 @receiver(pre_save, sender=MonitorEnvironment)
 def check_monitor_environment_limits(sender, instance, **kwargs):

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -547,6 +547,7 @@ class MarkFailedTestCase(TestCase):
             assert incidents.count() == 2
 
             second_incident = incidents.last()
+            assert second_incident
             assert second_incident.id != first_incident.id
             assert second_incident.grouphash == expected_fingerprint
             assert second_incident.grouphash == first_incident.grouphash

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -437,3 +437,116 @@ class MarkFailedTestCase(TestCase):
         grouphash = GroupHash.objects.get(hash=issue_platform_hash)
         group_assignee = GroupAssignee.objects.get(group_id=grouphash.group_id)
         assert group_assignee.user_id == monitor.owner_user_id
+
+    @mock.patch("sentry.monitors.logic.incidents.dispatch_incident_occurrence")
+    def test_mark_failed_with_consistent_fingerprint_feature_enabled(
+        self, mock_dispatch_incident_occurrence
+    ):
+        """Test that when the feature flag is enabled, the grouphash is set to the fingerprint"""
+        with self.feature("organizations:crons-consistent-fingerprint"):
+            monitor = Monitor.objects.create(
+                name="test monitor",
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                config={
+                    "schedule": [1, "hour"],
+                    "schedule_type": ScheduleType.INTERVAL,
+                    "failure_issue_threshold": 3,
+                },
+            )
+            monitor_environment = MonitorEnvironment.objects.create(
+                monitor=monitor,
+                environment_id=self.environment.id,
+                status=MonitorStatus.OK,
+            )
+
+            for i in range(3):
+                checkin = MonitorCheckIn.objects.create(
+                    monitor=monitor,
+                    monitor_environment=monitor_environment,
+                    project_id=self.project.id,
+                    status=CheckInStatus.ERROR,
+                )
+                mark_failed(checkin, failed_at=checkin.date_added)
+
+            incident = MonitorIncident.objects.get(monitor_environment=monitor_environment)
+            expected_fingerprint = f"crons:{monitor_environment.id}"
+            assert incident.grouphash == expected_fingerprint
+
+            assert mock_dispatch_incident_occurrence.call_count == 3
+            for call in mock_dispatch_incident_occurrence.call_args_list:
+                args, _ = call
+                incident = args[2]
+                assert incident.grouphash == expected_fingerprint
+
+    @mock.patch("sentry.monitors.logic.incidents.dispatch_incident_occurrence")
+    @mock.patch("sentry.monitors.logic.incident_occurrence.resolve_incident_group")
+    def test_mark_failed_consistent_fingerprint_after_resolution(
+        self, mock_resolve_incident_group, mock_dispatch_incident_occurrence
+    ):
+        """Test that resolving and recreating an incident maintains the same fingerprint"""
+        with self.feature("organizations:crons-consistent-fingerprint"):
+            monitor = Monitor.objects.create(
+                name="test monitor",
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                config={
+                    "schedule": [1, "hour"],
+                    "schedule_type": ScheduleType.INTERVAL,
+                    "failure_issue_threshold": 3,
+                },
+            )
+            monitor_environment = MonitorEnvironment.objects.create(
+                monitor=monitor,
+                environment_id=self.environment.id,
+                status=MonitorStatus.OK,
+            )
+            expected_fingerprint = f"crons:{monitor_environment.id}"
+
+            for i in range(3):
+                checkin = MonitorCheckIn.objects.create(
+                    monitor=monitor,
+                    monitor_environment=monitor_environment,
+                    project_id=self.project.id,
+                    status=CheckInStatus.ERROR,
+                )
+                mark_failed(checkin, failed_at=checkin.date_added)
+
+            first_incident = MonitorIncident.objects.get(monitor_environment=monitor_environment)
+            assert first_incident.grouphash == expected_fingerprint
+
+            ok_checkin = MonitorCheckIn.objects.create(
+                monitor=monitor,
+                monitor_environment=monitor_environment,
+                project_id=self.project.id,
+                status=CheckInStatus.OK,
+            )
+
+            from sentry.monitors.logic.mark_ok import mark_ok
+
+            mark_ok(ok_checkin, ok_checkin.date_added)
+
+            monitor_environment.refresh_from_db()
+            assert monitor_environment.status == MonitorStatus.OK
+
+            first_incident.refresh_from_db()
+            assert first_incident.resolving_checkin == ok_checkin
+
+            for i in range(3):
+                checkin = MonitorCheckIn.objects.create(
+                    monitor=monitor,
+                    monitor_environment=monitor_environment,
+                    project_id=self.project.id,
+                    status=CheckInStatus.ERROR,
+                )
+                mark_failed(checkin, failed_at=checkin.date_added)
+
+            incidents = MonitorIncident.objects.filter(
+                monitor_environment=monitor_environment
+            ).order_by("date_added")
+            assert incidents.count() == 2
+
+            second_incident = incidents.last()
+            assert second_incident.id != first_incident.id
+            assert second_incident.grouphash == expected_fingerprint
+            assert second_incident.grouphash == first_incident.grouphash

--- a/tests/sentry/monitors/test_models.py
+++ b/tests/sentry/monitors/test_models.py
@@ -283,6 +283,36 @@ class MonitorEnvironmentTestCase(TestCase):
         assert len(cm.records) == 1
         assert "invalid config" in cm.records[0].message
 
+    def test_build_occurrence_fingerprint(self):
+        """Test that build_occurrence_fingerprint returns the expected format"""
+        monitor = self.create_monitor()
+        monitor_environment = self.create_monitor_environment(
+            monitor=monitor,
+            environment_id=self.environment.id,
+        )
+        fingerprint = monitor_environment.build_occurrence_fingerprint()
+        assert fingerprint == f"crons:{monitor_environment.id}"
+
+    def test_build_occurrence_fingerprint_different_environments(self):
+        """Test that different MonitorEnvironments get different fingerprints"""
+        monitor = self.create_monitor()
+        env1 = self.create_environment(name="production")
+        env2 = self.create_environment(name="staging")
+
+        monitor_env1 = self.create_monitor_environment(
+            monitor=monitor,
+            environment_id=env1.id,
+        )
+        monitor_env2 = self.create_monitor_environment(
+            monitor=monitor,
+            environment_id=env2.id,
+        )
+        fingerprint1 = monitor_env1.build_occurrence_fingerprint()
+        fingerprint2 = monitor_env2.build_occurrence_fingerprint()
+        assert fingerprint1 != fingerprint2
+        assert fingerprint1 == f"crons:{monitor_env1.id}"
+        assert fingerprint2 == f"crons:{monitor_env2.id}"
+
 
 class CronMonitorDataSourceHandlerTest(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
We want to have a consistent issue when sending occurrences for a monitor environment to the issue platform, rather than creating a new one for every incident. Switch to just using the monitor id as the fingerprint.

<!-- Describe your PR here. -->