### PR TITLE
feat(checkout v3): Add billing info step

### DIFF
--- a/static/gsApp/components/billingDetailsForm.tsx
+++ b/static/gsApp/components/billingDetailsForm.tsx
@@ -33,6 +33,10 @@ type Props = {
   onSubmitSuccess: (data: Record<PropertyKey, unknown>) => void;
   organization: Organization;
   /**
+   * Extra button to render in the form footer.
+   */
+  extraButton?: React.ReactNode;
+  /**
    * Additional form field props for custom components.
    */
   fieldProps?: FieldGroupProps;
@@ -126,6 +130,7 @@ function BillingDetailsForm({
   isDetailed = true,
   wrapper = DefaultWrapper,
   fieldProps,
+  extraButton,
 }: Props) {
   const transformData = (data: Record<string, any>) => {
     // Clear tax number if not applicable to country code.
@@ -240,6 +245,7 @@ function BillingDetailsForm({
       onSubmitError={onSubmitError}
       initialData={transformedInitialData}
       footerStyle={footerStyle}
+      extraButton={extraButton}
     >
       <FieldWrapper>
         <Flex direction="column" gap="xl">

--- a/static/gsApp/components/billingDetailsForm.tsx
+++ b/static/gsApp/components/billingDetailsForm.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {AddressElement} from '@stripe/react-stripe-js';
 
 import {Flex} from 'sentry/components/core/layout';
-import {Heading, Text} from 'sentry/components/core/text';
+import {Text} from 'sentry/components/core/text';
 import type {FieldGroupProps} from 'sentry/components/forms/fieldGroup/types';
 import TextField from 'sentry/components/forms/fields/textField';
 import Form from 'sentry/components/forms/form';
@@ -229,86 +229,81 @@ function BillingDetailsForm({
   };
 
   return (
-    <Flex direction="column" gap="lg">
-      <Heading as="h2" size="md">
-        {t('Invoice Details')}
-      </Heading>
-      <Form
-        apiMethod="PUT"
-        model={form}
-        requireChanges={requireChanges}
-        apiEndpoint={`/customers/${organization.slug}/billing-details/`}
-        submitLabel={submitLabel}
-        onPreSubmit={onPreSubmit}
-        onSubmitSuccess={onSubmitSuccess}
-        onSubmitError={onSubmitError}
-        initialData={transformedInitialData}
-        footerStyle={footerStyle}
-      >
-        <FieldWrapper>
-          <Flex direction="column" gap="xl">
-            {isDetailed && (
-              <CustomBillingDetailsFormField
-                inputName="billingEmail"
-                label={t('Billing email')}
-                help={t(
-                  'If provided, all billing-related notifications will be sent to this address'
-                )}
-                placeholder={t('name@example.com (optional)')}
-                value={form.getValue('billingEmail') ?? ''}
-                fieldProps={fieldProps}
-              />
-            )}
-            <StripeWrapper>
-              <AddressElement
-                options={{
-                  mode: 'billing',
-                  autocomplete: GOOGLE_MAPS_API_KEY
-                    ? {
-                        mode: 'google_maps_api',
-                        apiKey: GOOGLE_MAPS_API_KEY,
-                      }
-                    : {
-                        mode: 'automatic', // if our key isn't available, see if we can use Stripe's
-                      },
-                  allowedCountries: COUNTRY_CODE_CHOICES.filter(([code]) =>
-                    defined(code)
-                  ).map(([code]) => code as string),
-                  fields: {phone: 'never'}, // don't show phone number field
-                  defaultValues: {
-                    name: initialData?.companyName,
-                    address: {
-                      line1: initialData?.addressLine1,
-                      line2: initialData?.addressLine2,
-                      city: initialData?.city,
-                      state: initialData?.region,
-                      postal_code: initialData?.postalCode,
-                      country: initialData?.countryCode ?? 'US',
+    <Form
+      apiMethod="PUT"
+      model={form}
+      requireChanges={requireChanges}
+      apiEndpoint={`/customers/${organization.slug}/billing-details/`}
+      submitLabel={submitLabel}
+      onPreSubmit={onPreSubmit}
+      onSubmitSuccess={onSubmitSuccess}
+      onSubmitError={onSubmitError}
+      initialData={transformedInitialData}
+      footerStyle={footerStyle}
+    >
+      <FieldWrapper>
+        <Flex direction="column" gap="xl">
+          {isDetailed && (
+            <CustomBillingDetailsFormField
+              inputName="billingEmail"
+              label={t('Billing email')}
+              help={t(
+                'If provided, all billing-related notifications will be sent to this address'
+              )}
+              placeholder={t('name@example.com (optional)')}
+              value={form.getValue('billingEmail') ?? ''}
+              fieldProps={fieldProps}
+            />
+          )}
+          <StripeWrapper>
+            <AddressElement
+              options={{
+                mode: 'billing',
+                autocomplete: GOOGLE_MAPS_API_KEY
+                  ? {
+                      mode: 'google_maps_api',
+                      apiKey: GOOGLE_MAPS_API_KEY,
+                    }
+                  : {
+                      mode: 'automatic', // if our key isn't available, see if we can use Stripe's
                     },
+                allowedCountries: COUNTRY_CODE_CHOICES.filter(([code]) =>
+                  defined(code)
+                ).map(([code]) => code as string),
+                fields: {phone: 'never'}, // don't show phone number field
+                defaultValues: {
+                  name: initialData?.companyName,
+                  address: {
+                    line1: initialData?.addressLine1,
+                    line2: initialData?.addressLine2,
+                    city: initialData?.city,
+                    state: initialData?.region,
+                    postal_code: initialData?.postalCode,
+                    country: initialData?.countryCode ?? 'US',
                   },
-                  display: {name: 'organization'},
-                }}
-                onChange={handleStripeFormChange}
-              />
-            </StripeWrapper>
-            {!!(state.showTaxNumber && taxFieldInfo) && (
-              // TODO: use Stripe's TaxIdElement when it's generally available
-              <CustomBillingDetailsFormField
-                inputName="taxNumber"
-                label={taxFieldInfo.label}
-                help={tct(
-                  "Your company's [taxNumberName] will appear on all receipts. You may be subject to taxes depending on country specific tax policies.",
-                  {taxNumberName: <strong>{taxFieldInfo.taxNumberName}</strong>}
-                )}
-                value={form.getValue('taxNumber') ?? ''}
-                placeholder={taxFieldInfo.placeholder}
-                fieldProps={fieldProps}
-              />
-            )}
-          </Flex>
-        </FieldWrapper>
-      </Form>
-    </Flex>
+                },
+                display: {name: 'organization'},
+              }}
+              onChange={handleStripeFormChange}
+            />
+          </StripeWrapper>
+          {!!(state.showTaxNumber && taxFieldInfo) && (
+            // TODO: use Stripe's TaxIdElement when it's generally available
+            <CustomBillingDetailsFormField
+              inputName="taxNumber"
+              label={taxFieldInfo.label}
+              help={tct(
+                "Your company's [taxNumberName] will appear on all receipts. You may be subject to taxes depending on country specific tax policies.",
+                {taxNumberName: <strong>{taxFieldInfo.taxNumberName}</strong>}
+              )}
+              value={form.getValue('taxNumber') ?? ''}
+              placeholder={taxFieldInfo.placeholder}
+              fieldProps={fieldProps}
+            />
+          )}
+        </Flex>
+      </FieldWrapper>
+    </Form>
   );
 }
 

--- a/static/gsApp/components/creditCardEditModal.tsx
+++ b/static/gsApp/components/creditCardEditModal.tsx
@@ -7,11 +7,8 @@ import type {Organization} from 'sentry/types/organization';
 import {decodeScalar} from 'sentry/utils/queryString';
 
 import CreditCardSetup from 'getsentry/components/creditCardSetup';
-import StripeCreditCardSetup from 'getsentry/components/stripeCreditCardSetup';
 import type {Subscription} from 'getsentry/types';
 import {FTCConsentLocation} from 'getsentry/types';
-import {hasStripeComponentsFeature} from 'getsentry/utils/billing';
-import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 
 type Props = ModalRenderProps & {
   onSuccess: (data: Subscription) => void;
@@ -30,50 +27,24 @@ function CreditCardEditModal({
   subscription,
 }: Props) {
   const referrer = decodeScalar(location?.query?.referrer);
-  const budgetModeText = subscription.planDetails.budgetTerm;
-  const shouldUseStripe = hasStripeComponentsFeature(organization);
-
-  const commonProps = {
-    organization,
-    location: FTCConsentLocation.BILLING_DETAILS,
-    referrer,
-    budgetModeText,
-    buttonText: t('Save Changes'),
-  };
+  const budgetTerm = subscription.planDetails.budgetTerm;
 
   return (
     <Fragment>
       <Header>{t('Update Credit Card')}</Header>
       <Body>
-        {shouldUseStripe ? (
-          <StripeCreditCardSetup
-            onCancel={closeModal}
-            onSuccessWithSubscription={onSuccess}
-            onSuccess={() => {
-              closeModal();
-              trackGetsentryAnalytics('billing_details.updated_cc', {
-                organization,
-                referrer: decodeScalar(referrer),
-                isStripeComponent: true,
-              });
-            }}
-            {...commonProps}
-          />
-        ) : (
-          <CreditCardSetup
-            isModal
-            onCancel={closeModal}
-            onSuccess={data => {
-              onSuccess(data);
-              closeModal();
-              trackGetsentryAnalytics('billing_details.updated_cc', {
-                organization,
-                referrer: decodeScalar(referrer),
-              });
-            }}
-            {...commonProps}
-          />
-        )}
+        <CreditCardSetup
+          isModal
+          onCancel={closeModal}
+          onSuccessWithSubscription={onSuccess}
+          onSuccess={closeModal}
+          analyticsEvent="billing_details.updated_cc"
+          organization={organization}
+          location={FTCConsentLocation.BILLING_DETAILS}
+          referrer={referrer}
+          budgetTerm={budgetTerm}
+          buttonText={t('Save Changes')}
+        />
       </Body>
     </Fragment>
   );

--- a/static/gsApp/components/creditCardForm.tsx
+++ b/static/gsApp/components/creditCardForm.tsx
@@ -14,6 +14,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {NODE_ENV} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
 
 import StripeWrapper from 'getsentry/components/stripeWrapper';
 import {FTCConsentLocation} from 'getsentry/types';
@@ -41,13 +42,13 @@ export type SubmitData = {
 
 type Props = {
   /**
+   * budget term to use for fine print.
+   */
+  budgetTerm: string;
+  /**
    * Handle the card form submission.
    */
   onSubmit: (data: SubmitData) => void;
-  /**
-   * budget mode text for fine print, if any.
-   */
-  budgetModeText?: string;
   /**
    * Text for the submit button.
    */
@@ -111,7 +112,7 @@ function CreditCardFormInner({
   footerClassName = 'form-actions',
   referrer,
   location,
-  budgetModeText,
+  budgetTerm,
 }: Props) {
   const theme = useTheme();
   const [busy, setBusy] = useState(false);
@@ -232,14 +233,13 @@ function CreditCardFormInner({
               stripe: <ExternalLink href="https://stripe.com/" />,
             })}
           </small>
-          {/* location is 0 on the checkout page which is why this isn't location && */}
-          {location !== null && location !== undefined && (
+          {defined(location) && (
             <FinePrint>
               {tct(
-                'By clicking [buttonText], you authorize Sentry to automatically charge you recurring subscription fees and applicable [budgetModeText] fees. Recurring charges occur at the start of your selected billing cycle for subscription fees and monthly for [budgetModeText] fees. You may cancel your subscription at any time [here:here].',
+                'By clicking [buttonText], you authorize Sentry to automatically charge you recurring subscription fees and applicable [budgetTerm] fees. Recurring charges occur at the start of your selected billing cycle for subscription fees and monthly for [budgetTerm] fees. You may cancel your subscription at any time [here:here].',
                 {
                   buttonText: <b>{buttonText}</b>,
-                  budgetModeText,
+                  budgetTerm,
                   here: (
                     <ExternalLink href="https://sentry.io/settings/billing/cancel/" />
                   ),

--- a/static/gsApp/components/creditCardSetup.tsx
+++ b/static/gsApp/components/creditCardSetup.tsx
@@ -1,161 +1,86 @@
-import {useCallback, useEffect, useState} from 'react';
-import * as Sentry from '@sentry/react';
-import {type SetupIntentResult} from '@stripe/stripe-js';
-
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
-import useApi from 'sentry/utils/useApi';
+import {decodeScalar} from 'sentry/utils/queryString';
 
-import type {SubmitData} from 'getsentry/components/creditCardForm';
-import CreditCardForm from 'getsentry/components/creditCardForm';
-import type {
-  FTCConsentLocation,
-  PaymentSetupCreateResponse,
-  Subscription,
-} from 'getsentry/types';
+import LegacyCreditCardSetup from 'getsentry/components/legacyCreditCardSetup';
+import StripeCreditCardSetup from 'getsentry/components/stripeCreditCardSetup';
+import type {FTCConsentLocation, Subscription} from 'getsentry/types';
+import {hasStripeComponentsFeature} from 'getsentry/utils/billing';
+import trackGetsentryAnalytics, {
+  type GetsentryEventKey,
+} from 'getsentry/utils/trackGetsentryAnalytics';
 
-type Props = {
-  onSuccess: (data: Subscription) => void;
+interface CreditCardSetupProps {
+  budgetTerm: string;
   organization: Organization;
-  budgetModeText?: string;
+  analyticsEvent?: GetsentryEventKey;
   buttonText?: string;
-  cancelButtonText?: string;
-  className?: string;
   isModal?: boolean;
   location?: FTCConsentLocation;
   onCancel?: () => void;
+  onSuccess?: () => void;
+  onSuccessWithSubscription?: (data: Subscription) => void;
   referrer?: string;
-};
+}
 
-/**
- * Credit Card form and submit handler for SetupIntent based cards.
- */
 function CreditCardSetup({
   organization,
-  onSuccess,
-  onCancel,
-  isModal,
-  className,
-  buttonText = t('Save Changes'),
-  cancelButtonText = t('Cancel'),
   referrer,
+  onSuccess,
+  onSuccessWithSubscription,
+  onCancel,
   location,
-  budgetModeText,
-}: Props) {
-  const api = useApi();
-  const [errorMessage, setErrorMessage] = useState<string | undefined>();
-  const [intentData, setIntentData] = useState<PaymentSetupCreateResponse | undefined>(
-    undefined
-  );
+  budgetTerm,
+  buttonText,
+  analyticsEvent,
+  isModal,
+}: CreditCardSetupProps) {
+  const shouldUseStripe = hasStripeComponentsFeature(organization);
 
-  const loadData = useCallback(async () => {
-    setErrorMessage(undefined);
-    try {
-      const payload: PaymentSetupCreateResponse = await api.requestPromise(
-        `/organizations/${organization.slug}/payments/setup/`,
-        {method: 'POST'}
-      );
-      setIntentData(payload);
-    } catch (e) {
-      setErrorMessage(t('Unable to initialize payment setup, please try again later.'));
-    }
-  }, [api, organization]);
+  const commonProps = {
+    organization,
+    location,
+    budgetTerm,
+    buttonText: buttonText ?? t('Save Changes'),
+    referrer,
+  };
 
-  useEffect(() => {
-    loadData();
-  }, [loadData]);
-
-  async function handleSubmit({
-    stripe,
-    cardElement,
-    onComplete,
-    validationErrors,
-  }: SubmitData) {
-    if (validationErrors.length) {
-      onComplete();
-      setErrorMessage(validationErrors[0]);
-      return;
-    }
-    if (!intentData) {
-      onComplete();
-      setErrorMessage(
-        t('Cannot complete your payment setup at this time, please try again later.')
-      );
-      return;
-    }
-
-    let setupResult: SetupIntentResult;
-    try {
-      setupResult = await stripe.confirmCardSetup(intentData.clientSecret, {
-        payment_method: {
-          card: cardElement,
-        },
-      });
-    } catch (error) {
-      Sentry.withScope(scope => {
-        scope.setLevel('warning' as any);
-        scope.setExtra('error', error);
-        Sentry.captureException(new Error('Could not complete setup intent.'));
-      });
-      onComplete();
-      setErrorMessage(
-        t('Could not complete your payment setup, please try again later.')
-      );
-      return;
-    }
-    if (setupResult.error) {
-      onComplete();
-      setErrorMessage(setupResult.error.message);
-      return;
-    }
-    if (!setupResult.setupIntent) {
-      onComplete();
-      setErrorMessage(
-        t('Could not complete your payment setup, please try again later.')
-      );
-      return;
-    }
-    try {
-      const subscription: Subscription = await api.requestPromise(
-        `/customers/${organization.slug}/`,
-        {
-          method: 'PUT',
-          data: {
-            paymentMethod: setupResult.setupIntent.payment_method,
-            ftcConsentLocation: location,
-          },
-        }
-      );
-      onComplete();
-      onSuccess(subscription);
-    } catch (error) {
-      Sentry.withScope(scope => {
-        scope.setLevel('warning' as any);
-        scope.setExtra('error', error);
-        Sentry.captureException(
-          new Error('Could not update subscription with payment method.')
-        );
-      });
-      onComplete();
-      setErrorMessage(
-        t('Could not complete your payment setup, please try again later.')
-      );
-      return;
-    }
+  if (shouldUseStripe) {
+    return (
+      <StripeCreditCardSetup
+        onCancel={onCancel ?? (() => {})}
+        onSuccess={() => {
+          onSuccess?.();
+          if (analyticsEvent) {
+            trackGetsentryAnalytics(analyticsEvent, {
+              organization,
+              referrer: decodeScalar(referrer),
+              isStripeComponent: true,
+            });
+          }
+        }}
+        onSuccessWithSubscription={onSuccessWithSubscription}
+        {...commonProps}
+      />
+    );
   }
 
   return (
-    <CreditCardForm
-      className={className}
-      buttonText={buttonText}
-      cancelButtonText={cancelButtonText}
-      error={errorMessage}
-      footerClassName={isModal ? 'modal-footer' : 'form-actions'}
+    <LegacyCreditCardSetup
+      isModal={isModal}
       onCancel={onCancel}
-      onSubmit={handleSubmit}
-      referrer={referrer}
-      location={location}
-      budgetModeText={budgetModeText}
+      onSuccess={data => {
+        onSuccessWithSubscription?.(data);
+        onSuccess?.();
+        if (analyticsEvent) {
+          trackGetsentryAnalytics(analyticsEvent, {
+            organization,
+            referrer: decodeScalar(referrer),
+            isStripeComponent: false,
+          });
+        }
+      }}
+      {...commonProps}
     />
   );
 }

--- a/static/gsApp/components/legacyCreditCardSetup.tsx
+++ b/static/gsApp/components/legacyCreditCardSetup.tsx
@@ -1,0 +1,163 @@
+import {useCallback, useEffect, useState} from 'react';
+import * as Sentry from '@sentry/react';
+import {type SetupIntentResult} from '@stripe/stripe-js';
+
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import useApi from 'sentry/utils/useApi';
+
+import type {SubmitData} from 'getsentry/components/creditCardForm';
+import CreditCardForm from 'getsentry/components/creditCardForm';
+import type {
+  FTCConsentLocation,
+  PaymentSetupCreateResponse,
+  Subscription,
+} from 'getsentry/types';
+
+type Props = {
+  budgetTerm: string;
+  onSuccess: (data: Subscription) => void;
+  organization: Organization;
+  buttonText?: string;
+  cancelButtonText?: string;
+  className?: string;
+  isModal?: boolean;
+  location?: FTCConsentLocation;
+  onCancel?: () => void;
+  referrer?: string;
+};
+
+/**
+ * Credit Card form and submit handler for SetupIntent based cards.
+ */
+function LegacyCreditCardSetup({
+  organization,
+  onSuccess,
+  onCancel,
+  isModal,
+  className,
+  buttonText = t('Save Changes'),
+  cancelButtonText = t('Cancel'),
+  referrer,
+  location,
+  budgetTerm,
+}: Props) {
+  const api = useApi();
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+  const [intentData, setIntentData] = useState<PaymentSetupCreateResponse | undefined>(
+    undefined
+  );
+
+  const loadData = useCallback(async () => {
+    setErrorMessage(undefined);
+    try {
+      const payload: PaymentSetupCreateResponse = await api.requestPromise(
+        `/organizations/${organization.slug}/payments/setup/`,
+        {method: 'POST'}
+      );
+      setIntentData(payload);
+    } catch (e) {
+      setErrorMessage(t('Unable to initialize payment setup, please try again later.'));
+    }
+  }, [api, organization]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  async function handleSubmit({
+    stripe,
+    cardElement,
+    onComplete,
+    validationErrors,
+  }: SubmitData) {
+    if (validationErrors.length) {
+      onComplete();
+      setErrorMessage(validationErrors[0]);
+      return;
+    }
+    if (!intentData) {
+      onComplete();
+      setErrorMessage(
+        t('Cannot complete your payment setup at this time, please try again later.')
+      );
+      return;
+    }
+
+    let setupResult: SetupIntentResult;
+    try {
+      setupResult = await stripe.confirmCardSetup(intentData.clientSecret, {
+        payment_method: {
+          card: cardElement,
+        },
+      });
+    } catch (error) {
+      Sentry.withScope(scope => {
+        scope.setLevel('warning' as any);
+        scope.setExtra('error', error);
+        Sentry.captureException(new Error('Could not complete setup intent.'));
+      });
+      onComplete();
+      setErrorMessage(
+        t('Could not complete your payment setup, please try again later.')
+      );
+      return;
+    }
+    if (setupResult.error) {
+      onComplete();
+      setErrorMessage(setupResult.error.message);
+      return;
+    }
+    if (!setupResult.setupIntent) {
+      onComplete();
+      setErrorMessage(
+        t('Could not complete your payment setup, please try again later.')
+      );
+      return;
+    }
+    try {
+      const subscription: Subscription = await api.requestPromise(
+        `/customers/${organization.slug}/`,
+        {
+          method: 'PUT',
+          data: {
+            paymentMethod: setupResult.setupIntent.payment_method,
+            ftcConsentLocation: location,
+          },
+        }
+      );
+      onComplete();
+      onSuccess(subscription);
+    } catch (error) {
+      Sentry.withScope(scope => {
+        scope.setLevel('warning' as any);
+        scope.setExtra('error', error);
+        Sentry.captureException(
+          new Error('Could not update subscription with payment method.')
+        );
+      });
+      onComplete();
+      setErrorMessage(
+        t('Could not complete your payment setup, please try again later.')
+      );
+      return;
+    }
+  }
+
+  return (
+    <CreditCardForm
+      className={className}
+      buttonText={buttonText}
+      cancelButtonText={cancelButtonText}
+      error={errorMessage}
+      footerClassName={isModal ? 'modal-footer' : 'form-actions'}
+      onCancel={onCancel}
+      onSubmit={handleSubmit}
+      referrer={referrer}
+      location={location}
+      budgetTerm={budgetTerm}
+    />
+  );
+}
+
+export default LegacyCreditCardSetup;

--- a/static/gsApp/components/stripeCreditCardSetup.tsx
+++ b/static/gsApp/components/stripeCreditCardSetup.tsx
@@ -5,31 +5,31 @@ import type {FTCConsentLocation, Subscription} from 'getsentry/types';
 
 export interface StripeCreditCardSetupProps {
   /**
-   * Handler for cancellation.
+   * budget term to use for fine print.
    */
-  onCancel: () => void;
+  budgetTerm: string;
   /**
-   * Handler for success.
+   * Text for the submit button.
    */
-  onSuccess: () => void;
+  buttonText: string;
   /**
    * The organization associated with the form
    */
   organization: Organization;
   /**
-   * budget mode text for fine print, if any.
-   */
-  budgetModeText?: string;
-
-  /**
-   * Text for the submit button.
-   */
-  buttonText?: string;
-
-  /**
    * Location of form, if any.
    */
   location?: FTCConsentLocation;
+
+  /**
+   * Handler for cancellation.
+   */
+  onCancel?: () => void;
+
+  /**
+   * Handler for success.
+   */
+  onSuccess?: () => void;
   /**
    * Handler for success called with new subscription state.
    */

--- a/static/gsApp/components/stripeForms/innerIntentForm.tsx
+++ b/static/gsApp/components/stripeForms/innerIntentForm.tsx
@@ -17,6 +17,8 @@ function InnerIntentForm({
   budgetTerm,
   buttonText,
   location,
+  isSubmitting,
+  busyButtonText,
   handleSubmit,
 }: InnerIntentFormProps) {
   const elements = useElements();
@@ -35,7 +37,7 @@ function InnerIntentForm({
     <Form
       onSubmit={() => handleSubmit({stripe, elements})}
       submitDisabled={submitDisabled}
-      submitLabel={buttonText}
+      submitLabel={isSubmitting && busyButtonText ? busyButtonText : buttonText}
       extraButton={
         onCancel && (
           <Button aria-label={t('Cancel')} onClick={onCancel}>

--- a/static/gsApp/components/stripeForms/innerIntentForm.tsx
+++ b/static/gsApp/components/stripeForms/innerIntentForm.tsx
@@ -8,12 +8,13 @@ import {ExternalLink} from 'sentry/components/core/link';
 import {Text} from 'sentry/components/core/text';
 import Form from 'sentry/components/forms/form';
 import {t, tct} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 
 import type {InnerIntentFormProps} from 'getsentry/components/stripeForms/types';
 
 function InnerIntentForm({
   onCancel,
-  budgetModeText,
+  budgetTerm,
   buttonText,
   location,
   handleSubmit,
@@ -36,9 +37,11 @@ function InnerIntentForm({
       submitDisabled={submitDisabled}
       submitLabel={buttonText}
       extraButton={
-        <Button aria-label={t('Cancel')} onClick={onCancel}>
-          {t('Cancel')}
-        </Button>
+        onCancel && (
+          <Button aria-label={t('Cancel')} onClick={onCancel}>
+            {t('Cancel')}
+          </Button>
+        )
       }
       footerStyle={{
         display: 'flex',
@@ -60,14 +63,13 @@ function InnerIntentForm({
               stripe: <ExternalLink href="https://stripe.com/" />,
             })}
           </small>
-          {/* location is 0 on the checkout page which is why this isn't location && */}
-          {location !== null && location !== undefined && (
+          {defined(location) && (
             <Text size="xs" variant="muted">
               {tct(
-                'By clicking [buttonText], you authorize Sentry to automatically charge you recurring subscription fees and applicable [budgetModeText] fees. Recurring charges occur at the start of your selected billing cycle for subscription fees and monthly for [budgetModeText] fees. You may cancel your subscription at any time [here:here].',
+                'By clicking [buttonText], you authorize Sentry to automatically charge you recurring subscription fees and applicable [budgetTerm] fees. Recurring charges occur at the start of your selected billing cycle for subscription fees and monthly for [budgetTerm] fees. You may cancel your subscription at any time [here:here].',
                 {
                   buttonText: <b>{buttonText}</b>,
-                  budgetModeText,
+                  budgetTerm,
                   here: (
                     <ExternalLink href="https://sentry.io/settings/billing/cancel/" />
                   ),

--- a/static/gsApp/components/stripeForms/paymentIntentForm.tsx
+++ b/static/gsApp/components/stripeForms/paymentIntentForm.tsx
@@ -86,7 +86,9 @@ function StripePaymentIntentForm(props: StripeIntentFormProps) {
       {isError && <Alert type="error">{errorMessage}</Alert>}
       <InnerIntentForm
         {...props}
-        buttonText={isSubmitting ? t('Sending Payment...') : props.buttonText}
+        buttonText={props.buttonText}
+        busyButtonText={t('Sending Payment...')}
+        isSubmitting={isSubmitting}
         intentData={intentData}
         onError={setErrorMessage}
         handleSubmit={handleSubmit}

--- a/static/gsApp/components/stripeForms/paymentIntentForm.tsx
+++ b/static/gsApp/components/stripeForms/paymentIntentForm.tsx
@@ -76,7 +76,7 @@ function StripePaymentIntentForm(props: StripeIntentFormProps) {
           isStripeComponent: true,
         });
         addSuccessMessage(t('Payment sent successfully.'));
-        onSuccess();
+        onSuccess?.();
         setIsSubmitting(false);
       });
   };

--- a/static/gsApp/components/stripeForms/setupIntentForm.tsx
+++ b/static/gsApp/components/stripeForms/setupIntentForm.tsx
@@ -45,7 +45,7 @@ function StripeSetupIntentForm(props: StripeIntentFormProps) {
     onSuccess: (data: Subscription) => {
       addSuccessMessage(t('Updated payment method.'));
       onSuccessWithSubscription?.(data);
-      onSuccess();
+      onSuccess?.();
       setIsSubmitting(false);
     },
     onError: () => {

--- a/static/gsApp/components/stripeForms/setupIntentForm.tsx
+++ b/static/gsApp/components/stripeForms/setupIntentForm.tsx
@@ -113,7 +113,9 @@ function StripeSetupIntentForm(props: StripeIntentFormProps) {
       {isError && <Alert type="error">{errorMessage}</Alert>}
       <InnerIntentForm
         {...props}
-        buttonText={isSubmitting ? t('Saving Changes...') : props.buttonText}
+        buttonText={props.buttonText}
+        busyButtonText={t('Saving Changes...')}
+        isSubmitting={isSubmitting}
         intentData={intentData}
         onError={setErrorMessage}
         handleSubmit={handleSubmit}

--- a/static/gsApp/components/stripeForms/types.tsx
+++ b/static/gsApp/components/stripeForms/types.tsx
@@ -26,6 +26,8 @@ export interface InnerIntentFormProps extends StripeIntentFormProps {
     elements: StripeElements | null;
     stripe: Stripe | null;
   }) => void;
+  isSubmitting: boolean;
   onError: (error: string) => void;
+  busyButtonText?: string;
   intentData?: PaymentSetupCreateResponse | PaymentCreateResponse;
 }

--- a/static/gsApp/hooks/useBillingDetails.tsx
+++ b/static/gsApp/hooks/useBillingDetails.tsx
@@ -1,0 +1,42 @@
+import {
+  keepPreviousData,
+  useApiQuery,
+  type QueryObserverResult,
+} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useOrganization from 'sentry/utils/useOrganization';
+
+import type {BillingDetails} from 'getsentry/types';
+
+interface HookResult {
+  data: BillingDetails | undefined;
+  error: RequestError | null;
+  isError: boolean;
+  isLoading: boolean;
+  refetch: () => Promise<QueryObserverResult<BillingDetails, unknown>>;
+}
+
+export function useBillingDetails(): HookResult {
+  const organization = useOrganization();
+
+  const {data, isPending, isLoading, isError, error, refetch} =
+    useApiQuery<BillingDetails>([`/customers/${organization.slug}/billing-details/`], {
+      staleTime: 0,
+      placeholderData: keepPreviousData,
+      retry: (failureCount, apiError: any) => {
+        // Don't retry on auth errors
+        if (apiError.status === 401 || apiError.status === 403) {
+          return false;
+        }
+        return failureCount < 3;
+      },
+    });
+
+  return {
+    data,
+    isLoading: isLoading || isPending,
+    isError,
+    error,
+    refetch,
+  };
+}

--- a/static/gsApp/utils/trackGetsentryAnalytics.tsx
+++ b/static/gsApp/utils/trackGetsentryAnalytics.tsx
@@ -23,6 +23,11 @@ type AddEventCTA = HasSub & {
   source: string;
   event_types?: string;
 };
+type BillingInfoUpdateEvent = {
+  isStripeComponent?: boolean;
+  referrer?: string;
+};
+type ManualPaymentEvent = BillingInfoUpdateEvent;
 
 type OnDemandBudgetStrategy = 'per_category' | 'shared';
 
@@ -44,10 +49,8 @@ export type ProductUnavailableUpsellAlert = {
 type GetsentryEventParameters = {
   'add_event_cta.clicked_cta': AddEventCTA;
   'am_checkout.viewed': HasSub;
-  'billing_details.updated_cc': {
-    isStripeComponent?: boolean;
-    referrer?: string;
-  };
+  'billing_details.updated_billing_details': BillingInfoUpdateEvent;
+  'billing_details.updated_cc': BillingInfoUpdateEvent;
   'billing_failure.button_clicked': {
     has_link?: boolean;
     has_permissions?: boolean;
@@ -57,13 +60,8 @@ type GetsentryEventParameters = {
     has_permissions?: boolean;
     referrer?: string;
   };
-  'billing_failure.paid_now': {
-    isStripeComponent?: boolean;
-    referrer?: string;
-  };
-  'billing_failure.updated_cc': {
-    referrer?: string;
-  };
+  'billing_failure.paid_now': ManualPaymentEvent;
+  'billing_failure.updated_cc': BillingInfoUpdateEvent;
   'business_landing.clicked': BusinessLanding & {type: string};
   'business_landing.clicked_compare': BusinessLanding;
   'business_landing.clicked_maybe_later': BusinessLanding & {closing_feature: string};
@@ -98,6 +96,8 @@ type GetsentryEventParameters = {
     previous_transactions: number;
     transactions: number;
   } & Checkout;
+  'checkout.updated_billing_details': BillingInfoUpdateEvent;
+  'checkout.updated_cc': BillingInfoUpdateEvent;
   // no sub here
   'checkout.upgrade': Partial<
     Record<DataCategory | `previous_${DataCategory}`, number | undefined>
@@ -279,8 +279,11 @@ const getsentryEventMap: Record<GetsentryEventKey, string> = {
   'checkout.data_slider_changed': 'Checkout: Data Slider Changed',
   'checkout.data_sliders_viewed': 'Checkout: Data Slider Viewed',
   'checkout.upgrade': 'Application: Upgrade',
+  'checkout.updated_cc': 'Checkout: Updated CC',
+  'checkout.updated_billing_details': 'Checkout: Updated billing details',
   'checkout.transactions_upgrade': 'Application: Transactions Upgrade',
   'billing_details.updated_cc': 'Billing Details: Updated CC',
+  'billing_details.updated_billing_details': 'Billing Details: Updated billing details',
   'billing_failure.displayed_banner': 'Billing Failure: Displayed Banner',
   'billing_failure.button_clicked': 'Billing Failure: Button Clicked',
   'billing_failure.paid_now': 'Billing Failure: Paid Now',

--- a/static/gsApp/views/amCheckout/cart.tsx
+++ b/static/gsApp/views/amCheckout/cart.tsx
@@ -19,6 +19,7 @@ import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 import useApi from 'sentry/utils/useApi';
 
 import {PAYG_BUSINESS_DEFAULT, PAYG_TEAM_DEFAULT} from 'getsentry/constants';
+import {useBillingDetails} from 'getsentry/hooks/useBillingDetails';
 import {useStripeInstance} from 'getsentry/hooks/useStripeInstance';
 import {
   InvoiceItemType,
@@ -55,7 +56,6 @@ interface CartProps {
   activePlan: Plan;
   formData: CheckoutFormData;
   formDataForPreview: CheckoutFormData;
-  hasCompleteBillingDetails: boolean;
   onSuccess: ({
     invoice,
     nextQueryParams,
@@ -580,7 +580,6 @@ function Cart({
   organization,
   referrer,
   formDataForPreview,
-  hasCompleteBillingDetails,
   onSuccess,
 }: CartProps) {
   const [previewState, setPreviewState] = useState<CartPreviewState>(NULL_PREVIEW_STATE);
@@ -590,6 +589,8 @@ function Cart({
   const [summaryIsOpen, setSummaryIsOpen] = useState(true);
   const [changesIsOpen, setChangesIsOpen] = useState(true);
   const api = useApi();
+  const {data: billingDetails} = useBillingDetails();
+  const hasCompleteBillingDetails = billingDetails && subscription.paymentSource;
 
   const resetPreviewState = () => setPreviewState(NULL_PREVIEW_STATE);
 

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -139,9 +139,11 @@ class AMCheckout extends Component<Props, State> {
     }
     // TODO(checkout v3): remove these checks once checkout v3 is GA'd
     if (props.location?.pathname.includes('checkout-v3') && !props.isNewCheckout) {
-      props.navigate(`/settings/${props.organization.slug}/billing/checkout/`);
+      props.navigate(`/settings/${props.organization.slug}/billing/checkout/`, {
+        replace: true,
+      });
     } else if (!props.location?.pathname.includes('checkout-v3') && props.isNewCheckout) {
-      props.navigate(`/checkout-v3/`);
+      props.navigate(`/checkout-v3/`, {replace: true});
     }
     let step = 1;
     if (props.location?.hash) {

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -74,6 +74,7 @@ import CheckoutSuccess from 'getsentry/views/amCheckout/checkoutSuccess';
 import AddBillingDetails from 'getsentry/views/amCheckout/steps/addBillingDetails';
 import AddDataVolume from 'getsentry/views/amCheckout/steps/addDataVolume';
 import AddPaymentMethod from 'getsentry/views/amCheckout/steps/addPaymentMethod';
+import AddBillingInformation from 'getsentry/views/amCheckout/steps/checkoutV3/addBillingInformation';
 import BillingCycle from 'getsentry/views/amCheckout/steps/checkoutV3/billingCycle';
 import BuildYourPlan from 'getsentry/views/amCheckout/steps/checkoutV3/buildYourPlan';
 import ContractSelect from 'getsentry/views/amCheckout/steps/contractSelect';
@@ -296,7 +297,7 @@ class AMCheckout extends Component<Props, State> {
       : OnDemandSpend;
 
     if (isNewCheckout) {
-      return [BuildYourPlan, SetSpendCap, BillingCycle];
+      return [BuildYourPlan, SetSpendCap, BillingCycle, AddBillingInformation];
     }
 
     const preAM3Tiers = [PlanTier.AM1, PlanTier.AM2];
@@ -903,7 +904,6 @@ class AMCheckout extends Component<Props, State> {
               <Cart
                 {...overviewProps}
                 referrer={this.referrer}
-                hasCompleteBillingDetails={!!subscription.paymentSource?.last4}
                 formDataForPreview={formDataForPreview}
                 onSuccess={params => {
                   this.setState(prev => ({...prev, ...params}));

--- a/static/gsApp/views/amCheckout/steps/addPaymentMethod.tsx
+++ b/static/gsApp/views/amCheckout/steps/addPaymentMethod.tsx
@@ -45,10 +45,10 @@ function AddPaymentMethod({
     const cardComponent = (
       <AddCardSetup
         organization={organization}
-        onSuccess={onPaymentAccepted}
+        onSuccessWithSubscription={onPaymentAccepted}
         buttonText="Continue"
         location={FTCConsentLocation.CHECKOUT}
-        budgetModeText={subscription.planDetails.budgetTerm}
+        budgetTerm={subscription.planDetails.budgetTerm}
       />
     );
 

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInformation.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInformation.tsx
@@ -2,36 +2,26 @@ import {Fragment, useState} from 'react';
 
 import {Flex} from 'sentry/components/core/layout';
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
+import {useLocation} from 'sentry/utils/useLocation';
 
-import type {Subscription} from 'getsentry/types';
+import {FTCConsentLocation} from 'getsentry/types';
 import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
 import type {CheckoutV3StepProps} from 'getsentry/views/amCheckout/types';
-import {BillingDetailsPanel} from 'getsentry/views/subscriptionPage/billingDetails';
-
-function InvoiceAddress({
-  subscription,
-  organization,
-}: {
-  organization: Organization;
-  subscription: Subscription;
-}) {
-  return (
-    <BillingDetailsPanel
-      organization={organization}
-      subscription={subscription}
-      isNewBillingUI
-    />
-  );
-}
+import {
+  BillingDetailsPanel,
+  PaymentMethodPanel,
+} from 'getsentry/views/subscriptionPage/billingDetails';
 
 function AddBillingInformation({
   subscription,
   onEdit,
   stepNumber,
   organization,
+  activePlan,
 }: CheckoutV3StepProps) {
   const [isOpen, setIsOpen] = useState(true);
+  const location = useLocation();
+
   return (
     <Flex direction="column" gap="xl">
       <StepHeader
@@ -41,12 +31,24 @@ function AddBillingInformation({
         onToggleStep={setIsOpen}
         isOpen={isOpen}
         stepNumber={stepNumber}
-        title={t('Add billing information')}
+        title={t('Add or edit billing information')}
         isNewCheckout
       />
       {isOpen && (
         <Fragment>
-          <InvoiceAddress organization={organization} subscription={subscription} />
+          <BillingDetailsPanel
+            organization={organization}
+            subscription={subscription}
+            isNewBillingUI
+          />
+          <PaymentMethodPanel
+            organization={organization}
+            subscription={subscription}
+            isNewBillingUI
+            location={location}
+            ftcLocation={FTCConsentLocation.CHECKOUT}
+            budgetTerm={activePlan.budgetTerm}
+          />
         </Fragment>
       )}
     </Flex>

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInformation.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInformation.tsx
@@ -1,0 +1,56 @@
+import {Fragment, useState} from 'react';
+
+import {Flex} from 'sentry/components/core/layout';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+
+import type {Subscription} from 'getsentry/types';
+import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
+import type {CheckoutV3StepProps} from 'getsentry/views/amCheckout/types';
+import {BillingDetailsPanel} from 'getsentry/views/subscriptionPage/billingDetails';
+
+function InvoiceAddress({
+  subscription,
+  organization,
+}: {
+  organization: Organization;
+  subscription: Subscription;
+}) {
+  return (
+    <BillingDetailsPanel
+      organization={organization}
+      subscription={subscription}
+      isNewBillingUI
+    />
+  );
+}
+
+function AddBillingInformation({
+  subscription,
+  onEdit,
+  stepNumber,
+  organization,
+}: CheckoutV3StepProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <Flex direction="column" gap="xl">
+      <StepHeader
+        isActive
+        isCompleted={false}
+        onEdit={onEdit}
+        onToggleStep={setIsOpen}
+        isOpen={isOpen}
+        stepNumber={stepNumber}
+        title={t('Add billing information')}
+        isNewCheckout
+      />
+      {isOpen && (
+        <Fragment>
+          <InvoiceAddress organization={organization} subscription={subscription} />
+        </Fragment>
+      )}
+    </Flex>
+  );
+}
+
+export default AddBillingInformation;

--- a/static/gsApp/views/subscriptionPage/billingDetails.tsx
+++ b/static/gsApp/views/subscriptionPage/billingDetails.tsx
@@ -2,6 +2,7 @@ import {Fragment, useCallback, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import type {Location} from 'history';
+import moment from 'moment-timezone';
 
 import {Button} from 'sentry/components/core/button';
 import {Container, Flex} from 'sentry/components/core/layout';
@@ -19,14 +20,18 @@ import withOrganization from 'sentry/utils/withOrganization';
 
 import {openEditBillingDetails, openEditCreditCard} from 'getsentry/actionCreators/modal';
 import BillingDetailsForm from 'getsentry/components/billingDetailsForm';
+import CreditCardSetup from 'getsentry/components/creditCardSetup';
 import withSubscription from 'getsentry/components/withSubscription';
 import {useBillingDetails} from 'getsentry/hooks/useBillingDetails';
 import SubscriptionStore from 'getsentry/stores/subscriptionStore';
-import type {Subscription} from 'getsentry/types';
+import {FTCConsentLocation, type Subscription} from 'getsentry/types';
+import {hasNewBillingUI} from 'getsentry/utils/billing';
 import formatCurrency from 'getsentry/utils/formatCurrency';
 import {getCountryByCode} from 'getsentry/utils/ISO3166codes';
 import {countryHasSalesTax, getTaxFieldInfo} from 'getsentry/utils/salesTax';
-import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
+import trackGetsentryAnalytics, {
+  type GetsentryEventKey,
+} from 'getsentry/utils/trackGetsentryAnalytics';
 import ContactBillingMembers from 'getsentry/views/contactBillingMembers';
 import RecurringCredits from 'getsentry/views/subscriptionPage/recurringCredits';
 
@@ -43,43 +48,11 @@ type Props = {
  * Update billing details view.
  */
 function BillingDetails({organization, subscription, location}: Props) {
-  const [cardLastFourDigits, setCardLastFourDigits] = useState<string | null>(null);
-  const [cardZipCode, setCardZipCode] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (subscription?.paymentSource) {
-      setCardLastFourDigits(prev => prev ?? (subscription.paymentSource?.last4 || null));
-      setCardZipCode(prev => prev ?? (subscription.paymentSource?.zipCode || null));
-    }
-  }, [subscription]);
-
-  const handleCardUpdated = useCallback((data: Subscription) => {
-    setCardLastFourDigits(data.paymentSource?.last4 || null);
-    setCardZipCode(data.paymentSource?.zipCode || null);
-    SubscriptionStore.set(data.slug, data);
-  }, []);
-
   useEffect(() => {
     if (!organization || !subscription) return;
 
     trackSubscriptionView(organization, subscription, 'details');
-
-    // Open update credit card modal and track clicks from payment failure emails and GS Banner
-    const queryReferrer = decodeScalar(location?.query?.referrer);
-    // There are multiple billing failure referrals and each should have analytics tracking
-    if (queryReferrer?.includes('billing-failure')) {
-      openEditCreditCard({
-        organization,
-        subscription,
-        onSuccess: handleCardUpdated,
-        location,
-      });
-      trackGetsentryAnalytics('billing_failure.button_clicked', {
-        organization,
-        referrer: queryReferrer,
-      });
-    }
-  }, [organization, subscription, location, handleCardUpdated]);
+  }, [organization, subscription, location]);
 
   const hasBillingPerms = organization.access?.includes('org:billing');
   if (!hasBillingPerms) {
@@ -90,50 +63,201 @@ function BillingDetails({organization, subscription, location}: Props) {
     return <LoadingIndicator />;
   }
 
+  const isNewBillingUI = hasNewBillingUI(organization);
+
+  if (isNewBillingUI) {
+    return (
+      <Container>
+        <SubscriptionHeader organization={organization} subscription={subscription} />
+        <RecurringCredits displayType="discount" planDetails={subscription.planDetails} />
+        <Flex direction="column" gap="xl">
+          <PaymentMethodPanel
+            organization={organization}
+            subscription={subscription}
+            location={location}
+            isNewBillingUI={isNewBillingUI}
+            ftcLocation={FTCConsentLocation.BILLING_DETAILS}
+            budgetTerm={subscription.planDetails.budgetTerm}
+          />
+          <BillingDetailsPanel
+            organization={organization}
+            subscription={subscription}
+            isNewBillingUI={isNewBillingUI}
+          />
+        </Flex>
+      </Container>
+    );
+  }
+
   return (
     <Container>
       <SubscriptionHeader organization={organization} subscription={subscription} />
       <RecurringCredits displayType="discount" planDetails={subscription.planDetails} />
-      <Panel className="ref-credit-card-details">
-        <PanelHeader hasButtons>
-          {t('Credit Card On File')}
-          <Button
-            data-test-id="update-card"
-            priority="primary"
-            size="sm"
-            onClick={() =>
-              openEditCreditCard({
-                organization,
-                subscription,
-                onSuccess: handleCardUpdated,
-              })
-            }
-          >
-            {t('Update card')}
-          </Button>
-        </PanelHeader>
-        <PanelBody>
-          <FieldGroup label={t('Credit Card Number')}>
-            <TextForField>
-              {cardLastFourDigits ? (
-                `xxxx xxxx xxxx ${cardLastFourDigits}`
-              ) : (
-                <em>{t('No card on file')}</em>
-              )}
-            </TextForField>
-          </FieldGroup>
-
-          <FieldGroup
-            label={t('Postal Code')}
-            help={t('Postal code associated with the card on file')}
-          >
-            <TextForField>{cardZipCode}</TextForField>
-          </FieldGroup>
-        </PanelBody>
-      </Panel>
-
-      <BillingDetailsPanel organization={organization} subscription={subscription} />
+      <PaymentMethodPanel
+        organization={organization}
+        subscription={subscription}
+        location={location}
+        isNewBillingUI={isNewBillingUI}
+        ftcLocation={FTCConsentLocation.BILLING_DETAILS}
+        budgetTerm={subscription.planDetails.budgetTerm}
+      />
+      <BillingDetailsPanel
+        organization={organization}
+        subscription={subscription}
+        isNewBillingUI={isNewBillingUI}
+      />
     </Container>
+  );
+}
+
+function PaymentMethodPanel({
+  organization,
+  subscription,
+  location,
+  isNewBillingUI,
+  budgetTerm,
+  ftcLocation,
+  analyticsEvent,
+}: Props & {
+  budgetTerm: string;
+  ftcLocation: FTCConsentLocation;
+  analyticsEvent?: GetsentryEventKey;
+  isNewBillingUI?: boolean;
+}) {
+  const [cardLastFourDigits, setCardLastFourDigits] = useState<string | null>(null);
+  const [cardZipCode, setCardZipCode] = useState<string | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [fromBillingFailure, setFromBillingFailure] = useState(false);
+
+  const handleCardUpdated = useCallback((data: Subscription) => {
+    setCardLastFourDigits(data.paymentSource?.last4 || null);
+    setCardZipCode(data.paymentSource?.zipCode || null);
+    SubscriptionStore.set(data.slug, data);
+  }, []);
+
+  useEffect(() => {
+    if (subscription?.paymentSource) {
+      setCardLastFourDigits(prev => prev ?? (subscription.paymentSource?.last4 || null));
+      setCardZipCode(prev => prev ?? (subscription.paymentSource?.zipCode || null));
+    }
+  }, [subscription]);
+
+  useEffect(() => {
+    if (!organization || !subscription) return;
+
+    // Open credit card update form/modal and track clicks from payment failure notifications (in app, email, etc.)
+    const queryReferrer = decodeScalar(location.query?.referrer);
+    // There are multiple billing failure referrals and each should have analytics tracking
+    if (queryReferrer?.includes('billing-failure')) {
+      setFromBillingFailure(true);
+      if (isNewBillingUI) {
+        setIsEditing(true);
+      } else {
+        openEditCreditCard({
+          organization,
+          subscription,
+          onSuccess: handleCardUpdated,
+          location,
+        });
+      }
+      trackGetsentryAnalytics('billing_failure.button_clicked', {
+        organization,
+        referrer: queryReferrer,
+      });
+    }
+  }, [organization, subscription, location, handleCardUpdated, isNewBillingUI]);
+
+  if (isNewBillingUI) {
+    const countryName = getCountryByCode(subscription.paymentSource?.countryCode)?.name;
+    return (
+      <Flex
+        justify={isEditing ? 'start' : 'between'}
+        align="start"
+        gap="3xl"
+        padding="xl"
+        background="primary"
+        border="primary"
+        radius="md"
+      >
+        <Flex direction="column" gap="lg" width="100%">
+          <Heading as="h2" size="lg">
+            {t('Payment method')}
+          </Heading>
+          {isEditing ? (
+            <CreditCardSetup
+              organization={organization}
+              onSuccess={() => {}}
+              onCancel={() => setIsEditing(false)}
+              onSuccessWithSubscription={handleCardUpdated}
+              location={ftcLocation}
+              budgetTerm={budgetTerm}
+              analyticsEvent={
+                (analyticsEvent ?? fromBillingFailure)
+                  ? 'billing_failure.updated_cc'
+                  : 'billing_details.updated_cc'
+              }
+            />
+          ) : subscription.paymentSource ? (
+            <Fragment>
+              <Text>{`****${subscription.paymentSource.last4} ${moment(new Date(subscription.paymentSource.expYear, subscription.paymentSource.expMonth)).format('MM/YY')}`}</Text>
+              <Text>{`${countryName ? `${countryName} ` : ''} ${subscription.paymentSource.zipCode}`}</Text>
+            </Fragment>
+          ) : (
+            <Text>{t('No payment method on file')}</Text>
+          )}
+        </Flex>
+        {!isEditing && (
+          <Button
+            priority="default"
+            size="sm"
+            onClick={() => setIsEditing(true)}
+            aria-label={t('Edit payment method')}
+          >
+            {t('Edit')}
+          </Button>
+        )}
+      </Flex>
+    );
+  }
+
+  return (
+    <Panel className="ref-credit-card-details">
+      <PanelHeader hasButtons>
+        {t('Credit Card On File')}
+        <Button
+          data-test-id="update-card"
+          priority="primary"
+          size="sm"
+          onClick={() =>
+            openEditCreditCard({
+              organization,
+              subscription,
+              onSuccess: handleCardUpdated,
+            })
+          }
+        >
+          {t('Update card')}
+        </Button>
+      </PanelHeader>
+      <PanelBody>
+        <FieldGroup label={t('Credit Card Number')}>
+          <TextForField>
+            {cardLastFourDigits ? (
+              `xxxx xxxx xxxx ${cardLastFourDigits}`
+            ) : (
+              <em>{t('No card on file')}</em>
+            )}
+          </TextForField>
+        </FieldGroup>
+
+        <FieldGroup
+          label={t('Postal Code')}
+          help={t('Postal code associated with the card on file')}
+        >
+          <TextForField>{cardZipCode}</TextForField>
+        </FieldGroup>
+      </PanelBody>
+    </Panel>
   );
 }
 
@@ -190,15 +314,25 @@ function BillingDetailsPanel({
         border="primary"
         radius="md"
       >
-        <Flex direction="column" gap="lg">
+        <Flex direction="column" gap="lg" width="100%">
           <Heading as="h2" size="lg">
-            {t('Invoice Address')}
+            {t('Invoice address')}
           </Heading>
           {isEditing ? (
             <BillingDetailsForm
               organization={organization}
               initialData={billingDetails}
               onSubmitSuccess={fetchBillingDetails}
+              extraButton={
+                <Button
+                  priority="default"
+                  size="sm"
+                  onClick={() => setIsEditing(false)}
+                  aria-label={t('Cancel editing invoice address')}
+                >
+                  {t('Cancel')}
+                </Button>
+              }
             />
           ) : billingDetails ? (
             <Fragment>
@@ -230,7 +364,12 @@ function BillingDetailsPanel({
           )}
         </Flex>
         {!isEditing && (
-          <Button priority="default" size="sm" onClick={() => setIsEditing(true)}>
+          <Button
+            priority="default"
+            size="sm"
+            onClick={() => setIsEditing(true)}
+            aria-label={t('Edit invoice address')}
+          >
             {t('Edit')}
           </Button>
         )}
@@ -314,7 +453,7 @@ const TextForField = styled('span')`
 `;
 
 export default withSubscription(withOrganization(BillingDetails));
-export {BillingDetailsPanel};
+export {BillingDetailsPanel, PaymentMethodPanel};
 
 /** @internal exported for tests only */
 export {BillingDetails};

--- a/static/gsApp/views/subscriptionPage/billingDetails.tsx
+++ b/static/gsApp/views/subscriptionPage/billingDetails.tsx
@@ -186,7 +186,7 @@ function PaymentMethodPanel({
           {isEditing ? (
             <CreditCardSetup
               organization={organization}
-              onSuccess={() => {}}
+              onSuccess={() => setIsEditing(false)}
               onCancel={() => setIsEditing(false)}
               onSuccessWithSubscription={handleCardUpdated}
               location={ftcLocation}
@@ -322,7 +322,10 @@ function BillingDetailsPanel({
             <BillingDetailsForm
               organization={organization}
               initialData={billingDetails}
-              onSubmitSuccess={fetchBillingDetails}
+              onSubmitSuccess={() => {
+                fetchBillingDetails();
+                setIsEditing(false);
+              }}
               extraButton={
                 <Button
                   priority="default"


### PR DESCRIPTION
TODO:
- fix analytics (make sure we emit them for every place billing details + CC can be updated)
- fix prop structure -- kinda messy rn because of the optional props and not being consistent with how they're populated across the different places we can make updates
- split PR so this one only focuses on adding the new step, another one can fix analytics, another one can introduce the new `PaymentMethodPanel` and make the changes to `BillingDetails` + include the prop changes