### PR TITLE
ref(codeowners): rollout case insensitive external actors

### DIFF
--- a/src/sentry/integrations/api/bases/external_actor.py
+++ b/src/sentry/integrations/api/bases/external_actor.py
@@ -103,16 +103,15 @@ class ExternalActorSerializerBase(CamelSnakeModelSerializer):
     def create(self, validated_data: MutableMapping[str, Any]) -> tuple[ExternalActor, bool]:
         actor_params = self.get_actor_params(validated_data)
 
-        if features.has("organizations:use-case-insensitive-codeowners", self.organization):
-            if validated_data["provider"] in CASE_INSENSITIVE_PROVIDERS:
-                external_name = validated_data.pop("external_name")
+        if validated_data["provider"] in CASE_INSENSITIVE_PROVIDERS:
+            external_name = validated_data.pop("external_name")
 
-                return ExternalActor.objects.get_or_create(
-                    external_name__iexact=external_name,
-                    **validated_data,
-                    organization=self.organization,
-                    defaults={**actor_params, "external_name": external_name},
-                )
+            return ExternalActor.objects.get_or_create(
+                external_name__iexact=external_name,
+                **validated_data,
+                organization=self.organization,
+                defaults={**actor_params, "external_name": external_name},
+            )
 
         return ExternalActor.objects.get_or_create(
             **validated_data,

--- a/tests/sentry/integrations/api/serializers/test_external_actor.py
+++ b/tests/sentry/integrations/api/serializers/test_external_actor.py
@@ -180,34 +180,3 @@ class ExternalActorSerializerTest(TestCase):
         assert created2 is False
         assert external_actor2.id == external_actor1.id
         assert external_actor2.external_name == "@getsentry/example-team"
-
-    def test_create_case_sensitive_team(self) -> None:
-        sentry_team = self.create_team(organization=self.organization, members=[self.user])
-
-        external_actor_team_data = {
-            "provider": get_provider_name(ExternalProviders.GITHUB.value),
-            "external_name": "@getsentry/example-team",
-            "integrationId": self.integration.id,
-            "team_id": sentry_team.id,
-        }
-
-        serializer = ExternalTeamSerializer(
-            data=external_actor_team_data,
-            context={"organization": self.organization},
-        )
-        assert serializer.is_valid() is True
-        external_actor1, created1 = serializer.create(serializer.validated_data)
-        assert created1 is True
-        assert external_actor1.external_name == "@getsentry/example-team"
-
-        external_actor_team_data["external_name"] = "@GETSENTRY/EXAMPLE-TEAM"
-        external_actor_team_data["team_id"] = sentry_team.id
-
-        serializer = ExternalTeamSerializer(
-            data=external_actor_team_data,
-            context={"organization": self.organization},
-        )
-        assert serializer.is_valid() is True
-        external_actor2, created2 = serializer.create(serializer.validated_data)
-        assert created2 is True
-        assert external_actor2.external_name == "@GETSENTRY/EXAMPLE-TEAM"

--- a/tests/sentry/integrations/api/serializers/test_external_actor.py
+++ b/tests/sentry/integrations/api/serializers/test_external_actor.py
@@ -8,7 +8,6 @@ from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.types import ExternalProviders
 from sentry.integrations.utils.providers import get_provider_name
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
 
 
 class ExternalActorSerializerTest(TestCase):
@@ -147,7 +146,6 @@ class ExternalActorSerializerTest(TestCase):
         )
         assert serializer.is_valid() is True
 
-    @with_feature("organizations:use-case-insensitive-codeowners")
     def test_create_case_insensitive_team(self) -> None:
         sentry_team = self.create_team(organization=self.organization, members=[self.user])
 

--- a/tests/sentry/issues/endpoints/test_project_codeowners_index.py
+++ b/tests/sentry/issues/endpoints/test_project_codeowners_index.py
@@ -4,7 +4,6 @@ from django.urls import reverse
 
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import with_feature
 
 
 class ProjectCodeOwnersEndpointTestCase(APITestCase):
@@ -354,7 +353,6 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         "sentry.integrations.source_code_management.repository.RepositoryIntegration.get_codeowner_file",
         return_value={"html_url": "https://github.com/test/CODEOWNERS"},
     )
-    @with_feature("organizations:use-case-insensitive-codeowners")
     def test_case_insensitive_team_matching(self, get_codeowner_mock_file: MagicMock) -> None:
         """Test that team names are matched case-insensitively in CODEOWNERS files."""
 


### PR DESCRIPTION
We've fixed all orgs that had conflicts with case-insensitive ExternalActors from the original comment in https://github.com/getsentry/sentry/issues/79296#issuecomment-2744359177, meaning that we can deprecate the old logic + the feature flag.