### PR TITLE
chore(spans-migration): add validation for returning migrated explore queries

### DIFF
--- a/src/sentry/explore/endpoints/explore_saved_queries.py
+++ b/src/sentry/explore/endpoints/explore_saved_queries.py
@@ -32,6 +32,7 @@ from sentry.explore.endpoints.bases import ExploreSavedQueryPermission
 from sentry.explore.endpoints.serializers import ExploreSavedQuerySerializer
 from sentry.explore.models import (
     ExploreSavedQuery,
+    ExploreSavedQueryDataset,
     ExploreSavedQueryLastVisited,
     ExploreSavedQueryStarred,
 )
@@ -333,6 +334,12 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
             .prefetch_related("projects")
             .extra(select={"lower_name": "lower(name)"})
         )
+
+        if not features.has(
+            "organizations:expose-migrated-discover-queries", organization, actor=request.user
+        ):
+            queryset = queryset.exclude(dataset=ExploreSavedQueryDataset.SEGMENT_SPANS)
+
         query = request.query_params.get("query")
         if query:
             tokens = tokenize_query(query)


### PR DESCRIPTION
In preparation for migration I've put in some validation in the get explore queries get endpoint to ensure we're not returning `SEGMENT_SPANS` queries for users/orgs that are not on the feature. 

https://linear.app/getsentry/issue/EXP-313/feature-flag-backend-api-for-returning-migrated-queries