### PR TITLE
feat(insights): add "add to dashboard" button for generic insight chart

### DIFF
--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -190,4 +190,5 @@ export enum DashboardWidgetSource {
   ISSUE_DETAILS = 'issueDetail',
   TRACE_EXPLORER = 'traceExplorer',
   LOGS = 'logs',
+  INSIGHTS = 'insights',
 }

--- a/static/app/views/insights/common/components/chartActionDropdown.tsx
+++ b/static/app/views/insights/common/components/chartActionDropdown.tsx
@@ -1,16 +1,31 @@
+import {useCallback} from 'react';
+import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
+import Feature from 'sentry/components/acl/feature';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {NewQuery} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {getIntervalForTimeSeriesQuery} from 'sentry/utils/timeSeries/getIntervalForTimeSeriesQuery';
-import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import useRouter from 'sentry/utils/useRouter';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {
+  DashboardWidgetSource,
+  DEFAULT_WIDGET_NAME,
+  WidgetType,
+} from 'sentry/views/dashboards/types';
+import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {CHART_TYPE_TO_DISPLAY_TYPE} from 'sentry/views/explore/hooks/useAddToDashboard';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import type {ChartType} from 'sentry/views/insights/common/components/chart';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
@@ -81,10 +96,19 @@ export function ChartActionDropdown({
     };
   });
 
+  const addToDashboardOptions: AddToDashboardOptions = {
+    chartType,
+    yAxes,
+    widgetName: title ?? DEFAULT_WIDGET_NAME,
+    groupBy,
+    search,
+  };
+
   return (
     <BaseChartActionDropdown
       alertMenuOptions={alertsUrls}
       exploreUrl={exploreUrl}
+      addToDashboardOptions={addToDashboardOptions}
       referrer={referrer}
     />
   );
