### PR TITLE
fix: slash on endpoint

### DIFF
--- a/src/sentry/integrations/github/tasks/codecov_account_link.py
+++ b/src/sentry/integrations/github/tasks/codecov_account_link.py
@@ -13,7 +13,7 @@ from sentry.taskworker.retry import Retry
 
 logger = logging.getLogger(__name__)
 
-account_link_endpoint = "sentry/internal/account/link/"
+account_link_endpoint = "/sentry/internal/account/link/"
 
 
 @instrumented_task(

--- a/src/sentry/integrations/github/tasks/codecov_account_unlink.py
+++ b/src/sentry/integrations/github/tasks/codecov_account_unlink.py
@@ -11,7 +11,7 @@ from sentry.taskworker.retry import Retry
 
 logger = logging.getLogger(__name__)
 
-account_unlink_endpoint = "sentry/internal/account/unlink/"
+account_unlink_endpoint = "/sentry/internal/account/unlink/"
 
 
 @instrumented_task(


### PR DESCRIPTION
Forgot the opening slash so endpoint contains .iosentry/blah blah

[related logs](https://console.cloud.google.com/logs/query;query=jsonPayload.event:%20%22codecov.account_link%22%0A;cursorTimestamp=2025-09-18T13:58:43.986266574Z;duration=PT3H?project=internal-sentry&rapt=AEjHL4PPhDlj9JOkF6UKIyGgMWC824rGrj6jRruj7vwr0k2dE6SN64zipMOREOAuSr_ODOORLhQsgDz-dvxfptnVyucFwYJjQfFsiSD1Re1tZToI7rsp5PQ)

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
