### PR TITLE
fix(issue-details): Set tag drawer value limit to 3

### DIFF
--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -97,6 +97,7 @@ export default function TagFacets({
   const {isPending, isError, data, refetch} = useGroupTagsReadable({
     groupId,
     environment: environments,
+    limit: 4,
   });
 
   const tagsData = useMemo((): Record<string, GroupTag> => {

--- a/static/app/views/issueDetails/groupTags/groupTagsTab.spec.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsTab.spec.tsx
@@ -47,7 +47,7 @@ describe('GroupTagsTab', () => {
     expect(tagsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/issues/1/tags/',
       expect.objectContaining({
-        query: {environment: ['dev']},
+        query: {environment: ['dev'], limit: 10},
       })
     );
     // Check headers have been sorted alphabetically

--- a/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
@@ -55,6 +55,7 @@ export function GroupTagsTab() {
   const {data, isPending, isError, refetch} = useGroupTags({
     groupId: group?.id,
     environment: environments,
+    limit: 10,
   });
 
   if (isPending || isGroupPending) {

--- a/static/app/views/issueDetails/groupTags/useGroupTags.tsx
+++ b/static/app/views/issueDetails/groupTags/useGroupTags.tsx
@@ -66,6 +66,7 @@ export function useGroupTags(
   return useApiQuery<GroupTag[]>(
     makeGroupTagsQueryKey({
       orgSlug: organization.slug,
+      limit: 3,
       ...parameters,
     }),
     {

--- a/static/app/views/issueDetails/groupTags/useGroupTags.tsx
+++ b/static/app/views/issueDetails/groupTags/useGroupTags.tsx
@@ -5,7 +5,6 @@ import {
   type UseApiQueryOptions,
 } from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 export interface GroupTag {
   key: string;

--- a/static/app/views/issueDetails/groupTags/useGroupTags.tsx
+++ b/static/app/views/issueDetails/groupTags/useGroupTags.tsx
@@ -81,14 +81,12 @@ export function useGroupTags(
  * Primarily used for tag facets
  */
 export function useGroupTagsReadable(
-  parameters: Omit<FetchIssueTagsParameters, 'orgSlug' | 'limit' | 'readable'>,
+  parameters: Omit<FetchIssueTagsParameters, 'orgSlug' | 'readable'>,
   options: GroupTagUseQueryOptions = {}
 ) {
-  const hasStreamlinedUI = useHasStreamlinedUI();
   return useGroupTags(
     {
       readable: true,
-      limit: hasStreamlinedUI ? 3 : 4,
       ...parameters,
     },
     options


### PR DESCRIPTION
Closes RTC-1070

Currently the issue tags drawer is making a request to `/issues/<id>/tags/` with no limit, which returns the top 10 values. We only use the top 3. 

I'm hoping this will prevent future problems with the linked linear issue where we believe that too many tag values prevented some from being returned from the API.

Side note: can we use `readable: true` here? We are unfortunately making this request twice because one is converting device names to a readable format and the other is not. I don't see why users would want the non-formatted version?