### PR TITLE
feat(aci): add uptime details timeline

### DIFF
--- a/static/app/views/alerts/rules/uptime/detailsSidebar.tsx
+++ b/static/app/views/alerts/rules/uptime/detailsSidebar.tsx
@@ -5,20 +5,16 @@ import {SectionHeading} from 'sentry/components/charts/styles';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import {ActorAvatar} from 'sentry/components/core/avatar/actorAvatar';
 import {Grid} from 'sentry/components/core/layout';
-import {ExternalLink} from 'sentry/components/core/link';
 import {Text} from 'sentry/components/core/text';
 import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
 import Placeholder from 'sentry/components/placeholder';
-import QuestionTooltip from 'sentry/components/questionTooltip';
-import {t, tct, tn} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
+import {t, tn} from 'sentry/locale';
 import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import getDuration from 'sentry/utils/duration/getDuration';
-import {CheckIndicator} from 'sentry/views/alerts/rules/uptime/checkIndicator';
-import {CheckStatus, type UptimeSummary} from 'sentry/views/alerts/rules/uptime/types';
+import {DetailsTimelineLegend} from 'sentry/views/alerts/rules/uptime/detailsTimelineLegend';
+import {type UptimeSummary} from 'sentry/views/alerts/rules/uptime/types';
 import {UptimeDuration} from 'sentry/views/insights/uptime/components/duration';
 import {UptimePercent} from 'sentry/views/insights/uptime/components/percent';
