### PR TITLE
ref(content-blocks): Capacitor

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/feedback/widgetCallout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/feedback/widgetCallout.tsx
@@ -1,18 +1,28 @@
 import {Alert} from 'sentry/components/core/alert';
 import {ExternalLink} from 'sentry/components/core/link';
+import type {ContentBlock} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {tct} from 'sentry/locale';
+
+const getCalloutText = (link: string) =>
+  tct(
+    `Want to receive user feedback at any time, not just when an error happens? [link:Read the docs] to learn how to set up our customizable widget.`,
+    {
+      link: <ExternalLink href={link} />,
+    }
+  );
 
 export default function widgetCallout({link}: {link: string}) {
   return (
     <Alert.Container>
-      <Alert type="info">
-        {tct(
-          `Want to receive user feedback at any time, not just when an error happens? [link:Read the docs] to learn how to set up our customizable widget.`,
-          {
-            link: <ExternalLink href={link} />,
-          }
-        )}
-      </Alert>
+      <Alert type="info">{getCalloutText(link)}</Alert>
     </Alert.Container>
   );
+}
+
+export function widgetCalloutBlock({link}: {link: string}): ContentBlock {
+  return {
+    type: 'alert',
+    alertType: 'info',
+    text: getCalloutText(link),
+  };
 }


### PR DESCRIPTION
Refactor the last configuration objects in capacitor docs to content blocks.

- part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)