### PR TITLE
fix(prevent): Only show active integrated orgs for Prevent

### DIFF
--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.spec.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.spec.tsx
@@ -4,8 +4,8 @@ import PreventQueryParamsProvider from 'sentry/components/prevent/container/prev
 import {IntegratedOrgSelector} from 'sentry/components/prevent/integratedOrgSelector/integratedOrgSelector';
 
 const mockIntegrations = [
-  {name: 'my-other-org-with-a-super-long-name', id: '1'},
-  {name: 'my-other-org-with-a-super-long-name', id: '2'},
+  {name: 'my-other-org-with-a-super-long-name', id: '1', status: 'active'},
+  {name: 'my-other-org-with-a-super-long-name', id: '2', status: 'active'},
 ];
 
 const mockApiCall = () => {

--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
@@ -12,10 +12,8 @@ import {integratedOrgIdToName} from 'sentry/components/prevent/utils';
 import {IconAdd, IconInfo} from 'sentry/icons';
 import {IconIntegratedOrg} from 'sentry/icons/iconIntegratedOrg';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
-import type {Integration} from 'sentry/types/integrations';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useGetActiveIntegratedOrgs} from 'sentry/views/prevent/tests/queries/useGetActiveIntegratedOrgs';
 
 const DEFAULT_ORG_LABEL = 'Select Integrated Org';
 
