### PR TITLE
ref(feedback): extend label and title seer timeouts

### DIFF
--- a/src/sentry/feedback/usecases/label_generation.py
+++ b/src/sentry/feedback/usecases/label_generation.py
@@ -25,12 +25,8 @@ MAX_AI_LABELS_JSON_LENGTH = 200
 
 SEER_LABEL_GENERATION_ENDPOINT_PATH = "/v1/automation/summarize/feedback/labels"
 
-seer_connection_pool = connection_from_url(
-    settings.SEER_SUMMARIZATION_URL, timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5)
-)
-fallback_connection_pool = connection_from_url(
-    settings.SEER_AUTOFIX_URL, timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5)
-)
+seer_connection_pool = connection_from_url(settings.SEER_SUMMARIZATION_URL, timeout=30)
+fallback_connection_pool = connection_from_url(settings.SEER_AUTOFIX_URL, timeout=30)
 
 
 @metrics.wraps("feedback.generate_labels")

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -13,12 +13,8 @@ logger = logging.getLogger(__name__)
 
 SEER_TITLE_GENERATION_ENDPOINT_PATH = "/v1/automation/summarize/feedback/title"
 
-seer_connection_pool = connection_from_url(
-    settings.SEER_SUMMARIZATION_URL, timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5)
-)
-fallback_connection_pool = connection_from_url(
-    settings.SEER_AUTOFIX_URL, timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5)
-)
+seer_connection_pool = connection_from_url(settings.SEER_SUMMARIZATION_URL, timeout=10)
+fallback_connection_pool = connection_from_url(settings.SEER_AUTOFIX_URL, timeout=10)
 
 
 class GenerateFeedbackTitleRequest(TypedDict):


### PR DESCRIPTION
These are hard upper bounds and can be a bit more generous. These are called in an ingest task which has a [65s time limit](https://github.com/getsentry/sentry/blob/81a64bf5714a1c9da7a88c5e214b0e9f1d06d8b3/src/sentry/tasks/store.py#L712).

Fixes [SENTRY-4MW9](https://sentry.sentry.io/issues/6869495062/events/94922a85f95446e4b9e7cd11941b744f/)
Fixes [SEER-4JM](https://sentry.sentry.io/issues/6845659438/events/7c51221245b04c2b82508cace75e119e/)