### PR TITLE
flags(insights): remove deprecated flags

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -88,13 +88,9 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
     owner = ApiOwner.VISIBILITY
 
     def has_feature(self, organization: Organization, request: Request) -> bool:
-        return (
-            features.has("organizations:discover-basic", organization, actor=request.user)
-            or features.has("organizations:performance-view", organization, actor=request.user)
-            or features.has(
-                "organizations:performance-issues-all-events-tab", organization, actor=request.user
-            )
-        )
+        return features.has(
+            "organizations:discover-basic", organization, actor=request.user
+        ) or features.has("organizations:performance-view", organization, actor=request.user)
 
     def get_equation_list(
         self, organization: Organization, request: Request, param_name: str = "field"

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -88,9 +88,13 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
     owner = ApiOwner.VISIBILITY
 
     def has_feature(self, organization: Organization, request: Request) -> bool:
-        return features.has(
-            "organizations:discover-basic", organization, actor=request.user
-        ) or features.has("organizations:performance-view", organization, actor=request.user)
+        return (
+            features.has("organizations:discover-basic", organization, actor=request.user)
+            or features.has("organizations:performance-view", organization, actor=request.user)
+            or features.has(
+                "organizations:visibility-explore-view", organization, actor=request.user
+            )
+        )
 
     def get_equation_list(
         self, organization: Organization, request: Request, param_name: str = "field"

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -244,8 +244,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-discover-widget-split-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables setting the fetch all custom measurements request time range to match the user selected time range instead of 90 days
     manager.add("organizations:performance-discover-get-custom-measurements-reduced-range", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enables updated all events tab in a performance issue
-    manager.add("organizations:performance-issues-all-events-tab", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Temporary flag to test search performance that's running slow in S4S
     manager.add("organizations:performance-issues-search", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
     # Detect performance issues in the new standalone spans pipeline instead of on transactions
@@ -412,8 +410,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:insights-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable access to Mobile Screens insights module
     manager.add("organizations:insights-mobile-screens-module", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Removes performance landing page from sidebar and updates transaction summary breadcrumbs for insights
-    manager.add("organizations:insights-performance-landing-removal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Seer Webhooks to be sent and listened to
     manager.add("organizations:seer-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new SentryApp webhook request endpoint


### PR DESCRIPTION
Removes some unused/deprecated flags
1. `performance-issues-all-events-tab` - this feature doesn't even exists anymore
2. `insights-performance-landing-removal` this feature has 100% GAd and the flag is unused

Corresponding sentry PR https://github.com/getsentry/sentry-options-automator/pull/5227