### PR TITLE
ref(grouping): remove should_handle_grouphash_metadata()

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -8,7 +8,6 @@ the `GroupHash` model file, so that existing records will get updated with the n
 from __future__ import annotations
 
 import logging
-import random
 from datetime import datetime
 from typing import Any, TypeIs, cast
 
@@ -113,14 +112,7 @@ def should_handle_grouphash_metadata(project: Project, grouphash_is_new: bool) -
     if not options.get("grouping.grouphash_metadata.ingestion_writes_enabled"):
         return False
 
-    # While we're backfilling metadata for existing grouphash records, if the load is too high, we
-    # want to prioritize metadata for new grouphashes because there's certain information
-    # (timestamp, Seer data) which is only available at group creation time.
-    if grouphash_is_new:
-        return True
-    else:
-        result = random.random() <= options.get("grouping.grouphash_metadata.backfill_sample_rate")
-        return result
+    return True
 
 
 def create_or_update_grouphash_metadata_if_needed(

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -11,7 +11,6 @@ import logging
 from datetime import datetime
 from typing import Any, TypeIs, cast
 
-from sentry import options
 from sentry.grouping.api import get_contributing_variant_and_component
 from sentry.grouping.component import (
     ChainedExceptionGroupingComponent,
@@ -105,14 +104,6 @@ METRICS_TAGS_BY_HASH_BASIS = {
     HashBasis.FALLBACK: ["fallback_reason"],
     HashBasis.UNKNOWN: [],
 }
-
-
-def should_handle_grouphash_metadata(project: Project, grouphash_is_new: bool) -> bool:
-    # Killswitches
-    if not options.get("grouping.grouphash_metadata.ingestion_writes_enabled"):
-        return False
-
-    return True
 
 
 def create_or_update_grouphash_metadata_if_needed(

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -233,7 +233,7 @@ def get_or_create_grouphashes(
     for hash_value in hashes:
         grouphash, created = GroupHash.objects.get_or_create(project=project, hash=hash_value)
 
-        if not options.get("grouping.grouphash_metadata.ingestion_writes_enabled"):
+        if options.get("grouping.grouphash_metadata.ingestion_writes_enabled"):
             try:
                 # We don't expect this to throw any errors, but collecting this metadata
                 # shouldn't ever derail ingestion, so better to be safe

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import sentry_sdk
 
+from sentry import options
 from sentry.exceptions import HashDiscarded
 from sentry.grouping.api import (
     NULL_GROUPING_CONFIG,
@@ -22,7 +23,6 @@ from sentry.grouping.ingest.config import is_in_transition
 from sentry.grouping.ingest.grouphash_metadata import (
     create_or_update_grouphash_metadata_if_needed,
     record_grouphash_metadata_metrics,
-    should_handle_grouphash_metadata,
 )
 from sentry.grouping.variants import BaseVariant
 from sentry.models.grouphash import GroupHash
@@ -233,7 +233,7 @@ def get_or_create_grouphashes(
     for hash_value in hashes:
         grouphash, created = GroupHash.objects.get_or_create(project=project, hash=hash_value)
 
-        if should_handle_grouphash_metadata(project, created):
+        if not options.get("grouping.grouphash_metadata.ingestion_writes_enabled"):
             try:
                 # We don't expect this to throw any errors, but collecting this metadata
                 # shouldn't ever derail ingestion, so better to be safe


### PR DESCRIPTION
Since `grouping.grouphash_metadata.backfill_sample_rate` is always set to 1, `should_handle_grouphash_metadata()` always returns `true` unless `grouping.grouphash_metadata.ingestion_writes_enabled` is false. 

Remove `should_handle_grouphash_metadata()` and move check for `ingestion_writes_enabled` to `get_or_create_grouphashes()`.