@@ -60,13 +58,7 @@ export function IntegratedOrgSelector() {
   const {integratedOrgId, preventPeriod, changeContextValue} = usePreventContext();
   const organization = useOrganization();
 
-  const {data: integrations = []} = useApiQuery<Integration[]>(
-    [
-      `/organizations/${organization.slug}/integrations/`,
-      {query: {includeConfig: 0, provider_key: 'github'}},
-    ],
-    {staleTime: 0}
-  );
+  const {data: integrations = []} = useGetActiveIntegratedOrgs({organization});
 
   const handleChange = useCallback(
     (selectedOption: SelectOption<string>) => {
@@ -160,7 +152,7 @@ const FooterInfoSubheading = styled('p')`
 
 const MenuFooterDivider = styled('div')`
   position: relative;
-  padding: ${space(1)} 0;
+  padding: ${p => p.theme.space.md} 0;
   &:before {
     display: block;
     white-space: normal;

--- a/static/app/views/prevent/tests/onboarding.spec.tsx
+++ b/static/app/views/prevent/tests/onboarding.spec.tsx
@@ -21,6 +21,7 @@ const mockGitHubIntegration = {
     name: 'GitHub',
   },
   externalId: '88888888',
+  status: 'active',
 };
 
 const mockRepositories = [

--- a/static/app/views/prevent/tests/onboardingSteps/addUploadTokenStep.spec.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/addUploadTokenStep.spec.tsx
@@ -36,6 +36,7 @@ describe('AddUploadTokenStep', () => {
       key: 'github',
       name: 'GitHub',
     },
+    status: 'active',
   };
 
   const renderComponent = (props = {}) => {

--- a/static/app/views/prevent/tests/onboardingSteps/addUploadTokenStep.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/addUploadTokenStep.tsx
@@ -12,10 +12,9 @@ import {ExternalLink} from 'sentry/components/core/link';
 import {usePreventContext} from 'sentry/components/prevent/context/preventContext';
 import {integratedOrgIdToDomainName} from 'sentry/components/prevent/utils';
 import {t, tct} from 'sentry/locale';
-import type {Integration} from 'sentry/types/integrations';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {OnboardingStep} from 'sentry/views/prevent/tests/onboardingSteps/onboardingStep';
+import {useGetActiveIntegratedOrgs} from 'sentry/views/prevent/tests/queries/useGetActiveIntegratedOrgs';
 
 interface AddUploadTokenStepProps {
   step: string;
@@ -32,13 +31,7 @@ export function AddUploadTokenStep({step}: AddUploadTokenStepProps) {
   const theme = useTheme();
   const isDarkMode = theme.type === 'dark';
 
-  const {data: integrations = []} = useApiQuery<Integration[]>(
-    [
-      `/organizations/${organization.slug}/integrations/`,
-      {query: {includeConfig: 0, provider_key: 'github'}},
-    ],
-    {staleTime: 0}
-  );
+  const {data: integrations = []} = useGetActiveIntegratedOrgs({organization});
   const githubOrgDomain = integratedOrgIdToDomainName(integratedOrgId, integrations);
   const githubUrl =
     githubOrgDomain && repository

--- a/static/app/views/prevent/tests/queries/useGetActiveIntegratedOrgs.spec.tsx
+++ b/static/app/views/prevent/tests/queries/useGetActiveIntegratedOrgs.spec.tsx
@@ -15,7 +15,7 @@ describe('useGetActiveIntegratedOrgs', () => {
 
   it('fetches repository data successfully', async () => {
     const organization = OrganizationFixture({slug: 'test-org'});
-    const mockIntegratedOrgs = [
+    const mockIntegrations = [
       {
         id: '123',
         name: 'github-org-name',
@@ -31,7 +31,7 @@ describe('useGetActiveIntegratedOrgs', () => {
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/`,
-      body: mockIntegratedOrgs,
+      body: mockIntegrations,
     });
 
     const wrapper = ({children}: {children: React.ReactNode}) => (
@@ -48,10 +48,52 @@ describe('useGetActiveIntegratedOrgs', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(result.current.data).toEqual(mockIntegratedOrgs);
+    expect(result.current.data).toEqual(mockIntegrations);
     expect(result.current.data?.[0]?.id).toBe('123');
     expect(result.current.data?.[0]?.name).toBe('github-org-name');
     expect(result.current.data?.[0]?.status).toBe('active');
+  });
+
+  it('filters out inactive integrated orgs', async () => {
+    const organization = OrganizationFixture({slug: 'test-org'});
+    const mockIntegrations = [
+      {
+        id: '123',
+        name: 'github-org-name',
+        status: 'inactive',
+      },
+      {
+        id: '456',
+        name: 'github-org-name-2',
+        status: 'inactive',
+      },
+      {
+        id: '789',
+        name: 'github-org-name-3',
+        status: 'active',
+      },
+    ];
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body: mockIntegrations,
+    });
+
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
+      </QueryClientProvider>
+    );
+
+    const {result} = renderHook(() => useGetActiveIntegratedOrgs({organization}), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual([mockIntegrations[2]]);
   });
 
   it('handles API errors gracefully', async () => {

--- a/static/app/views/prevent/tests/queries/useGetActiveIntegratedOrgs.spec.tsx
+++ b/static/app/views/prevent/tests/queries/useGetActiveIntegratedOrgs.spec.tsx
@@ -1,0 +1,83 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+import {useGetActiveIntegratedOrgs} from './useGetActiveIntegratedOrgs';
+
+describe('useGetActiveIntegratedOrgs', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('fetches repository data successfully', async () => {
+    const organization = OrganizationFixture({slug: 'test-org'});
+    const mockIntegratedOrgs = [
+      {
+        id: '123',
+        name: 'github-org-name',
+        domainName: 'github.com/github-org-name',
+        provider: {
+          key: 'github',
+          name: 'GitHub',
+        },
+        externalId: '88888888',
+        status: 'active',
+      },
+    ];
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body: mockIntegratedOrgs,
+    });
+
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
+      </QueryClientProvider>
+    );
+
+    const {result} = renderHook(() => useGetActiveIntegratedOrgs({organization}), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockIntegratedOrgs);
+    expect(result.current.data?.[0]?.id).toBe('123');
+    expect(result.current.data?.[0]?.name).toBe('github-org-name');
+    expect(result.current.data?.[0]?.status).toBe('active');
+  });
+
+  it('handles API errors gracefully', async () => {
+    const organization = OrganizationFixture({slug: 'test-org'});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      statusCode: 404,
+      body: {detail: 'Repository not found'},
+    });
+
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+      <QueryClientProvider client={makeTestQueryClient()}>
+        <OrganizationContext value={organization}>{children}</OrganizationContext>
+      </QueryClientProvider>
+    );
+
+    const {result} = renderHook(() => useGetActiveIntegratedOrgs({organization}), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/static/app/views/prevent/tests/queries/useGetActiveIntegratedOrgs.tsx
+++ b/static/app/views/prevent/tests/queries/useGetActiveIntegratedOrgs.tsx
@@ -1,0 +1,29 @@
+import type {Integration} from 'sentry/types/integrations';
+import type {OrganizationSummary} from 'sentry/types/organization';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import {useApiQuery} from 'sentry/utils/queryClient';
+
+function makeIntegrationsQueryKey(organization: OrganizationSummary): ApiQueryKey {
+  return [
+    `/organizations/${organization.slug}/integrations/`,
+    {query: {includeConfig: 0, provider_key: 'github'}},
+  ];
+}
+
+export function useGetActiveIntegratedOrgs({
+  organization,
+}: {
+  organization: OrganizationSummary;
+}) {
+  const {data: integrations, ...rest} = useApiQuery<Integration[]>(
+    makeIntegrationsQueryKey(organization),
+    {
+      staleTime: 0,
+    }
+  );
+
+  return {
+    data: integrations?.filter(integration => integration.status === 'active'),
+    ...rest,
+  };
+}

--- a/static/app/views/prevent/tests/tests.spec.tsx
+++ b/static/app/views/prevent/tests/tests.spec.tsx
@@ -69,8 +69,8 @@ const mockBranches = [
 ];
 
 const mockIntegrations = [
-  {name: 'integration-1', id: '1'},
-  {name: 'integration-2', id: '2'},
+  {name: 'integration-1', id: '1', status: 'active'},
+  {name: 'integration-2', id: '2', status: 'active'},
 ];
 
 const mockApiCall = () => {

--- a/static/app/views/prevent/tokens/tokens.spec.tsx
+++ b/static/app/views/prevent/tokens/tokens.spec.tsx
@@ -16,8 +16,8 @@ jest.mock('sentry/components/pagination', () => {
 });
 
 const mockIntegrations = [
-  {name: 'some-org-name', id: '1'},
-  {name: 'test-org', id: '2'},
+  {name: 'some-org-name', id: '1', status: 'active'},
+  {name: 'test-org', id: '2', status: 'active'},
 ];
 
 const mockRepositoryTokensResponse = {

--- a/static/app/views/prevent/tokens/tokens.tsx
+++ b/static/app/views/prevent/tokens/tokens.tsx
@@ -8,12 +8,11 @@ import {usePreventContext} from 'sentry/components/prevent/context/preventContex
 import {IntegratedOrgSelector} from 'sentry/components/prevent/integratedOrgSelector/integratedOrgSelector';
 import {integratedOrgIdToName} from 'sentry/components/prevent/utils';
 import {t, tct} from 'sentry/locale';
-import type {Integration} from 'sentry/types/integrations';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeSorts} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useGetActiveIntegratedOrgs} from 'sentry/views/prevent/tests/queries/useGetActiveIntegratedOrgs';
 
 import {useInfiniteRepositoryTokens} from './repoTokenTable/hooks/useInfiniteRepositoryTokens';
 import RepoTokenTable, {isAValidSort} from './repoTokenTable/repoTokenTable';
@@ -22,13 +21,7 @@ export default function TokensPage() {
   const {integratedOrgId} = usePreventContext();
   const organization = useOrganization();
   const navigate = useNavigate();
-  const {data: integrations = []} = useApiQuery<Integration[]>(
-    [
-      `/organizations/${organization.slug}/integrations/`,
-      {query: {includeConfig: 0, provider_key: 'github'}},
-    ],
-    {staleTime: 0}
-  );
+  const {data: integrations = []} = useGetActiveIntegratedOrgs({organization});
   const location = useLocation();
 
   const sort = decodeSorts(location.query?.sort).find(isAValidSort);


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/CCMRG-1649/bug-multiple-app-installations-for-same-app-id-showing-up

We will now filter out not active integrated orgs from the orgs list for Prevent use such as the Integrated Org Selector.

<img width="807" height="194" alt="Screenshot 2025-09-18 at 9 21 18 AM" src="https://github.com/user-attachments/assets/1f724a11-70f0-4328-a40e-6234af2ce19f" />
<img width="535" height="515" alt="Screenshot 2025-09-18 at 9 19 35 AM" src="https://github.com/user-attachments/assets/6d7a28fa-b9b0-47ec-adbf-469227aa6656" />
