### PR TITLE
chore(notif-platform): Serialize the email previews

### DIFF
--- a/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
+++ b/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
@@ -68,7 +68,9 @@ def serialize_slack_preview[T: NotificationData](
     return {"blocks": serialized_blocks}
 
 
-def serialize_email_preview(template: NotificationTemplate[NotificationData]) -> dict[str, Any]:
+def serialize_email_preview[T: NotificationData](
+    template: NotificationTemplate[T],
+) -> dict[str, Any]:
     data = template.example_data
     rendered_template = template.render_example()
     email = EmailRenderer.render(data=data, rendered_template=rendered_template)

--- a/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
+++ b/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
@@ -53,21 +53,6 @@ def serialize_rendered_example(rendered_template: NotificationRenderedTemplate) 
     return response
 
 
-def serialize_slack_preview[T: NotificationData](
-    template: NotificationTemplate[T],
-) -> dict[str, Any]:
-    data = template.example_data
-    rendered_template = template.render_example()
-    message = SlackRenderer.render(data=data, rendered_template=rendered_template)
-
-    # Convert Slack Block objects to dictionaries for JSON serialization
-    serialized_blocks = []
-    for block in message.get("blocks", []):
-        serialized_blocks.append(block.to_dict())
-
-    return {"blocks": serialized_blocks}
-
-
 def serialize_email_preview[T: NotificationData](
     template: NotificationTemplate[T],
 ) -> dict[str, Any]:
@@ -81,6 +66,20 @@ def serialize_email_preview[T: NotificationData](
     }
 
 
+def serialize_slack_preview[T: NotificationData](
+    template: NotificationTemplate[T],
+) -> dict[str, Any]:
+    data = template.example_data
+    rendered_template = template.render_example()
+    message = SlackRenderer.render(data=data, rendered_template=rendered_template)
+
+    serialized_blocks = []
+    for block in message.get("blocks", []):
+        serialized_blocks.append(block.to_dict())
+
+    return {"blocks": serialized_blocks}
+
+
 def serialize_template[T: NotificationData](
     template: NotificationTemplate[T], source: str
 ) -> dict[str, Any]:
@@ -89,8 +88,8 @@ def serialize_template[T: NotificationData](
         "category": template.category,
         "example": serialize_rendered_example(rendered_template=template.render_example()),
         "previews": {
-            NotificationProviderKey.SLACK: serialize_slack_preview(template=template),
             NotificationProviderKey.EMAIL: serialize_email_preview(template=template),
+            NotificationProviderKey.SLACK: serialize_slack_preview(template=template),
         },
     }
     return response

--- a/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
+++ b/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
@@ -8,6 +8,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.permissions import SentryIsAuthenticated
+from sentry.notifications.platform.email.provider import EmailRenderer
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.slack.provider import SlackRenderer
 from sentry.notifications.platform.types import (
@@ -64,8 +65,17 @@ def serialize_slack_preview[T: NotificationData](
     for block in message.get("blocks", []):
         serialized_blocks.append(block.to_dict())
 
+    return {"blocks": serialized_blocks}
+
+
+def serialize_email_preview(template: NotificationTemplate[NotificationData]) -> dict[str, Any]:
+    data = template.example_data
+    rendered_template = template.render_example()
+    email = EmailRenderer.render(data=data, rendered_template=rendered_template)
     return {
-        "blocks": serialized_blocks,
+        "subject": email.subject,
+        "text_content": email.body,
+        "html_content": email.alternatives[0][0],
     }
 
 
@@ -78,6 +88,7 @@ def serialize_template[T: NotificationData](
         "example": serialize_rendered_example(rendered_template=template.render_example()),
         "previews": {
             NotificationProviderKey.SLACK: serialize_slack_preview(template=template),
+            NotificationProviderKey.EMAIL: serialize_email_preview(template=template),
         },
     }
     return response

--- a/src/sentry/notifications/platform/email/provider.py
+++ b/src/sentry/notifications/platform/email/provider.py
@@ -82,9 +82,6 @@ class EmailNotificationProvider(NotificationProvider[EmailRenderable]):
 
     @classmethod
     def send(cls, *, target: NotificationTarget, renderable: EmailRenderable) -> None:
-        if target.resource_type != NotificationTargetResourceType.EMAIL:
-            raise ValueError(f"EmailNotificationProvider cannot send to {target.resource_type}")
-
-        message = renderable
-        message.to = [target.resource_id]
-        send_messages([message])
+        email = renderable
+        email.to = [target.resource_id]
+        send_messages([email])

--- a/src/sentry/templates/sentry/emails/platform/default.txt
+++ b/src/sentry/templates/sentry/emails/platform/default.txt
@@ -2,9 +2,8 @@
 
 {{body}}
 {% if actions %}{% for action_label, action_link in actions %}
-* {{ action_label }}: {{ action_link }}
-{% endfor %}{% endif %}
-{% if chart_alt_text %}{{chart_alt_text}}:{% endif %}
-{% if chart_url %}{{chart_url}}{% endif %}
+* {{ action_label }}: {{ action_link }}{% endfor %}{% endif %}
+{% if chart_alt_text %}{{chart_alt_text}}:{% endif %}{% if chart_url %}
+{{chart_url}}{% endif %}{% if footer %}
 
-{% if footer %}{{footer}}{% endif %}
+{{footer}}{% endif %}

--- a/tests/sentry/notifications/platform/email/test_provider.py
+++ b/tests/sentry/notifications/platform/email/test_provider.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-import pytest
 from django.core.mail import EmailMultiAlternatives
 
 from sentry import options
@@ -77,13 +76,3 @@ class EmailNotificationProviderTest(TestCase):
         mock_send_messages.assert_called_once()
         [sent_message] = mock_send_messages.call_args[0][0]
         assert sent_message.to == [self.email]
-
-    def test_send_with_invalid_resource_type(self) -> None:
-        target = GenericNotificationTarget(
-            provider_key=NotificationProviderKey.EMAIL,
-            resource_type=NotificationTargetResourceType.CHANNEL,
-            resource_id="C01234567890",
-        )
-        email = EmailRenderer.render(data=self.data, rendered_template=self.rendered_template)
-        with pytest.raises(ValueError, match="EmailNotificationProvider cannot send to channel"):
-            EmailNotificationProvider.send(target=target, renderable=email)


### PR DESCRIPTION
Adds the email contents to the example serialize. I will use this in a follow up PR to add it to the debugger app. Also addressing a [previous comment](https://github.com/getsentry/sentry/pull/99672#discussion_r2356709667), and reformatting the TXT emails since I noticed some spacing issues when things were omitted.