### PR TITLE
feat(uptime): Use config values for thresholds

### DIFF
--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -17,7 +17,12 @@ from sentry.models.group import GroupStatus
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
 from sentry.uptime.models import UptimeStatus, UptimeSubscription
-from sentry.uptime.types import GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE, UptimeMonitorMode
+from sentry.uptime.types import (
+    DEFAULT_DOWNTIME_THRESHOLD,
+    DEFAULT_RECOVERY_THRESHOLD,
+    GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
+    UptimeMonitorMode,
+)
 from sentry.utils import metrics
 from sentry.workflow_engine.handlers.detector.base import DetectorOccurrence, EventData
 from sentry.workflow_engine.handlers.detector.stateful import (
@@ -70,22 +75,6 @@ def build_detector_fingerprint_component(detector: Detector) -> str:
 
 def build_fingerprint(detector: Detector) -> list[str]:
     return [build_detector_fingerprint_component(detector)]
-
-
-def get_active_failure_threshold() -> int:
-    """
-    When in active monitoring mode, overrides how many failures in a row we
-    need to see to mark the monitor as down
-    """
-    return options.get("uptime.active-failure-threshold")
-
-
-def get_active_recovery_threshold() -> int:
-    """
-    When in active monitoring mode, how many successes in a row do we need to
-    mark it as up
-    """
-    return options.get("uptime.active-recovery-threshold")
 
 
 def build_evidence_display(result: CheckResult) -> list[IssueEvidence]:
@@ -147,9 +136,17 @@ class UptimeDetectorHandler(StatefulDetectorHandler[UptimePacketValue, CheckStat
     @override
     @property
     def thresholds(self) -> DetectorThresholds:
+        # TODO: Drop these fallbacks once migration 0045 is deployed and all detectors have config values
+        recovery_threshold = self.detector.config.get(
+            "recovery_threshold", DEFAULT_RECOVERY_THRESHOLD
+        )
+        downtime_threshold = self.detector.config.get(
+            "downtime_threshold", DEFAULT_DOWNTIME_THRESHOLD
+        )
+
         return {
-            DetectorPriorityLevel.OK: get_active_recovery_threshold(),
-            DetectorPriorityLevel.HIGH: get_active_failure_threshold(),
+            DetectorPriorityLevel.OK: recovery_threshold,
+            DetectorPriorityLevel.HIGH: downtime_threshold,
         }
 
     @override

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -67,6 +67,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         )
         self.detector = self.create_uptime_detector(
             uptime_subscription=self.subscription,
+            downtime_threshold=2,
+            recovery_threshold=2,
             owner=self.user,
         )
 
@@ -103,7 +105,6 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         with (
             self.feature(features),
             mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics,
-            mock.patch("sentry.uptime.grouptype.get_active_failure_threshold", return_value=2),
         ):
             # First processed result does NOT create an occurrence since we
             # have not yet met the active threshold
@@ -163,10 +164,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         assert self.subscription.uptime_status == UptimeStatus.FAILED
 
         # Issue is resolved
-        with (
-            self.feature(features),
-            mock.patch("sentry.uptime.grouptype.get_active_recovery_threshold", return_value=2),
-        ):
+        with (self.feature(features),):
             # First processed result does NOT resolve since we have not yet met
             # the recovery threshold
             self.send_result(
@@ -216,11 +214,12 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             mock_remove_uptime_subscription_if_unused.assert_called_with(self.subscription)
 
     def test_no_create_issues_feature(self) -> None:
+        self.detector.config.update({"downtime_threshold": 1, "recovery_threshold": 1})
+        self.detector.save()
         result = self.create_uptime_result(self.subscription.subscription_id)
         with (
             self.feature(["organizations:uptime"]),
             mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics,
-            mock.patch("sentry.uptime.grouptype.get_active_failure_threshold", return_value=1),
         ):
             self.send_result(result)
             metrics.incr.assert_has_calls(
@@ -862,7 +861,6 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         with (
             self.feature(features),
             mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics,
-            mock.patch("sentry.uptime.grouptype.get_active_failure_threshold", return_value=2),
             mock.patch(
                 "sentry.uptime.consumers.results_consumer.TOTAL_PROVIDERS_TO_INCLUDE_AS_TAGS",
                 new=1,
@@ -930,15 +928,14 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         assert parsed_value["incident_status"] == 0
         assert parsed_value["retention_days"] == 90
 
-    @mock.patch("sentry.uptime.consumers.results_consumer._snuba_uptime_checks_producer.produce")
-    @mock.patch("sentry.uptime.grouptype.get_active_failure_threshold", return_value=1)
     @override_options({"uptime.snuba_uptime_results.enabled": True})
-    def test_produces_snuba_uptime_results_in_incident(
-        self, _: MagicMock, mock_produce: MagicMock
-    ) -> None:
+    @mock.patch("sentry.uptime.consumers.results_consumer._snuba_uptime_checks_producer.produce")
+    def test_produces_snuba_uptime_results_in_incident(self, mock_produce: MagicMock) -> None:
         """
         Validates that the consumer produces a message to Snuba's Kafka topic for uptime check results
         """
+        self.detector.config.update({"downtime_threshold": 1, "recovery_threshold": 1})
+        self.detector.save()
         result = self.create_uptime_result(
             self.subscription.subscription_id,
             status=CHECKSTATUS_FAILURE,

--- a/tests/sentry/uptime/test_grouptype.py
+++ b/tests/sentry/uptime/test_grouptype.py
@@ -149,17 +149,14 @@ class TestUptimeHandler(UptimeTestCase):
         return evaluation[None]
 
     def test_simple_evaluate(self) -> None:
-        detector = self.create_uptime_detector()
+        detector = self.create_uptime_detector(downtime_threshold=2, recovery_threshold=1)
         uptime_subscription = get_uptime_subscription(detector)
 
         assert uptime_subscription.uptime_status == UptimeStatus.OK
 
         now = datetime.now()
 
-        with (
-            self.feature("organizations:uptime-create-issues"),
-            mock.patch("sentry.uptime.grouptype.get_active_failure_threshold", return_value=2),
-        ):
+        with self.feature("organizations:uptime-create-issues"):
             evaluation = self.handle_result(
                 detector,
                 uptime_subscription,
@@ -191,14 +188,13 @@ class TestUptimeHandler(UptimeTestCase):
             assert uptime_subscription.uptime_status == UptimeStatus.FAILED
 
     def test_issue_creation_disabled(self) -> None:
-        detector = self.create_uptime_detector()
+        detector = self.create_uptime_detector(downtime_threshold=1, recovery_threshold=1)
         uptime_subscription = get_uptime_subscription(detector)
 
         assert uptime_subscription.uptime_status == UptimeStatus.OK
 
         with (
             # uptime-create-issues flag not enabled. No issue created
-            mock.patch("sentry.uptime.grouptype.get_active_failure_threshold", return_value=1),
             mock.patch("sentry.uptime.grouptype.logger") as logger,
         ):
             check_result = self.create_uptime_result()
@@ -231,7 +227,6 @@ class TestUptimeHandler(UptimeTestCase):
             # All features enabled, but the host provider is disabled
             self.feature(["organizations:uptime-create-issues"]),
             self.options(options),
-            mock.patch("sentry.uptime.grouptype.get_active_failure_threshold", return_value=1),
         ):
             evaluation = self.handle_result(
                 detector,
@@ -245,17 +240,14 @@ class TestUptimeHandler(UptimeTestCase):
         Test that a uptime monitor that flaps between failure, success success,
         failure, etc does not produce any evaluations.
         """
-        detector = self.create_uptime_detector()
+        detector = self.create_uptime_detector(downtime_threshold=3, recovery_threshold=1)
         uptime_subscription = get_uptime_subscription(detector)
 
         assert uptime_subscription.uptime_status == UptimeStatus.OK
 
         now = datetime.now()
 
-        with (
-            self.feature(["organizations:uptime-create-issues"]),
-            mock.patch("sentry.uptime.grouptype.get_active_failure_threshold", return_value=3),
-        ):
+        with self.feature(["organizations:uptime-create-issues"]):
             status_cycle: cycle[CheckStatus] = cycle(
                 [CHECKSTATUS_FAILURE, CHECKSTATUS_SUCCESS, CHECKSTATUS_SUCCESS]
             )


### PR DESCRIPTION
Updates UptimeDetectorHandler to read recovery_threshold and downtime_threshold from detector config instead of hardcoded global options. This allows per-detector threshold customization while maintaining backward compatibility with fallbacks to default values.

- Update thresholds property to read from detector.config with fallbacks

- Remove unused get_active_failure_threshold and get_active_recovery_threshold functions

- Update tests to use fixture threshold parameters instead of mocking global options

This completes the backend threshold configuration work and enables the migration to populate existing detectors with default threshold values.

Part of [NEW-302: Configurable downtime and recovery thresholds for uptime](https://linear.app/getsentry/issue/NEW-302/configurable-downtime-and-recovery-thresholds-for-uptime)

>[!IMPORTANT]
> Should not be merged until the migration #99719 