### PR TITLE
ref(replay/feedback): use larger shared seer connection pools with no fallback

### DIFF
--- a/src/sentry/feedback/endpoints/organization_feedback_summary.py
+++ b/src/sentry/feedback/endpoints/organization_feedback_summary.py
@@ -1,10 +1,10 @@
 import logging
 from datetime import timedelta
 
-from django.conf import settings
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
+from urllib3 import Retry
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
@@ -13,11 +13,11 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationUserReportsPermission
 from sentry.api.utils import get_date_range_from_stats_period
 from sentry.exceptions import InvalidParams
+from sentry.feedback.lib.seer_api import seer_summarization_connection_pool
 from sentry.grouping.utils import hash_from_values
 from sentry.issues.grouptype import FeedbackGroup
 from sentry.models.group import Group, GroupStatus
 from sentry.models.organization import Organization
-from sentry.net.http import connection_from_url
 from sentry.seer.seer_setup import has_seer_access
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.utils import json
@@ -34,40 +34,25 @@ MAX_FEEDBACKS_TO_SUMMARIZE_CHARS = 1000000
 SUMMARY_CACHE_TIMEOUT = 86400
 
 SEER_SUMMARIZE_FEEDBACKS_ENDPOINT_PATH = "/v1/automation/summarize/feedback/summarize"
-
-seer_connection_pool = connection_from_url(
-    settings.SEER_SUMMARIZATION_URL, timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5)
-)
-fallback_connection_pool = connection_from_url(
-    settings.SEER_AUTOFIX_URL, timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5)
-)
+SEER_TIMEOUT_S = 30
+SEER_RETRIES = Retry(total=1, backoff_factor=3)  # 1 retry after a 3 second delay.
 
 
 def get_summary_from_seer(feedback_msgs: list[str]) -> str | None:
     request_body = json.dumps({"feedbacks": feedback_msgs}).encode("utf-8")
     try:
         response = make_signed_seer_api_request(
-            connection_pool=seer_connection_pool,
+            connection_pool=seer_summarization_connection_pool,
             path=SEER_SUMMARIZE_FEEDBACKS_ENDPOINT_PATH,
             body=request_body,
+            timeout=SEER_TIMEOUT_S,
+            retries=SEER_RETRIES,
         )
     except Exception:
-        # If summarization pod fails, fall back to autofix pod
-        logger.warning(
-            "Summarization pod connection failed for feedback summary, falling back to autofix",
-            exc_info=True,
+        logger.exception(
+            "Seer failed to generate a summary for a list of feedbacks",
         )
-        try:
-            response = make_signed_seer_api_request(
-                connection_pool=fallback_connection_pool,
-                path=SEER_SUMMARIZE_FEEDBACKS_ENDPOINT_PATH,
-                body=request_body,
-            )
-        except Exception:
-            logger.exception(
-                "Seer failed to generate a summary for a list of feedbacks on both pods"
-            )
-            return None
+        return None
 
     if response.status < 200 or response.status >= 300:
         logger.error(

--- a/src/sentry/feedback/lib/seer_api.py
+++ b/src/sentry/feedback/lib/seer_api.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+
+from sentry.net.http import connection_from_url
+
+# Shared connection pool for feedback AI usecases. No timeout or retries by default, but requests can override these params.
+seer_summarization_connection_pool = connection_from_url(
+    settings.SEER_SUMMARIZATION_URL,
+    timeout=None,
+    retries=0,
+    maxsize=10,  # Number of open connections. If the number of concurrent requests exceeds this, temporary connections are created.
+)

--- a/src/sentry/feedback/lib/seer_api.py
+++ b/src/sentry/feedback/lib/seer_api.py
@@ -7,5 +7,5 @@ seer_summarization_connection_pool = connection_from_url(
     settings.SEER_SUMMARIZATION_URL,
     timeout=None,
     retries=0,
-    maxsize=10,  # Number of open connections. If the number of concurrent requests exceeds this, temporary connections are created.
+    maxsize=10,  # Max persisted connections. If the number of concurrent requests exceeds this, temporary connections are created.
 )

--- a/src/sentry/feedback/usecases/label_generation.py
+++ b/src/sentry/feedback/usecases/label_generation.py
@@ -25,12 +25,8 @@ MAX_AI_LABELS_JSON_LENGTH = 200
 
 SEER_LABEL_GENERATION_ENDPOINT_PATH = "/v1/automation/summarize/feedback/labels"
 
-seer_connection_pool = connection_from_url(
-    settings.SEER_SUMMARIZATION_URL, timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5)
-)
-fallback_connection_pool = connection_from_url(
-    settings.SEER_AUTOFIX_URL, timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5)
-)
+seer_connection_pool = connection_from_url(settings.SEER_SUMMARIZATION_URL, timeout=30)
+fallback_connection_pool = connection_from_url(settings.SEER_AUTOFIX_URL, timeout=30)
 
 
 @metrics.wraps("feedback.generate_labels")

