### PR TITLE
feat(tasks) Reduce application module usage in task worker

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -5,7 +5,6 @@ import os
 import random
 import signal
 import time
-from collections.abc import Mapping
 from multiprocessing import cpu_count
 from typing import Any
 
@@ -257,30 +256,22 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
     """
     from django.conf import settings
 
-    from sentry import options as runtime_options
-    from sentry.conf.types.taskworker import ScheduleConfig
-    from sentry.taskworker.registry import taskregistry
+    from sentry.taskworker.runtime import app
     from sentry.taskworker.scheduler.runner import RunStorage, ScheduleRunner
     from sentry.utils.redis import redis_clusters
 
-    for module in settings.TASKWORKER_IMPORTS:
-        __import__(module)
-
+    app.load_modules()
     run_storage = RunStorage(redis_clusters.get(redis_cluster))
 
     with managed_bgtasks(role="taskworker-scheduler"):
-        runner = ScheduleRunner(taskregistry, run_storage)
-        schedules: Mapping[str, ScheduleConfig] = {}
-        if runtime_options.get("taskworker.enabled"):
-            schedules = settings.TASKWORKER_SCHEDULES
-
-        for key, schedule_data in schedules.items():
+        runner = ScheduleRunner(app, run_storage)
+        for key, schedule_data in settings.TASKWORKER_SCHEDULES.items():
             runner.add(key, schedule_data)
 
         logger.info(
             "taskworker.scheduler.schedule_data",
             extra={
-                "schedule_keys": list(schedules.keys()),
+                "schedule_keys": list(settings.TASKWORKER_SCHEDULES.keys()),
             },
         )
 
@@ -376,6 +367,7 @@ def run_taskworker(
 
     with managed_bgtasks(role="taskworker"):
         worker = TaskWorker(
+            app_module="sentry.taskworker.runtime:app",
             broker_hosts=make_broker_hosts(
                 host_prefix=rpc_host, num_brokers=num_brokers, host_list=rpc_host_list
             ),

--- a/src/sentry/taskworker/app.py
+++ b/src/sentry/taskworker/app.py
@@ -1,3 +1,4 @@
+import importlib
 from collections.abc import Iterable
 from typing import Any, Protocol
 
@@ -19,6 +20,7 @@ class TaskworkerApp:
         self._config = {
             "rpc_secret": None,
             "at_most_once_timeout": None,
+            "grpc_config": None,
         }
         self._modules: Iterable[str] = []
         self._taskregistry = taskregistry or TaskRegistry()
@@ -74,3 +76,13 @@ class TaskworkerApp:
 def get_at_most_once_key(namespace: str, taskname: str, task_id: str) -> str:
     # tw:amo -> taskworker:at_most_once
     return f"tw:amo:{namespace}:{taskname}:{task_id}"
+
+
+def import_app(app_module: str) -> TaskworkerApp:
+    """
+    Resolve an application path like `acme.worker.runtime:app`
+    into the `app` symbol defined in the module.
+    """
+    module_name, name = app_module.split(":")
+    module = importlib.import_module(module_name)
+    return getattr(module, name)

--- a/src/sentry/taskworker/app.py
+++ b/src/sentry/taskworker/app.py
@@ -1,0 +1,69 @@
+from collections.abc import Iterable
+from typing import Any, Protocol
+
+from sentry_protos.taskbroker.v1.taskbroker_pb2 import TaskActivation
+
+from sentry.taskworker.registry import TaskRegistry
+
+
+class AtMostOnceStore(Protocol):
+    def add(self, key: str, value: str, timeout: int) -> bool: ...
+
+
+class TaskworkerApp:
+    def __init__(self, taskregistry: TaskRegistry | None = None) -> None:
+        self._config = {
+            "rpc_secret": None,
+            "at_most_once_timeout": None,
+        }
+        self._modules: Iterable[str] = []
+        self._taskregistry = taskregistry or TaskRegistry()
+
+    @property
+    def taskregistry(self) -> TaskRegistry:
+        """Get the TaskRegistry instance from this app"""
+        return self._taskregistry
+
+    @property
+    def config(self) -> dict[str, Any]:
+        """Get the config data"""
+        return self._config
+
+    def set_config(self, config: dict[str, Any]) -> None:
+        """
+        Update the configuration values.
+        """
+        for key, value in config.items():
+            if key in self._config:
+                self._config[key] = value
+
+    def set_modules(self, modules: Iterable[str]) -> None:
+        """
+        Set the list of modules to be loaded by workers when they start.
+        """
+        self._modules = modules
+
+    def load_modules(self) -> None:
+        """Load all of the configured modules"""
+        for mod in self._modules:
+            __import__(mod)
+
+    def at_most_once_store(self, backend: AtMostOnceStore) -> None:
+        self._at_most_once_store = backend
+
+    def should_attempt_at_most_once(self, activation: TaskActivation) -> bool:
+        if not self._at_most_once_store:
+            return True
+        key = get_at_most_once_key(
+            activation.namespace,
+            activation.taskname,
+            activation.id,
+        )
+        return self._at_most_once_store.add(
+            key, "1", timeout=self._config["at_most_once_timeout"] or 60
+        )
+
+
+def get_at_most_once_key(namespace: str, taskname: str, task_id: str) -> str:
+    # tw:amo -> taskworker:at_most_once
+    return f"tw:amo:{namespace}:{taskname}:{task_id}"

--- a/src/sentry/taskworker/app.py
+++ b/src/sentry/taskworker/app.py
@@ -11,6 +11,10 @@ class AtMostOnceStore(Protocol):
 
 
 class TaskworkerApp:
+    """
+    Container for an application's task setup and configuration.
+    """
+
     def __init__(self, taskregistry: TaskRegistry | None = None) -> None:
         self._config = {
             "rpc_secret": None,
@@ -30,16 +34,14 @@ class TaskworkerApp:
         return self._config
 
     def set_config(self, config: dict[str, Any]) -> None:
-        """
-        Update the configuration values.
-        """
+        """Update configuration data"""
         for key, value in config.items():
             if key in self._config:
                 self._config[key] = value
 
     def set_modules(self, modules: Iterable[str]) -> None:
         """
