### PR TITLE
chore(autofix): Style cleanup

### DIFF
--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -724,8 +724,7 @@ const InputWrapper = styled('form')`
 
 const StyledInput = styled(TextArea)`
   flex-grow: 1;
-  background: ${p => p.theme.background}
-    linear-gradient(to left, ${p => p.theme.background}, ${p => p.theme.pink400}20);
+  background: ${p => p.theme.background};
   border-color: ${p => p.theme.innerBorder};
   padding-right: ${space(4)};
   padding-top: ${space(0.75)};

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -712,7 +712,7 @@ const VerticalLine = styled('div')`
   top: 0;
   bottom: 0;
   width: 1px;
-  background-color: ${p => p.theme.subText};
+  background-color: ${p => p.theme.border};
   transition: background-color 0.2s ease;
   z-index: 0;
 `;
@@ -765,7 +765,7 @@ const MiniHeader = styled('p')<{expanded?: boolean}>`
 
 const ContextBody = styled('div')`
   padding: ${space(2)} ${space(2)} 0 ${space(2)};
-  background: ${p => p.theme.pink400}05;
+  background: ${p => p.theme.alert.info.backgroundLight};
   border-radius: 0 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius};
   overflow: hidden;
   position: relative;
@@ -796,9 +796,6 @@ const AnimationWrapper = styled(motion.div)`
 
 const StyledIconChevron = styled(IconChevron)`
   color: ${p => p.theme.subText};
-  &:hover {
-    color: ${p => p.theme.pink400};
-  }
 `;
 
 const RightSection = styled('div')`
@@ -826,9 +823,6 @@ const EditInput = styled(TextArea)`
 
 const EditButton = styled(Button)`
   color: ${p => p.theme.subText};
-  &:hover {
-    color: ${p => p.theme.pink400};
-  }
 `;
 
 const CollapseButton = styled(Button)`
@@ -862,9 +856,6 @@ const DiffContainer = styled('div')`
 
 const AddButton = styled(Button)`
   color: ${p => p.theme.subText};
-  &:hover {
-    color: ${p => p.theme.pink400};
-  }
 `;
 
 export function FlippedReturnIcon(props: React.HTMLAttributes<HTMLSpanElement>) {

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -381,12 +381,13 @@ const Container = styled(motion.div)<{required: boolean}>`
     background: linear-gradient(
       90deg,
       transparent,
-      ${p => (p.required ? p.theme.pink400 : p.theme.active)}20,
+      ${p => (p.required ? p.theme.pink400 : p.theme.active)}10,
       transparent
     );
     background-size: 2000px 100%;
-    animation: ${shimmer} 2s infinite linear;
+    animation: ${shimmer} 1s infinite linear;
     pointer-events: none;
+    border-radius: ${p => p.theme.borderRadius};
   }
 `;
 
@@ -421,7 +422,7 @@ const ActiveLog = styled('div')`
 const VerticalLine = styled('div')`
   width: 0;
   height: ${space(4)};
-  border-left: 1px dashed ${p => p.theme.subText};
+  border-left: 1px dashed ${p => p.theme.border};
   margin-left: 16.5px;
   margin-bottom: -1px;
 `;
@@ -434,8 +435,6 @@ const InputWrapper = styled('form')`
 
 const StyledInput = styled(TextArea)`
   flex-grow: 1;
-  background: ${p => p.theme.background}
-    linear-gradient(to left, ${p => p.theme.background}, ${p => p.theme.pink400}20);
   border-color: ${p => p.theme.innerBorder};
   padding-right: ${space(4)};
   resize: none;

--- a/static/app/components/events/autofix/autofixProgressBar.tsx
+++ b/static/app/components/events/autofix/autofixProgressBar.tsx
@@ -56,7 +56,7 @@ const ProgressBarTrack = styled('div')`
 
 const ProgressBarFill = styled('div')`
   height: 100%;
