### PR TITLE
feat(span-first): Add dashboard widget migration

### DIFF
--- a/src/sentry/explore/translation/dashboards_translation.py
+++ b/src/sentry/explore/translation/dashboards_translation.py
@@ -61,6 +61,9 @@ def translate_dashboard_widget(widget: DashboardWidget) -> DashboardWidget:
             )
         )
 
+        dropped_cols = dropped_fields["selected_columns"]
+        dropped_equations = [dropped["equation"] for dropped in dropped_fields["equations"]]
+
         new_conditions = eap_query_parts["query"] or ""
         new_orderby = eap_query_parts["orderby"][0] if eap_query_parts["orderby"] else ""
 
@@ -77,7 +80,7 @@ def translate_dashboard_widget(widget: DashboardWidget) -> DashboardWidget:
         equation_index = 0
         for old_index, field in enumerate(original_fields):
             is_selected_aggregate = selected_aggregate_field == field
-            if field in dropped_fields["selected_columns"] or field in dropped_fields["equations"]:
+            if field in dropped_cols or field in dropped_equations:
                 if is_selected_aggregate:
                     new_selected_aggregate = 0
                 continue
@@ -128,7 +131,7 @@ def translate_dashboard_widget(widget: DashboardWidget) -> DashboardWidget:
         DashboardWidgetQuery.objects.filter(widget_id=widget.id).delete()
         DashboardWidgetQuery.objects.bulk_create(new_widget_queries)
 
-    widget.changed_reason = {"reason": dropped_fields_info}
+    widget.changed_reason = dropped_fields_info
     widget.save()
 
     return widget

--- a/src/sentry/explore/translation/dashboards_translation.py
+++ b/src/sentry/explore/translation/dashboards_translation.py
@@ -1,0 +1,128 @@
+from sentry.api.serializers.base import serialize
+from sentry.discover.arithmetic import is_equation, is_equation_alias
+from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_eap
+from sentry.explore.translation.discover_translation import _format_orderby_for_translation
+from sentry.models.dashboard_widget import (
+    DashboardWidget,
+    DashboardWidgetQuery,
+    DashboardWidgetTypes,
+)
+from sentry.search.events.fields import is_function
+
+
+def snapshot_widget(widget: DashboardWidget):
+    if widget.widget_type != DashboardWidgetTypes.TRANSACTION_LIKE:
+        return
+
+    serialized_widget = serialize(widget)
+    serialized_widget["dateCreated"] = serialized_widget["dateCreated"].timestamp()
+    widget.widget_snapshot = serialized_widget
+    widget.save()
+
+
+def translate_dashboard_widget(widget: DashboardWidget) -> DashboardWidget:
+    snapshot_widget(widget)
+
+    if not widget.widget_snapshot:
+        return
+
+    transaction_widget = widget.widget_snapshot
+    new_widget_queries = []
+    dropped_fields_info = []
+    for q_index, query in enumerate(transaction_widget["queries"]):
+        name = query.get("name", "")
+        original_fields = query.get("fields", [])
+        orderby = query.get("orderby", "")
+        conditions = query.get("conditions", "")
+        field_aliases = query.get("fieldAliases", [])
+        is_hidden = query.get("isHidden", [])
+        selected_aggregate = query.get("selectedAggregate", None)
+
+        equations = [field for field in original_fields if is_equation(field)]
+        other_fields = [field for field in original_fields if not is_equation(field)]
+
+        fields_with_orderby = original_fields[:]
+        if orderby and is_equation_alias(orderby):
+            fields_with_orderby.append(orderby)
+
+        eap_query_parts, dropped_fields = translate_mep_to_eap(
+            QueryParts(
+                selected_columns=other_fields,
+                query=conditions,
+                equations=equations,
+                orderby=(
+                    _format_orderby_for_translation(orderby, fields_with_orderby)
+                    if orderby
+                    else None
+                ),
+            )
+        )
+
+        new_conditions = eap_query_parts["query"] or ""
+        new_orderby = eap_query_parts["orderby"][0] if eap_query_parts["orderby"] else ""
+
+        new_fields = []
+        new_columns = []
+        new_aggregates = []
+        new_aliases = []
+        new_selected_aggregate = None
+        selected_aggregate_field = (
+            original_fields[selected_aggregate] if selected_aggregate is not None else None
+        )
+
+        col_index = 0
+        equation_index = 0
+        for old_index, field in enumerate(original_fields):
+            is_selected_aggregate = selected_aggregate_field == field
+            if field in dropped_fields["selected_columns"] or field in dropped_fields["equations"]:
+                if is_selected_aggregate:
+                    new_selected_aggregate = 0
+                continue
+
+            is_equation_field = is_equation(field)
+            is_function_field = is_function(field)
+
+            if is_equation_field:
+                new_fields.append(eap_query_parts["equations"][equation_index])
+                new_aggregates.append(eap_query_parts["equations"][equation_index])
+                equation_index += 1
+
+            elif is_function_field:
+                new_fields.append(eap_query_parts["selected_columns"][col_index])
+                new_aggregates.append(eap_query_parts["selected_columns"][col_index])
+                col_index += 1
+
+            else:
+                new_fields.append(eap_query_parts["selected_columns"][col_index])
+                new_columns.append(eap_query_parts["selected_columns"][col_index])
+                col_index += 1
+
+            if is_selected_aggregate:
+                new_selected_aggregate = len(new_fields) - 1
+
+            if len(field_aliases) == len(original_fields):
+                new_aliases.append(field_aliases[old_index])
+
+        new_widget_queries.append(
+            DashboardWidgetQuery(
+                widget_id=widget.id,
+                order=q_index,
+                name=name,
+                fields=new_fields,
+                conditions=new_conditions,
+                aggregates=new_aggregates,
+                columns=new_columns,
+                field_aliases=new_aliases,
+                orderby=new_orderby,
+                is_hidden=is_hidden,
+                selected_aggregate=new_selected_aggregate,
+            )
+        )
+
+        dropped_fields_info.append(dropped_fields)
+
+    DashboardWidgetQuery.objects.filter(widget_id=widget.id).delete()
+    DashboardWidgetQuery.objects.bulk_create(new_widget_queries)
+
+    widget.changed_reason = {"reason": dropped_fields_info}
+    widget.save()

