### PR TITLE
fix(detectors): Fix `urlparse` ValueErrors

### DIFF
--- a/src/sentry/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/performance_issues/detectors/consecutive_http_detector.py
@@ -6,10 +6,11 @@ from sentry.issues.grouptype import PerformanceConsecutiveHTTPQueriesGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.performance_issues.base import get_url_from_span
 from sentry.performance_issues.detectors.utils import (
     get_max_span_duration,
     get_total_span_duration,
-    has_filtered_url,
+    is_filtered_url,
 )
 from sentry.utils.event import is_event_from_browser_javascript_sdk
 from sentry.utils.safe import get_path
@@ -167,7 +168,8 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         if any([x in description for x in ["_next/static/", "_next/data/", "googleapis.com"]]):
             return False
 
-        if has_filtered_url(self._event, span):
+        url = get_url_from_span(span)
+        if is_filtered_url(url):
             return False
 
         return True

--- a/src/sentry/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
+++ b/src/sentry/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
@@ -22,7 +22,7 @@ from sentry.performance_issues.base import (
     parameterize_url,
     parameterize_url_with_result,
 )
-from sentry.performance_issues.detectors.utils import get_total_span_duration, has_filtered_url
+from sentry.performance_issues.detectors.utils import get_total_span_duration, is_filtered_url
 from sentry.performance_issues.performance_problem import PerformanceProblem
 from sentry.performance_issues.types import Span
 
@@ -132,7 +132,7 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
         if not url:
             return False
 
-        if has_filtered_url(self._event, span):
+        if is_filtered_url(url):
             return False
 
         # Once most users update their SDKs to use the latest standard, we

--- a/src/sentry/performance_issues/detectors/http_overhead_detector.py
+++ b/src/sentry/performance_issues/detectors/http_overhead_detector.py
@@ -9,7 +9,8 @@ from sentry.issues.grouptype import PerformanceHTTPOverheadGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.performance_issues.detectors.utils import has_filtered_url
+from sentry.performance_issues.base import get_url_from_span
+from sentry.performance_issues.detectors.utils import is_filtered_url
 
 from ..base import (
     DetectorType,
@@ -116,7 +117,8 @@ class HTTPOverheadDetector(PerformanceDetector):
             return False
 
         # Check if any spans have filtered URLs
-        if has_filtered_url(self._event, span):
+        url = get_url_from_span(span)
+        if is_filtered_url(url):
             return False
 
         return True

--- a/src/sentry/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -24,7 +24,7 @@ from sentry.performance_issues.base import (
     get_url_from_span,
     parameterize_url,
 )
-from sentry.performance_issues.detectors.utils import get_total_span_duration, has_filtered_url
+from sentry.performance_issues.detectors.utils import get_total_span_duration, is_filtered_url
 from sentry.performance_issues.performance_problem import PerformanceProblem
 from sentry.performance_issues.types import Span
 
@@ -132,7 +132,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
             return False
 
         # Check if any spans have filtered URLs
-        if has_filtered_url(self._event, span):
+        if is_filtered_url(url):
             return False
 
         # Once most users update their SDKs to use the latest standard, we

--- a/src/sentry/performance_issues/detectors/utils.py
+++ b/src/sentry/performance_issues/detectors/utils.py
@@ -1,9 +1,10 @@
 import re
-from typing import Any
 
 from sentry.performance_issues.base import get_span_duration
 
 from ..types import Span
+
+FILTERED_KEYWORDS = ["[Filtered]", "[ip]", "[REDACTED]", "[id]"]
 
 
 def get_total_span_duration(spans: list[Span]) -> float:
@@ -25,10 +26,5 @@ def escape_transaction(transaction: str) -> str:
     return transaction
 
 
-def has_filtered_url(event: dict[str, Any], span: Span) -> bool:
-    event_spans = event.get("spans", [])
-    span_index = str(event_spans.index(span) if span in event_spans else -1)
-    meta = event.get("_meta", {}).get("spans", {})
-    if span_index in meta and meta[span_index].get("data", {}).get("url", {}):
-        return True
-    return False
+def is_filtered_url(url: str) -> bool:
+    return any(keyword in url for keyword in FILTERED_KEYWORDS)


### PR DESCRIPTION
original fix in https://github.com/getsentry/sentry/pull/97694 doesn't fully work in production because of the `_meta` attribute.

while not an optimal solution, for now we will search for the known strings that cause this error until we are able to clarify why the original solution doesn't work and hopefully update it. 