### PR TITLE
ref(timeseries): Use `/events-timeseries/` in Web Vitals module

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.spec.tsx
@@ -1,5 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
@@ -33,14 +34,18 @@ describe('PerformanceScoreBreakdownChartWidget', () => {
     });
 
     eventsStatsMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       body: {
-        'performance_score(measurements.score.lcp)': {
-          data: [[1743348600, [{count: 0.6106921965623204}]]],
-        },
-        'performance_score(measurements.score.fcp)': {
-          data: [[1743435000, [{count: 0.7397871866098699}]]],
-        },
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'performance_score(measurements.score.lcp)',
+            values: [{timestamp: 1743348600000, value: 0.6106921965623204}],
+          }),
+          TimeSeriesFixture({
+            yAxis: 'performance_score(measurements.score.fcp)',
+            values: [{timestamp: 1743435000000, value: 0.7397871866098699}],
+          }),
+        ],
       },
     });
   });
@@ -63,7 +68,7 @@ describe('PerformanceScoreBreakdownChartWidget', () => {
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
     expect(eventsStatsMock).toHaveBeenCalledWith(
-      '/organizations/org-slug/events-stats/',
+      '/organizations/org-slug/events-timeseries/',
       expect.objectContaining({
         method: 'GET',
         query: expect.objectContaining({

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
@@ -47,9 +47,9 @@ describe('PageOverviewSidebar', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       body: {
-        data: [],
+        timeSeries: [],
       },
     });
 

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -87,8 +87,13 @@ export function PageOverviewSidebar({
 
   const shouldDoublePeriod = false;
 
+  const countTimeSeries = data?.timeSeries?.find(ts => ts.yAxis === 'count()');
+  const countData = countTimeSeries
+    ? countTimeSeries.values.map(v => ({name: v.timestamp, value: v.value || 0}))
+    : [];
+
   const {countDiff, currentSeries, currentCount, initialCount} = processSeriesData(
-    data['count()'].data,
+    countData,
     isLoading,
     pageFilters.selection.datetime,
     shouldDoublePeriod
@@ -101,13 +106,20 @@ export function PageOverviewSidebar({
     },
   ];
 
+  const inpTimeSeries = data?.timeSeries?.find(
+    ts => ts.yAxis === 'count_scores(measurements.score.inp)'
+  );
+  const inpData = inpTimeSeries
+    ? inpTimeSeries.values.map(v => ({name: v.timestamp, value: v.value || 0}))
+    : [];
+
   const {
     countDiff: inpCountDiff,
     currentSeries: currentInpSeries,
     currentCount: currentInpCount,
     initialCount: initialInpCount,
   } = processSeriesData(
-    data['count_scores(measurements.score.inp)'].data,
+    inpData,
     isLoading,
     pageFilters.selection.datetime,
     shouldDoublePeriod

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.spec.tsx
@@ -60,12 +60,9 @@ describe('PageOverviewWebVitalsDetailPanel', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       body: {
-        data: [
-          [1543449600, [20, 12]],
-          [1543449601, [10, 5]],
-        ],
+        timeSeries: [],
       },
     });
   });

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.spec.tsx
@@ -35,12 +35,9 @@ describe('WebVitalsDetailPanel', () => {
       },
     });
     eventsStatsMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       body: {
-        data: [
-          [1543449600, [20, 12]],
-          [1543449601, [10, 5]],
-        ],
+        timeSeries: [],
       },
     });
   });

--- a/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
@@ -1,10 +1,10 @@
 import {getInterval} from 'sentry/components/charts/utils';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {Referrer} from 'sentry/views/insights/browser/webVitals/referrers';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {SpanFields, type SubregionCode} from 'sentry/views/insights/types';
 
 type Props = {
@@ -31,9 +31,9 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
     search.addDisjunctionFilterValues(SpanFields.USER_GEO_SUBREGION, subregions);
   }
 
-  const result = useSpanSeries(
+  const result = useFetchSpanTimeSeries(
     {
-      search: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
+      query: [DEFAULT_QUERY_FILTER, search.formatString()].join(' ').trim(),
       interval: getInterval(pageFilters.selection.datetime, 'spans-low'),
       yAxis: [
         'p75(measurements.lcp)',

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
@@ -65,7 +65,7 @@ describe('PageOverview', () => {
       },
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       body: {},
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.spec.tsx
@@ -1,6 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
@@ -49,14 +50,28 @@ describe('WebVitalsLandingPage', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-stats/`,
+      url: `/organizations/${organization.slug}/events-timeseries/`,
       body: {
-        'performance_score(measurements.score.lcp)': {
-          data: [[1743348600, [{count: 0.6106921965623204}]]],
-        },
-        'performance_score(measurements.score.fcp)': {
-          data: [[1743435000, [{count: 0.7397871866098699}]]],
-        },
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'performance_score(measurements.score.lcp)',
+            values: [
+              {
+                timestamp: 1743348600000,
+                value: 0.6106921965623204,
+              },
+            ],
+          }),
+          TimeSeriesFixture({
+            yAxis: 'performance_score(measurements.score.fcp)',
+            values: [
+              {
+                timestamp: 1743348600000,
+                value: 0.7397871866098699,
+              },
+            ],
+          }),
+        ],
       },
     });
   });

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -271,6 +271,7 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
 
 const COMMON_COLORS = (theme: Theme): Record<string, string> => {
   const colors = theme.chart.getColorPalette(2);
+  const vitalColors = theme.chart.getColorPalette(4);
   return {
     'epm()': THROUGHPUT_COLOR(theme),
     'count()': COUNT_COLOR(theme),
@@ -280,5 +281,10 @@ const COMMON_COLORS = (theme: Theme): Record<string, string> => {
     'http_response_rate(5)': HTTP_RESPONSE_5XX_COLOR,
     'avg(messaging.message.receive.latency)': colors[1],
     'avg(span.duration)': colors[2],
+    'performance_score(measurements.score.lcp)': vitalColors[0],
+    'performance_score(measurements.score.fcp)': vitalColors[1],
+    'performance_score(measurements.score.inp)': vitalColors[2],
+    'performance_score(measurements.score.cls)': vitalColors[3],
+    'performance_score(measurements.score.ttfb)': vitalColors[4],
   };
 };

--- a/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
@@ -1,9 +1,11 @@
-import {useTheme} from '@emotion/react';
-
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import {decodeList} from 'sentry/utils/queryString';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {ORDER} from 'sentry/views/insights/browser/webVitals/components/charts/performanceScoreChart';
 import {WebVitalsWeightList} from 'sentry/views/insights/browser/webVitals/components/charts/webVitalWeightList';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
@@ -12,10 +14,6 @@ import {getWeights} from 'sentry/views/insights/browser/webVitals/utils/getWeigh
 import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {InsightsTimeSeriesWidget} from 'sentry/views/insights/common/components/insightsTimeSeriesWidget';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {
-  useSpanSeries,
-  type DiscoverSeries,
-} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {SpanFields} from 'sentry/views/insights/types';
 
 export default function PerformanceScoreBreakdownChartWidget(
@@ -32,8 +30,6 @@ export default function PerformanceScoreBreakdownChartWidget(
       transaction: decodeList,
     },
   });
-  const theme = useTheme();
-  const segmentColors = theme.chart.getColorPalette(4).slice(0, 5);
   const search = new MutableSearch(
     `${DEFAULT_QUERY_FILTER} has:measurements.score.total`
   );
@@ -54,11 +50,11 @@ export default function PerformanceScoreBreakdownChartWidget(
     data: vitalScoresData,
     isLoading: areVitalScoresLoading,
     error: vitalScoresError,
-  } = useSpanSeries(
+  } = useFetchSpanTimeSeries(
     {
-      samplingMode: 'HIGHEST_ACCURACY',
+      sampling: SAMPLING_MODE.HIGH_ACCURACY,
       interval: '12h',
-      search,
+      query: search,
       yAxis: [
         'performance_score(measurements.score.lcp)',
         'performance_score(measurements.score.fcp)',
@@ -67,49 +63,43 @@ export default function PerformanceScoreBreakdownChartWidget(
         'performance_score(measurements.score.ttfb)',
         'count()',
       ],
-      transformAliasToInputFormat: true,
+      pageFilters: props.pageFilters,
     },
-    'api.insights.web-vitals.timeseries-scores2',
-    props.pageFilters
+    'api.insights.web-vitals.timeseries-scores2'
   );
 
+  const timeSeries = vitalScoresData?.timeSeries || [];
   const webVitalsThatHaveData: WebVitals[] = vitalScoresData
     ? ORDER.filter(webVital => {
         const key = `performance_score(measurements.score.${webVital})` as const;
-        const series = vitalScoresData[key];
+        const series = timeSeries.find(ts => ts.yAxis === key);
 
-        return series.data.some(datum => datum.value > 0);
+        return series ? series.values.some(datum => (datum.value || 0) > 0) : false;
       })
     : [];
 
   const weights = getWeights(webVitalsThatHaveData);
 
-  const allSeries: DiscoverSeries[] = vitalScoresData
-    ? ORDER.map((webVital, index) => {
+  const allSeries: TimeSeries[] = vitalScoresData?.timeSeries
+    ? ORDER.map(webVital => {
         const key = `performance_score(measurements.score.${webVital})` as const;
-        const series = vitalScoresData[key];
+        const series = timeSeries.find(ts => ts.yAxis === key);
 
-        const scaledSeries: DiscoverSeries = {
+        if (!series) return null;
+
+        return {
           ...series,
-          data: series.data.map(datum => {
-            return {
-              ...datum,
-              value: datum.value * weights[webVital],
-            };
-          }),
-          color: segmentColors[index],
           meta: {
+            ...series.meta,
             // TODO: The backend doesn't return these score fields with the "score" type yet. Fill this in manually for now.
-            fields: {
-              ...series.meta?.fields,
-              [key]: 'score',
-            },
-            units: series.meta?.units,
+            valueType: 'score' as const,
           },
+          values: series.values.map(item => ({
+            ...item,
+            value: (item.value ?? 0) * weights[webVital],
+          })),
         };
-
-        return scaledSeries;
-      })
+      }).filter(defined)
     : [];
 
   return (
@@ -121,7 +111,7 @@ export default function PerformanceScoreBreakdownChartWidget(
       visualizationType="area"
       isLoading={areVitalScoresLoading}
       error={vitalScoresError}
-      series={allSeries}
+      timeSeries={allSeries}
       description={<WebVitalsWeightList weights={weights} />}
     />
   );

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -75,6 +75,11 @@ describe('Performance > Widgets > WidgetContainer', () => {
       url: `/organizations/org-slug/events-stats/`,
       body: [],
     });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/org-slug/events-timeseries/`,
+      body: {},
+    });
     eventsMock = MockApiClient.addMockResponse({
       method: 'GET',
       url: `/organizations/org-slug/events/`,
@@ -272,6 +277,14 @@ describe('Performance > Widgets > WidgetContainer', () => {
         detail: 'Request did not work :(',
       },
     });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/org-slug/events-timeseries/`,
+      statusCode: 400,
+      body: {
+        detail: 'Request did not work :(',
+      },
+    });
 
     wrapper = render(
       <PageAlertProvider>
@@ -368,6 +381,13 @@ describe('Performance > Widgets > WidgetContainer', () => {
         isMetricsData: true,
       },
     });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/org-slug/events-timeseries/`,
+      body: {
+        timeSeries: [],
+      },
+    });
 
     eventsMock = MockApiClient.addMockResponse({
       method: 'GET',
@@ -423,6 +443,13 @@ describe('Performance > Widgets > WidgetContainer', () => {
         isMetricsData: undefined,
       },
     });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/org-slug/events-timeseries/`,
+      body: {
+        timeSeries: [],
+      },
+    });
 
     wrapper = render(
       <WrappedComponent
@@ -456,6 +483,13 @@ describe('Performance > Widgets > WidgetContainer', () => {
       body: {
         data: [],
         isMetricsData: false,
+      },
+    });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/org-slug/events-timeseries/`,
+      body: {
+        timeSeries: [],
       },
     });
 


### PR DESCRIPTION
More work to replace `/events-stats/` usage with the new `/events-timeseries/` endpoint. This PR makes that update in the Web Vitals sections of Insights.

There are a few places where the frontend does additional data processing or checking. That code expects output from `/events-stats/` and in most places I opted to just leave it alone, to keep the changes minimal for now. These UIs will be heavily affected by incoming refactoring anyway, so there's not much gain there.

The most glaring differences are:

1. Having to iterate through `timeSeries` to find the right one rather than looking by key. IMO this is minor, and is offset by the other cases where the output can be passed straight to charts with no alteration
2. `useFetchSpanTimeSeries` does _not_ guarantee that every requested `yAxis` will be present, it doesn't do any backfilling! Therefore, a bit more error checking is needed while iterating. In practice this isn't a problem, since the server will return the empty time series, but it matters while running specs