--- a/src/sentry/explore/translation/dashboards_translation.py
+++ b/src/sentry/explore/translation/dashboards_translation.py
@@ -24,7 +24,7 @@ def translate_dashboard_widget(widget: DashboardWidget) -> DashboardWidget:
     snapshot_widget(widget)
 
     if not widget.widget_snapshot:
-        return
+        return widget
 
     transaction_widget = widget.widget_snapshot
     new_widget_queries = []
@@ -126,3 +126,5 @@ def translate_dashboard_widget(widget: DashboardWidget) -> DashboardWidget:
 
     widget.changed_reason = {"reason": dropped_fields_info}
     widget.save()
+
+    return widget

--- a/tests/sentry/explore/translation/test_dashboard_translation.py
+++ b/tests/sentry/explore/translation/test_dashboard_translation.py
@@ -68,6 +68,7 @@ class DashboardTranslationTestCase(TestCase):
         assert new_queries.count() == 1
 
         new_query = new_queries.first()
+        assert new_query is not None
         assert new_query.widget_id == transaction_widget.id
         assert new_query.order == 0
         assert new_query.fields == ["release", "count(span.duration)", "count_unique(user)"]
@@ -109,6 +110,7 @@ class DashboardTranslationTestCase(TestCase):
         assert new_queries.count() == 1
 
         new_query = new_queries.first()
+        assert new_query is not None
         assert new_query.widget_id == transaction_widget.id
         assert new_query.order == 0
 
@@ -162,6 +164,7 @@ class DashboardTranslationTestCase(TestCase):
         assert new_queries.count() == 1
 
         new_query = new_queries.first()
+        assert new_query is not None
         assert new_query.widget_id == transaction_widget.id
         assert new_query.order == 0
 
@@ -224,6 +227,7 @@ class DashboardTranslationTestCase(TestCase):
         assert new_queries.count() == 1
 
         new_query = new_queries.first()
+        assert new_query is not None
         assert new_query.widget_id == transaction_widget.id
         assert new_query.order == 0
 

