### PR TITLE
feat: make branch undefined if nothing is provided

### DIFF
--- a/static/app/views/prevent/tests/queries/useTestResultsAggregates.ts
+++ b/static/app/views/prevent/tests/queries/useTestResultsAggregates.ts
@@ -29,7 +29,15 @@ type QueryKey = [url: string, endpointOptions: QueryKeyEndpointOptions];
 export function useTestResultsAggregates() {
   const api = useApi();
   const organization = useOrganization();
-  const {integratedOrgId, repository, branch, preventPeriod} = usePreventContext();
+  const {
+    integratedOrgId,
+    repository,
+    branch: rawBranch,
+    preventPeriod,
+  } = usePreventContext();
+
+  // Normalize branch to undefined when falsy for consistent caching
+  const branch = rawBranch || undefined;
 
   const {data, ...rest} = useQuery<
     TestResultAggregate,

--- a/static/app/views/prevent/tests/queries/useTestResultsAggregates.ts
+++ b/static/app/views/prevent/tests/queries/useTestResultsAggregates.ts
@@ -61,6 +61,7 @@ export function useTestResultsAggregates() {
 
       return result as TestResultAggregate;
     },
+    enabled: !!(integratedOrgId && repository && preventPeriod),
   });
 
   const memoizedData = useMemo(() => {


### PR DESCRIPTION
This PR adjusts the branch param to work for the flake aggregates endpoint when "all branches" is selected