### PR TITLE
fix(eco): Cut down on SCM issue noise

### DIFF
--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -215,15 +215,15 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
                 # Preserve path separators and query params etc.
                 return urlunparse(parsed._replace(path=encoded_path))
 
-            if version:
-                scope.set_tag("stacktrace_link.tried_version", True)
-                source_url = self.check_file(repo, filepath, version)
-                if source_url:
-                    scope.set_tag("stacktrace_link.used_version", True)
-                    return encode_url(source_url)
-
-            scope.set_tag("stacktrace_link.used_version", False)
             try:
+                if version:
+                    scope.set_tag("stacktrace_link.tried_version", True)
+                    source_url = self.check_file(repo, filepath, version)
+                    if source_url:
+                        scope.set_tag("stacktrace_link.used_version", True)
+                        return encode_url(source_url)
+
+                scope.set_tag("stacktrace_link.used_version", False)
                 source_url = self.check_file(repo, filepath, default)
             except ApiForbiddenError as e:
                 # Similar to the `check_file` implementation, we need to re-raise

--- a/src/sentry/integrations/source_code_management/tasks.py
+++ b/src/sentry/integrations/source_code_management/tasks.py
@@ -286,7 +286,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
                 repo=repo, pr=pull_request
             )
         except ApiInvalidRequestError as e:
-            if not e.text and integration.provider_key == IntegrationProviderSlug.GITLAB.value:
+            if not e.text and integration_name == IntegrationProviderSlug.GITLAB.value:
                 lifecycle.record_halt(e)
             raise
 

--- a/src/sentry/integrations/source_code_management/tasks.py
+++ b/src/sentry/integrations/source_code_management/tasks.py
@@ -20,12 +20,13 @@ from sentry.integrations.source_code_management.metrics import (
     CommitContextIntegrationInteractionEvent,
     SCMIntegrationInteractionType,
 )
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.pullrequest import CommentType, PullRequest
 from sentry.models.repository import Repository
-from sentry.shared_integrations.exceptions import ApiError
+from sentry.shared_integrations.exceptions import ApiError, ApiInvalidRequestError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
@@ -278,11 +279,16 @@ def open_pr_comment_workflow(pr_id: int) -> None:
         provider_key=integration_name,
         repository=repo,
         pull_request_id=pull_request.id,
-    ).capture():
-        # fetch the files in the PR and determine if it is safe to comment
-        pullrequest_files = open_pr_comment_workflow.get_pr_files_safe_for_comment(
-            repo=repo, pr=pull_request
-        )
+    ).capture() as lifecycle:
+        try:
+            # fetch the files in the PR and determine if it is safe to comment
+            pullrequest_files = open_pr_comment_workflow.get_pr_files_safe_for_comment(
+                repo=repo, pr=pull_request
+            )
+        except ApiInvalidRequestError as e:
+            if not e.text and integration.provider_key == IntegrationProviderSlug.GITLAB.value:
+                lifecycle.record_halt(e)
+            raise
 
     issue_table_contents = {}
     top_issues_per_file = []

--- a/tests/sentry/integrations/gitlab/tasks/test_open_pr_comment.py
+++ b/tests/sentry/integrations/gitlab/tasks/test_open_pr_comment.py
@@ -15,8 +15,8 @@ from sentry.integrations.source_code_management.tasks import open_pr_comment_wor
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.group import Group
 from sentry.models.pullrequest import CommentType, PullRequestComment
-from sentry.shared_integrations.exceptions import ApiError
-from sentry.testutils.asserts import assert_slo_metric
+from sentry.shared_integrations.exceptions import ApiError, ApiInvalidRequestError
+from sentry.testutils.asserts import assert_failure_metric, assert_halt_metric, assert_slo_metric
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
@@ -606,3 +606,50 @@ Your merge request is modifying functions with the following pre-existing issues
             open_pr_comment_workflow(self.pr.id)
 
         assert_slo_metric(mock_record_event, EventLifecycleOutcome.FAILURE)
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_comment_workflow_mysterious_validation_errors(
+        self,
+        mock_record_event,
+        mock_analytics,
+        mock_commit_context_metrics,
+        mock_task_metrics,
+        mock_integration_metrics,
+        mock_extract_functions_from_patch,
+        mock_get_top_5_issues_by_count_for_file,
+        mock_get_projects_and_filenames_from_source_file,
+        mock_get_pr_files_safe_for_comment,
+    ):
+        # Tests a case where Gitlab decides to return a 400 with an empty body.
+        # We haven't found a definitive reason for these failures, so we record
+        # this as a halt instead of a failure.
+        mock_get_pr_files_safe_for_comment.side_effect = ApiInvalidRequestError("")
+
+        with pytest.raises(ApiInvalidRequestError):
+            open_pr_comment_workflow(self.pr.id)
+
+        assert_halt_metric(mock_record_event, ApiInvalidRequestError(""))
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_comment_workflow_api_invalid_request_error_with_text(
+        self,
+        mock_record_event,
+        mock_analytics,
+        mock_commit_context_metrics,
+        mock_task_metrics,
+        mock_integration_metrics,
+        mock_extract_functions_from_patch,
+        mock_get_top_5_issues_by_count_for_file,
+        mock_get_projects_and_filenames_from_source_file,
+        mock_get_pr_files_safe_for_comment,
+    ):
+        mock_get_pr_files_safe_for_comment.side_effect = ApiInvalidRequestError(
+            "Some actual valid error"
+        )
+
+        with pytest.raises(ApiInvalidRequestError):
+            open_pr_comment_workflow(self.pr.id)
+
+        assert_failure_metric(mock_record_event, ApiInvalidRequestError("Some actual valid error"))


### PR DESCRIPTION
- Adds handling for Gitlab 400s without bodies, which we haven't been able to reliably triage or reproduce
- Expands Auth error handling to cover another `check_file` case I previously missed
