### PR TITLE
fix(profiling): Remove profile ids from shared schema

### DIFF
--- a/static/app/types/profiling.d.ts
+++ b/static/app/types/profiling.d.ts
@@ -324,8 +324,7 @@ declare namespace Profiling {
     >;
     shared: {
       frames: ReadonlyArray<Omit<Profiling.Frame, 'key'>>;
-      frame_infos?: ReadonlyArray<Profiling.FrameInfo, 'key'>;
-      profile_ids?: ReadonlyArray<string>[];
+      frame_infos?: ReadonlyArray<Profiling.FrameInfo>;
       profiles?: ReadonlyArray<ProfileReference>;
     };
     activeProfileIndex?: number;

--- a/static/app/types/profiling.d.ts
+++ b/static/app/types/profiling.d.ts
@@ -168,7 +168,6 @@ declare namespace Profiling {
   interface SampledProfile extends RawProfileBase {
     weights: number[];
     samples: number[][];
-    samples_profiles?: number[][];
     samples_examples?: number[][];
     sample_durations_ns?: number[];
     type: 'sampled';

--- a/static/app/utils/profiling/profile/continuousProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/continuousProfile.spec.tsx
@@ -115,7 +115,6 @@ describe('ContinuousProfile', () => {
         span: undefined,
         type: 'flamechart',
         frameFilter: undefined,
-        profileIds: undefined,
       });
 
       expect(profile.profiles[0]!.duration).toBe(0);

--- a/static/app/utils/profiling/profile/importProfile.tsx
+++ b/static/app/utils/profiling/profile/importProfile.tsx
@@ -35,9 +35,7 @@ interface ImportOptions {
   activeThreadId?: string | null;
   continuous?: boolean;
   frameFilter?: (frame: Frame) => boolean;
-  profileIds?:
-    | Profiling.Schema['shared']['profiles']
-    | Profiling.Schema['shared']['profile_ids'];
+  profiles?: Profiling.Schema['shared']['profiles'];
 }
 
 export interface ProfileGroup {
@@ -252,7 +250,7 @@ function importSchema(
     profiles: input.profiles.map(profile =>
       importSingleProfile(profile, frameIndex, {
         ...options,
-        profileIds: input.shared.profile_ids ?? input.shared.profiles,
+        profiles: input.shared.profiles,
       })
     ),
   };
@@ -568,7 +566,7 @@ function importSingleProfile(
     | ReturnType<typeof createFrameIndex>
     | ReturnType<typeof createContinuousProfileFrameIndex>
     | ReturnType<typeof createSentrySampleProfileFrameIndex>,
-  {span, type, frameFilter, profileIds}: ImportOptions
+  {span, type, frameFilter, profiles}: ImportOptions
 ): Profile {
   if (isSentryContinuousProfile(profile)) {
     const minTimestamp = minTimestampInChunk(profile);
@@ -617,14 +615,14 @@ function importSingleProfile(
       return SampledProfile.FromProfile(profile, frameIndex, {
         type,
         frameFilter,
-        profileIds,
+        profiles,
       });
     }
 
     return wrapWithSpan(
       span,
       () =>
-        SampledProfile.FromProfile(profile, frameIndex, {type, frameFilter, profileIds}),
+        SampledProfile.FromProfile(profile, frameIndex, {type, frameFilter, profiles}),
       {
         op: 'profile.import',
         description: 'sampled',

--- a/static/app/utils/profiling/profile/sampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.tsx
@@ -65,20 +65,6 @@ function sortSamples(
   return stacksWithWeights(profile, profiles, frameFilter).sort(sortStacks);
 }
 
-function mergeProfileExamples(
-  profiles: Readonly<Profiling.SampledProfile['samples_profiles']>,
-  profileReferences: Readonly<Profiling.SampledProfile['samples_examples']>
-): number[][] {
-  const merged: number[][] = [];
-
-  const l = Math.max(profiles?.length ?? 0, profileReferences?.length ?? 0);
-  for (let i = 0; i < l; i++) {
-    merged[i] = (profiles?.[i] ?? []).concat(profileReferences?.[i] ?? []);
-  }
-
-  return merged;
-}
-
 // We should try and remove these as we adopt our own profile format and only rely on the sampled format.
 export class SampledProfile extends Profile {
   static FromProfile(
@@ -110,14 +96,11 @@ export class SampledProfile extends Profile {
     let resolvedProfileIds: Profiling.ProfileReference[][] = [];
     if (
       options.type === 'flamegraph' &&
-      (sampledProfile.samples_profiles || sampledProfile.samples_examples) &&
+      sampledProfile.samples_examples &&
       options.profiles
     ) {
       resolvedProfileIds = resolveFlamegraphSamplesProfileIds(
-        mergeProfileExamples(
-          sampledProfile.samples_profiles,
-          sampledProfile.samples_examples
-        ),
+        sampledProfile.samples_examples,
         options.profiles.slice()
       );
     }


### PR DESCRIPTION
Profile ids aren't used anymore. Instead we just use the profiles array which contain profile references for either a transaction style or continuous profile.