### PR TITLE
Add selected builds to compare page

### DIFF
--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -11,9 +11,11 @@ import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {SizeCompareItemDiffTable} from 'sentry/views/preprod/buildComparison/main/sizeCompareItemDiffTable';
+import {SizeCompareSelectedBuilds} from 'sentry/views/preprod/buildComparison/main/sizeCompareSelectedBuilds';
 import {BuildError} from 'sentry/views/preprod/components/buildError';
 import {
   MetricsArtifactType,
@@ -26,6 +28,7 @@ import type {
 
 export function SizeCompareMainContent() {
   const organization = useOrganization();
+  const navigate = useNavigate();
   const {baseArtifactId, headArtifactId, projectId} = useParams<{
     baseArtifactId: string;
     headArtifactId: string;
@@ -138,7 +141,16 @@ export function SizeCompareMainContent() {
 
   return (
     <Flex direction="column" gap="2xl">
-      {/* TODO: Build compare details */}
+      <SizeCompareSelectedBuilds
+        headBuildDetails={sizeComparisonQuery.data.head_build_details}
+        baseBuildDetails={sizeComparisonQuery.data.base_build_details}
+        isComparing={false}
+        onClearBaseBuild={() => {
+          navigate(
+            `/organizations/${organization.slug}/preprod/${projectId}/compare/${headArtifactId}/`
+          );
+        }}
+      />
 
       {/* Metrics Grid */}
       <Grid columns="repeat(3, 1fr)" gap="lg">

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -11,8 +11,8 @@ interface SizeCompareSelectedBuildsProps {
   headBuildDetails: BuildDetailsApiResponse;
   isComparing: boolean;
   onClearBaseBuild: () => void;
-  onTriggerComparison: () => void;
   baseBuildDetails?: BuildDetailsApiResponse;
+  onTriggerComparison?: () => void;
 }
 
 export function SizeCompareSelectedBuilds({
@@ -107,20 +107,22 @@ export function SizeCompareSelectedBuilds({
         )}
       </Flex>
 
-      <Flex align="center" gap="sm">
-        <Button
-          onClick={() => {
-            if (baseBuildDetails) {
-              onTriggerComparison();
-            }
-          }}
-          disabled={!baseBuildDetails || isComparing}
-          priority="primary"
-          icon={<IconTelescope size="sm" />}
-        >
-          {isComparing ? t('Comparing...') : t('Compare builds')}
-        </Button>
-      </Flex>
+      {onTriggerComparison && (
+        <Flex align="center" gap="sm">
+          <Button
+            onClick={() => {
+              if (baseBuildDetails) {
+                onTriggerComparison();
+              }
+            }}
+            disabled={!baseBuildDetails || isComparing}
+            priority="primary"
+            icon={<IconTelescope size="sm" />}
+          >
+            {isComparing ? t('Comparing...') : t('Compare builds')}
+          </Button>
+        </Flex>
+      )}
     </Flex>
   );
 }

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -208,13 +208,13 @@ const BuildItemContainer = styled(Flex)<{isSelected: boolean}>`
   cursor: pointer;
 
   &:hover {
-    background-color: ${p => p.theme.surface200};
+    background-color: ${p => p.theme.surface100};
   }
 
   ${p =>
     p.isSelected &&
     `
-      background-color: ${p.theme.surface100};
+      background-color: ${p.theme.surface200};
     `}
 `;
 

--- a/static/app/views/preprod/types/appSizeTypes.ts
+++ b/static/app/views/preprod/types/appSizeTypes.ts
@@ -2,6 +2,8 @@
  * API response types
  */
 
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+
 export interface AppSizeApiResponse {
   generated_at: string;
   treemap: TreemapResults;
@@ -28,9 +30,9 @@ interface SizeAnalysisComparison {
 }
 
 export interface SizeComparisonApiResponse {
-  base_artifact_id: number;
+  base_build_details: BuildDetailsApiResponse;
   comparisons: SizeAnalysisComparison[];
-  head_artifact_id: number;
+  head_build_details: BuildDetailsApiResponse;
 }
 
 /**


### PR DESCRIPTION
There's not actually this much padding underneath, there's usually size metrics there, they're just missing for this build (wonky local state).

<img width="1180" height="579" alt="Screenshot 2025-09-18 at 2 56 15 PM" src="https://github.com/user-attachments/assets/66293ebf-70cb-425a-b0ef-12603e0d2eca" />
