### PR TITLE
chore(aci): require integration id for integration actions only

### DIFF
--- a/src/sentry/notifications/notification_action/action_validation.py
+++ b/src/sentry/notifications/notification_action/action_validation.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-from django.core.exceptions import ValidationError
-
 from sentry.integrations.discord.actions.issue_alert.form import DiscordNotifyServiceForm
 from sentry.integrations.jira.actions.form import JiraNotifyServiceForm
 from sentry.integrations.jira_server.actions.form import JiraServerNotifyServiceForm
@@ -17,23 +15,14 @@ from sentry.workflow_engine.models.action import Action
 from .types import BaseActionValidatorHandler
 
 
-# TODO: move this to the base or refactor to use for integration actions only
-def _get_integration_id(validated_data: dict[str, Any], provider: str) -> str:
-    if not (integration_id := validated_data.get("integration_id")):
-        raise ValidationError(f"Integration ID is required for {provider} action")
-    return integration_id
-
-
 @action_validator_registry.register(Action.Type.SLACK)
 class SlackActionValidatorHandler(BaseActionValidatorHandler):
     provider = Action.Type.SLACK
     notify_action_form = SlackNotifyServiceForm
 
     def generate_action_form_data(self) -> dict[str, Any]:
-        integration_id = _get_integration_id(self.validated_data, self.provider)
-
         return {
-            "workspace": integration_id,
+            "workspace": self.validated_data["integration_id"],
             "channel": self.validated_data["config"]["target_display"],
             "channel_id": self.validated_data["config"].get("target_identifier"),
             "tags": self.validated_data["data"].get("tags"),
@@ -55,10 +44,8 @@ class MSTeamsActionValidatorHandler(BaseActionValidatorHandler):
     notify_action_form = MsTeamsNotifyServiceForm
 
     def generate_action_form_data(self) -> dict[str, Any]:
-        integration_id = _get_integration_id(self.validated_data, self.provider)
-
         return {
-            "team": integration_id,
+            "team": self.validated_data["integration_id"],
             "channel": self.validated_data["config"]["target_display"],
         }
 
@@ -78,10 +65,8 @@ class DiscordActionValidatorHandler(BaseActionValidatorHandler):
     notify_action_form = DiscordNotifyServiceForm
 
     def generate_action_form_data(self) -> dict[str, Any]:
-        integration_id = _get_integration_id(self.validated_data, self.provider)
-
         return {
-            "server": integration_id,
+            "server": self.validated_data["integration_id"],
             "channel_id": self.validated_data["config"]["target_identifier"],
             "tags": self.validated_data["data"].get("tags"),
         }
@@ -99,10 +84,8 @@ class TicketingActionValidatorHandler(BaseActionValidatorHandler):
     notify_action_form = IntegrationNotifyServiceForm
 
     def generate_action_form_data(self) -> dict[str, Any]:
-        integration_id = _get_integration_id(self.validated_data, self.provider)
-
         return {
-            "integration": integration_id,
+            "integration": self.validated_data["integration_id"],
         }
 
     def update_action_data(self, cleaned_data: dict[str, Any]) -> dict[str, Any]:
@@ -160,10 +143,8 @@ class PagerdutyActionValidatorHandler(BaseActionValidatorHandler):
         }
 
     def generate_action_form_data(self) -> dict[str, Any]:
-        integration_id = _get_integration_id(self.validated_data, self.provider)
-
         return {
-            "account": integration_id,
+            "account": self.validated_data["integration_id"],
             "service": self.validated_data["config"]["target_identifier"],
         }
 
@@ -198,10 +179,8 @@ class OpsgenieActionValidatorHandler(BaseActionValidatorHandler):
         }
 
     def generate_action_form_data(self) -> dict[str, Any]:
-        integration_id = _get_integration_id(self.validated_data, self.provider)
-
         return {
-            "account": integration_id,
+            "account": self.validated_data["integration_id"],
             "team": self.validated_data["config"]["target_identifier"],
         }
 

--- a/src/sentry/workflow_engine/endpoints/validators/base/action.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/action.py
@@ -66,9 +66,16 @@ class BaseActionValidator(CamelSnakeSerializer):
 
         attrs = super().validate(attrs)
 
-        if not Action.Type(attrs["type"]).is_integration() and attrs.get("integration_id"):
+        is_integration = Action.Type(attrs["type"]).is_integration()
+        has_integration_id = attrs.get("integration_id") is not None
+
+        if not is_integration and has_integration_id:
             raise serializers.ValidationError(
                 f"Integration ID is not allowed for action type {attrs["type"]}"
+            )
+        if is_integration and not has_integration_id:
+            raise serializers.ValidationError(
+                f"Integration ID is required for action type {attrs["type"]}"
             )
 
         if not (organization := self.context.get("organization")):

--- a/src/sentry/workflow_engine/endpoints/validators/base/action.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/action.py
@@ -66,6 +66,11 @@ class BaseActionValidator(CamelSnakeSerializer):
 
         attrs = super().validate(attrs)
 