-  background-color: ${p => p.theme.pink400};
+  background-color: ${p => p.theme.active};
   opacity: 0.7;
   transition: width 1s ease-in-out;
 `;

--- a/static/app/components/events/autofix/autofixStartBox.tsx
+++ b/static/app/components/events/autofix/autofixStartBox.tsx
@@ -75,7 +75,7 @@ export function AutofixStartBox({onSend, groupId}: AutofixStartBoxProps) {
                   handleSubmit(e);
                 }
               }}
-              placeholder="(Optional) Share helpful context here..."
+              placeholder="Share helpful context here... (optional)"
               maxLength={4096}
               maxRows={10}
               size="sm"
@@ -175,7 +175,6 @@ const InputWrapper = styled('form')`
 
 const StyledInput = styled(TextArea)`
   resize: none;
-  background: ${p => p.theme.background};
   width: 50%;
   min-width: 250px;
 

--- a/static/app/components/events/autofix/autofixStartBox.tsx
+++ b/static/app/components/events/autofix/autofixStartBox.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState} from 'react';
+import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import starImage from 'sentry-images/spot/banner-star.svg';
@@ -28,40 +28,41 @@ export function AutofixStartBox({onSend, groupId}: AutofixStartBoxProps) {
         <StyledArrow direction="down" size="sm" />
         <Container>
           <AutofixStartText>
-            <BackgroundStar
-              src={starImage}
-              style={{
-                width: '20px',
-                height: '20px',
-                right: '5%',
-                top: '20%',
-                transform: 'rotate(15deg)',
-              }}
-            />
-            <BackgroundStar
-              src={starImage}
-              style={{
-                width: '16px',
-                height: '16px',
-                right: '35%',
-                top: '40%',
-                transform: 'rotate(45deg)',
-              }}
-            />
-            <BackgroundStar
-              src={starImage}
-              style={{
-                width: '14px',
-                height: '14px',
-                right: '25%',
-                top: '60%',
-                transform: 'rotate(30deg)',
-              }}
-            />
-            <StartTextRow>
-              <IconSeer variant="waiting" color="textColor" size="lg" />
-              <Fragment>{t('Need help digging deeper?')}</Fragment>
-            </StartTextRow>
+            <SeerIconWrapper>
+              <IconSeer variant="waiting" color="textColor" size="xl" />
+
+              <BackgroundStar
+                src={starImage}
+                style={{
+                  width: '20px',
+                  height: '20px',
+                  top: '-4px',
+                  right: '-56px',
+                  transform: 'rotate(15deg)',
+                }}
+              />
+              <BackgroundStar
+                src={starImage}
+                style={{
+                  width: '16px',
+                  height: '16px',
+                  top: '-12px',
+                  left: '-64px',
+                  transform: 'rotate(45deg)',
+                }}
+              />
+              <BackgroundStar
+                src={starImage}
+                style={{
+                  width: '14px',
+                  height: '14px',
+                  bottom: '-4px',
+                  right: '-24px',
+                  transform: 'rotate(30deg)',
+                }}
+              />
+            </SeerIconWrapper>
+            <StartTextRow />
           </AutofixStartText>
           <InputWrapper onSubmit={handleSubmit}>
             <StyledInput
@@ -94,7 +95,7 @@ export function AutofixStartBox({onSend, groupId}: AutofixStartBoxProps) {
               }
               analyticsParams={{group_id: groupId}}
             >
-              {t('Start Seer')}
+              {t('Start Root Cause Analysis')}
             </StyledButton>
           </InputWrapper>
         </Container>
@@ -123,19 +124,16 @@ const Container = styled('div')`
   position: relative;
   width: 100%;
   border-radius: ${p => p.theme.borderRadius};
-  background: ${p => p.theme.background}
-    linear-gradient(135deg, ${p => p.theme.pink400}08, ${p => p.theme.pink400}20);
   overflow: hidden;
   padding: ${space(0.5)};
