### PR TITLE
fix(preprod): use chart theme for treemap colors

### DIFF
--- a/static/app/views/preprod/components/visualizations/appSizeTheme.ts
+++ b/static/app/views/preprod/components/visualizations/appSizeTheme.ts
@@ -11,7 +11,7 @@ export function getAppSizeCategoryInfo(
     return color(baseColor).alpha(0.6).string();
   };
 
-  const colorPalette = theme.chart.getColorPalette(7);
+  const colorPalette = theme.chart.getColorPalette(6);
 
   const neutralColor = 'hsla(270, 20%, 50%, 0.5)';
   const groupColor1 = colorPalette[0];
@@ -68,8 +68,8 @@ export function getAppSizeCategoryInfo(
       displayName: t('Plist Files'),
     },
     [TreemapType.DYLD]: {
-      color: groupColor5,
-      headerColor: createHeaderColor(groupColor5),
+      color: groupColor1,
+      headerColor: createHeaderColor(groupColor1),
       displayName: t('Dynamic Libraries'),
     },
     [TreemapType.MACHO]: {

--- a/static/app/views/preprod/components/visualizations/appSizeTheme.ts
+++ b/static/app/views/preprod/components/visualizations/appSizeTheme.ts
@@ -11,135 +11,146 @@ export function getAppSizeCategoryInfo(
     return color(baseColor).alpha(0.6).string();
   };
 
+  const colorPalette = theme.chart.getColorPalette(7);
+
+  const filesColor = 'hsla(270, 20%, 50%, 0.5)';
+  const groupColor1 = colorPalette[0];
+  const groupColor2 = colorPalette[1];
+  const groupColor3 = colorPalette[2];
+  const groupColor4 = colorPalette[3];
+  const groupColor5 = colorPalette[4];
+  const groupColor6 = colorPalette[5];
+  const groupColor7 = colorPalette[6];
+
   return {
     [TreemapType.FILES]: {
-      color: 'hsla(270, 20%, 50%, 0.5)',
-      headerColor: createHeaderColor('hsla(270, 20%, 50%, 0.5)'),
+      color: filesColor,
+      headerColor: createHeaderColor(filesColor),
       displayName: t('Files'),
     },
     [TreemapType.EXECUTABLES]: {
-      color: theme.blue300,
-      headerColor: createHeaderColor(theme.blue300),
+      color: groupColor1,
+      headerColor: createHeaderColor(groupColor1),
       displayName: t('Executables'),
     },
     [TreemapType.RESOURCES]: {
-      color: theme.pink400,
-      headerColor: createHeaderColor(theme.pink400),
+      color: groupColor2,
+      headerColor: createHeaderColor(groupColor2),
       displayName: t('Resources'),
     },
     [TreemapType.ASSETS]: {
-      color: theme.green300,
-      headerColor: createHeaderColor(theme.green300),
+      color: groupColor3,
+      headerColor: createHeaderColor(groupColor3),
       displayName: t('Assets'),
     },
     [TreemapType.MANIFESTS]: {
-      color: theme.blue300,
-      headerColor: createHeaderColor(theme.blue300),
+      color: groupColor1,
+      headerColor: createHeaderColor(groupColor1),
       displayName: t('Manifests'),
     },
     [TreemapType.SIGNATURES]: {
-      color: theme.blue300,
-      headerColor: createHeaderColor(theme.blue300),
+      color: groupColor1,
+      headerColor: createHeaderColor(groupColor1),
       displayName: t('Signatures'),
     },
     [TreemapType.FONTS]: {
-      color: theme.purple400,
-      headerColor: createHeaderColor(theme.purple400),
+      color: groupColor4,
+      headerColor: createHeaderColor(groupColor4),
       displayName: t('Fonts'),
     },
     [TreemapType.FRAMEWORKS]: {
-      color: theme.pink400,
-      headerColor: createHeaderColor(theme.pink400),
+      color: groupColor2,
+      headerColor: createHeaderColor(groupColor2),
       displayName: t('Frameworks'),
     },
     [TreemapType.PLISTS]: {
-      color: theme.pink400,
-      headerColor: createHeaderColor(theme.pink400),
+      color: groupColor2,
+      headerColor: createHeaderColor(groupColor2),
       displayName: t('Plist Files'),
     },
     [TreemapType.DYLD]: {
-      color: theme.blue400,
-      headerColor: createHeaderColor(theme.blue400),
+      color: groupColor5,
+      headerColor: createHeaderColor(groupColor5),
       displayName: t('Dynamic Libraries'),
     },
     [TreemapType.MACHO]: {
-      color: theme.pink400,
-      headerColor: createHeaderColor(theme.pink400),
+      color: groupColor2,
+      headerColor: createHeaderColor(groupColor2),
       displayName: t('Mach-O Files'),
     },
     [TreemapType.FUNCTION_STARTS]: {
-      color: theme.pink400,
-      headerColor: createHeaderColor(theme.pink400),
+      color: groupColor2,
+      headerColor: createHeaderColor(groupColor2),
       displayName: t('Function Starts'),
     },
     [TreemapType.DEX]: {
-      color: theme.blue300,
-      headerColor: createHeaderColor(theme.blue300),
+      color: groupColor1,
+      headerColor: createHeaderColor(groupColor1),
       displayName: 'Dex', // not translated because it's an Android term
     },
     [TreemapType.NATIVE_LIBRARIES]: {
-      color: theme.yellow300,
-      headerColor: createHeaderColor(theme.yellow300),
+      color: groupColor6,
+      headerColor: createHeaderColor(groupColor6),
       displayName: t('Native Libraries'),
     },
     [TreemapType.COMPILED_RESOURCES]: {
-      color: theme.green300,
-      headerColor: createHeaderColor(theme.green300),
+      color: groupColor3,
+      headerColor: createHeaderColor(groupColor3),
       displayName: t('Compiled Resources'),
     },
     [TreemapType.MODULES]: {
-      color: theme.blue400,
-      headerColor: createHeaderColor(theme.blue400),
+      color: groupColor5,
+      headerColor: createHeaderColor(groupColor5),
       displayName: t('Modules'),
     },
     [TreemapType.CLASSES]: {
-      color: theme.blue400,
-      headerColor: createHeaderColor(theme.blue400),
+      color: groupColor5,
+      headerColor: createHeaderColor(groupColor5),
       displayName: t('Classes'),
     },
     [TreemapType.METHODS]: {
-      color: theme.blue400,
-      headerColor: createHeaderColor(theme.blue400),
+      color: groupColor5,
+      headerColor: createHeaderColor(groupColor5),
       displayName: t('Methods'),
     },
     [TreemapType.STRINGS]: {
-      color: theme.blue400,
-      headerColor: createHeaderColor(theme.blue400),
+      color: groupColor5,
+      headerColor: createHeaderColor(groupColor5),
       displayName: t('Strings'),
     },
     [TreemapType.SYMBOLS]: {
-      color: theme.blue400,
-      headerColor: createHeaderColor(theme.blue400),
+      color: groupColor5,
+      headerColor: createHeaderColor(groupColor5),
       displayName: t('Symbols'),
     },
     [TreemapType.BINARY]: {
-      color: theme.blue400,
-      headerColor: createHeaderColor(theme.blue400),
+      color: groupColor5,
+      headerColor: createHeaderColor(groupColor5),
       displayName: t('Binary Data'),
     },
     [TreemapType.EXTERNAL_METHODS]: {
-      color: theme.blue400,
-      headerColor: createHeaderColor(theme.blue400),
+      color: groupColor5,
+      headerColor: createHeaderColor(groupColor5),
       displayName: t('External Methods'),
     },
     [TreemapType.OTHER]: {
-      color: theme.gray300,
-      headerColor: createHeaderColor(theme.gray300),
+      color: groupColor7,
+      headerColor: createHeaderColor(groupColor7),
       displayName: t('Other'),
     },
     [TreemapType.UNMAPPED]: {
-      color: theme.gray300,
-      headerColor: createHeaderColor(theme.gray300),
+      color: groupColor7,
+      headerColor: createHeaderColor(groupColor7),
       displayName: t('Unmapped'),
     },
     [TreemapType.EXTENSIONS]: {
-      color: theme.pink400,
-      headerColor: createHeaderColor(theme.pink400),
+      color: groupColor2,
+      headerColor: createHeaderColor(groupColor2),
       displayName: t('Extensions'),
     },
     [TreemapType.CODE_SIGNATURE]: {
-      color: theme.blue300,
-      headerColor: createHeaderColor(theme.blue300),
+      color: groupColor1,
+      headerColor: createHeaderColor(groupColor1),
       displayName: t('Code Signature'),
     },
   };

--- a/static/app/views/preprod/components/visualizations/appSizeTheme.ts
+++ b/static/app/views/preprod/components/visualizations/appSizeTheme.ts
@@ -13,19 +13,18 @@ export function getAppSizeCategoryInfo(
 
   const colorPalette = theme.chart.getColorPalette(7);
 
-  const filesColor = 'hsla(270, 20%, 50%, 0.5)';
+  const neutralColor = 'hsla(270, 20%, 50%, 0.5)';
   const groupColor1 = colorPalette[0];
   const groupColor2 = colorPalette[1];
   const groupColor3 = colorPalette[2];
   const groupColor4 = colorPalette[3];
   const groupColor5 = colorPalette[4];
   const groupColor6 = colorPalette[5];
-  const groupColor7 = colorPalette[6];
 
   return {
     [TreemapType.FILES]: {
-      color: filesColor,
-      headerColor: createHeaderColor(filesColor),
+      color: neutralColor,
+      headerColor: createHeaderColor(neutralColor),
       displayName: t('Files'),
     },
     [TreemapType.EXECUTABLES]: {
@@ -134,13 +133,13 @@ export function getAppSizeCategoryInfo(
       displayName: t('External Methods'),
     },
     [TreemapType.OTHER]: {
-      color: groupColor7,
-      headerColor: createHeaderColor(groupColor7),
+      color: neutralColor,
+      headerColor: createHeaderColor(neutralColor),
       displayName: t('Other'),
     },
     [TreemapType.UNMAPPED]: {
-      color: groupColor7,
-      headerColor: createHeaderColor(groupColor7),
+      color: neutralColor,
+      headerColor: createHeaderColor(neutralColor),
       displayName: t('Unmapped'),
     },
     [TreemapType.EXTENSIONS]: {


### PR DESCRIPTION
We were directly referencing color values which suddenly broke and looked ugly when design removed blue from the color palette. Looking at other usages, I believe this is the canonical way to get pretty colors for visualizations and it looks decent. The orange/purple clashes a little but seems fine IMO.

<img width="1052" height="543" alt="Screenshot 2025-09-17 at 3 58 58 PM" src="https://github.com/user-attachments/assets/e8239781-5fd8-4d8b-9b76-cf7107b83f4d" />
