### PR TITLE
fix(performance): Fixes an issue on the Transaction Summary Sampled Events table with sorting by http method

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -110,8 +110,12 @@ function EventsContent(props: Props) {
     if (platform === ProjectPerformanceType.BACKEND) {
       const userIndex = transactionsListTitles.indexOf('user');
       if (userIndex > 0) {
-        transactionsListTitles.splice(userIndex + 1, 0, 'http.method');
-        fields.splice(userIndex + 1, 0, {field: 'http.method'});
+        if (!transactionsListTitles.includes('http.method')) {
+          transactionsListTitles.splice(userIndex + 1, 0, 'http.method');
+        }
+        if (!fields.some(f => f.field === 'http.method')) {
+          fields.splice(userIndex + 1, 0, {field: 'http.method'});
+        }
       }
     }
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
@@ -240,10 +240,13 @@ function generateEventView({
     }
   });
 
+  const orderby = decodeScalar(location.query.sort, '-timestamp');
+
   // Default fields for relative span view
   const fields = [
     'id',
     'user.display',
+    ...(orderby.endsWith('http.method') ? ['http.method'] : []),
     SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
     'transaction.duration',
     'trace',
@@ -268,7 +271,7 @@ function generateEventView({
       fields,
       query: conditions.formatString(),
       projects: [],
-      orderby: decodeScalar(location.query.sort, '-timestamp'),
+      orderby,
     },
     location
   );


### PR DESCRIPTION
Fixes an issue where the user is unable to sort by http method. This is due to the EventView dropping the `http.method` orderby during creation, since the `http.method` field only gets added to the EventView post creation (based on the transaction platform). Updates so that we always include `http.method` as a selected field if the orderby would contain `http.method`.