### PR TITLE
feat(repo): Case-insensitive repository name lookup for VCS integrations

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -127,6 +127,29 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
             if provider is not None and provider not in SUPPORTED_VCS_PROVIDERS:
                 return Response({"error": "Unsupported provider"}, status=400)
 
+            # Validate VCS parameters: if any are provided, all required ones must be present
+            vcs_params = {
+                "head_sha": data.get("head_sha"),
+                "head_repo_name": data.get("head_repo_name"),
+                "provider": data.get("provider"),
+                "head_ref": data.get("head_ref"),
+            }
+
+            # Check if any VCS parameters are provided
+            has_any_vcs_param = any(param is not None for param in vcs_params.values())
+
+            if has_any_vcs_param:
+                # If any VCS parameter is provided, all required ones must be present
+                missing_params = [name for name, value in vcs_params.items() if not value]
+                if missing_params:
+                    return Response(
+                        {
+                            "error": f"Incomplete VCS information: missing required parameters: {', '.join(missing_params)}. "
+                            f"When providing VCS parameters, all of {', '.join(vcs_params.keys())} are required."
+                        },
+                        status=400,
+                    )
+
             checksum = data.get("checksum")
             chunks = data.get("chunks", [])
 

--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -127,29 +127,6 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
             if provider is not None and provider not in SUPPORTED_VCS_PROVIDERS:
                 return Response({"error": "Unsupported provider"}, status=400)
 
-            # Validate VCS parameters: if any are provided, all required ones must be present
-            vcs_params = {
-                "head_sha": data.get("head_sha"),
-                "head_repo_name": data.get("head_repo_name"),
-                "provider": data.get("provider"),
-                "head_ref": data.get("head_ref"),
-            }
-
-            # Check if any VCS parameters are provided
-            has_any_vcs_param = any(param is not None for param in vcs_params.values())
-
-            if has_any_vcs_param:
-                # If any VCS parameter is provided, all required ones must be present
-                missing_params = [name for name, value in vcs_params.items() if not value]
-                if missing_params:
-                    return Response(
-                        {
-                            "error": f"Incomplete VCS information: missing required parameters: {', '.join(missing_params)}. "
-                            f"When providing VCS parameters, all of {', '.join(vcs_params.keys())} are required."
-                        },
-                        status=400,
-                    )
-
             checksum = data.get("checksum")
             chunks = data.get("chunks", [])
 

--- a/src/sentry/preprod/api/endpoints/organization_pullrequest_details.py
+++ b/src/sentry/preprod/api/endpoints/organization_pullrequest_details.py
@@ -104,13 +104,12 @@ class OrganizationPullRequestDetailsEndpoint(OrganizationEndpoint):
 
 def get_github_client(organization: Organization, repo_name: str) -> GitHubApiClient | None:
     """Get the GitHub integration for this organization."""
