### PR TITLE
Fix unused exported type in SmartSearchBar

### DIFF
--- a/static/app/components/deprecatedSmartSearchBar/index.tsx
+++ b/static/app/components/deprecatedSmartSearchBar/index.tsx
@@ -2224,7 +2224,6 @@ class SmartSearchBarContainer extends Component<Props, ContainerState> {
 
 export default withApi(withSentryRouter(withOrganization(SmartSearchBarContainer)));
 
-export type {Props as SmartSearchBarProps};
 export {DeprecatedSmartSearchBar};
 
 const Container = styled('div')<{inputHasFocus: boolean}>`


### PR DESCRIPTION
<!-- Describe your PR here. -->
Removes the unused `SmartSearchBarProps` type export to resolve a knip error. This type was not utilized anywhere in the codebase.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/D090L9MST54/p1758206490909919?thread_ts=1758206490.909919&cid=D090L9MST54)

<a href="https://cursor.com/background-agent?bcId=bc-0ada9d70-7d45-4caa-a472-a4aa3f13e36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0ada9d70-7d45-4caa-a472-a4aa3f13e36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

