### PR TITLE
fix(performance): Fix Transaction Summary threshold modal error not displaying properly

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionThresholdModal.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdModal.tsx
@@ -104,8 +104,11 @@ class TransactionThresholdModal extends Component<Props, State> {
         this.setState({
           error: err,
         });
-        const errorMessage =
+        let errorMessage =
           err.responseJSON?.threshold ?? err.responseJSON?.non_field_errors ?? null;
+        if (Array.isArray(errorMessage)) {
+          errorMessage = errorMessage[0];
+        }
         addErrorMessage(errorMessage);
       });
   };


### PR DESCRIPTION
Fixes a scenario where saving transaction threshold settings doesn't properly display errors.

<img width="382" height="118" alt="image" src="https://github.com/user-attachments/assets/6074bc04-0644-4d76-a28c-9a3506ace35f" />
