### PR TITLE
fix(insights): fix backend page crashes due to null param

### DIFF
--- a/static/app/views/insights/common/components/widgets/overviewTimeConsumingQueriesWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewTimeConsumingQueriesWidget.tsx
@@ -105,12 +105,6 @@ export default function OverviewTimeConsumingQueriesWidget(
 
   const colorPalette = theme.chart.getColorPalette(dataLength - 1);
 
-  const aliases: Record<string, string> = {};
-
-  queriesListData.forEach(item => {
-    aliases[item[groupBy]] = `${yAxes}, ${ellipsize(item[groupBy], 50)}`;
-  });
-
   const plottables =
     queriesSeriesData?.timeSeries.map(
       (ts, index) =>


### PR DESCRIPTION
fixes JAVASCRIPT-33HG
`ellipsize(item[groupBy], 50)` was causing the error`Cannot read properties of null (reading 'length')` because `item[groupBy]` could be null.

However, turns out the `aliases` object isn't even used so this code doesn't do anything so we can delete it and fix this bug.
