### PR TITLE
Revert "chore(tasks) Remove commands and task decorators for celery"

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -80,6 +80,8 @@ x-sentry-service-config:
         branch: main
         repo_link: https://github.com/getsentry/taskbroker.git
         mode: containerized
+    rabbitmq:
+      description: Messaging and streaming broker
     memcached:
       description: Memcached used for caching
     spotlight:
@@ -152,6 +154,8 @@ x-sentry-service-config:
     # Uptime monitoring
     uptime-results:
       description: Kafka consumer for uptime monitoring results
+    celery-worker:
+      description: Worker that processes tasks from celery
 
   modes:
     default: [snuba, postgres, relay, spotlight]
@@ -164,6 +168,7 @@ x-sentry-service-config:
     taskworker:
       [snuba, postgres, relay, taskbroker, spotlight, taskworker, taskworker-scheduler]
     backend-ci: [snuba, postgres, redis, bigtable, redis-cluster, symbolicator]
+    rabbitmq: [postgres, snuba, rabbitmq, spotlight]
     symbolicator: [postgres, snuba, symbolicator, spotlight]
     memcached: [postgres, snuba, memcached, spotlight]
     tracing:
@@ -363,6 +368,8 @@ x-programs:
     command: sentry run consumer metrics-subscription-results --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
   generic-metrics-subscription-results:
     command: sentry run consumer generic-metrics-subscription-results --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
+  celery-worker:
+    command: sentry run worker -c 1 --autoreload
 
 services:
   postgres:
@@ -415,6 +422,19 @@ services:
       - '127.0.0.1:7003:7003'
       - '127.0.0.1:7004:7004'
       - '127.0.0.1:7005:7005'
