### PR TITLE
fix(preprod): Remove size_analysis_state from backend

### DIFF
--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -80,8 +80,6 @@ class BuildDetailsApiResponse(BaseModel):
     app_info: BuildDetailsAppInfo
     vcs_info: BuildDetailsVcsInfo
     size_info: SizeInfo | None = None
-    # Deprecated, to be removed once frontend uses size_info.state
-    size_analysis_state: PreprodArtifactSizeMetrics.SizeAnalysisState | None = None
 
 
 def platform_from_artifact_type(artifact_type: PreprodArtifact.ArtifactType) -> Platform:
@@ -175,5 +173,4 @@ def transform_preprod_artifact_to_build_details(
         app_info=app_info,
         vcs_info=vcs_info,
         size_info=size_info,
-        size_analysis_state=size_info.state if size_info else None,
     )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the deprecated `size_analysis_state` from `BuildDetailsApiResponse` and its population, relying on `size_info.state` instead.
> 
> - **Backend/API**:
>   - **Build details response**: Remove deprecated `size_analysis_state` from `BuildDetailsApiResponse` in `src/sentry/preprod/api/models/project_preprod_build_details_models.py`.
>   - **Transformation**: Stop setting `size_analysis_state` in `transform_preprod_artifact_to_build_details`; use `size_info.state` via `size_info`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31ca57b936e904952ed581be1c389eeceef0bf08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->