### PR TITLE
Increase timeout from 5 to 10 minutes for migrations

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -56,7 +56,7 @@ jobs:
 
   devenv:
     runs-on: ubuntu-24.04
-    timeout-minutes: 7
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -56,7 +56,7 @@ jobs:
 
   devenv:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 7
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 


### PR DESCRIPTION
Migrations have been [timing]( https://sentry.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22failure_rate%28%29%22%5D%7D&field=id&field=span.op&field=span.description&field=span.duration&field=transaction&field=timestamp&field=span.status&mode=samples&project=5899451&query=devenv%20span.status%3Aunimplemented&statsPeriod=90d&table=span) out on PRs