### PR TITLE
feat(notif-platform): Allow emails to be previewed in app

### DIFF
--- a/static/app/debug/notifications/components/debugNotificationsExample.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsExample.tsx
@@ -21,7 +21,7 @@ export function DebugNotificationsExample({
   registration: NotificationTemplateRegistration;
 }) {
   const [displayFormat, setDisplayFormat] = useLocalStorageState(
-    'debug-notifications-example-displayed-raw',
+    'debug-notifications-example-display-format',
     ExampleDataFormat.FORMATTED
   );
   return (
@@ -146,7 +146,7 @@ const PlaceholderChart = styled('div')`
 
 const InlineButton = styled(Button)`
   display: inline-block;
-  margin: ${p => `0 ${p.theme.space.md} ${p.theme.space.md} 0`};
+  margin: ${p => `0 ${p.theme.space.xs} 0 0`};
 `;
 
 const ExampleGrid = styled(Grid)`

--- a/static/app/debug/notifications/components/debugNotificationsPreview.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsPreview.tsx
@@ -1,16 +1,21 @@
-import {Container} from 'sentry/components/core/layout';
+import {Container, Flex} from 'sentry/components/core/layout';
 import {Heading} from 'sentry/components/core/text';
 
 export function DebugNotificationsPreview({
   title,
   children,
+  actions = null,
 }: {
   children: React.ReactNode;
   title: string;
+  actions?: React.ReactNode;
 }) {
   return (
     <Container>
-      <Heading as="h2">{title}</Heading>
+      <Flex justify="between" gap="md" padding="md 0">
+        <Heading as="h2">{title}</Heading>
+        <Flex>{actions}</Flex>
+      </Flex>
       {children}
     </Container>
   );

--- a/static/app/debug/notifications/components/debugNotificationsSidebar.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsSidebar.tsx
@@ -5,10 +5,10 @@ import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Container, Flex} from 'sentry/components/core/layout';
 import {Heading} from 'sentry/components/core/text';
 import {useRegistry} from 'sentry/debug/notifications/hooks/useRegistry';
-import {useLocation} from 'sentry/utils/useLocation';
+import {useRouteSource} from 'sentry/debug/notifications/hooks/useRouteSource';
 
 export function DebugNotificationsSidebar() {
-  const location = useLocation();
+  const {routeSource, baseRoute} = useRouteSource();
   const {data: registry = {}} = useRegistry();
   return (
     <Flex direction="column" gap="xl" padding="xl 0">
@@ -26,11 +26,11 @@ export function DebugNotificationsSidebar() {
                 <Container key={registration.source} as="li">
                   <NotificationLinkButton
                     borderless
-                    active={location.query.source === registration.source}
+                    active={routeSource === registration.source}
                     to={
-                      location.query.source === registration.source
-                        ? {query: {...location.query, source: undefined}}
-                        : {query: {...location.query, source: registration.source}}
+                      routeSource === registration.source
+                        ? baseRoute
+                        : {pathname: `${baseRoute}${registration.source}/`}
                     }
                   >
                     {registration.source}

--- a/static/app/debug/notifications/hooks/useRegistry.tsx
+++ b/static/app/debug/notifications/hooks/useRegistry.tsx
@@ -4,6 +4,6 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 export function useRegistry() {
   return useApiQuery<NotificationTemplateRegistry>(
     ['/internal/notifications/registered-templates/'],
-    {staleTime: Infinity}
+    {staleTime: 30000}
   );
 }

--- a/static/app/debug/notifications/hooks/useRouteSource.tsx
+++ b/static/app/debug/notifications/hooks/useRouteSource.tsx
@@ -1,0 +1,20 @@
+import {useLocation} from 'sentry/utils/useLocation';
+import {useParams} from 'sentry/utils/useParams';
+
+/**
+ * Returns the notification source from the URL route if available.
+ * Also returns the base route to make building relative links easier
+ */
+export function useRouteSource() {
+  const location = useLocation();
+  const {notificationSource} = useParams<{notificationSource?: string}>();
+  return {
+    routeSource: notificationSource,
+    baseRoute: notificationSource
+      ? // Removes the last route segment. This is to ensure `/debug/notifications/` and
+        // `/organizations/:slug/debug/notifications/` are valid as base routes
+        // It does mean we'll have to change this if we add change the routes but works for now
+        location.pathname.replace(/[\w-]+\/{0,1}$/, '')
+      : location.pathname,
+  };
+}

--- a/static/app/debug/notifications/previews/emailPreview.tsx
+++ b/static/app/debug/notifications/previews/emailPreview.tsx
@@ -1,9 +1,69 @@
-import {DebugNotificationsPreview} from 'sentry/debug/notifications/components/debugNotificationsPreview';
+import styled from '@emotion/styled';
 
-export function EmailPreview() {
+import {Container, Flex} from 'sentry/components/core/layout';
+import {SegmentedControl} from 'sentry/components/core/segmentedControl';
+import {Text} from 'sentry/components/core/text';
+import {DebugNotificationsPreview} from 'sentry/debug/notifications/components/debugNotificationsPreview';
+import {
+  NotificationProviderKey,
+  type NotificationTemplateRegistration,
+} from 'sentry/debug/notifications/types';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+
+const enum EmailFormat {
+  HTML = 'html',
+  TXT = 'txt',
+}
+
+export function EmailPreview({
+  registration,
+}: {
+  registration: NotificationTemplateRegistration;
+}) {
+  const [emailFormat, setEmailFormat] = useLocalStorageState(
+    'debug-notifications-email-format',
+    EmailFormat.HTML
+  );
+
+  const {html_content, text_content, subject} =
+    registration.previews[NotificationProviderKey.EMAIL];
   return (
-    <DebugNotificationsPreview title="Email">
-      <div>todo: insert email preview here</div>
+    <DebugNotificationsPreview
+      title="Email"
+      actions={
+        <SegmentedControl
+          value={emailFormat}
+          onChange={setEmailFormat}
+          size="xs"
+          aria-label="Change example data format"
+        >
+          <SegmentedControl.Item key={EmailFormat.HTML}>HTML</SegmentedControl.Item>
+          <SegmentedControl.Item key={EmailFormat.TXT}>TXT</SegmentedControl.Item>
+        </SegmentedControl>
+      }
+    >
+      <Container border="primary" radius="md">
+        <Flex direction="column" padding="xl">
+          <Text bold>{subject}</Text>
+          <Text variant="muted">To: user@example.com</Text>
+          {emailFormat === EmailFormat.HTML && (
+            <div dangerouslySetInnerHTML={{__html: html_content}} />
+          )}
+          {emailFormat === EmailFormat.TXT && (
+            <EmailTextBlock>
+              <pre>{text_content}</pre>
+            </EmailTextBlock>
+          )}
+        </Flex>
+      </Container>
     </DebugNotificationsPreview>
   );
 }
+
+const EmailTextBlock = styled('code')`
+  margin: ${p => p.theme.space.md} 0;
+  padding: 0;
+  pre {
+    margin: 0;
+  }
+`;

--- a/static/app/debug/notifications/types.ts
+++ b/static/app/debug/notifications/types.ts
@@ -1,3 +1,10 @@
+export enum NotificationProviderKey {
+  EMAIL = 'email',
+  SLACK = 'slack',
+  DISCORD = 'discord',
+  TEAMS = 'teams',
+}
+
 export interface NotificationTemplateRegistration {
   category: string;
   example: {
@@ -6,6 +13,13 @@ export interface NotificationTemplateRegistration {
     subject: string;
     chart?: {alt_text: string; url: string};
     footer?: string;
+  };
+  previews: {
+    [NotificationProviderKey.EMAIL]: {
+      html_content: TrustedHTML;
+      subject: string;
+      text_content: string;
+    };
   };
   source: string;
 }

--- a/static/app/debug/notifications/views/index.tsx
+++ b/static/app/debug/notifications/views/index.tsx
@@ -54,9 +54,9 @@ export default function DebugNotificationsIndex() {
                     <Tag type="success">{selectedRegistration.category}</Tag>
                   </Flex>
                 </Heading>
-                <Flex gap="xl" justify="between" wrap="wrap" position="relative">
-                  <Flex direction="column" gap="2xl" position="relative">
-                    <EmailPreview />
+                <Flex justify="between" wrap="wrap" position="relative" gap="2xl">
+                  <Flex direction="column" gap="2xl" position="relative" flex="1">
+                    <EmailPreview registration={selectedRegistration} />
                     <SlackPreview />
                     <DiscordPreview />
                     <TeamsPreview />
@@ -102,6 +102,6 @@ const SidebarContainer = styled('nav')`
 const ExampleContainer = styled('div')`
   position: sticky;
   top: ${p => `calc(${HEADER_HEIGHT}px + ${p.theme.space.xl})`};
-  max-width: 450px;
+  max-width: 375px;
   align-self: flex-start;
 `;

--- a/static/app/debug/notifications/views/index.tsx
+++ b/static/app/debug/notifications/views/index.tsx
@@ -8,22 +8,22 @@ import {DebugNotificationsHeader} from 'sentry/debug/notifications/components/de
 import {DebugNotificationsLanding} from 'sentry/debug/notifications/components/debugNotificationsLanding';
 import {DebugNotificationsSidebar} from 'sentry/debug/notifications/components/debugNotificationsSidebar';
 import {useRegistry} from 'sentry/debug/notifications/hooks/useRegistry';
+import {useRouteSource} from 'sentry/debug/notifications/hooks/useRouteSource';
 import {DiscordPreview} from 'sentry/debug/notifications/previews/discordPreview';
 import {EmailPreview} from 'sentry/debug/notifications/previews/emailPreview';
 import {SlackPreview} from 'sentry/debug/notifications/previews/slackPreview';
 import {TeamsPreview} from 'sentry/debug/notifications/previews/teamsPreview';
-import {useLocation} from 'sentry/utils/useLocation';
 import OrganizationContainer from 'sentry/views/organizationContainer';
 import RouteAnalyticsContextProvider from 'sentry/views/routeAnalyticsContextProvider';
 
 const HEADER_HEIGHT = 52;
 
 export default function DebugNotificationsIndex() {
-  const location = useLocation();
+  const {routeSource} = useRouteSource();
   const {data: registry = {}} = useRegistry();
   const registrations = Object.values(registry).flat();
   const selectedRegistration = registrations.find(
-    registration => location.query.source === registration.source
+    registration => routeSource === registration.source
   );
   return (
     <RouteAnalyticsContextProvider>

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -324,7 +324,7 @@ function buildRoutes(): RouteObject[] {
       withOrgPath: true,
     },
     {
-      path: '/debug/notifications/',
+      path: '/debug/notifications/:notificationSource?/',
       component: make(() => import('sentry/debug/notifications/views/index')),
       withOrgPath: true,
     },

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -32,6 +32,7 @@ type ParamKeys =
   | 'integrationSlug'
   | 'issueId'
   | 'memberId'
+  | 'notificationSource'
   | 'orgId'
   | 'projectId'
   | 'regionName'


### PR DESCRIPTION
Display emails in the debugger app, two options, txt and html, stores the state in local storage.

<img width="715" height="665" alt="image" src="https://github.com/user-attachments/assets/46c34ccc-db64-4b2d-a7de-0401a95670f3" />
<img width="727" height="451" alt="image" src="https://github.com/user-attachments/assets/fd056087-261f-442e-b0a5-6fc20910e67c" />
