### PR TITLE
fix(agent-insights): Detect JSON in  attribute

### DIFF
--- a/static/app/views/insights/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/agents/utils/aiTraceNodes.tsx
@@ -64,7 +64,7 @@ export function getTraceNodeAttribute(
   node: TraceTreeNode<TraceTree.NodeValue>,
   event?: EventTransaction,
   attributes?: TraceItemResponseAttribute[]
-) {
+): string | number | boolean | undefined {
   const attributeObject = ensureAttributeObject(node, event, attributes);
   return attributeObject?.[name];
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -15,6 +15,23 @@ import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/tr
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 
+function isJson(value: string) {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+function renderAIResponse(text: string) {
+  return isJson(text) ? (
+    <TraceDrawerComponents.MultilineJSON value={text} maxDefaultDepth={2} />
+  ) : (
+    <TraceDrawerComponents.MultilineText>{text}</TraceDrawerComponents.MultilineText>
+  );
+}
+
 export function AIOutputSection({
   node,
   attributes,
@@ -64,9 +81,7 @@ export function AIOutputSection({
           <TraceDrawerComponents.MultilineTextLabel>
             {t('Response')}
           </TraceDrawerComponents.MultilineTextLabel>
-          <TraceDrawerComponents.MultilineText>
-            {responseText.toString().trim()}
-          </TraceDrawerComponents.MultilineText>
+          {renderAIResponse(responseText)}
         </Fragment>
       )}
       {responseObject && (
@@ -74,10 +89,7 @@ export function AIOutputSection({
           <TraceDrawerComponents.MultilineTextLabel>
             {t('Response Object')}
           </TraceDrawerComponents.MultilineTextLabel>
-          <TraceDrawerComponents.MultilineJSON
-            value={responseObject}
-            maxDefaultDepth={2}
-          />
+          {renderAIResponse(responseObject)}
         </Fragment>
       )}
       {toolCalls && (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -81,7 +81,7 @@ export function AIOutputSection({
           <TraceDrawerComponents.MultilineTextLabel>
             {t('Response')}
           </TraceDrawerComponents.MultilineTextLabel>
-          {renderAIResponse(responseText)}
+          {renderAIResponse(responseText.toString())}
         </Fragment>
       )}
       {responseObject && (
@@ -89,7 +89,7 @@ export function AIOutputSection({
           <TraceDrawerComponents.MultilineTextLabel>
             {t('Response Object')}
           </TraceDrawerComponents.MultilineTextLabel>
-          {renderAIResponse(responseObject)}
+          {renderAIResponse(responseObject.toString())}
         </Fragment>
       )}
       {toolCalls && (


### PR DESCRIPTION
Render the `gen_ai.response.text` attribute as interactive JSON if the string is a valid JSON.
In the same fashion, fallback to text rendering with truncation if `gen_ai.response.object` is not a valid JSON.