### PR TITLE
fix(groups): use event timestamp when creating group environment

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -560,7 +560,7 @@ class EventManager:
         job["event"].data.bind_ref(job["event"])
 
         _get_or_create_environment_many(jobs, projects)
-        _get_or_create_group_environment_many(jobs, job["event"].datetime)
+        _get_or_create_group_environment_many(jobs)
         _get_or_create_release_associated_models(jobs, projects)
         _increment_release_associated_counts_many(jobs, projects)
         _get_or_create_group_release_many(jobs)
@@ -910,10 +910,10 @@ def _get_or_create_environment_many(jobs: Sequence[Job], projects: ProjectsMappi
 
 
 @sentry_sdk.tracing.trace
-def _get_or_create_group_environment_many(jobs: Sequence[Job], event_datetime: datetime) -> None:
+def _get_or_create_group_environment_many(jobs: Sequence[Job]) -> None:
     for job in jobs:
         _get_or_create_group_environment(
-            job["environment"], job["release"], job["groups"], event_datetime
+            job["environment"], job["release"], job["groups"], job["event"].datetime
         )
 
 

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -66,7 +66,7 @@ def save_issue_occurrence(
     group_info = save_issue_from_occurrence(occurrence, event, release)
     if group_info:
         environment = event.get_environment()
-        _get_or_create_group_environment(environment, release, [group_info])
+        _get_or_create_group_environment(environment, release, [group_info], event.datetime)
         _increment_release_associated_counts(
             group_info.group.project, environment, release, [group_info]
         )

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1555,7 +1555,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
     @mock.patch("sentry.event_manager.eventstream.backend.insert")
     def test_multi_group_environment(self, eventstream_insert: mock.MagicMock) -> None:
-        def save_event(env) -> Event:
+        def save_event(env: str) -> Event:
             manager = EventManager(
                 make_event(
                     **{
@@ -1570,6 +1570,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             return manager.save(self.project.id)
 
         event = save_event("dev")
+        assert event.group_id is not None
 
         instance = GroupEnvironment.objects.get(
             group_id=event.group_id,
@@ -1581,6 +1582,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert instance.first_seen == event.datetime
 
         event = save_event("prod")
+        assert event.group_id is not None
 
         new_instance = GroupEnvironment.objects.get(
             group_id=event.group_id,

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1554,6 +1554,45 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert None not in event.tags
 
     @mock.patch("sentry.event_manager.eventstream.backend.insert")
+    def test_multi_group_environment(self, eventstream_insert: mock.MagicMock) -> None:
+        def save_event(env) -> Event:
+            manager = EventManager(
+                make_event(
+                    **{
+                        "message": "foo",
+                        "event_id": uuid.uuid1().hex,
+                        "environment": env,
+                        "release": "1.0",
+                    }
+                )
+            )
+            manager.normalize()
+            return manager.save(self.project.id)
+
+        event = save_event("dev")
+
+        instance = GroupEnvironment.objects.get(
+            group_id=event.group_id,
+            environment_id=Environment.objects.get(
+                organization_id=self.project.organization_id, name="dev"
+            ).id,
+        )
+
+        assert instance.first_seen == event.datetime
+
+        event = save_event("prod")
+
+        new_instance = GroupEnvironment.objects.get(
+            group_id=event.group_id,
+            environment_id=Environment.objects.get(
+                organization_id=self.project.organization_id, name="prod"
+            ).id,
+        )
+
+        assert new_instance.id != instance.id
+        assert new_instance.first_seen == event.datetime
+
+    @mock.patch("sentry.event_manager.eventstream.backend.insert")
     def test_group_environment(self, eventstream_insert: mock.MagicMock) -> None:
         release_version = "1.0"
 
@@ -1582,6 +1621,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             ).id,
         )
 
+        assert instance.first_seen == event.datetime
         assert Release.objects.get(id=instance.first_release_id).version == release_version
 
         group_states1 = {

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -406,9 +406,9 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         assert result["count"] == "3"
         # result is rounded down to nearest second
         assert result["lastSeen"] == self.min_ago.replace(microsecond=0)
-        assert result["firstSeen"] == group_env.first_seen
+        assert result["firstSeen"] == group_env2.first_seen
         assert group_env2.first_seen is not None
-        assert group_env2.first_seen > group_env.first_seen
+        assert group_env2.first_seen < group_env.first_seen
         assert result["userCount"] == 3
 
         result = serialize(


### PR DESCRIPTION
Currently, we use the default timestamp, which at best, is slightly after when the issue was actually seen, and at worst (if jobs are delayed for some reason) is incredibly late.