--- a/src/sentry/feedback/usecases/label_generation.py
+++ b/src/sentry/feedback/usecases/label_generation.py
@@ -22,7 +22,8 @@ MAX_AI_LABELS = 15
 MAX_AI_LABELS_JSON_LENGTH = 200
 
 SEER_LABEL_GENERATION_ENDPOINT_PATH = "/v1/automation/summarize/feedback/labels"
-SEER_TIMEOUT_S = 10
+SEER_TIMEOUT_S = 15
+SEER_RETRIES = 0  # Do not retry since this is called in ingest.
 
 
 @metrics.wraps("feedback.generate_labels")
@@ -43,7 +44,7 @@ def generate_labels(feedback_message: str, organization_id: int) -> list[str]:
             path=SEER_LABEL_GENERATION_ENDPOINT_PATH,
             body=json.dumps(request).encode("utf-8"),
             timeout=SEER_TIMEOUT_S,
-            retries=0,  # Do not retry since this is called in ingest.
+            retries=SEER_RETRIES,
         )
         response_data = response.json()
     except Exception:

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TypedDict
 
-from sentry.replays.lib.seer_api import seer_summarization_connection_pool
+from sentry.feedback.lib.seer_api import seer_summarization_connection_pool
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.utils import json, metrics
 

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -10,7 +10,8 @@ from sentry.utils import json, metrics
 logger = logging.getLogger(__name__)
 
 SEER_TITLE_GENERATION_ENDPOINT_PATH = "/v1/automation/summarize/feedback/title"
-SEER_TIMEOUT_S = 10
+SEER_TIMEOUT_S = 15
+SEER_RETRIES = 0  # Do not retry since this is called in ingest.
 
 
 class GenerateFeedbackTitleRequest(TypedDict):
@@ -74,7 +75,7 @@ def get_feedback_title_from_seer(feedback_message: str, organization_id: int) ->
             path=SEER_TITLE_GENERATION_ENDPOINT_PATH,
             body=json.dumps(seer_request).encode("utf-8"),
             timeout=SEER_TIMEOUT_S,
-            retries=0,  # Do not retry since this is called in ingest.
+            retries=SEER_RETRIES,
         )
         response_data = response.json()
     except Exception:

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -13,12 +13,8 @@ logger = logging.getLogger(__name__)
 
 SEER_TITLE_GENERATION_ENDPOINT_PATH = "/v1/automation/summarize/feedback/title"
 
-seer_connection_pool = connection_from_url(
-    settings.SEER_SUMMARIZATION_URL, timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5)
-)
-fallback_connection_pool = connection_from_url(
-    settings.SEER_AUTOFIX_URL, timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5)
-)
+seer_connection_pool = connection_from_url(settings.SEER_SUMMARIZATION_URL, timeout=10)
+fallback_connection_pool = connection_from_url(settings.SEER_AUTOFIX_URL, timeout=10)
 
 
 class GenerateFeedbackTitleRequest(TypedDict):

--- a/src/sentry/replays/lib/seer_api.py
+++ b/src/sentry/replays/lib/seer_api.py
@@ -7,5 +7,5 @@ seer_summarization_connection_pool = connection_from_url(
     settings.SEER_SUMMARIZATION_URL,
     timeout=None,
     retries=0,
-    maxsize=100,  # Number of open connections. If the number of concurrent requests exceeds this, temporary connections are created.
+    maxsize=100,  # Max persisted connections. If the number of concurrent requests exceeds this, temporary connections are created.
 )

--- a/src/sentry/replays/lib/seer_api.py
+++ b/src/sentry/replays/lib/seer_api.py
@@ -7,5 +7,5 @@ seer_summarization_connection_pool = connection_from_url(
     settings.SEER_SUMMARIZATION_URL,
     timeout=None,
     retries=0,
-    maxsize=100,  # Max persisted connections. If the number of concurrent requests exceeds this, temporary connections are created.
+    maxsize=20,  # Max persisted connections. If the number of concurrent requests exceeds this, temporary connections are created.
 )

