### PR TITLE
feat(content-blocks): Add subheader and list block types

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/contentBlocks/defaultRenderers.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/contentBlocks/defaultRenderers.tsx
@@ -109,6 +109,8 @@ const TextBlockWrapper = styled('div')`
 `;
 
 function SubHeaderBlock(block: Extract<ContentBlock, {type: 'subheader'}>) {
+  // TODO(aknaus): Use <Heading/> throughout the onboarding docs codebase
+  // <Heading as="h5"> has a different styling and does not match the other headings we currently use
   return <h5 css={baseBlockStyles}>{block.text}</h5>;
 }
 

--- a/static/app/components/onboarding/gettingStartedDoc/contentBlocks/defaultRenderers.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/contentBlocks/defaultRenderers.tsx
@@ -1,7 +1,9 @@
-import {css} from '@emotion/react';
+import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Alert} from 'sentry/components/core/alert';
+import List from 'sentry/components/list';
+import ListItem from 'sentry/components/list/listItem';
 import {useRendererContext} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/rendererContext';
 import type {
   BlockRenderers,
@@ -16,9 +18,16 @@ import {
   TabbedCodeSnippet,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
 
+// TODO(aknaus): Remove !important once we can remove style overrides from the onboarding layouts
 const baseBlockStyles = css`
   :not(:last-child) {
-    margin-bottom: var(${ContentBlockCssVariables.BLOCK_SPACING});
+    margin-bottom: var(${ContentBlockCssVariables.BLOCK_SPACING}) !important;
+  }
+`;
+
+const coloredCodeStyles = (theme: Theme) => css`
+  code:not([class*='language-']) {
+    color: ${theme.pink400};
   }
 `;
 
@@ -95,11 +104,25 @@ function TextBlock(block: Extract<ContentBlock, {type: 'text'}>) {
 
 const TextBlockWrapper = styled('div')`
   ${baseBlockStyles}
-
-  code:not([class*='language-']) {
-    color: ${p => p.theme.pink400};
-  }
+  white-space: pre-wrap;
+  ${p => coloredCodeStyles(p.theme)}
 `;
+
+function SubHeaderBlock(block: Extract<ContentBlock, {type: 'subheader'}>) {
+  return <h5 css={baseBlockStyles}>{block.text}</h5>;
+}
+
+function ListBlock(block: Extract<ContentBlock, {type: 'list'}>) {
+  return (
+    <List symbol="bullet" css={baseBlockStyles}>
+      {block.items.map((item, index) => (
+        <ListItem css={coloredCodeStyles} key={index}>
+          {item}
+        </ListItem>
+      ))}
+    </List>
+  );
+}
 
 export const defaultRenderers: BlockRenderers = {
   text: TextBlock,
@@ -107,4 +130,6 @@ export const defaultRenderers: BlockRenderers = {
   custom: CustomBlock,
   alert: AlertBlock,
   conditional: ConditionalBlock,
+  subheader: SubHeaderBlock,
+  list: ListBlock,
 };

--- a/static/app/components/onboarding/gettingStartedDoc/contentBlocks/types.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/contentBlocks/types.tsx
@@ -50,6 +50,20 @@ type TextBlock = BaseBlock<'text'> & {
 };
 
 /**
+ * Subheader blocks are used to render a subheader.
+ */
+type SubHeaderBlock = BaseBlock<'subheader'> & {
+  text: React.ReactNode;
+};
+
+/**
+ * List blocks are used to render a list of items.
+ */
+type ListBlock = BaseBlock<'list'> & {
+  items: React.ReactNode[];
+};
+
+/**
  * Custom blocks can be used to render any content that is not covered by the other block types.
  */
 type CustomBlock = BaseBlock<'custom'> & {
@@ -62,7 +76,9 @@ export type ContentBlock =
   | CodeBlock
   | ConditionalBlock
   | CustomBlock
-  | TextBlock;
+  | TextBlock
+  | SubHeaderBlock
+  | ListBlock;
 
 export type BlockRenderers = {
   [key in ContentBlock['type']]: (

--- a/static/app/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding.tsx
@@ -1,6 +1,7 @@
 import {Alert} from 'sentry/components/core/alert';
 import {ExternalLink} from 'sentry/components/core/link';
 import type {
+  ContentBlock,
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -139,12 +140,10 @@ export const getCrashReportModalConfigDescription = ({link}: {link: string}) =>
 
 const getCrashReportModalSnippetJavaScript = (params: any) => [
   {
-    code: [
-      {
-        label: 'HTML',
-        value: 'html',
-        language: 'html',
-        code: `<script>
+    label: 'HTML',
+    value: 'html',
+    language: 'html',
+    code: `<script>
   Sentry.init({
     dsn: "${params.dsn.public}",
     beforeSend(event, hint) {
@@ -156,8 +155,6 @@ const getCrashReportModalSnippetJavaScript = (params: any) => [
     },
   });
 </script>`,
-      },
-    ],
   },
 ];
 
@@ -165,7 +162,16 @@ export const getCrashReportJavaScriptInstallStep = (params: any) => [
   {
     type: StepType.INSTALL,
     description: getCrashReportModalInstallDescriptionJavaScript(),
-    configurations: getCrashReportModalSnippetJavaScript(params),
+    content: [
+      {
+        type: 'text',
+        text: getCrashReportModalInstallDescriptionJavaScript(),
+      },
+      {
+        type: 'code',
+        tabs: getCrashReportModalSnippetJavaScript(params),
+      },
+    ] satisfies ContentBlock[],
   },
 ];
 

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -1069,7 +1069,7 @@ export const featureFlagOnboarding: OnboardingConfig = {
         content: [
           {
             type: 'text',
-            text: t(
+            text: tct(
               'Add [name] to your integrations list, and initialize your feature flag SDK.',
               {
                 name: <code>{integrationName}</code>,

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -1,10 +1,8 @@
-import {Fragment} from 'react';
-
 import {ExternalLink, Link} from 'sentry/components/core/link';
 import {SdkProviderEnum as FeatureFlagProviderEnum} from 'sentry/components/events/featureFlags/utils';
 import {buildSdkConfig} from 'sentry/components/onboarding/gettingStartedDoc/buildSdkConfig';
 import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/crashReportCallout';
-import widgetCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
+import {widgetCalloutBlock} from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
 import {tracePropagationBlock} from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import type {
   BasePlatformOptions,
@@ -487,42 +485,47 @@ const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
             },
           ],
         },
-      ],
-      additionalInfo: (
-        <Fragment>
-          <h5>{t('Default Configuration')}</h5>
-          <p>
-            {t(
-              'The Loader Script settings are automatically updated based on the product selection above. Toggling products will dynamically configure the SDK defaults.'
-            )}
-          </p>
-          <p>
-            {tct(
+        {
+          type: 'subheader',
+          text: t('Default Configuration'),
+        },
+        {
+          type: 'text',
+          text: t(
+            'The Loader Script settings are automatically updated based on the product selection above. Toggling products will dynamically configure the SDK defaults.'
+          ),
+        },
+        {
+          type: 'list',
+          items: [
+            tct(
               'For Tracing, the SDK is initialized with [code:tracesSampleRate: 1], meaning all traces will be captured.',
               {
                 code: <code />,
               }
-            )}
-          </p>
-          <p>
-            {tct(
+            ),
+            tct(
               'For Session Replay, the default rates are [code:replaysSessionSampleRate: 0.1] and [code:replaysOnErrorSampleRate: 1]. This captures 10% of regular sessions and 100% of sessions with an error.',
               {
                 code: <code />,
               }
-            )}
-          </p>
-          <p>
-            {tct('You can review or change these settings in [link:Project Settings].', {
+            ),
+          ],
+        },
+        {
+          type: 'text',
+          text: tct(
+            'You can review or change these settings in [link:Project Settings].',
+            {
               link: (
                 <Link
                   to={`/settings/${params.organization.slug}/projects/${params.project.slug}/loader-script/`}
                 />
               ),
-            })}
-          </p>
-        </Fragment>
-      ),
+            }
+          ),
+        },
+      ],
     },
   ],
   configure: params => [
@@ -543,30 +546,30 @@ const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
               label: 'HTML',
               language: 'html',
               code: `
-              <script>
-                Sentry.onLoad(function() {
-                  Sentry.init({${
-                    params.isPerformanceSelected || params.isReplaySelected
-                      ? ''
-                      : `
-                      // You can add any additional configuration here`
-                  }${
-                    params.isPerformanceSelected
-                      ? `
-                      // Tracing
-                      tracesSampleRate: 1.0, // Capture 100% of the transactions`
-                      : ''
-                  }${
-                    params.isReplaySelected
-                      ? `
-                      // Session Replay
-                      replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-                      replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.`
-                      : ''
-                  }
-                    });
-                });
-              </script>`,
+<script>
+  Sentry.onLoad(function() {
+    Sentry.init({${
+      params.isPerformanceSelected || params.isReplaySelected
+        ? ''
+        : `
+      // You can add any additional configuration here`
+    }${
+      params.isPerformanceSelected
+        ? `
+      // Tracing
+      tracesSampleRate: 1.0, // Capture 100% of the transactions`
+        : ''
+    }${
+      params.isReplaySelected
+        ? `
+      // Session Replay
+      replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+      replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.`
+        : ''
+    }
+    });
+  });
+</script>`,
             },
           ],
         },
@@ -870,12 +873,17 @@ const crashReportOnboarding: OnboardingConfig<PlatformOptions> = {
   configure: () => [
     {
       type: StepType.CONFIGURE,
-      description: getCrashReportModalConfigDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/user-feedback/configuration/#crash-report-modal',
-      }),
-      additionalInfo: widgetCallout({
-        link: 'https://docs.sentry.io/platforms/javascript/user-feedback/#user-feedback-widget',
-      }),
+      content: [
+        {
+          type: 'text',
+          text: getCrashReportModalConfigDescription({
+            link: 'https://docs.sentry.io/platforms/javascript/user-feedback/configuration/#crash-report-modal',
+          }),
+        },
+        widgetCalloutBlock({
+          link: 'https://docs.sentry.io/platforms/javascript/user-feedback/#user-feedback-widget',
+        }),
+      ],
     },
   ],
   verify: () => [],
@@ -1026,62 +1034,78 @@ export const featureFlagOnboarding: OnboardingConfig = {
         featureFlagOptions.integration as keyof typeof FEATURE_FLAG_CONFIGURATION_MAP
       ];
 
-    const installConfig = [
-      {
-        language: 'bash',
-        code: [
-          {
-            label: 'npm',
-            value: 'npm',
-            language: 'bash',
-            code: `npm install --save @sentry/browser ${packageName}`,
-          },
-          {
-            label: 'yarn',
-            value: 'yarn',
-            language: 'bash',
-            code: `yarn add @sentry/browser ${packageName}`,
-          },
-          {
-            label: 'pnpm',
-            value: 'pnpm',
-            language: 'bash',
-            code: `pnpm add @sentry/browser ${packageName}`,
-          },
-        ],
-      },
-    ];
-
     return [
       {
         type: StepType.INSTALL,
-        description: t('Install Sentry and the selected feature flag SDK.'),
-        configurations: installConfig,
+        content: [
+          {
+            type: 'text',
+            text: t('Install Sentry and the selected feature flag SDK.'),
+          },
+          {
+            type: 'code',
+            tabs: [
+              {
+                label: 'npm',
+                language: 'bash',
+                code: `npm install --save @sentry/browser ${packageName}`,
+              },
+              {
+                label: 'yarn',
+                language: 'bash',
+                code: `yarn add @sentry/browser ${packageName}`,
+              },
+              {
+                label: 'pnpm',
+                language: 'bash',
+                code: `pnpm add @sentry/browser ${packageName}`,
+              },
+            ],
+          },
+        ],
       },
       {
         type: StepType.CONFIGURE,
-        description: tct(
-          'Add [name] to your integrations list, and initialize your feature flag SDK.',
+        content: [
           {
-            name: <code>{integrationName}</code>,
-          }
-        ),
-        configurations: [
+            type: 'text',
+            text: t(
+              'Add [name] to your integrations list, and initialize your feature flag SDK.',
+              {
+                name: <code>{integrationName}</code>,
+              }
+            ),
+          },
           {
-            language: 'JavaScript',
-            code: makeConfigureCode(dsn.public),
+            type: 'code',
+            tabs: [
+              {
+                label: 'JavaScript',
+                language: 'javascript',
+                code: makeConfigureCode(dsn.public),
+              },
+            ],
           },
         ],
       },
       {
         type: StepType.VERIFY,
-        description: t(
-          'Test your setup by evaluating a flag, then capturing an exception. Check the Feature Flags table in Issue Details to confirm that your error event has recorded the flag and its result.'
-        ),
-        configurations: [
+        content: [
           {
-            language: 'JavaScript',
-            code: makeVerifyCode(),
+            type: 'text',
+            text: t(
+              'Test your setup by evaluating a flag, then capturing an exception. Check the Feature Flags table in Issue Details to confirm that your error event has recorded the flag and its result.'
+            ),
+          },
+          {
+            type: 'code',
+            tabs: [
+              {
+                label: 'JavaScript',
+                language: 'javascript',
+                code: makeVerifyCode(),
+              },
+            ],
           },
         ],
       },


### PR DESCRIPTION
Add block types for subheader and list.
Fix javascript loader onboarding.

- part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)