### PR TITLE
fix(flags): bring back flags on issue event chart

### DIFF
--- a/static/app/components/featureFlags/hooks/useFlagSeries.tsx
+++ b/static/app/components/featureFlags/hooks/useFlagSeries.tsx
@@ -29,7 +29,7 @@ export function useFlagSeries({event, flags}: FlagSeriesProps) {
   const markLine = MarkLine({
     animation: false,
     lineStyle: {
-      color: theme.blue300,
+      color: theme.blue400,
       opacity: 0.3,
       type: 'solid',
     },
@@ -75,7 +75,7 @@ export function useFlagSeries({event, flags}: FlagSeriesProps) {
     seriesName: t('Feature Flags'),
     id: 'flag-lines',
     data: [],
-    color: theme.blue200,
+    color: theme.blue400,
     markLine,
     type: 'line', // use this type so the bar chart doesn't shrink/grow
   };

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -197,7 +197,12 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
         {issueTypeConfig.header.graph.enabled && (
           <GraphSection>
             {issueTypeConfig.header.graph.type === 'discover-events' && (
-              <EventGraph event={event} group={group} style={{flex: 1}} />
+              <EventGraph
+                event={event}
+                group={group}
+                showReleasesAs="bubble"
+                style={{flex: 1}}
+              />
             )}
             {issueTypeConfig.header.graph.type === 'detector-history' && (
               <MetricIssueChart group={group} project={project} />

--- a/static/app/views/issueDetails/streamline/eventGraph.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.spec.tsx
@@ -21,7 +21,7 @@ describe('EventGraph', () => {
   const group = GroupFixture();
   const event = EventFixture({id: 'event-id'});
   const persistantQuery = `issue:${group.shortId}`;
-  const defaultProps = {group, event, project};
+  const defaultProps = {group, event, project, showReleasesAs: 'bubble' as const};
 
   let mockEventStats: jest.Mock;
 

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -301,9 +301,14 @@ export function EventGraph({
     onReleaseClick: handleReleaseLineClick,
   });
 
+  const flagsForSeries = useMemo(() => {
+    const result = shouldShowBubbles ? flags : [];
+    return result;
+  }, [shouldShowBubbles, flags]);
+
   const flagSeries = useFlagSeries({
     event,
-    flags: shouldShowBubbles ? [] : flags,
+    flags: flagsForSeries,
   });
 
   // Do some manipulation to make sure the release buckets match up to `eventSeries`

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -63,6 +63,12 @@ enum EventGraphSeries {
 interface EventGraphProps {
   event: Event | undefined;
   group: Group;
+  /**
+   * Configures showing releases on the chart as bubbles or lines. This is used
+   * when showing the chart inside of the flyout drawer. Bubbles are shown when
+   * this prop is anything besides "line".
+   */
+  showReleasesAs: 'line' | 'bubble';
   className?: string;
   /**
    * Disables navigation via router when the chart is zoomed. This is so the
@@ -73,12 +79,6 @@ interface EventGraphProps {
   disableZoomNavigation?: boolean;
   eventView?: EventView;
   ref?: React.Ref<ReactEchartsRef>;
-  /**
-   * Configures showing releases on the chart as bubbles or lines. This is used
-   * when showing the chart inside of the flyout drawer. Bubbles are shown when
-   * this prop is anything besides "line".
-   */
-  showReleasesAs?: 'line' | 'bubble';
   /**
    * Enable/disables showing the event and user summary
    */

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -301,14 +301,10 @@ export function EventGraph({
     onReleaseClick: handleReleaseLineClick,
   });
 
-  const flagsForSeries = useMemo(() => {
-    const result = shouldShowBubbles ? flags : [];
-    return result;
-  }, [shouldShowBubbles, flags]);
-
+  // always show flag lines regardless of release line/bubble display
   const flagSeries = useFlagSeries({
     event,
-    flags: flagsForSeries,
+    flags,
   });
 
   // Do some manipulation to make sure the release buckets match up to `eventSeries`

--- a/static/app/views/issueDetails/streamline/eventGraphWidget.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraphWidget.tsx
@@ -91,7 +91,7 @@ function EventGraphLoadedWidget({
           eventView={eventView}
           group={group}
           showSummary={false}
-          showReleasesAs="line"
+          showReleasesAs="bubble"
           disableZoomNavigation
         />
       }


### PR DESCRIPTION
the feature flag lines (+ series legend option) were being hidden due to the release bubble logic

before:

<img width="632" height="160" alt="SCR-20250919-kxjq" src="https://github.com/user-attachments/assets/bac1fc31-26a2-436e-8552-37d152a40853" />

after: 
<img width="535" height="165" alt="SCR-20250919-kxym" src="https://github.com/user-attachments/assets/3dd96eff-23f5-4ccb-a51a-88d4a5f2b4c4" />


https://github.com/user-attachments/assets/723c3ad9-3534-4546-b4ee-139bc46101f4