--- a/src/sentry/replays/lib/seer_api.py
+++ b/src/sentry/replays/lib/seer_api.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+
+from sentry.net.http import connection_from_url
+
+# Shared connection pool for replay AI usecases. No timeout or retries by default, but requests can override these params.
+seer_summarization_connection_pool = connection_from_url(
+    settings.SEER_SUMMARIZATION_URL,
+    timeout=None,
+    retries=0,
+    maxsize=100,  # Number of open connections. If the number of concurrent requests exceeds this, temporary connections are created.
+)

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -21,6 +21,7 @@ from snuba_sdk import (
     OrderBy,
     Query,
 )
+from urllib3 import Retry
 
 from sentry.api.event_search import parse_search_query
 from sentry.models.organization import Organization
@@ -209,7 +210,7 @@ def delete_seer_replay_data(project_id: int, replay_ids: list[str]) -> bool:
             path=SEER_DELETE_SUMMARIES_ENDPOINT_PATH,
             body=json.dumps(seer_request).encode("utf-8"),
             timeout=getattr(settings, "SEER_DEFAULT_TIMEOUT", 5),
-            retries=None,  # Default behavior of 3 retries.
+            retries=Retry(total=1, backoff_factor=3),  # 1 retry after a 3 second delay.
         )
     except Exception:
         logger.exception(

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 
 import sentry_sdk
 from django.conf import settings
-from urllib3 import BaseHTTPResponse, HTTPConnectionPool
+from urllib3 import BaseHTTPResponse, HTTPConnectionPool, Retry
 
 from sentry import options
 from sentry.utils import metrics
@@ -21,7 +21,7 @@ def make_signed_seer_api_request(
     path: str,
     body: bytes,
     timeout: int | float | None = None,
-    retries: int | None = None,
+    retries: int | None | Retry = None,
     metric_tags: dict[str, Any] | None = None,
 ) -> BaseHTTPResponse:
     host = connection_pool.host

--- a/tests/sentry/feedback/usecases/test_label_generation.py
+++ b/tests/sentry/feedback/usecases/test_label_generation.py
@@ -62,8 +62,7 @@ def test_generate_labels_network_error(mock_make_seer_request) -> None:
             "I don't like the new right sidebar, it makes navigating everywhere hard!", 1
         )
 
-    # Should be called twice: once for summarization URL, once for autofix fallback
-    assert mock_make_seer_request.call_count == 2
+    assert mock_make_seer_request.call_count == 1
     request_body = json.loads(mock_make_seer_request.call_args[1]["body"].decode("utf-8"))
     expected_request = {
         "feedback_message": "I don't like the new right sidebar, it makes navigating everywhere hard!",

--- a/tests/sentry/feedback/usecases/test_title_generation.py
+++ b/tests/sentry/feedback/usecases/test_title_generation.py
@@ -66,8 +66,7 @@ def test_get_feedback_title_from_seer_exception(mock_make_seer_request):
     """Test the get_feedback_title_from_seer function with exception during API call."""
     mock_make_seer_request.side_effect = Exception("Network error")
     assert get_feedback_title_from_seer("Login button broken", 123) is None
-    # Should be called twice: once for summarization URL, once for autofix fallback
-    assert mock_make_seer_request.call_count == 2
+    assert mock_make_seer_request.call_count == 1
 
 
 @patch("sentry.feedback.usecases.title_generation.make_signed_seer_api_request")


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/99960. Cleaning up the fallback URL now the seer migration is complete. 

This PR creates larger connection pools shared by all replay/feedback usecases, with 20 max connections each. Right now we have one pool per usecase with 1 open conn (`maxsize` defaults to 1). See [urllib3 ConnectionPool docs](https://urllib3.readthedocs.io/en/stable/reference/urllib3.connectionpool.html#urllib3.HTTPConnectionPool). We weren't aware of this behavior - it kind of defeats the purpose of connection pooling since the connection can only serve 1 request at a time, and concurrent requests open temporary connections. 

See `block` - false by default
> block ([bool](https://docs.python.org/3/library/functions.html#bool)) – If set to True, no more than maxsize connections will be used at a time. When no free connections are available, the call will block until a connection has been released. This is a useful side effect for particular multithreaded situations where one does not want to use more than maxsize connections per host to prevent flooding.

Also tweaks the timeout/retries for each usecase. I just learned the default retries is 3.
- replay summaries: 5s / don't retry
- replay deletes: 5s / 1 retry after 3s (recommended by @Mihir-Mavalankar )
- feedback summary/categories: 30s / 1 retry after 3s
- feedback titles/labels: 15s / don't retry