### PR TITLE
ref(content-blocks): Prepare user feedback and replay onboarding

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/contentBlocks/defaultRenderers.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/contentBlocks/defaultRenderers.tsx
@@ -82,7 +82,11 @@ function ConditionalBlock({
 }
 
 function CustomBlock(block: Extract<ContentBlock, {type: 'custom'}>) {
-  return <div css={baseBlockStyles}>{block.content}</div>;
+  return (
+    <div css={block.bottomMargin === false ? undefined : baseBlockStyles}>
+      {block.content}
+    </div>
+  );
 }
 
 function TextBlock(block: Extract<ContentBlock, {type: 'text'}>) {

--- a/static/app/components/onboarding/gettingStartedDoc/contentBlocks/types.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/contentBlocks/types.tsx
@@ -54,6 +54,7 @@ type TextBlock = BaseBlock<'text'> & {
  */
 type CustomBlock = BaseBlock<'custom'> & {
   content: React.ReactNode;
+  bottomMargin?: boolean;
 };
 
 export type ContentBlock =

--- a/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
+++ b/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
@@ -91,31 +91,56 @@ export function ReplayOnboardingLayout({
     projectKeyId,
   ]);
 
+  const replayConfigToggle = (
+    <ReplayConfigToggle
+      blockToggle={block}
+      maskToggle={mask}
+      onBlockToggle={() => setBlock(!block)}
+      onMaskToggle={() => setMask(!mask)}
+    />
+  );
+
   return (
     <AuthTokenGeneratorProvider projectSlug={project.slug}>
       <Wrapper>
         {introduction && <Introduction>{introduction}</Introduction>}
         <Steps>
-          {steps.map(step =>
-            step.type === StepType.CONFIGURE ? (
-              <Step
-                key={step.title ?? step.type}
-                {...{
+          {steps
+            // TODO(aknaus): Move inserting the toggle into the docs definitions
+            // once the content blocks migration is done. This logic here is very brittle.
+            .map(step => {
+              if (step.type !== StepType.CONFIGURE || hideMaskBlockToggles) {
+                return step;
+              }
+
+              if (step.content) {
+                // Insert the feedback config toggle before the code block
+                const codeIndex = step.content?.findIndex(b => b.type === 'code');
+                if (codeIndex === -1) {
+                  return step;
+                }
+                const newContent = [...step.content];
+                if (codeIndex !== undefined) {
+                  newContent.splice(codeIndex, 0, {
+                    type: 'custom',
+                    bottomMargin: false,
+                    content: replayConfigToggle,
+                  });
+                }
+                return {
                   ...step,
-                  codeHeader: hideMaskBlockToggles ? null : (
-                    <ReplayConfigToggle
-                      blockToggle={block}
-                      maskToggle={mask}
-                      onBlockToggle={() => setBlock(!block)}
-                      onMaskToggle={() => setMask(!mask)}
-                    />
-                  ),
-                }}
-              />
-            ) : (
+                  content: newContent,
+                };
+              }
+
+              return {
+                ...step,
+                codeHeader: replayConfigToggle,
+              };
+            })
+            .map(step => (
               <Step key={step.title ?? step.type} {...step} />
-            )
-          )}
+            ))}
         </Steps>
       </Wrapper>
     </AuthTokenGeneratorProvider>

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -5,7 +5,7 @@ import {SdkProviderEnum as FeatureFlagProviderEnum} from 'sentry/components/even
 import {buildSdkConfig} from 'sentry/components/onboarding/gettingStartedDoc/buildSdkConfig';
 import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/crashReportCallout';
 import widgetCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
-import TracePropagationMessage from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
+import {tracePropagationBlock} from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import type {
   BasePlatformOptions,
   ContentBlock,
@@ -789,12 +789,16 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: getReplayConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/session-replay/',
-      }),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: getReplayConfigureDescription({
+            link: 'https://docs.sentry.io/platforms/javascript/session-replay/',
+          }),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JavaScript',
               value: 'javascript',
@@ -803,8 +807,8 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
             },
           ],
         },
+        tracePropagationBlock,
       ],
-      additionalInfo: <TracePropagationMessage />,
     },
   ],
   verify: getReplayVerifyStep(),
@@ -832,27 +836,28 @@ const feedbackOnboarding: OnboardingConfig<PlatformOptions> = {
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: getFeedbackConfigureDescription({
-        linkConfig:
-          'https://docs.sentry.io/platforms/javascript/user-feedback/configuration/',
-        linkButton:
-          'https://docs.sentry.io/platforms/javascript/user-feedback/configuration/#bring-your-own-button',
-      }),
-      configurations: [
+      content: [
         {
-          code: [
-            {
-              label: 'JavaScript',
-              value: 'javascript',
-              language: 'javascript',
-              code: getSdkSetupSnippet(params),
-            },
-          ],
+          type: 'text',
+          text: getFeedbackConfigureDescription({
+            linkConfig:
+              'https://docs.sentry.io/platforms/javascript/user-feedback/configuration/',
+            linkButton:
+              'https://docs.sentry.io/platforms/javascript/user-feedback/configuration/#bring-your-own-button',
+          }),
+        },
+        {
+          type: 'code',
+          language: 'javascript',
+          code: getSdkSetupSnippet(params),
+        },
+        {
+          type: 'text',
+          text: crashReportCallout({
+            link: 'https://docs.sentry.io/platforms/javascript/user-feedback/#crash-report-modal',
+          }),
         },
       ],
-      additionalInfo: crashReportCallout({
-        link: 'https://docs.sentry.io/platforms/javascript/user-feedback/#crash-report-modal',
-      }),
     },
   ],
   verify: () => [],


### PR DESCRIPTION
Allow custom blocks to opt-out of the bottom margin.
Adapt codeHeader logic in user feedback and replays onboarding to support content blocks.

*Note:* This is a temporary measure until the content block migration is done. Afterwards we should move the toggles into the docs definition instead of injecting them.

- part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)