### PR TITLE
ref(ds): Switch msr rule from transaction to project

### DIFF
--- a/src/sentry/dynamic_sampling/rules/biases/minimum_sample_rate_bias.py
+++ b/src/sentry/dynamic_sampling/rules/biases/minimum_sample_rate_bias.py
@@ -12,7 +12,7 @@ class MinimumSampleRateBias(Bias):
         return [
             {
                 "samplingValue": {"type": "minimumSampleRate", "value": base_sample_rate},
-                "type": "transaction",
+                "type": "project",
                 "condition": {
                     "inner": [],
                     "op": "and",

--- a/tests/sentry/dynamic_sampling/rules/biases/test_minimum_sample_rate_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_minimum_sample_rate_bias.py
@@ -15,7 +15,7 @@ def test_generate_rules_with_different_sample_rates(default_project) -> None:
         expected_rules = [
             {
                 "samplingValue": {"type": "minimumSampleRate", "value": base_sample_rate},
-                "type": "transaction",
+                "type": "project",
                 "condition": {
                     "inner": [],
                     "op": "and",

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -733,7 +733,7 @@ def test_generate_rules_return_minimum_sample_rate_when_enabled(
                 "condition": {"inner": [], "op": "and"},
                 "id": 1006,
                 "samplingValue": {"type": "minimumSampleRate", "value": 0.3},
-                "type": "transaction",
+                "type": "project",
             },
             {
                 "condition": {"inner": [], "op": "and"},


### PR DESCRIPTION
The `project` rule type is described in [INGEST-489](https://linear.app/getsentry/issue/INGEST-489/introduce-project-dynamic-sampling-rule-type) and was implemented in https://github.com/getsentry/relay/pull/5077.

The `transaction` rule type only applies to transactions, the `project` one will also apply to spans. Additionally by using the `trace_id` as the decision seed, minimum sample rates will now sample entire traces not just singular transactions, which could improve the result (having all spans/transactions of a trace instead of just a singular transaction).