### PR TITLE
ref(content-blocks): Migrate android and apple

### DIFF
--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -1,8 +1,4 @@
-import {Fragment} from 'react';
-
 import {ExternalLink} from 'sentry/components/core/link';
-import List from 'sentry/components/list/';
-import ListItem from 'sentry/components/list/listItem';
 import type {
   BasePlatformOptions,
   Docs,
@@ -169,60 +165,54 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       ? [
           {
             type: StepType.INSTALL,
-            description: tct(
-              'Add Sentry automatically to your app with the [wizardLink:Sentry wizard] (call this inside your project directory).',
+            content: [
               {
-                wizardLink: (
-                  <ExternalLink href="https://docs.sentry.io/platforms/android/#install" />
+                type: 'text',
+                text: tct(
+                  'Add Sentry automatically to your app with the [wizardLink:Sentry wizard] (call this inside your project directory).',
+                  {
+                    wizardLink: (
+                      <ExternalLink href="https://docs.sentry.io/platforms/android/#install" />
+                    ),
+                  }
                 ),
-              }
-            ),
-            configurations: [
+              },
               {
-                code: getWizardInstallSnippet({
+                type: 'code',
+                tabs: getWizardInstallSnippet({
                   platform: 'android',
                   params,
                 }),
               },
               {
-                description: (
-                  <Fragment>
-                    <p>
-                      {t('The Sentry wizard will automatically patch your application:')}
-                    </p>
-                    <List symbol="bullet">
-                      <ListItem>
-                        {tct(
-                          "Update your app's [buildGradle:build.gradle] file with the Sentry Gradle plugin and configure it.",
-                          {
-                            buildGradle: <code />,
-                          }
-                        )}
-                      </ListItem>
-                      <ListItem>
-                        {tct(
-                          'Update your [manifest: AndroidManifest.xml] with the default Sentry configuration',
-                          {
-                            manifest: <code />,
-                          }
-                        )}
-                      </ListItem>
-                      <ListItem>
-                        {tct(
-                          'Create [code: sentry.properties] with an auth token to upload proguard mappings (this file is automatically added to [code: .gitignore])',
-                          {
-                            code: <code />,
-                          }
-                        )}
-                      </ListItem>
-                      <ListItem>
-                        {t(
-                          "Add an example error to your app's Main Activity to verify your Sentry setup"
-                        )}
-                      </ListItem>
-                    </List>
-                  </Fragment>
-                ),
+                type: 'text',
+                text: t('The Sentry wizard will automatically patch your application:'),
+              },
+              {
+                type: 'list',
+                items: [
+                  tct(
+                    "Update your app's [buildGradle:build.gradle] file with the Sentry Gradle plugin and configure it.",
+                    {
+                      buildGradle: <code />,
+                    }
+                  ),
+                  tct(
+                    'Update your [manifest: AndroidManifest.xml] with the default Sentry configuration',
+                    {
+                      manifest: <code />,
+                    }
+                  ),
+                  tct(
+                    'Create [code: sentry.properties] with an auth token to upload proguard mappings (this file is automatically added to [code: .gitignore])',
+                    {
+                      code: <code />,
+                    }
+                  ),
+                  t(
+                    "Add an example error to your app's Main Activity to verify your Sentry setup"
+                  ),
+                ],
               },
             ],
           },
@@ -230,20 +220,28 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       : [
           {
             type: StepType.INSTALL,
-            description: tct(
-              'Add the [sagpLink:Sentry Android Gradle plugin] to your [app:app] module:',
+            content: [
               {
-                sagpLink: (
-                  <ExternalLink href="https://docs.sentry.io/platforms/android/configuration/gradle/" />
+                type: 'text',
+                text: tct(
+                  'Add the [sagpLink:Sentry Android Gradle plugin] to your [app:app] module:',
+                  {
+                    sagpLink: (
+                      <ExternalLink href="https://docs.sentry.io/platforms/android/configuration/gradle/" />
+                    ),
+                    app: <code />,
+                  }
                 ),
-                app: <code />,
-              }
-            ),
-            configurations: [
+              },
               {
-                language: 'groovy',
-                partialLoading: params.sourcePackageRegistries?.isLoading,
-                code: getManualInstallSnippet(params),
+                type: 'code',
+                tabs: [
+                  {
+                    label: 'Groovy',
+                    language: 'groovy',
+                    code: getManualInstallSnippet(params),
+                  },
+                ],
               },
             ],
           },
@@ -254,23 +252,30 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       : [
           {
             type: StepType.CONFIGURE,
-            description: (
-              <Fragment>
-                <p>
-                  {tct(
-                    'Configuration is done via the application [code: AndroidManifest.xml]. Under the hood Sentry uses a [code:ContentProvider] to initialize the SDK based on the values provided below. This way the SDK can capture important crashes and metrics right from the app start.',
-                    {
-                      code: <code />,
-                    }
-                  )}
-                </p>
-                <p>{t("Here's an example config which should get you started:")}</p>
-              </Fragment>
-            ),
-            configurations: [
+            content: [
               {
-                language: 'xml',
-                code: getConfigurationSnippet(params),
+                type: 'text',
+                text: tct(
+                  'Configuration is done via the application [code: AndroidManifest.xml]. Under the hood Sentry uses a [code:ContentProvider] to initialize the SDK based on the values provided below. This way the SDK can capture important crashes and metrics right from the app start.',
+                  {
+                    code: <code />,
+                  }
+                ),
+              },
+              {
+                type: 'text',
+                text: t("Here's an example config which should get you started:"),
+              },
+              {
+                type: 'code',
+                tabs: [
+                  {
+                    label: 'XML',
+                    language: 'xml',
+                    filename: 'AndroidManifest.xml',
+                    code: getConfigurationSnippet(params),
+                  },
+                ],
               },
             ],
           },
@@ -281,16 +286,25 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       : [
           {
             type: StepType.VERIFY,
-            description: tct(
-              "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected. You can add it to your app's [mainActivity: MainActivity].",
+            content: [
               {
-                mainActivity: <code />,
-              }
-            ),
-            configurations: [
+                type: 'text',
+                text: tct(
+                  "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected. You can add it to your app's [mainActivity: MainActivity].",
+                  {
+                    mainActivity: <code />,
+                  }
+                ),
+              },
               {
-                language: 'kotlin',
-                code: getVerifySnippet(params),
+                type: 'code',
+                tabs: [
+                  {
+                    label: 'Kotlin',
+                    language: 'kotlin',
+                    code: getVerifySnippet(params),
+                  },
+                ],
               },
             ],
           },
@@ -363,16 +377,19 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        "Make sure your Sentry Android SDK version is at least 7.20.0. The easiest way to update the SDK is through the Sentry Android Gradle plugin in your app module's [code:build.gradle] file.",
-        {code: <code />}
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: tct(
+            "Make sure your Sentry Android SDK version is at least 7.20.0. The easiest way to update the SDK is through the Sentry Android Gradle plugin in your app module's [code:build.gradle] file.",
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'Groovy',
-              value: 'groovy',
               language: 'groovy',
               filename: 'app/build.gradle',
               code: `plugins {
@@ -386,7 +403,6 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
             },
             {
               label: 'Kotlin',
-              value: 'kotlin',
               language: 'kotlin',
               filename: 'app/build.gradle.kts',
               code: `plugins {
@@ -401,16 +417,17 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'If you have the SDK installed without the Sentry Gradle Plugin, you can update the version directly in the [code:build.gradle] through:',
             {code: <code />}
           ),
         },
         {
-          code: [
+          type: 'code',
+          tabs: [
             {
               label: 'Groovy',
-              value: 'groovy',
               language: 'groovy',
               filename: 'app/build.gradle',
               code: `dependencies {
@@ -423,7 +440,6 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
             },
             {
               label: 'Kotlin',
-              value: 'kotlin',
               language: 'kotlin',
               filename: 'app/build.gradle.kts',
               code: `dependencies {
@@ -437,21 +453,21 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
           ],
         },
         {
-          description: t(
+          type: 'text',
+          text: t(
             'To set up the integration, add the following to your Sentry initialization:'
           ),
         },
         {
-          code: [
+          type: 'code',
+          tabs: [
             {
               label: 'Kotlin',
-              value: 'kotlin',
               language: 'kotlin',
               code: getReplaySetupSnippetKotlin(params),
             },
             {
               label: 'XML',
-              value: 'xml',
               language: 'xml',
               filename: 'AndroidManifest.xml',
               code: getReplaySetupSnippetXml(),
@@ -464,18 +480,24 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
   configure: () => [
     {
       type: StepType.CONFIGURE,
-      description: getReplayMobileConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/android/session-replay/#privacy',
-      }),
-      configurations: [
+      content: [
         {
-          description: t(
+          type: 'text',
+          text: getReplayMobileConfigureDescription({
+            link: 'https://docs.sentry.io/platforms/android/session-replay/#privacy',
+          }),
+        },
+        {
+          type: 'text',
+          text: t(
             'The following code is the default configuration, which masks and blocks everything.'
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'Kotlin',
-              value: 'kotlin',
               language: 'kotlin',
               code: getReplayConfigurationSnippet(),
             },
@@ -495,25 +517,30 @@ const profilingOnboarding: OnboardingConfig<PlatformOptions> = {
   install: params => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'Android UI Profiling is available starting in SDK version [code:8.7.0].',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: [
+          type: 'text',
+          text: tct(
+            'Android UI Profiling is available starting in SDK version [code:8.7.0].',
+            {
+              code: <code />,
+            }
+          ),
+        },
         {
-          partialLoading: params.sourcePackageRegistries?.isLoading,
-          code: [
+          type: 'code',
+          tabs: [
             {
               label: 'Groovy',
-              value: 'groovy',
               language: 'groovy',
               filename: 'app/build.gradle',
               code: getManualInstallSnippet(params),
             },
           ],
-          additionalInfo: tct(
+        },
+        {
+          type: 'text',
+          text: tct(
             'Version [versionPlugin] of the plugin will automatically add the Sentry Android SDK (version [versionSdk]) to your app.',
             {
               versionPlugin: (
@@ -537,16 +564,18 @@ const profilingOnboarding: OnboardingConfig<PlatformOptions> = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: tct('Set up profiling in your [code:AndroidManifest.xml] file.', {
-        code: <code />,
-      }),
-      configurations: [
+      content: [
         {
-          language: 'xml',
-          code: [
+          type: 'text',
+          text: tct('Set up profiling in your [code:AndroidManifest.xml] file.', {
+            code: <code />,
+          }),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'XML',
-              value: 'xml',
               language: 'xml',
               filename: 'AndroidManifest.xml',
               code: `
@@ -598,7 +627,8 @@ const profilingOnboarding: OnboardingConfig<PlatformOptions> = {
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'For more detailed information on profiling, see the [link:profiling documentation].',
             {
               link: (
@@ -615,9 +645,14 @@ const profilingOnboarding: OnboardingConfig<PlatformOptions> = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        'Verify that profiling is working correctly by simply using your application.'
-      ),
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Verify that profiling is working correctly by simply using your application.'
+          ),
+        },
+      ],
     },
   ],
 };

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -1,6 +1,4 @@
 import {ExternalLink} from 'sentry/components/core/link';
-import List from 'sentry/components/list/';
-import ListItem from 'sentry/components/list/listItem';
 import type {
   BasePlatformOptions,
   Docs,
@@ -274,21 +272,21 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       ? [
           {
             type: StepType.INSTALL,
-            description: (
-              <p>
-                {tct(
+            content: [
+              {
+                type: 'text',
+                text: tct(
                   'Add Sentry automatically to your app with the [wizardLink:Sentry wizard] (call this inside your project directory).',
                   {
                     wizardLink: (
                       <ExternalLink href="https://docs.sentry.io/platforms/apple/guides/ios/#install" />
                     ),
                   }
-                )}
-              </p>
-            ),
-            configurations: [
+                ),
+              },
               {
-                code: getWizardInstallSnippet({
+                type: 'code',
+                tabs: getWizardInstallSnippet({
                   platform: 'ios',
                   params,
                 }),
@@ -299,34 +297,43 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       : [
           {
             type: StepType.INSTALL,
-            description: tct(
-              'We recommend installing the SDK with Swift Package Manager (SPM), but we also support [alternateMethods: alternate installation methods]. To integrate Sentry into your Xcode project using SPM, open your App in Xcode and open [addPackage: File > Add Packages]. Then add the SDK by entering the Git repo url in the top right search field:',
+            content: [
               {
-                alternateMethods: (
-                  <ExternalLink href="https://docs.sentry.io/platforms/apple/install/" />
+                type: 'text',
+                text: tct(
+                  'We recommend installing the SDK with Swift Package Manager (SPM), but we also support [alternateMethods: alternate installation methods]. To integrate Sentry into your Xcode project using SPM, open your App in Xcode and open [addPackage: File > Add Packages]. Then add the SDK by entering the Git repo url in the top right search field:',
+                  {
+                    alternateMethods: (
+                      <ExternalLink href="https://docs.sentry.io/platforms/apple/install/" />
+                    ),
+                    addPackage: <strong />,
+                  }
                 ),
-                addPackage: <strong />,
-              }
-            ),
-            configurations: [
+              },
               {
+                type: 'code',
                 language: 'url',
                 code: `https://github.com/getsentry/sentry-cocoa.git`,
               },
               {
-                description: (
-                  <p>
-                    {tct(
-                      'Alternatively, when your project uses a [packageSwift: Package.swift] file to manage dependencies, you can specify the target with:',
-                      {
-                        packageSwift: <code />,
-                      }
-                    )}
-                  </p>
+                type: 'text',
+                text: tct(
+                  'Alternatively, when your project uses a [packageSwift: Package.swift] file to manage dependencies, you can specify the target with:',
+                  {
+                    packageSwift: <code />,
+                  }
                 ),
-                language: 'swift',
+              },
+              {
+                type: 'code',
+                tabs: [
+                  {
+                    label: 'Swift',
+                    language: 'swift',
+                    code: getManualInstallSnippet(params),
+                  },
+                ],
                 partialLoading: params.sourcePackageRegistries.isLoading,
-                code: getManualInstallSnippet(params),
               },
             ],
           },
@@ -336,47 +343,37 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       ? [
           {
             type: StepType.CONFIGURE,
-            description: (
-              <p>{t('The Sentry wizard will automatically patch your application:')}</p>
-            ),
-            configurations: [
+            content: [
               {
-                description: (
-                  <List symbol="bullet">
-                    <ListItem>
-                      {t('Install the Sentry SDK via Swift Package Manager or Cocoapods')}
-                    </ListItem>
-                    <ListItem>
-                      {tct(
-                        'Update your [appDelegate: AppDelegate] or SwiftUI App Initializer with the default Sentry configuration and an example error',
-                        {
-                          appDelegate: <code />,
-                        }
-                      )}
-                    </ListItem>
-                    <ListItem>
-                      {tct(
-                        'Add a new [code: Upload Debug Symbols] phase to your [code: xcodebuild] build script',
-                        {
-                          code: <code />,
-                        }
-                      )}
-                    </ListItem>
-                    <ListItem>
-                      {tct(
-                        'Create [code: .sentryclirc] with an auth token to upload debug symbols (this file is automatically added to [code: .gitignore])',
-                        {
-                          code: <code />,
-                        }
-                      )}
-                    </ListItem>
-                    <ListItem>
-                      {t(
-                        "When you're using Fastlane, it will add a Sentry lane for uploading debug symbols"
-                      )}
-                    </ListItem>
-                  </List>
-                ),
+                type: 'text',
+                text: t('The Sentry wizard will automatically patch your application:'),
+              },
+              {
+                type: 'list',
+                items: [
+                  t('Install the Sentry SDK via Swift Package Manager or Cocoapods'),
+                  tct(
+                    'Update your [appDelegate: AppDelegate] or SwiftUI App Initializer with the default Sentry configuration and an example error',
+                    {
+                      appDelegate: <code />,
+                    }
+                  ),
+                  tct(
+                    'Add a new [code: Upload Debug Symbols] phase to your [code: xcodebuild] build script',
+                    {
+                      code: <code />,
+                    }
+                  ),
+                  tct(
+                    'Create [code: .sentryclirc] with an auth token to upload debug symbols (this file is automatically added to [code: .gitignore])',
+                    {
+                      code: <code />,
+                    }
+                  ),
+                  t(
+                    "When you're using Fastlane, it will add a Sentry lane for uploading debug symbols"
+                  ),
+                ],
               },
             ],
           },
@@ -384,9 +381,10 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       : [
           {
             type: StepType.CONFIGURE,
-            description: (
-              <p>
-                {tct(
+            content: [
+              {
+                type: 'text',
+                text: tct(
                   'Make sure you initialize the SDK as soon as possible in your application lifecycle e.g. in your [appDelegate:] method:',
                   {
                     appDelegate: (
@@ -395,38 +393,55 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
                       </code>
                     ),
                   }
-                )}
-              </p>
-            ),
-            configurations: isManualSwift(params)
-              ? [
-                  {
-                    language: 'swift',
-                    code: getConfigurationSnippetSwift(params),
-                  },
-                  {
-                    description: (
-                      <p>
-                        {tct(
-                          "When using SwiftUI and your app doesn't implement an app delegate, initialize the SDK within the [initializer: App conformer's initializer]:",
-                          {
-                            initializer: (
-                              <ExternalLink href="https://developer.apple.com/documentation/swiftui/app/main()" />
-                            ),
-                          }
-                        )}
-                      </p>
-                    ),
-                    language: 'swift',
-                    code: getConfigurationSnippetSwiftUi(params),
-                  },
-                ]
-              : [
-                  {
-                    language: 'objc',
-                    code: getConfigurationSnippetObjectiveC(params),
-                  },
-                ],
+                ),
+              },
+              ...(isManualSwift(params)
+                ? [
+                    {
+                      type: 'code' as const,
+                      tabs: [
+                        {
+                          label: 'Swift',
+                          language: 'swift',
+                          code: getConfigurationSnippetSwift(params),
+                        },
+                      ],
+                    },
+                    {
+                      type: 'text' as const,
+                      text: tct(
+                        "When using SwiftUI and your app doesn't implement an app delegate, initialize the SDK within the [initializer: App conformer's initializer]:",
+                        {
+                          initializer: (
+                            <ExternalLink href="https://developer.apple.com/documentation/swiftui/app/main()" />
+                          ),
+                        }
+                      ),
+                    },
+                    {
+                      type: 'code' as const,
+                      tabs: [
+                        {
+                          label: 'SwiftUI',
+                          language: 'swift',
+                          code: getConfigurationSnippetSwiftUi(params),
+                        },
+                      ],
+                    },
+                  ]
+                : [
+                    {
+                      type: 'code' as const,
+                      tabs: [
+                        {
+                          label: 'Objective-C',
+                          language: 'objc',
+                          code: getConfigurationSnippetObjectiveC(params),
+                        },
+                      ],
+                    },
+                  ]),
+            ],
           },
         ],
   verify: params =>
@@ -434,28 +449,38 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       ? [
           {
             type: StepType.VERIFY,
-            description: t(
-              'The Sentry wizard automatically adds a code snippet that captures a message to your project. Simply run your app and you should see this message in your Sentry project.'
-            ),
+            content: [
+              {
+                type: 'text',
+                text: t(
+                  'The Sentry wizard automatically adds a code snippet that captures a message to your project. Simply run your app and you should see this message in your Sentry project.'
+                ),
+              },
+            ],
           },
         ]
       : [
           {
             type: StepType.VERIFY,
-            description: (
-              <p>
-                {tct(
+            content: [
+              {
+                type: 'text',
+                text: tct(
                   'This snippet contains an intentional error you can use to test that errors are uploaded to Sentry correctly. You can call [verifySentrySDK: verifySentrySDK()] from where you want to test it.',
                   {
                     verifySentrySDK: <code />,
                   }
-                )}
-              </p>
-            ),
-            configurations: [
+                ),
+              },
               {
-                language: selectedLanguage(params),
-                code: getVerifySnippet(params),
+                type: 'code',
+                tabs: [
+                  {
+                    label: isManualSwift(params) ? 'Swift' : 'Objective-C',
+                    language: selectedLanguage(params),
+                    code: getVerifySnippet(params),
+                  },
+                ],
               },
             ],
           },
@@ -488,15 +513,18 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      description: t(
-        'Make sure your Sentry Cocoa SDK version is at least 8.43.0. If you already have the SDK installed, you can update it to the latest version with:'
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: t(
+            'Make sure your Sentry Cocoa SDK version is at least 8.43.0. If you already have the SDK installed, you can update it to the latest version with:'
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'SPM',
-              value: 'spm',
               language: 'swift',
               code: `.package(url: "https://github.com/getsentry/sentry-cocoa", from: "${getPackageVersion(
                 params,
@@ -506,13 +534,11 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
             },
             {
               label: 'CocoaPods',
-              value: 'cocoapods',
               language: 'ruby',
               code: `pod update`,
             },
             {
               label: 'Carthage',
-              value: 'carthage',
               language: 'swift',
               code: `github "getsentry/sentry-cocoa" "${getPackageVersion(
                 params,
@@ -523,15 +549,16 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
           ],
         },
         {
-          description: t(
+          type: 'text',
+          text: t(
             'To set up the integration, add the following to your Sentry initialization:'
           ),
         },
         {
-          code: [
+          type: 'code',
+          tabs: [
             {
               label: 'Swift',
-              value: 'swift',
               language: 'swift',
               code: getReplaySetupSnippet(params),
             },
@@ -543,18 +570,24 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
   configure: () => [
     {
       type: StepType.CONFIGURE,
-      description: getReplayMobileConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/apple/guides/ios/session-replay/#privacy',
-      }),
-      configurations: [
+      content: [
         {
-          description: t(
+          type: 'text',
+          text: getReplayMobileConfigureDescription({
+            link: 'https://docs.sentry.io/platforms/apple/guides/ios/session-replay/#privacy',
+          }),
+        },
+        {
+          type: 'text',
+          text: t(
             'The following code is the default configuration, which masks and blocks everything.'
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'Swift',
-              value: 'swift',
               language: 'swift',
               code: getReplayConfigurationSnippet(),
             },

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -395,52 +395,59 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
                   }
                 ),
               },
-              ...(isManualSwift(params)
-                ? [
-                    {
-                      type: 'code' as const,
-                      tabs: [
-                        {
-                          label: 'Swift',
-                          language: 'swift',
-                          code: getConfigurationSnippetSwift(params),
-                        },
-                      ],
-                    },
-                    {
-                      type: 'text' as const,
-                      text: tct(
-                        "When using SwiftUI and your app doesn't implement an app delegate, initialize the SDK within the [initializer: App conformer's initializer]:",
-                        {
-                          initializer: (
-                            <ExternalLink href="https://developer.apple.com/documentation/swiftui/app/main()" />
-                          ),
-                        }
-                      ),
-                    },
-                    {
-                      type: 'code' as const,
-                      tabs: [
-                        {
-                          label: 'SwiftUI',
-                          language: 'swift',
-                          code: getConfigurationSnippetSwiftUi(params),
-                        },
-                      ],
-                    },
-                  ]
-                : [
-                    {
-                      type: 'code' as const,
-                      tabs: [
-                        {
-                          label: 'Objective-C',
-                          language: 'objc',
-                          code: getConfigurationSnippetObjectiveC(params),
-                        },
-                      ],
-                    },
-                  ]),
+              {
+                type: 'conditional',
+                condition: isManualSwift(params),
+                content: [
+                  {
+                    type: 'code',
+                    tabs: [
+                      {
+                        label: 'Swift',
+                        language: 'swift',
+                        code: getConfigurationSnippetSwift(params),
+                      },
+                    ],
+                  },
+                  {
+                    type: 'text',
+                    text: tct(
+                      "When using SwiftUI and your app doesn't implement an app delegate, initialize the SDK within the [initializer: App conformer's initializer]:",
+                      {
+                        initializer: (
+                          <ExternalLink href="https://developer.apple.com/documentation/swiftui/app/main()" />
+                        ),
+                      }
+                    ),
+                  },
+                  {
+                    type: 'code',
+                    tabs: [
+                      {
+                        label: 'SwiftUI',
+                        language: 'swift',
+                        code: getConfigurationSnippetSwiftUi(params),
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: 'conditional',
+                condition: !isManualSwift(params),
+                content: [
+                  {
+                    type: 'code',
+                    tabs: [
+                      {
+                        label: 'Objective-C',
+                        language: 'objc',
+                        code: getConfigurationSnippetObjectiveC(params),
+                      },
+                    ],
+                  },
+                ],
+              },
             ],
           },
         ],

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -333,7 +333,6 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
                     code: getManualInstallSnippet(params),
                   },
                 ],
-                partialLoading: params.sourcePackageRegistries.isLoading,
               },
             ],
           },

--- a/static/app/gettingStartedDocs/apple/macos.tsx
+++ b/static/app/gettingStartedDocs/apple/macos.tsx
@@ -147,13 +147,8 @@ const onboarding: OnboardingConfig = {
         },
         {
           type: 'code',
-          tabs: [
-            {
-              label: 'Git URL',
-              language: 'url',
-              code: `https://github.com/getsentry/sentry-cocoa.git`,
-            },
-          ],
+          language: 'url',
+          code: `https://github.com/getsentry/sentry-cocoa.git`,
         },
         {
           type: 'text',

--- a/static/app/gettingStartedDocs/apple/macos.tsx
+++ b/static/app/gettingStartedDocs/apple/macos.tsx
@@ -132,9 +132,10 @@ const onboarding: OnboardingConfig = {
   install: params => [
     {
       type: StepType.INSTALL,
-      description: (
-        <p>
-          {tct(
+      content: [
+        {
+          type: 'text',
+          text: tct(
             'We recommend installing the SDK with Swift Package Manager (SPM), but we also support [alternateMethods: alternate installation methods]. To integrate Sentry into your Xcode project using SPM, open your App in Xcode and open [addPackage: File > Add Packages]. Then add the SDK by entering the Git repo url in the top right search field:',
             {
               alternateMethods: (
@@ -142,28 +143,36 @@ const onboarding: OnboardingConfig = {
               ),
               addPackage: <strong />,
             }
-          )}
-        </p>
-      ),
-      configurations: [
-        {
-          language: 'url',
-          code: `https://github.com/getsentry/sentry-cocoa.git`,
+          ),
         },
         {
-          description: (
-            <p>
-              {tct(
-                'Alternatively, when your project uses a [packageSwift: Package.swift] file to manage dependencies, you can specify the target with:',
-                {
-                  packageSwift: <code />,
-                }
-              )}
-            </p>
+          type: 'code',
+          tabs: [
+            {
+              label: 'Git URL',
+              language: 'url',
+              code: `https://github.com/getsentry/sentry-cocoa.git`,
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: tct(
+            'Alternatively, when your project uses a [packageSwift: Package.swift] file to manage dependencies, you can specify the target with:',
+            {
+              packageSwift: <code />,
+            }
           ),
-          language: 'swift',
-          partialLoading: params.sourcePackageRegistries.isLoading,
-          code: getInstallSnippet(params),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'Swift',
+              language: 'swift',
+              code: getInstallSnippet(params),
+            },
+          ],
         },
       ],
     },
@@ -171,9 +180,10 @@ const onboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: (
-        <p>
-          {tct(
+      content: [
+        {
+          type: 'text',
+          text: tct(
             'Make sure you initialize the SDK as soon as possible in your application lifecycle e.g. in your [appDelegate:] method:',
             {
               appDelegate: (
@@ -182,29 +192,38 @@ const onboarding: OnboardingConfig = {
                 </code>
               ),
             }
-          )}
-        </p>
-      ),
-      configurations: [
-        {
-          language: 'swift',
-          code: getConfigurationSnippet(params),
+          ),
         },
         {
-          description: (
-            <p>
-              {tct(
-                "When using SwiftUI and your app doesn't implement an app delegate, initialize the SDK within the [initializer: App conformer's initializer]:",
-                {
-                  initializer: (
-                    <ExternalLink href="https://developer.apple.com/documentation/swiftui/app/main()" />
-                  ),
-                }
-              )}
-            </p>
+          type: 'code',
+          tabs: [
+            {
+              label: 'Swift',
+              language: 'swift',
+              code: getConfigurationSnippet(params),
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: tct(
+            "When using SwiftUI and your app doesn't implement an app delegate, initialize the SDK within the [initializer: App conformer's initializer]:",
+            {
+              initializer: (
+                <ExternalLink href="https://developer.apple.com/documentation/swiftui/app/main()" />
+              ),
+            }
           ),
-          language: 'swift',
-          code: getConfigurationSnippetSwiftUi(params),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'SwiftUI',
+              language: 'swift',
+              code: getConfigurationSnippetSwiftUi(params),
+            },
+          ],
         },
       ],
     },
@@ -212,20 +231,25 @@ const onboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: (
-        <p>
-          {tct(
+      content: [
+        {
+          type: 'text',
+          text: tct(
             'This snippet contains an intentional error you can use to test that errors are uploaded to Sentry correctly. You can add it to your main [viewController: ViewController].',
             {
               viewController: <code />,
             }
-          )}
-        </p>
-      ),
-      configurations: [
+          ),
+        },
         {
-          language: 'swift',
-          code: getVerifySnippet(),
+          type: 'code',
+          tabs: [
+            {
+              label: 'Swift',
+              language: 'swift',
+              code: getVerifySnippet(),
+            },
+          ],
         },
       ],
     },
@@ -259,13 +283,16 @@ export const appleFeedbackOnboarding: OnboardingConfig = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      description: getCrashReportInstallDescription(),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: getCrashReportInstallDescription(),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'Swift',
-              value: 'swift',
               language: 'swift',
               code: `import Sentry
 
@@ -279,7 +306,6 @@ SentrySDK.capture(userFeedback: userFeedback)`,
             },
             {
               label: 'Objective-C',
-              value: 'c',
               language: 'c',
               code: `@import Sentry;
 
@@ -294,14 +320,17 @@ userFeedback.name = @"John Doe";
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'To capture user feedback regarding a crash, use the [code:SentryOptions.onCrashedLastRun] callback. This callback gets called shortly after the initialization of the SDK when the last program execution terminated with a crash. It is not guaranteed that this is called on the main thread.',
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'Swift',
-              value: 'swift',
               language: 'swift',
               code: `import Sentry
 
@@ -315,7 +344,6 @@ SentrySDK.start { options in
             },
             {
               label: 'Objective-C',
-              value: 'c',
               language: 'c',
               code: `@import Sentry;
 


### PR DESCRIPTION
Migrate android and apple platform docs.

- part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)