### PR TITLE
fix(deletions): GroupHash pointing to group in deletion should detatch

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -434,6 +434,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:symbol-sources", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enable tracking of tombstone hits. When enabled, the feature increments the times_seen column and updates the last_seen timestamp
     manager.add("organizations:grouptombstones-hit-counter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable preventing group hashes from being associated with groups in deletion in progress
+    manager.add("organizations:group-deletion-in-progress", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable static ClickHouse sampling for `OrganizationTagsEndpoint`
     manager.add("organizations:tag-key-sample-n", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable team workflow notifications

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -435,7 +435,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable tracking of tombstone hits. When enabled, the feature increments the times_seen column and updates the last_seen timestamp
     manager.add("organizations:grouptombstones-hit-counter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preventing group hashes from being associated with groups in deletion in progress
-    manager.add("organizations:group-deletion-in-progress", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:no-group-match-when-deletion-in-progress", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable static ClickHouse sampling for `OrganizationTagsEndpoint`
     manager.add("organizations:tag-key-sample-n", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable team workflow notifications

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -232,7 +232,9 @@ def get_or_create_grouphashes(
         hashes = filter(lambda hash_value: hash_value in existing_hashes, hashes)
 
     for hash_value in hashes:
-        grouphash, created = GroupHash.objects.get_or_create(project=project, hash=hash_value)
+        grouphash, created = GroupHash.objects.get_or_create(
+            project=project, hash=hash_value
+        ).select_related("group")
         if features.has("organizations:group-deletion-in-progress", project.organization):
             # If the group a group hash is associated with is in deletion in progress, we don't
             # want to associate the group hash with it so we can create a new group for the event
@@ -242,7 +244,7 @@ def get_or_create_grouphashes(
             ]:
                 # This will cause a new group to be created
                 grouphash.group = None
-                grouphash.save()
+                grouphash.save(update_fields=["group"])
 
         if options.get("grouping.grouphash_metadata.ingestion_writes_enabled"):
             try:

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -249,7 +249,6 @@ def get_or_create_grouphashes(
             ]:
                 # This will cause a new group to be created
                 grouphash.group = None
-                grouphash.save(update_fields=["group"])
 
         if options.get("grouping.grouphash_metadata.ingestion_writes_enabled"):
             try:

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -249,6 +249,7 @@ def get_or_create_grouphashes(
             ]:
                 # This will cause a new group to be created
                 grouphash.group = None
+                grouphash.save()
 
         if options.get("grouping.grouphash_metadata.ingestion_writes_enabled"):
             try:

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -231,7 +231,7 @@ def get_or_create_grouphashes(
         )
         hashes = filter(lambda hash_value: hash_value in existing_hashes, hashes)
 
-    do_not_associate_with_group = features.has(
+    detach_in_deletion_groups = features.has(
         "organizations:group-deletion-in-progress", project.organization
     )
 

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -232,9 +232,10 @@ def get_or_create_grouphashes(
         hashes = filter(lambda hash_value: hash_value in existing_hashes, hashes)
 
     for hash_value in hashes:
-        grouphash, created = GroupHash.objects.get_or_create(
+        # Fetching the group with the grouphash is necessary to avoid N+1 queries
+        grouphash, created = GroupHash.objects.select_related("group").get_or_create(
             project=project, hash=hash_value
-        ).select_related("group")
+        )
         if features.has("organizations:group-deletion-in-progress", project.organization):
             # If the group a group hash is associated with is in deletion in progress, we don't
             # want to associate the group hash with it so we can create a new group for the event

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -218,40 +218,21 @@ def get_or_create_grouphashes(
     grouping_config_id: str,
 ) -> list[GroupHash]:
     is_secondary = grouping_config_id == project.get_option("sentry:secondary_grouping_config")
-    hashes_list = list(hashes)
+    grouphashes: list[GroupHash] = []
 
     if is_secondary:
         # The only utility of secondary hashes is to link new primary hashes to an existing group
         # via an existing grouphash. Secondary hashes which are new are therefore of no value, so
         # filter them out before creating grouphash records.
         existing_hashes = set(
-            GroupHash.objects.filter(project=project, hash__in=hashes_list).values_list(
+            GroupHash.objects.filter(project=project, hash__in=hashes).values_list(
                 "hash", flat=True
             )
         )
-        hashes_list = [hash_value for hash_value in hashes_list if hash_value in existing_hashes]
+        hashes = filter(lambda hash_value: hash_value in existing_hashes, hashes)
 
-    # First, fetch existing grouphashes with their groups to avoid N+1 queries
-    existing_grouphashes = {
-        gh.hash: gh
-        for gh in GroupHash.objects.filter(project=project, hash__in=hashes_list).select_related(
-            "group"
-        )
-    }
-
-    # Create grouphashes for missing hashes
-    missing_hashes = [h for h in hashes_list if h not in existing_grouphashes]
-    new_grouphashes = {}
-    for hash_value in missing_hashes:
+    for hash_value in hashes:
         grouphash, created = GroupHash.objects.get_or_create(project=project, hash=hash_value)
-        new_grouphashes[hash_value] = grouphash
-
-    # Combine existing and new grouphashes, maintaining order
-    grouphashes: list[GroupHash] = []
-    for hash_value in hashes_list:
-        grouphash = existing_grouphashes.get(hash_value) or new_grouphashes[hash_value]
-        created = hash_value in new_grouphashes
-
         if features.has("organizations:group-deletion-in-progress", project.organization):
             # If the group a group hash is associated with is in deletion in progress, we don't
             # want to associate the group hash with it so we can create a new group for the event

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -240,7 +240,7 @@ def get_or_create_grouphashes(
         grouphash, created = GroupHash.objects.select_related("group").get_or_create(
             project=project, hash=hash_value
         )
-        if do_not_associate_with_group:
+        if detach_in_deletion_groups:
             # If the group a group hash is associated with is in deletion in progress, we don't
             # want to associate the group hash with it so we can create a new group for the event
             if grouphash.group and grouphash.group.status in [

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -232,7 +232,7 @@ def get_or_create_grouphashes(
         hashes = filter(lambda hash_value: hash_value in existing_hashes, hashes)
 
     detach_in_deletion_groups = features.has(
-        "organizations:group-deletion-in-progress", project.organization
+        "organizations:no-group-match-when-deletion-in-progress", project.organization
     )
 
     for hash_value in hashes:

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -143,12 +143,11 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         new_event = self.store_event(data=data, project_id=self.project.id)
         new_event_hash = new_event.get_primary_hash()
         assert new_event_hash == first_event_hash
-        assert new_event.group_id != group.id
         assert GroupHash.objects.get(group_id=new_event.group_id).group_id != group.id
         assert new_event.group_id != group.id
 
     @with_feature("organizations:group-deletion-in-progress")
-    def test_group_in_deletion_in_progress_should_create_new_group(self) -> None:
+    def test_group_in_deletion_in_progress_should_create_new_group_when_flag_on(self) -> None:
         data = {"timestamp": before_now(minutes=1).isoformat()}
 
         event = self.store_event(data=data, project_id=self.project.id)

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -156,12 +156,13 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         group = event.group
         first_event_hash = event.get_primary_hash()
 
-        # New events will still be associated with the group in deletion in progress
+        # New events will create a new group since the group is in deletion in progress
         group.update(status=GroupStatus.DELETION_IN_PROGRESS, substatus=None)
         group.save()
         new_event = self.store_event(data=data, project_id=self.project.id)
         # The new event has the same hash as the first event
         assert new_event.get_primary_hash() == first_event_hash
+        # The existing group hash will be associated to the new group
         assert GroupHash.objects.get(group_id=new_event.group_id).group_id != group.id
         assert new_event.group_id != group.id
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -120,6 +120,51 @@ class EventManagerTestMixin:
 
 
 class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, PerformanceIssueTestCase):
+    def test_group_in_deletion_in_progress_should_not_create_new_group(self) -> None:
+        data = {"timestamp": before_now(minutes=1).isoformat()}
+
+        event = self.store_event(data=data, project_id=self.project.id)
+        assert event.group_id is not None
+        group = event.group
+        first_event_hash = event.get_primary_hash()
+
+        # New events will still be associated with the group in deletion in progress
+        group.update(status=GroupStatus.DELETION_IN_PROGRESS, substatus=None)
+        group.save()
+        new_event = self.store_event(data=data, project_id=self.project.id)
+        # The new event has the same hash as the first event
+        assert new_event.get_primary_hash() == first_event_hash
+        assert GroupHash.objects.get(group_id=new_event.group_id).group_id == group.id
+        assert new_event.group_id == group.id
+
+        # Now, if the group hash is deleted then the group will create a new group
+        assert len(GroupHash.objects.filter(group_id=group.id)) == 1
+        GroupHash.objects.get(group_id=group.id).delete()
+        new_event = self.store_event(data=data, project_id=self.project.id)
+        new_event_hash = new_event.get_primary_hash()
+        assert new_event_hash == first_event_hash
+        assert new_event.group_id != group.id
+        assert GroupHash.objects.get(group_id=new_event.group_id).group_id != group.id
+        assert new_event.group_id != group.id
+
+    @with_feature("organizations:group-deletion-in-progress")
+    def test_group_in_deletion_in_progress_should_create_new_group(self) -> None:
+        data = {"timestamp": before_now(minutes=1).isoformat()}
+
+        event = self.store_event(data=data, project_id=self.project.id)
+        assert event.group_id is not None
+        group = event.group
+        first_event_hash = event.get_primary_hash()
+
+        # New events will still be associated with the group in deletion in progress
+        group.update(status=GroupStatus.DELETION_IN_PROGRESS, substatus=None)
+        group.save()
+        new_event = self.store_event(data=data, project_id=self.project.id)
+        # The new event has the same hash as the first event
+        assert new_event.get_primary_hash() == first_event_hash
+        assert GroupHash.objects.get(group_id=new_event.group_id).group_id != group.id
+        assert new_event.group_id != group.id
+
     def test_ephemeral_interfaces_removed_on_save(self) -> None:
         manager = EventManager(make_event(platform="python"))
         manager.normalize()

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -146,7 +146,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert GroupHash.objects.get(group_id=new_event.group_id).group_id != group.id
         assert new_event.group_id != group.id
 
-    @with_feature("organizations:group-deletion-in-progress")
+    @with_feature("organizations:no-group-match-when-deletion-in-progress")
     def test_group_in_deletion_in_progress_should_create_new_group_when_flag_on(self) -> None:
         data = {"timestamp": before_now(minutes=1).isoformat()}
 


### PR DESCRIPTION
If a group is being deleted, there's the possibility of an event to be processed and re-create a __deleted__ group hash before the group is fully deleted, thus, preventing the creation of new groups.

Whenever this gets fully rolled out, I expect a large spike of groups to be created since we have over 70k groups pending deletion (this is a known issue we're working on). We can roll this out slowly to avoid stress.