### PR TITLE
ref(grouping): remove default for grouping.grouphash_metadata.backfill_sample_rate

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3120,12 +3120,6 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "grouping.grouphash_metadata.backfill_sample_rate",
-    type=Float,
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "workflow_engine.issue_alert.group.type_id.rollout",


### PR DESCRIPTION
Remove default for `grouping.grouphash_metadata.backfill_sample_rate` now that it is not an option
