### PR TITLE
ref(grouping): Remove unneeded grouphash metadata logs and metrics

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1323,23 +1323,6 @@ def assign_event_to_group(
 
     # From here on out, we're just doing housekeeping
 
-    # TODO: Temporary metric to debug missing grouphash metadata. This metric *should* exactly match
-    # the `grouping.grouphashmetadata.backfill_needed` metric collected in
-    # `get_or_create_grouphashes`. If it doesn't, perhaps there's a race condition between creation
-    # of the metadata and our ability to pull it from the database immediately thereafter.
-    for grouphash in [*primary.grouphashes, *secondary.grouphashes]:
-        grouphash.refresh_from_db()
-        if not grouphash.metadata:
-            logger.warning(
-                "grouphash_metadata.hash_without_metadata",
-                extra={
-                    "event_id": event.event_id,
-                    "project_id": project.id,
-                    "hash": grouphash.hash,
-                },
-            )
-            metrics.incr("grouping.grouphashmetadata.backfill_needed_2", sample_rate=1.0)
-
     # Background grouping is a way for us to get performance metrics for a new
     # config without having it actually affect on how events are grouped. It runs
     # either before or after the main grouping logic, depending on the option value.

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -111,27 +111,15 @@ METRICS_TAGS_BY_HASH_BASIS = {
 def should_handle_grouphash_metadata(project: Project, grouphash_is_new: bool) -> bool:
     # Killswitches
     if not options.get("grouping.grouphash_metadata.ingestion_writes_enabled"):
-        metrics.incr(
-            "grouping.grouphash_metadata.should_handle",
-            tags={"result": False, "reason": "killswitch"},
-        )
         return False
 
     # While we're backfilling metadata for existing grouphash records, if the load is too high, we
     # want to prioritize metadata for new grouphashes because there's certain information
     # (timestamp, Seer data) which is only available at group creation time.
     if grouphash_is_new:
-        metrics.incr(
-            "grouping.grouphash_metadata.should_handle",
-            tags={"result": True, "reason": "new_group"},
-        )
         return True
     else:
         result = random.random() <= options.get("grouping.grouphash_metadata.backfill_sample_rate")
-        metrics.incr(
-            "grouping.grouphash_metadata.should_handle",
-            tags={"result": result, "reason": f"die_roll_{result}"},
-        )
         return result
 
 

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -248,8 +248,8 @@ def get_or_create_grouphashes(
                 logger.warning(
                     "grouphash_metadata.exception", extra={"event_id": event_id, "error": repr(exc)}
                 )
-
-        record_grouphash_metadata_metrics(grouphash.metadata, event.platform)
+        if grouphash.metadata:
+            record_grouphash_metadata_metrics(grouphash.metadata, event.platform)
 
         grouphashes.append(grouphash)
 

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -249,22 +249,7 @@ def get_or_create_grouphashes(
                     "grouphash_metadata.exception", extra={"event_id": event_id, "error": repr(exc)}
                 )
 
-        if grouphash.metadata:
-            record_grouphash_metadata_metrics(grouphash.metadata, event.platform)
-        else:
-            # Now that the sample rate for grouphash metadata creation is 100%, we should never land
-            # here, and yet we still do. Log some data for debugging purposes.
-            logger.warning(
-                "grouphash_metadata.hash_without_metadata",
-                extra={
-                    "event_id": event.event_id,
-                    "project_id": project.id,
-                    "hash": hash_value,
-                    "is_new": created,
-                    "has_group": bool(grouphash.group_id),
-                },
-            )
-            metrics.incr("grouping.grouphashmetadata.backfill_needed", sample_rate=1.0)
+        record_grouphash_metadata_metrics(grouphash.metadata, event.platform)
 
         grouphashes.append(grouphash)
 


### PR DESCRIPTION
Remove unneeded grouphash metadata logs and metrics. The `backfill` metrics and `hash_without_metadata` logs are never hit so we can remove them. 

Also remove in `should_handle_grouphash_metadata()`
