### PR TITLE
chore(aci): Report project counts when scheduling

### DIFF
--- a/src/sentry/workflow_engine/processors/schedule.py
+++ b/src/sentry/workflow_engine/processors/schedule.py
@@ -123,11 +123,13 @@ def process_buffered_workflows() -> None:
             max=fetch_time,
         )
 
-        log_str = ", ".join(
-            f"{project_id}: {timestamps}"
-            for project_id, timestamps in all_project_ids_and_timestamps.items()
+        metrics.distribution(
+            "workflow_engine.schedule.projects", len(all_project_ids_and_timestamps)
         )
-        logger.info("delayed_workflow.project_id_list", extra={"project_ids": log_str})
+        logger.info(
+            "delayed_workflow.project_id_list",
+            extra={"project_ids": sorted(all_project_ids_and_timestamps.keys())},
+        )
 
         project_ids = list(all_project_ids_and_timestamps.keys())
         for project_id in project_ids:


### PR DESCRIPTION
To keep an eye on how many projects we're scheduling at a time, we publish a distribution of the count.
Also, log the project IDs in a more compact format so it's less likely to be truncated.