### PR TITLE
fix: make sure to include all mdx files in knip analysis

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -35,6 +35,8 @@ const testingEntryPoints = [
 const storyBookEntryPoints = [
   // our storybook implementation is here
   'static/app/stories/storybook.tsx',
+  'static/**/*.stories.{js,mjs,ts,tsx}',
+  'static/**/*.mdx',
 ];
 
 const config: KnipConfig = {
@@ -43,7 +45,6 @@ const config: KnipConfig = {
     ...testingEntryPoints,
     ...storyBookEntryPoints,
   ],
-  storybook: true,
   project: [
     'static/**/*.{js,mjs,ts,tsx}!',
     'config/**/*.ts',


### PR DESCRIPTION
the default `storybook` plugin only includes *.stories.mdx, which isn't the convention we're using.

also, we aren't using the real "storybook" dependency, so moving away from that plugin and listing our entries manually is more explicit