### PR TITLE
fix(aci milestone 3): only write to IGOP if we should write to IGOP

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -517,24 +517,30 @@ class GroupManager(BaseManager["Group"]):
                     resolution_time=activity.datetime,
                     resolution_activity=activity,
                 )
+                # TODO (aci cleanup): remove this once we've deprecated the incident model
+                if group.type == MetricIssue.type_id:
+                    if detector_id is None:
+                        logger.error(
+                            "Call to update metric issue status missing detector ID",
+                            extra={"group_id": group.id},
+                        )
+                        continue
+                    update_incident_based_on_open_period_status_change(group, status, detector_id)
+
             elif status == GroupStatus.UNRESOLVED and should_reopen_open_period[group.id]:
                 update_group_open_period(
                     group=group,
                     new_status=GroupStatus.UNRESOLVED,
                 )
-
-            # TODO (aci cleanup): remove this once we've deprecated the incident model
-            if group.type == MetricIssue.type_id and status in (
-                GroupStatus.RESOLVED,
-                GroupStatus.UNRESOLVED,
-            ):
-                if detector_id is None:
-                    logger.error(
-                        "Call to update metric issue status missing detector ID",
-                        extra={"group_id": group.id},
-                    )
-                    continue
-                update_incident_based_on_open_period_status_change(group, status, detector_id)
+                # TODO (aci cleanup): remove this once we've deprecated the incident model
+                if group.type == MetricIssue.type_id:
+                    if detector_id is None:
+                        logger.error(
+                            "Call to update metric issue status missing detector ID",
+                            extra={"group_id": group.id},
+                        )
+                        continue
+                    update_incident_based_on_open_period_status_change(group, status, detector_id)
 
     def from_share_id(self, share_id: str) -> Group:
         if not share_id or len(share_id) != 32:

--- a/tests/sentry/issues/test_ingest_incident_integration.py
+++ b/tests/sentry/issues/test_ingest_incident_integration.py
@@ -243,14 +243,13 @@ class IncidentGroupOpenPeriodIntegrationTest(TestCase):
     def test_bulk_transition_new_group_to_ongoing__metric_issues__no_incident_activites(
         self, mock_logger
     ) -> None:
-        """Don't want to trigger an IGOP write for this status change"""
+        """Ensure we do not trigger an IGOP write for a new to ongoing status change"""
         _, group_info = self.save_issue_occurrence()
         group = group_info.group
         assert group is not None
 
-        assert GroupOpenPeriod.objects.filter(group=group, project=self.project).exists()
-
         open_period = GroupOpenPeriod.objects.get(group=group, project=self.project)
+        assert open_period
 
         dummy_relationship = IncidentGroupOpenPeriod.objects.get(group_open_period=open_period)
         incident = Incident.objects.get(id=dummy_relationship.incident_id)
@@ -276,14 +275,13 @@ class IncidentGroupOpenPeriodIntegrationTest(TestCase):
     def test_bulk_transition_regressed_group_to_ongoing__metric_issues__no_incident_activites(
         self, mock_logger
     ) -> None:
-        """Don't want to trigger an IGOP write for this status change"""
+        """Ensure we do not trigger an IGOP write for a regressed to ongoing status change"""
         _, group_info = self.save_issue_occurrence()
         group = group_info.group
         assert group is not None
 
-        assert GroupOpenPeriod.objects.filter(group=group, project=self.project).exists()
-
         open_period = GroupOpenPeriod.objects.get(group=group, project=self.project)
+        assert open_period
 
         dummy_relationship = IncidentGroupOpenPeriod.objects.get(group_open_period=open_period)
         incident = Incident.objects.get(id=dummy_relationship.incident_id)

--- a/tests/sentry/issues/test_ingest_incident_integration.py
+++ b/tests/sentry/issues/test_ingest_incident_integration.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest import mock
 from unittest.mock import patch
 
 from django.utils import timezone
@@ -10,15 +11,20 @@ from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.issues.grouptype import FeedbackGroup
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.issues.issue_occurrence import IssueOccurrence, IssueOccurrenceData
+from sentry.issues.ongoing import bulk_transition_group_to_ongoing
 from sentry.issues.status_change_consumer import update_status
 from sentry.issues.status_change_message import StatusChangeMessageData
+from sentry.models.activity import Activity
 from sentry.models.group import GroupStatus
+from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
 from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
+from sentry.types.activity import ActivityType
+from sentry.types.group import GroupSubStatus
 from sentry.workflow_engine.models import IncidentGroupOpenPeriod
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
@@ -232,3 +238,61 @@ class IncidentGroupOpenPeriodIntegrationTest(TestCase):
         assert last_activity_entry.type == 2
         assert last_activity_entry.previous_value == str(IncidentStatus.CRITICAL.value)
         assert last_activity_entry.value == str(IncidentStatus.CLOSED.value)
+
+    @mock.patch("sentry.models.group.logger")
+    def test_new_to_ongoing_no_igop_write(self, mock_logger) -> None:
+        """Don't want to trigger an IGOP write for this status change"""
+        _, group_info = self.save_issue_occurrence()
+        group = group_info.group
+        assert group is not None
+
+        assert GroupOpenPeriod.objects.filter(group=group, project=self.project).exists()
+
+        open_period = GroupOpenPeriod.objects.get(group=group, project=self.project)
+
+        dummy_relationship = IncidentGroupOpenPeriod.objects.get(group_open_period=open_period)
+        incident = Incident.objects.get(id=dummy_relationship.incident_id)
+        group.substatus = GroupSubStatus.NEW
+        group.save()
+
+        bulk_transition_group_to_ongoing(GroupStatus.UNRESOLVED, GroupSubStatus.NEW, [group.id])
+        assert Activity.objects.filter(
+            group=group, type=ActivityType.AUTO_SET_ONGOING.value
+        ).exists()
+        assert GroupHistory.objects.filter(
+            group=group, status=GroupHistoryStatus.UNRESOLVED
+        ).exists()
+        assert mock_logger.error.call_count == 0
+
+        activity = IncidentActivity.objects.filter(incident_id=incident.id)
+        assert len(activity) == 3  # detected, created, priority change
+
+    @mock.patch("sentry.models.group.logger")
+    def test_regressed_to_ongoing_no_igop_write(self, mock_logger) -> None:
+        """Don't want to trigger an IGOP write for this status change"""
+        _, group_info = self.save_issue_occurrence()
+        group = group_info.group
+        assert group is not None
+
+        assert GroupOpenPeriod.objects.filter(group=group, project=self.project).exists()
+
+        open_period = GroupOpenPeriod.objects.get(group=group, project=self.project)
+
+        dummy_relationship = IncidentGroupOpenPeriod.objects.get(group_open_period=open_period)
+        incident = Incident.objects.get(id=dummy_relationship.incident_id)
+        group.substatus = GroupSubStatus.REGRESSED
+        group.save()
+
+        bulk_transition_group_to_ongoing(
+            GroupStatus.UNRESOLVED, GroupSubStatus.REGRESSED, [group.id]
+        )
+        assert Activity.objects.filter(
+            group=group, type=ActivityType.AUTO_SET_ONGOING.value
+        ).exists()
+        assert GroupHistory.objects.filter(
+            group=group, status=GroupHistoryStatus.UNRESOLVED
+        ).exists()
+        assert mock_logger.error.call_count == 0
+
+        activity = IncidentActivity.objects.filter(incident_id=incident.id)
+        assert len(activity) == 3  # detected, created, priority change


### PR DESCRIPTION
I realized that we forgot a check for the resolve status. To make things clear, just move the IGOP write to within the if statements. Also add tests to make sure we're not running into the error again.