@@ -94,14 +118,18 @@ type BaseProps = {
   alertMenuOptions: MenuItemProps[];
   exploreUrl: LocationDescriptor;
   referrer: string;
+  addToDashboardOptions?: AddToDashboardOptions;
 };
 
 export function BaseChartActionDropdown({
   alertMenuOptions,
   exploreUrl,
   referrer,
+  addToDashboardOptions,
 }: BaseProps) {
   const organization = useOrganization();
+  const hasDashboardEdit = organization.features.includes('dashboards-edit');
+  const {addToDashboard} = useAddToDashboard();
 
   const menuOptions: MenuItemProps[] = [
     {
@@ -135,6 +163,27 @@ export function BaseChartActionDropdown({
     });
   }
 
+  if (addToDashboardOptions) {
+    menuOptions.push({
+      key: 'add-to-dashboard',
+      label: (
+        <Feature
+          hookName="feature-disabled:dashboards-edit"
+          features="organizations:dashboards-edit"
+          renderDisabled={() => <DisabledText>{t('Add to Dashboard')}</DisabledText>}
+        >
+          {t('Add to Dashboard')}
+        </Feature>
+      ),
+      textValue: t('Add to Dashboard'),
+      onAction: () => {
+        addToDashboard(addToDashboardOptions);
+      },
+      isSubmenu: false,
+      disabled: !hasDashboardEdit,
+    });
+  }
+
   return (
     <DropdownMenu
       items={menuOptions}
@@ -149,3 +198,64 @@ export function BaseChartActionDropdown({
     />
   );
 }
+
+type AddToDashboardOptions = {
+  chartType: ChartType;
+  widgetName: string;
+  yAxes: string[];
+  groupBy?: SpanFields[];
+  search?: MutableSearch;
+};
+
+const useAddToDashboard = () => {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const location = useLocation();
+  const router = useRouter();
+
+  const addToDashboard = useCallback(
+    ({
+      yAxes,
+      groupBy = [],
+      search = new MutableSearch(''),
+      chartType,
+      widgetName,
+    }: AddToDashboardOptions) => {
+      const fields = [...groupBy, ...yAxes];
+      const dataset = DiscoverDatasets.SPANS;
+
+      const discoverQuery: NewQuery = {
+        name: widgetName,
+        fields,
+        query: search.formatString(),
+        version: 2,
+        dataset,
+        yAxis: yAxes,
+      };
+
+      const eventView = EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
+      eventView.dataset = dataset;
+      eventView.display = CHART_TYPE_TO_DISPLAY_TYPE[chartType];
+
+      handleAddQueryToDashboard({
+        eventView,
+        organization,
+        yAxis: yAxes,
+        query: discoverQuery,
+        location,
+        router,
+        source: DashboardWidgetSource.INSIGHTS,
+        widgetType: WidgetType.SPANS,
+      });
+    },
+    [organization, selection, location, router]
+  );
+
+  return {
+    addToDashboard,
+  };
+};
+
+const DisabledText = styled('span')`
+  color: ${p => p.theme.disabled};
+`;

--- a/static/app/views/insights/common/components/chartActionDropdown.tsx
+++ b/static/app/views/insights/common/components/chartActionDropdown.tsx
@@ -1,4 +1,3 @@
-import {useCallback} from 'react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
@@ -7,28 +6,21 @@ import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {NewQuery} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import EventView from 'sentry/utils/discover/eventView';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {getIntervalForTimeSeriesQuery} from 'sentry/utils/timeSeries/getIntervalForTimeSeriesQuery';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useRouter from 'sentry/utils/useRouter';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
-import {
-  DashboardWidgetSource,
-  DEFAULT_WIDGET_NAME,
-  WidgetType,
-} from 'sentry/views/dashboards/types';
-import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
+import {DEFAULT_WIDGET_NAME} from 'sentry/views/dashboards/types';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {CHART_TYPE_TO_DISPLAY_TYPE} from 'sentry/views/explore/hooks/useAddToDashboard';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import type {ChartType} from 'sentry/views/insights/common/components/chart';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
+import {
+  useAddToSpanDashboard,
+  type AddToSpanDashboardOptions,
+} from 'sentry/views/insights/common/utils/useAddToSpanDashboard';
 import {useAlertsProject} from 'sentry/views/insights/common/utils/useAlertsProject';
 import type {SpanFields} from 'sentry/views/insights/types';
 
@@ -96,7 +88,7 @@ export function ChartActionDropdown({
     };
   });
 
-  const addToDashboardOptions: AddToDashboardOptions = {
+  const addToDashboardOptions: AddToSpanDashboardOptions = {
     chartType,
     yAxes,
     widgetName: title ?? DEFAULT_WIDGET_NAME,
@@ -118,7 +110,7 @@ type BaseProps = {
   alertMenuOptions: MenuItemProps[];
   exploreUrl: LocationDescriptor;
   referrer: string;
-  addToDashboardOptions?: AddToDashboardOptions;
+  addToDashboardOptions?: AddToSpanDashboardOptions;
 };
 
 export function BaseChartActionDropdown({
@@ -198,63 +190,6 @@ export function BaseChartActionDropdown({
     />
   );
 }
-
-type AddToDashboardOptions = {
-  chartType: ChartType;
-  widgetName: string;
-  yAxes: string[];
-  groupBy?: SpanFields[];
-  search?: MutableSearch;
-};
-
-const useAddToSpanDashboard = () => {
-  const organization = useOrganization();
-  const {selection} = usePageFilters();
-  const location = useLocation();
-  const router = useRouter();
-
-  const addToSpanDashboard = useCallback(
-    ({
-      yAxes,
-      groupBy = [],
-      search = new MutableSearch(''),
-      chartType,
-      widgetName,
-    }: AddToDashboardOptions) => {
-      const fields = [...groupBy, ...yAxes];
-      const dataset = DiscoverDatasets.SPANS;
-
-      const discoverQuery: NewQuery = {
-        name: widgetName,
-        fields,
-        query: search.formatString(),
-        version: 2,
-        dataset,
-        yAxis: yAxes,
-      };
-
-      const eventView = EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
-      eventView.dataset = dataset;
-      eventView.display = CHART_TYPE_TO_DISPLAY_TYPE[chartType];
-
-      handleAddQueryToDashboard({
-        eventView,
-        organization,
-        yAxis: yAxes,
-        query: discoverQuery,
-        location,
-        router,
-        source: DashboardWidgetSource.INSIGHTS,
-        widgetType: WidgetType.SPANS,
-      });
-    },
-    [organization, selection, location, router]
-  );
-
-  return {
-    addToSpanDashboard,
-  };
-};
 
 const DisabledText = styled('span')`
   color: ${p => p.theme.disabled};

--- a/static/app/views/insights/common/components/chartActionDropdown.tsx
+++ b/static/app/views/insights/common/components/chartActionDropdown.tsx
@@ -129,7 +129,7 @@ export function BaseChartActionDropdown({
 }: BaseProps) {
   const organization = useOrganization();
   const hasDashboardEdit = organization.features.includes('dashboards-edit');
-  const {addToDashboard} = useAddToDashboard();
+  const {addToSpanDashboard} = useAddToSpanDashboard();
 
   const menuOptions: MenuItemProps[] = [
     {
@@ -177,7 +177,7 @@ export function BaseChartActionDropdown({
       ),
       textValue: t('Add to Dashboard'),
       onAction: () => {
-        addToDashboard(addToDashboardOptions);
+        addToSpanDashboard(addToDashboardOptions);
       },
       isSubmenu: false,
       disabled: !hasDashboardEdit,
@@ -207,13 +207,13 @@ type AddToDashboardOptions = {
   search?: MutableSearch;
 };
 
-const useAddToDashboard = () => {
+const useAddToSpanDashboard = () => {
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const location = useLocation();
   const router = useRouter();
 
-  const addToDashboard = useCallback(
+  const addToSpanDashboard = useCallback(
     ({
       yAxes,
       groupBy = [],
@@ -252,7 +252,7 @@ const useAddToDashboard = () => {
   );
 
   return {
-    addToDashboard,
+    addToSpanDashboard,
   };
 };
 

--- a/static/app/views/insights/common/utils/useAddToSpanDashboard.ts
+++ b/static/app/views/insights/common/utils/useAddToSpanDashboard.ts
@@ -1,0 +1,72 @@
+import {useCallback} from 'react';
+
+import type {NewQuery} from 'sentry/types/organization';
+import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useRouter from 'sentry/utils/useRouter';
+import {DashboardWidgetSource, WidgetType} from 'sentry/views/dashboards/types';
+import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
+import {CHART_TYPE_TO_DISPLAY_TYPE} from 'sentry/views/explore/hooks/useAddToDashboard';
+import type {ChartType} from 'sentry/views/insights/common/components/chart';
+import type {SpanFields} from 'sentry/views/insights/types';
+
+export type AddToSpanDashboardOptions = {
+  chartType: ChartType;
+  widgetName: string;
+  yAxes: string[];
+  groupBy?: SpanFields[];
+  search?: MutableSearch;
+};
+
+export const useAddToSpanDashboard = () => {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const location = useLocation();
+  const router = useRouter();
+
+  const addToSpanDashboard = useCallback(
+    ({
+      yAxes,
+      groupBy = [],
+      search = new MutableSearch(''),
+      chartType,
+      widgetName,
+    }: AddToSpanDashboardOptions) => {
+      const fields = [...groupBy, ...yAxes];
+      const dataset = DiscoverDatasets.SPANS;
+
+      const discoverQuery: NewQuery = {
+        name: widgetName,
+        fields,
+        query: search.formatString(),
+        version: 2,
+        dataset,
+        yAxis: yAxes,
+      };
+
+      const eventView = EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
+      eventView.dataset = dataset;
+      eventView.display = CHART_TYPE_TO_DISPLAY_TYPE[chartType];
+
+      handleAddQueryToDashboard({
+        eventView,
+        organization,
+        yAxis: yAxes,
+        query: discoverQuery,
+        location,
+        router,
+        source: DashboardWidgetSource.INSIGHTS,
+        widgetType: WidgetType.SPANS,
+      });
+    },
+    [organization, selection, location, router]
+  );
+
+  return {
+    addToSpanDashboard,
+  };
+};


### PR DESCRIPTION
Add the "add to dashboard" button to the generic insight chart alongside the explore/alert links. Note, there are instances where we manually generate explore/alert links, in those cases we'll have to manually create the dashboard link, but that can be done in a follow up pr.