### PR TITLE
fix(aci): Always display bulk edit detector/automation checkbox

### DIFF
--- a/static/app/components/workflowEngine/ui/selectAllHeaderCheckbox.tsx
+++ b/static/app/components/workflowEngine/ui/selectAllHeaderCheckbox.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+
+import {Checkbox} from 'sentry/components/core/checkbox';
+import {t} from 'sentry/locale';
+
+type SelectAllHeaderCheckboxProps = {
+  checked: boolean | 'indeterminate';
+  onChange: (checked: boolean) => void;
+  className?: string;
+  disabled?: boolean;
+};
+
+export function SelectAllHeaderCheckbox({
+  checked,
+  onChange,
+  disabled,
+  className,
+}: SelectAllHeaderCheckboxProps) {
+  return (
+    <Wrapper
+      className={className}
+      onClick={event => {
+        event.stopPropagation();
+      }}
+    >
+      <Checkbox
+        checked={checked}
+        disabled={disabled}
+        onChange={event => onChange(event.target.checked)}
+        aria-label={t('Select all on page')}
+      />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled('div')`
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+`;

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -95,7 +95,7 @@ function AutomationListTable({
     setSelected(newSelected);
   };
   const automationIds = new Set(automations.map(a => a.id));
-  const pageSelected = automationIds.difference(selected).size === 0;
+  const pageSelected = !isPending && automationIds.difference(selected).size === 0;
   const anySelected = selected.size > 0;
 
   const canEnable = useMemo(

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -2,6 +2,7 @@ import {useCallback, useMemo, useState, type ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
+import {Flex} from 'sentry/components/core/layout';
 import LoadingError from 'sentry/components/loadingError';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {SelectAllHeaderCheckbox} from 'sentry/components/workflowEngine/ui/selectAllHeaderCheckbox';
@@ -127,13 +128,13 @@ function AutomationListTable({
       {canEditAutomations && selected.size === 0 ? (
         <SimpleTable.Header key="header">
           <HeaderCell sort={sort} sortKey="name">
-            <NameHeader>
+            <Flex gap="md" align="center">
               <SelectAllHeaderCheckbox
                 checked={pageSelected || (anySelected ? 'indeterminate' : false)}
                 onChange={checked => togglePageSelected(checked)}
               />
               <span>{t('Name')}</span>
-            </NameHeader>
+            </Flex>
           </HeaderCell>
           <HeaderCell
             data-column-name="last-triggered"
@@ -229,12 +230,6 @@ const AutomationsSimpleTable = styled(SimpleTable)`
       display: flex;
     }
   }
-`;
-
-const NameHeader = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.md};
 `;
 
 export default AutomationListTable;

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import LoadingError from 'sentry/components/loadingError';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {SelectAllHeaderCheckbox} from 'sentry/components/workflowEngine/ui/selectAllHeaderCheckbox';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
@@ -95,6 +96,7 @@ function AutomationListTable({
   };
   const automationIds = new Set(automations.map(a => a.id));
   const pageSelected = automationIds.difference(selected).size === 0;
+  const anySelected = selected.size > 0;
 
   const canEnable = useMemo(
     () =>
@@ -125,7 +127,13 @@ function AutomationListTable({
       {canEditAutomations && selected.size === 0 ? (
         <SimpleTable.Header key="header">
           <HeaderCell sort={sort} sortKey="name">
-            <NamePadding>{t('Name')}</NamePadding>
+            <NameHeader>
+              <SelectAllHeaderCheckbox
+                checked={pageSelected || (anySelected ? 'indeterminate' : false)}
+                onChange={checked => togglePageSelected(checked)}
+              />
+              <span>{t('Name')}</span>
+            </NameHeader>
           </HeaderCell>
           <HeaderCell
             data-column-name="last-triggered"
@@ -223,8 +231,10 @@ const AutomationsSimpleTable = styled(SimpleTable)`
   }
 `;
 
-const NamePadding = styled('div')`
-  padding-left: 28px;
+const NameHeader = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.md};
 `;
 
 export default AutomationListTable;

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -124,7 +124,9 @@ describe('AutomationsList', () => {
     );
 
     // Click on Name column header to sort
-    await userEvent.click(screen.getByRole('columnheader', {name: 'Name'}));
+    await userEvent.click(
+      screen.getByRole('columnheader', {name: 'Select all on page Name'})
+    );
 
     await waitFor(() => {
       expect(mockAutomationsRequest).toHaveBeenLastCalledWith(
@@ -139,7 +141,9 @@ describe('AutomationsList', () => {
     expect(router.location.query.sort).toBe('name');
 
     // Click on Name column header again to change sort direction
-    await userEvent.click(screen.getByRole('columnheader', {name: 'Name'}));
+    await userEvent.click(
+      screen.getByRole('columnheader', {name: 'Select all on page Name'})
+    );
 
     await waitFor(() => {
       expect(mockAutomationsRequest).toHaveBeenLastCalledWith(
@@ -220,7 +224,7 @@ describe('AutomationsList', () => {
       expect(rows).toHaveLength(3);
 
       // Initially no checkboxes should be checked
-      const checkboxes = screen.getAllByRole('checkbox');
+      let checkboxes = screen.getAllByRole('checkbox');
       checkboxes.forEach(checkbox => {
         expect(checkbox).not.toBeChecked();
       });
@@ -245,7 +249,8 @@ describe('AutomationsList', () => {
       await userEvent.click(masterCheckbox);
       expect(masterCheckbox).toBeChecked();
 
-      // // All checkboxes should be checked
+      // All checkboxes should be checked
+      checkboxes = screen.getAllByRole('checkbox');
       checkboxes.forEach(checkbox => {
         expect(checkbox).toBeChecked();
       });

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -89,7 +89,7 @@ function DetectorListTable({
       setSelected(new Set<string>());
     }
   };
-  const pageSelected = detectorIds.difference(selected).size === 0;
+  const pageSelected = !isPending && detectorIds.difference(selected).size === 0;
   const anySelected = selected.size > 0;
 
   const handleSelect = useCallback(

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useMemo, useState, type ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
+import {Flex} from 'sentry/components/core/layout';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {SelectAllHeaderCheckbox} from 'sentry/components/workflowEngine/ui/selectAllHeaderCheckbox';
 import {t} from 'sentry/locale';
@@ -123,13 +124,13 @@ function DetectorListTable({
         {selected.size === 0 ? (
           <SimpleTable.Header>
             <HeaderCell sortKey="name" sort={sort}>
-              <NameHeader>
+              <Flex gap="md" align="center">
                 <SelectAllHeaderCheckbox
                   checked={pageSelected || (anySelected ? 'indeterminate' : false)}
                   onChange={checked => togglePageSelected(checked)}
                 />
                 <span>{t('Name')}</span>
-              </NameHeader>
+              </Flex>
             </HeaderCell>
             <HeaderCell data-column-name="type" divider sortKey="type" sort={sort}>
               {t('Type')}
@@ -189,12 +190,6 @@ function DetectorListTable({
 
 const Container = styled('div')`
   container-type: inline-size;
-`;
-
-const NameHeader = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.md};
 `;
 
 const DetectorListSimpleTable = styled(SimpleTable)`

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -2,6 +2,7 @@ import {useCallback, useMemo, useState, type ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {SelectAllHeaderCheckbox} from 'sentry/components/workflowEngine/ui/selectAllHeaderCheckbox';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
@@ -89,6 +90,7 @@ function DetectorListTable({
     }
   };
   const pageSelected = detectorIds.difference(selected).size === 0;
+  const anySelected = selected.size > 0;
 
   const handleSelect = useCallback(
     (id: string) => {
@@ -121,7 +123,13 @@ function DetectorListTable({
         {selected.size === 0 ? (
           <SimpleTable.Header>
             <HeaderCell sortKey="name" sort={sort}>
-              <NamePadding>{t('Name')}</NamePadding>
+              <NameHeader>
+                <SelectAllHeaderCheckbox
+                  checked={pageSelected || (anySelected ? 'indeterminate' : false)}
+                  onChange={checked => togglePageSelected(checked)}
+                />
+                <span>{t('Name')}</span>
+              </NameHeader>
             </HeaderCell>
             <HeaderCell data-column-name="type" divider sortKey="type" sort={sort}>
               {t('Type')}
@@ -183,9 +191,13 @@ const Container = styled('div')`
   container-type: inline-size;
 `;
 
-const NamePadding = styled('div')`
-  padding-left: 28px;
+const NameHeader = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.md};
 `;
+
+//
 
 const DetectorListSimpleTable = styled(SimpleTable)`
   grid-template-columns: 1fr;

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -197,8 +197,6 @@ const NameHeader = styled('div')`
   gap: ${p => p.theme.space.md};
 `;
 
-//
-
 const DetectorListSimpleTable = styled(SimpleTable)`
   grid-template-columns: 1fr;
 

--- a/static/app/views/detectors/list.spec.tsx
+++ b/static/app/views/detectors/list.spec.tsx
@@ -305,7 +305,7 @@ describe('DetectorsList', () => {
       expect(rows).toHaveLength(3);
 
       // Initially no checkboxes should be checked
-      const checkboxes = screen.getAllByRole('checkbox');
+      let checkboxes = screen.getAllByRole('checkbox');
       checkboxes.forEach(checkbox => {
         expect(checkbox).not.toBeChecked();
       });
@@ -331,6 +331,7 @@ describe('DetectorsList', () => {
       expect(masterCheckbox).toBeChecked();
 
       // // All checkboxes should be checked
+      checkboxes = screen.getAllByRole('checkbox');
       checkboxes.forEach(checkbox => {
         expect(checkbox).toBeChecked();
       });

--- a/static/app/views/detectors/list.spec.tsx
+++ b/static/app/views/detectors/list.spec.tsx
@@ -229,7 +229,9 @@ describe('DetectorsList', () => {
       );
 
       // Click on Name column header to sort
-      await userEvent.click(screen.getByRole('columnheader', {name: 'Name'}));
+      await userEvent.click(
+        screen.getByRole('columnheader', {name: 'Select all on page Name'})
+      );
 
       await waitFor(() => {
         expect(mockDetectorsRequest).toHaveBeenLastCalledWith(
@@ -244,7 +246,9 @@ describe('DetectorsList', () => {
       expect(router.location.query.sort).toBe('name');
 
       // Click on Name column header again to change sort direction
-      await userEvent.click(screen.getByRole('columnheader', {name: 'Name'}));
+      await userEvent.click(
+        screen.getByRole('columnheader', {name: 'Select all on page Name'})
+      );
 
       await waitFor(() => {
         expect(mockDetectorsRequest).toHaveBeenLastCalledWith(


### PR DESCRIPTION
On the list of monitors/automations, the checkbox will always be shown regardless if anything is checked

<img width="285" height="139" alt="image" src="https://github.com/user-attachments/assets/5e0758fe-0314-4275-94eb-90f45c905cd2" />
