### PR TITLE
fix(chonk-alert): showIcon gets overwritten by undefined value

### DIFF
--- a/static/app/components/core/alert/index.tsx
+++ b/static/app/components/core/alert/index.tsx
@@ -70,13 +70,13 @@ export function Alert({
       system={system}
       expand={expand}
       trailingItems={trailingItems}
-      showIcon={showIcon as false}
       onClick={handleClick}
       hovered={isHovered && !expandIsHovered}
       className={classNames(type ? `ref-${type}` : '', className)}
       type={type}
       {...hoverProps}
       {...props}
+      showIcon={showIcon}
     >
       <PanelProvider>
         {showIcon && (


### PR DESCRIPTION
### Problem
Passing `showIcon={undefined}` will render the icon overlaying the text and without background. 
<img width="132" height="100" alt="Screenshot 2025-09-18 at 15 51 11" src="https://github.com/user-attachments/assets/72c701c5-7030-4921-9e7b-adedc04650d1" />

### Solution
We already use `true` as fallback value `const showIcon = props.showIcon ?? true;`.
When passing it down to the wrapper component we need to make sure that the calculated value overwrites the prop. 