### PR TITLE
chore(aci): add banner about user-snooze deprecation

### DIFF
--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -298,14 +298,3 @@ export type NoteType = {
   mentions: string[];
   text: string;
 };
-
-/**
- * Used when determining what types of actions a rule has. The default action is "sentry.mail.actions.NotifyEmailAction"
- * while other actions can be integration (Slack, PagerDuty, etc) actions. We need to know this to determine what kind of muting
- * the alert should have.
- */
-export enum RuleActionsCategories {
-  ALL_DEFAULT = 'all_default',
-  SOME_DEFAULT = 'some_default',
-  NO_DEFAULT = 'no_default',
-}

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
@@ -27,7 +27,6 @@ import {IconCopy, IconEdit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {IssueAlertRule} from 'sentry/types/alerts';
-import {RuleActionsCategories} from 'sentry/types/alerts';
 import type {DateString} from 'sentry/types/core';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -41,7 +40,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 import {findIncompatibleRules} from 'sentry/views/alerts/rules/issue';
 import {ALERT_DEFAULT_CHART_PERIOD} from 'sentry/views/alerts/rules/metric/details/constants';
-import {getRuleActionCategory} from 'sentry/views/alerts/rules/utils';
+import {UserSnoozeDeprecationBanner} from 'sentry/views/alerts/rules/userSnoozeDeprecationBanner';
 
 import {IssueAlertDetailsChart} from './alertChart';
 import AlertRuleIssuesList from './issuesList';
@@ -268,10 +267,6 @@ function AlertRuleDetails({params, location, router}: AlertRuleDetailsProps) {
     );
   }
 