-        Set the list of modules to be loaded by workers when they start.
+        Set the list of modules containing tasks to be loaded by workers and schedulers.
         """
         self._modules = modules
 
@@ -49,6 +51,11 @@ class TaskworkerApp:
             __import__(mod)
 
     def at_most_once_store(self, backend: AtMostOnceStore) -> None:
+        """
+        Set the backend store for `at_most_once` tasks.
+        The storage implementation should support atomic operations
+        to avoid races with at_most_once tasks.
+        """
         self._at_most_once_store = backend
 
     def should_attempt_at_most_once(self, activation: TaskActivation) -> bool:

--- a/src/sentry/taskworker/client/client.py
+++ b/src/sentry/taskworker/client/client.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import grpc
-from django.conf import settings
 from google.protobuf.message import Message
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     FetchNextTask,
@@ -19,7 +18,6 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
 )
 from sentry_protos.taskbroker.v1.taskbroker_pb2_grpc import ConsumerServiceStub
 
-from sentry import options
 from sentry.taskworker.client.inflight_task_activation import InflightTaskActivation
 from sentry.taskworker.client.processing_result import ProcessingResult
 from sentry.taskworker.constants import (
@@ -137,11 +135,13 @@ class TaskworkerClient:
         max_consecutive_unavailable_errors: int = DEFAULT_CONSECUTIVE_UNAVAILABLE_ERRORS,
         temporary_unavailable_host_timeout: int = DEFAULT_TEMPORARY_UNAVAILABLE_HOST_TIMEOUT,
         health_check_settings: HealthCheckSettings | None = None,
+        rpc_secret: str | None = None,
+        grpc_config: list[tuple[str, Any]] | None = None,
     ) -> None:
         assert len(hosts) > 0, "You must provide at least one RPC host to connect to"
-
         self._hosts = hosts
-        grpc_config = options.get("taskworker.grpc_service_config")
+        self._rpc_secret = rpc_secret
+
         self._grpc_options: list[tuple[str, Any]] = [
             ("grpc.max_receive_message_length", MAX_ACTIVATION_SIZE)
         ]
@@ -191,8 +191,8 @@ class TaskworkerClient:
     def _connect_to_host(self, host: str) -> ConsumerServiceStub:
         logger.info("taskworker.client.connect", extra={"host": host})
         channel = grpc.insecure_channel(host, options=self._grpc_options)
-        if settings.TASKWORKER_SHARED_SECRET:
-            secrets = json.loads(settings.TASKWORKER_SHARED_SECRET)
+        if self._rpc_secret:
+            secrets = json.loads(self._rpc_secret)
             channel = grpc.intercept_channel(channel, RequestSignatureInterceptor(secrets))
         return ConsumerServiceStub(channel)
 

--- a/src/sentry/taskworker/runtime.py
+++ b/src/sentry/taskworker/runtime.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+from django.core.cache import cache
+
+from sentry.taskworker.app import TaskworkerApp
+from sentry.taskworker.registry import taskregistry
+
+app = TaskworkerApp(taskregistry=taskregistry)
+app.set_config(
+    {
+        "rpc_secret": settings.TASKWORKER_SHARED_SECRET,
+        "at_most_once_timeout": 60 * 60 * 24,  # 1 day
+    }
+)
+app.set_modules(settings.TASKWORKER_IMPORTS)
+app.at_most_once_store(cache)

--- a/src/sentry/taskworker/runtime.py
+++ b/src/sentry/taskworker/runtime.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.core.cache import cache
 
+from sentry import options
 from sentry.taskworker.app import TaskworkerApp
 from sentry.taskworker.registry import taskregistry
 
@@ -9,6 +10,7 @@ app.set_config(
     {
         "rpc_secret": settings.TASKWORKER_SHARED_SECRET,
         "at_most_once_timeout": 60 * 60 * 24,  # 1 day
+        "grpc_config": options.get("taskworker.grpc_service_config"),
     }
 )
 app.set_modules(settings.TASKWORKER_IMPORTS)

--- a/src/sentry/taskworker/scheduler/runner.py
+++ b/src/sentry/taskworker/scheduler/runner.py
@@ -13,7 +13,7 @@ from sentry_sdk import capture_exception
 from sentry_sdk.crons import MonitorStatus, capture_checkin
 
 from sentry.conf.types.taskworker import ScheduleConfig, crontab
-from sentry.taskworker.registry import TaskRegistry
+from sentry.taskworker.app import TaskworkerApp
 from sentry.taskworker.scheduler.schedules import CrontabSchedule, Schedule, TimedeltaSchedule
 from sentry.taskworker.task import Task
 from sentry.utils import metrics
@@ -178,9 +178,9 @@ class ScheduleRunner:
     is used in a while loop to spawn tasks and sleep.
     """
 
