### PR TITLE
fix(demo-mode): Prevent linking identities for demo user

### DIFF
--- a/src/sentry/demo_mode/utils.py
+++ b/src/sentry/demo_mode/utils.py
@@ -4,6 +4,7 @@ from sentry import options
 from sentry.models.organization import Organization
 from sentry.organizations.services.organization import RpcOrganization
 from sentry.users.models.user import User
+from sentry.users.services.user.model import RpcUser
 
 READONLY_SCOPES = frozenset(
     [
@@ -22,7 +23,7 @@ def is_demo_mode_enabled() -> bool:
     return options.get("demo-mode.enabled")
 
 
-def is_demo_user(user: User | AnonymousUser | None) -> bool:
+def is_demo_user(user: User | AnonymousUser | None | RpcUser) -> bool:
 
     if not user:
         return False

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3490,3 +3490,11 @@ register(
     default=None,
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK,
 )
+
+# Killswitch for linking identities for demo users
+register(
+    "identity.prevent-link-identity-for-demo-users.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/users/models/identity.py
+++ b/src/sentry/users/models/identity.py
@@ -10,7 +10,7 @@ from django.db import IntegrityError, models
 from django.db.models import Q, QuerySet
 from django.utils import timezone
 
-from sentry import analytics
+from sentry import analytics, options
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedPositiveIntegerField,
@@ -19,6 +19,7 @@ from sentry.db.models import (
     control_silo_model,
 )
 from sentry.db.models.manager.base import BaseManager
+from sentry.demo_mode.utils import is_demo_user
 from sentry.integrations.types import ExternalProviders, IntegrationProviderSlug
 from sentry.users.services.user import RpcUser
 
@@ -83,12 +84,18 @@ class IdentityManager(BaseManager["Identity"]):
         external_id: str,
         should_reattach: bool = True,
         defaults: Mapping[str, Any | None] | None = None,
-    ) -> Identity:
+    ) -> Identity | None:
         """
         Link the user with the identity. If `should_reattach` is passed, handle
         the case where the user is linked to a different identity or the
         identity is linked to a different user.
         """
+        # NOTE(vgrozdanic): temporary fix for #inc-1373 to stop the bleed
+        if is_demo_user(user) and options.get(
+            "identity.prevent-link-identity-for-demo-users.enabled"
+        ):
+            return None
+
         from sentry.integrations.slack.analytics import IntegrationIdentityLinked
 
         defaults = {

--- a/tests/sentry/users/models/test_identity.py
+++ b/tests/sentry/users/models/test_identity.py
@@ -1,7 +1,9 @@
 from sentry.identity import register
 from sentry.identity.providers.dummy import DummyProvider
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.silo import control_silo_test
+from sentry.users.models.identity import Identity
 
 
 @control_silo_test
@@ -19,3 +21,30 @@ class IdentityTestCase(TestCase):
         provider = identity_model.get_provider()
         assert provider.name == "Dummy"
         assert provider.key == "dummy"
+
+    def test_link_identity_for_demo_users(self) -> None:
+        user = self.create_user()
+        idp = self.create_identity_provider(type="dummy", external_id="1234")
+
+        # if the setting is disabled, the identity should be linked even for demo users
+        with override_options({"demo-mode.enabled": True, "demo-mode.users": [user.id]}):
+            assert Identity.objects.link_identity(user, idp, "1234") is not None
+
+        # if the setting is enabled, the identity should not be linked for demo users
+        with override_options(
+            {
+                "identity.prevent-link-identity-for-demo-users.enabled": True,
+                "demo-mode.enabled": True,
+                "demo-mode.users": [user.id],
+            }
+        ):
+            assert Identity.objects.link_identity(user, idp, "1234") is None
+
+        # if the setting is enabled, the identity should still be linked for non-demo users
+        with override_options(
+            {
+                "identity.prevent-link-identity-for-demo-users.enabled": True,
+                "demo-mode.enabled": True,
+            }
+        ):
+            assert Identity.objects.link_identity(user, idp, "1234") is not None


### PR DESCRIPTION
This is a temporary fix to prevent linking identities to demo user account until the exact route cause is discovered.

This is a no-op change until the option `identity.prevent-link-identity-for-demo-users.enabled` is switched to `true`, and then it will work only for a demo user.