-  const isSnoozed = rule.snooze;
-
-  const ruleActionCategory = getRuleActionCategory(rule);
-
   const duplicateLink = {
     pathname: makeAlertsPathname({
       path: `/new/issue/`,
@@ -421,7 +416,7 @@ function AlertRuleDetails({params, location, router}: AlertRuleDetailsProps) {
             <Access access={['alerts:write']}>
               {({hasAccess}) => (
                 <SnoozeAlert
-                  isSnoozed={isSnoozed}
+                  isSnoozed={rule.snoozeForEveryone ?? false}
                   onSnooze={onSnooze}
                   ruleId={rule.id}
                   projectSlug={projectSlug}
@@ -462,22 +457,20 @@ function AlertRuleDetails({params, location, router}: AlertRuleDetailsProps) {
         <Layout.Main>
           {renderIncompatibleAlert()}
           {renderDisabledAlertBanner()}
-          {isSnoozed && (
+          {rule.snooze && (
             <Alert.Container>
-              <Alert type="info">
-                {ruleActionCategory === RuleActionsCategories.NO_DEFAULT
-                  ? tct(
-                      "[creator] muted this alert so these notifications won't be sent in the future.",
-                      {creator: rule.snoozeCreatedBy}
-                    )
-                  : tct(
-                      "[creator] muted this alert[forEveryone]so you won't get these notifications in the future.",
-                      {
-                        creator: rule.snoozeCreatedBy,
-                        forEveryone: rule.snoozeForEveryone ? ' for everyone ' : ' ',
-                      }
-                    )}
-              </Alert>
+              {rule.snoozeForEveryone ? (
+                <Alert type="info">
+                  {tct(
+                    "[creator] muted this alert for everyone so you won't get these notifications in the future.",
+                    {
+                      creator: rule.snoozeCreatedBy,
+                    }
+                  )}
+                </Alert>
+              ) : (
+                <UserSnoozeDeprecationBanner projectId={project.id} />
+              )}
             </Alert.Container>
           )}
           <StyledTimeRangeSelector

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -16,7 +16,6 @@ import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
 import {IconClose} from 'sentry/icons';
 import {t, tct, tctCode} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {RuleActionsCategories} from 'sentry/types/alerts';
 import type {Project} from 'sentry/types/project';
 import {shouldShowOnDemandMetricAlertUI} from 'sentry/utils/onDemandMetrics/features';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -34,7 +33,7 @@ import {
 import {extractEventTypeFilterFromRule} from 'sentry/views/alerts/rules/metric/utils/getEventTypeFilter';
 import {isCrashFreeAlert} from 'sentry/views/alerts/rules/metric/utils/isCrashFreeAlert';
 import {isOnDemandMetricAlert} from 'sentry/views/alerts/rules/metric/utils/onDemandMetricAlert';
-import {getAlertRuleActionCategory} from 'sentry/views/alerts/rules/utils';
+import {UserSnoozeDeprecationBanner} from 'sentry/views/alerts/rules/userSnoozeDeprecationBanner';
 import type {Anomaly, Incident} from 'sentry/views/alerts/types';
 import {AlertRuleStatus} from 'sentry/views/alerts/types';
 import {alertDetailsLink} from 'sentry/views/alerts/utils';
@@ -129,9 +128,6 @@ export default function MetricDetailsBody({
       : {}),
   };
 
-  const isSnoozed = rule.snooze;
-  const ruleActionCategory = getAlertRuleActionCategory(rule);
-
   const showOnDemandMetricAlertUI =
     isOnDemandMetricAlert(dataset, aggregate, query) &&
     shouldShowOnDemandMetricAlertUI(organization);
@@ -161,22 +157,20 @@ export default function MetricDetailsBody({
       )}
       <Layout.Body>
         <Layout.Main>
-          {isSnoozed && (
+          {rule.snooze && (
             <Alert.Container>
-              <Alert type="warning">
-                {ruleActionCategory === RuleActionsCategories.NO_DEFAULT
-                  ? tct(
-                      "[creator] muted this alert so these notifications won't be sent in the future.",
-                      {creator: rule.snoozeCreatedBy}
-                    )
-                  : tct(
-                      "[creator] muted this alert[forEveryone]so you won't get these notifications in the future.",
-                      {
-                        creator: rule.snoozeCreatedBy,
-                        forEveryone: rule.snoozeForEveryone ? ' for everyone ' : ' ',
-                      }
-                    )}
-              </Alert>
+              {rule.snoozeForEveryone ? (
+                <Alert type="info">
+                  {tct(
+                    "[creator] muted this alert for everyone so you won't get these notifications in the future.",
+                    {
+                      creator: rule.snoozeCreatedBy,
+                    }
+                  )}
+                </Alert>
+              ) : (
+                <UserSnoozeDeprecationBanner projectId={project.id} />
+              )}
             </Alert.Container>
           )}
           {deprecateTransactionsAlertsWarning && showTransactionsDeprecationAlert && (

--- a/static/app/views/alerts/rules/metric/details/header.tsx
+++ b/static/app/views/alerts/rules/metric/details/header.tsx
@@ -65,8 +65,6 @@ function DetailsHeader({
     },
   };
 
-  const isSnoozed = rule?.snooze ?? false;
-
   const ruleType =
     rule &&
     getAlertTypeFromAggregateDataset({
@@ -118,7 +116,7 @@ function DetailsHeader({
             <Access access={['alerts:write']}>
               {({hasAccess}) => (
                 <SnoozeAlert
-                  isSnoozed={isSnoozed}
+                  isSnoozed={rule?.snoozeForEveryone ?? false}
                   onSnooze={onSnooze}
                   ruleId={rule.id}
                   projectSlug={project.slug}

--- a/static/app/views/alerts/rules/userSnoozeDeprecationBanner.tsx
+++ b/static/app/views/alerts/rules/userSnoozeDeprecationBanner.tsx
@@ -1,0 +1,49 @@
+import {usePrompt} from 'sentry/actionCreators/prompts';
+import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
+import {ExternalLink} from 'sentry/components/core/link';
+import {IconClose} from 'sentry/icons';
+import {tct} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface Props {
+  projectId: string;
+}
+
+export function UserSnoozeDeprecationBanner({projectId}: Props) {
+  const organization = useOrganization();
+
+  const {isLoading, isError, isPromptDismissed, dismissPrompt} = usePrompt({
+    feature: 'user_snooze_deprecation',
+    organization,
+    projectId,
+  });
+
+  if (isLoading || isError || isPromptDismissed) {
+    return null;
+  }
+
+  return (
+    <Alert
+      type="info"
+      trailingItems={
+        <Button
+          aria-label="Dismiss banner"
+          icon={<IconClose color="purple400" />}
+          borderless
+          onClick={dismissPrompt}
+          size="zero"
+        />
+      }
+    >
+      {tct(
+        'Individual user snoozing is no longer supported. Please read these [FAQLink:FAQs] for more information.',
+        {
+          FAQLink: (
+            <ExternalLink href="https://sentry.zendesk.com/hc/en-us/articles/41126598038043-Where-is-the-Mute-For-Me-button" />
+          ),
+        }
+      )}
+    </Alert>
+  );
+}

--- a/static/app/views/alerts/rules/utils.tsx
+++ b/static/app/views/alerts/rules/utils.tsx
@@ -2,8 +2,6 @@ import * as qs from 'query-string';
 
 import IdBadge from 'sentry/components/idBadge';
 import {t} from 'sentry/locale';
-import type {IssueAlertRule} from 'sentry/types/alerts';
-import {IssueAlertActionType, RuleActionsCategories} from 'sentry/types/alerts';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
@@ -78,39 +76,6 @@ function renderIdBadge(project: Project) {
       hideName
     />
   );
-}
-
-export function getRuleActionCategory(rule: IssueAlertRule) {
-  const numDefaultActions = rule.actions.filter(
-    action => action.id === IssueAlertActionType.NOTIFY_EMAIL
-  ).length;
-
-  switch (numDefaultActions) {
-    // Are all actions default actions?
-    case rule.actions.length:
-      return RuleActionsCategories.ALL_DEFAULT;
-    // Are none of the actions default actions?
-    case 0:
-      return RuleActionsCategories.NO_DEFAULT;
-    default:
-      return RuleActionsCategories.SOME_DEFAULT;
-  }
-}
-
-export function getAlertRuleActionCategory(rule: MetricRule) {
-  const actions = rule.triggers.flatMap(trigger => trigger.actions);
-  const numDefaultActions = actions.filter(action => action.type === 'email').length;
-
-  switch (numDefaultActions) {
-    // Are all actions default actions?
-    case actions.length:
-      return RuleActionsCategories.ALL_DEFAULT;
-    // Are none of the actions default actions?
-    case 0:
-      return RuleActionsCategories.NO_DEFAULT;
-    default:
-      return RuleActionsCategories.SOME_DEFAULT;
-  }
 }
 
 export function shouldUseErrorsDiscoverDataset(


### PR DESCRIPTION
displays a banner on rules that the user has snoozed. FAQ links to https://sentry.zendesk.com/hc/en-us/articles/41126598038043-Where-is-the-Mute-For-Me-button

<img width="968" height="220" alt="Screenshot 2025-09-17 at 1 05 27 PM" src="https://github.com/user-attachments/assets/394284f0-e85c-43f2-8a89-f67571f4a1fd" />

also updated the `isSnoozed` prop for the `<SnoozeAlert />` component to only be true if the rule is snoozed for **everyone**, so that the button does not say "Unmute" when the rule is only user-snoozed