### PR TITLE
fix(uptime): Deleted graduated onboarding tasks if no seats are available

### DIFF
--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -777,7 +777,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             mock.patch("sentry.uptime.detectors.result_handler.logger") as onboarding_logger,
             mock.patch(
                 "sentry.uptime.detectors.result_handler.update_uptime_detector",
-                side_effect=UptimeMonitorNoSeatAvailable("No seat available"),
+                side_effect=UptimeMonitorNoSeatAvailable(None),
             ),
             self.tasks(),
             self.feature(features),


### PR DESCRIPTION
This resolves an issue where we end up throwing an uncaught `UptimeMonitorNoSeatAvailable` if we try to graduate an auto-detected monitor but there are no seats.

It's fine to just delete it in this case - the customer has never seen this monitor.

Fixes SENTRY-41W2

<!-- Describe your PR here. -->