### PR TITLE
ref(analytics): extracting common base class for NotificationSent analytics events

### DIFF
--- a/src/sentry/analytics/events/base_notification_sent.py
+++ b/src/sentry/analytics/events/base_notification_sent.py
@@ -11,7 +11,7 @@ class BaseNotificationSent(analytics.Event, abc.ABC):
     actor_id: int | None = None
     user_id: int | None = None
     group_id: int | None = None
-    id: int
-    actor_type: str
+    id: int | None = None
+    actor_type: str | None = None
     notification_uuid: str
     alert_id: int | None = None

--- a/src/sentry/analytics/events/base_notification_sent.py
+++ b/src/sentry/analytics/events/base_notification_sent.py
@@ -1,0 +1,17 @@
+import abc
+
+from sentry import analytics
+
+
+@analytics.eventclass()
+class BaseNotificationSent(analytics.Event, abc.ABC):
+    organization_id: int
+    project_id: int | None = None
+    category: str
+    actor_id: int | None = None
+    user_id: int | None = None
+    group_id: int | None = None
+    id: int
+    actor_type: str
+    notification_uuid: str
+    alert_id: int | None = None

--- a/src/sentry/integrations/discord/analytics.py
+++ b/src/sentry/integrations/discord/analytics.py
@@ -1,14 +1,10 @@
 from sentry import analytics
+from sentry.analytics.events.base_notification_sent import BaseNotificationSent
 
 
 @analytics.eventclass("integrations.discord.notification_sent")
-class DiscordIntegrationNotificationSent(analytics.Event):
-    organization_id: int
-    project_id: int | None = None
-    category: str
-    group_id: int | None = None
-    notification_uuid: str
-    alert_id: int | None = None
+class DiscordIntegrationNotificationSent(BaseNotificationSent):
+    pass
 
 
 @analytics.eventclass("integrations.discord.command_interaction")

--- a/src/sentry/integrations/msteams/analytics.py
+++ b/src/sentry/integrations/msteams/analytics.py
@@ -1,15 +1,10 @@
 from sentry import analytics
+from sentry.analytics.events.base_notification_sent import BaseNotificationSent
 
 
 @analytics.eventclass("integrations.msteams.notification_sent")
-class MSTeamsIntegrationNotificationSent(analytics.Event):
-    organization_id: int
-    project_id: int | None = None
-    category: str
-    actor_id: int | None = None
-    user_id: int | None = None
-    notification_uuid: str
-    alert_id: int | None = None
+class MSTeamsIntegrationNotificationSent(BaseNotificationSent):
+    pass
 
 
 analytics.register(MSTeamsIntegrationNotificationSent)

--- a/src/sentry/integrations/opsgenie/analytics.py
+++ b/src/sentry/integrations/opsgenie/analytics.py
@@ -1,14 +1,10 @@
 from sentry import analytics
+from sentry.analytics.events.base_notification_sent import BaseNotificationSent
 
 
 @analytics.eventclass("integrations.opsgenie.notification_sent")
-class OpsgenieIntegrationNotificationSent(analytics.Event):
-    organization_id: int
-    project_id: int | None = None
-    category: str
-    group_id: int | None = None
-    notification_uuid: str
-    alert_id: int | None = None
+class OpsgenieIntegrationNotificationSent(BaseNotificationSent):
+    pass
 
 
 analytics.register(OpsgenieIntegrationNotificationSent)

--- a/src/sentry/integrations/pagerduty/analytics.py
+++ b/src/sentry/integrations/pagerduty/analytics.py
@@ -1,14 +1,10 @@
 from sentry import analytics
+from sentry.analytics.events.base_notification_sent import BaseNotificationSent
 
 
 @analytics.eventclass("integrations.pagerduty.notification_sent")
-class PagerdutyIntegrationNotificationSent(analytics.Event):
-    organization_id: int
-    project_id: int | None = None
-    category: str
-    group_id: int | None = None
-    notification_uuid: str
-    alert_id: int | None = None
+class PagerdutyIntegrationNotificationSent(BaseNotificationSent):
+    pass
 
 
 analytics.register(PagerdutyIntegrationNotificationSent)

--- a/src/sentry/integrations/slack/analytics.py
+++ b/src/sentry/integrations/slack/analytics.py
@@ -1,4 +1,5 @@
 from sentry import analytics
+from sentry.analytics.events.base_notification_sent import BaseNotificationSent
 
 
 @analytics.eventclass("integrations.slack.assign")
@@ -15,16 +16,8 @@ class SlackIntegrationStatus(analytics.Event):
 
 
 @analytics.eventclass("integrations.slack.notification_sent")
