### PR TITLE
feat(mcp-insights): Hide panel and breakdown on mcp spans

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -54,7 +54,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {getIsAiNode} from 'sentry/views/insights/agents/utils/aiTraceNodes';
-import {hasAgentInsightsFeature} from 'sentry/views/insights/agents/utils/features';
+import {
+  hasAgentInsightsFeature,
+  hasMCPInsightsFeature,
+} from 'sentry/views/insights/agents/utils/features';
+import {getIsMCPNode} from 'sentry/views/insights/mcp/utils/mcpTraceNodes';
 import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
 import {useTransaction} from 'sentry/views/performance/newTraceDetails/traceApi/useTransaction';
 import {useDrawerContainerRef} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/drawerContainerRefContext';
@@ -444,7 +448,10 @@ function Highlights({
     return null;
   }
 
-  const isAiNode = getIsAiNode(node);
+  const isAiNode = hasAgentInsightsFeature(organization) && getIsAiNode(node);
+  const isMCPNode = hasMCPInsightsFeature(organization) && getIsMCPNode(node);
+
+  const hidePanelAndBreakdown = isAiNode || isMCPNode;
 
   const startTimestamp = node.space[0];
   const endTimestamp = node.space[0] + node.space[1];
@@ -496,27 +503,26 @@ function Highlights({
               ))}
             </HighlightedAttributesWrapper>
           ) : null}
-          {isAiNode && hasAgentInsightsFeature(organization) ? (
-            hideNodeActions ? null : (
-              <OpenInAIFocusButton
-                size="xs"
-                onClick={() => {
-                  trackAnalytics('agent-monitoring.view-ai-trace-click', {
-                    organization,
-                  });
-                }}
-                to={{
-                  ...location,
-                  query: {
-                    ...location.query,
-                    tab: TraceLayoutTabKeys.AI_SPANS,
-                  },
-                }}
-              >
-                {t('Open in AI View')}
-              </OpenInAIFocusButton>
-            )
-          ) : (
+          {isAiNode && !hideNodeActions && (
+            <OpenInAIFocusButton
+              size="xs"
+              onClick={() => {
+                trackAnalytics('agent-monitoring.view-ai-trace-click', {
+                  organization,
+                });
+              }}
+              to={{
+                ...location,
+                query: {
+                  ...location.query,
+                  tab: TraceLayoutTabKeys.AI_SPANS,
+                },
+              }}
+            >
+              {t('Open in AI View')}
+            </OpenInAIFocusButton>
+          )}
+          {!hidePanelAndBreakdown && (
             <Fragment>
               <StyledPanel>
                 <StyledPanelHeader>{headerContent}</StyledPanelHeader>


### PR DESCRIPTION
Hide the same UI elements as for ai spans inside span details.