### PR TITLE
ref(analytics): modernize some onboarding related analytics.record calls

### DIFF
--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -11,6 +11,7 @@ from sentry.analytics.events.cron_monitor_created import CronMonitorCreated, Fir
 from sentry.analytics.events.first_cron_checkin_sent import FirstCronCheckinSent
 from sentry.analytics.events.first_event_sent import (
     FirstEventSentEvent,
+    FirstEventSentEventWithMinifiedStackTraceForProject,
     FirstEventSentForProjectEvent,
 )
 from sentry.analytics.events.first_feedback_sent import FirstFeedbackSentEvent
@@ -19,8 +20,12 @@ from sentry.analytics.events.first_insight_span_sent import FirstInsightSpanSent
 from sentry.analytics.events.first_log_sent import FirstLogSentEvent
 from sentry.analytics.events.first_new_feedback_sent import FirstNewFeedbackSentEvent
 from sentry.analytics.events.first_profile_sent import FirstProfileSentEvent
+from sentry.analytics.events.first_release_tag_sent import FirstReleaseTagSentEvent
 from sentry.analytics.events.first_replay_sent import FirstReplaySentEvent
-from sentry.analytics.events.first_sourcemaps_sent import FirstSourcemapsSentEvent
+from sentry.analytics.events.first_sourcemaps_sent import (
+    FirstSourcemapsSentEvent,
+    FirstSourcemapsSentEventForProject,
+)
 from sentry.analytics.events.first_transaction_sent import FirstTransactionSentEvent
 from sentry.analytics.events.member_invited import MemberInvitedEvent
 from sentry.analytics.events.project_created import ProjectCreatedEvent
@@ -388,10 +393,11 @@ def record_release_received(project, release, **kwargs):
             return
 
         analytics.record(
-            "first_release_tag.sent",
-            user_id=owner_id,
-            project_id=project.id,
-            organization_id=project.organization_id,
+            FirstReleaseTagSentEvent(
+                user_id=owner_id,
+                project_id=project.id,
+                organization_id=project.organization_id,
+            )
         )
 
 
@@ -412,13 +418,14 @@ def record_event_with_first_minified_stack_trace_for_project(project, event, **k
 
     if project.date_added > START_DATE_TRACKING_FIRST_EVENT_WITH_MINIFIED_STACK_TRACE_PER_PROJ:
         analytics.record(
-            "first_event_with_minified_stack_trace_for_project.sent",
-            user_id=owner_id,
-            organization_id=project.organization_id,
-            project_id=project.id,
-            platform=event.platform,
-            project_platform=project.platform,
-            url=dict(event.tags).get("url", None),
+            FirstEventSentEventWithMinifiedStackTraceForProject(
+                user_id=owner_id,
+                organization_id=project.organization_id,
+                project_id=project.id,
+                platform=event.platform,
+                project_platform=project.platform,
+                url=dict(event.tags).get("url", None),
+            )
         )
 
 
@@ -479,13 +486,14 @@ def record_sourcemaps_received_for_project(project, event, **kwargs):
 
         if project.date_added > START_DATE_TRACKING_FIRST_SOURCEMAP_PER_PROJ and affected > 0:
             analytics.record(
-                "first_sourcemaps_for_project.sent",
-                user_id=owner_id,
-                organization_id=project.organization_id,
-                project_id=project.id,
-                platform=event.platform,
-                project_platform=project.platform,
-                url=dict(event.tags).get("url", None),
+                FirstSourcemapsSentEventForProject(
+                    user_id=owner_id,
+                    organization_id=project.organization_id,
+                    project_id=project.id,
+                    platform=event.platform,
+                    project_platform=project.platform,
+                    url=dict(event.tags).get("url", None),
+                )
             )
 
 

--- a/src/sentry/testutils/helpers/analytics.py
+++ b/src/sentry/testutils/helpers/analytics.py
@@ -113,6 +113,11 @@ def get_event_count(
     expected_event_type: type[Event],
     exact: bool = False,
 ) -> int:
+    """
+    Get the number of events recorded for a given event type.
+    If exact is True, only events of the exact type will be counted.
+    If exact is False, events of the exact type or a subclass will be counted.
+    """
     if exact:
         return len(
             [

--- a/src/sentry/testutils/helpers/analytics.py
+++ b/src/sentry/testutils/helpers/analytics.py
@@ -106,3 +106,26 @@ def assert_analytics_events(
     with patch("sentry.analytics.record") as mock_record:
         yield
         assert_analytics_events_recorded(mock_record, expected_events, exclude_fields)
+
+
+def get_event_count(
+    mock_record: MagicMock,
+    expected_event_type: type[Event] | tuple[type[Event], ...],
+    exact: bool = False,
+) -> int:
+    if exact:
+        return len(
+            [
+                call
+                for call in mock_record.call_args_list
+                if type(call.args[0]) is expected_event_type
+            ]
+        )
+    else:
+        return len(
+            [
+                call
+                for call in mock_record.call_args_list
+                if isinstance(call.args[0], expected_event_type)
+            ]
+        )

--- a/src/sentry/testutils/helpers/analytics.py
+++ b/src/sentry/testutils/helpers/analytics.py
@@ -110,7 +110,7 @@ def assert_analytics_events(
 
 def get_event_count(
     mock_record: MagicMock,
-    expected_event_type: type[Event] | tuple[type[Event], ...],
+    expected_event_type: type[Event],
     exact: bool = False,
 ) -> int:
     if exact:

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -516,7 +516,7 @@ class OrganizationOnboardingTaskTest(TestCase):
 
         count = 0
         for call_arg in record_analytics.call_args_list:
-            if isinstance(call_arg[0], FirstEventSentEventWithMinifiedStackTraceForProject):
+            if isinstance(call_arg[0][0], FirstEventSentEventWithMinifiedStackTraceForProject):
                 count += 1
 
         assert count == 1
@@ -582,7 +582,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         # The analytic's event "first_event_with_minified_stack_trace_for_project" shall not be sent
         count = 0
         for call_arg in record_analytics.call_args_list:
-            if isinstance(call_arg[0], FirstEventSentEventWithMinifiedStackTraceForProject):
+            if isinstance(call_arg[0][0], FirstEventSentEventWithMinifiedStackTraceForProject):
                 count += 1
 
         assert count == 0
@@ -614,7 +614,7 @@ class OrganizationOnboardingTaskTest(TestCase):
 
         count = 0
         for call_arg in record_analytics.call_args_list:
-            if isinstance(call_arg[0], FirstSourcemapsSentEventForProject):
+            if isinstance(call_arg[0][0], FirstSourcemapsSentEventForProject):
                 count += 1
 
         assert count == 0
@@ -713,7 +713,7 @@ class OrganizationOnboardingTaskTest(TestCase):
 
         count = 0
         for call_arg in record_analytics.call_args_list:
-            if isinstance(call_arg[0], FirstSourcemapsSentEventForProject):
+            if isinstance(call_arg[0][0], FirstSourcemapsSentEventForProject):
                 count += 1
 
         assert count == 1
@@ -764,7 +764,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         # The analytic's event "first_event_with_minified_stack_trace_for_project" shall not be sent
         count = 0
         for call_arg in record_analytics.call_args_list:
-            if isinstance(call_arg[0], FirstSourcemapsSentEventForProject):
+            if isinstance(call_arg[0][0], FirstSourcemapsSentEventForProject):
                 count += 1
 
         assert count == 0


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/TET-1164/convert-missing-onboarding-analyticsrecord-calls