+        if not Action.Type(attrs["type"]).is_integration() and attrs.get("integration_id"):
+            raise serializers.ValidationError(
+                f"Integration ID is not allowed for action type {attrs["type"]}"
+            )
+
         if not (organization := self.context.get("organization")):
             raise serializers.ValidationError("Organization is required in the context")
 

--- a/src/sentry/workflow_engine/endpoints/validators/base/action.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/action.py
@@ -77,7 +77,6 @@ class BaseActionValidator(CamelSnakeSerializer):
         try:
             handler = action_validator_registry.get(attrs["type"])
         except NoRegistrationExistsError:
-            # TODO: remove try/catch when all existing action types are registered
             return attrs
 
         return handler(attrs, organization).clean_data()

--- a/src/sentry/workflow_engine/endpoints/validators/base/action.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/action.py
@@ -64,6 +64,9 @@ class BaseActionValidator(CamelSnakeSerializer):
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         from sentry.notifications.notification_action.registry import action_validator_registry
 
+        if not (organization := self.context.get("organization")):
+            raise serializers.ValidationError("Organization is required in the context")
+
         attrs = super().validate(attrs)
 
         is_integration = Action.Type(attrs["type"]).is_integration()
@@ -77,9 +80,6 @@ class BaseActionValidator(CamelSnakeSerializer):
             raise serializers.ValidationError(
                 f"Integration ID is required for action type {attrs["type"]}"
             )
-
-        if not (organization := self.context.get("organization")):
-            raise serializers.ValidationError("Organization is required in the context")
 
         try:
             handler = action_validator_registry.get(attrs["type"])

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_discord.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_discord.py
@@ -43,21 +43,6 @@ class TestDiscordActionValidator(TestCase):
         assert result is True
         validator.save()
 
-    def test_validate__missing_integration_id(self):
-        del self.valid_data["integrationId"]
-        validator = BaseActionValidator(
-            data={**self.valid_data},
-            context={"organization": self.organization},
-        )
-
-        result = validator.is_valid()
-        assert result is False
-        assert validator.errors == {
-            "nonFieldErrors": [
-                ErrorDetail(string="Integration ID is required for discord action", code="invalid")
-            ]
-        }
-
     def test_validate__empty_server(self):
         validator = BaseActionValidator(
             data={

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_msteams.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_msteams.py
@@ -35,21 +35,6 @@ class TestMSTeamsActionValidator(TestCase):
         assert result is True
         validator.save()
 
-    def test_validate__missing_integration_id(self):
-        del self.valid_data["integrationId"]
-        validator = BaseActionValidator(
-            data={**self.valid_data},
-            context={"organization": self.organization},
-        )
-
-        result = validator.is_valid()
-        assert result is False
-        assert validator.errors == {
-            "nonFieldErrors": [
-                ErrorDetail(string="Integration ID is required for msteams action", code="invalid")
-            ]
-        }
-
     @mock.patch("sentry.integrations.msteams.actions.form.find_channel_id")
     def test_validate__invalid_channel_id(self, mock_find_channel_id):
         mock_find_channel_id.return_value = None

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_opsgenie.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_opsgenie.py
@@ -50,21 +50,6 @@ class TestOpsgenieActionValidator(TestCase):
         assert result is True
         validator.save()
 
-    def test_validate__missing_integration_id(self):
-        del self.valid_data["integrationId"]
-        validator = BaseActionValidator(
-            data={**self.valid_data},
-            context={"organization": self.organization},
-        )
-
-        result = validator.is_valid()
-        assert result is False
-        assert validator.errors == {
-            "nonFieldErrors": [
-                ErrorDetail(string="Integration ID is required for opsgenie action", code="invalid")
-            ]
-        }
-
     def test_validate__invalid_team(self):
         validator = BaseActionValidator(
             data={

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_pagerduty.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_pagerduty.py
@@ -50,23 +50,6 @@ class TestPagerDutyActionValidator(TestCase):
         assert result is True
         validator.save()
 
-    def test_validate__missing_integration_id(self):
-        del self.valid_data["integrationId"]
-        validator = BaseActionValidator(
-            data={**self.valid_data},
-            context={"organization": self.organization},
-        )
-
-        result = validator.is_valid()
-        assert result is False
-        assert validator.errors == {
-            "nonFieldErrors": [
-                ErrorDetail(
-                    string="Integration ID is required for pagerduty action", code="invalid"
-                )
-            ]
-        }
-
     def test_validate__invalid_service(self):
         validator = BaseActionValidator(
             data={

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_slack.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_slack.py
@@ -44,21 +44,6 @@ class TestSlackActionValidator(TestCase):
         assert result is True
         validator.save()
 
-    def test_validate__missing_integration_id(self):
-        del self.valid_data["integrationId"]
-        validator = BaseActionValidator(
-            data={**self.valid_data},
-            context={"organization": self.organization},
-        )
-
-        result = validator.is_valid()
-        assert result is False
-        assert validator.errors == {
-            "nonFieldErrors": [
-                ErrorDetail(string="Integration ID is required for slack action", code="invalid")
-            ]
-        }
-
     @mock.patch("sentry.integrations.slack.actions.form.validate_slack_entity_id")
     def test_validate__invalid_channel_id(self, mock_validate_slack_entity_id):
         mock_validate_slack_entity_id.side_effect = ValidationError("Invalid channel id")

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_ticketing.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_ticketing.py
@@ -1,5 +1,3 @@
-from rest_framework.serializers import ErrorDetail
-
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
 from sentry.workflow_engine.models import Action
@@ -32,23 +30,6 @@ class BaseTicketingActionValidatorTest(TestCase):
         )
         result = validator.is_valid()
         assert result is True
-
-    def test_validate__missing_integration_id(self):
-        del self.valid_data["integrationId"]
-        validator = BaseActionValidator(
-            data={**self.valid_data},
-            context={"organization": self.organization},
-        )
-
-        result = validator.is_valid()
-        assert result is False
-        assert validator.errors == {
-            "nonFieldErrors": [
-                ErrorDetail(
-                    string=f"Integration ID is required for {self.provider} action", code="invalid"
-                )
-            ]
-        }
 
 
 class TestJiraActionValidator(BaseTicketingActionValidatorTest):

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+from rest_framework.serializers import ErrorDetail
+
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
 from sentry.workflow_engine.models import Action
@@ -127,3 +129,25 @@ class TestBaseActionValidator(TestCase):
         validator2 = make_validator()
         with self.feature("organizations:integrations-alert-rule"):
             assert validator2.is_valid()
+
+    def test_validate_data__extra_integration_id(
+        self, mock_action_handler_get: mock.MagicMock, mock_action_validator_get: mock.MagicMock
+    ) -> None:
+        # non integration actions should not have an integration id
+        validator = BaseActionValidator(
+            data={
+                "type": Action.Type.PLUGIN,
+                "config": {"foo": "bar"},
+                "data": {"baz": "bar"},
+                "integrationId": 1,
+            },
+        )
+        result = validator.is_valid()
+        assert result is False
+        assert validator.errors == {
+            "nonFieldErrors": [
+                ErrorDetail(
+                    string="Integration ID is not allowed for action type plugin", code="invalid"
+                )
+            ]
+        }

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
@@ -47,7 +47,8 @@ class TestBaseActionValidator(TestCase):
             data={
                 **self.valid_data,
                 "type": "invalid_test",
-            }
+            },
+            context={"organization": self.organization},
         )
 
         result = validator.is_valid()
@@ -75,6 +76,7 @@ class TestBaseActionValidator(TestCase):
                 **self.valid_data,
                 "config": {"invalid": 1},
             },
+            context={"organization": self.organization},
         )
 
         result = validator.is_valid()
@@ -102,6 +104,7 @@ class TestBaseActionValidator(TestCase):
                 **self.valid_data,
                 "data": {"invalid": 1},
             },