-  border: 1px solid ${p => p.theme.border};
 `;
 
 const AutofixStartText = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   margin: 0;
   padding: ${space(1)};
-  white-space: pre-wrap;
-  word-break: break-word;
-  font-size: ${p => p.theme.fontSize.lg};
   position: relative;
 `;
 
@@ -153,6 +151,13 @@ const BackgroundStar = styled('img')`
   z-index: 0;
 `;
 
+const SeerIconWrapper = styled('div')`
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+`;
+
 const StyledArrow = styled(IconArrow)`
   color: ${p => p.theme.subText};
   opacity: 0.5;
@@ -160,13 +165,19 @@ const StyledArrow = styled(IconArrow)`
 
 const InputWrapper = styled('form')`
   display: flex;
-  gap: ${space(0.5)};
-  padding: ${space(0.25)} ${space(0.25)};
+  flex-direction: column;
+  gap: ${p => p.theme.formSpacing.md};
+  padding: ${space(0.5)} ${space(0.5)};
+  align-items: center;
+  width: 100%;
+  justify-content: center;
 `;
 
 const StyledInput = styled(TextArea)`
   resize: none;
   background: ${p => p.theme.background};
+  width: 50%;
+  min-width: 250px;
 
   border-color: ${p => p.theme.innerBorder};
   &:hover {
@@ -176,4 +187,6 @@ const StyledInput = styled(TextArea)`
 
 const StyledButton = styled(Button)`
   flex-shrink: 0;
+  width: 50%;
+  min-width: 250px;
 `;

--- a/static/app/components/group/groupSummaryWithAutofix.tsx
+++ b/static/app/components/group/groupSummaryWithAutofix.tsx
@@ -364,7 +364,7 @@ const CardTitle = styled('div')<{preview?: boolean}>`
   display: flex;
   align-items: center;
   gap: ${space(1)};
-  color: ${p => p.theme.subText};
+  color: ${p => p.theme.textColor};
   padding: ${space(0.5)} ${space(0.5)} 0 ${space(1)};
   justify-content: space-between;
 `;
@@ -386,7 +386,7 @@ const CardTitleText = styled('p')`
 const CardTitleIcon = styled('div')`
   display: flex;
   align-items: center;
-  color: ${p => p.theme.subText};
+  color: ${p => p.theme.textColor};
 `;
 
 const CardContent = styled('div')`

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -176,7 +176,7 @@ describe('SeerDrawer', () => {
     expect(screen.getByTestId('ai-setup-data-consent')).toBeInTheDocument();
   });
 
-  it('renders initial state with Start Seer button', async () => {
+  it('renders initial state with Start Root Cause Analysis button', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: null},
@@ -194,8 +194,8 @@ describe('SeerDrawer', () => {
 
     expect(screen.getByRole('heading', {name: 'Seer'})).toBeInTheDocument();
 
-    // Verify the Start Seer button is available
-    const startButton = screen.getByRole('button', {name: 'Start Seer'});
+    // Verify the Start Root Cause Analysis button is available
+    const startButton = screen.getByRole('button', {name: 'Start Root Cause Analysis'});
     expect(startButton).toBeInTheDocument();
   });
 
@@ -227,7 +227,7 @@ describe('SeerDrawer', () => {
     expect(screen.getByText('Set Up the GitHub Integration')).toBeInTheDocument();
     expect(screen.getByText('Set Up Integration')).toBeInTheDocument();
 
-    const startButton = screen.getByRole('button', {name: 'Start Seer'});
+    const startButton = screen.getByRole('button', {name: 'Start Root Cause Analysis'});
     expect(startButton).toBeInTheDocument();
   });
 
@@ -253,7 +253,7 @@ describe('SeerDrawer', () => {
       screen.queryByTestId('ai-setup-loading-indicator')
     );
 
-    const startButton = screen.getByRole('button', {name: 'Start Seer'});
+    const startButton = screen.getByRole('button', {name: 'Start Root Cause Analysis'});
     await userEvent.click(startButton);
 
     expect(await screen.findByRole('button', {name: 'Start Over'})).toBeInTheDocument();
@@ -431,7 +431,9 @@ describe('SeerDrawer', () => {
     );
 
     expect(await screen.findByRole('button', {name: 'Start Over'})).toBeInTheDocument();
-    expect(await screen.findByRole('button', {name: 'Start Seer'})).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', {name: 'Start Root Cause Analysis'})
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Start Over'})).toBeDisabled();
   });
 
@@ -454,7 +456,9 @@ describe('SeerDrawer', () => {
     await userEvent.click(startOverButton);
 
     await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Start Seer'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Start Root Cause Analysis'})
+      ).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -171,7 +171,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
               <IconSeer variant="waiting" size="xl" />
               Debug Faster with Seer
             </StepsHeader>
-            <GuidedSteps>
+            <StyledGuidedSteps>
               {/* Step 1: GitHub Integration */}
               <GuidedSteps.Step
                 key="github-setup"
@@ -359,7 +359,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
                   </CustomStepButtons>
                 </GuidedSteps.Step>
               )}
