### PR TITLE
ref(replay): use field qparam instead of fields

### DIFF
--- a/static/app/utils/replays/hooks/useReplayListQueryKey.tsx
+++ b/static/app/utils/replays/hooks/useReplayListQueryKey.tsx
@@ -61,7 +61,7 @@ export default function useReplayListQueryKey({
         query: {
           per_page: 50,
           ...query,
-          fields,
+          field: fields, // Passed as multiple params - field=a&field=b..
           project,
           queryReferrer,
         },


### PR DESCRIPTION
Closes [REPLAY-718: Update replay index page to use 'field' instead of 'fields'](https://linear.app/getsentry/issue/REPLAY-718/update-replay-index-page-to-use-field-instead-of-fields)

tested in dev-ui
<img width="846" height="442" alt="Screenshot 2025-09-19 at 11 01 43 AM" src="https://github.com/user-attachments/assets/b4520ddb-e30d-4a9e-89f8-a59d84ebd5b3" />

before (prod):
<img width="849" height="302" alt="Screenshot 2025-09-19 at 11 03 37 AM" src="https://github.com/user-attachments/assets/461cab5a-3fc5-4366-b418-fe873a49f99f" />
