### PR TITLE
ref(ui): use react-query in WaitingForEvents

### DIFF
--- a/static/app/components/waitingForEvents.tsx
+++ b/static/app/components/waitingForEvents.tsx
@@ -1,15 +1,15 @@
-import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
+import {skipToken, useQuery} from '@tanstack/react-query';
 
 import waitingForEventImg from 'sentry-images/spot/waiting-for-event.svg';
 
+import {apiOptions} from 'sentry/api/apiOptions';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Link} from 'sentry/components/core/link';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import useApi from 'sentry/utils/useApi';
 import CreateSampleEventButton from 'sentry/views/onboarding/createSampleEventButton';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
@@ -26,43 +26,23 @@ type Props = {
 };
 
 function WaitingForEvents({org, project, sampleIssueId: sampleIssueIdProp}: Props) {
-  const api = useApi();
+  const {data, error, isPending} = useQuery(
+    apiOptions.as<Array<{id: string}>>()('/projects/$orgSlug/$projectSlug/issues/', {
+      staleTime: Infinity,
+      path:
+        project && sampleIssueIdProp === undefined
+          ? {
+              orgSlug: org.slug,
+              projectSlug: project.slug,
+            }
+          : skipToken,
+    })
+  );
 
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<boolean | string>(false);
-  const [sampleIssueId, setSampleIssueId] = useState(sampleIssueIdProp);
-
-  useEffect(() => {
-    async function loadSampleData() {
-      if (!project) {
-        return;
-      }
-
-      if (sampleIssueIdProp !== undefined) {
-        return;
-      }
-
-      setLoading(true);
-
-      try {
-        const data = await api.requestPromise(
-          `/projects/${org.slug}/${project.slug}/issues/`,
-          {
-            method: 'GET',
-            data: {limit: 1},
-          }
-        );
-        setSampleIssueId((data.length > 0 && data[0].id) || '');
-      } catch (err: any) {
-        setError(err?.responseJSON?.detail ?? true);
-      }
-    }
-
-    loadSampleData();
-  }, [api, org, project, sampleIssueIdProp]);
+  const sampleIssueId = sampleIssueIdProp ?? data?.[0]?.id ?? '';
 
   const sampleLink =
-    project && (loading || error ? null : sampleIssueId) ? (
+    project && (isPending || error ? null : sampleIssueId) ? (
       <p>
         <Link to={`/${org.slug}/${project.slug}/issues/${sampleIssueId}/?sample`}>
           {t('Or see your sample event')}

--- a/static/app/components/waitingForEvents.tsx
+++ b/static/app/components/waitingForEvents.tsx
@@ -29,6 +29,7 @@ function WaitingForEvents({org, project, sampleIssueId: sampleIssueIdProp}: Prop
   const {data, error, isPending} = useQuery(
     apiOptions.as<Array<{id: string}>>()('/projects/$orgSlug/$projectSlug/issues/', {
       staleTime: Infinity,
+      data: {limit: 1},
       path:
         project && sampleIssueIdProp === undefined
           ? {


### PR DESCRIPTION
`api.requestPromise` is deprecated, and this usage triggered an additional eslint error for a new plugin I’m evaluating, so I thought it would be a good candidate to refactor towards react-query.