### PR TITLE
fix: Keep query params when nav between onboard and test results

### DIFF
--- a/static/app/components/prevent/utils.tsx
+++ b/static/app/components/prevent/utils.tsx
@@ -1,3 +1,5 @@
+import type {Location} from 'history';
+
 import type {Integration} from 'sentry/types/integrations';
 
 export const integratedOrgIdToName = (id?: string, integrations?: Integration[]) => {
@@ -17,4 +19,29 @@ export const integratedOrgIdToDomainName = (
   }
   const result = integrations.find(item => item.id === id);
   return result?.domainName || null;
+};
+
+export const getPreventParamsString = (location: Location) => {
+  const preventParams: Record<string, string | string[]> = {};
+
+  if (location.query?.integratedOrgId) {
+    preventParams.integratedOrgId = location.query.integratedOrgId;
+  }
+  if (location.query?.repository) {
+    preventParams.repository = location.query.repository;
+  }
+  if (location.query?.branch) {
+    preventParams.branch = location.query.branch;
+  }
+  if (location.query?.preventPeriod) {
+    preventParams.preventPeriod = location.query.preventPeriod;
+  }
+
+  return new URLSearchParams(
+    Object.fromEntries(
+      Object.entries(preventParams)
+        .map(([key, value]) => [key, Array.isArray(value) ? value[0] : value])
+        .filter(([, value]) => Boolean(value))
+    )
+  ).toString();
 };

--- a/static/app/views/prevent/tests/onboarding.tsx
+++ b/static/app/views/prevent/tests/onboarding.tsx
@@ -14,9 +14,11 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {usePreventContext} from 'sentry/components/prevent/context/preventContext';
 import {IntegratedOrgSelector} from 'sentry/components/prevent/integratedOrgSelector/integratedOrgSelector';
 import {RepoSelector} from 'sentry/components/prevent/repoSelector/repoSelector';
+import {getPreventParamsString} from 'sentry/components/prevent/utils';
 import {t, tct} from 'sentry/locale';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AddScriptToYamlStep} from 'sentry/views/prevent/tests/onboardingSteps/addScriptToYamlStep';
 import {AddUploadTokenStep} from 'sentry/views/prevent/tests/onboardingSteps/addUploadTokenStep';
@@ -40,6 +42,7 @@ enum SetupOption {
 }
 
 export default function TestsOnboardingPage() {
+  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const organization = useOrganization();
@@ -61,9 +64,10 @@ export default function TestsOnboardingPage() {
 
   useEffect(() => {
     if (repoData?.testAnalyticsEnabled && isSuccess) {
-      navigate('/prevent/tests');
+      const queryString = getPreventParamsString(location);
+      navigate(`/prevent/tests${queryString ? `?${queryString}` : ''}`, {replace: true});
     }
-  }, [repoData?.testAnalyticsEnabled, navigate, isSuccess]);
+  }, [repoData?.testAnalyticsEnabled, navigate, isSuccess, location]);
 
   const {data: integrations = [], isPending} = useApiQuery<OrganizationIntegration[]>(
     [

--- a/static/app/views/prevent/tests/onboardingSteps/installPreventCLIStep.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/installPreventCLIStep.tsx
@@ -16,7 +16,7 @@ interface InstallPreventCLIStepProps {
 type Method = 'pip' | 'binary';
 
 const PLATFORMS = {
-  macOS: {label: 'MacOS', value: 'macos'},
+  macos: {label: 'MacOS', value: 'macos'},
   windows: {label: 'Windows', value: 'windows.exe'},
   linux_x86_64: {label: 'Linux x86_64', value: 'linux_x86_64'},
   linux_arm64: {label: 'Linux Arm64', value: 'linux_arm64'},
@@ -37,7 +37,7 @@ chmod u+x sentry-prevent-cli_${platformSuffix}
 
 export function InstallPreventCLIStep({step}: InstallPreventCLIStepProps) {
   const [method, setMethod] = useState<Method>('pip');
-  const [selectedPlatform, setSelectedPlatform] = useState<Platform>('macOS');
+  const [selectedPlatform, setSelectedPlatform] = useState<Platform>('linux_arm64');
 
   const headerText = tct(
     'Step [step]: Install the [preventLink] to your CI environment',

--- a/static/app/views/prevent/tests/tests.tsx
+++ b/static/app/views/prevent/tests/tests.tsx
@@ -9,6 +9,7 @@ import {DateSelector} from 'sentry/components/prevent/dateSelector/dateSelector'
 import {IntegratedOrgSelector} from 'sentry/components/prevent/integratedOrgSelector/integratedOrgSelector';
 import {RepoSelector} from 'sentry/components/prevent/repoSelector/repoSelector';
 import {TestSuiteDropdown} from 'sentry/components/prevent/testSuiteDropdown/testSuiteDropdown';
+import {getPreventParamsString} from 'sentry/components/prevent/utils';
 import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {decodeSorts} from 'sentry/utils/queryString';
@@ -84,9 +85,12 @@ function Content({response}: TestResultsContentData) {
 
   useEffect(() => {
     if (!repoData?.testAnalyticsEnabled && isSuccess) {
-      navigate('/prevent/tests/new');
+      const queryString = getPreventParamsString(location);
+      navigate(`/prevent/tests/new${queryString ? `?${queryString}` : ''}`, {
+        replace: true,
+      });
     }
-  }, [repoData?.testAnalyticsEnabled, navigate, isSuccess]);
+  }, [repoData?.testAnalyticsEnabled, navigate, isSuccess, location]);
 
   const sorts: [ValidSort] = [
     decodeSorts(location.query?.sort).find(isAValidSort) ?? DEFAULT_SORT,


### PR DESCRIPTION
Fixes "Clicking org redirects back to previous org" bug and fixes a small install step text change to set the default platform to linux arm64.

A problem is occurring that makes it so you can't switch to certain orgs if the last remembered repo for that org is not test analytics enabled yet.

Scenario:
- User switches to that org with repo remembered.
- We check to see if repo is test analytics enabled. If not, we redirect to /new.
- On /new, we render onboarding page using preventContext. preventContext still returns the previous org and repo. So we check again if that org and repo have test analytics enabled, we get true and that redirects back to test results page.

This change carries over the new integrated org and repo query params on redirect instead of throwing them away.