### PR TITLE
ref(settings): Update number of items per page in Client Keys

### DIFF
--- a/static/app/views/settings/project/projectKeys/list/index.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.tsx
@@ -56,7 +56,7 @@ function ProjectKeys({project}: Props) {
       {
         query: {
           cursor: decodeScalar(location.query.cursor),
-          per_page: 100,
+          per_page: 5,
         },
       },
     ],


### PR DESCRIPTION
While 100 seemed like a good number, 5 looks better visually because the components in the list are quite large