-class SlackIntegrationNotificationSent(analytics.Event):
-    organization_id: int
-    project_id: int | None = None
-    category: str
-    actor_id: int | None = None
-    user_id: int | None = None
-    group_id: int | None = None
-    notification_uuid: str
-    alert_id: int | None = None
-    actor_type: str | None = None
+class SlackIntegrationNotificationSent(BaseNotificationSent):
+    pass
 
 
 @analytics.eventclass("integrations.slack.identity_linked")

--- a/src/sentry/mail/analytics.py
+++ b/src/sentry/mail/analytics.py
@@ -1,19 +1,10 @@
 from sentry import analytics
+from sentry.analytics.events.base_notification_sent import BaseNotificationSent
 
 
-# TODO: should have same base class as SlackIntegrationNotificationSent
 @analytics.eventclass("integrations.email.notification_sent")
-class EmailNotificationSent(analytics.Event):
-    organization_id: int
-    project_id: int | None = None
-    category: str
-    actor_id: int | None = None
-    user_id: int | None = None
-    group_id: int | None = None
-    id: int
-    actor_type: str
-    notification_uuid: str
-    alert_id: int | None = None
+class EmailNotificationSent(BaseNotificationSent):
+    pass
 
 
 analytics.register(EmailNotificationSent)

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -195,8 +195,7 @@ class BaseNotification(abc.ABC):
             }
 
             try:
-                event_class = PROVIDER_TO_EVENT_CLASS.get(provider)
-                if event_class is None:
+                if event_class := PROVIDER_TO_EVENT_CLASS.get(provider):
                     analytics.record(
                         event_class(
                             organization_id=self.organization.id,

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -182,105 +182,35 @@ class BaseNotification(abc.ABC):
         from sentry.integrations.slack.analytics import SlackIntegrationNotificationSent
 
         with sentry_sdk.start_span(op="notification.send", name="record_notification_sent"):
-            event: analytics.Event | None = None
-
             project: Project | None = getattr(self, "project", None)
             group: Group | None = getattr(self, "group", None)
 
-            def create_notification_sent_event(
-                provider: ExternalProviders,
-                organization_id: int,
-                project_id: int | None,
-                category: str,
-                actor_id: int | None,
-                user_id: int | None,
-                group_id: int | None,
-                id: int,
-                actor_type: str,
-                notification_uuid: str,
-                alert_id: int | None,
-            ) -> analytics.Event | None:
-                if provider == ExternalProviders.EMAIL:
-                    return EmailNotificationSent(
-                        organization_id=organization_id,
-                        project_id=project_id,
-                        category=category,
-                        actor_id=actor_id,
-                        user_id=user_id,
-                        group_id=group_id,
-                        id=id,
-                        actor_type=actor_type,
-                        notification_uuid=notification_uuid,
-                        alert_id=alert_id,
-                    )
-                elif provider == ExternalProviders.SLACK:
-                    return SlackIntegrationNotificationSent(
-                        organization_id=organization_id,
-                        project_id=project_id,
-                        category=category,
-                        actor_id=actor_id,
-                        user_id=user_id,
-                        group_id=group_id,
-                        notification_uuid=notification_uuid,
-                        alert_id=alert_id,
-                        actor_type=actor_type,
-                    )
-                elif provider == ExternalProviders.PAGERDUTY:
-                    return PagerdutyIntegrationNotificationSent(
-                        organization_id=organization_id,
-                        project_id=project_id,
-                        category=category,
-                        group_id=group_id,
-                        notification_uuid=notification_uuid,
-                        alert_id=alert_id,
-                    )
-                elif provider == ExternalProviders.OPSGENIE:
-                    return OpsgenieIntegrationNotificationSent(
-                        organization_id=organization_id,
-                        project_id=project_id,
-                        category=category,
-                        group_id=group_id,
-                        notification_uuid=notification_uuid,
-                        alert_id=alert_id,
-                    )
-                elif provider == ExternalProviders.DISCORD:
-                    return DiscordIntegrationNotificationSent(
-                        organization_id=organization_id,
-                        project_id=project_id,
-                        category=category,
-                        group_id=group_id,
-                        notification_uuid=notification_uuid,
-                        alert_id=alert_id,
-                    )
-                elif provider == ExternalProviders.MSTEAMS:
-                    return MSTeamsIntegrationNotificationSent(
-                        organization_id=organization_id,
-                        project_id=project_id,
-                        category=category,
-                        actor_id=actor_id,
-                        user_id=user_id,
-                        notification_uuid=notification_uuid,
-                        alert_id=alert_id,
-                    )
-                return None
+            PROVIDER_TO_EVENT_CLASS = {
+                ExternalProviders.EMAIL: EmailNotificationSent,
+                ExternalProviders.SLACK: SlackIntegrationNotificationSent,
+                ExternalProviders.MSTEAMS: MSTeamsIntegrationNotificationSent,
+                ExternalProviders.PAGERDUTY: PagerdutyIntegrationNotificationSent,
+                ExternalProviders.OPSGENIE: OpsgenieIntegrationNotificationSent,
+                ExternalProviders.DISCORD: DiscordIntegrationNotificationSent,
+            }
 
             try:
-                event = create_notification_sent_event(
-                    provider,
-                    organization_id=self.organization.id,
-                    project_id=project.id if project else None,
-                    category=self.metrics_key,
-                    actor_id=recipient.id if recipient.is_user else None,
-                    user_id=recipient.id if recipient.is_user else None,
-                    group_id=group.id if group else None,
-                    id=recipient.id,
-                    actor_type=recipient.actor_type,
-                    notification_uuid=self.notification_uuid,
-                    alert_id=self.alert_id if self.alert_id else None,
-                )
-
-                if event is not None:
-                    analytics.record(event)
+                event_class = PROVIDER_TO_EVENT_CLASS.get(provider)
+                if event_class is None:
+                    analytics.record(
+                        event_class(
+                            organization_id=self.organization.id,
+                            project_id=project.id if project else None,
+                            category=self.metrics_key,
+                            actor_id=recipient.id if recipient.is_user else None,
+                            user_id=recipient.id if recipient.is_user else None,
+                            group_id=group.id if group else None,
+                            id=recipient.id,
+                            actor_type=recipient.actor_type,
+                            notification_uuid=self.notification_uuid,
+                            alert_id=self.alert_id if self.alert_id else None,
+                        )
+                    )
             except Exception as e:
                 sentry_sdk.capture_exception(e)
 

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -290,7 +290,7 @@ class ActivityNotificationTest(APITestCase):
                 actor_type="User",
                 category="",
             ),
-            exclude_fields=["category", "project_id", "actor_id", "actor_type"],
+            exclude_fields=["category", "id", "project_id", "actor_id", "actor_type"],
         )
 
     @patch("sentry.analytics.record")
