### PR TITLE
fix(ourlogs): Hide advanced replayid before flag

### DIFF
--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -548,7 +548,10 @@ function BasicDiscoverRenderer(props: LogFieldRendererProps) {
 
 function ReplayIDRenderer(props: LogFieldRendererProps) {
   const replayId = props.item.value;
-  if (typeof replayId !== 'string' || !replayId) {
+
+  const hasFeature = props.extra.organization.features.includes('ourlogs-replay-ui');
+
+  if (typeof replayId !== 'string' || !replayId || !hasFeature) {
     return props.basicRendered;
   }
 


### PR DESCRIPTION
Flag should control whether the link is shown as well
