### PR TITLE
ref(insights): replace slow db queries with most time spent db queries backend

### DIFF
--- a/static/app/components/charts/chartWidgetLoader.tsx
+++ b/static/app/components/charts/chartWidgetLoader.tsx
@@ -175,6 +175,10 @@ const CHART_MAP = {
     ),
   overviewSlowAssetsWidget: () =>
     import('sentry/views/insights/common/components/widgets/overviewSlowAssetsWidget'),
+  overviewTimeConsumingQueriesWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/overviewTimeConsumingQueriesWidget'
+    ),
   overviewTimeConsumingRequestsWidget: () =>
     import(
       'sentry/views/insights/common/components/widgets/overviewTimeConsumingRequestsWidget'

--- a/static/app/views/insights/common/components/widgets/overviewTimeConsumingQueriesWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewTimeConsumingQueriesWidget.tsx
@@ -12,7 +12,6 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
-import {formatTimeSeriesName} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';

--- a/static/app/views/insights/common/components/widgets/overviewTimeConsumingQueriesWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewTimeConsumingQueriesWidget.tsx
@@ -1,0 +1,236 @@
+import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
+
+import {openInsightChartModal} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/core/button';
+import {IconExpand} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {ellipsize} from 'sentry/utils/string/ellipsize';
+import {getIntervalForTimeSeriesQuery} from 'sentry/utils/timeSeries/getIntervalForTimeSeriesQuery';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {getExploreUrl} from 'sentry/views/explore/utils';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {BaseChartActionDropdown} from 'sentry/views/insights/common/components/chartActionDropdown';
+import {ModalChartContainer} from 'sentry/views/insights/common/components/insightsChartContainer';
+import {SpanDescriptionCell} from 'sentry/views/insights/common/components/tableCells/spanDescriptionCell';
+import {TimeSpentCell} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
+import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
+import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
+import {useAlertsProject} from 'sentry/views/insights/common/utils/useAlertsProject';
+import {SupportedDatabaseSystem} from 'sentry/views/insights/database/utils/constants';
+import {Referrer} from 'sentry/views/insights/pages/backend/referrers';
+import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared/getReleaseBubbleProps';
+import {
+  SeriesColorIndicator,
+  WidgetFooterTable,
+} from 'sentry/views/insights/pages/platform/shared/styles';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
+import {ModuleName, SpanFields} from 'sentry/views/insights/types';
+import {WidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
+
+export default function OverviewTimeConsumingQueriesWidget(
+  props: LoadableChartWidgetProps
+) {
+  const theme = useTheme();
+  const {query} = useTransactionNameQuery();
+  const releaseBubbleProps = useReleaseBubbleProps(props);
+  const {selection} = usePageFilters();
+  const organization = useOrganization();
+  const project = useAlertsProject();
+  const supportedSystems = Object.values(SupportedDatabaseSystem);
+
+  const search = new MutableSearch(
+    `${SpanFields.DB_SYSTEM}:[${supportedSystems.join(',')}] ${query}`.trim()
+  );
+  const referrer = Referrer.OVERVIEW_TIME_CONSUMING_QUERIES_WIDGET;
+  const groupBy = SpanFields.NORMALIZED_DESCRIPTION;
+  const yAxes = `p75(${SpanFields.SPAN_DURATION})`;
+  const totalTimeField = `sum(${SpanFields.SPAN_SELF_TIME})`;
+  const title = t('Queries by Time Spent');
+  const interval = getIntervalForTimeSeriesQuery(yAxes, selection.datetime);
+
+  const {
+    data: queriesListData,
+    isLoading: isQueriesListLoading,
+    error: queriesListError,
+  } = useSpans(
+    {
+      fields: [
+        SpanFields.PROJECT_ID,
+        SpanFields.NORMALIZED_DESCRIPTION,
+        SpanFields.SPAN_GROUP,
+        SpanFields.DB_SYSTEM,
+        'time_spent_percentage()',
+        totalTimeField,
+      ],
+      sorts: [{field: totalTimeField, kind: 'desc'}],
+      search,
+      limit: 3,
+      noPagination: true,
+    },
+    referrer
+  );
+
+  const {
+    data: queriesSeriesData,
+    isLoading: isQueriesSeriesLoading,
+    error: queriesSeriesError,
+  } = useTopNSpanSeries(
+    {
+      search: `${SpanFields.SPAN_GROUP}:[${queriesListData?.map(item => `"${item[SpanFields.SPAN_GROUP]}"`).join(',')}]`,
+      fields: [groupBy, yAxes],
+      yAxis: [yAxes],
+      topN: 3,
+      enabled: queriesListData?.length > 0,
+      interval,
+    },
+    referrer
+  );
+
+  const isLoading = isQueriesSeriesLoading || isQueriesListLoading;
+  const error = queriesSeriesError || queriesListError;
+
+  const hasData =
+    queriesListData && queriesListData.length > 0 && queriesSeriesData.length > 0;
+
+  const colorPalette = theme.chart.getColorPalette(queriesSeriesData.length - 1);
+
+  const aliases: Record<string, string> = {};
+
+  queriesListData.forEach(item => {
+    aliases[item[groupBy]] = `${yAxes}, ${ellipsize(item[groupBy], 50)}`;
+  });
+
+  const visualization = (
+    <WidgetVisualizationStates
+      isEmpty={!hasData}
+      isLoading={isLoading}
+      error={error}
+      emptyMessage={<WidgetEmptyStateWarning />}
+      VisualizationType={TimeSeriesWidgetVisualization}
+      visualizationProps={{
+        id: 'overviewTimeConsumingQueriesWidget',
+        showLegend: props.loaderSource === 'releases-drawer' ? 'auto' : 'never',
+        plottables: queriesSeriesData.map(
+          (ts, index) =>
+            new Line(convertSeriesToTimeseries(ts), {
+              color: colorPalette[index],
+              alias: aliases[ts.seriesName],
+            })
+        ),
+        ...props,
+        ...releaseBubbleProps,
+      }}
+    />
+  );
+
+  const footer = hasData && (
+    <WidgetFooterTable>
+      {queriesListData?.map((item, index) => (
+        <Fragment
+          key={`${item[SpanFields.PROJECT_ID]}-${item[SpanFields.NORMALIZED_DESCRIPTION]}`}
+        >
+          <div>
+            <SeriesColorIndicator
+              style={{
+                backgroundColor: colorPalette[index],
+              }}
+            />
+          </div>
+          <SpanDescriptionCell
+            projectId={Number(item[SpanFields.PROJECT_ID])}
+            group={item[SpanFields.SPAN_GROUP]}
+            description={item[SpanFields.NORMALIZED_DESCRIPTION]}
+            moduleName={ModuleName.DB}
+          />
+          <TimeSpentCell
+            percentage={item['time_spent_percentage()']}
+            total={item[totalTimeField]}
+            op={'db'}
+          />
+        </Fragment>
+      ))}
+    </WidgetFooterTable>
+  );
+
+  const exploreUrl = getExploreUrl({
+    selection,
+    organization,
+    visualize: [
+      {
+        chartType: ChartType.LINE,
+        yAxes: [yAxes],
+      },
+      {
+        chartType: ChartType.LINE,
+        yAxes: [totalTimeField],
+      },
+    ],
+    mode: Mode.AGGREGATE,
+    title,
+    query: search?.formatString(),
+    sort: `-${totalTimeField}`,
+    groupBy: [groupBy],
+    interval,
+    referrer,
+  });
+
+  return (
+    <Widget
+      Title={<Widget.WidgetTitle title={title} />}
+      Visualization={visualization}
+      Actions={
+        hasData && (
+          <Widget.WidgetToolbar>
+            <Fragment>
+              <BaseChartActionDropdown
+                key="time consuming queries widget"
+                exploreUrl={exploreUrl}
+                referrer={referrer}
+                alertMenuOptions={queriesSeriesData.map(series => ({
+                  key: series.seriesName,
+                  label: aliases[series.seriesName],
+                  to: getAlertsUrl({
+                    project,
+                    aggregate: yAxes,
+                    organization,
+                    pageFilters: selection,
+                    dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+                    query: `${SpanFields.NORMALIZED_DESCRIPTION}:"${series.seriesName}"`,
+                    referrer,
+                  }),
+                }))}
+              />
+              <Button
+                size="xs"
+                aria-label={t('Open Full-Screen View')}
+                borderless
+                icon={<IconExpand />}
+                onClick={() => {
+                  openInsightChartModal({
+                    title,
+                    footer,
+                    children: <ModalChartContainer>{visualization}</ModalChartContainer>,
+                  });
+                }}
+              />
+            </Fragment>
+          </Widget.WidgetToolbar>
+        )
+      }
+      noFooterPadding
+      Footer={props.loaderSource === 'releases-drawer' ? undefined : footer}
+    />
+  );
+}

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -27,7 +27,7 @@ import OverviewApiLatencyChartWidget from 'sentry/views/insights/common/componen
 import OverviewCacheMissChartWidget from 'sentry/views/insights/common/components/widgets/overviewCacheMissChartWidget';
 import OverviewJobsChartWidget from 'sentry/views/insights/common/components/widgets/overviewJobsChartWidget';
 import OverviewRequestsChartWidget from 'sentry/views/insights/common/components/widgets/overviewRequestsChartWidget';
-import OverviewSlowQueriesChartWidget from 'sentry/views/insights/common/components/widgets/overviewSlowQueriesChartWidget';
+import OverviewTimeConsumingQueriesWidget from 'sentry/views/insights/common/components/widgets/overviewTimeConsumingQueriesWidget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
@@ -237,7 +237,7 @@ function EAPBackendOverviewPage() {
                       <OverviewJobsChartWidget />
                     </ModuleLayout.Third>
                     <ModuleLayout.Third>
-                      <OverviewSlowQueriesChartWidget />
+                      <OverviewTimeConsumingQueriesWidget />
                     </ModuleLayout.Third>
                     <ModuleLayout.Third>
                       <OverviewCacheMissChartWidget />

--- a/static/app/views/insights/pages/backend/referrers.ts
+++ b/static/app/views/insights/pages/backend/referrers.ts
@@ -1,3 +1,4 @@
 export enum Referrer {
   BACKEND_LANDING_TABLE = 'api.insights.backend.landing-table',
+  OVERVIEW_TIME_CONSUMING_QUERIES_WIDGET = 'api.insights.backend.overview.time-consuming-queries-widget',
 }


### PR DESCRIPTION
Capturing the most time consuming queries captures more then just the slowest as they have more impact on the application.
<img width="418" height="328" alt="image" src="https://github.com/user-attachments/assets/d43395e8-a06e-40eb-b988-75d5d71b71a0" />
