### PR TITLE
fix(crons): Fix overlinking migration

### DIFF
--- a/src/sentry/workflow_engine/migrations/0086_fix_cron_to_cron_workflow_links.py
+++ b/src/sentry/workflow_engine/migrations/0086_fix_cron_to_cron_workflow_links.py
@@ -40,7 +40,8 @@ def fix_cron_to_cron_workflow_links(
         )
         rule_workflows = {link.rule_id: link.workflow for link in links}
 
-        rules = [r for r in rules if r.id in rule_workflows]
+        # Process ALL rules, not just those with workflows
+        # Rules without workflows need to be mapped to the primary workflow of their hash group
         if not rules:
             continue
 


### PR DESCRIPTION
We were overfiltering here on issue rules, which caused rules that have already had their workflow deleted, but were mapped to another workflow to be ignored.

Luckily this just raised an error log rather than deleting all links, so this is an easy fix

Fixes SENTRY-555H

<!-- Describe your PR here. -->