### PR TITLE
feat(aci): webhook action validator

### DIFF
--- a/src/sentry/notifications/notification_action/__init__.py
+++ b/src/sentry/notifications/notification_action/__init__.py
@@ -34,6 +34,9 @@ __all__ = [
     "GithubActionValidatorHandler",
     "GithubEnterpriseActionValidatorHandler",
     "PagerdutyActionValidatorHandler",
+    "OpsgenieActionValidatorHandler",
+    "SentryAppActionValidatorHandler",
+    "WebhookActionValidatorHandler",
 ]
 
 from .action_handler_registry import (
@@ -49,8 +52,11 @@ from .action_validation import (
     JiraActionValidatorHandler,
     JiraServerActionValidatorHandler,
     MSTeamsActionValidatorHandler,
+    OpsgenieActionValidatorHandler,
     PagerdutyActionValidatorHandler,
+    SentryAppActionValidatorHandler,
     SlackActionValidatorHandler,
+    WebhookActionValidatorHandler,
 )
 from .group_type_notification_registry import IssueAlertRegistryHandler, MetricAlertRegistryHandler
 from .grouptype import SendTestNotification

--- a/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
@@ -22,11 +22,6 @@ class EmailActionHandler(ActionHandler):
         },
         "required": ["target_type"],
         "additionalProperties": False,
-        "if": {"properties": {"target_type": {"enum": [ActionTarget.USER, ActionTarget.TEAM]}}},
-        "then": {
-            "properties": {"target_identifier": {"type": "string"}},
-            "required": ["target_type", "target_identifier"],
-        },
     }
     data_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
@@ -22,6 +22,11 @@ class EmailActionHandler(ActionHandler):
         },
         "required": ["target_type"],
         "additionalProperties": False,
+        "if": {"properties": {"target_type": {"enum": [ActionTarget.USER, ActionTarget.TEAM]}}},
+        "then": {
+            "properties": {"target_identifier": {"type": "string"}},
+            "required": ["target_type", "target_identifier"],
+        },
     }
     data_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/src/sentry/notifications/notification_action/action_validation.py
+++ b/src/sentry/notifications/notification_action/action_validation.py
@@ -13,9 +13,12 @@ from sentry.integrations.slack.actions.form import SlackNotifyServiceForm
 from sentry.models.organization import Organization
 from sentry.notifications.notification_action.registry import action_validator_registry
 from sentry.rules.actions.integrations.create_ticket.form import IntegrationNotifyServiceForm
+from sentry.rules.actions.notify_event_service import NotifyEventServiceForm
 from sentry.rules.actions.sentry_apps.utils import validate_sentry_app_action
+from sentry.sentry_apps.services.app.service import app_service
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.workflow_engine.models.action import Action
+from sentry.workflow_engine.processors.action import get_notification_plugins_for_org
 from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 from .types import BaseActionValidatorHandler
@@ -220,3 +223,31 @@ class SentryAppActionValidatorHandler:
             return self.validated_data
         except SentryAppBaseError as e:
             raise ValidationError(e.message) from e
+
+
+@action_validator_registry.register(Action.Type.WEBHOOK)
+class WebhookActionValidatorHandler(BaseActionValidatorHandler):
+    provider = Action.Type.WEBHOOK
+    notify_action_form = NotifyEventServiceForm
+
+    def _get_services(self) -> list[Any]:
+        plugins = get_notification_plugins_for_org(self.organization)
+        sentry_apps = app_service.find_alertable_services(organization_id=self.organization.id)
+        return [
+            *plugins,
+            *sentry_apps,
+        ]
+
+    def generate_action_form_payload(self) -> dict[str, Any]:
+        return {
+            "services": self._get_services(),
+            "data": self.generate_action_form_data(),
+        }
+
+    def generate_action_form_data(self) -> dict[str, Any]:
+        return {
+            "service": self.validated_data["config"]["target_identifier"],
+        }
+
+    def update_action_data(self, cleaned_data: dict[str, Any]) -> dict[str, Any]:
+        return self.validated_data

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_webhook.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_webhook.py
@@ -1,0 +1,100 @@
+from rest_framework.exceptions import ErrorDetail
+
+from sentry.plugins.base import plugins
+from sentry.plugins.sentry_webhooks.plugin import WebHooksPlugin
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
+from sentry.workflow_engine.models import Action
+from sentry_plugins.trello.plugin import TrelloPlugin
+
+
+class TestWebhookActionValidator(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.webhooks_plugin = plugins.get(WebHooksPlugin.slug)
+        self.webhooks_plugin.enable(self.project)
+
+        # non notification plugin
+        self.trello_plugin = plugins.get(TrelloPlugin.slug)
+        self.trello_plugin.enable(self.project)
+
+        self.alertable_sentry_app = self.create_sentry_app(
+            organization=self.organization,
+            name="Test Application 1",
+            is_alertable=True,
+        )
+        self.create_sentry_app_installation(
+            slug=self.alertable_sentry_app.slug, organization=self.organization
+        )
+
+        self.non_alertable_sentry_app = self.create_sentry_app(
+            organization=self.organization,
+            name="Test Application 2",
+            is_alertable=False,
+        )
+        self.create_sentry_app_installation(
+            slug=self.non_alertable_sentry_app.slug, organization=self.organization
+        )
+
+        self.valid_data = {
+            "type": Action.Type.WEBHOOK,
+            "config": {"targetIdentifier": self.alertable_sentry_app.slug},
+            "data": {},
+        }
+
+    def test_validate__sentry_app(self):
+        validator = BaseActionValidator(
+            data=self.valid_data,
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is True
+        validator.save()
+
+    def test_validate__invalid_sentry_app(self):
+        validator = BaseActionValidator(
+            data={
+                **self.valid_data,
+                "config": {"targetIdentifier": self.non_alertable_sentry_app.slug},
+            },
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False
+        assert validator.errors == {
+            "service": [
+                ErrorDetail(
+                    string=f"Select a valid choice. {self.non_alertable_sentry_app.slug} is not one of the available choices.",
+                    code="invalid",
+                )
+            ]
+        }
+
+    def test_validate__plugin(self):
+        validator = BaseActionValidator(
+            data={**self.valid_data, "config": {"targetIdentifier": self.webhooks_plugin.slug}},
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is True
+        validator.save()
+
+    def test_validate__invalid_plugin(self):
+        validator = BaseActionValidator(
+            data={**self.valid_data, "config": {"targetIdentifier": self.trello_plugin.slug}},
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False
+        assert validator.errors == {
+            "service": [
+                ErrorDetail(
+                    string=f"Select a valid choice. {self.trello_plugin.slug} is not one of the available choices.",
+                    code="invalid",
+                )
+            ]
+        }


### PR DESCRIPTION
The `webhook` action type represents individual plugin or alertable sentry app actions.

Plugins are project-based but Actions are org-based. We allow adding an action with any valid plugin for the org (see https://github.com/getsentry/sentry/pull/88361)