### PR TITLE
fix(grouping): Fix `EventDatastore._tags` type

### DIFF
--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -56,7 +56,7 @@ class EventDatastore:
         self._messages: list[_MessageInfo] | None = None
         self._log_info: list[_LogInfo] | None = None
         self._toplevel: list[_MessageInfo | _ExceptionInfo] | None = None
-        self._tags: list[dict[str, str]] | None = None
+        self._tags: list[dict[str, str | None]] | None = None
         self._sdk: list[_SdkInfo] | None = None
         self._family: list[_FamilyInfo] | None = None
         self._release: list[_ReleaseInfo] | None = None
@@ -128,7 +128,7 @@ class EventDatastore:
             self._toplevel = [*self._get_messages(), *self._get_exceptions()]
         return self._toplevel
 
-    def _get_tags(self) -> list[dict[str, str]]:
+    def _get_tags(self) -> list[dict[str, str | None]]:
         if self._tags is None:
             self._tags = [
                 {"tags.%s" % k: v for (k, v) in get_path(self.event, "tags", filter=True) or ()}


### PR DESCRIPTION
During ingest, before we apply server-side fingerprinting rules, we extract the necessary data into a custom container called `EventDatastore`, to make it easier to find the right data against which to test. In that class, tag values are typed as always being strings. [Elsewhere in the code](https://github.com/getsentry/sentry/blob/8305fb6d38b9913f4cc81f6707b7686ee3fd8eaf/src/sentry/grouping/utils.py#L150), though, we acknowledge that tag values can be `None`. This fixes the types to reflect that fact.