### PR TITLE
fix(grouping): Add default `StrategyConfig.id` value

### DIFF
--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -318,7 +318,7 @@ class Strategy(Generic[ConcreteInterface]):
 
 
 class StrategyConfiguration:
-    id: str | None
+    id: str | None = None
     base: type[StrategyConfiguration] | None = None
     strategies: dict[str, Strategy[Any]] = {}
     delegates: dict[str, Strategy[Any]] = {}


### PR DESCRIPTION
In certain tests, where grouping config doesn't matter, an empty config is provided. This turns out to make grouping variant equality comparisons error out, because variants include their grouping config, configs include their `id` when serialized, and empty configs don't have an `id` value to use. Since a config's `id` is allowed to be `None`, this adds that in as a default value. No change in behavior in prod, since in real life grouping configs are never empty, but a small convenience for tests.