-    def __init__(self, registry: TaskRegistry, run_storage: RunStorage) -> None:
+    def __init__(self, app: TaskworkerApp, run_storage: RunStorage) -> None:
         self._entries: list[ScheduleEntry] = []
-        self._registry = registry
+        self._registry = app.taskregistry
         self._run_storage = run_storage
         self._heap: list[tuple[int, ScheduleEntry]] = []
 

--- a/src/sentry/taskworker/scheduler/runner.py
+++ b/src/sentry/taskworker/scheduler/runner.py
@@ -180,7 +180,7 @@ class ScheduleRunner:
 
     def __init__(self, app: TaskworkerApp, run_storage: RunStorage) -> None:
         self._entries: list[ScheduleEntry] = []
-        self._registry = app.taskregistry
+        self._app = app
         self._run_storage = run_storage
         self._heap: list[tuple[int, ScheduleEntry]] = []
 
@@ -191,7 +191,7 @@ class ScheduleRunner:
         except ValueError:
             raise ValueError("Invalid task name. Must be in the format namespace:taskname")
 
-        task = self._registry.get_task(namespace, taskname)
+        task = self._app.taskregistry.get_task(namespace, taskname)
         entry = ScheduleEntry(key=key, task=task, schedule=task_config["schedule"])
         self._entries.append(entry)
         self._heap = []

--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 import contextlib
-import importlib
 import logging
 import queue
 import signal
@@ -26,7 +25,7 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
 from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS
 from sentry_sdk.crons import MonitorStatus, capture_checkin
 
