### PR TITLE
ref(prevent-ui): replace useState + useEffect with derived state

### DIFF
--- a/static/app/components/prevent/branchSelector/branchSelector.tsx
+++ b/static/app/components/prevent/branchSelector/branchSelector.tsx
@@ -18,7 +18,6 @@ const ALL_BRANCHES = 'All Branches';
 export function BranchSelector() {
   const {branch, integratedOrgId, repository, preventPeriod, changeContextValue} =
     usePreventContext();
-  const [displayedBranches, setDisplayedBranches] = useState<string[]>([]);
   const [searchValue, setSearchValue] = useState<string | undefined>();
 
   const {data, isFetching, isLoading} = useInfiniteRepositoryBranches({
@@ -48,6 +47,11 @@ export function BranchSelector() {
     [setSearchValue]
   );
 
+  const displayedBranches = useMemo(
+    () => (isFetching ? [] : (branches?.map(item => item.name) ?? [])),
+    [branches, isFetching]
+  );
+
   const options = useMemo((): Array<SelectOption<string>> => {
     if (isFetching) {
       return [];
@@ -69,13 +73,6 @@ export function BranchSelector() {
 
     return [...optionSet].map(makeOption);
   }, [branch, displayedBranches, isFetching]);
-
-  useEffect(() => {
-    // Only update displayedBranches if the hook returned something non-empty
-    if (!isFetching) {
-      setDisplayedBranches((branches ?? []).map(item => item.name));
-    }
-  }, [branches, isFetching]);
 
   useEffect(() => {
     // Create a use effect to cancel handleOnSearch fn on unmount to avoid memory leaks

--- a/static/app/components/prevent/repoSelector/repoSelector.tsx
+++ b/static/app/components/prevent/repoSelector/repoSelector.tsx
@@ -70,7 +70,6 @@ function MenuFooter({repoAccessLink}: MenuFooterProps) {
 export function RepoSelector() {
   const {repository, integratedOrgId, preventPeriod, changeContextValue} =
     usePreventContext();
-  const [displayedRepos, setDisplayedRepos] = useState<string[]>([]);
   const organization = useOrganization();
 
   const [searchValue, setSearchValue] = useState<string | undefined>();
@@ -117,6 +116,11 @@ export function RepoSelector() {
     [setSearchValue]
   );
 
+  const displayedRepos = useMemo(
+    () => (isFetching ? [] : (repositories?.map(item => item.name) ?? [])),
+    [repositories, isFetching]
+  );
+
   const options = useMemo((): Array<SelectOption<string>> => {
     const repoSet = new Set([...(repository ? [repository] : []), ...displayedRepos]);
 
@@ -142,13 +146,6 @@ export function RepoSelector() {
 
     return t('No repositories found');
   }
-
-  useEffect(() => {
-    // Only update displayedRepos if the hook returned something non-empty
-    if (!isFetching) {
-      setDisplayedRepos((repositories ?? []).map(item => item.name));
-    }
-  }, [isFetching, repositories]);
 
   useEffect(() => {
     // Create a use effect to cancel handleOnSearch fn on unmount to avoid memory leaks


### PR DESCRIPTION
when the state setter of `useState` is only used inside an effect, we can simply replace it with derived state.

I’ve adapted the usages in `prevent` because of an upcoming eslint rule change and this was an easy fix.