### PR TITLE
feat(search-bar): Hide wildcard footer when using wildcard ops

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -176,6 +176,89 @@ describe('SearchQueryBuilder', () => {
     expect(await screen.findByPlaceholderText('foo')).toBeInTheDocument();
   });
 
+  describe('rendering search query builder', () => {
+    describe('footer', () => {
+      it('displays wildcard footer when canUseWildcard is true', async () => {
+        render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:Firefox" />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+
+        expect(await screen.findByText('Type to search suggestions')).toBeInTheDocument();
+        expect(screen.getByText('Wildcard (*) matching allowed')).toBeInTheDocument();
+      });
+
+      it('does not display footer when disallowWildcard is true', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            disallowWildcard
+            initialQuery="browser.name:Firefox"
+          />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+
+        expect(await screen.findByText('Type to search suggestions')).toBeInTheDocument();
+
+        expect(
+          screen.queryByText('Wildcard (*) matching allowed')
+        ).not.toBeInTheDocument();
+      });
+
+      it('does not display footer when canUseWildcard is false', async () => {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="assigned:me" />);
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: assigned'})
+        );
+
+        expect(await screen.findByText('Type to search suggestions')).toBeInTheDocument();
+
+        expect(
+          screen.queryByText('Wildcard (*) matching allowed')
+        ).not.toBeInTheDocument();
+      });
+
+      it('does not display footer when using a wildcard operator', async () => {
+        render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:Firefox" />,
+          {organization: {features: ['search-query-builder-wildcard-operators']}}
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {
+            name: 'Edit value for filter: browser.name',
+          })
+        );
+
+        expect(await screen.findByText('Type to search suggestions')).toBeInTheDocument();
+
+        expect(screen.getByText('Wildcard (*) matching allowed')).toBeInTheDocument();
+        await userEvent.keyboard('{escape}');
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+        );
+
+        await userEvent.click(screen.getByRole('option', {name: 'contains'}));
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+
+        expect(
+          screen.queryByText('Wildcard (*) matching allowed')
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
   describe('callbacks', () => {
     it('calls onChange, onBlur, and onSearch with the query string', async () => {
       const mockOnChange = jest.fn();

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -858,6 +858,7 @@ export function SearchQueryBuilderValueCombobox({
               items={items}
               isLoading={isFetching}
               canUseWildcard={canUseWildcard}
+              token={token}
             />
           );
         };

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -12,7 +12,6 @@ import {itemIsSection} from 'sentry/components/searchQueryBuilder/tokens/utils';
 import {type Token, type TokenResult} from 'sentry/components/searchSyntax/parser';
 import {isWildcardOperator} from 'sentry/components/searchSyntax/utils';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 
 interface ConstrainAndAlignListBoxArgs {
   popoverRef: React.RefObject<HTMLElement | null>;
@@ -223,13 +222,13 @@ const StyledPositionWrapper = styled('div')<{visible?: boolean}>`
 `;
 
 const FooterContainer = styled('div')`
-  padding: ${space(1)} ${space(2)};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
   color: ${p => p.theme.subText};
   border-top: 1px solid ${p => p.theme.innerBorder};
   font-size: ${p => p.theme.fontSize.sm};
   display: flex;
   flex-direction: column;
-  gap: ${space(0.5)};
+  gap: ${p => p.theme.space.xs};
 `;
 
 const LoadingWrapper = styled('div')<{height?: string; width?: string}>`

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -9,6 +9,8 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Overlay} from 'sentry/components/overlay';
 import type {CustomComboboxMenuProps} from 'sentry/components/searchQueryBuilder/tokens/combobox';
 import {itemIsSection} from 'sentry/components/searchQueryBuilder/tokens/utils';
+import {type Token, type TokenResult} from 'sentry/components/searchSyntax/parser';
+import {isWildcardOperator} from 'sentry/components/searchSyntax/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
@@ -48,11 +50,30 @@ function constrainAndAlignListBox({
   }
 }
 
+function WildcardFooter({
+  canUseWildcard,
+  token,
+}: {
+  canUseWildcard: boolean;
+  token: TokenResult<Token.FILTER>;
+}) {
+  if (isWildcardOperator(token.operator)) {
+    return null;
+  }
+
+  if (canUseWildcard) {
+    return <Label>{t('Wildcard (*) matching allowed')}</Label>;
+  }
+
+  return null;
+}
+
 interface ValueListBoxProps<T> extends CustomComboboxMenuProps<T> {
   canUseWildcard: boolean;
   isLoading: boolean;
   isMultiSelect: boolean;
   items: T[];
+  token: TokenResult<Token.FILTER>;
   wrapperRef: React.RefObject<HTMLDivElement | null>;
   portalTarget?: HTMLElement | null;
 }
@@ -60,9 +81,11 @@ interface ValueListBoxProps<T> extends CustomComboboxMenuProps<T> {
 function Footer({
   isMultiSelect,
   canUseWildcard,
+  token,
 }: {
   canUseWildcard: boolean;
   isMultiSelect: boolean;
+  token: TokenResult<Token.FILTER>;
 }) {
   if (!isMultiSelect && !canUseWildcard) {
     return null;
@@ -74,7 +97,7 @@ function Footer({
         <Label>{t('Hold %s to select multiple', isMac() ? '⌘' : 'Ctrl')}</Label>
       ) : null}
       <Label>{t('Type to search suggestions')}</Label>
-      {canUseWildcard ? <Label>{t('Wildcard (*) matching allowed')}</Label> : null}
+      <WildcardFooter canUseWildcard={canUseWildcard} token={token} />
     </FooterContainer>
   );
 }
@@ -93,6 +116,7 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
   items,
   canUseWildcard,
   portalTarget,
+  token,
   wrapperRef,
 }: ValueListBoxProps<T>) {
   const totalOptions = items.reduce(
@@ -162,7 +186,11 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
                 <LoadingIndicator size={24} />
               </LoadingWrapper>
             ) : null}
-            <Footer isMultiSelect={isMultiSelect} canUseWildcard={canUseWildcard} />
+            <Footer
+              isMultiSelect={isMultiSelect}
+              canUseWildcard={canUseWildcard}
+              token={token}
+            />
           </Fragment>
         )}
       </SectionedOverlay>


### PR DESCRIPTION
This PR makes a small tweak to the value list box to hide the wildcard footer message, when users have a wildcard op selected.

<img width="423" height="239" alt="Screenshot 2025-09-19 at 08 04 16" src="https://github.com/user-attachments/assets/c1c2b7bf-4ab4-46d3-9b19-093d9e98eae6" />
