### PR TITLE
ref: decouple profiling filters from DeprecatedSmartSearchBar

### DIFF
--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -5,7 +5,6 @@ import type {Location} from 'history';
 import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/core/alert';
 import {TabList, Tabs} from 'sentry/components/core/tabs';
-import type {SmartSearchBarProps} from 'sentry/components/deprecatedSmartSearchBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
@@ -240,7 +239,7 @@ interface TabbedContentProps extends ProfilingTabProps {
 
 function TransactionsTab({onDataState, location, selection}: TabbedContentProps) {
   const query = decodeScalar(location.query.query, '');
-  const handleSearch: SmartSearchBarProps['onSearch'] = useCallback(
+  const handleSearch = useCallback(
     (searchQuery: string) => {
       browserHistory.push({
         ...location,

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -11,7 +11,6 @@ import {SegmentedControl} from 'sentry/components/core/segmentedControl';
 import {TabList, Tabs} from 'sentry/components/core/tabs';
 import Count from 'sentry/components/count';
 import {DateTime} from 'sentry/components/dateTime';
-import type {SmartSearchBarProps} from 'sentry/components/deprecatedSmartSearchBar';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import IdBadge from 'sentry/components/idBadge';
@@ -210,7 +209,7 @@ interface ProfileFiltersProps {
 }
 
 function ProfileFilters(props: ProfileFiltersProps) {
-  const handleSearch: SmartSearchBarProps['onSearch'] = useCallback(
+  const handleSearch = useCallback(
     (searchQuery: string) => {
       browserHistory.push({
         ...props.location,


### PR DESCRIPTION
profiling filters are no longer rendering a DeprecatedSmartSearchBar - they are already rendering the recommended alternative `SearchQueryBuilder`. However, the types are still coupled to DeprecatedSmartSearchBar.

The motivation here is to be able to completely remove DeprecatedSmartSearchBar in the near future.
