### PR TITLE
feat(detectors): Use first occurrence per fingerprint and add logging 

### DIFF
--- a/src/sentry/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
+++ b/src/sentry/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
@@ -169,6 +169,13 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
         if not fingerprint:
             return
 
+        if self.stored_problems.get(fingerprint):
+            logging.info(
+                "Multiple occurrences detected for fingerprint",
+                extra={"detector": self.settings_key},
+            )
+            return
+
         offender_span_ids = [span["span_id"] for span in self.spans]
         problem_description = self._get_parameterized_url(self.spans[0])
         if problem_description == "":
@@ -177,8 +184,7 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
             )
 
         parent_span_id = last_span.get("parent_span_id")
-        if self.stored_problems.get(fingerprint):
-            logging.info("Multiple N+1 API Call Problems for Fingerprint")
+
         parameters = self._get_parameters()
         self.stored_problems[fingerprint] = PerformanceProblem(
             fingerprint=fingerprint,

--- a/src/sentry/performance_issues/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/performance_issues/detectors/uncompressed_asset_detector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 from typing import Any
 
@@ -94,7 +95,13 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
 
         fingerprint = self._fingerprint(span)
         span_id = span.get("span_id", None)
-        if fingerprint and span_id and not self.stored_problems.get(fingerprint, False):
+        if self.stored_problems.get(fingerprint):
+            logging.info(
+                "Multiple occurrences detected for fingerprint",
+                extra={"detector": self.settings_key},
+            )
+            return
+        if fingerprint and span_id:
             self.stored_problems[fingerprint] = PerformanceProblem(
                 fingerprint=fingerprint,
                 op=op,


### PR DESCRIPTION
right now we only support detecting one "performance problem" per fingerprint. for some detectors, we use the first, for others we use the last (and overwrite the first ones). this pr unifies the detectors to all use the first one and adds some logging to give more insight into this