### PR TITLE
feat(seer): Make seer button primary

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
@@ -130,7 +130,7 @@ describe('SeerSection', () => {
       expect(
         await screen.findByText('Meet Seer, the AI debugging agent.')
       ).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Fix it for me'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Fix with Seer'})).toBeInTheDocument();
     });
 
     it('shows "Find Root Cause" even when autofix needs setup', async () => {

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -151,7 +151,7 @@ export function SeerSectionCtaButton({
       (aiConfig.orgNeedsGenAiAcknowledgement || !aiConfig.hasAutofixQuota) &&
       !aiConfig.isAutofixSetupLoading
     ) {
-      return t('Fix it for me');
+      return t('Fix with Seer');
     }
 
     if (!lastStep) {
@@ -175,18 +175,10 @@ export function SeerSectionCtaButton({
     }
 
     if (isAutofixCompleted) {
-      if (lastStep.type === AutofixStepType.ROOT_CAUSE_ANALYSIS) {
-        return t('View Root Cause');
-      }
-      if (lastStep.type === AutofixStepType.SOLUTION) {
-        return t('View Solution');
-      }
-      if (lastStep.type === AutofixStepType.CHANGES) {
-        return t('View Code Changes');
-      }
+      return t('Open Seer');
     }
 
-    return t('Find Root Cause');
+    return t('Fix with Seer');
   };
 
   if (isButtonLoading) {
@@ -208,6 +200,7 @@ export function SeerSectionCtaButton({
         autofix_exists: Boolean(autofixData?.steps?.length),
         autofix_step_type: lastStep?.type ?? null,
       }}
+      priority="primary"
     >
       {getButtonText()}
       <ChevronContainer>
@@ -224,9 +217,6 @@ export function SeerSectionCtaButton({
 const StyledButton = styled(LinkButton)`
   margin-top: ${space(1)};
   width: 100%;
-  background: ${p => p.theme.background}
-    linear-gradient(to right, ${p => p.theme.background}, ${p => p.theme.pink400}20);
-  color: ${p => p.theme.pink400};
 `;
 
 const ChevronContainer = styled('div')`

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -175,6 +175,9 @@ export function SeerSectionCtaButton({
     }
 
     if (isAutofixCompleted) {
+      if (lastStep.type === AutofixStepType.SOLUTION) {
+        return t('Fix with Seer');
+      }
       return t('Open Seer');
     }
 


### PR DESCRIPTION
Make seer button primary and change language to be more clear that you're opening seer

<img width="660" height="526" alt="CleanShot 2025-09-19 at 12 22 27@2x" src="https://github.com/user-attachments/assets/1b5828a0-e897-4f66-9f11-c74c99f995bb" />
<img width="636" height="748" alt="CleanShot 2025-09-19 at 12 21 49@2x" src="https://github.com/user-attachments/assets/1c8e1865-2dce-44ef-851c-7e82feb70058" />
<img width="650" height="898" alt="CleanShot 2025-09-19 at 12 21 37@2x" src="https://github.com/user-attachments/assets/cbc1b0a7-e0c6-4901-a774-45d1831fc9e9" />
