### PR TITLE
ref: Remove "small integer" data type

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric.tsx
@@ -32,17 +32,3 @@ export function getNumericSuggestions(inputValue: string): SuggestionSection[] {
   // If the value is not numeric, don't show any suggestions
   return [];
 }
-
-const DEFAULT_SMALL_NUMERIC_SUGGESTIONS: SuggestionSection[] = [
-  {
-    sectionText: '',
-    suggestions: [{value: '1'}, {value: '10'}, {value: '100'}, {value: '1000'}],
-  },
-];
-
-export function getSmallNumericSuggestions(inputValue: string): SuggestionSection[] {
-  if (!inputValue) {
-    return DEFAULT_SMALL_NUMERIC_SUGGESTIONS;
-  }
-  return [];
-}

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils.tsx
@@ -6,10 +6,7 @@ import {escapeTagValue} from 'sentry/components/searchQueryBuilder/tokens/filter
 import {DEFAULT_BOOLEAN_SUGGESTIONS} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/boolean';
 import {getRelativeDateSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/date';
 import {getDurationSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/duration';
-import {
-  getNumericSuggestions,
-  getSmallNumericSuggestions,
-} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric';
+import {getNumericSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/numeric';
 import {getSizeSuggestions} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/size';
 import type {SuggestionSection} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/types';
 import {Token, type TokenResult} from 'sentry/components/searchSyntax/parser';
@@ -31,8 +28,6 @@ export function getValueSuggestions({
     case FieldValueType.NUMBER:
     case FieldValueType.INTEGER:
       return getNumericSuggestions(filterValue);
-    case FieldValueType.SMALL_INTEGER:
-      return getSmallNumericSuggestions(filterValue);
     case FieldValueType.DURATION:
       return getDurationSuggestions(filterValue, token);
     case FieldValueType.SIZE:
@@ -72,7 +67,6 @@ export function cleanFilterValue({
       }
       return null;
     case FieldValueType.INTEGER:
-    case FieldValueType.SMALL_INTEGER:
       if (FILTER_VALUE_INT.test(value)) {
         return value;
       }

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -50,8 +50,6 @@ export function getDefaultValueForValueType(valueType: FieldValueType | null): s
     case FieldValueType.INTEGER:
     case FieldValueType.NUMBER:
       return '100';
-    case FieldValueType.SMALL_INTEGER:
-      return '1';
     case FieldValueType.DATE:
       return '-24h';
     case FieldValueType.DURATION:
@@ -124,7 +122,6 @@ export function getInitialFilterText(
 
   switch (valueType) {
     case FieldValueType.INTEGER:
-    case FieldValueType.SMALL_INTEGER:
     case FieldValueType.NUMBER:
     case FieldValueType.DURATION:
     case FieldValueType.SIZE:

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -47,7 +47,6 @@ function getSearchConfigFromKeys(
         break;
       case FieldValueType.NUMBER:
       case FieldValueType.INTEGER:
-      case FieldValueType.SMALL_INTEGER:
       case FieldValueType.PERCENTAGE:
         config.numericKeys.add(key);
         break;

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2638,11 +2638,15 @@ export const REPLAY_TAG_ALIASES = {
   [ReplayFieldKey.URLS]: ReplayFieldKey.URL,
 };
 
+const SMALL_INTEGER_VALUES = ['1', '10', '11', '100', '1000'];
+
 const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
   [ReplayFieldKey.ACTIVITY]: {
     desc: t('Amount of activity in the replay from 0 to 10'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.SMALL_INTEGER,
+    valueType: FieldValueType.INTEGER,
+    defaultValue: SMALL_INTEGER_VALUES[0],
+    values: SMALL_INTEGER_VALUES,
   },
   [ReplayFieldKey.BROWSER_NAME]: {
     desc: t('Name of the browser'),
@@ -2657,47 +2661,65 @@ const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
   [ReplayFieldKey.COUNT_DEAD_CLICKS]: {
     desc: t('Number of dead clicks in the replay'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.SMALL_INTEGER,
+    valueType: FieldValueType.INTEGER,
+    defaultValue: SMALL_INTEGER_VALUES[0],
+    values: SMALL_INTEGER_VALUES,
   },
   [ReplayFieldKey.COUNT_RAGE_CLICKS]: {
     desc: t('Number of rage clicks in the replay'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.SMALL_INTEGER,
+    valueType: FieldValueType.INTEGER,
+    defaultValue: SMALL_INTEGER_VALUES[0],
+    values: SMALL_INTEGER_VALUES,
   },
   [ReplayFieldKey.COUNT_ERRORS]: {
     desc: t('Number of issues in the replay with level=error'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.SMALL_INTEGER,
+    valueType: FieldValueType.INTEGER,
+    defaultValue: SMALL_INTEGER_VALUES[0],
+    values: SMALL_INTEGER_VALUES,
   },
   [ReplayFieldKey.COUNT_INFOS]: {
     desc: t('Number of issues in the replay with level=info'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.SMALL_INTEGER,
+    valueType: FieldValueType.INTEGER,
+    defaultValue: SMALL_INTEGER_VALUES[0],
+    values: SMALL_INTEGER_VALUES,
   },
   [ReplayFieldKey.COUNT_SCREENS]: {
     desc: t('Number of screens visited within the replay. Alias of count_urls.'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.SMALL_INTEGER,
+    valueType: FieldValueType.INTEGER,
+    defaultValue: SMALL_INTEGER_VALUES[0],
+    values: SMALL_INTEGER_VALUES,
   },
   [ReplayFieldKey.COUNT_SEGMENTS]: {
     desc: t('Number of segments in the replay'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.SMALL_INTEGER,
+    valueType: FieldValueType.INTEGER,
+    defaultValue: SMALL_INTEGER_VALUES[0],
+    values: SMALL_INTEGER_VALUES,
   },
   [ReplayFieldKey.COUNT_TRACES]: {
     desc: t('Number of traces in the replay'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.SMALL_INTEGER,
+    valueType: FieldValueType.INTEGER,
+    defaultValue: SMALL_INTEGER_VALUES[0],
+    values: SMALL_INTEGER_VALUES,
   },
   [ReplayFieldKey.COUNT_URLS]: {
     desc: t('Number of urls visited within the replay'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.SMALL_INTEGER,
+    valueType: FieldValueType.INTEGER,
+    defaultValue: SMALL_INTEGER_VALUES[0],
+    values: SMALL_INTEGER_VALUES,
   },
   [ReplayFieldKey.COUNT_WARNINGS]: {
     desc: t('Number of issues in the replay with level=warning'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.SMALL_INTEGER,
+    valueType: FieldValueType.INTEGER,
+    defaultValue: SMALL_INTEGER_VALUES[0],
+    values: SMALL_INTEGER_VALUES,
   },
   [ReplayFieldKey.DURATION]: {
     desc: t('Duration of the replay, in seconds'),

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -292,7 +292,6 @@ export enum FieldValueType {
   RATE = 'rate',
   PERCENT_CHANGE = 'percent_change',
   SCORE = 'score',
-  SMALL_INTEGER = 'small_integer', // Value suggestions are 1-1000.
 }
 
 export enum WebVital {

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2637,7 +2637,7 @@ export const REPLAY_TAG_ALIASES = {
   [ReplayFieldKey.URLS]: ReplayFieldKey.URL,
 };
 
-const SMALL_INTEGER_VALUES = ['1', '10', '11', '100', '1000'];
+const SMALL_INTEGER_VALUES = ['1', '10', '100', '1000'];
 
 const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
   [ReplayFieldKey.ACTIVITY]: {

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -5,7 +5,6 @@ import type {ThresholdsConfig} from 'sentry/views/dashboards/widgetBuilder/build
 type AttributeValueType =
   | 'number'
   | 'integer'
-  | 'small_integer'
   | 'date'
   | 'boolean'
   | 'duration'


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/99212/ updated the dropdown values for some Replay fields via a clever mechanism of adding a new type. This works well, however it has a few downsides:

1. Surprising: there's no telemetry type called "small integer", so anyone reading through the list of supported types might be confused (as I was)
2. Adds another branch to all the logic that checks renderable types
3. Is somewhat vague. What's the boundary for "small"? etc.

More importantly, there's already an existing way to express the desired behaviour! This PR replaces the new type with an updated definition for the updated fields, which already allow specifying values and defaults for the autocomplete. The resulting behaviour is the same as far as I can see, and the code is much tidier 🙏🏻 
