### PR TITLE
fix(nav-cleanup): Fix onboarding links to use new url structure

### DIFF
--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -58,14 +58,14 @@ function getOnboardingInstructionsUrl({projects, organization}: Options) {
   // but if the user falls into this case for some reason,
   // he needs to select the platform again since it is not available as a parameter here
   if (!projects?.length) {
-    return `/${organization.slug}/:projectId/getting-started/`;
+    return `/organizations/${organization.slug}/insights/projects/:projectId/getting-started/`;
   }
 
   const allProjectsWithoutErrors = projects.every(project => !project.firstEvent);
   // If all created projects don't have any errors,
   // we ask the user to pick a project before navigating to the instructions
   if (allProjectsWithoutErrors) {
-    return `/${organization.slug}/:projectId/getting-started/`;
+    return `/organizations/${organization.slug}/insights/projects/:projectId/getting-started/`;
   }
 
   // Pick the first project without an error
@@ -74,7 +74,7 @@ function getOnboardingInstructionsUrl({projects, organization}: Options) {
   // but if the user falls into this case for some reason, we pick the first project
   const project = firstProjectWithoutError ?? projects[0]!;
 
-  let url = `/${organization.slug}/${project.slug}/getting-started/`;
+  let url = `/organizations/${organization.slug}/insights/projects/${project.slug}/getting-started/`;
 
   if (project.platform) {
     url = url + `${project.platform}/`;

--- a/static/app/components/waitingForEvents.tsx
+++ b/static/app/components/waitingForEvents.tsx
@@ -11,6 +11,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import useApi from 'sentry/utils/useApi';
 import CreateSampleEventButton from 'sentry/views/onboarding/createSampleEventButton';
+import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
 type Props = {
   org: Organization;
@@ -96,9 +97,10 @@ function WaitingForEvents({org, project, sampleIssueId: sampleIssueIdProp}: Prop
             <LinkButton
               data-test-id="install-instructions"
               priority="primary"
-              to={`/${org.slug}/${project.slug}/getting-started/${
-                project.platform || ''
-              }`}
+              to={makeProjectsPathname({
+                path: `/${project.slug}/getting-started/`,
+                organization: org,
+              })}
             >
               {t('Installation Instructions')}
             </LinkButton>

--- a/static/app/views/issueDetails/sampleEventAlert.tsx
+++ b/static/app/views/issueDetails/sampleEventAlert.tsx
@@ -5,6 +5,7 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {AvatarProject} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
 export function SampleEventAlert({
   organization,
@@ -22,9 +23,10 @@ export function SampleEventAlert({
         <LinkButton
           size="xs"
           priority="primary"
-          to={`/${organization.slug}/${project.slug}/getting-started/${
-            project.platform || ''
-          }`}
+          to={makeProjectsPathname({
+            organization,
+            path: `/${project.slug}/getting-started/`,
+          })}
           onClick={() =>
             trackAnalytics('growth.sample_error_onboarding_link_clicked', {
               project_id: project.id?.toString(),


### PR DESCRIPTION
There were a couple locations that were still using the old urls:

- In the onboarding flyout for "capture your first error", it linked to /projects/
- In the old "waiting for events" UI, it also linked to /proejcts/

<img width="422" alt="CleanShot 2025-09-18 at 11 09 43@2x" src="https://github.com/user-attachments/assets/df5d5ddf-456d-48b1-af49-96adef0ed840" />
