### PR TITLE
fix(settings): Adjust org stats yAxis min interval

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -237,7 +237,7 @@ export const DEFAULT_RELATIVE_PERIODS = {
 const DEFAULT_STATS_INFO = {
   showExternalStats: false,
   showInternalStats: true,
-  yAxisMinInterval: 100,
+  yAxisMinInterval: 10,
 };
 const GIGABYTE = 10 ** 9;
 const KILOBYTE = 10 ** 3;


### PR DESCRIPTION
0 -> 100 is a big jump. Charts with 0-5 events per interval start to look too small

before
<img width="1404" height="305" alt="image" src="https://github.com/user-attachments/assets/74c54916-8e38-452b-8cd0-021a9eac72b4" />

after
<img width="1402" height="309" alt="image" src="https://github.com/user-attachments/assets/939537c5-acf9-43da-b6a6-d42a627694d9" />
