### PR TITLE
fix(content-blocks): Add support in profiling onboarding

### DIFF
--- a/static/app/views/profiling/onboarding.tsx
+++ b/static/app/views/profiling/onboarding.tsx
@@ -6,6 +6,7 @@ import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
+import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
 import {
   OnboardingCodeSnippet,
   TabbedCodeSnippet,
@@ -130,7 +131,11 @@ function StepRenderer({
 
   return (
     <GuidedSteps.Step stepKey={type || title} title={title || (type && StepTitles[type])}>
-      <ConfigurationRenderer configuration={step} />
+      {step.content ? (
+        <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
+      ) : (
+        <ConfigurationRenderer configuration={step} />
+      )}
       <GuidedSteps.ButtonWrapper>
         <GuidedSteps.BackButton size="md" />
         <GuidedSteps.NextButton size="md" />


### PR DESCRIPTION
Add support for rendering content blocks in the profiling onboarding.