### PR TITLE
fix(replay): set replayer skipInactive to false

### DIFF
--- a/static/app/utils/replays/playback/providers/replayPlayerStateContext.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlayerStateContext.tsx
@@ -182,7 +182,7 @@ function invokeUserAction(replayer: Replayer, userAction: UserAction): void {
       // If the replayer is set to skip inactive, we should turn it off before
       // manually scrubbing, so when the player resumes playing it's not stuck
       // fast-forwarding even through sections with activity
-      replayer.setConfig({skipInactive});
+      replayer.setConfig({skipInactive: false});
 
       if (replayer.service.state.value === 'playing') {
         replayer.play(offsetMs);


### PR DESCRIPTION
relates to REPLAY-667
relates to REPLAY-558

relates to https://github.com/getsentry/rrweb/pull/248 

Fix a small bug where the skipInactive field in the replayer was not actually being set to false.