### PR TITLE
ref(ui): remove unnecessary isOpen state

### DIFF
--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -16,7 +16,6 @@ import type {Block, ExplorerPanelProps} from './types';
 function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
   const organization = useOrganization({allowNull: true});
 
-  const [isOpen, setIsOpen] = useState(isVisible);
   const [inputValue, setInputValue] = useState('');
   const [focusedBlockIndex, setFocusedBlockIndex] = useState(-1); // -1 means input is focused
   const [showSlashCommands, setShowSlashCommands] = useState(false);
@@ -33,7 +32,7 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
   const blocks = useMemo(() => sessionData?.blocks || [], [sessionData]);
 
   useBlockNavigation({
-    isOpen,
+    isOpen: isVisible,
     focusedBlockIndex,
     blocks,
     blockRefs,
@@ -43,7 +42,6 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
   });
 
   useEffect(() => {
-    setIsOpen(isVisible);
     // Focus textarea when panel opens and reset focus
     if (isVisible) {
       setFocusedBlockIndex(-1);
@@ -126,7 +124,7 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
 
   const panelContent = (
     <PanelContainers
-      isOpen={isOpen}
+      isOpen={isVisible}
       panelSize={panelSize}
       blocks={blocks}
       onSubmit={sendMessage}


### PR DESCRIPTION
the value is initialized with isVisible, and the only place the state updater is called is in an effect that keeps it in-sync with isVisible

that means we can just use `isVisible` instead everywhere and remove both the state and the effect