-from sentry.taskworker.app import TaskworkerApp
+from sentry.taskworker.app import import_app
 from sentry.taskworker.client.inflight_task_activation import InflightTaskActivation
 from sentry.taskworker.client.processing_result import ProcessingResult
 from sentry.taskworker.constants import CompressionType
@@ -92,12 +91,6 @@ def status_name(status: TaskActivationStatus.ValueType) -> str:
     if status == TASK_ACTIVATION_STATUS_RETRY:
         return "retry"
     return f"unknown-{status}"
-
-
-def import_app(app_module: str) -> TaskworkerApp:
-    module_name, name = app_module.split(":")
-    module = importlib.import_module(module_name)
-    return getattr(module, name)
 
 
 def child_process(

--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import contextlib
+import importlib
 import logging
 import queue
 import signal
@@ -94,9 +95,9 @@ def status_name(status: TaskActivationStatus.ValueType) -> str:
 
 
 def import_app(app_module: str) -> TaskworkerApp:
-    module, name = app_module.split(":")
-    mod = __import__(module)
-    return getattr(mod, name)
+    module_name, name = app_module.split(":")
+    module = importlib.import_module(module_name)
+    return getattr(module, name)
 
 
 def child_process(
@@ -124,6 +125,7 @@ def child_process(
     from sentry.utils.memory import track_memory_usage
 
     app = import_app(app_module)
+    app.load_modules()
     taskregistry = app.taskregistry
 
     def _get_known_task(activation: TaskActivation) -> Task[Any, Any] | None:

--- a/tests/sentry/taskworker/scheduler/test_runner.py
+++ b/tests/sentry/taskworker/scheduler/test_runner.py
@@ -5,7 +5,7 @@ import pytest
 from django.utils import timezone
 
 from sentry.conf.types.taskworker import crontab
-from sentry.taskworker.registry import TaskRegistry
+from sentry.taskworker.app import TaskworkerApp
 from sentry.taskworker.scheduler.runner import RunStorage, ScheduleRunner
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.thread_leaks.pytest import thread_leak_allowlist
@@ -13,9 +13,9 @@ from sentry.utils.redis import redis_clusters
 
 
 @pytest.fixture
-def taskregistry() -> TaskRegistry:
-    registry = TaskRegistry()
-    namespace = registry.create_namespace("test")
+def task_app() -> TaskworkerApp:
+    app = TaskworkerApp()
+    namespace = app.taskregistry.create_namespace("test")
 
     @namespace.register(name="valid")
     def test_func() -> None:
@@ -25,7 +25,7 @@ def taskregistry() -> TaskRegistry:
     def second_func() -> None:
         pass
 
-    return registry
+    return app
 
 
 @pytest.fixture
@@ -53,9 +53,9 @@ def test_runstorage_double_set(run_storage: RunStorage) -> None:
 
 
 @pytest.mark.django_db
-def test_schedulerunner_add_invalid(taskregistry) -> None:
+def test_schedulerunner_add_invalid(task_app) -> None:
     run_storage = Mock(spec=RunStorage)
-    schedule_set = ScheduleRunner(registry=taskregistry, run_storage=run_storage)
+    schedule_set = ScheduleRunner(app=task_app, run_storage=run_storage)
 
     with pytest.raises(ValueError) as err:
         schedule_set.add(
@@ -89,8 +89,8 @@ def test_schedulerunner_add_invalid(taskregistry) -> None:
 
 
 @pytest.mark.django_db
-def test_schedulerunner_tick_no_tasks(taskregistry: TaskRegistry, run_storage: RunStorage) -> None:
-    schedule_set = ScheduleRunner(registry=taskregistry, run_storage=run_storage)
+def test_schedulerunner_tick_no_tasks(task_app: TaskworkerApp, run_storage: RunStorage) -> None:
+    schedule_set = ScheduleRunner(app=task_app, run_storage=run_storage)
 
     with freeze_time("2025-01-24 14:25:00"):
         sleep_time = schedule_set.tick()
@@ -99,9 +99,9 @@ def test_schedulerunner_tick_no_tasks(taskregistry: TaskRegistry, run_storage: R
 
 @pytest.mark.django_db
 def test_schedulerunner_tick_one_task_time_remaining(
-    taskregistry: TaskRegistry, run_storage: RunStorage
+    task_app: TaskworkerApp, run_storage: RunStorage
 ) -> None:
-    schedule_set = ScheduleRunner(registry=taskregistry, run_storage=run_storage)
+    schedule_set = ScheduleRunner(app=task_app, run_storage=run_storage)
 
     schedule_set.add(
         "valid",
@@ -114,7 +114,7 @@ def test_schedulerunner_tick_one_task_time_remaining(
     with freeze_time("2025-01-24 14:23:00"):
         run_storage.set("test:valid", datetime(2025, 1, 24, 14, 28, 0, tzinfo=UTC))
 
-    namespace = taskregistry.get("test")
+    namespace = task_app.taskregistry.get("test")
     with freeze_time("2025-01-24 14:25:00"), patch.object(namespace, "send_task") as mock_send:
         sleep_time = schedule_set.tick()
         assert sleep_time == 180
@@ -126,10 +126,10 @@ def test_schedulerunner_tick_one_task_time_remaining(
 
 @pytest.mark.django_db
 def test_schedulerunner_tick_one_task_spawned(
-    taskregistry: TaskRegistry, run_storage: RunStorage
+    task_app: TaskworkerApp, run_storage: RunStorage
 ) -> None:
     run_storage = Mock(spec=RunStorage)
-    schedule_set = ScheduleRunner(registry=taskregistry, run_storage=run_storage)
+    schedule_set = ScheduleRunner(app=task_app, run_storage=run_storage)
     schedule_set.add(
         "valid",
         {
@@ -144,7 +144,7 @@ def test_schedulerunner_tick_one_task_spawned(
     }
     run_storage.set.return_value = True
 
-    namespace = taskregistry.get("test")
+    namespace = task_app.taskregistry.get("test")
     with freeze_time("2025-01-24 14:25:00"), patch.object(namespace, "send_task") as mock_send:
         sleep_time = schedule_set.tick()
         assert sleep_time == 300
@@ -163,10 +163,10 @@ def test_schedulerunner_tick_one_task_spawned(
 @pytest.mark.django_db
 @patch("sentry.taskworker.scheduler.runner.capture_checkin")
 def test_schedulerunner_tick_create_checkin(
-    mock_capture_checkin: Mock, taskregistry: TaskRegistry, run_storage: RunStorage
+    mock_capture_checkin: Mock, task_app: TaskworkerApp, run_storage: RunStorage
 ) -> None:
     run_storage = Mock(spec=RunStorage)
-    schedule_set = ScheduleRunner(registry=taskregistry, run_storage=run_storage)
+    schedule_set = ScheduleRunner(app=task_app, run_storage=run_storage)
     schedule_set.add(
         "important-task",
         {
@@ -182,7 +182,7 @@ def test_schedulerunner_tick_create_checkin(
     run_storage.set.return_value = True
     mock_capture_checkin.return_value = "checkin-id"
 
-    namespace = taskregistry.get("test")
+    namespace = task_app.taskregistry.get("test")
     with (
         freeze_time("2025-01-24 14:25:00"),
         patch.object(namespace, "send_task") as mock_send,
@@ -217,9 +217,9 @@ def test_schedulerunner_tick_create_checkin(
 
 @pytest.mark.django_db
 def test_schedulerunner_tick_key_exists_no_spawn(
-    taskregistry: TaskRegistry, run_storage: RunStorage
+    task_app: TaskworkerApp, run_storage: RunStorage
 ) -> None:
-    schedule_set = ScheduleRunner(registry=taskregistry, run_storage=run_storage)
+    schedule_set = ScheduleRunner(app=task_app, run_storage=run_storage)
     schedule_set.add(
         "valid",
         {
@@ -228,7 +228,7 @@ def test_schedulerunner_tick_key_exists_no_spawn(
         },
     )
 
-    namespace = taskregistry.get("test")
+    namespace = task_app.taskregistry.get("test")
     with patch.object(namespace, "send_task") as mock_send, freeze_time("2025-01-24 14:25:00"):
         # Run tick() to initialize state in the scheduler. This will write a key to run_storage.
         sleep_time = schedule_set.tick()
@@ -252,9 +252,9 @@ def test_schedulerunner_tick_key_exists_no_spawn(
 @pytest.mark.django_db
 @thread_leak_allowlist(reason="taskworker", issue=97034)
 def test_schedulerunner_tick_one_task_multiple_ticks(
-    taskregistry: TaskRegistry, run_storage: RunStorage
+    task_app: TaskworkerApp, run_storage: RunStorage
 ) -> None:
-    schedule_set = ScheduleRunner(registry=taskregistry, run_storage=run_storage)
+    schedule_set = ScheduleRunner(app=task_app, run_storage=run_storage)
     schedule_set.add(
         "valid",
         {
@@ -278,9 +278,9 @@ def test_schedulerunner_tick_one_task_multiple_ticks(
 
 @pytest.mark.django_db
 def test_schedulerunner_tick_one_task_multiple_ticks_crontab(
-    taskregistry: TaskRegistry, run_storage: RunStorage
+    task_app: TaskworkerApp, run_storage: RunStorage
 ) -> None:
-    schedule_set = ScheduleRunner(registry=taskregistry, run_storage=run_storage)
+    schedule_set = ScheduleRunner(app=task_app, run_storage=run_storage)
     schedule_set.add(
         "valid",
         {
@@ -289,7 +289,7 @@ def test_schedulerunner_tick_one_task_multiple_ticks_crontab(
         },
     )
 
-    namespace = taskregistry.get("test")
+    namespace = task_app.taskregistry.get("test")
     with patch.object(namespace, "send_task") as mock_send:
         with freeze_time("2025-01-24 14:24:00"):
             sleep_time = schedule_set.tick()
@@ -310,9 +310,9 @@ def test_schedulerunner_tick_one_task_multiple_ticks_crontab(
 
 @pytest.mark.django_db
 def test_schedulerunner_tick_multiple_tasks(
-    taskregistry: TaskRegistry, run_storage: RunStorage
+    task_app: TaskworkerApp, run_storage: RunStorage
 ) -> None:
-    schedule_set = ScheduleRunner(registry=taskregistry, run_storage=run_storage)
+    schedule_set = ScheduleRunner(app=task_app, run_storage=run_storage)
     schedule_set.add(
         "valid",
         {
@@ -328,7 +328,7 @@ def test_schedulerunner_tick_multiple_tasks(
         },
     )
 
-    namespace = taskregistry.get("test")
+    namespace = task_app.taskregistry.get("test")
     with patch.object(namespace, "send_task") as mock_send:
         with freeze_time("2025-01-24 14:25:00"):
             sleep_time = schedule_set.tick()
@@ -354,9 +354,9 @@ def test_schedulerunner_tick_multiple_tasks(
 
 @pytest.mark.django_db
 def test_schedulerunner_tick_fast_and_slow(
-    taskregistry: TaskRegistry, run_storage: RunStorage
+    task_app: TaskworkerApp, run_storage: RunStorage
 ) -> None:
-    schedule_set = ScheduleRunner(registry=taskregistry, run_storage=run_storage)
+    schedule_set = ScheduleRunner(app=task_app, run_storage=run_storage)
     schedule_set.add(
         "valid",
         {
@@ -372,7 +372,7 @@ def test_schedulerunner_tick_fast_and_slow(
         },
     )
 
-    namespace = taskregistry.get("test")
+    namespace = task_app.taskregistry.get("test")
     with patch.object(namespace, "send_task") as mock_send:
         with freeze_time("2025-01-24 14:25:00"):
             sleep_time = schedule_set.tick()

--- a/tests/sentry/taskworker/test_app.py
+++ b/tests/sentry/taskworker/test_app.py
@@ -1,0 +1,38 @@
+import pytest
+from django.core.cache import cache
+from sentry_protos.taskbroker.v1.taskbroker_pb2 import TaskActivation
+
+from sentry.taskworker.app import TaskworkerApp
+from sentry.taskworker.registry import TaskRegistry
+
+
+@pytest.fixture
+def clear_cache():
+    cache.clear()
+
+
+def test_taskregistry_param_and_property():
+    registry = TaskRegistry()
+    app = TaskworkerApp(taskregistry=registry)
+    assert app.taskregistry == registry
+
+
+def test_set_config():
+    app = TaskworkerApp()
+    app.set_config({"rpc_secret": "testing", "ignored": "key"})
+    assert app.config["rpc_secret"] == "testing"
+    assert "ignored" not in app.config
+
+
+def test_should_attempt_at_most_once(clear_cache):
+    activation = TaskActivation(
+        id="111",
+        taskname="examples.simple_task",
+        namespace="examples",
+        parameters='{"args": [], "kwargs": {}}',
+        processing_deadline_duration=2,
+    )
+    app = TaskworkerApp()
+    app.at_most_once_store(cache)
+    assert app.should_attempt_at_most_once(activation)
+    assert not app.should_attempt_at_most_once(activation)

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -10,7 +10,6 @@ from unittest.mock import Mock, patch
 
 import grpc
 import pytest
-from django.test import override_settings
 from google.protobuf.message import Message
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     TASK_ACTIVATION_STATUS_COMPLETE,
@@ -240,7 +239,6 @@ def test_get_task_writes_to_health_check_file() -> None:
 
 
 @django_db_all
-@override_settings(TASKWORKER_SHARED_SECRET='["a long secret value","notused"]')
 def test_get_task_with_interceptor() -> None:
     channel = MockChannel()
     channel.add_response(
@@ -262,9 +260,10 @@ def test_get_task_with_interceptor() -> None:
             ),
         ),
     )
+    secret = '["a long secret value","notused"]'
     with patch("sentry.taskworker.client.client.grpc.insecure_channel") as mock_channel:
         mock_channel.return_value = channel
-        client = TaskworkerClient(["localhost-0:50051"])
+        client = TaskworkerClient(["localhost-0:50051"], rpc_secret=secret)
         result = client.get_task()
 
         assert result

--- a/tests/sentry/taskworker/test_worker.py
+++ b/tests/sentry/taskworker/test_worker.py
@@ -161,7 +161,10 @@ class TestTaskWorker(TestCase):
 
     def test_fetch_task(self) -> None:
         taskworker = TaskWorker(
-            broker_hosts=["127.0.0.1:50051"], max_child_task_count=100, process_type="fork"
+            app_module="sentry.taskworker.runtime:app",
+            broker_hosts=["127.0.0.1:50051"],
+            max_child_task_count=100,
+            process_type="fork",
         )
         with mock.patch.object(taskworker.client, "get_task") as mock_get:
             mock_get.return_value = SIMPLE_TASK
@@ -174,7 +177,10 @@ class TestTaskWorker(TestCase):
 
     def test_fetch_no_task(self) -> None:
         taskworker = TaskWorker(
-            broker_hosts=["127.0.0.1:50051"], max_child_task_count=100, process_type="fork"
+            app_module="sentry.taskworker.runtime:app",
+            broker_hosts=["127.0.0.1:50051"],
+            max_child_task_count=100,
+            process_type="fork",
         )
         with mock.patch.object(taskworker.client, "get_task") as mock_get:
             mock_get.return_value = None
@@ -186,7 +192,10 @@ class TestTaskWorker(TestCase):
     def test_run_once_no_next_task(self) -> None:
         max_runtime = 5
         taskworker = TaskWorker(
-            broker_hosts=["127.0.0.1:50051"], max_child_task_count=1, process_type="fork"
+            app_module="sentry.taskworker.runtime:app",
+            broker_hosts=["127.0.0.1:50051"],
+            max_child_task_count=1,
+            process_type="fork",
         )
         with mock.patch.object(taskworker, "client") as mock_client:
             mock_client.get_task.return_value = SIMPLE_TASK
@@ -219,7 +228,10 @@ class TestTaskWorker(TestCase):
         # be processed.
         max_runtime = 5
         taskworker = TaskWorker(
-            broker_hosts=["127.0.0.1:50051"], max_child_task_count=1, process_type="fork"
+            app_module="sentry.taskworker.runtime:app",
+            broker_hosts=["127.0.0.1:50051"],
+            max_child_task_count=1,
+            process_type="fork",
         )
         with mock.patch.object(taskworker, "client") as mock_client:
 
@@ -258,6 +270,7 @@ class TestTaskWorker(TestCase):
         # Cover the scenario where taskworker.fetch_next.disabled_pools is defined
         max_runtime = 5
         taskworker = TaskWorker(
+            app_module="sentry.taskworker.runtime:app",
             broker_hosts=["127.0.0.1:50051"],
             max_child_task_count=1,
             process_type="fork",
@@ -294,7 +307,10 @@ class TestTaskWorker(TestCase):
         # We should retain the result until RPC succeeds.
         max_runtime = 5
         taskworker = TaskWorker(
-            broker_hosts=["127.0.0.1:50051"], max_child_task_count=1, process_type="fork"
+            app_module="sentry.taskworker.runtime:app",
+            broker_hosts=["127.0.0.1:50051"],
+            max_child_task_count=1,
+            process_type="fork",
         )
         with mock.patch.object(taskworker, "client") as mock_client:
 
@@ -337,7 +353,10 @@ class TestTaskWorker(TestCase):
         # to raise and catch a NoRetriesRemainingError
         max_runtime = 5
         taskworker = TaskWorker(
-            broker_hosts=["127.0.0.1:50051"], max_child_task_count=1, process_type="fork"
+            app_module="sentry.taskworker.runtime:app",
+            broker_hosts=["127.0.0.1:50051"],
+            max_child_task_count=1,
+            process_type="fork",
         )
         with mock.patch.object(taskworker, "client") as mock_client:
 
@@ -386,6 +405,7 @@ def test_child_process_complete(mock_capture_checkin: mock.MagicMock) -> None:
 
     todo.put(SIMPLE_TASK)
     child_process(
+        "sentry.taskworker.runtime:app",
         todo,
         processed,
         shutdown,
@@ -420,6 +440,7 @@ def test_child_process_remove_start_time_kwargs() -> None:
 
     todo.put(activation)
     child_process(
+        "sentry.taskworker.runtime:app",
         todo,
         processed,
         shutdown,
@@ -442,6 +463,7 @@ def test_child_process_retry_task() -> None:
 
     todo.put(RETRY_TASK)
     child_process(
+        "sentry.taskworker.runtime:app",
         todo,
         processed,
         shutdown,
@@ -482,6 +504,7 @@ def test_child_process_retry_task_max_attempts(mock_capture: mock.Mock) -> None:
 
     todo.put(activation)
     child_process(
+        "sentry.taskworker.runtime:app",
         todo,
         processed,
         shutdown,
@@ -510,6 +533,7 @@ def test_child_process_failure_task() -> None:
 
     todo.put(FAIL_TASK)
     child_process(
+        "sentry.taskworker.runtime:app",
         todo,
         processed,
         shutdown,
@@ -533,6 +557,7 @@ def test_child_process_shutdown() -> None:
 
     todo.put(SIMPLE_TASK)
     child_process(
+        "sentry.taskworker.runtime:app",
         todo,
         processed,
         shutdown,
@@ -555,6 +580,7 @@ def test_child_process_unknown_task() -> None:
     todo.put(UNDEFINED_TASK)
     todo.put(SIMPLE_TASK)
     child_process(
+        "sentry.taskworker.runtime:app",
         todo,
         processed,
         shutdown,
@@ -582,6 +608,7 @@ def test_child_process_at_most_once() -> None:
     todo.put(AT_MOST_ONCE_TASK)
     todo.put(SIMPLE_TASK)
     child_process(
+        "sentry.taskworker.runtime:app",
         todo,
         processed,
         shutdown,
@@ -609,6 +636,7 @@ def test_child_process_record_checkin(mock_capture_checkin: mock.Mock) -> None:
 
     todo.put(SCHEDULED_TASK)
     child_process(
+        "sentry.taskworker.runtime:app",
         todo,
         processed,
         shutdown,
@@ -652,6 +680,7 @@ def test_child_process_terminate_task(mock_capture: mock.Mock) -> None:
 
     todo.put(sleepy)
     child_process(
+        "sentry.taskworker.runtime:app",
         todo,
         processed,
         shutdown,
@@ -678,6 +707,7 @@ def test_child_process_decompression(mock_capture_checkin: mock.MagicMock) -> No
 
     todo.put(COMPRESSED_TASK)
     child_process(
+        "sentry.taskworker.runtime:app",
         todo,
         processed,
         shutdown,


### PR DESCRIPTION
We'll eventually need to separate out the `taskworker` module into a separate package so that other applications can also use it. By introducing an `app` we can remove django dependencies within the worker, scheduler and client.