### PR TITLE
ref(content-blocks): Convert unity

### DIFF
--- a/static/app/gettingStartedDocs/unity/unity.tsx
+++ b/static/app/gettingStartedDocs/unity/unity.tsx
@@ -155,13 +155,16 @@ export const feedbackOnboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: getCrashReportInstallDescription(),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: getCrashReportInstallDescription(),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'C#',
-              value: 'csharp',
               language: 'csharp',
               code: `var eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.");
 
@@ -169,7 +172,6 @@ SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The Use
             },
             {
               label: 'F#',
-              value: 'fsharp',
               language: 'fsharp',
               code: `let eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.")
 


### PR DESCRIPTION
- part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)