@@ -365,7 +365,7 @@ class ActivityNotificationTest(APITestCase):
                 actor_type="User",
                 category="",
             ),
-            exclude_fields=["category", "project_id", "actor_id", "actor_type"],
+            exclude_fields=["category", "id", "project_id", "actor_id", "actor_type"],
         )
 
     @patch("sentry.analytics.record")
@@ -442,7 +442,7 @@ class ActivityNotificationTest(APITestCase):
                 actor_type="User",
                 category="",
             ),
-            exclude_fields=["category", "project_id", "actor_id", "actor_type"],
+            exclude_fields=["category", "id", "project_id", "actor_id", "actor_type"],
         )
 
     @patch("sentry.analytics.record")
@@ -513,7 +513,7 @@ class ActivityNotificationTest(APITestCase):
                 actor_type="User",
                 category="",
             ),
-            exclude_fields=["category", "project_id", "actor_id", "actor_type"],
+            exclude_fields=["category", "id", "project_id", "actor_id", "actor_type"],
         )
 
     def test_sends_processing_issue_notification(self, mock_post: MagicMock) -> None:
@@ -606,5 +606,5 @@ class ActivityNotificationTest(APITestCase):
                 actor_type="User",
                 category="",
             ),
-            exclude_fields=["category", "project_id", "actor_id", "actor_type"],
+            exclude_fields=["category", "id", "project_id", "actor_id", "actor_type"],
         )


### PR DESCRIPTION
Effectively this adds the following fields to these events:

DiscordIntegrationNotificationSent

-     actor_id: int | None = None
-     user_id: int | None = None
-     id: int | None = None
-     actor_type: str | None = None

MSTeamsIntegrationNotificationSent

-     group_id: int | None = None
-     id: int | None = None
-     actor_type: str | None = None

OpsgenieIntegrationNotificationSent

-     actor_id: int | None = None
-     user_id: int | None = None
-     id: int | None = None
-     actor_type: str | None = None

PagerdutyIntegrationNotificationSent

-     actor_id: int | None = None
-     user_id: int | None = None
-     id: int | None = None
-     actor_type: str | None = None

SlackIntegrationNotificationSent

-     id: int | None = None


For EmailNotificationSent it effectively changes the `id` and `actor_type` fields to be optional

-     id: int | None = None
-     actor_type: str | None = None


Closes https://linear.app/getsentry/issue/TET-1136/analytics-standardize-analytics-events-for-notification-sent-across