### PR TITLE
fix(seer): Fix cta loading indicator color

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -234,12 +234,6 @@ const ChevronContainer = styled('div')`
 const StyledLoadingIndicator = styled(LoadingIndicator)`
   position: relative;
   margin-left: ${space(1)};
-  color: ${p => p.theme.pink400};
-
-  .loading-indicator {
-    border-color: ${p => p.theme.pink100};
-    border-left-color: ${p => p.theme.pink400};
-  }
 `;
 
 const ButtonPlaceholder = styled(Placeholder)`

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -234,6 +234,10 @@ const ChevronContainer = styled('div')`
 const StyledLoadingIndicator = styled(LoadingIndicator)`
   position: relative;
   margin-left: ${space(1)};
+
+  .loading-indicator {
+    border-left-color: ${p => p.theme.progressBackground};
+  }
 `;
 
 const ButtonPlaceholder = styled(Placeholder)`


### PR DESCRIPTION
Oops

Now:
<img width="646" height="152" alt="CleanShot 2025-09-19 at 15 13 00@2x" src="https://github.com/user-attachments/assets/f706bb1f-1c0f-4579-bc28-38b3c10673c4" />


Before:
<img width="630" height="170" alt="CleanShot 2025-09-19 at 15 00 22@2x" src="https://github.com/user-attachments/assets/a05dcb71-fd84-46ce-b53e-3ce61adf4ceb" />
