### PR TITLE
fix(ourlogs): Autorefresh only currently works for descending timestamps

### DIFF
--- a/static/app/views/explore/logs/logsAutoRefresh.tsx
+++ b/static/app/views/explore/logs/logsAutoRefresh.tsx
@@ -81,6 +81,15 @@ export function AutorefreshToggle({averageLogsPerSecond = 0}: AutorefreshToggleP
     }
   }, [selectionString, previousSelection, setAutorefresh]);
 
+  const sortBysAreTimeBasedDescending = checkSortIsTimeBasedDescending(sortBys);
+
+  // Changing the sort should also disable autorefresh as there is only one sort (and direction) currently allowed.
+  useEffect(() => {
+    if (!sortBysAreTimeBasedDescending && autoRefresh !== 'idle') {
+      setAutorefresh('idle');
+    }
+  }, [setAutorefresh, sortBysAreTimeBasedDescending, autoRefresh]);
+
   const hasAbsoluteDates = Boolean(selection.datetime.start && selection.datetime.end);
 
   const preFlightDisableReason = getPreFlightDisableReason({


### PR DESCRIPTION
### Summary
There was already a preflight check to disable the toggle for any sort aside from timestamp desc, but if you had enabled the toggle and changed the sort halfway through it kept autorefreshing. This adds the same check when sortBys change. We can eventually add ascending timestamp ability when we split apart GridEditable and are able to have a bounded scroll body for logs.

Refs LOGS-349

