### PR TITLE
ref(aci): Refactor interactions with delayed workflow batching

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3154,7 +3154,7 @@ register(
 register(
     "workflow_engine.use_new_scheduling_task",
     type=Bool,
-    default=False,
+    default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/rules/processing/buffer_processing.py
+++ b/src/sentry/rules/processing/buffer_processing.py
@@ -238,8 +238,4 @@ def process_buffer() -> None:
     Process all registered delayed processing types.
     """
     for processing_type, handler in delayed_processing_registry.registrations.items():
-        # If the new scheduling task is enabled and this is delayed_workflow, skip it
-        use_new_scheduling = options.get("workflow_engine.use_new_scheduling_task")
-        if use_new_scheduling and processing_type == "delayed_workflow":
-            continue
         process_buffer_for_type(processing_type, handler)

--- a/src/sentry/workflow_engine/buffer/batch_client.py
+++ b/src/sentry/workflow_engine/buffer/batch_client.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import random
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+import sentry.workflow_engine.buffer as buffer
+from sentry.workflow_engine.models import Workflow
+
+if TYPE_CHECKING:
+    from sentry.workflow_engine.buffer.redis_hash_sorted_set_buffer import RedisHashSortedSetBuffer
+
+
+class DelayedWorkflowClient:
+    """
+    Client for interacting with batch processing of delayed workflows.
+    This is used for managing the listing of projects that need to be processed
+    """
+
+    _BUFFER_KEY = "workflow_engine_delayed_processing_buffer"
+    _BUFFER_SHARDS = 8
+    option = "delayed_workflow.rollout"
+
+    def __init__(
+        self, buf: RedisHashSortedSetBuffer | None = None, buffer_keys: list[str] | None = None
+    ) -> None:
+        self._buffer = buf or buffer.get_backend()
+        self._buffer_keys = buffer_keys or self._get_buffer_keys()
+
+    def add_project_ids(self, project_ids: list[int]) -> None:
+        """Add project IDs to a random shard for processing."""
+        sharded_key = random.choice(self._buffer_keys)
+        self._buffer.push_to_sorted_set(key=sharded_key, value=project_ids)
+
+    def get_project_ids(self, min: float, max: float) -> dict[int, list[float]]:
+        """Get project IDs within the specified score range from all shards."""
+        return self._buffer.bulk_get_sorted_set(
+            self._buffer_keys,
+            min=min,
+            max=max,
+        )
+
+    def clear_project_ids(self, min: float, max: float) -> None:
+        """Remove project IDs within the specified score range from all shards."""
+        self._buffer.delete_keys(
+            self._buffer_keys,
+            min=min,
+            max=max,
+        )
+
+    @classmethod
+    def _get_buffer_keys(cls) -> list[str]:
+        return [
+            f"{cls._BUFFER_KEY}:{shard}" if shard > 0 else cls._BUFFER_KEY
+            for shard in range(cls._BUFFER_SHARDS)
+        ]
+
+    def for_project(self, project_id: int) -> ProjectDelayedWorkflowClient:
+        """Create a project-specific client for workflow operations."""
+        return ProjectDelayedWorkflowClient(project_id, self._buffer)
+
+
+class ProjectDelayedWorkflowClient:
+    """
+    Project-specific client for interacting with batch processing of delayed workflows.
+    This is used for managing the hash (aka dictionary) of group-to-event data used to
+    aggregate event data that needs to be processed.
+    """
+
+    def __init__(self, project_id: int, buffer: RedisHashSortedSetBuffer) -> None:
+        self.project_id = project_id
+        self._buffer = buffer
+
+    def _filters(self, batch_key: str | None) -> Mapping[str, int | str]:
+        filters: dict[str, int | str] = {"project_id": self.project_id}
+        if batch_key:
+            filters["batch_key"] = batch_key
+        return filters
+
+    def delete_hash_fields(self, batch_key: str | None, fields: list[str]) -> None:
+        """Delete specific fields from the workflow hash."""
+        self._buffer.delete_hash(model=Workflow, filters=self._filters(batch_key), fields=fields)
+
+    def get_hash_length(self, batch_key: str | None = None) -> int:
+        """Get the number of fields in the workflow hash."""
+        return self._buffer.get_hash_length(model=Workflow, filters=self._filters(batch_key))
+
+    def get_hash_data(self, batch_key: str | None = None) -> dict[str, str]:
+        """Fetch all group-to-event data from the workflow hash."""
+        return self._buffer.get_hash(model=Workflow, filters=self._filters(batch_key))
+
+    def push_to_hash(self, batch_key: str | None, data: dict[str, str]) -> None:
+        """Push data to the workflow hash in bulk."""
+        self._buffer.push_to_hash_bulk(model=Workflow, filters=self._filters(batch_key), data=data)

--- a/src/sentry/workflow_engine/buffer/redis_hash_sorted_set_buffer.py
+++ b/src/sentry/workflow_engine/buffer/redis_hash_sorted_set_buffer.py
@@ -120,10 +120,10 @@ class RedisHashSortedSetBuffer:
         self._execute_redis_operation(key, "hmset", data)
 
     def get_hash(
-        self, model: type[models.Model], field: Mapping[str, BufferField]
+        self, model: type[models.Model], filters: Mapping[str, BufferField]
     ) -> dict[str, str]:
         """Get all field-value pairs from a Redis hash."""
-        key = make_key(model, field)
+        key = make_key(model, filters)
         redis_hash = self._execute_redis_operation(key, "hgetall")
         decoded_hash = {}
         for k, v in redis_hash.items():
@@ -134,9 +134,9 @@ class RedisHashSortedSetBuffer:
             decoded_hash[k] = v
         return decoded_hash
 
-    def get_hash_length(self, model: type[models.Model], field: Mapping[str, BufferField]) -> int:
+    def get_hash_length(self, model: type[models.Model], filters: Mapping[str, BufferField]) -> int:
         """Get the number of fields in a Redis hash."""
-        key = make_key(model, field)
+        key = make_key(model, filters)
         return self._execute_redis_operation(key, "hlen")
 
     def delete_hash(

--- a/src/sentry/workflow_engine/processors/schedule.py
+++ b/src/sentry/workflow_engine/processors/schedule.py
@@ -1,38 +1,18 @@
 import logging
 import math
 import uuid
-from dataclasses import asdict
 from datetime import datetime, timezone
 from itertools import islice
 
 from sentry import options
-from sentry.buffer.base import BufferField
-from sentry.db import models
 from sentry.utils import metrics
-from sentry.workflow_engine.buffer import get_backend
-from sentry.workflow_engine.buffer.redis_hash_sorted_set_buffer import RedisHashSortedSetBuffer
 from sentry.workflow_engine.tasks.delayed_workflows import (
-    DelayedWorkflow,
+    DelayedWorkflowClient,
+    ProjectDelayedWorkflowClient,
     process_delayed_workflows,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def fetch_group_to_event_data(
-    buffer: RedisHashSortedSetBuffer,
-    project_id: int,
-    model: type[models.Model],
-    batch_key: str | None = None,
-) -> dict[str, str]:
-    field: dict[str, models.Model | int | str] = {
-        "project_id": project_id,
-    }
-
-    if batch_key:
-        field["batch_key"] = batch_key
-
-    return buffer.get_hash(model=model, field=field)
 
 
 def bucket_num_groups(num_groups: int) -> str:
@@ -42,7 +22,7 @@ def bucket_num_groups(num_groups: int) -> str:
     return "1"
 
 
-def process_in_batches(buffer: RedisHashSortedSetBuffer, project_id: int) -> None:
+def process_in_batches(client: ProjectDelayedWorkflowClient) -> None:
     """
     This will check the number of alertgroup_to_event_data items in the Redis buffer for a project.
 
@@ -58,27 +38,24 @@ def process_in_batches(buffer: RedisHashSortedSetBuffer, project_id: int) -> Non
     batch_size = options.get(
         "delayed_processing.batch_size"
     )  # TODO: Use workflow engine-specific option.
-    processing_info = DelayedWorkflow(project_id)
 
-    hash_args = processing_info.hash_args
-    filters: dict[str, BufferField] = asdict(hash_args.filters)
-
-    event_count = buffer.get_hash_length(model=hash_args.model, field=filters)
+    event_count = client.get_hash_length()
     metrics.incr("delayed_workflow.num_groups", tags={"num_groups": bucket_num_groups(event_count)})
     metrics.distribution("delayed_workflow.event_count", event_count)
 
     if event_count < batch_size:
         return process_delayed_workflows.apply_async(
-            kwargs={"project_id": project_id}, headers={"sentry-propagate-traces": False}
+            kwargs={"project_id": client.project_id},
+            headers={"sentry-propagate-traces": False},
         )
 
     logger.info(
         "delayed_workflow.process_large_batch",
-        extra={"project_id": project_id, "count": event_count},
+        extra={"project_id": client.project_id, "count": event_count},
     )
 
     # if the dictionary is large, get the items and chunk them.
-    alertgroup_to_event_data = fetch_group_to_event_data(buffer, project_id, hash_args.model)
+    alertgroup_to_event_data = client.fetch_group_to_event_data(batch_key=None)
 
     with metrics.timer("delayed_workflow.process_batch.duration"):
         items = iter(alertgroup_to_event_data.items())
@@ -86,28 +63,24 @@ def process_in_batches(buffer: RedisHashSortedSetBuffer, project_id: int) -> Non
         while batch := dict(islice(items, batch_size)):
             batch_key = str(uuid.uuid4())
 
-            buffer.push_to_hash_bulk(
-                model=hash_args.model,
-                filters={**filters, "batch_key": batch_key},
+            # Write items to batched hash and delete from original hash.
+            client.push_to_hash(
+                batch_key=batch_key,
                 data=batch,
             )
-
-            # remove the batched items from the project alertgroup_to_event_data
-            buffer.delete_hash(**asdict(hash_args), fields=list(batch.keys()))
+            client.delete_hash(batch_key=None, fields=list(batch.keys()))
 
             process_delayed_workflows.apply_async(
-                kwargs={"project_id": project_id, "batch_key": batch_key},
+                kwargs={"project_id": client.project_id, "batch_key": batch_key},
                 headers={"sentry-propagate-traces": False},
             )
 
 
-def process_buffered_workflows() -> None:
-    option_name = DelayedWorkflow.option
+def process_buffered_workflows(buffer_client: DelayedWorkflowClient) -> None:
+    option_name = buffer_client.option
     if option_name and not options.get(option_name):
         logger.info("delayed_workflow.disabled", extra={"option": option_name})
         return
-
-    buffer = get_backend()
 
     with metrics.timer("delayed_workflow.process_all_conditions.duration"):
         # We need to use a very fresh timestamp here; project scores (timestamps) are
@@ -116,9 +89,7 @@ def process_buffered_workflows() -> None:
         # and the more likely we'll have frequently updated projects that are never actually
         # retrieved and processed here.
         fetch_time = datetime.now(tz=timezone.utc).timestamp()
-        buffer_keys = DelayedWorkflow.get_buffer_keys()
-        all_project_ids_and_timestamps = buffer.bulk_get_sorted_set(
-            buffer_keys,
+        all_project_ids_and_timestamps = buffer_client.get_project_ids(
             min=0,
             max=fetch_time,
         )
@@ -133,10 +104,9 @@ def process_buffered_workflows() -> None:
 
         project_ids = list(all_project_ids_and_timestamps.keys())
         for project_id in project_ids:
-            process_in_batches(buffer, project_id)
+            process_in_batches(buffer_client.for_project(project_id))
 
-        buffer.delete_keys(
-            buffer_keys,
+        buffer_client.clear_project_ids(
             min=0,
             max=fetch_time,
         )

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -13,6 +13,7 @@ from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.services.eventstore.models import GroupEvent
 from sentry.utils import json
+from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
 from sentry.workflow_engine.models import (
     Action,
     DataConditionGroup,
@@ -32,7 +33,6 @@ from sentry.workflow_engine.processors.data_condition_group import (
 )
 from sentry.workflow_engine.processors.detector import get_detector_by_event
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
-from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflowClient
 from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.utils import log_context, scopedstats
 from sentry.workflow_engine.utils.metrics import metrics_incr

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -1,4 +1,3 @@
-import random
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime
@@ -14,7 +13,6 @@ from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.services.eventstore.models import GroupEvent
 from sentry.utils import json
-from sentry.workflow_engine import buffer
 from sentry.workflow_engine.models import (
     Action,
     DataConditionGroup,
@@ -34,6 +32,7 @@ from sentry.workflow_engine.processors.data_condition_group import (
 )
 from sentry.workflow_engine.processors.detector import get_detector_by_event
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
+from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflowClient
 from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.utils import log_context, scopedstats
 from sentry.workflow_engine.utils.metrics import metrics_incr
@@ -109,8 +108,6 @@ class DelayedWorkflowItem:
 def enqueue_workflows(
     items_by_workflow: dict[Workflow, DelayedWorkflowItem],
 ) -> None:
-    from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflow
-
     items_by_project_id = DefaultDict[int, list[DelayedWorkflowItem]](list)
     for queue_item in items_by_workflow.values():
         if not queue_item.delayed_if_group_ids and not queue_item.passing_if_group_ids:
@@ -126,11 +123,10 @@ def enqueue_workflows(
         sentry_sdk.set_tag("delayed_workflow_items", items)
         return
 
-    backend = buffer.get_backend()
+    client = DelayedWorkflowClient()
     for project_id, queue_items in items_by_project_id.items():
-        backend.push_to_hash_bulk(
-            model=Workflow,
-            filters={"project_id": project_id},
+        client.for_project(project_id).push_to_hash(
+            buffer_key=None,
             data={queue_item.buffer_key(): queue_item.buffer_value() for queue_item in queue_items},
         )
         items += len(queue_items)
@@ -138,8 +134,7 @@ def enqueue_workflows(
 
     sentry_sdk.set_tag("delayed_workflow_items", items)
 
-    sharded_key = random.choice(DelayedWorkflow.get_buffer_keys())
-    backend.push_to_sorted_set(key=sharded_key, value=list(items_by_project_id.keys()))
+    client.add_project_ids(list(items_by_project_id.keys()))
 
     logger.debug(
         "workflow_engine.workflows.enqueued",

--- a/src/sentry/workflow_engine/tasks/__init__.py
+++ b/src/sentry/workflow_engine/tasks/__init__.py
@@ -1,9 +1,8 @@
 __all__ = [
-    "DelayedWorkflow",
     "process_delayed_workflows",
     "process_workflow_activity",
     "process_workflows_event",
 ]
 
-from .delayed_workflows import DelayedWorkflow, process_delayed_workflows
+from .delayed_workflows import process_delayed_workflows
 from .workflows import process_workflow_activity, process_workflows_event

--- a/src/sentry/workflow_engine/tasks/delayed_workflows.py
+++ b/src/sentry/workflow_engine/tasks/delayed_workflows.py
@@ -302,19 +302,6 @@ def fetch_project(project_id: int) -> Project | None:
         return None
 
 
-def fetch_group_to_event_data(
-    project_id: int, model: type[models.Model], batch_key: str | None = None
-) -> dict[str, str]:
-    field: dict[str, models.Model | int | str] = {
-        "project_id": project_id,
-    }
-
-    if batch_key:
-        field["batch_key"] = batch_key
-
-    return buffer.get_backend().get_hash(model=model, field=field)
-
-
 def fetch_workflows_envs(
     workflow_ids: list[WorkflowId],
 ) -> Mapping[WorkflowId, int | None]:
@@ -963,10 +950,6 @@ class DelayedWorkflowClient:
             f"{cls.buffer_key}:{shard}" if shard > 0 else cls.buffer_key
             for shard in range(cls.buffer_shards)
         ]
-
-    @staticmethod
-    def buffer_backend() -> RedisHashSortedSetBuffer:
-        return buffer.get_backend()
 
     def for_project(self, project_id: int) -> ProjectDelayedWorkflowClient:
         return ProjectDelayedWorkflowClient(project_id, self._buffer)

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -6,7 +6,6 @@ from typing import Any
 from django.db import router, transaction
 from google.api_core.exceptions import RetryError
 
-from sentry import options
 from sentry.eventstream.base import GroupState
 from sentry.locks import locks
 from sentry.models.activity import Activity
@@ -169,6 +168,7 @@ def schedule_delayed_workflows(**kwargs: Any) -> None:
     Schedule delayed workflow buffers in a batch.
     """
     from sentry.workflow_engine.processors.schedule import process_buffered_workflows
+    from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflowClient
 
     lock_name = "schedule_delayed_workflows"
     lock = locks.get(f"workflow_engine:{lock_name}", duration=60, name=lock_name)
@@ -183,6 +183,6 @@ def schedule_delayed_workflows(**kwargs: Any) -> None:
                 )
                 return
             with quiet_redis_noise():
-                process_buffered_workflows()
+                process_buffered_workflows(DelayedWorkflowClient())
     except UnableToAcquireLock as error:
         logger.warning("schedule_delayed_workflows.fail", extra={"error": error})

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -183,13 +183,6 @@ def schedule_delayed_workflows(**kwargs: Any) -> None:
 
     try:
         with lock.acquire():
-            # Only process delayed_workflow type
-            use_new_scheduling = options.get("workflow_engine.use_new_scheduling_task")
-            if not use_new_scheduling:
-                logger.info(
-                    "Configured to use process_pending_batch for delayed_workflow; exiting."
-                )
-                return
             with quiet_redis_noise():
                 process_buffered_workflows(DelayedWorkflowClient())
     except UnableToAcquireLock as error:

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -55,7 +55,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
     The task will get the Activity from the database, create a WorkflowEventData object,
     and then process the data in `process_workflows`.
     """
-    from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflowClient
+    from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
 
     with transaction.atomic(router.db_for_write(Detector)):
         try:
@@ -119,7 +119,7 @@ def process_workflows_event(
     start_timestamp_seconds: float | None = None,
     **kwargs: dict[str, Any],
 ) -> None:
-    from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflowClient
+    from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
 
     recorder = scopedstats.Recorder()
     start_time = time.time()
@@ -175,8 +175,8 @@ def schedule_delayed_workflows(**kwargs: Any) -> None:
     """
     Schedule delayed workflow buffers in a batch.
     """
+    from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
     from sentry.workflow_engine.processors.schedule import process_buffered_workflows
-    from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflowClient
 
     lock_name = "schedule_delayed_workflows"
     lock = locks.get(f"workflow_engine:{lock_name}", duration=60, name=lock_name)

--- a/tests/sentry/workflow_engine/processors/test_schedule.py
+++ b/tests/sentry/workflow_engine/processors/test_schedule.py
@@ -6,21 +6,14 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
-from sentry.workflow_engine.buffer.redis_hash_sorted_set_buffer import RedisHashSortedSetBuffer
+from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
 from sentry.workflow_engine.processors.schedule import (
     bucket_num_groups,
     process_buffered_workflows,
     process_in_batches,
 )
-from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflowClient
 
 FROZEN_TIME = before_now(days=1).replace(hour=1, minute=30, second=0, microsecond=0)
-
-
-def mock_workflows_buffer():
-    return patch(
-        "sentry.workflow_engine.buffer.get_backend", new=lambda: RedisHashSortedSetBuffer()
-    )
 
 
 def test_bucket_num_groups() -> None:
@@ -33,16 +26,11 @@ def test_bucket_num_groups() -> None:
 class CreateEventTestCase(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.mock_redis_buffer = mock_workflows_buffer()
-        self.mock_redis_buffer.__enter__()
-
-    def tearDown(self) -> None:
-        self.mock_redis_buffer.__exit__(None, None, None)
+        self.batch_client = DelayedWorkflowClient()
 
     def push_to_hash(self, project_id, rule_id, group_id, event_id=None, occurrence_id=None):
         value = json.dumps({"event_id": event_id, "occurrence_id": occurrence_id})
-        client = DelayedWorkflowClient().for_project(project_id)
-        client.push_to_hash(
+        self.batch_client.for_project(project_id).push_to_hash(
             batch_key=None,
             data={f"{rule_id}:{group_id}": value},
         )
@@ -59,43 +47,41 @@ class ProcessBufferedWorkflowsTest(CreateEventTestCase):
         rule = self.create_alert_rule()
 
         # Push data to buffer (need actual workflow data, not just rule data)
-        client = DelayedWorkflowClient()
-        client.for_project(project.id).push_to_hash(
+        self.batch_client.for_project(project.id).push_to_hash(
             batch_key=None,
             data={f"{rule.id}:{group.id}": json.dumps({"event_id": "event-1"})},
         )
-        client.for_project(project_two.id).push_to_hash(
+        self.batch_client.for_project(project_two.id).push_to_hash(
             batch_key=None,
             data={f"{rule.id}:{group_two.id}": json.dumps({"event_id": "event-2"})},
         )
 
         # Add projects to sorted set
-        client.add_project_ids([project.id, project_two.id])
+        self.batch_client.add_project_ids([project.id, project_two.id])
 
-        process_buffered_workflows(client)
+        process_buffered_workflows(self.batch_client)
 
         # Should be called for each project
         assert mock_process_in_batches.call_count == 2
 
         # Verify that the buffer keys are cleaned up
         fetch_time = datetime.now().timestamp()
-        all_project_ids = client.get_project_ids(min=0, max=fetch_time)
+        all_project_ids = self.batch_client.get_project_ids(min=0, max=fetch_time)
         assert all_project_ids == {}
 
     @patch("sentry.workflow_engine.processors.schedule.process_in_batches")
     @override_options({"delayed_workflow.rollout": False})
     def test_skips_processing_with_option(self, mock_process_in_batches) -> None:
         project = self.create_project()
-        client = DelayedWorkflowClient()
-        client.add_project_ids([project.id])
+        self.batch_client.add_project_ids([project.id])
 
-        process_buffered_workflows(client)
+        process_buffered_workflows(self.batch_client)
 
         assert mock_process_in_batches.call_count == 0
 
         # Verify that the buffer keys are NOT cleaned up when disabled
         fetch_time = datetime.now().timestamp()
-        all_project_ids = client.get_project_ids(min=0, max=fetch_time)
+        all_project_ids = self.batch_client.get_project_ids(min=0, max=fetch_time)
         # Should still contain our project
         assert project.id in all_project_ids
 
@@ -112,8 +98,7 @@ class ProcessInBatchesTest(CreateEventTestCase):
 
     @patch("sentry.workflow_engine.tasks.delayed_workflows.process_delayed_workflows.apply_async")
     def test_no_redis_data(self, mock_apply_delayed: MagicMock) -> None:
-        client = DelayedWorkflowClient().for_project(self.project.id)
-        process_in_batches(client)
+        process_in_batches(self.batch_client.for_project(self.project.id))
         mock_apply_delayed.assert_called_once_with(
             kwargs={"project_id": self.project.id}, headers={"sentry-propagate-traces": False}
         )
@@ -124,7 +109,7 @@ class ProcessInBatchesTest(CreateEventTestCase):
         self.push_to_hash(self.project.id, self.rule.id, self.group_two.id)
         self.push_to_hash(self.project.id, self.rule.id, self.group_three.id)
 
-        client = DelayedWorkflowClient().for_project(self.project.id)
+        client = self.batch_client.for_project(self.project.id)
         process_in_batches(client)
         mock_apply_delayed.assert_called_once_with(
             kwargs={"project_id": self.project.id}, headers={"sentry-propagate-traces": False}
@@ -137,23 +122,22 @@ class ProcessInBatchesTest(CreateEventTestCase):
         self.push_to_hash(self.project.id, self.rule.id, self.group_two.id)
         self.push_to_hash(self.project.id, self.rule.id, self.group_three.id)
 
-        client = DelayedWorkflowClient().for_project(self.project.id)
+        client = self.batch_client.for_project(self.project.id)
         process_in_batches(client)
         assert mock_apply_delayed.call_count == 2
 
         # Validate the batches are created correctly
         batch_one_key = mock_apply_delayed.call_args_list[0][1]["kwargs"]["batch_key"]
-        client = DelayedWorkflowClient().for_project(self.project.id)
 
-        batch_one = client.fetch_group_to_event_data(batch_key=batch_one_key)
+        batch_one = client.get_hash_data(batch_key=batch_one_key)
         batch_two_key = mock_apply_delayed.call_args_list[1][1]["kwargs"]["batch_key"]
-        batch_two = client.fetch_group_to_event_data(batch_key=batch_two_key)
+        batch_two = client.get_hash_data(batch_key=batch_two_key)
 
         assert len(batch_one) == 2
         assert len(batch_two) == 1
 
         # Validate that we've cleared the original data to reduce storage usage
-        original_data = client.fetch_group_to_event_data(batch_key=None)
+        original_data = client.get_hash_data(batch_key=None)
         assert not original_data
 
 
@@ -163,26 +147,26 @@ class FetchGroupToEventDataTest(CreateEventTestCase):
         self.project = self.create_project()
         self.group = self.create_group(self.project)
         self.rule = self.create_alert_rule()
-        self.project_client = DelayedWorkflowClient().for_project(self.project.id)
+        self.project_client = self.batch_client.for_project(self.project.id)
 
-    def test_fetch_group_to_event_data_basic(self) -> None:
+    def test_get_hash_data_basic(self) -> None:
         self.push_to_hash(self.project.id, self.rule.id, self.group.id, "event-123")
 
-        result = self.project_client.fetch_group_to_event_data(batch_key=None)
+        result = self.project_client.get_hash_data(batch_key=None)
 
         assert f"{self.rule.id}:{self.group.id}" in result
         data = json.loads(result[f"{self.rule.id}:{self.group.id}"])
         assert data["event_id"] == "event-123"
 
-    def test_fetch_group_to_event_data_with_batch_key(self) -> None:
+    def test_get_hash_data_with_batch_key(self) -> None:
         batch_key = str(uuid4())
         self.push_to_hash(self.project.id, self.rule.id, self.group.id, "event-456")
 
         # Move data to batch
-        original_data = self.project_client.fetch_group_to_event_data(batch_key=None)
+        original_data = self.project_client.get_hash_data(batch_key=None)
         self.project_client.push_to_hash(batch_key=batch_key, data=original_data)
 
-        result = self.project_client.fetch_group_to_event_data(batch_key=batch_key)
+        result = self.project_client.get_hash_data(batch_key=batch_key)
 
         assert f"{self.rule.id}:{self.group.id}" in result
         data = json.loads(result[f"{self.rule.id}:{self.group.id}"])

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from django.utils import timezone
@@ -16,8 +16,6 @@ from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.types.activity import ActivityType
 from sentry.utils import json
 from sentry.utils.cache import cache
-from sentry.workflow_engine import buffer as workflow_buffer
-from sentry.workflow_engine.buffer.redis_hash_sorted_set_buffer import RedisHashSortedSetBuffer
 from sentry.workflow_engine.models import (
     Action,
     DataConditionGroup,
@@ -39,7 +37,7 @@ from sentry.workflow_engine.processors.workflow import (
     evaluate_workflows_action_filters,
     process_workflows,
 )
-from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflow
+from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflowClient
 from sentry.workflow_engine.tasks.workflows import process_workflows_event
 from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
@@ -72,6 +70,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
                 id=1, is_new=False, is_regression=True, is_new_group_environment=False
             ),
         )
+        self.batch_client = DelayedWorkflowClient()
 
     def test_skips_disabled_workflows(self) -> None:
         workflow_triggers = self.create_data_condition_group()
@@ -89,11 +88,11 @@ class TestProcessWorkflows(BaseWorkflowTest):
             workflow=workflow,
         )
 
-        triggered_workflows = process_workflows(self.event_data, FROZEN_TIME)
+        triggered_workflows = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert triggered_workflows == {self.error_workflow}
 
     def test_error_event(self) -> None:
-        triggered_workflows = process_workflows(self.event_data, FROZEN_TIME)
+        triggered_workflows = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert triggered_workflows == {self.error_workflow}
 
     @patch("sentry.workflow_engine.processors.action.fire_actions")
@@ -162,7 +161,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         assert self.event_data.group_state
         self.event_data.group_state["is_new"] = True
 
-        process_workflows(self.event_data, FROZEN_TIME)
+        process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
         mock_filter.assert_called_with({workflow_filters}, self.event_data)
 
@@ -209,14 +208,14 @@ class TestProcessWorkflows(BaseWorkflowTest):
             workflow=mismatched_env_workflow,
         )
 
-        triggered_workflows = process_workflows(self.event_data, FROZEN_TIME)
+        triggered_workflows = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert triggered_workflows == {self.error_workflow, matching_env_workflow}
 
     def test_issue_occurrence_event(self) -> None:
         issue_occurrence = self.build_occurrence(evidence_data={"detector_id": self.detector.id})
         self.group_event.occurrence = issue_occurrence
 
-        triggered_workflows = process_workflows(self.event_data, FROZEN_TIME)
+        triggered_workflows = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert triggered_workflows == {self.workflow}
 
     def test_regressed_event(self) -> None:
@@ -234,7 +233,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
             workflow=workflow,
         )
 
-        triggered_workflows = process_workflows(self.event_data, FROZEN_TIME)
+        triggered_workflows = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert triggered_workflows == {self.error_workflow, workflow}
 
     @patch("sentry.utils.metrics.incr")
@@ -242,7 +241,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
     def test_no_detector(self, mock_logger: MagicMock, mock_incr: MagicMock) -> None:
         self.group_event.occurrence = self.build_occurrence(evidence_data={})
 
-        triggered_workflows = process_workflows(self.event_data, FROZEN_TIME)
+        triggered_workflows = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
         assert not triggered_workflows
 
@@ -261,7 +260,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
     def test_no_environment(self, mock_logger: MagicMock, mock_incr: MagicMock) -> None:
         Environment.objects.all().delete()
         cache.clear()
-        triggered_workflows = process_workflows(self.event_data, FROZEN_TIME)
+        triggered_workflows = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
         assert not triggered_workflows
 
@@ -278,13 +277,13 @@ class TestProcessWorkflows(BaseWorkflowTest):
     def test_no_metrics_triggered(self, mock_logger: MagicMock, mock_incr: MagicMock) -> None:
         self.event_data.event.project_id = 0
 
-        process_workflows(self.event_data, FROZEN_TIME)
+        process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         mock_incr.assert_called_once_with("workflow_engine.detectors.error")
         mock_logger.exception.assert_called_once()
 
     @patch("sentry.utils.metrics.incr")
     def test_metrics_with_workflows(self, mock_incr: MagicMock) -> None:
-        process_workflows(self.event_data, FROZEN_TIME)
+        process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
         mock_incr.assert_any_call(
             "workflow_engine.process_workflows",
@@ -294,7 +293,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
     @patch("sentry.utils.metrics.incr")
     def test_metrics_triggered_workflows(self, mock_incr: MagicMock) -> None:
-        process_workflows(self.event_data, FROZEN_TIME)
+        process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
         mock_incr.assert_any_call(
             "workflow_engine.process_workflows.triggered_workflows",
@@ -329,7 +328,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
         self.action_group_3, self.action_3 = self.create_workflow_action(workflow=error_workflow_3)
 
-        process_workflows(self.event_data, FROZEN_TIME)
+        process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
         assert WorkflowFireHistory.objects.count() == 3
         assert mock_trigger_action.call_count == 3
@@ -339,17 +338,10 @@ class TestProcessWorkflows(BaseWorkflowTest):
         self.group_event.occurrence = issue_occurrence
         self.group.update(type=issue_occurrence.type.type_id)
 
-        triggered_workflows = process_workflows(self.event_data, FROZEN_TIME)
+        triggered_workflows = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert triggered_workflows == {self.error_workflow}
 
 
-def mock_workflows_buffer():
-    return patch(
-        "sentry.workflow_engine.buffer.get_backend", new=lambda: RedisHashSortedSetBuffer()
-    )
-
-
-@mock_workflows_buffer()
 class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
     def setUp(self) -> None:
         (
@@ -552,12 +544,7 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
         self.event_data = WorkflowEventData(event=self.group_event, group=self.group)
         self.action_group, _ = self.create_workflow_action(self.workflow)
 
-        self.buffer_keys = DelayedWorkflow.get_buffer_keys()
-        self.mock_redis_buffer = mock_workflows_buffer()
-        self.mock_redis_buffer.__enter__()
-
-    def tearDown(self) -> None:
-        self.mock_redis_buffer.__exit__(None, None, None)
+        self.batch_client = DelayedWorkflowClient()
 
     def test_enqueues_workflow_all_logic_type(self) -> None:
         assert self.workflow.when_condition_group
@@ -577,10 +564,9 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
         )
         assert not triggered_workflows
 
-        process_workflows(self.event_data, FROZEN_TIME)
+        process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        project_ids = workflow_buffer.get_backend().bulk_get_sorted_set(
-            self.buffer_keys,
+        project_ids = self.batch_client.get_project_ids(
             min=0,
             max=self.buffer_timestamp,
         )
@@ -611,10 +597,9 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
         )
         assert not triggered_workflows
 
-        process_workflows(self.event_data, FROZEN_TIME)
+        process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        project_ids = workflow_buffer.get_backend().bulk_get_sorted_set(
-            self.buffer_keys,
+        project_ids = self.batch_client.get_project_ids(
             min=0,
             max=self.buffer_timestamp,
         )
@@ -693,10 +678,9 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
             condition_result=True,
         )
 
-        process_workflows(self.event_data, FROZEN_TIME)
+        process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        project_ids = workflow_buffer.get_backend().bulk_get_sorted_set(
-            self.buffer_keys,
+        project_ids = self.batch_client.get_project_ids(
             min=0,
             max=self.buffer_timestamp,
         )
@@ -722,10 +706,9 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
             condition_result=True,
         )
 
-        process_workflows(self.event_data, FROZEN_TIME)
+        process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        project_ids = workflow_buffer.get_backend().bulk_get_sorted_set(
-            self.buffer_keys,
+        project_ids = self.batch_client.get_project_ids(
             min=0,
             max=self.buffer_timestamp,
         )
@@ -734,10 +717,9 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
         # enqueue if the tag condition is met
         tag_condition.update(comparison={"key": "level", "value": "error", "match": "eq"})
 
-        process_workflows(self.event_data, FROZEN_TIME)
+        process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        project_ids = workflow_buffer.get_backend().bulk_get_sorted_set(
-            self.buffer_keys,
+        project_ids = self.batch_client.get_project_ids(
             min=0,
             max=self.buffer_timestamp,
         )
@@ -745,7 +727,6 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
 
 
 @freeze_time(FROZEN_TIME)
-@mock_workflows_buffer()
 class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
     def setUp(self) -> None:
         (
@@ -761,12 +742,12 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
             occurrence=self.build_occurrence(evidence_data={"detector_id": self.detector.id})
         )
         self.event_data = WorkflowEventData(event=self.group_event, group=self.group)
-        self.buffer_keys = DelayedWorkflow.get_buffer_keys()
+        self.batch_client = DelayedWorkflowClient()
 
     @patch("sentry.utils.metrics.incr")
     def test_metrics_issue_dual_processing_metrics(self, mock_incr: MagicMock) -> None:
         with self.tasks():
-            process_workflows(self.event_data, FROZEN_TIME)
+            process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         mock_incr.assert_any_call(
             "workflow_engine.tasks.trigger_action_task_started",
             tags={
@@ -915,10 +896,9 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         )
         assert not triggered_action_filters
 
-        enqueue_workflows(queue_items)
+        enqueue_workflows(self.batch_client, queue_items)
 
-        project_ids = workflow_buffer.get_backend().bulk_get_sorted_set(
-            self.buffer_keys,
+        project_ids = self.batch_client.get_project_ids(
             min=0,
             max=timezone.now().timestamp(),
         )
@@ -954,15 +934,10 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
             group=self.group_event.group,
         )
 
-    @patch("sentry.workflow_engine.buffer.get_backend")
-    @patch("random.choice")
-    def test_enqueue_workflows__adds_to_workflow_engine_buffer(
-        self, mock_randchoice, mock_get_backend
-    ) -> None:
-        mock_buffer = MagicMock(spec=RedisHashSortedSetBuffer)
-        mock_get_backend.return_value = mock_buffer
-        mock_randchoice.return_value = f"{DelayedWorkflow.buffer_key}:{5}"
+    def test_enqueue_workflows__adds_to_workflow_engine_buffer(self) -> None:
+        batch_client = Mock(spec=DelayedWorkflowClient)
         enqueue_workflows(
+            batch_client,
             {
                 self.workflow: DelayedWorkflowItem(
                     self.workflow,
@@ -972,20 +947,14 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
                     [self.workflow_filter_group.id],
                     timestamp=timezone.now(),
                 )
-            }
+            },
         )
 
-        mock_buffer.push_to_sorted_set.assert_called_once_with(
-            key=f"{DelayedWorkflow.buffer_key}:{5}",
-            value=[self.group_event.project_id],
+        batch_client.add_project_ids.assert_called_once_with(
+            [self.group_event.project_id],
         )
 
-    @patch("sentry.workflow_engine.buffer.get_backend")
-    def test_enqueue_workflow__adds_to_workflow_engine_set(
-        self, mock_get_backend: MagicMock
-    ) -> None:
-        mock_buffer = MagicMock(spec=RedisHashSortedSetBuffer)
-        mock_get_backend.return_value = mock_buffer
+    def test_enqueue_workflow__adds_to_workflow_engine_set(self) -> None:
         current_time = timezone.now()
         workflow_filter_group_2 = self.create_data_condition_group()
         self.create_workflow_data_condition_group(
@@ -1003,7 +972,9 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
             type=Condition.EVENT_FREQUENCY_COUNT,
             comparison={"interval": "1d", "value": 7},
         )
+        batch_client = Mock(spec=DelayedWorkflowClient)
         enqueue_workflows(
+            batch_client,
             {
                 self.workflow: DelayedWorkflowItem(
                     self.workflow,
@@ -1013,7 +984,7 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
                     [self.workflow_filter_group.id, workflow_filter_group_2.id],
                     timestamp=current_time,
                 )
-            }
+            },
         )
 
         slow_condition_group_ids = ",".join(
@@ -1022,9 +993,9 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
         passing_condition_group_ids = ",".join(
             str(id) for id in [self.workflow_filter_group.id, workflow_filter_group_2.id]
         )
-        mock_buffer.push_to_hash_bulk.assert_called_once_with(
-            model=Workflow,
-            filters={"project_id": self.group_event.project_id},
+        batch_client.for_project.assert_called_once_with(self.group_event.project_id)
+        batch_client.for_project.return_value.push_to_hash.assert_called_once_with(
+            batch_key=None,
             data={
                 f"{self.workflow.id}:{self.group_event.group_id}:{self.workflow.when_condition_group_id}:{slow_condition_group_ids}:{passing_condition_group_ids}": json.dumps(
                     {

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -16,6 +16,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.types.activity import ActivityType
 from sentry.utils import json
 from sentry.utils.cache import cache
+from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
 from sentry.workflow_engine.models import (
     Action,
     DataConditionGroup,
@@ -37,7 +38,6 @@ from sentry.workflow_engine.processors.workflow import (
     evaluate_workflows_action_filters,
     process_workflows,
 )
-from sentry.workflow_engine.tasks.delayed_workflows import DelayedWorkflowClient
 from sentry.workflow_engine.tasks.workflows import process_workflows_event
 from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest

--- a/tests/sentry/workflow_engine/tasks/test_delayed_workflows.py
+++ b/tests/sentry/workflow_engine/tasks/test_delayed_workflows.py
@@ -20,7 +20,6 @@ from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.utils import json
 from sentry.utils.snuba import RateLimitExceeded
 from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
-from sentry.workflow_engine.buffer.redis_hash_sorted_set_buffer import RedisHashSortedSetBuffer
 from sentry.workflow_engine.handlers.condition.event_frequency_query_handlers import (
     BaseEventFrequencyQueryHandler,
     EventFrequencyQueryHandler,
@@ -65,12 +64,6 @@ from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
 
 FROZEN_TIME = before_now(days=1).replace(hour=1, minute=30, second=0, microsecond=0)
-
-
-def mock_workflows_buffer():
-    return patch(
-        "sentry.workflow_engine.buffer.get_backend", new=lambda: RedisHashSortedSetBuffer()
-    )
 
 
 class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):

--- a/tests/sentry/workflow_engine/tasks/test_workflows.py
+++ b/tests/sentry/workflow_engine/tasks/test_workflows.py
@@ -11,45 +11,40 @@ class ScheduleDelayedWorkflowsTest(TestCase):
         self,
         mock_process_buffered_workflows: mock.MagicMock,
     ) -> None:
-        with self.options({"workflow_engine.use_new_scheduling_task": True}):
-            with self.assertLogs(
-                "sentry.workflow_engine.tasks.workflows", level="WARNING"
-            ) as logger:
-                lock = locks.get(
-                    "workflow_engine:schedule_delayed_workflows",
-                    duration=60,
-                    name="schedule_delayed_workflows",
-                )
-                with lock.acquire():
-                    schedule_delayed_workflows()
-                    self.assertEqual(len(logger.output), 1)
-                    assert len(mock_process_buffered_workflows.mock_calls) == 0
-
-            with self.assertNoLogs("sentry.workflow_engine.tasks.workflows", level="WARNING"):
+        with self.assertLogs("sentry.workflow_engine.tasks.workflows", level="WARNING") as logger:
+            lock = locks.get(
+                "workflow_engine:schedule_delayed_workflows",
+                duration=60,
+                name="schedule_delayed_workflows",
+            )
+            with lock.acquire():
                 schedule_delayed_workflows()
-                assert len(mock_process_buffered_workflows.mock_calls) == 1
-                mock_process_buffered_workflows.assert_called_with()
+                self.assertEqual(len(logger.output), 1)
+                assert len(mock_process_buffered_workflows.mock_calls) == 0
+
+        with self.assertNoLogs("sentry.workflow_engine.tasks.workflows", level="WARNING"):
+            schedule_delayed_workflows()
+            assert len(mock_process_buffered_workflows.mock_calls) == 1
+            mock_process_buffered_workflows.assert_called_with()
 
     @mock.patch("sentry.workflow_engine.processors.schedule.process_buffered_workflows")
     def test_schedule_delayed_workflows_config_option_false(
         self,
         mock_process_buffered_workflows: mock.MagicMock,
     ) -> None:
-        with self.options({"workflow_engine.use_new_scheduling_task": False}):
-            with self.assertLogs("sentry.workflow_engine.tasks.workflows", level="INFO") as logger:
-                schedule_delayed_workflows()
-                assert len(mock_process_buffered_workflows.mock_calls) == 0
-                assert any(
-                    "Configured to use process_pending_batch" in output for output in logger.output
-                )
+        with self.assertLogs("sentry.workflow_engine.tasks.workflows", level="INFO") as logger:
+            schedule_delayed_workflows()
+            assert len(mock_process_buffered_workflows.mock_calls) == 0
+            assert any(
+                "Configured to use process_pending_batch" in output for output in logger.output
+            )
 
     @mock.patch("sentry.workflow_engine.processors.schedule.process_buffered_workflows")
     def test_schedule_delayed_workflows_normal_operation(
         self,
         mock_process_buffered_workflows: mock.MagicMock,
     ) -> None:
-        with self.options({"workflow_engine.use_new_scheduling_task": True}):
-            schedule_delayed_workflows()
+        schedule_delayed_workflows()
 
         assert len(mock_process_buffered_workflows.mock_calls) == 1
         mock_process_buffered_workflows.assert_called_once_with()

--- a/tests/sentry/workflow_engine/tasks/test_workflows.py
+++ b/tests/sentry/workflow_engine/tasks/test_workflows.py
@@ -25,19 +25,7 @@ class ScheduleDelayedWorkflowsTest(TestCase):
         with self.assertNoLogs("sentry.workflow_engine.tasks.workflows", level="WARNING"):
             schedule_delayed_workflows()
             assert len(mock_process_buffered_workflows.mock_calls) == 1
-            mock_process_buffered_workflows.assert_called_with()
-
-    @mock.patch("sentry.workflow_engine.processors.schedule.process_buffered_workflows")
-    def test_schedule_delayed_workflows_config_option_false(
-        self,
-        mock_process_buffered_workflows: mock.MagicMock,
-    ) -> None:
-        with self.assertLogs("sentry.workflow_engine.tasks.workflows", level="INFO") as logger:
-            schedule_delayed_workflows()
-            assert len(mock_process_buffered_workflows.mock_calls) == 0
-            assert any(
-                "Configured to use process_pending_batch" in output for output in logger.output
-            )
+            mock_process_buffered_workflows.assert_called_with(mock.ANY)
 
     @mock.patch("sentry.workflow_engine.processors.schedule.process_buffered_workflows")
     def test_schedule_delayed_workflows_normal_operation(
@@ -47,4 +35,4 @@ class ScheduleDelayedWorkflowsTest(TestCase):
         schedule_delayed_workflows()
 
         assert len(mock_process_buffered_workflows.mock_calls) == 1
-        mock_process_buffered_workflows.assert_called_once_with()
+        mock_process_buffered_workflows.assert_called_once_with(mock.ANY)

--- a/tests/sentry/workflow_engine/tasks/test_workflows.py
+++ b/tests/sentry/workflow_engine/tasks/test_workflows.py
@@ -1,36 +1,35 @@
-from unittest import mock
+from unittest import TestCase, mock
+from unittest.mock import MagicMock, patch
 
 from sentry.locks import locks
-from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.tasks.workflows import schedule_delayed_workflows
 
 
 class ScheduleDelayedWorkflowsTest(TestCase):
-    @mock.patch("sentry.workflow_engine.processors.schedule.process_buffered_workflows")
+    @patch("sentry.workflow_engine.processors.schedule.process_buffered_workflows")
     def test_schedule_delayed_workflows_locked_out(
         self,
-        mock_process_buffered_workflows: mock.MagicMock,
+        mock_process_buffered_workflows: MagicMock,
     ) -> None:
-        with self.assertLogs("sentry.workflow_engine.tasks.workflows", level="WARNING") as logger:
-            lock = locks.get(
-                "workflow_engine:schedule_delayed_workflows",
-                duration=60,
-                name="schedule_delayed_workflows",
-            )
-            with lock.acquire():
-                schedule_delayed_workflows()
-                self.assertEqual(len(logger.output), 1)
-                assert len(mock_process_buffered_workflows.mock_calls) == 0
-
-        with self.assertNoLogs("sentry.workflow_engine.tasks.workflows", level="WARNING"):
+        lock = locks.get(
+            "workflow_engine:schedule_delayed_workflows",
+            duration=60,
+            name="schedule_delayed_workflows",
+        )
+        with lock.acquire():
+            # Lock already held; no call.
             schedule_delayed_workflows()
-            assert len(mock_process_buffered_workflows.mock_calls) == 1
-            mock_process_buffered_workflows.assert_called_with(mock.ANY)
+            assert len(mock_process_buffered_workflows.mock_calls) == 0
 
-    @mock.patch("sentry.workflow_engine.processors.schedule.process_buffered_workflows")
+        # Lock not held; call.
+        schedule_delayed_workflows()
+        assert len(mock_process_buffered_workflows.mock_calls) == 1
+        mock_process_buffered_workflows.assert_called_with(mock.ANY)
+
+    @patch("sentry.workflow_engine.processors.schedule.process_buffered_workflows")
     def test_schedule_delayed_workflows_normal_operation(
         self,
-        mock_process_buffered_workflows: mock.MagicMock,
+        mock_process_buffered_workflows: MagicMock,
     ) -> None:
         schedule_delayed_workflows()
 

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -528,12 +528,7 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         with patch(
             "sentry.workflow_engine.tasks.delayed_workflows.process_delayed_workflows.apply_async"
         ) as mock_apply_async:
-            with self.options(
-                {
-                    "workflow_engine.use_new_scheduling_task": True,
-                    "delayed_workflow.rollout": True,
-                }
-            ):
+            with self.options({"delayed_workflow.rollout": True}):
                 # Call schedule_delayed_workflows - this runs the real buffer processing
                 schedule_delayed_workflows()
 

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -18,13 +18,12 @@ from sentry.tasks.post_process import post_process_group
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import Feature, with_feature
 from sentry.utils.cache import cache_key_for_event
-from sentry.workflow_engine import buffer
 from sentry.workflow_engine.models import Detector, DetectorWorkflow
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.processors.data_source import process_data_source
 from sentry.workflow_engine.processors.detector import process_detectors
 from sentry.workflow_engine.tasks.delayed_workflows import (
-    DelayedWorkflow,
+    DelayedWorkflowClient,
     process_delayed_workflows,
 )
 from sentry.workflow_engine.tasks.workflows import schedule_delayed_workflows
@@ -211,7 +210,6 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         )
         self.workflow_triggers.conditions.all().delete()
         self.action_group, self.action = self.create_workflow_action(workflow=self.workflow)
-        self.buffer_keys = DelayedWorkflow.get_buffer_keys()
 
     @pytest.fixture(autouse=True)
     def with_feature_flags(self):
@@ -403,9 +401,8 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         self.post_process_error(event_1, is_new=True)
         assert not mock_trigger.called
 
-        project_ids = buffer.get_backend().bulk_get_sorted_set(
-            self.buffer_keys, 0, timezone.now().timestamp()
-        )
+        batch_client = DelayedWorkflowClient()
+        project_ids = batch_client.get_project_ids(0, timezone.now().timestamp())
         assert not project_ids
 
         # event that does not have the tags = no enqueue
@@ -413,9 +410,7 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         self.post_process_error(event_2, is_new=True)
         assert not mock_trigger.called
 
-        project_ids = buffer.get_backend().bulk_get_sorted_set(
-            self.buffer_keys, 0, timezone.now().timestamp()
-        )
+        project_ids = batch_client.get_project_ids(0, timezone.now().timestamp())
         assert not project_ids
 
         # event that fires
@@ -427,8 +422,7 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         self.post_process_error(event_5)
         assert not mock_trigger.called
 
-        project_ids = buffer.get_backend().bulk_get_sorted_set(
-            self.buffer_keys,
+        project_ids = batch_client.get_project_ids(
             min=0,
             max=timezone.now().timestamp(),
         )
@@ -457,6 +451,7 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         )
         now = timezone.now()
 
+        batch_client = DelayedWorkflowClient()
         with freeze_time(now):
             event_1 = self.create_error_event(environment="production", tags=[["hello", "world"]])
             self.post_process_error(event_1)
@@ -470,8 +465,7 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
             self.post_process_error(event_3)
             assert not mock_trigger.called
 
-            project_ids = buffer.get_backend().bulk_get_sorted_set(
-                self.buffer_keys,
+            project_ids = batch_client.get_project_ids(
                 min=0,
                 max=timezone.now().timestamp(),
             )
@@ -485,8 +479,7 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
             self.post_process_error(event_4)
             assert not mock_trigger.called
 
-            project_ids = buffer.get_backend().bulk_get_sorted_set(
-                self.buffer_keys,
+            project_ids = batch_client.get_project_ids(
                 min=0,
                 max=timezone.now().timestamp(),
             )
@@ -504,10 +497,10 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
                 "value": 2,
             },
         )
+        batch_client = DelayedWorkflowClient()
 
         assert (
-            buffer.get_backend().bulk_get_sorted_set(
-                self.buffer_keys,
+            batch_client.get_project_ids(
                 min=0,
                 max=timezone.now().timestamp(),
             )
@@ -518,8 +511,7 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         event = self.create_error_event()
         self.post_process_error(event)
 
-        project_ids = buffer.get_backend().bulk_get_sorted_set(
-            self.buffer_keys,
+        project_ids = batch_client.get_project_ids(
             min=0,
             max=timezone.now().timestamp(),
         )
@@ -539,8 +531,7 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
             assert call_kwargs["project_id"] == self.project.id
 
         assert (
-            buffer.get_backend().bulk_get_sorted_set(
-                self.buffer_keys,
+            batch_client.get_project_ids(
                 min=0,
                 max=timezone.now().timestamp(),
             )

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -18,14 +18,12 @@ from sentry.tasks.post_process import post_process_group
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import Feature, with_feature
 from sentry.utils.cache import cache_key_for_event
+from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
 from sentry.workflow_engine.models import Detector, DetectorWorkflow
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.processors.data_source import process_data_source
 from sentry.workflow_engine.processors.detector import process_detectors
-from sentry.workflow_engine.tasks.delayed_workflows import (
-    DelayedWorkflowClient,
-    process_delayed_workflows,
-)
+from sentry.workflow_engine.tasks.delayed_workflows import process_delayed_workflows
 from sentry.workflow_engine.tasks.workflows import schedule_delayed_workflows
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest


### PR DESCRIPTION
Rather than methods to manage redis interactions being called on a client class held in a global,
this moves to using a pair of helper client classes that are largely pass in.

This simplifies many of the methods and allows them to be more product-focused, offers better encapsulation and ability to mock, and removes the need to patch globals to test effectively.

There are further simplifications and clarifications to be done here, but this is already quite large, so I tried to find a good stopping point.

Note that to adopt this new structure, we moved away from the DelayedProcessingBase registry approach, and in doing so lost the ability to fall back to that, so this change also removes the use of the config option for using the old task and changes the default value to True.
