### PR TITLE
Add base/head buildDetails to compare get API response

### DIFF
--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -13,6 +13,9 @@ from sentry.preprod.analytics import (
     PreprodArtifactApiSizeAnalysisComparePostEvent,
 )
 from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactEndpoint
+from sentry.preprod.api.models.project_preprod_build_details_models import (
+    transform_preprod_artifact_to_build_details,
+)
 from sentry.preprod.api.models.size_analysis.project_preprod_size_analysis_compare_models import (
     SizeAnalysisCompareGETResponse,
     SizeAnalysisComparePOSTResponse,
@@ -222,9 +225,11 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
                 "comparisons": len(comparisons),
             },
         )
+        head_build_details = transform_preprod_artifact_to_build_details(head_artifact)
+        base_build_details = transform_preprod_artifact_to_build_details(base_artifact)
         response = SizeAnalysisCompareGETResponse(
-            head_artifact_id=int(head_artifact_id),
-            base_artifact_id=int(base_artifact_id),
+            head_build_details=head_build_details,
+            base_build_details=base_build_details,
             comparisons=comparisons,
         )
         return Response(response.dict())

--- a/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
+++ b/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 
+from sentry.preprod.api.models.project_preprod_build_details_models import BuildDetailsApiResponse
 from sentry.preprod.models import PreprodArtifactSizeComparison, PreprodArtifactSizeMetrics
 
 
@@ -20,8 +21,8 @@ class SizeAnalysisComparison(BaseModel):
 
 
 class SizeAnalysisCompareGETResponse(BaseModel):
-    head_artifact_id: int
-    base_artifact_id: int
+    head_build_details: BuildDetailsApiResponse
+    base_build_details: BuildDetailsApiResponse
     comparisons: list[SizeAnalysisComparison]
 
 

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
@@ -66,6 +66,8 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
             identifier="main",
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=1000,
+            max_download_size=500,
         )
 
         # Create size metrics for base artifact
@@ -75,6 +77,8 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
             identifier="main",
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=1000,
+            max_download_size=500,
         )
 
     def _get_url(self, head_artifact_id=None, base_artifact_id=None):
@@ -105,8 +109,8 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
 
         data = response.data
-        assert data["head_artifact_id"] == self.head_artifact.id
-        assert data["base_artifact_id"] == self.base_artifact.id
+        assert data["head_build_details"]["id"] == str(self.head_artifact.id)
+        assert data["base_build_details"]["id"] == str(self.base_artifact.id)
         assert len(data["comparisons"]) == 1
 
         comparison_data = data["comparisons"][0]


### PR DESCRIPTION
Need full buildDetails for showing the selected builds content, added in #99868.