### PR TITLE
chore(prevent): Update TA onboarding code snippets

### DIFF
--- a/static/app/views/prevent/tests/onboardingSteps/GHAWorkflowExpandable.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/GHAWorkflowExpandable.tsx
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
       - name: Set up Python 3.11
@@ -32,12 +32,9 @@ jobs:
         run: |
           pytest --cov --junitxml=junit.xml
       # Copy and paste the getsentry/prevent-action here
-      - name: Upload test results to Prevent
+      - name: Upload test results to Sentry Prevent
         if: \${{ !cancelled() }}
-        uses: getsentry/prevent-action
-
-      - name: Upload coverage to Prevent
-        uses: getsentry/prevent-action
+        uses: getsentry/prevent-action@latest
 `;
 
 export function GHAWorkflowExpandable() {

--- a/static/app/views/prevent/tests/onboardingSteps/addScriptToYamlStep.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/addScriptToYamlStep.tsx
@@ -10,11 +10,11 @@ interface AddScriptToYamlStepProps {
   step: string;
 }
 
-const SNIPPET = `- name: Upload test results to Codecov
+const SNIPPET = `- name: Upload test results to Sentry Prevent
   if: \${{ !cancelled() }}
-  uses: codecov/test-results-action@v1
+  uses: getsentry/prevent-action@latest
   with:
-    token: \${{ secrets.CODECOV_TOKEN }}
+    token: \${{ secrets.SENTRY_PREVENT_TOKEN }}
 `;
 
 export function AddScriptToYamlStep({step}: AddScriptToYamlStepProps) {

--- a/static/app/views/prevent/tests/onboardingSteps/editGHAWorkflowStep.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/editGHAWorkflowStep.tsx
@@ -15,9 +15,9 @@ const PERMISSIONS_SNIPPET = `permissions:
     id-token: write
 `;
 
-const ACTION_SNIPPET = `- name: Upload test results to Codecov
+const ACTION_SNIPPET = `- name: Upload test results to Sentry Prevent
   if: \${{ !cancelled() }}
-  uses: getsentry/prevent-action
+  uses: getsentry/prevent-action@latest
 `;
 
 export function EditGHAWorkflowStep({step}: EditGHAWorkflowStepProps) {
@@ -74,7 +74,7 @@ export function EditGHAWorkflowStep({step}: EditGHAWorkflowStepProps) {
           </CodeSnippet>
           <Paragraph>
             {t(
-              'This action will download the Sentry Prevent CLI, and upload the junit.xml file generated in the previous step to Sentry.'
+              'This action will download the Sentry Prevent CLI, and upload the junit.xml file generated in the previous step to Sentry.'
             )}
           </Paragraph>
         </OnboardingStep.Content>

--- a/static/app/views/prevent/tests/onboardingSteps/installPreventCLIStep.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/installPreventCLIStep.tsx
@@ -16,10 +16,26 @@ interface InstallPreventCLIStepProps {
 
 type Method = 'pip' | 'binary';
 
-// TODO: confirm these platform choices
-type Platform = 'macOS' | 'Linux' | 'Windows';
+const PLATFORMS = {
+  macOS: {label: 'MacOS', value: 'macOS'},
+  'windows.exe': {label: 'Windows', value: 'windows'},
+  linux_x86_64: {label: 'Linux x86_64', value: 'linux_x86_64'},
+  linux_arm64: {label: 'Linux Arm64', value: 'linux_arm64'},
+  alpine_arm64: {label: 'Alpine Linux Arm64', value: 'alpine_arm64'},
+  alpine_x86_64: {label: 'Alpine Linux x86_64', value: 'alpine_x86_64'},
+} as const;
+type Platform = keyof typeof PLATFORMS;
 
-const SNIPPET = `snippet still tbd`;
+const PLATFORM_OPTIONS = Object.values(PLATFORMS);
+
+const PIP_SNIPPET = `pip install sentry-prevent-cli
+sentry-prevent-cli upload --report-type test-results --token <SENTRY_PREVENT_TOKEN>`;
+
+const getBinarySnippet = (
+  platformSuffix: string
+) => `curl -LOs https://github.com/getsentry/prevent-cli/releases/latest/download/sentry-prevent-cli_${platformSuffix}
+chmod u+x sentry-prevent-cli_${platformSuffix}
+./sentry-prevent-cli_${platformSuffix} -v upload --report-type test-results --token <SENTRY_PREVENT_TOKEN>`;
 
 export function InstallPreventCLIStep({step}: InstallPreventCLIStepProps) {
   const [method, setMethod] = useState<Method>('pip');
@@ -59,7 +75,7 @@ export function InstallPreventCLIStep({step}: InstallPreventCLIStepProps) {
                 )}
               </Paragraph>
               <CodeSnippet dark language="bash">
-                {SNIPPET}
+                {PIP_SNIPPET}
               </CodeSnippet>
               {CLILink}
             </Fragment>
@@ -73,18 +89,14 @@ export function InstallPreventCLIStep({step}: InstallPreventCLIStepProps) {
               </Paragraph>
               <StyledSelectControl
                 size="md"
-                options={[
-                  {label: 'macOS', value: 'macOS'},
-                  {label: 'Linux', value: 'linux'},
-                  {label: 'Windows', value: 'windows'},
-                ]}
+                options={PLATFORM_OPTIONS}
                 value={selectedPlatform}
                 onChange={(option: {value: Platform}) =>
                   setSelectedPlatform(option.value)
                 }
               />
               <CodeSnippet dark language="bash">
-                {SNIPPET}
+                {getBinarySnippet(selectedPlatform)}
               </CodeSnippet>
               {CLILink}
             </Fragment>
@@ -96,7 +108,7 @@ export function InstallPreventCLIStep({step}: InstallPreventCLIStepProps) {
 }
 
 const StyledSelectControl = styled(Select)`
-  width: 110px;
+  width: 200px;
   margin-bottom: ${space(1.5)};
 `;
 

--- a/static/app/views/prevent/tests/onboardingSteps/installPreventCLIStep.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/installPreventCLIStep.tsx
@@ -7,7 +7,6 @@ import {Select} from 'sentry/components/core/select';
 import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import {IconOpen} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {OnboardingStep} from 'sentry/views/prevent/tests/onboardingSteps/onboardingStep';
 
 interface InstallPreventCLIStepProps {
@@ -17,15 +16,14 @@ interface InstallPreventCLIStepProps {
 type Method = 'pip' | 'binary';
 
 const PLATFORMS = {
-  macOS: {label: 'MacOS', value: 'macOS'},
-  'windows.exe': {label: 'Windows', value: 'windows'},
+  macOS: {label: 'MacOS', value: 'macos'},
+  windows: {label: 'Windows', value: 'windows.exe'},
   linux_x86_64: {label: 'Linux x86_64', value: 'linux_x86_64'},
   linux_arm64: {label: 'Linux Arm64', value: 'linux_arm64'},
   alpine_arm64: {label: 'Alpine Linux Arm64', value: 'alpine_arm64'},
   alpine_x86_64: {label: 'Alpine Linux x86_64', value: 'alpine_x86_64'},
 } as const;
 type Platform = keyof typeof PLATFORMS;
-
 const PLATFORM_OPTIONS = Object.values(PLATFORMS);
 
 const PIP_SNIPPET = `pip install sentry-prevent-cli
@@ -109,16 +107,16 @@ export function InstallPreventCLIStep({step}: InstallPreventCLIStepProps) {
 
 const StyledSelectControl = styled(Select)`
   width: 200px;
-  margin-bottom: ${space(1.5)};
+  margin-bottom: ${p => p.theme.space.lg};
 `;
 
 const Paragraph = styled('div')`
-  margin-top: ${space(2)};
-  margin-bottom: ${space(1)};
+  margin-top: ${p => p.theme.space.xl};
+  margin-bottom: ${p => p.theme.space.md};
 `;
 
 const BottomParagraph = styled('div')`
-  margin-top: ${space(2)};
+  margin-top: ${p => p.theme.space.xl};
 `;
 
 const CLILink = (

--- a/static/app/views/prevent/tests/onboardingSteps/outputCoverageFileStep.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/outputCoverageFileStep.tsx
@@ -22,8 +22,7 @@ const INSTALL_REQUIREMENTS_SNIPPETS: Record<Frameworks, string> = {
 };
 
 const GENERATE_FILE_SNIPPETS: Record<Frameworks, string> = {
-  jest: `npm i --save-dev jest-junit
-JEST_JUNIT_CLASSNAME="{filepath}" jest --reporters=jest-junit`,
+  jest: `JEST_JUNIT_CLASSNAME="{filepath}" jest --reporters=jest-junit`,
   vitest: 'vitest --reporter=junit --outputFile=test-report.junit.xml',
   pytest: 'pytest --cov --junitxml=junit.xml -o junit_family=legacy',
   phpunit: './vendor/bin/phpunit --log-junit junit.xml',


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/CCMRG-1657/update-cli-onboarding-step-snippet

Updates snippets according to https://www.notion.so/sentry/Prevent-TA-Tutorial-2728b10e4b5d80f49ddcc1c84e56626d#2728b10e4b5d8070a39ecbed1f7b627f and cross-referencing with https://github.com/getsentry/prevent-cli/releases.

- Just plain `linux` isn't a part of the release file list's contents like in the Notion currently so I've added linux x86_64 for now instead as that is part of the list


**To Test**
- go to onboarding page
- switch to "Use Sentry Prevent's CLI" radio button at top
- in step 3: switch to "By downloading and installing a binary" radio button

<img width="1000" height="429" alt="Screenshot 2025-09-18 at 3 54 37 PM" src="https://github.com/user-attachments/assets/f1004598-987e-4df7-96d6-03dfacec588a" />
