### PR TITLE
feat(uptime): Expose thresholds in API responses

### DIFF
--- a/src/sentry/uptime/endpoints/serializers.py
+++ b/src/sentry/uptime/endpoints/serializers.py
@@ -62,6 +62,8 @@ class UptimeDetectorSerializerResponse(UptimeSubscriptionSerializerResponse):
     uptimeStatus: int
     mode: int
     owner: ActorSerializerResponse
+    recoveryThreshold: int
+    downtimeThreshold: int
 
 
 class UptimeDetectorSerializer(Serializer):
@@ -132,6 +134,8 @@ class UptimeDetectorSerializer(Serializer):
             "uptimeStatus": uptime_status,
             "mode": obj.config.get("mode", 1),  # Default to MANUAL mode
             "owner": attrs["owner"],
+            "recoveryThreshold": obj.config["recovery_threshold"],
+            "downtimeThreshold": obj.config["downtime_threshold"],
             **serialized_subscription,
         }
 

--- a/tests/sentry/uptime/endpoints/test_serializers.py
+++ b/tests/sentry/uptime/endpoints/test_serializers.py
@@ -26,6 +26,8 @@ class UptimeDetectorSerializerTest(UptimeTestCase):
             "timeoutMs": uptime_subscription.timeout_ms,
             "owner": None,
             "traceSampling": False,
+            "recoveryThreshold": detector.config["recovery_threshold"],
+            "downtimeThreshold": detector.config["downtime_threshold"],
         }
 
     def test_default_name(self) -> None:
@@ -52,6 +54,8 @@ class UptimeDetectorSerializerTest(UptimeTestCase):
             "timeoutMs": uptime_subscription.timeout_ms,
             "owner": None,
             "traceSampling": False,
+            "recoveryThreshold": detector.config["recovery_threshold"],
+            "downtimeThreshold": detector.config["downtime_threshold"],
         }
 
     def test_owner(self) -> None:
@@ -80,6 +84,8 @@ class UptimeDetectorSerializerTest(UptimeTestCase):
                 "type": "user",
             },
             "traceSampling": False,
+            "recoveryThreshold": detector.config["recovery_threshold"],
+            "downtimeThreshold": detector.config["downtime_threshold"],
         }
 
     def test_trace_sampling(self) -> None:
@@ -88,6 +94,14 @@ class UptimeDetectorSerializerTest(UptimeTestCase):
         result = serialize(detector, serializer=UptimeDetectorSerializer())
 
         assert result["traceSampling"] is True
+
+    def test_custom_thresholds(self) -> None:
+        """Test that custom threshold values are properly serialized."""
+        detector = self.create_uptime_detector(recovery_threshold=2, downtime_threshold=5)
+        result = serialize(detector, serializer=UptimeDetectorSerializer())
+
+        assert result["recoveryThreshold"] == 2
+        assert result["downtimeThreshold"] == 5
 
     def test_bulk_detector_id_lookup(self) -> None:
         """Test that detector IDs are properly included when serializing multiple monitors."""


### PR DESCRIPTION
Part of [NEW-302: Configurable downtime and recovery thresholds for uptime](https://linear.app/getsentry/issue/NEW-302/configurable-downtime-and-recovery-thresholds-for-uptime)