+    networks:
+      - devservices
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    environment:
+      - IP=0.0.0.0
+    labels:
+      - orchestrator=devservices
+  rabbitmq:
+    image: ghcr.io/getsentry/image-mirror-library-rabbitmq:3-management
+    ports:
+      - '127.0.0.1:5672:5672'
+      - '127.0.0.1:15672:15672'
     networks:
       - devservices
     extra_hosts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -720,6 +720,7 @@ module = [
     "tests.sentry.auth.providers.google.*",
     "tests.sentry.auth.services.*",
     "tests.sentry.auth_v2.endpoints.*",
+    "tests.sentry.celery.*",
     "tests.sentry.charts.*",
     "tests.sentry.data_export.*",
     "tests.sentry.data_secrecy.*",

--- a/src/sentry/celery.py
+++ b/src/sentry/celery.py
@@ -1,15 +1,78 @@
 import gc
 import logging
+import random
 from datetime import datetime
+from itertools import chain
 from typing import Any
 
 from celery import Celery, Task, signals
 from celery.worker.request import Request
 from django.conf import settings
+from django.db import models
+from django.utils.safestring import SafeString
 
-from sentry.utils import metrics
+from sentry.utils import json, metrics
 
 logger = logging.getLogger("celery.pickle")
+
+# XXX: Pickle parameters are not allowed going forward
+LEGACY_PICKLE_TASKS: frozenset[str] = frozenset([])
+
+
+def holds_bad_pickle_object(value, memo=None):
+    if memo is None:
+        memo = {}
+
+    value_id = id(value)
+    if value_id in memo:
+        return
+    memo[value_id] = value
+
+    if isinstance(value, (tuple, list)):
+        for item in value:
+            bad_object = holds_bad_pickle_object(item, memo)
+            if bad_object is not None:
+                return bad_object
+        return
+    elif isinstance(value, dict):
+        for item in value.values():
+            bad_object = holds_bad_pickle_object(item, memo)
+            if bad_object is not None:
+                return bad_object
+        return
+    if isinstance(value, models.Model):
+        return (
+            value,
+            "django database models are large and likely to be stale when your task is run. "
+            "Instead pass primary key values to the task and load records from the database within your task.",
+        )
+    app_module = type(value).__module__
+    if app_module.startswith(("sentry.", "getsentry.")):
+        return value, "do not pickle application classes"
+    elif app_module.startswith("kombu."):
+        # Celery injects these into calls, they don't get passed with taskworker
+        return None
+    elif isinstance(value, SafeString):
+        # Django string wrappers json encode fine
+        return None
+    elif value is None:
+        return None
+    elif not isinstance(value, (str, float, int, bool)):
+        return value, "do not pickle stdlib classes"
+    return None
+
+
+def good_use_of_pickle_or_bad_use_of_pickle(task, args, kwargs):
+    argiter = chain(enumerate(args), kwargs.items())
+
+    for name, value in argiter:
+        bad = holds_bad_pickle_object(value)
+        if bad is not None:
+            bad_object, reason = bad
+            raise TypeError(
+                "Task %s was called with a parameter that cannot be JSON "
+                "encoded (%r, reason is %s) in argument %s" % (task.name, bad_object, reason, name)
+            )
 
 
 @signals.worker_before_create_process.connect
@@ -37,6 +100,7 @@ class SentryTask(Task):
         kwargs["__start_time"] = datetime.now().timestamp()
 
     def __call__(self, *args, **kwargs):
+        self._validate_parameters(args, kwargs)
         return super().__call__(*args, **kwargs)
 
     def delay(self, *args, **kwargs):
@@ -45,9 +109,48 @@ class SentryTask(Task):
 
     def apply_async(self, *args, **kwargs):
         self._add_metadata(kwargs)
+        self._validate_parameters(args, kwargs)
 
         with metrics.timer("jobs.delay", instance=self.name):
             return Task.apply_async(self, *args, **kwargs)
+
+    def _validate_parameters(self, args: tuple[Any, ...], kwargs: dict[str, Any]):
+        # If there is a bad use of pickle create a sentry exception to be found and fixed later.
+        # If this is running in tests, instead raise the exception and fail outright.
+        should_complain = (
+            settings.CELERY_COMPLAIN_ABOUT_BAD_USE_OF_PICKLE
+            and self.name not in LEGACY_PICKLE_TASKS
+        )
+        should_sample = random.random() <= settings.CELERY_PICKLE_ERROR_REPORT_SAMPLE_RATE
+        if should_complain or should_sample:
+            try:
+                cleaned_kwargs: dict[str, Any] = {}
+                for k, v in kwargs.items():
+                    # Remove kombu objects that celery injects
+                    module_name = type(v).__module__
+                    if module_name.startswith("kombu."):
+                        continue
+                    cleaned_kwargs[k] = v
+                param_size = json.dumps({"args": args, "kwargs": cleaned_kwargs})
+                metrics.distribution(
+                    "celery.task.parameter_bytes",
+                    len(param_size.encode("utf8")),
+                    tags={"taskname": self.name},
+                    sample_rate=1.0,
+                )
+            except Exception as e:
+                logger.warning(
+                    "task.payload.measure.failure", extra={"error": str(e), "task": self.name}
+                )
+
+            try:
+                good_use_of_pickle_or_bad_use_of_pickle(self, args, kwargs)
+            except TypeError:
+                logger.exception(
+                    "Task args contain unserializable objects",
+                )
+                if should_complain:
+                    raise
 
 
 class SentryRequest(Request):

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -797,6 +797,11 @@ BROKER_TRANSPORT_OPTIONS: dict[str, int] = {}
 # though it would cause timeouts/recursions in some cases
 CELERY_ALWAYS_EAGER = False
 
+# Complain about bad use of pickle.  See sentry.celery.SentryTask.apply_async for how
+# this works.
+CELERY_COMPLAIN_ABOUT_BAD_USE_OF_PICKLE = False
+CELERY_PICKLE_ERROR_REPORT_SAMPLE_RATE = 0.02
+
 # We use the old task protocol because during benchmarking we noticed that it's faster
 # than the new protocol. If we ever need to bump this it should be fine, there were no
 # compatibility issues, just need to run benchmarks and do some tests to make sure

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -6,9 +6,11 @@ import random
 import signal
 import time
 from collections.abc import Mapping
+from multiprocessing import cpu_count
 from typing import Any
 
 import click
+from django.utils import autoreload
 
 import sentry.taskworker.constants as taskworker_constants
 from sentry.bgtasks.api import managed_bgtasks
@@ -125,6 +127,118 @@ def web(
         from sentry.services.http import SentryHTTPServer
 
         SentryHTTPServer(host=bind[0], port=bind[1], workers=workers).run()
+
+
+def run_worker(**options: Any) -> None:
+    """
+    This is the inner function to actually start worker.
+    """
+    from django.conf import settings
+
+    if settings.CELERY_ALWAYS_EAGER:
+        raise click.ClickException(
+            "Disable CELERY_ALWAYS_EAGER in your settings file to spawn workers."
+        )
+
+    # These options are no longer used, but keeping around
+    # for backwards compatibility
+    for o in "without_gossip", "without_mingle", "without_heartbeat":
+        options.pop(o, None)
+
+    from sentry.celery import app
+
+    # NOTE: without_mingle breaks everything,
+    # we can't get rid of this. Intentionally kept
+    # here as a warning. Jobs will not process.
+    without_mingle = os.getenv("SENTRY_WORKER_FORCE_WITHOUT_MINGLE", "false").lower() == "true"
+
+    with managed_bgtasks(role="worker"):
+        worker = app.Worker(
+            without_mingle=without_mingle,
+            without_gossip=True,
+            without_heartbeat=True,
+            pool_cls="processes",
+            **options,
+        )
+        worker.start()
+        raise SystemExit(worker.exitcode)
+
+
+@run.command()
+@click.option(
+    "--hostname",
+    "-n",
+    help=(
+        "Set custom hostname, e.g. 'w1.%h'. Expands: %h" "(hostname), %n (name) and %d, (domain)."
+    ),
+)
+@click.option(
+    "--queues",
+    "-Q",
+    type=QueueSet,
+    help=(
+        "List of queues to enable for this worker, separated by "
+        "comma. By default all configured queues are enabled. "
+        "Example: -Q video,image"
+    ),
+)
+@click.option("--exclude-queues", "-X", type=QueueSet)
+@click.option(
+    "--concurrency",
+    "-c",
+    default=cpu_count(),
+    help=(
+        "Number of child processes processing the queue. The "
+        "default is the number of CPUs available on your "
+        "system."
+    ),
+)
+@click.option(
+    "--logfile", "-f", help=("Path to log file. If no logfile is specified, stderr is used.")
+)
+@click.option("--quiet", "-q", is_flag=True, default=False)
+@click.option("--no-color", is_flag=True, default=False)
+@click.option("--autoreload", is_flag=True, default=False, help="Enable autoreloading.")
+@click.option("--without-gossip", is_flag=True, default=False)
+@click.option("--without-mingle", is_flag=True, default=False)
+@click.option("--without-heartbeat", is_flag=True, default=False)
+@click.option("--max-tasks-per-child", default=10000)
+@click.option("--ignore-unknown-queues", is_flag=True, default=False)
+@log_options()
+@configuration
+def worker(ignore_unknown_queues: bool, **options: Any) -> None:
+    """Run background worker instance and autoreload if necessary."""
+
+    from sentry.celery import app
+
+    known_queues = frozenset(c_queue.name for c_queue in app.conf.CELERY_QUEUES)
+
+    if options["queues"] is not None:
+        if not options["queues"].issubset(known_queues):
+            unknown_queues = options["queues"] - known_queues
+            message = "Following queues are not found: %s" % ",".join(sorted(unknown_queues))
+            if ignore_unknown_queues:
+                options["queues"] -= unknown_queues
+                click.echo(message)
+            else:
+                raise click.ClickException(message)
+
+    if options["exclude_queues"] is not None:
+        if not options["exclude_queues"].issubset(known_queues):
+            unknown_queues = options["exclude_queues"] - known_queues
+            message = "Following queues cannot be excluded as they don't exist: %s" % ",".join(
+                sorted(unknown_queues)
+            )
+            if ignore_unknown_queues:
+                options["exclude_queues"] -= unknown_queues
+                click.echo(message)
+            else:
+                raise click.ClickException(message)
+
+    if options["autoreload"]:
+        autoreload.run_with_reloader(run_worker, **options)
+    else:
+        run_worker(**options)
 
 
 @run.command()
@@ -370,6 +484,59 @@ def taskbroker_send_tasks(
             click.echo(message=f"{int((i / repeat) * 100)}% complete")
 
     click.echo(message=f"Successfully sent {repeat} messages.")
+
+
+@run.command()
+@click.option(
+    "--pidfile",
+    help=(
+        "Optional file used to store the process pid. The "
+        "program will not start if this file already exists and "
+        "the pid is still alive."
+    ),
+)
+@click.option(
+    "--logfile", "-f", help=("Path to log file. If no logfile is specified, stderr is used.")
+)
+@click.option("--quiet", "-q", is_flag=True, default=False)
+@click.option("--no-color", is_flag=True, default=False)
+@click.option("--autoreload", is_flag=True, default=False, help="Enable autoreloading.")
+@click.option("--without-gossip", is_flag=True, default=False)
+@click.option("--without-mingle", is_flag=True, default=False)
+@click.option("--without-heartbeat", is_flag=True, default=False)
+@log_options()
+@configuration
+def cron(**options: Any) -> None:
+    "Run periodic task dispatcher."
+    from django.conf import settings
+
+    from sentry import options as runtime_options
+
+    if settings.CELERY_ALWAYS_EAGER:
+        raise click.ClickException(
+            "Disable CELERY_ALWAYS_EAGER in your settings file to spawn workers."
+        )
+
+    from sentry.celery import app
+
+    schedule = app.conf.CELERYBEAT_SCHEDULE
+    if runtime_options.get("taskworker.enabled"):
+        click.secho(
+            "You have `taskworker.enabled` active, run `sentry run taskworker-scheduler` instead.",
+            fg="yellow",
+        )
+        click.secho("Ignoring all schedules in settings.CELERYBEAT_SCHEDULE", fg="yellow")
+        schedule = {}
+
+    app.conf.update(CELERYBEAT_SCHEDULE=schedule)
+
+    with managed_bgtasks(role="cron"):
+        app.Beat(
+            # without_gossip=True,
+            # without_mingle=True,
+            # without_heartbeat=True,
+            **options
+        ).run()
 
 
 @run.command("consumer")

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -3,17 +3,25 @@ from __future__ import annotations
 import functools
 import logging
 from collections.abc import Callable, Iterable
+from datetime import datetime
 from typing import Any, ParamSpec, TypeVar
 
 import sentry_sdk
+from celery import Task
+from celery.exceptions import Ignore, MaxRetriesExceededError, Reject, Retry, SoftTimeLimitExceeded
+from django.conf import settings
 from django.db.models import Model
 
+from sentry import options
+from sentry.celery import app
 from sentry.silo.base import SiloLimit, SiloMode
-from sentry.taskworker.config import TaskworkerConfig  # noqa (used in getsentry)
+from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.retry import RetryError, retry_task
 from sentry.taskworker.state import current_task
+from sentry.taskworker.task import Task as TaskworkerTask
 from sentry.taskworker.workerchild import ProcessingDeadlineExceeded
 from sentry.utils import metrics
+from sentry.utils.memory import track_memory_usage
 
 ModelT = TypeVar("ModelT", bound=Model)
 
@@ -25,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 class TaskSiloLimit(SiloLimit):
     """
-    Silo limiter for tasks
+    Silo limiter for celery tasks
 
     We don't want tasks to be spawned in the incorrect silo.
     We can't reliably cause tasks to fail as not all tasks use
@@ -46,8 +54,8 @@ class TaskSiloLimit(SiloLimit):
         return handle
 
     def __call__(self, decorated_task: Any) -> Any:
-        # Replace the sentry.taskworker.Task interface used to schedule tasks.
-        replacements = {"delay", "apply_async"}
+        # Replace the celery.Task interface we use.
+        replacements = {"delay", "apply_async", "s", "signature", "retry", "apply", "run"}
         for attr_name in replacements:
             task_attr = getattr(decorated_task, attr_name)
             if callable(task_attr):
@@ -58,6 +66,46 @@ class TaskSiloLimit(SiloLimit):
         if hasattr(decorated_task, "name"):
             limited_func.name = decorated_task.name  # type: ignore[attr-defined]
         return limited_func
+
+
+def taskworker_override(
+    celery_task_attr: Callable[P, R],
+    taskworker_attr: Callable[P, R],
+) -> Callable[P, R]:
+    def override(*args: P.args, **kwargs: P.kwargs) -> R:
+        if options.get("taskworker.enabled"):
+            return taskworker_attr(*args, **kwargs)
+
+        return celery_task_attr(*args, **kwargs)
+
+    functools.update_wrapper(override, celery_task_attr)
+    return override
+
+
+def override_task(
+    celery_task: Task,
+    taskworker_task: TaskworkerTask,
+    taskworker_config: TaskworkerConfig,
+    task_name: str,
+) -> Task:
+    """
+    This function is used to override SentryTasks methods with TaskworkerTask methods
+    depending on the rollout percentage set in sentry options.
+
+    This is used to migrate tasks from celery to taskworker in a controlled manner.
+    """
+    replacements = {"delay", "apply_async"}
+    for attr_name in replacements:
+        celery_task_attr = getattr(celery_task, attr_name)
+        taskworker_attr = getattr(taskworker_task, attr_name)
+        if callable(celery_task_attr) and callable(taskworker_attr):
+            limited_attr = taskworker_override(
+                celery_task_attr,
+                taskworker_attr,
+            )
+            setattr(celery_task, attr_name, limited_attr)
+
+    return celery_task
 
 
 def load_model_from_db(
@@ -73,12 +121,14 @@ def load_model_from_db(
 
 def instrumented_task(
     name,
+    stat_suffix=None,
     silo_mode=None,
+    record_timing=False,
     taskworker_config=None,
     **kwargs,
 ):
     """
-    Decorator for defining tasks.
+    Decorator for defining celery tasks.
 
     Includes a few application specific batteries like:
 
@@ -89,16 +139,71 @@ def instrumented_task(
     """
 
     def wrapped(func):
-        assert taskworker_config, "The `taskworker_config` parameter is required to define a task"
-        task = taskworker_config.namespace.register(
-            name=name,
-            retry=taskworker_config.retry,
-            expires=taskworker_config.expires,
-            processing_deadline_duration=taskworker_config.processing_deadline_duration,
-            at_most_once=taskworker_config.at_most_once,
-            wait_for_delivery=taskworker_config.wait_for_delivery,
-            compression_type=taskworker_config.compression_type,
-        )(func)
+        @functools.wraps(func)
+        def _wrapped(*args, **kwargs):
+            record_queue_wait_time = record_timing
+
+            # Use a try/catch here to contain the blast radius of an exception being unhandled through the options lib
+            # Unhandled exception could cause all tasks to be effected and not work
+
+            # TODO(dcramer): we want to tag a transaction ID, but overriding
+            # the base on app.task seems to cause problems w/ Celery internals
+            transaction_id = kwargs.pop("__transaction_id", None)
+            start_time = kwargs.pop("__start_time", None)
+
+            key = "jobs.duration"
+            if stat_suffix:
+                instance = f"{name}.{stat_suffix(*args, **kwargs)}"
+            else:
+                instance = name
+
+            if start_time and record_queue_wait_time:
+                curr_time = datetime.now().timestamp()
+                duration = (curr_time - start_time) * 1000
+                metrics.distribution(
+                    "jobs.queue_time", duration, instance=instance, unit="millisecond"
+                )
+
+            scope = sentry_sdk.get_isolation_scope()
+            scope.set_tag("task_name", name)
+            scope.set_tag("transaction_id", transaction_id)
+
+            with (
+                metrics.timer(key, instance=instance),
+                track_memory_usage("jobs.memory_change", instance=instance),
+            ):
+                result = func(*args, **kwargs)
+
+            return result
+
+        # If the split task router is configured for the task, always use queues defined
+        # in the split task configuration
+        if name in settings.CELERY_SPLIT_QUEUE_TASK_ROUTES and "queue" in kwargs:
+            q = kwargs.pop("queue")
+            logger.warning("ignoring queue: %s, using value from CELERY_SPLIT_QUEUE_TASK_ROUTES", q)
+
+        # We never use result backends in Celery. Leaving `trail=True` means that if we schedule
+        # many tasks from a parent task, each task leaks memory. This can lead to the scheduler
+        # being OOM killed.
+        kwargs["trail"] = False
+
+        task = app.task(name=name, **kwargs)(_wrapped)
+        if taskworker_config:
+            taskworker_task = taskworker_config.namespace.register(
+                name=name,
+                retry=taskworker_config.retry,
+                expires=taskworker_config.expires,
+                processing_deadline_duration=taskworker_config.processing_deadline_duration,
+                at_most_once=taskworker_config.at_most_once,
+                wait_for_delivery=taskworker_config.wait_for_delivery,
+                compression_type=taskworker_config.compression_type,
+            )(func)
+
+            task = override_task(task, taskworker_task, taskworker_config, name)
+        else:
+            raise Exception(
+                f"taskworker_config must be defined, please add TaskworkerConfig to instrumented_task call for {name}"
+            )
 
         if silo_mode:
             silo_limiter = TaskSiloLimit(silo_mode)
@@ -131,7 +236,7 @@ def retry(
         return retry()(func)
 
     timeout_exceptions: tuple[type[BaseException], ...]
-    timeout_exceptions = (ProcessingDeadlineExceeded,)
+    timeout_exceptions = (ProcessingDeadlineExceeded, SoftTimeLimitExceeded)
     if not timeouts:
         timeout_exceptions = ()
 
@@ -142,7 +247,7 @@ def retry(
                 return func(*args, **kwargs)
             except ignore:
                 return
-            except RetryError:
+            except (RetryError, Retry, Ignore, Reject, MaxRetriesExceededError):
                 # We shouldn't interfere with exceptions that exist to communicate
                 # retry state.
                 raise

--- a/tests/sentry/api/endpoints/test_internal_queue_tasks.py
+++ b/tests/sentry/api/endpoints/test_internal_queue_tasks.py
@@ -9,4 +9,4 @@ class InternalQueueTasksListTest(APITestCase):
         url = "/api/0/internal/queue/tasks/"
         response = self.client.get(url)
         assert response.status_code == 200
-        assert "celery.chord" in response.data
+        assert "sentry.tasks.send_beacon" in response.data

--- a/tests/sentry/celery/test_app.py
+++ b/tests/sentry/celery/test_app.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+from celery.beat import ScheduleEntry
+from django.conf import settings
+
+from sentry.celery import app
+
+app.loader.import_default_modules()
+
+
+# XXX(dcramer): this doesn't actually work as we'd expect, as if the task is imported
+# anywhere else before this code is run it will still show up as registered
+@pytest.mark.parametrize("name,entry_data", list(settings.CELERYBEAT_SCHEDULE.items()))
+def test_validate_celerybeat_schedule(name: str, entry_data: dict[str, Any]) -> None:
+    entry = ScheduleEntry(name=name, app=app, **entry_data)
+    assert entry.task in app.tasks
+    mod_name = app.tasks[entry.task].__module__
+    assert mod_name in settings.CELERY_IMPORTS, f"{mod_name} is missing from CELERY_IMPORTS"
+    # Test that the schedules are valid. Throws a RuntimeError if one is invalid.
+    entry.is_due()
+
+
+@pytest.mark.parametrize("name,entry_data", list(settings.CELERYBEAT_SCHEDULE.items()))
+def test_validate_scheduled_task_parameters(name: str, entry_data: dict[str, Any]) -> None:
+    entry = ScheduleEntry(name=name, app=app, **entry_data)
+    task = app.tasks[entry.task]
+    signature = inspect.signature(task)
+    for parameter in signature.parameters.values():
+        # Skip *args and **kwargs
+        if parameter.kind in (parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD):
+            continue
+        if parameter.default == parameter.empty:
+            raise AssertionError(
+                f"Parameter `{parameter.name}` for task `{task.name}` must have a default value"
+            )

--- a/tests/sentry/integrations/github/tasks/test_link_all_repos.py
+++ b/tests/sentry/integrations/github/tasks/test_link_all_repos.py
@@ -10,8 +10,8 @@ from sentry.integrations.github.tasks.link_all_repos import link_all_repos
 from sentry.integrations.source_code_management.metrics import LinkAllReposHaltReason
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.repository import Repository
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
-from sentry.taskworker.retry import RetryError
 from sentry.testutils.asserts import assert_failure_metric, assert_halt_metric, assert_slo_metric
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -194,7 +194,7 @@ class LinkAllReposTestCase(IntegrationTestCase):
             status=400,
         )
 
-        with pytest.raises(RetryError):
+        with pytest.raises(ApiError):
             link_all_repos(
                 integration_key=self.key,
                 integration_id=self.integration.id,

--- a/tests/sentry/integrations/tasks/test_create_comment.py
+++ b/tests/sentry/integrations/tasks/test_create_comment.py
@@ -7,7 +7,6 @@ from sentry.integrations.models import ExternalIssue, Integration
 from sentry.integrations.tasks import create_comment
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.activity import Activity
-from sentry.taskworker.retry import RetryError
 from sentry.testutils.asserts import assert_failure_metric, assert_slo_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode_of
@@ -157,7 +156,9 @@ class TestCreateComment(TestCase):
             integration=self.example_integration,
         )
 
-        with pytest.raises(RetryError):
+        with pytest.raises(Exception) as exc:
             create_comment(external_issue.id, self.user.id, self.activity.id)
+
+        assert exc.match("Something went wrong creating comment")
 
         assert_failure_metric(mock_record_event, Exception("Something went wrong creating comment"))

--- a/tests/sentry/integrations/tasks/test_sync_assignee_outbound.py
+++ b/tests/sentry/integrations/tasks/test_sync_assignee_outbound.py
@@ -10,7 +10,6 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.tasks import sync_assignee_outbound
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
-from sentry.taskworker.retry import RetryError
 from sentry.testutils.asserts import assert_halt_metric, assert_success_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode_of
@@ -72,9 +71,10 @@ class TestSyncAssigneeOutbound(TestCase):
     ) -> None:
         mock_sync_assignee.side_effect = raise_sync_assignee_exception
 
-        with pytest.raises(RetryError):
+        with pytest.raises(Exception) as exc:
             sync_assignee_outbound(self.external_issue.id, self.user.id, True, None)
 
+        assert exc.match("Something went wrong")
         mock_record_failure.assert_called_once()
         mock_record_failure_args = mock_record_failure.call_args_list[0][0]
         assert mock_record_failure_args[0] is not None

--- a/tests/sentry/integrations/tasks/test_sync_status_outbound.py
+++ b/tests/sentry/integrations/tasks/test_sync_status_outbound.py
@@ -7,7 +7,6 @@ from sentry.integrations.models import ExternalIssue, Integration
 from sentry.integrations.tasks import sync_status_outbound
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.shared_integrations.exceptions import ApiUnauthorized, IntegrationFormError
-from sentry.taskworker.retry import RetryError
 from sentry.testutils.asserts import assert_count_of_metric, assert_halt_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode_of, region_silo_test
@@ -111,8 +110,10 @@ class TestSyncStatusOutbound(TestCase):
             group=self.group, key="foo_integration", integration=self.example_integration
         )
 
-        with pytest.raises(RetryError):
+        with pytest.raises(Exception) as exc:
             sync_status_outbound(self.group.id, external_issue_id=external_issue.id)
+
+        assert exc.match("Something went wrong")
 
         assert mock_record_failure.call_count == 1
         mock_record_event_args = mock_record_failure.call_args_list[0][0]

--- a/tests/sentry/integrations/tasks/test_update_comment.py
+++ b/tests/sentry/integrations/tasks/test_update_comment.py
@@ -7,7 +7,6 @@ from sentry.integrations.models import ExternalIssue, Integration
 from sentry.integrations.tasks import update_comment
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.activity import Activity
-from sentry.taskworker.retry import RetryError
 from sentry.testutils.asserts import assert_failure_metric, assert_slo_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode_of
@@ -150,7 +149,9 @@ class TestUpdateComment(TestCase):
             integration=self.example_integration,
         )
 
-        with pytest.raises(RetryError):
+        with pytest.raises(Exception) as exc:
             update_comment(external_issue.id, self.user.id, self.activity.id)
+
+        assert exc.match("Something went wrong updating comment")
 
         assert_failure_metric(mock_record_event, Exception("Something went wrong updating comment"))

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -1,6 +1,8 @@
+import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
+from celery.exceptions import SoftTimeLimitExceeded
 from django.test import override_settings
 
 from sentry.silo.base import SiloLimit, SiloMode
@@ -8,6 +10,8 @@ from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import test_tasks
 from sentry.taskworker.workerchild import ProcessingDeadlineExceeded
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.options import override_options
 
 
 @instrumented_task(
@@ -113,6 +117,53 @@ def test_exclude_exception_retry(capture_exception: MagicMock) -> None:
     assert capture_exception.call_count == 0
 
 
+@override_settings(
+    CELERY_COMPLAIN_ABOUT_BAD_USE_OF_PICKLE=True,
+    CELERY_PICKLE_ERROR_REPORT_SAMPLE_RATE=1.0,
+)
+@override_options(
+    {
+        "taskworker.enabled": False,
+        "taskworker.route.overrides": {},
+    }
+)
+@patch("sentry.tasks.base.metrics.distribution")
+@freeze_time("2025-01-01 00:00:00")  # so size of params isn't impacted by current time.
+def test_capture_payload_metrics(mock_distribution: MagicMock) -> None:
+    region_task.apply_async(args=("bruh",))
+
+    mock_distribution.assert_called_once_with(
+        "celery.task.parameter_bytes",
+        66,
+        tags={"taskname": "test.tasks.test_base.region_task"},
+        sample_rate=1.0,
+    )
+
+
+@override_settings(
+    CELERY_COMPLAIN_ABOUT_BAD_USE_OF_PICKLE=True,
+    CELERY_PICKLE_ERROR_REPORT_SAMPLE_RATE=1.0,
+)
+@override_options(
+    {
+        "taskworker.enabled": False,
+        "taskworker.route.overrides": {},
+    }
+)
+def test_validate_parameters_call() -> None:
+    with pytest.raises(TypeError) as err:
+        region_task.apply_async(args=(datetime.datetime.now(),))
+    assert "region_task was called with a parameter that cannot be JSON encoded" in str(err)
+
+    with pytest.raises(TypeError) as err:
+        region_task.delay(datetime.datetime.now())
+    assert "region_task was called with a parameter that cannot be JSON encoded" in str(err)
+
+    with pytest.raises(TypeError) as err:
+        region_task(datetime.datetime.now())
+    assert "region_task was called with a parameter that cannot be JSON encoded" in str(err)
+
+
 @override_settings(SILO_MODE=SiloMode.CONTROL)
 @patch("sentry.taskworker.retry.current_task")
 @patch("sentry_sdk.capture_exception")
@@ -131,7 +182,16 @@ def test_retry_on(capture_exception: MagicMock, current_task: MagicMock) -> None
 
 @pytest.mark.parametrize(
     "method_name",
-    ("apply_async", "delay"),
+    (
+        "apply",
+        "apply_async",
+        "delay",
+        "run",
+        "s",
+        "signature",
+        "retry",
+        "run",
+    ),
 )
 @override_settings(SILO_MODE=SiloMode.CONTROL)
 def test_task_silo_limit_celery_task_methods(method_name: str) -> None:
@@ -177,12 +237,12 @@ def test_retry_timeout_disabled_taskbroker(capture_exception, current_task) -> N
 
 @patch("sentry.taskworker.retry.current_task")
 @patch("sentry_sdk.capture_exception")
-def test_retry_timeout_enabled(capture_exception, current_task) -> None:
+def test_retry_soft_timeout_enabled(capture_exception, current_task) -> None:
     current_task.retry.side_effect = ExpectedException("retry called")
 
     @retry(timeouts=True)
     def soft_timeout_retry_task():
-        raise ProcessingDeadlineExceeded()
+        raise SoftTimeLimitExceeded()
 
     with pytest.raises(ExpectedException):
         soft_timeout_retry_task()
@@ -193,15 +253,31 @@ def test_retry_timeout_enabled(capture_exception, current_task) -> None:
 
 @patch("sentry.taskworker.retry.current_task")
 @patch("sentry_sdk.capture_exception")
-def test_retry_timeout_disabled(capture_exception, current_task) -> None:
+def test_retry_soft_timeout_disabled(capture_exception, current_task) -> None:
     current_task.retry.side_effect = ExpectedException("retry called")
 
     @retry(on=(ValueError,), timeouts=False)
     def soft_timeout_retry_task():
-        raise ProcessingDeadlineExceeded()
+        raise SoftTimeLimitExceeded()
 
-    with pytest.raises(ProcessingDeadlineExceeded):
+    with pytest.raises(SoftTimeLimitExceeded):
         soft_timeout_retry_task()
 
     assert capture_exception.call_count == 0
     assert current_task.retry.call_count == 0
+
+
+@patch("sentry.taskworker.retry.current_task")
+@patch("sentry_sdk.capture_exception")
+def test_retry_soft_timeouts_by_default(capture_exception, current_task) -> None:
+    current_task.retry.side_effect = ExpectedException("retry called")
+
+    @retry
+    def soft_timeout_no_retry_task():
+        raise SoftTimeLimitExceeded()
+
+    with pytest.raises(ExpectedException):
+        soft_timeout_no_retry_task()
+
+    assert capture_exception.call_count == 1
+    assert current_task.retry.call_count == 1

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import responses
+from celery.exceptions import Retry
 from django.utils import timezone
 
 from sentry.analytics.events.integration_commit_context_all_frames import (
@@ -36,7 +37,6 @@ from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.commit_context import PR_COMMENT_WINDOW, process_commit_context
-from sentry.taskworker.retry import NoRetriesRemainingError, RetryError
 from sentry.testutils.asserts import assert_halt_metric
 from sentry.testutils.cases import IntegrationTestCase, TestCase
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
@@ -825,7 +825,7 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         with self.tasks():
             assert not GroupOwner.objects.filter(group=self.event.group).exists()
             event_frames = get_frame_paths(self.event)
-            with pytest.raises(RetryError):
+            with pytest.raises(Retry):
                 process_commit_context(
                     event_id=self.event.event_id,
                     event_platform=self.event.platform,
@@ -865,20 +865,21 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
         assert not GroupOwner.objects.filter(group=self.event.group).exists()
         mock_process_suspect_commits.assert_not_called()
 
-    @patch("sentry.tasks.commit_context.retry_task")
+    @patch("celery.app.task.Task.request")
     @patch("sentry.tasks.groupowner.process_suspect_commits.delay")
     @patch(
         "sentry.integrations.github.integration.GitHubIntegration.get_commit_context_all_frames",
         side_effect=ApiError("Unknown API error"),
     )
     def test_no_fall_back_on_max_retries(
-        self, mock_get_commit_context, mock_process_suspect_commits, mock_retry_task
+        self, mock_get_commit_context, mock_process_suspect_commits, mock_request
     ):
         """
         A failure case where the integration hits an unknown API error a fifth time.
         After 5 retries, the task should bail.
         """
-        mock_retry_task.side_effect = NoRetriesRemainingError()
+        mock_request.called_directly = False
+        mock_request.retries = 5
 
         with self.tasks():
             assert not GroupOwner.objects.filter(group=self.event.group).exists()

--- a/tests/sentry/tasks/test_taskworker_rollout.py
+++ b/tests/sentry/tasks/test_taskworker_rollout.py
@@ -1,0 +1,56 @@
+from unittest import mock
+
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.registry import TaskRegistry
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
+
+
+class TestTaskworkerRollout(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.registry = TaskRegistry()
+        self.namespace = self.registry.create_namespace(name="test_namespace")
+        self.config = TaskworkerConfig(
+            namespace=self.namespace,
+            retry=None,
+            expires=None,
+            processing_deadline_duration=None,
+            at_most_once=False,
+            wait_for_delivery=False,
+        )
+
+    @mock.patch("sentry.taskworker.registry.TaskNamespace.send_task")
+    @override_options({"taskworker.enabled": True})
+    def test_with_taskworker_enabled_option(self, mock_send_task: mock.MagicMock) -> None:
+        @instrumented_task(
+            name="test.test_with_taskworker_rollout",
+            taskworker_config=self.config,
+        )
+        def test_task() -> str:
+            return "done"
+
+        assert test_task.name == "test.test_with_taskworker_rollout"
+        task = self.namespace.get("test.test_with_taskworker_rollout")
+        assert task is not None
+        assert task.name == "test.test_with_taskworker_rollout"
+        test_task.delay()
+        test_task.apply_async()
+        assert mock_send_task.call_count == 2
+
+    @mock.patch("sentry.celery.Task.apply_async")
+    @override_options({"taskworker.enabled": False})
+    def test_without_taskworker_rollout(self, mock_celery_apply_async: mock.MagicMock) -> None:
+        @instrumented_task(
+            name="test.test_without_taskworker_rollout",
+            taskworker_config=self.config,
+        )
+        def test_task(msg) -> str:
+            return f"hello {msg}"
+
+        assert test_task.name == "test.test_without_taskworker_rollout"
+        assert self.namespace.contains("test.test_without_taskworker_rollout") is True
+        test_task.delay()
+        test_task.apply_async()
+        assert mock_celery_apply_async.call_count == 2

--- a/tests/sentry/taskworker/test_config.py
+++ b/tests/sentry/taskworker/test_config.py
@@ -9,13 +9,6 @@ from sentry.conf.types.taskworker import crontab
 from sentry.taskworker.registry import taskregistry
 
 
-@pytest.fixture
-def load_tasks() -> None:
-    """Ensure that tasks are loaded for schedule tests"""
-    for path in settings.TASKWORKER_IMPORTS:
-        __import__(path)
-
-
 def test_import_paths() -> None:
     for path in settings.TASKWORKER_IMPORTS:
         try:
@@ -38,7 +31,7 @@ def test_taskworker_schedule_unique() -> None:
 
 
 @pytest.mark.parametrize("name,config", list(settings.TASKWORKER_SCHEDULES.items()))
-def test_taskworker_schedule_type(name: str, config: dict[str, Any], load_tasks) -> None:
+def test_taskworker_schedule_type(name: str, config: dict[str, Any]) -> None:
     assert config["task"], f"schedule {name} is missing a task name"
     (namespace, taskname) = config["task"].split(":")
     assert taskregistry.get_task(namespace, taskname), f"task for {name} is not registered"

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -170,7 +170,7 @@ class TestProcessWorkflowActivity(TestCase):
             "sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers",
             return_value=set(),
         ) as mock_evaluate:
-            process_workflow_activity(
+            process_workflow_activity.run(
                 activity_id=self.activity.id,
                 group_id=self.group.id,
                 detector_id=self.detector.id,
@@ -195,7 +195,7 @@ class TestProcessWorkflowActivity(TestCase):
             workflow=self.workflow,
         )
 
-        process_workflow_activity(
+        process_workflow_activity.run(
             activity_id=self.activity.id,
             group_id=self.group.id,
             detector_id=self.detector.id,
@@ -231,7 +231,7 @@ class TestProcessWorkflowActivity(TestCase):
             group=self.group,
         )
 
-        process_workflow_activity(
+        process_workflow_activity.run(
             activity_id=self.activity.id,
             group_id=self.group.id,
             detector_id=self.detector.id,


### PR DESCRIPTION
Reverts getsentry/sentry#99677

This is breaking e2e tests as self-hosted still relies on Celery commands. We should remove them there first.