### PR TITLE
fix(uptime): Add missing migration dependency

### DIFF
--- a/src/sentry/uptime/migrations/0045_backfill_detector_thresholds.py
+++ b/src/sentry/uptime/migrations/0045_backfill_detector_thresholds.py
@@ -52,6 +52,7 @@ class Migration(CheckedMigration):
 
     dependencies = [
         ("uptime", "0044_remove_project_uptime_subscription"),
+        ("workflow_engine", "0085_crons_link_detectors_to_all_workflows"),
     ]
 
     operations = [


### PR DESCRIPTION
Since we're using the Detector model we need a dependency on the
workflow engine.

Without it we get errors like this while trying to run the migration

```
LookupError: No installed app with label 'workflow_engine'.
```