-import {statusToText} from 'sentry/views/insights/uptime/timelineConfig';
 
 interface UptimeDetailsSidebarProps {
   showMissedLegend: boolean;
@@ -43,85 +39,10 @@ export function UptimeDetailsSidebar({
         columns={summary && summary.avgDurationUs !== null ? '2fr 1fr 1fr' : '1fr 1fr'}
         gap="2xl"
       >
-        <div>
+        <UptimeContainer>
           <SectionHeading>{t('Legend')}</SectionHeading>
-          <CheckLegend>
-            <CheckLegendItem>
-              <CheckIndicator status={CheckStatus.SUCCESS} />
-              <LegendText>
-                {statusToText[CheckStatus.SUCCESS]}
-                <QuestionTooltip
-                  isHoverable
-                  size="sm"
-                  title={tct(
-                    'A check status is considered uptime when it meets the uptime check criteria. [link:Learn more].',
-                    {
-                      link: (
-                        <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-criteria" />
-                      ),
-                    }
-                  )}
-                />
-              </LegendText>
-            </CheckLegendItem>
-            <CheckLegendItem>
-              <CheckIndicator status={CheckStatus.FAILURE} />
-              <LegendText>
-                {statusToText[CheckStatus.FAILURE]}
-                <QuestionTooltip
-                  isHoverable
-                  size="sm"
-                  title={tct(
-                    'A check status is considered as a failure when a check fails but hasn’t recorded three consecutive failures needed for Downtime. [link:Learn more].',
-                    {
-                      link: (
-                        <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
-                      ),
-                    }
-                  )}
-                />
-              </LegendText>
-            </CheckLegendItem>
-            <CheckLegendItem>
-              <CheckIndicator status={CheckStatus.FAILURE_INCIDENT} />
-              <LegendText>
-                {statusToText[CheckStatus.FAILURE_INCIDENT]}
-                <QuestionTooltip
-                  isHoverable
-                  size="sm"
-                  title={tct(
-                    'A check status is considered downtime when it fails 3 consecutive times, meeting the Downtime threshold. [link:Learn more].',
-                    {
-                      link: (
-                        <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
-                      ),
-                    }
-                  )}
-                />
-              </LegendText>
-            </CheckLegendItem>
-            {showMissedLegend && (
-              <CheckLegendItem>
-                <CheckIndicator status={CheckStatus.MISSED_WINDOW} />
-                <LegendText>
-                  {statusToText[CheckStatus.MISSED_WINDOW]}
-                  <QuestionTooltip
-                    isHoverable
-                    size="sm"
-                    title={tct(
-                      'A check status is unknown when Sentry is unable to execute an uptime check at the scheduled time. [link:Learn more].',
-                      {
-                        link: (
-                          <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
-                        ),
-                      }
-                    )}
-                  />
-                </LegendText>
-              </CheckLegendItem>
-            )}
-          </CheckLegend>
-        </div>
+          <DetailsTimelineLegend showMissedLegend={showMissedLegend} />
+        </UptimeContainer>
         {summary?.avgDurationUs !== null && (
           <div>
             <SectionHeading>{t('Duration')}</SectionHeading>
@@ -200,29 +121,8 @@ export function UptimeDetailsSidebar({
   );
 }
 
-const CheckLegend = styled('ul')`
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  margin-bottom: ${space(2)};
-  padding: 0;
-  gap: ${space(1)};
-`;
-
-const CheckLegendItem = styled('li')`
-  display: grid;
-  grid-template-columns: subgrid;
-  align-items: center;
-  grid-column: 1 / -1;
-`;
-
-const LegendText = styled('div')`
-  display: flex;
-  gap: ${space(1)};
-  align-items: center;
-`;
-
 const MonitorUrlContainer = styled('div')`
-  margin-bottom: ${space(2)};
+  margin-bottom: ${p => p.theme.space.xl};
 
   h4 {
     margin-top: 0;
@@ -230,5 +130,5 @@ const MonitorUrlContainer = styled('div')`
 `;
 
 const UptimeContainer = styled('div')`
-  margin-bottom: ${space(2)};
+  margin-bottom: ${p => p.theme.space.xl};
 `;

--- a/static/app/views/alerts/rules/uptime/detailsTimelineLegend.tsx
+++ b/static/app/views/alerts/rules/uptime/detailsTimelineLegend.tsx
@@ -1,0 +1,110 @@
+import styled from '@emotion/styled';
+
+import {ExternalLink} from 'sentry/components/core/link';
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import {tct} from 'sentry/locale';
+import {CheckIndicator} from 'sentry/views/alerts/rules/uptime/checkIndicator';
+import {CheckStatus} from 'sentry/views/alerts/rules/uptime/types';
+import {statusToText} from 'sentry/views/insights/uptime/timelineConfig';
+
+export function DetailsTimelineLegend({showMissedLegend}: {showMissedLegend: boolean}) {
+  return (
+    <CheckLegend>
+      <CheckLegendItem>
+        <CheckIndicator status={CheckStatus.SUCCESS} />
+        <LegendText>
+          {statusToText[CheckStatus.SUCCESS]}
+          <QuestionTooltip
+            isHoverable
+            size="sm"
+            title={tct(
+              'A check status is considered uptime when it meets the uptime check criteria. [link:Learn more].',
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-criteria" />
+                ),
+              }
+            )}
+          />
+        </LegendText>
+      </CheckLegendItem>
+      <CheckLegendItem>
+        <CheckIndicator status={CheckStatus.FAILURE} />
+        <LegendText>
+          {statusToText[CheckStatus.FAILURE]}
+          <QuestionTooltip
+            isHoverable
+            size="sm"
+            title={tct(
+              'A check status is considered as a failure when a check fails but hasn’t recorded three consecutive failures needed for Downtime. [link:Learn more].',
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
+                ),
+              }
+            )}
+          />
+        </LegendText>
+      </CheckLegendItem>
+      <CheckLegendItem>
+        <CheckIndicator status={CheckStatus.FAILURE_INCIDENT} />
+        <LegendText>
+          {statusToText[CheckStatus.FAILURE_INCIDENT]}
+          <QuestionTooltip
+            isHoverable
+            size="sm"
+            title={tct(
+              'A check status is considered downtime when it fails 3 consecutive times, meeting the Downtime threshold. [link:Learn more].',
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
+                ),
+              }
+            )}
+          />
+        </LegendText>
+      </CheckLegendItem>
+      {showMissedLegend && (
+        <CheckLegendItem>
+          <CheckIndicator status={CheckStatus.MISSED_WINDOW} />
+          <LegendText>
+            {statusToText[CheckStatus.MISSED_WINDOW]}
+            <QuestionTooltip
+              isHoverable
+              size="sm"
+              title={tct(
+                'A check status is unknown when Sentry is unable to execute an uptime check at the scheduled time. [link:Learn more].',
+                {
+                  link: (
+                    <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
+                  ),
+                }
+              )}
+            />
+          </LegendText>
+        </CheckLegendItem>
+      )}
+    </CheckLegend>
+  );
+}
+
+const CheckLegend = styled('ul')`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  padding: 0;
+  gap: ${p => p.theme.space.md};
+  margin-bottom: 0;
+`;
+
+const CheckLegendItem = styled('li')`
+  display: grid;
+  grid-template-columns: subgrid;
+  align-items: center;
+  grid-column: 1 / -1;
+`;
+
+const LegendText = styled('div')`
+  display: flex;
+  gap: ${p => p.theme.space.md};
+  align-items: center;
+`;

--- a/static/app/views/detectors/components/details/uptime/index.tsx
+++ b/static/app/views/detectors/components/details/uptime/index.tsx
@@ -1,3 +1,5 @@
+import {useCallback, useState} from 'react';
+
 import {KeyValueTableRow} from 'sentry/components/keyValueTable';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
@@ -6,6 +8,12 @@ import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import getDuration from 'sentry/utils/duration/getDuration';
+import {DetailsTimeline} from 'sentry/views/alerts/rules/uptime/detailsTimeline';
+import {DetailsTimelineLegend} from 'sentry/views/alerts/rules/uptime/detailsTimelineLegend';
+import {
+  CheckStatus,
+  type CheckStatusBucket,
+} from 'sentry/views/alerts/rules/uptime/types';
 import {UptimeChecksTable} from 'sentry/views/alerts/rules/uptime/uptimeChecksTable';
 import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details/common/assignee';
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
@@ -20,12 +28,24 @@ type UptimeDetectorDetailsProps = {
 export function UptimeDetectorDetails({detector, project}: UptimeDetectorDetailsProps) {
   const dataSource = detector.dataSources[0];
 
+  // Only display the missed window legend when there are visible missed window
+  // check-ins in the timeline
+  const [showMissedLegend, setShowMissedLegend] = useState(false);
+
+  const checkHasUnknown = useCallback((stats: CheckStatusBucket[]) => {
+    const hasUnknown = stats.some(bucket =>
+      Boolean(bucket[1][CheckStatus.MISSED_WINDOW])
+    );
+    setShowMissedLegend(hasUnknown);
+  }, []);
+
   return (
     <DetailLayout>
       <DetectorDetailsHeader detector={detector} project={project} />
       <DetailLayout.Body>
         <DetailLayout.Main>
           <DatePageFilter />
+          <DetailsTimeline uptimeDetector={detector} onStatsLoaded={checkHasUnknown} />
           <Section title={t('Recent Check-Ins')}>
             <div>
               <UptimeChecksTable
@@ -41,6 +61,9 @@ export function UptimeDetectorDetails({detector, project}: UptimeDetectorDetails
           <Section title={t('Detect')}>{t('Three consecutive failed checks.')}</Section>
           <Section title={t('Resolve')}>
             {t('Three consecutive successful checks.')}
+          </Section>
+          <Section title={t('Legend')}>
+            <DetailsTimelineLegend showMissedLegend={showMissedLegend} />
           </Section>
           <DetectorDetailsAssignee owner={detector.owner} />
           <DetectorExtraDetails>

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -302,10 +302,10 @@ describe('DetectorDetails', () => {
       expect(await screen.findByText('Recent Check-Ins')).toBeInTheDocument();
 
       // Verify check-in data is displayed
-      expect(screen.getByText('Uptime')).toBeInTheDocument();
+      expect(screen.getAllByText('Uptime')).toHaveLength(2); // timeline legend + check-in row
       expect(screen.getByText('200')).toBeInTheDocument();
       expect(screen.getByText('US East')).toBeInTheDocument();
-      expect(screen.getByText('Failure')).toBeInTheDocument();
+      expect(screen.getAllByText('Failure')).toHaveLength(2); // timeline legend + check-in row
       expect(screen.getByText('500')).toBeInTheDocument();
       expect(screen.getByText('US West')).toBeInTheDocument();
     });


### PR DESCRIPTION
reusing the <DetailsTimeline /> component for detector details

also moved the timeline legend to its own component so that it could be shared between the existing uptime monitors view and the new detector details view

<img width="1396" height="439" alt="Screenshot 2025-09-19 at 10 15 31 AM" src="https://github.com/user-attachments/assets/2dc25eba-8f0e-4bda-a712-948392a7fb59" />