+            context={"organization": self.organization},
         )
 
         result = validator.is_valid()
@@ -119,6 +122,7 @@ class TestBaseActionValidator(TestCase):
                     **self.valid_data,
                     "type": Action.Type.SLACK,
                 },
+                context={"organization": organization},
             )
 
         validator = make_validator()
@@ -139,6 +143,7 @@ class TestBaseActionValidator(TestCase):
                 "config": {"foo": "bar"},
                 "data": {"baz": "bar"},
             },
+            context={"organization": self.organization},
         )
         result = validator.is_valid()
         assert result is False
@@ -161,6 +166,7 @@ class TestBaseActionValidator(TestCase):
                 "data": {"baz": "bar"},
                 "integrationId": 1,
             },
+            context={"organization": self.organization},
         )
         result = validator.is_valid()
         assert result is False

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
@@ -117,7 +117,6 @@ class TestBaseActionValidator(TestCase):
 
         def make_validator() -> BaseActionValidator:
             return BaseActionValidator(
-                context={"organization": organization},
                 data={
                     **self.valid_data,
                     "type": Action.Type.SLACK,

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
@@ -130,6 +130,26 @@ class TestBaseActionValidator(TestCase):
         with self.feature("organizations:integrations-alert-rule"):
             assert validator2.is_valid()
 
+    def test_validate_data__missing_integration_id(
+        self, mock_action_handler_get: mock.MagicMock, mock_action_validator_get: mock.MagicMock
+    ) -> None:
+        validator = BaseActionValidator(
+            data={
+                "type": Action.Type.SLACK,
+                "config": {"foo": "bar"},
+                "data": {"baz": "bar"},
+            },
+        )
+        result = validator.is_valid()
+        assert result is False
+        assert validator.errors == {
+            "nonFieldErrors": [
+                ErrorDetail(
+                    string="Integration ID is required for action type slack", code="invalid"
+                )
+            ]
+        }
+
     def test_validate_data__extra_integration_id(
         self, mock_action_handler_get: mock.MagicMock, mock_action_validator_get: mock.MagicMock
     ) -> None:


### PR DESCRIPTION
After combing the DB, only integration related Action types have integration id