### PR TITLE
ref(✂️): remove unused screenSummaryPage

### DIFF
--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.spec.tsx
@@ -7,7 +7,7 @@ import {render, screen, waitFor, within} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {ScreenSummary} from 'sentry/views/insights/mobile/appStarts/views/screenSummaryPage';
+import {ScreenSummaryContentPage} from 'sentry/views/insights/mobile/appStarts/views/screenSummaryPage';
 import {SpanFields} from 'sentry/views/insights/types';
 
 jest.mock('sentry/utils/usePageFilters');
@@ -115,7 +115,7 @@ describe('Screen Summary', () => {
         ],
       });
 
-      render(<ScreenSummary />, {organization, deprecatedRouterMocks: true});
+      render(<ScreenSummaryContentPage />, {organization, deprecatedRouterMocks: true});
 
       await waitFor(() => {
         expect(eventsMock).toHaveBeenCalled();

--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
@@ -3,11 +3,9 @@ import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DurationUnit} from 'sentry/utils/discover/fields';
-import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
@@ -28,7 +26,6 @@ import {
 import AppStartWidgets from 'sentry/views/insights/mobile/appStarts/components/widgets';
 import {SpanSamplesPanel} from 'sentry/views/insights/mobile/common/components/spanSamplesPanel';
 import {MobileMetricsRibbon} from 'sentry/views/insights/mobile/screenload/components/metricsRibbon';
-import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
 type Query = {
@@ -42,34 +39,6 @@ type Query = {
   spanOp: string;
   transaction: string;
 };
-
-export function ScreenSummary() {
-  const location = useLocation<Query>();
-  const {transaction: transactionName} = location.query;
-
-  return (
-    <Layout.Page>
-      <PageAlertProvider>
-        <MobileHeader
-          hideDefaultTabs
-          module={ModuleName.MOBILE_VITALS}
-          headerTitle={transactionName}
-          breadcrumbs={[
-            {
-              label: t('Screen Summary'),
-            },
-          ]}
-        />
-        <Layout.Body>
-          <Layout.Main fullWidth>
-            <PageAlert />
-            <ScreenSummaryContentPage />
-          </Layout.Main>
-        </Layout.Body>
-      </PageAlertProvider>
-    </Layout.Page>
-  );
-}
 
 export function ScreenSummaryContentPage() {
   const navigate = useNavigate();


### PR DESCRIPTION
it was only used in a test to wrap the actually used ScreenSummaryContentPage, and the test also works when that is rendered directly