### PR TITLE
chore: rename 'Prevent AI' to 'AI Code Review'

### DIFF
--- a/static/app/data/forms/organizationGeneralSettings.tsx
+++ b/static/app/data/forms/organizationGeneralSettings.tsx
@@ -52,7 +52,7 @@ const formGroups: JsonFormObject[] = [
       {
         name: 'enablePrReviewTestGeneration',
         type: 'boolean',
-        label: tct('Enable Prevent AI [badge]', {
+        label: tct('Enable AI Code Review [badge]', {
           badge: <FeatureBadge type="beta" style={{marginBottom: '2px'}} />,
         }),
         help: tct(

--- a/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.spec.tsx
+++ b/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.spec.tsx
@@ -109,7 +109,7 @@ describe('PreventSecondaryNav', () => {
       }
     );
 
-    const preventAILink = screen.getByRole('link', {name: 'Prevent AI'});
+    const preventAILink = screen.getByRole('link', {name: 'AI Code Review'});
     expect(preventAILink).toBeInTheDocument();
     expect(preventAILink).toHaveAttribute(
       'href',

--- a/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.tsx
@@ -57,7 +57,7 @@ function PreventSecondaryNav() {
             to={`${preventAIPathName}new/`}
             activeTo={`${preventAIPathName}new/`}
           >
-            {t('Prevent AI')}
+            {t('AI Code Review')}
           </SecondaryNav.Item>
         </SecondaryNav.Section>
         <Feature features={['prevent-test-analytics']}>

--- a/static/app/views/prevent/preventAI/onboarding.spec.tsx
+++ b/static/app/views/prevent/preventAI/onboarding.spec.tsx
@@ -37,12 +37,16 @@ describe('PreventAIOnboarding', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText('Prevent AI is an AI agent that automates tasks in your PR:')
+      screen.getByText('AI Code Review is an AI agent that automates tasks in your PR:')
     ).toBeInTheDocument();
 
-    expect(screen.getByRole('heading', {name: 'Setup Prevent AI'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {name: 'Setup AI Code Review'})
+    ).toBeInTheDocument();
 
-    expect(screen.getByText('How to use Prevent AI', {exact: false})).toBeInTheDocument();
+    expect(
+      screen.getByText('How to use AI Code Review', {exact: false})
+    ).toBeInTheDocument();
   });
 
   it('renders all three onboarding steps', () => {
@@ -50,7 +54,7 @@ describe('PreventAIOnboarding', () => {
 
     expect(screen.getByText('1')).toBeInTheDocument();
     expect(
-      screen.getByRole('heading', {name: 'Enable Prevent AI features'})
+      screen.getByRole('heading', {name: 'Enable AI Code Review features'})
     ).toBeInTheDocument();
 
     expect(screen.getByText('2')).toBeInTheDocument();
@@ -112,7 +116,7 @@ describe('PreventAIOnboarding', () => {
     render(<PreventAIOnboarding />, {organization});
 
     expect(
-      screen.getByText('Prevent AI helps you ship better code with three features:')
+      screen.getByText('AI Code Review helps you ship better code with three features:')
     ).toBeInTheDocument();
 
     expect(
@@ -143,7 +147,7 @@ describe('PreventAIOnboarding', () => {
   it('renders images with correct alt text', () => {
     render(<PreventAIOnboarding />, {organization});
 
-    const heroImage = screen.getByAltText('Prevent AI Hero');
+    const heroImage = screen.getByAltText('AI Code Review Hero');
     expect(heroImage).toBeInTheDocument();
 
     const prCommentsImage = screen.getByAltText('Prevent PR Comments');
@@ -178,7 +182,7 @@ describe('PreventAIOnboarding', () => {
     const stepHeadings = screen.getAllByRole('heading', {level: 3});
     expect(stepHeadings).toHaveLength(3);
 
-    expect(stepHeadings[0]).toHaveTextContent('Enable Prevent AI features');
+    expect(stepHeadings[0]).toHaveTextContent('Enable AI Code Review features');
     expect(stepHeadings[1]).toHaveTextContent('Setup GitHub Integration');
     expect(stepHeadings[2]).toHaveTextContent('Setup Seer');
   });
@@ -190,7 +194,7 @@ describe('PreventAIOnboarding', () => {
       expect(
         screen.getByText(
           textWithMarkupMatcher(
-            'An organization admin needs to turn on two toggles: Enable Prevent AI and Show Generative AI Features in your organization settings.'
+            'An organization admin needs to turn on two toggles: Enable AI Code Review and Show Generative AI Features in your organization settings.'
           )
         )
       ).toBeInTheDocument();
@@ -200,7 +204,7 @@ describe('PreventAIOnboarding', () => {
       render(<PreventAIOnboarding />, {organization});
 
       // Check that the italic text components are rendered
-      const enablePreventAIText = screen.getByText('Enable Prevent AI');
+      const enablePreventAIText = screen.getByText('Enable AI Code Review');
       const showGenerativeAIText = screen.getByText('Show Generative AI Features');
 
       expect(enablePreventAIText).toBeInTheDocument();
@@ -229,7 +233,7 @@ describe('PreventAIOnboarding', () => {
       expect(
         screen.getByText(
           textWithMarkupMatcher(
-            'Prevent AI uses the Sentry Seer agent to power its core functionalities. Install the Seer by Sentry GitHub App within the same GitHub organization.'
+            'AI Code Review uses the Sentry Seer agent to power its core functionalities. Install the Seer by Sentry GitHub App within the same GitHub organization.'
           )
         )
       ).toBeInTheDocument();

--- a/static/app/views/prevent/preventAI/onboarding.tsx
+++ b/static/app/views/prevent/preventAI/onboarding.tsx
@@ -49,13 +49,13 @@ export default function PreventAIOnboarding() {
         padding="xl 2xl"
         maxWidth="1000px"
       >
-        <StyledImg src={preventHero} alt="Prevent AI Hero" />
+        <StyledImg src={preventHero} alt="AI Code Review Hero" />
         <Flex direction="column" gap="md" maxWidth="500px" padding="2xl 0">
           <Heading as="h1" style={{maxWidth: '400px'}}>
             {t('Ship Code That Breaks Less With Code Reviews And Tests')}
           </Heading>
           <Text variant="primary" size="md">
-            {t('Prevent AI is an AI agent that automates tasks in your PR:')}
+            {t('AI Code Review is an AI agent that automates tasks in your PR:')}
           </Text>
           <Container as="ul" style={{margin: 0, fontSize: '12px'}}>
             <Container as="li">
@@ -84,7 +84,7 @@ export default function PreventAIOnboarding() {
             padding="0 0 xl 0"
             style={{borderBottom: `1px solid ${theme.border}`}}
           >
-            <Heading as="h1">{t('Setup Prevent AI')}</Heading>
+            <Heading as="h1">{t('Setup AI Code Review')}</Heading>
             <Text variant="primary" size="sm">
               {t(
                 `These setups must be installed or approved by an admin. If you're not an admin, reach out to your organization's admins to ensure they approve the installation.`
@@ -94,13 +94,13 @@ export default function PreventAIOnboarding() {
           <Flex direction="column" gap="xl">
             <OnboardingStep
               step={1}
-              title={t(`Enable Prevent AI features`)}
+              title={t(`Enable AI Code Review features`)}
               description={tct(
                 'An organization admin needs to turn on two toggles: [enablePreventAI] and [showGenerativeAI] in your [organizationSettingsLink:organization settings].',
                 {
                   enablePreventAI: (
                     <Text italic variant="muted" size="md">
-                      Enable Prevent AI
+                      Enable AI Code Review
                     </Text>
                   ),
                   showGenerativeAI: (
@@ -133,7 +133,7 @@ export default function PreventAIOnboarding() {
               step={3}
               title={t(`Setup Seer`)}
               description={tct(
-                'Prevent AI uses the Sentry Seer agent to power its core functionalities. Install the [link:Seer by Sentry GitHub App] within the same GitHub organization.',
+                'AI Code Review uses the Sentry Seer agent to power its core functionalities. Install the [link:Seer by Sentry GitHub App] within the same GitHub organization.',
                 {
                   link: <ExternalLink href="https://github.com/apps/seer-by-sentry" />,
                 }
@@ -148,10 +148,10 @@ export default function PreventAIOnboarding() {
             radius="md"
           >
             <Text variant="primary" size="md" bold>
-              {t('How to use Prevent AI')}
+              {t('How to use AI Code Review')}
             </Text>
             <Text variant="muted" size="md">
-              {t('Prevent AI helps you ship better code with three features:')}
+              {t('AI Code Review helps you ship better code with three features:')}
             </Text>
             <Container as="ul" style={{margin: 0, fontSize: '12px'}}>
               <li>

--- a/static/app/views/prevent/settings.tsx
+++ b/static/app/views/prevent/settings.tsx
@@ -11,5 +11,5 @@ export const TESTS_BASE_URL = 'tests';
 export const TOKENS_PAGE_TITLE = t('Tokens');
 export const TOKENS_BASE_URL = 'tokens';
 
-export const PREVENT_AI_PAGE_TITLE = t('Prevent AI');
+export const PREVENT_AI_PAGE_TITLE = t('AI Code Review');
 export const PREVENT_AI_BASE_URL = 'prevent-ai';

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -249,7 +249,7 @@ describe('OrganizationSettingsForm', () => {
     expect(toggle).toBeEnabled();
   });
 
-  it('renders Prevent AI field', () => {
+  it('renders AI Code Review field', () => {
     render(
       <OrganizationSettingsForm
         {...routerProps}
@@ -258,7 +258,7 @@ describe('OrganizationSettingsForm', () => {
       />
     );
 
-    expect(screen.getByText('Enable Prevent AI')).toBeInTheDocument();
+    expect(screen.getByText('Enable AI Code Review')).toBeInTheDocument();
 
     expect(screen.getByText('beta')).toBeInTheDocument();
 
@@ -274,7 +274,7 @@ describe('OrganizationSettingsForm', () => {
     );
   });
 
-  it('hides Prevent AI field when AI features are disabled', () => {
+  it('hides AI Code Review field when AI features are disabled', () => {
     render(
       <OrganizationSettingsForm
         {...routerProps}
@@ -284,7 +284,7 @@ describe('OrganizationSettingsForm', () => {
       />
     );
 
-    expect(screen.queryByText('Enable Prevent AI')).not.toBeInTheDocument();
+    expect(screen.queryByText('Enable AI Code Review')).not.toBeInTheDocument();
     expect(
       screen.queryByText(
         'Use AI to review, find bugs, and generate tests in pull requests'
@@ -301,7 +301,7 @@ describe('OrganizationSettingsForm', () => {
       />
     );
 
-    expect(screen.getByText('Enable Prevent AI')).toBeInTheDocument();
+    expect(screen.getByText('Enable AI Code Review')).toBeInTheDocument();
     expect(
       screen.getByText('Use AI to review, find bugs, and generate tests in pull requests')
     ).toBeInTheDocument();
@@ -322,17 +322,17 @@ describe('OrganizationSettingsForm', () => {
     });
 
     // Initially AI features are disabled, so PR Review field should be hidden
-    expect(screen.queryByText('Enable Prevent AI')).not.toBeInTheDocument();
+    expect(screen.queryByText('Enable AI Code Review')).not.toBeInTheDocument();
 
     const aiToggle = screen.getByRole('checkbox', {name: 'Show Generative AI Features'});
     await userEvent.click(aiToggle);
 
     // PR Review field should now be visible
-    expect(screen.getByText('Enable Prevent AI')).toBeInTheDocument();
+    expect(screen.getByText('Enable AI Code Review')).toBeInTheDocument();
 
     await userEvent.click(aiToggle);
 
     // PR Review field should be hidden again
-    expect(screen.queryByText('Enable Prevent AI')).not.toBeInTheDocument();
+    expect(screen.queryByText('Enable AI Code Review')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
from Rohan:

I think we should update stuff to call it "AI Code Review" . Here's what needs to change
* Sub nav title
* Title and copy on onboarding page (routing can remain unchanged)
* Org settings toggle
* Docs (https://docs.sentry.io/product/ai-in-sentry/sentry-prevent-ai/)

This changes pretty much anything that was in the Sentry UI (not docs)

## Summary of changes

Note: The title in the onboarding page was updated to "Setup AI Code Review", not just "AI Code Review" as in the image (but I forced pushed like an amateur, my bad)

<img width="1343" height="979" alt="Screenshot 2025-09-19 at 16 08 04" src="https://github.com/user-attachments/assets/53fdc1c6-b247-47f3-b32e-663b06748725" />

<img width="1650" height="642" alt="image" src="https://github.com/user-attachments/assets/c990cb10-9aba-434e-b216-3297ee99f5f3" />

(not highlighted, but the toggle in the 2nd image "Enable AI Code Review" is the change)