### PR TITLE
debug(demo-user): Add logs to figure out identity linkingw

### DIFF
--- a/src/sentry/users/models/identity.py
+++ b/src/sentry/users/models/identity.py
@@ -94,6 +94,11 @@ class IdentityManager(BaseManager["Identity"]):
         if is_demo_user(user) and options.get(
             "identity.prevent-link-identity-for-demo-users.enabled"
         ):
+            logger.info(
+                "Preventing link identity for demo user",
+                extra={"user_id": user.id, "idp_id": idp.id, "external_id": external_id},
+                stack_info=True,
+            )
             return None
 
         from sentry.integrations.slack.analytics import IntegrationIdentityLinked


### PR DESCRIPTION
Add logs to help us figure out the path and what is happening when we try to link identity provider with demo user.
