### PR TITLE
fix(span-first): Update widget type and dataset source

### DIFF
--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -110,6 +110,10 @@ class DatasetSourcesTypes(Enum):
      Dataset inferred by split script, version 2
     """
     SPLIT_VERSION_2 = 5
+    """
+     Dataset modified by transaction -> span migration
+    """
+    SPAN_MIGRATION_VERSION_1 = 6
 
     @classmethod
     def as_choices(cls):

--- a/tests/sentry/explore/translation/test_dashboard_translation.py
+++ b/tests/sentry/explore/translation/test_dashboard_translation.py
@@ -9,6 +9,7 @@ from sentry.models.dashboard_widget import (
     DashboardWidgetDisplayTypes,
     DashboardWidgetQuery,
     DashboardWidgetTypes,
+    DatasetSourcesTypes,
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -88,6 +89,12 @@ class DashboardTranslationTestCase(TestCase):
         assert new_query.conditions == "(transaction:foo) AND is_transaction:1"
         assert new_query.aggregates == ["count(span.duration)", "count_unique(user)"]
         assert new_query.columns == ["release"]
+
+        # Assert widget type and dataset source are set correctly
+        assert transaction_widget.widget_type == DashboardWidgetTypes.SPANS
+        assert (
+            transaction_widget.dataset_source == DatasetSourcesTypes.SPAN_MIGRATION_VERSION_1.value
+        )
 
         assert not DashboardWidgetQuery.objects.filter(id=query.id).exists()
 


### PR DESCRIPTION
I forgot to update widget type after the translation! Also tracking the
"source" so it's easy to identify the span widgets that were created
by the migration.