### PR TITLE
fix(dashboards): add spacing between groupBy key/value in timeseriesname

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.spec.tsx
@@ -100,6 +100,17 @@ describe('ContinuousTimeSeries', () => {
       expect(plottable.end).toBe(1729798200000);
     });
   });
+
+  describe('name', () => {
+    it('name is properly formatted', () => {
+      const timeSeries = TimeSeriesFixture({
+        groupBy: [{key: 'release', value: 'v0.0.2'}],
+      });
+
+      const plottable = new Dots(timeSeries);
+      expect(plottable.name).toBe('eps() : release : v0.0.2');
+    });
+  });
 });
 
 class Dots extends ContinuousTimeSeries implements Plottable {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
@@ -67,7 +67,7 @@ export abstract class ContinuousTimeSeries<
     if (this.timeSeries.groupBy?.length) {
       name += ` : ${this.timeSeries.groupBy
         ?.map(groupBy => {
-          return `${groupBy.key}:${groupBy.value}`;
+          return `${groupBy.key} : ${groupBy.value}`;
         })
         .join(',')}`;
     }


### PR DESCRIPTION
Adds a space between the groupBy key and value to make things a little easier to read

Before
<img width="627" height="137" alt="image" src="https://github.com/user-attachments/assets/ce12be5c-3a18-4a44-b439-58c9d5760fdc" />


After
<img width="629" height="143" alt="image" src="https://github.com/user-attachments/assets/06995f8e-7fc8-47ab-9528-4ebd79d1beea" />
