### PR TITLE
feat(mcp-insights): Promote prompt result attributes

### DIFF
--- a/static/app/views/insights/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/agents/utils/aiTraceNodes.tsx
@@ -11,22 +11,47 @@ import {
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 
-function ensureAttributeObject(
-  attributes: Record<string, string> | TraceItemResponseAttribute[]
+export function getAttributeValue(
+  attribute: TraceItemResponseAttribute
+): string | number | boolean {
+  if (attribute.type === 'int') {
+    return Number(attribute.value);
+  }
+  if (attribute.type === 'float') {
+    return Number(attribute.value);
+  }
+  if (attribute.type === 'bool') {
+    return Boolean(attribute.value);
+  }
+  return attribute.value;
+}
+
+export function ensureAttributeObject(
+  node: TraceTreeNode<TraceTree.NodeValue>,
+  event?: EventTransaction,
+  attributes?: TraceItemResponseAttribute[]
 ) {
-  if (Array.isArray(attributes)) {
+  if (isEAPSpanNode(node) && attributes) {
     return attributes.reduce(
       (acc, attribute) => {
         // Some attribute keys include prefixes and metadata (e.g. "tags[ai.prompt_tokens.used,number]")
         // prettifyAttributeName normalizes those
-        acc[prettifyAttributeName(attribute.name)] = attribute.value;
+        acc[prettifyAttributeName(attribute.name)] = getAttributeValue(attribute);
         return acc;
       },
       {} as Record<string, string | number | boolean>
     );
   }
 
-  return attributes;
+  if (isTransactionNode(node) && event) {
+    return event.contexts.trace?.data;
+  }
+
+  if (isSpanNode(node)) {
+    return node.value.data;
+  }
+
+  return undefined;
 }
 
 export function getTraceNodeAttribute(
@@ -35,24 +60,8 @@ export function getTraceNodeAttribute(
   event?: EventTransaction,
   attributes?: TraceItemResponseAttribute[]
 ) {
-  if (!isTransactionNode(node) && !isSpanNode(node) && !isEAPSpanNode(node)) {
-    return undefined;
-  }
-
-  if (isEAPSpanNode(node) && attributes) {
-    const attributeObject = ensureAttributeObject(attributes);
-    return attributeObject[name];
-  }
-
-  if (isTransactionNode(node) && event) {
-    return event.contexts.trace?.data?.[name];
-  }
-
-  if (isSpanNode(node)) {
-    return node.value.data?.[name];
-  }
-
-  return undefined;
+  const attributeObject = ensureAttributeObject(node, event, attributes);
+  return attributeObject?.[name];
 }
 
 function createGetIsAiNode(predicate: ({op}: {op?: string}) => boolean) {

--- a/static/app/views/insights/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/agents/utils/aiTraceNodes.tsx
@@ -11,9 +11,13 @@ import {
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 
-export function getAttributeValue(
+// TODO(aknaus): Remove the special handling for tags once the endpoint returns the correct type
+function getAttributeValue(
   attribute: TraceItemResponseAttribute
 ): string | number | boolean {
+  if (!attribute.name.startsWith('tags[')) {
+    return attribute.value;
+  }
   if (attribute.type === 'int') {
     return Number(attribute.value);
   }
@@ -21,7 +25,8 @@ export function getAttributeValue(
     return Number(attribute.value);
   }
   if (attribute.type === 'bool') {
-    return Boolean(attribute.value);
+    /* @ts-expect-error - tags are always returned as strings */
+    return attribute.value === 'true';
   }
   return attribute.value;
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1321,7 +1321,16 @@ function MultilineJSON({
   const json = tryParseJson(value);
   return (
     <MultilineTextWrapperMonospace>
-      <StructuredData value={json} maxDefaultDepth={maxDefaultDepth} withAnnotatedText />
+      <StructuredData
+        config={{
+          isString: v => typeof v === 'string',
+          isBoolean: v => typeof v === 'boolean',
+          isNumber: v => typeof v === 'number',
+        }}
+        value={json}
+        maxDefaultDepth={maxDefaultDepth}
+        withAnnotatedText
+      />
     </MultilineTextWrapperMonospace>
   );
 }


### PR DESCRIPTION
Add proper syntax highlighting for JSON content in input and output sections (MCP and AI).
Add `mcp.prompt.result.*` properties to `MCPOutput` section
 
<img width="745" height="380" alt="Screenshot 2025-09-19 at 12 24 12" src="https://github.com/user-attachments/assets/41bdf75c-3299-4569-95dc-398cac5b889c" />
