### PR TITLE
ref(api): use RateLimitConfig for auth endpoints

### DIFF
--- a/src/sentry/auth_v2/endpoints/csrf.py
+++ b/src/sentry/auth_v2/endpoints/csrf.py
@@ -10,6 +10,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.auth_v2.utils.session import SessionSerializer
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -27,16 +28,18 @@ class CsrfTokenEndpoint(Endpoint):
     permission_classes = ()
 
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.USER: RateLimit(limit=10, window=60),  # 10 per minute per user
-            RateLimitCategory.IP: RateLimit(limit=20, window=60),  # 20 per minute per IP
-        },
-        "PUT": {
-            RateLimitCategory.USER: RateLimit(limit=10, window=60),  # 10 per minute per user
-            RateLimitCategory.IP: RateLimit(limit=20, window=60),  # 20 per minute per IP
-        },
-    }
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.USER: RateLimit(limit=10, window=60),  # 10 per minute per user
+                RateLimitCategory.IP: RateLimit(limit=20, window=60),  # 20 per minute per IP
+            },
+            "PUT": {
+                RateLimitCategory.USER: RateLimit(limit=10, window=60),  # 10 per minute per user
+                RateLimitCategory.IP: RateLimit(limit=20, window=60),  # 20 per minute per IP
+            },
+        }
+    )
 
     @extend_schema(
         operation_id="Retrieve the CSRF token in your session",

--- a/src/sentry/auth_v2/endpoints/feature_flag_view.py
+++ b/src/sentry/auth_v2/endpoints/feature_flag_view.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 from .base import AuthV2Endpoint
@@ -14,9 +15,11 @@ class FeatureFlagView(AuthV2Endpoint):
     owner = ApiOwner.ENTERPRISE
     publish_status = {"GET": ApiPublishStatus.EXPERIMENTAL}
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {RateLimitCategory.IP: RateLimit(limit=30, window=60)}  # 30 per minute per IP
-    }
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {RateLimitCategory.IP: RateLimit(limit=30, window=60)}  # 30 per minute per IP
+        }
+    )
 
     def get(self, request: Request) -> Response:
         """

--- a/src/sentry/users/api/endpoints/user_emails_confirm.py
+++ b/src/sentry/users/api/endpoints/user_emails_confirm.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.api.bases.user import UserEndpoint
 from sentry.users.api.parsers.email import AllowedEmailField
@@ -40,12 +41,14 @@ class UserEmailsConfirmEndpoint(UserEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }
-    rate_limits = {
-        "POST": {
-            RateLimitCategory.USER: RateLimit(limit=10, window=60),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=60),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "POST": {
+                RateLimitCategory.USER: RateLimit(limit=10, window=60),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=60),
+            }
         }
-    }
+    )
 
     def post(self, request: Request, user: User) -> Response:
         """

--- a/src/sentry/users/api/endpoints/user_password.py
+++ b/src/sentry/users/api/endpoints/user_password.py
@@ -9,6 +9,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.auth import password_validation
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.security.utils import capture_security_activity
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.api.bases.user import UserEndpoint
@@ -59,13 +60,15 @@ class UserPasswordEndpoint(UserEndpoint):
     }
 
     enforce_rate_limit = True
-    rate_limits = {
-        "PUT": {
-            RateLimitCategory.USER: RateLimit(
-                limit=5, window=60 * 60
-            ),  # 5 PUT requests per hour per user
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "PUT": {
+                RateLimitCategory.USER: RateLimit(
+                    limit=5, window=60 * 60
+                ),  # 5 PUT requests per hour per user
+            }
         }
-    }
+    )
 
     def put(self, request: Request, user: User) -> Response:
         # pass some context to serializer otherwise when we create a new serializer instance,


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/99484, moving to RateLimitConfig instead of the rate limit dict.