### PR TITLE
ref(flags): change graph widget back to release line

### DIFF
--- a/static/app/components/featureFlags/featureFlagsLogTable.tsx
+++ b/static/app/components/featureFlags/featureFlagsLogTable.tsx
@@ -1,4 +1,5 @@
-import {Fragment, useCallback} from 'react';
+import {useCallback} from 'react';
+import styled from '@emotion/styled';
 
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {getFlagActionLabel, type RawFlag} from 'sentry/components/featureFlags/utils';
@@ -60,7 +61,7 @@ export function FeatureFlagsLogTable({
   );
 
   return (
-    <Fragment>
+    <div>
       <GridEditable
         error={error}
         isLoading={isPending}
@@ -78,8 +79,8 @@ export function FeatureFlagsLogTable({
         data-test-id="audit-log-table"
       />
 
-      <Pagination pageLinks={pageLinks} onCursor={handlePageChange} />
-    </Fragment>
+      <PaginationNoMargin pageLinks={pageLinks} onCursor={handlePageChange} />
+    </div>
   );
 }
 
@@ -103,3 +104,7 @@ function renderBodyCell(
       return dataRow[column.key];
   }
 }
+
+const PaginationNoMargin = styled(Pagination)`
+  margin: 0;
+`;

--- a/static/app/components/featureFlags/hooks/useFlagSeries.tsx
+++ b/static/app/components/featureFlags/hooks/useFlagSeries.tsx
@@ -29,7 +29,7 @@ export function useFlagSeries({event, flags}: FlagSeriesProps) {
   const markLine = MarkLine({
     animation: false,
     lineStyle: {
-      color: theme.blue400,
+      color: theme.pink200,
       opacity: 0.3,
       type: 'solid',
     },
@@ -75,7 +75,7 @@ export function useFlagSeries({event, flags}: FlagSeriesProps) {
     seriesName: t('Feature Flags'),
     id: 'flag-lines',
     data: [],
-    color: theme.blue400,
+    color: theme.pink200,
     markLine,
     type: 'line', // use this type so the bar chart doesn't shrink/grow
   };

--- a/static/app/components/featureFlags/hooks/useFlagSeries.tsx
+++ b/static/app/components/featureFlags/hooks/useFlagSeries.tsx
@@ -29,7 +29,7 @@ export function useFlagSeries({event, flags}: FlagSeriesProps) {
   const markLine = MarkLine({
     animation: false,
     lineStyle: {
-      color: theme.pink200,
+      color: theme.pink300,
       opacity: 0.3,
       type: 'solid',
     },
@@ -75,7 +75,7 @@ export function useFlagSeries({event, flags}: FlagSeriesProps) {
     seriesName: t('Feature Flags'),
     id: 'flag-lines',
     data: [],
-    color: theme.pink200,
+    color: theme.pink300,
     markLine,
     type: 'line', // use this type so the bar chart doesn't shrink/grow
   };

--- a/static/app/views/issueDetails/streamline/eventGraphWidget.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraphWidget.tsx
@@ -91,7 +91,7 @@ function EventGraphLoadedWidget({
           eventView={eventView}
           group={group}
           showSummary={false}
-          showReleasesAs="bubble"
+          showReleasesAs="line" // this is intentionally set to line, for more granularity
           disableZoomNavigation
         />
       }

--- a/static/app/views/issueDetails/streamline/hooks/useReleaseMarkLineSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useReleaseMarkLineSeries.tsx
@@ -91,7 +91,7 @@ export function useReleaseMarkLineSeries({
     seriesName: t('Releases'),
     data: [],
     markLine,
-    color: theme.purple200,
+    color: theme.purple400,
     type: 'line',
   };
 }

--- a/static/app/views/releases/drawer/releasesDrawerTable.tsx
+++ b/static/app/views/releases/drawer/releasesDrawerTable.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -197,7 +197,7 @@ export function ReleasesDrawerTable({
   );
 
   return (
-    <Fragment>
+    <div>
       <GridEditable
         error={isError}
         isLoading={isLoading}
@@ -221,7 +221,7 @@ export function ReleasesDrawerTable({
           });
         }}
       />
-    </Fragment>
+    </div>
   );
 }
 

--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -184,7 +184,7 @@ function ReleaseBubbleSeries({
         // in the "padding" areas (i.e. so tooltips open)
         lineWidth: bubblePadding,
         stroke: 'transparent',
-        fill: theme.blue400,
+        fill: theme.purple400,
         // TODO: figure out correct opacity calculations
         opacity: Math.round((Number(numberReleases) / avgReleases) * 50) / 100,
       },
@@ -198,7 +198,7 @@ function ReleaseBubbleSeries({
     renderItem: renderReleaseBubble,
     name: t('Releases'),
     data,
-    color: theme.blue300,
+    color: theme.purple300,
     animation: false,
     markLine: {
       silent: true,
@@ -517,7 +517,7 @@ export function useReleaseBubbles({
           type: 'custom',
           renderItem: () => null,
           markArea: {
-            itemStyle: {color: theme.blue400, opacity: 0.1},
+            itemStyle: {color: theme.purple400, opacity: 0.1},
             data: [
               [
                 {
@@ -644,7 +644,7 @@ export function useReleaseBubbles({
       legendSelected,
       releaseBubbleGrid,
       releaseBubbleXAxis,
-      theme.blue400,
+      theme.purple400,
     ]
   );
 

--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -198,7 +198,7 @@ function ReleaseBubbleSeries({
     renderItem: renderReleaseBubble,
     name: t('Releases'),
     data,
-    color: theme.purple300,
+    color: theme.purple400,
     animation: false,
     markLine: {
       silent: true,


### PR DESCRIPTION
blue is no longer in our new ui2 color palette, so switch the flag line color to pink.

## before (old ui):
- releases on the drawer were bubbles
- both releases & flags were blue

<img width="1400" height="364" alt="SCR-20250922-igdi" src="https://github.com/user-attachments/assets/17ae02cc-6d1c-454b-a79d-a87bae8e7f73" />

## after (old ui):
- releases on the drawer are lines
- flags are consistently pink, releases are consistently purple

<img width="1364" height="365" alt="SCR-20250922-isyh" src="https://github.com/user-attachments/assets/24dbc398-9abc-498f-8a63-a597f622f37f" />


## before flag table on release drawer was not rendering:

<img width="716" height="721" alt="SCR-20250922-igdy" src="https://github.com/user-attachments/assets/8222f34c-d6fa-48a5-a400-8c69683661b4" />

## after fix rendering of flag table on release drawer:

<img width="725" height="302" alt="SCR-20250922-ifxv" src="https://github.com/user-attachments/assets/f5f9d6b2-8439-4589-88c5-a27b5e77099e" />

## after (new ui): 
<img width="1374" height="415" alt="SCR-20250922-isoc" src="https://github.com/user-attachments/assets/9ea56b97-7bf7-40db-8cfd-0d07fb6cb6fa" />


