### PR TITLE
ref(api): use `RateLimitConfig` in misc endpoints

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -26,6 +26,7 @@ from sentry.auth.services.auth.impl import promote_request_rpc_user
 from sentry.auth.superuser import SUPERUSER_ORG_ID
 from sentry.demo_mode.utils import is_demo_user
 from sentry.organizations.services.organization import organization_service
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.api.serializers.user import DetailedSelfUserSerializer
 from sentry.users.models.authenticator import Authenticator
@@ -133,13 +134,15 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
     and simple HTTP authentication.
     """
     enforce_rate_limit = True
-    rate_limits = {
-        "PUT": {
-            RateLimitCategory.USER: RateLimit(
-                limit=5, window=60 * 60
-            ),  # 5 PUT requests per hour per user
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "PUT": {
+                RateLimitCategory.USER: RateLimit(
+                    limit=5, window=60 * 60
+                ),  # 5 PUT requests per hour per user
+            }
         }
-    }
+    )
 
     def _validate_superuser(
         self, validator: AuthVerifyValidator, request: Request, verify_authenticator: bool

--- a/src/sentry/api/endpoints/auth_validate.py
+++ b/src/sentry/api/endpoints/auth_validate.py
@@ -9,6 +9,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import OrgAuthTokenAuthentication, UserAuthTokenAuthentication
 from sentry.api.base import Endpoint, control_silo_endpoint
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -28,7 +29,9 @@ class AuthValidateEndpoint(Endpoint):
     permission_classes = ()
 
     enforce_rate_limit = True
-    rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(limit=1250, window=60)}}
+    rate_limits = RateLimitConfig(
+        limit_overrides={"GET": {RateLimitCategory.IP: RateLimit(limit=1250, window=60)}}
+    )
 
     def get(self, request: Request) -> Response:
         if request.auth or request.user.is_authenticated:

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -15,6 +15,7 @@ from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors
 from sentry.models.organization import Organization
 from sentry.performance_issues.detectors.utils import escape_transaction
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.search.events.constants import METRICS_GRANULARITIES
 from sentry.seer.breakpoints import detect_breakpoints
 from sentry.snuba import metrics_performance
@@ -50,19 +51,21 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
         "GET": ApiPublishStatus.PRIVATE,
     }
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(
-                DEFAULT_RATE_LIMIT, DEFAULT_RATE_LIMIT_WINDOW, DEFAULT_CONCURRENT_RATE_LIMIT
-            ),
-            RateLimitCategory.USER: RateLimit(
-                DEFAULT_RATE_LIMIT, DEFAULT_RATE_LIMIT_WINDOW, DEFAULT_CONCURRENT_RATE_LIMIT
-            ),
-            RateLimitCategory.ORGANIZATION: RateLimit(
-                ORGANIZATION_RATE_LIMIT, DEFAULT_RATE_LIMIT_WINDOW, ORGANIZATION_RATE_LIMIT
-            ),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(
+                    DEFAULT_RATE_LIMIT, DEFAULT_RATE_LIMIT_WINDOW, DEFAULT_CONCURRENT_RATE_LIMIT
+                ),
+                RateLimitCategory.USER: RateLimit(
+                    DEFAULT_RATE_LIMIT, DEFAULT_RATE_LIMIT_WINDOW, DEFAULT_CONCURRENT_RATE_LIMIT
+                ),
+                RateLimitCategory.ORGANIZATION: RateLimit(
+                    ORGANIZATION_RATE_LIMIT, DEFAULT_RATE_LIMIT_WINDOW, ORGANIZATION_RATE_LIMIT
+                ),
+            }
         }
-    }
+    )
 
     def has_feature(self, organization, request):
         return features.has(

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -46,6 +46,7 @@ from sentry.models.release import (
 from sentry.models.releases.exceptions import ReleaseCommitError
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.releases.util import SemverFilter
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.releases.use_cases.release import serialize as release_serializer
 from sentry.search.events.constants import (
     OPERATOR_TO_DJANGO,
@@ -268,18 +269,20 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
         "POST": ApiPublishStatus.UNKNOWN,
     }
 
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=40, window=1),
-            RateLimitCategory.USER: RateLimit(limit=40, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
-        },
-        "POST": {
-            RateLimitCategory.IP: RateLimit(limit=40, window=1),
-            RateLimitCategory.USER: RateLimit(limit=40, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
-        },
-    }
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=40, window=1),
+                RateLimitCategory.USER: RateLimit(limit=40, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
+            },
+            "POST": {
+                RateLimitCategory.IP: RateLimit(limit=40, window=1),
+                RateLimitCategory.USER: RateLimit(limit=40, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
+            },
+        }
+    )
 
     SESSION_SORTS = frozenset(
         [

--- a/src/sentry/api/endpoints/organization_sampling_admin_metrics.py
+++ b/src/sentry/api/endpoints/organization_sampling_admin_metrics.py
@@ -10,6 +10,7 @@ from sentry.api.utils import get_date_range_from_params
 from sentry.constants import ObjectStatus
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.sentry_metrics.querying.data import (
     MetricsAPIQueryResultsTransformer,
     MQLQuery,
@@ -41,13 +42,15 @@ class OrganizationDynamicSamplingAdminMetricsEndpoint(OrganizationEndpoint):
     # 60 req/s to allow for metric dashboard loading
     default_rate_limit = RateLimit(limit=60, window=1)
 
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: default_rate_limit,
-            RateLimitCategory.USER: default_rate_limit,
-            RateLimitCategory.ORGANIZATION: default_rate_limit,
-        },
-    }
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: default_rate_limit,
+                RateLimitCategory.USER: default_rate_limit,
+                RateLimitCategory.ORGANIZATION: default_rate_limit,
+            },
+        }
+    )
 
     default_per_page = 50
 

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -21,6 +21,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.exceptions import InvalidParams
 from sentry.models.organization import Organization
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.search.utils import InvalidQuery
 from sentry.snuba.outcomes import (
     COLUMN_MAP,
@@ -159,13 +160,15 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
     }
     owner = ApiOwner.ENTERPRISE
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=20, window=1),
-            RateLimitCategory.USER: RateLimit(limit=20, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=20, window=1),
+                RateLimitCategory.USER: RateLimit(limit=20, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1),
+            }
         }
-    }
+    )
     permission_classes = (OrganizationAndStaffPermission,)
 
     @extend_schema(

--- a/src/sentry/api/endpoints/project_tagkey_values.py
+++ b/src/sentry/api/endpoints/project_tagkey_values.py
@@ -11,6 +11,7 @@ from sentry.api.helpers.environments import get_environment_id
 from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.models.environment import Environment
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -22,13 +23,15 @@ class ProjectTagKeyValuesEndpoint(ProjectEndpoint):
     }
 
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
-            RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1, concurrent_limit=5),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
+                RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1, concurrent_limit=5),
+            }
         }
-    }
+    )
 
     def get(self, request: Request, project, key) -> Response:
         """


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/99490 and https://github.com/getsentry/sentry/pull/99484, moving to `RateLimitConfig` instead of the rate limit dict.