### PR TITLE
fix(aci milestone 3): only dual write to IGOP if it's resolve/unresolve status

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -524,7 +524,10 @@ class GroupManager(BaseManager["Group"]):
                 )
 
             # TODO (aci cleanup): remove this once we've deprecated the incident model
-            if group.type == MetricIssue.type_id:
+            if group.type == MetricIssue.type_id and status in (
+                GroupStatus.RESOLVED,
+                GroupStatus.UNRESOLVED,
+            ):
                 if detector_id is None:
                     logger.error(
                         "Call to update metric issue status missing detector ID",


### PR DESCRIPTION
Prevent the logger.error statement that happens when metric issues are transitioned from new/regressed to ongoing.