### PR TITLE
ref(seer): use `RateLimitConfig` in seer endpoints

### DIFF
--- a/src/sentry/seer/endpoints/group_ai_summary.py
+++ b/src/sentry/seer/endpoints/group_ai_summary.py
@@ -11,6 +11,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.models.group import Group
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.constants import SeerAutomationSource
 from sentry.seer.autofix.issue_summary import get_issue_summary
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -25,13 +26,15 @@ class GroupAiSummaryEndpoint(GroupAiEndpoint):
     }
     owner = ApiOwner.ML_AI
     enforce_rate_limit = True
-    rate_limits = {
-        "POST": {
-            RateLimitCategory.IP: RateLimit(limit=20, window=60),
-            RateLimitCategory.USER: RateLimit(limit=20, window=60),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=100, window=60),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "POST": {
+                RateLimitCategory.IP: RateLimit(limit=20, window=60),
+                RateLimitCategory.USER: RateLimit(limit=20, window=60),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=100, window=60),
+            }
         }
-    }
+    )
 
     def post(self, request: Request, group: Group) -> Response:
         data = orjson.loads(request.body) if request.body else {}

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -18,6 +18,7 @@ from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.utils import get_autofix_repos_from_project_code_mappings
 from sentry.seer.seer_setup import get_seer_org_acknowledgement, get_seer_user_acknowledgement
 from sentry.seer.signed_seer_api import sign_with_seer_secret
@@ -110,13 +111,17 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
     }
     owner = ApiOwner.ML_AI
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=200, window=60, concurrent_limit=20),
-            RateLimitCategory.USER: RateLimit(limit=100, window=60, concurrent_limit=10),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=1000, window=60, concurrent_limit=100),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=200, window=60, concurrent_limit=20),
+                RateLimitCategory.USER: RateLimit(limit=100, window=60, concurrent_limit=10),
+                RateLimitCategory.ORGANIZATION: RateLimit(
+                    limit=1000, window=60, concurrent_limit=100
+                ),
+            }
         }
-    }
+    )
 
     def get(self, request: Request, group: Group) -> Response:
         """

--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -13,6 +13,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.organization import Organization
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.seer_setup import get_seer_org_acknowledgement
 from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -116,18 +117,20 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
     }
     owner = ApiOwner.ML_AI
     enforce_rate_limit = True
-    rate_limits = {
-        "POST": {
-            RateLimitCategory.IP: RateLimit(limit=25, window=60),
-            RateLimitCategory.USER: RateLimit(limit=25, window=60),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=100, window=60 * 60),
-        },
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=100, window=60),
-            RateLimitCategory.USER: RateLimit(limit=100, window=60),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=1000, window=60),
-        },
-    }
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "POST": {
+                RateLimitCategory.IP: RateLimit(limit=25, window=60),
+                RateLimitCategory.USER: RateLimit(limit=25, window=60),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=100, window=60 * 60),
+            },
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=100, window=60),
+                RateLimitCategory.USER: RateLimit(limit=100, window=60),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=1000, window=60),
+            },
+        }
+    )
     permission_classes = (OrganizationSeerExplorerChatPermission,)
 
     def get(

--- a/src/sentry/seer/endpoints/organization_seer_setup_check.py
+++ b/src/sentry/seer/endpoints/organization_seer_setup_check.py
@@ -12,6 +12,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.constants import DataCategory
 from sentry.models.organization import Organization
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.seer_setup import get_seer_org_acknowledgement, get_seer_user_acknowledgement
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -25,13 +26,17 @@ class OrganizationSeerSetupCheck(OrganizationEndpoint):
     }
     owner = ApiOwner.ML_AI
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=200, window=60, concurrent_limit=20),
-            RateLimitCategory.USER: RateLimit(limit=100, window=60, concurrent_limit=10),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=1000, window=60, concurrent_limit=100),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=200, window=60, concurrent_limit=20),
+                RateLimitCategory.USER: RateLimit(limit=100, window=60, concurrent_limit=10),
+                RateLimitCategory.ORGANIZATION: RateLimit(
+                    limit=1000, window=60, concurrent_limit=100
+                ),
+            }
         }
-    }
+    )
 
     def get(self, request: Request, organization: Organization) -> Response:
         """

--- a/src/sentry/seer/endpoints/organization_trace_summary.py
+++ b/src/sentry/seer/endpoints/organization_trace_summary.py
@@ -13,6 +13,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.endpoints.organization_trace import OrganizationTraceEndpoint
 from sentry.models.organization import Organization
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.trace_summary import get_trace_summary
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -33,13 +34,15 @@ class OrganizationTraceSummaryEndpoint(OrganizationEndpoint):
     owner = ApiOwner.ML_AI
     enforce_rate_limit = True
     # Keeping same rate limits as GroupAISummary endpoint for now
-    rate_limits = {
-        "POST": {
-            RateLimitCategory.IP: RateLimit(limit=10, window=60),
-            RateLimitCategory.USER: RateLimit(limit=10, window=60),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=30, window=60),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "POST": {
+                RateLimitCategory.IP: RateLimit(limit=10, window=60),
+                RateLimitCategory.USER: RateLimit(limit=10, window=60),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=30, window=60),
+            }
         }
-    }
+    )
 
     permission_classes = (OrganizationTraceSummaryPermission,)
 


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/99484. Switches to using `RateLimitConfig` so we can remove the old dict.