### PR TITLE
Adjust position of BetaBadge to the right

### DIFF
--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -207,5 +207,5 @@ const BetaBadge = styled(FeatureBadge)`
   position: absolute;
   pointer-events: none;
   top: -2px;
-  right: 0;
+  right: 6px;
 `;

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -207,5 +207,5 @@ const BetaBadge = styled(FeatureBadge)`
   position: absolute;
   pointer-events: none;
   top: -2px;
-  right: 6px;
+  right: 4px;
 `;


### PR DESCRIPTION
change `right:` from 0px to 6px
Before:
<img width="171" height="240" alt="Screenshot 2025-09-17 at 3 16 21 PM" src="https://github.com/user-attachments/assets/ff5b192d-f436-4da4-9b82-c7f655f3820a" />

After:
<img width="83" height="162" alt="Screenshot 2025-09-17 at 3 19 45 PM" src="https://github.com/user-attachments/assets/5120a156-bc5f-4eef-be4c-23ae30847c83" />

<img width="89" height="235" alt="Screenshot 2025-09-17 at 3 18 28 PM" src="https://github.com/user-attachments/assets/d47aad14-3346-4ddf-b1cd-e26feb2c93f4" />


<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