-    try:
-        repository = Repository.objects.get(
-            organization_id=organization.id,
-            name=repo_name,
-            provider="integrations:github",
-        )
-    except Repository.DoesNotExist:
+    repository = Repository.get_by_name_case_insensitive(
+        organization_id=organization.id,
+        name=repo_name,
+        provider="integrations:github",
+    )
+    if repository is None:
         logger.info(
             "preprod.pullrequest_files.no_repository",
             extra={

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -185,13 +185,12 @@ def _get_status_check_client(
     Returns None for expected failure cases (missing repo, integration, etc).
     Raises exceptions for unexpected errors that should be handled upstream.
     """
-    try:
-        repository = Repository.objects.get(
-            organization_id=project.organization_id,
-            name=commit_comparison.head_repo_name,
-            provider=f"integrations:{commit_comparison.provider}",
-        )
-    except Repository.DoesNotExist:
+    repository = Repository.get_by_name_case_insensitive(
+        organization_id=project.organization_id,
+        name=commit_comparison.head_repo_name,
+        provider=f"integrations:{commit_comparison.provider}",
+    )
+    if repository is None:
         logger.info(
             "preprod.status_checks.create.no_repository",
             extra={

--- a/tests/sentry/models/test_repository_case_insensitive.py
+++ b/tests/sentry/models/test_repository_case_insensitive.py
@@ -1,0 +1,146 @@
+from sentry.models.repository import Repository
+from sentry.testutils.cases import TestCase
+
+
+class RepositoryCaseInsensitiveTest(TestCase):
+    def setUp(self):
+        self.organization = self.create_organization()
+
+    def test_get_by_name_case_insensitive_exact_match(self):
+        """Test that exact case match works (performance optimization path)."""
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="MyOrg/MyRepo",
+            provider="integrations:github",
+        )
+
+        # Should find via exact match
+        found = Repository.get_by_name_case_insensitive(
+            organization_id=self.organization.id,
+            name="MyOrg/MyRepo",
+            provider="integrations:github",
+        )
+        assert found is not None
+        assert found.id == repo.id
+
+    def test_get_by_name_case_insensitive_different_case(self):
+        """Test that case-insensitive lookup works when case differs."""
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="MyOrg/MyRepo",
+            provider="integrations:github",
+        )
+
+        # Should find via case-insensitive lookup
+        found = Repository.get_by_name_case_insensitive(
+            organization_id=self.organization.id,
+            name="myorg/myrepo",  # Different case
+            provider="integrations:github",
+        )
+        assert found is not None
+        assert found.id == repo.id
+        assert found.name == "MyOrg/MyRepo"  # Original case preserved
+
+    def test_get_by_name_case_insensitive_mixed_case(self):
+        """Test various case combinations."""
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="MyOrg/MyRepo",
+            provider="integrations:github",
+        )
+
+        test_cases = [
+            "MYORG/MYREPO",
+            "myorg/MYREPO",
+            "MyOrg/myrepo",
+            "myOrg/MyRepo",
+        ]
+
+        for test_name in test_cases:
+            found = Repository.get_by_name_case_insensitive(
+                organization_id=self.organization.id,
+                name=test_name,
+                provider="integrations:github",
+            )
+            assert found is not None, f"Failed to find repo with name: {test_name}"
+            assert found.id == repo.id
+            assert found.name == "MyOrg/MyRepo"  # Original case preserved
+
+    def test_get_by_name_case_insensitive_not_found(self):
+        """Test that nonexistent repository returns None."""
+        Repository.objects.create(
+            organization_id=self.organization.id,
+            name="MyOrg/MyRepo",
+            provider="integrations:github",
+        )
+
+        # Different repo name entirely
+        found = Repository.get_by_name_case_insensitive(
+            organization_id=self.organization.id,
+            name="DifferentOrg/DifferentRepo",
+            provider="integrations:github",
+        )
+        assert found is None
+
+    def test_get_by_name_case_insensitive_wrong_provider(self):
+        """Test that wrong provider returns None."""
+        Repository.objects.create(
+            organization_id=self.organization.id,
+            name="MyOrg/MyRepo",
+            provider="integrations:github",
+        )
+
+        # Same name but different provider
+        found = Repository.get_by_name_case_insensitive(
+            organization_id=self.organization.id,
+            name="myorg/myrepo",
+            provider="integrations:gitlab",  # Different provider
+        )
+        assert found is None
+
+    def test_get_by_name_case_insensitive_wrong_organization(self):
+        """Test that wrong organization returns None."""
+        other_org = self.create_organization()
+        Repository.objects.create(
+            organization_id=self.organization.id,
+            name="MyOrg/MyRepo",
+            provider="integrations:github",
+        )
+
+        # Same name but different organization
+        found = Repository.get_by_name_case_insensitive(
+            organization_id=other_org.id,  # Different org
+            name="myorg/myrepo",
+            provider="integrations:github",
+        )
+        assert found is None
+
+    def test_get_by_name_case_insensitive_multiple_repos_different_orgs(self):
+        """Test that lookup correctly scopes by organization."""
+        other_org = self.create_organization()
+
+        repo1 = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="MyOrg/MyRepo",
+            provider="integrations:github",
+        )
+        repo2 = Repository.objects.create(
+            organization_id=other_org.id,
+            name="myorg/myrepo",  # Same name, different case, different org
+            provider="integrations:github",
+        )
+
+        # Should find the right repo for each org
+        found1 = Repository.get_by_name_case_insensitive(
+            organization_id=self.organization.id,
+            name="myorg/myrepo",
+            provider="integrations:github",
+        )
+        found2 = Repository.get_by_name_case_insensitive(
+            organization_id=other_org.id,
+            name="MYORG/MYREPO",
+            provider="integrations:github",
+        )
+
+        assert found1.id == repo1.id
+        assert found2.id == repo2.id


### PR DESCRIPTION
## Summary
- Add case-insensitive repository lookup to fix VCS integration failures
- Preserve canonical case in database while enabling flexible lookups
- Performance optimized: exact match first, case-insensitive fallback

## Problem
VCS providers (GitHub, GitLab) treat repository names as case-insensitive (`github.com/User/Repo` = `github.com/user/repo`), but Sentry's database stores them case-sensitively. This mismatch causes:

- **Failed pull request API calls** in preprod endpoints when case differs
- **Missing GitHub status checks** on commits due to repo lookup failures  
- **Silent VCS functionality loss** in artifact processing
- User confusion when CLI parameters work with GitHub but fail in Sentry

## Solution
Added `Repository.get_by_name_case_insensitive()` method that:

1. **First tries exact case match** (performance optimization - most common case)
2. **Falls back to case-insensitive lookup** using Django's `name__iexact`
3. **Preserves canonical case** in database - no schema changes
4. **Scopes properly** by organization and provider

## Changes
- **Repository Model**: Added `get_by_name_case_insensitive()` class method
- **Preprod Pull Request Endpoint**: Updated to use case-insensitive lookup
- **Status Check Creation**: Updated to use case-insensitive lookup  
- **Tests**: 7 comprehensive test cases covering various scenarios

## Usage
```python
# Before - case-sensitive, could fail
repo = Repository.objects.get(name="myorg/myrepo", ...)  # DoesNotExist if stored as "MyOrg/MyRepo"

# After - case-insensitive, robust
repo = Repository.get_by_name_case_insensitive(name="myorg/myrepo", ...)  # Finds "MyOrg/MyRepo"
```

This fixes the case sensitivity mismatch between VCS providers and Sentry's database lookups.

Fixes EME-312