### PR TITLE
fix(playstation): Remove beta badge

### DIFF
--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -132,7 +132,6 @@ export default function getConfiguration({
         {
           path: `${pathPrefix}/playstation/`,
           title: t('PlayStation'),
-          badge: () => 'beta',
           show: () => !!(organization && hasTempestAccess(organization)) && !isSelfHosted,
         },
       ],


### PR DESCRIPTION
Since we are no longer in the beta might be time to remove the badge.