### PR TITLE
ref(content-blocks): Convert ruby platforms

### DIFF
--- a/static/app/gettingStartedDocs/ruby/rack.tsx
+++ b/static/app/gettingStartedDocs/ruby/rack.tsx
@@ -71,16 +71,23 @@ const onboarding: OnboardingConfig = {
   install: params => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'The Sentry SDK for Ruby comes as a gem that should be added to your [gemfileCode:Gemfile]:',
+      content: [
         {
-          gemfileCode: <code />,
-        }
-      ),
-      configurations: [
+          type: 'text',
+          text: tct(
+            'The Sentry SDK for Ruby comes as a gem that should be added to your [gemfileCode:Gemfile]:',
+            {
+              gemfileCode: <code />,
+            }
+          ),
+        },
         {
-          description: params.isProfilingSelected
-            ? tct(
+          type: 'conditional',
+          condition: params.isProfilingSelected,
+          content: [
+            {
+              type: 'text',
+              text: tct(
                 'Ruby Profiling beta is available since SDK version 5.9.0. We use the [stackprofLink:stackprof gem] to collect profiles for Ruby. Make sure [code:stackprof] is loaded before [code:sentry-ruby].',
                 {
                   stackprofLink: (
@@ -88,13 +95,21 @@ const onboarding: OnboardingConfig = {
                   ),
                   code: <code />,
                 }
-              )
-            : undefined,
+              ),
+            },
+          ],
+        },
+        {
+          type: 'code',
           language: 'ruby',
           code: getInstallSnippet(params),
         },
         {
-          description: t('After adding the gems, run the following to install the SDK:'),
+          type: 'text',
+          text: t('After adding the gems, run the following to install the SDK:'),
+        },
+        {
+          type: 'code',
           language: 'ruby',
           code: 'bundle install',
         },
@@ -104,14 +119,18 @@ const onboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        'Add [code:use Sentry::Rack::CaptureExceptions] to your [code:config.ru] or other rackup file (this is automatically inserted in Rails):',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: [
+          type: 'text',
+          text: tct(
+            'Add [code:use Sentry::Rack::CaptureExceptions] to your [code:config.ru] or other rackup file (this is automatically inserted in Rails):',
+            {
+              code: <code />,
+            }
+          ),
+        },
         {
+          type: 'code',
           language: 'ruby',
           code: getConfigureSnippet(params),
         },
@@ -121,15 +140,18 @@ const onboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        "This snippet contains a deliberate error and message sent to Sentry and can be used as a test to make sure that everything's working as expected."
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: t(
+            "This snippet contains a deliberate error and message sent to Sentry and can be used as a test to make sure that everything's working as expected."
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'ruby',
-              value: 'ruby',
               language: 'ruby',
               code: getVerifySnippet(),
             },

--- a/static/app/gettingStartedDocs/ruby/rails.tsx
+++ b/static/app/gettingStartedDocs/ruby/rails.tsx
@@ -84,18 +84,28 @@ const onboarding: OnboardingConfig = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'The Sentry SDK for Rails comes as two gems that should be added to your [gemfileCode:Gemfile]:',
+      content: [
         {
-          gemfileCode: <code />,
-        }
-      ),
-      configurations: [
+          type: 'text',
+          text: tct(
+            'The Sentry SDK for Rails comes as two gems that should be added to your [gemfileCode:Gemfile]:',
+            {
+              gemfileCode: <code />,
+            }
+          ),
+        },
         {
+          type: 'code',
           language: 'ruby',
           code: getInstallSnippet(params),
-          additionalInfo: params.isProfilingSelected
-            ? tct(
+        },
+        {
+          type: 'conditional',
+          condition: params.isProfilingSelected,
+          content: [
+            {
+              type: 'text',
+              text: tct(
                 'Ruby Profiling beta is available since SDK version 5.9.0. We use the [stackprofLink:stackprof gem] to collect profiles for Ruby. Make sure [code:stackprof] is loaded before [code:sentry-ruby].',
                 {
                   stackprofLink: (
@@ -103,11 +113,16 @@ const onboarding: OnboardingConfig = {
                   ),
                   code: <code />,
                 }
-              )
-            : undefined,
+              ),
+            },
+          ],
         },
         {
-          description: t('After adding the gems, run the following to install the SDK:'),
+          type: 'text',
+          text: t('After adding the gems, run the following to install the SDK:'),
+        },
+        {
+          type: 'code',
           language: 'ruby',
           code: 'bundle install',
         },
@@ -117,21 +132,27 @@ const onboarding: OnboardingConfig = {
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        'Run the following Rails generator to create the initializer file [code:config/initializers/sentry.rb].',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: [
+          type: 'text',
+          text: tct(
+            'Run the following Rails generator to create the initializer file [code:config/initializers/sentry.rb].',
+            {
+              code: <code />,
+            }
+          ),
+        },
         {
+          type: 'code',
           language: 'ruby',
           code: generatorSnippet,
         },
         {
-          description: t('You can then change the Sentry configuration as follows:'),
+          type: 'text',
+          text: t('You can then change the Sentry configuration as follows:'),
         },
         {
+          type: 'code',
           language: 'ruby',
           code: getConfigureSnippet(params),
         },
@@ -141,15 +162,18 @@ const onboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        "This snippet contains a deliberate error and message sent to Sentry and can be used as a test to make sure that everything's working as expected."
-      ),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: t(
+            "This snippet contains a deliberate error and message sent to Sentry and can be used as a test to make sure that everything's working as expected."
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'ruby',
-              value: 'ruby',
               language: 'ruby',
               code: getVerifySnippet(),
             },

--- a/static/app/gettingStartedDocs/ruby/ruby.tsx
+++ b/static/app/gettingStartedDocs/ruby/ruby.tsx
@@ -13,25 +13,32 @@ type Params = DocsParams;
 
 export const getRubyProfilingOnboarding = ({
   frameworkPackage,
-}: {frameworkPackage?: string} = {}) => ({
+}: {frameworkPackage?: string} = {}): OnboardingConfig => ({
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'We use the [code:stackprof] [stackprofLink:gem] to collect profiles for Ruby.',
+      content: [
         {
-          code: <code />,
-          stackprofLink: <ExternalLink href="https://github.com/tmm1/stackprof" />,
-        }
-      ),
-      configurations: [
+          type: 'text',
+          text: tct(
+            'We use the [code:stackprof] [stackprofLink:gem] to collect profiles for Ruby.',
+            {
+              code: <code />,
+              stackprofLink: <ExternalLink href="https://github.com/tmm1/stackprof" />,
+            }
+          ),
+        },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'First add [code:stackprof] to your [code:Gemfile] and make sure it is loaded before the Sentry SDK.',
             {
               code: <code />,
             }
           ),
+        },
+        {
+          type: 'code',
           language: 'ruby',
           code: `
 gem 'stackprof'
@@ -48,18 +55,21 @@ gem '${frameworkPackage}'`
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        'Then, make sure both [code:traces_sample_rate] and [code:profiles_sample_rate] are set and non-zero in your Sentry initializer.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: [
+          type: 'text',
+          text: tct(
+            'Then, make sure both [code:traces_sample_rate] and [code:profiles_sample_rate] are set and non-zero in your Sentry initializer.',
+            {
+              code: <code />,
+            }
+          ),
+        },
         {
-          code: [
+          type: 'code',
+          tabs: [
             {
               label: 'Ruby',
-              value: 'ruby',
               filename: 'config/initializers/sentry.rb',
               language: 'ruby',
               code: `
@@ -78,9 +88,14 @@ end
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        'Verify that profiling is working correctly by simply using your application.'
-      ),
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Verify that profiling is working correctly by simply using your application.'
+          ),
+        },
+      ],
     },
   ],
 });
@@ -142,16 +157,23 @@ const onboarding: OnboardingConfig = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'The Sentry SDK for Ruby comes as a gem that should be added to your [gemfileCode:Gemfile]:',
+      content: [
         {
-          gemfileCode: <code />,
-        }
-      ),
-      configurations: [
+          type: 'text',
+          text: tct(
+            'The Sentry SDK for Ruby comes as a gem that should be added to your [gemfileCode:Gemfile]:',
+            {
+              gemfileCode: <code />,
+            }
+          ),
+        },
         {
-          description: params.isProfilingSelected
-            ? tct(
+          type: 'conditional',
+          condition: params.isProfilingSelected,
+          content: [
+            {
+              type: 'text',
+              text: tct(
                 'Ruby Profiling beta is available since SDK version 5.9.0. We use the [stackprofLink:stackprof gem] to collect profiles for Ruby. Make sure [code:stackprof] is loaded before [code:sentry-ruby].',
                 {
                   stackprofLink: (
@@ -159,13 +181,21 @@ const onboarding: OnboardingConfig = {
                   ),
                   code: <code />,
                 }
-              )
-            : undefined,
+              ),
+            },
+          ],
+        },
+        {
+          type: 'code',
           language: 'ruby',
           code: getInstallSnippet(params),
         },
         {
-          description: t('After adding the gems, run the following to install the SDK:'),
+          type: 'text',
+          text: t('After adding the gems, run the following to install the SDK:'),
+        },
+        {
+          type: 'code',
           language: 'ruby',
           code: 'bundle install',
         },
@@ -175,12 +205,16 @@ const onboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        'To use Sentry Ruby all you need is your DSN. Like most Sentry libraries it will honor the [code:SENTRY_DSN] environment variable. You can find it on the project settings page under API Keys. You can either export it as environment variable or manually configure it with [code:Sentry.init]:',
-        {code: <code />}
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: tct(
+            'To use Sentry Ruby all you need is your DSN. Like most Sentry libraries it will honor the [code:SENTRY_DSN] environment variable. You can find it on the project settings page under API Keys. You can either export it as environment variable or manually configure it with [code:Sentry.init]:',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
           language: 'ruby',
           code: getConfigureSnippet(params),
         },
@@ -190,11 +224,15 @@ const onboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        "This snippet contains a deliberate error and message sent to Sentry and can be used as a test to make sure that everything's working as expected."
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: t(
+            "This snippet contains a deliberate error and message sent to Sentry and can be used as a test to make sure that everything's working as expected."
+          ),
+        },
+        {
+          type: 'code',
           language: 'ruby',
           code: getVerifySnippet(),
         },


### PR DESCRIPTION
- part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)