### PR TITLE
ref(timeseries): Use `/events-timeseries/` on Transaction Summary in a few spots

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -5,6 +5,7 @@ import {Tag} from 'sentry/components/core/badge/tag';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -12,9 +13,7 @@ import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
-import {eapSeriesDataToTimeSeries} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 
 type Props = {
   hasWebVitals: boolean;
@@ -51,9 +50,9 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
     data: failureRateSeriesData,
     isPending: isFailureRateSeriesPending,
     isError: isFailureRateSeriesError,
-  } = useSpanSeries(
+  } = useFetchSpanTimeSeries(
     {
-      search: new MutableSearch(`transaction:${transactionName}`),
+      query: new MutableSearch(`transaction:${transactionName}`),
       yAxis: ['failure_rate()'],
     },
     REFERRER
@@ -94,8 +93,9 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
     );
   }
 
-  const timeSeries = eapSeriesDataToTimeSeries(failureRateSeriesData);
-  const plottables = timeSeries.map(series => new Line(series, {color: theme.red300}));
+  const plottables = failureRateSeriesData.timeSeries.map(
+    ts => new Line(ts, {color: theme.red300})
+  );
 
   return (
     <Widget

--- a/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
@@ -1,6 +1,7 @@
 import {useTheme} from '@emotion/react';
 
 import {decodeScalar} from 'sentry/utils/queryString';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -8,7 +9,6 @@ import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {SpanFields} from 'sentry/views/insights/types';
 import {
   filterToColor,
@@ -16,7 +16,6 @@ import {
 } from 'sentry/views/performance/transactionSummary/filter';
 import {transformData} from 'sentry/views/performance/transactionSummary/transactionOverview/durationPercentileChart/utils';
 import {EAPWidgetType} from 'sentry/views/performance/transactionSummary/transactionOverview/eapChartsWidget';
-import {eapSeriesDataToTimeSeries} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 
 import DurationPercentileChart from './durationPercentileChart/chart';
 
@@ -98,7 +97,7 @@ function useDurationBreakdownVisualization({
     data: spanSeriesData,
     isPending: isSpanSeriesPending,
     isError: isSpanSeriesError,
-  } = useSpanSeries(
+  } = useFetchSpanTimeSeries(
     {
       yAxis: [
         'avg(span.duration)',
@@ -109,8 +108,7 @@ function useDurationBreakdownVisualization({
         'p75(span.duration)',
         'p50(span.duration)',
       ],
-      search: newQuery,
-      transformAliasToInputFormat: true,
+      query: new MutableSearch(`transaction:${transactionName}`),
       enabled,
     },
     REFERRER
@@ -124,8 +122,7 @@ function useDurationBreakdownVisualization({
     return <TimeSeriesWidgetVisualization.LoadingPlaceholder />;
   }
 
-  const timeSeries = eapSeriesDataToTimeSeries(spanSeriesData);
-  const plottables = timeSeries.map(series => new Line(series));
+  const plottables = spanSeriesData?.timeSeries.map(series => new Line(series));
 
   return (
     <TimeSeriesWidgetVisualization

--- a/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
@@ -108,7 +108,7 @@ function useDurationBreakdownVisualization({
         'p75(span.duration)',
         'p50(span.duration)',
       ],
-      query: new MutableSearch(`transaction:${transactionName}`),
+      query: newQuery,
       enabled,
     },
     REFERRER

--- a/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
@@ -3,8 +3,6 @@ import type {MetricsCardinalityContext} from 'sentry/utils/performance/contexts/
 import type {MetricsEnhancedPerformanceDataContext} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import type {MetricsEnhancedSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {canUseMetricsData} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
-import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
-import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {getMEPQueryParams} from 'sentry/views/performance/landing/widgets/utils';
 
 export function canUseTransactionMetricsData(
@@ -38,9 +36,4 @@ export function getTransactionMEPParamsIfApplicable(
   }
 
   return getMEPQueryParams(mepSetting, true);
-}
-
-type EAPSeriesData = Record<string, DiscoverSeries>;
-export function eapSeriesDataToTimeSeries(data: EAPSeriesData) {
-  return Object.values(data).map(convertSeriesToTimeseries);
 }


### PR DESCRIPTION
More work to replace `/events-stats/` with `/events-timeseries/`, this is just for some EAP-friendly parts of the Transaction Summary that use the `useSpanSeries` hook. This UI is behind a feature-flag, so not currently visible.