-            </GuidedSteps>
+            </StyledGuidedSteps>
             <StepsDivider />
           </motion.div>
         </AnimatePresence>
@@ -497,4 +497,8 @@ const CollapsedSummaryCard = styled('div')`
   &:hover {
     background: ${p => p.theme.backgroundTertiary};
   }
+`;
+
+const StyledGuidedSteps = styled(GuidedSteps)`
+  max-width: 600px;
 `;

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -483,7 +483,7 @@ const CollapsedSummaryCard = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(1)};
-  background: ${p => p.theme.pink400}10;
+  background: ${p => p.theme.alert.info.backgroundLight};
   border: 1px solid ${p => p.theme.border};
   border-radius: 6px;
   padding: ${space(1)};
@@ -495,6 +495,6 @@ const CollapsedSummaryCard = styled('div')`
   transition: box-shadow 0.2s;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
   &:hover {
-    background: ${p => p.theme.pink400}20;
+    background: ${p => p.theme.backgroundTertiary};
   }
 `;

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
@@ -127,10 +127,7 @@ export default function SeerSection({
   const titleComponent = onlyHasResources ? (
     <HeaderContainer>{t('Resources')}</HeaderContainer>
   ) : (
-    <HeaderContainer>
-      {t('Seer')}
-      <IconSeer />
-    </HeaderContainer>
+    <HeaderContainer>{t('Seer')}</HeaderContainer>
   );
 
   return (

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
@@ -9,7 +9,6 @@ import {Text} from 'sentry/components/core/text';
 import {GroupSummary} from 'sentry/components/group/groupSummary';
 import {GroupSummaryWithAutofix} from 'sentry/components/group/groupSummaryWithAutofix';
 import Placeholder from 'sentry/components/placeholder';
-import {IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -175,7 +175,10 @@ export function SeerSectionCtaButton({
     }
 
     if (isAutofixCompleted) {
-      if (lastStep.type === AutofixStepType.SOLUTION) {
+      if (
+        lastStep.type === AutofixStepType.ROOT_CAUSE_ANALYSIS ||
+        lastStep.type === AutofixStepType.SOLUTION
+      ) {
         return t('Fix with Seer');
       }
       return t('Open Seer');


### PR DESCRIPTION
Remove the pink theming since the main button is purple now. Lighten or simplify a few other colors. Simplify the start screen to make the CTA more obvious
<img width="720" height="695" alt="Screenshot 2025-09-20 at 10 46 48 AM" src="https://github.com/user-attachments/assets/f92da103-1a59-43a9-9412-ab7ee74dd908" />



<img width="322" height="278" alt="Screenshot 2025-09-20 at 10 02 38 AM" src="https://github.com/user-attachments/assets/5bc8377a-6de8-410e-b8a0-c2aca3fa4a8d" />