--- a/tests/sentry/explore/translation/test_dashboard_translation.py
+++ b/tests/sentry/explore/translation/test_dashboard_translation.py
@@ -1,0 +1,246 @@
+from datetime import datetime
+
+import pytest
+
+from sentry.explore.translation.dashboards_translation import translate_dashboard_widget
+from sentry.models.dashboard import Dashboard
+from sentry.models.dashboard_widget import (
+    DashboardWidget,
+    DashboardWidgetDisplayTypes,
+    DashboardWidgetQuery,
+    DashboardWidgetTypes,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.silo import assume_test_silo_mode_of
+from sentry.users.models.user import User
+
+pytestmark = pytest.mark.sentry_metrics
+
+
+class DashboardTranslationTestCase(TestCase):
+    @property
+    def now(self) -> datetime:
+        return before_now(minutes=10)
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.org = self.create_organization()
+        with assume_test_silo_mode_of(User):
+            self.user = User.objects.create(email="test@sentry.io")
+        self.project_2 = self.create_project(organization=self.org)
+        self.project_3 = self.create_project(organization=self.org)
+
+        self.dashboard = Dashboard.objects.create(
+            title="Dashboard With Split Widgets",
+            created_by_id=self.user.id,
+            organization=self.organization,
+        )
+        self.dashboard.projects.set([self.project, self.project_2])
+
+    def test_simple_case(self) -> None:
+        transaction_widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=0,
+            title="transaction widget",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=DashboardWidgetTypes.TRANSACTION_LIKE,
+            interval="1d",
+            detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+        )
+        query = DashboardWidgetQuery.objects.create(
+            widget=transaction_widget,
+            fields=["release", "count()", "count_unique(user)"],
+            columns=["release"],
+            aggregates=["count()", "count_unique(user)"],
+            conditions="transaction:foo",
+            order=0,
+        )
+
+        translate_dashboard_widget(transaction_widget)
+        transaction_widget.refresh_from_db()
+
+        assert transaction_widget.widget_snapshot
+        assert transaction_widget.changed_reason is not None
+        assert "reason" in transaction_widget.changed_reason
+
+        new_queries = DashboardWidgetQuery.objects.filter(widget=transaction_widget)
+        assert new_queries.count() == 1
+
+        new_query = new_queries.first()
+        assert new_query.widget_id == transaction_widget.id
+        assert new_query.order == 0
+        assert new_query.fields == ["release", "count(span.duration)", "count_unique(user)"]
+        assert new_query.conditions == "(transaction:foo) AND is_transaction:1"
+        assert new_query.aggregates == ["count(span.duration)", "count_unique(user)"]
+        assert new_query.columns == ["release"]
+
+        assert not DashboardWidgetQuery.objects.filter(id=query.id).exists()
+
+    def test_field_order_preserved(self) -> None:
+        transaction_widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=0,
+            title="transaction widget",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=DashboardWidgetTypes.TRANSACTION_LIKE,
+            interval="1d",
+            detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+        )
+        query = DashboardWidgetQuery.objects.create(
+            widget=transaction_widget,
+            fields=["release", "count()", "total.count", "count_unique(user)"],
+            columns=["release", "total.count"],
+            field_aliases=["Release", "Count", "Total Count", "Unique User"],
+            aggregates=["count()", "count_unique(user)"],
+            conditions="transaction:foo",
+            orderby="total.count",
+            order=0,
+        )
+
+        translate_dashboard_widget(transaction_widget)
+        transaction_widget.refresh_from_db()
+
+        assert transaction_widget.widget_snapshot
+        assert transaction_widget.changed_reason is not None
+        assert "reason" in transaction_widget.changed_reason
+
+        new_queries = DashboardWidgetQuery.objects.filter(widget=transaction_widget)
+        assert new_queries.count() == 1
+
+        new_query = new_queries.first()
+        assert new_query.widget_id == transaction_widget.id
+        assert new_query.order == 0
+
+        assert new_query.fields == ["release", "count(span.duration)", "count_unique(user)"]
+        assert new_query.conditions == "(transaction:foo) AND is_transaction:1"
+        assert new_query.aggregates == ["count(span.duration)", "count_unique(user)"]
+        assert new_query.columns == ["release"]
+        assert new_query.field_aliases == ["Release", "Count", "Unique User"]
+        assert new_query.orderby == ""
+
+        assert not DashboardWidgetQuery.objects.filter(id=query.id).exists()
+
+    def test_equations_index_notation_orderby(self) -> None:
+        transaction_widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=0,
+            title="transaction widget",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=DashboardWidgetTypes.TRANSACTION_LIKE,
+            interval="1d",
+            detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+        )
+        query = DashboardWidgetQuery.objects.create(
+            widget=transaction_widget,
+            fields=[
+                "transaction",
+                "equation|count_if(transaction.duration,less,300)",
+                "equation|count_if(transaction.duration,greater,300)",
+                "count_unique(user)",
+            ],
+            columns=["transaction"],
+            field_aliases=["Txn", "Count Fast Txn", "Count Slow Txn", "Unique User"],
+            aggregates=[
+                "equation|count_if(transaction.duration,less,300)",
+                "equation|count_if(transaction.duration,greater,300)",
+                "count_unique(user)",
+            ],
+            conditions="",
+            orderby="-equation[1]",
+            order=0,
+        )
+
+        translate_dashboard_widget(transaction_widget)
+        transaction_widget.refresh_from_db()
+
+        assert transaction_widget.widget_snapshot
+        assert transaction_widget.changed_reason is not None
+        assert "reason" in transaction_widget.changed_reason
+
+        new_queries = DashboardWidgetQuery.objects.filter(widget=transaction_widget)
+        assert new_queries.count() == 1
+
+        new_query = new_queries.first()
+        assert new_query.widget_id == transaction_widget.id
+        assert new_query.order == 0
+
+        assert new_query.fields == [
+            "transaction",
+            "equation|count_if(span.duration,less,300)",
+            "equation|count_if(span.duration,greater,300)",
+            "count_unique(user)",
+        ]
+        assert new_query.conditions == "is_transaction:1"
+        assert new_query.aggregates == [
+            "equation|count_if(span.duration,less,300)",
+            "equation|count_if(span.duration,greater,300)",
+            "count_unique(user)",
+        ]
+        assert new_query.columns == ["transaction"]
+        assert new_query.field_aliases == ["Txn", "Count Fast Txn", "Count Slow Txn", "Unique User"]
+        assert new_query.orderby == "-equation[1]"
+
+        assert not DashboardWidgetQuery.objects.filter(id=query.id).exists()
+
+    def test_equations_alias_notation_orderby(self) -> None:
+        transaction_widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=0,
+            title="transaction widget",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=DashboardWidgetTypes.TRANSACTION_LIKE,
+            interval="1d",
+            detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+        )
+        query = DashboardWidgetQuery.objects.create(
+            widget=transaction_widget,
+            fields=[
+                "transaction",
+                "equation|count_if(transaction.duration,less,300)",
+                "equation|count_if(transaction.duration,greater,300)",
+                "count_unique(user)",
+            ],
+            columns=["transaction"],
+            field_aliases=["Txn", "Count Fast Txn", "Count Slow Txn", "Unique User"],
+            aggregates=[
+                "equation|count_if(transaction.duration,less,300)",
+                "equation|count_if(transaction.duration,greater,300)",
+                "count_unique(user)",
+            ],
+            conditions="",
+            orderby="-equation|count() / 100",
+            order=0,
+        )
+
+        translate_dashboard_widget(transaction_widget)
+        transaction_widget.refresh_from_db()
+
+        assert transaction_widget.widget_snapshot
+        assert transaction_widget.changed_reason is not None
+        assert "reason" in transaction_widget.changed_reason
+
+        new_queries = DashboardWidgetQuery.objects.filter(widget=transaction_widget)
+        assert new_queries.count() == 1
+
+        new_query = new_queries.first()
+        assert new_query.widget_id == transaction_widget.id
+        assert new_query.order == 0
+
+        assert new_query.fields == [
+            "transaction",
+            "equation|count_if(span.duration,less,300)",
+            "equation|count_if(span.duration,greater,300)",
+            "count_unique(user)",
+        ]
+        assert new_query.conditions == "is_transaction:1"
+        assert new_query.aggregates == [
+            "equation|count_if(span.duration,less,300)",
+            "equation|count_if(span.duration,greater,300)",
+            "count_unique(user)",
+        ]
+        assert new_query.columns == ["transaction"]
+        assert new_query.field_aliases == ["Txn", "Count Fast Txn", "Count Slow Txn", "Unique User"]
+        assert new_query.orderby == "-equation|count(span.duration) / 100"
+
+        assert not DashboardWidgetQuery.objects.filter(id=query.id).exists()


### PR DESCRIPTION
Adds a function that takes in a dashboard widget, stores a snapshot and translates the widget query.