### PR TITLE
chore(aci): remove dual processing flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -520,8 +520,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:workflow-engine-issue-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable workflow processing for metric issues
     manager.add("organizations:workflow-engine-process-metric-issue-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable workflow engine for issue alerts
-    manager.add("organizations:workflow-engine-process-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable single processing through workflow engine for issue alerts
     manager.add("organizations:workflow-engine-single-process-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable logging to debug workflow engine process workflows

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -149,16 +149,11 @@ class LogConfig:
 
     # Cached value of features.has("projects:num-events-issue-debugging", project)
     num_events_issue_debugging: bool
-    # Cached value of features.has("organizations:workflow-engine-process-workflows", organization)
-    workflow_engine_process_workflows: bool
 
     @classmethod
     def create(cls, project: Project) -> "LogConfig":
         return cls(
             num_events_issue_debugging=features.has("projects:num-events-issue-debugging", project),
-            workflow_engine_process_workflows=features.has(
-                "organizations:workflow-engine-process-workflows", project.organization
-            ),
         )
 
 

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -527,7 +527,7 @@ def fire_rules(
         group_to_groupevent = get_group_to_groupevent(
             log_config, parsed_rulegroup_to_event_data, project_id, groups_to_fire
         )
-        if log_config.num_events_issue_debugging or log_config.workflow_engine_process_workflows:
+        if log_config.num_events_issue_debugging:
             serialized_groups = {
                 group.id: group_event.event_id
                 for group, (group_event, _) in group_to_groupevent.items()

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -604,10 +604,7 @@ def fire_rules(
                         rule, group, groupevent.event_id, notification_uuid
                     )
 
-                    if (
-                        log_config.workflow_engine_process_workflows
-                        or log_config.num_events_issue_debugging
-                    ):
+                    if log_config.num_events_issue_debugging:
                         logger.info(
                             "post_process.delayed_processing.triggered_rule",
                             extra={
@@ -727,7 +724,7 @@ def apply_delayed(project_id: int, batch_key: str | None = None, *args: Any, **k
     ):
         condition_group_results = get_condition_group_results(condition_groups, project)
 
-    if log_config.workflow_engine_process_workflows or log_config.num_events_issue_debugging:
+    if log_config.num_events_issue_debugging:
         serialized_results = (
             {str(query): count_dict for query, count_dict in condition_group_results.items()}
             if condition_group_results
@@ -754,10 +751,7 @@ def apply_delayed(project_id: int, batch_key: str | None = None, *args: Any, **k
             rules_to_fire = get_rules_to_fire(
                 condition_group_results, rules_to_slow_conditions, rules_to_groups, project.id
             )
-            if (
-                log_config.workflow_engine_process_workflows
-                or log_config.num_events_issue_debugging
-            ):
+            if log_config.num_events_issue_debugging:
                 logger.info(
                     "delayed_processing.rules_to_fire",
                     extra={

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -11,7 +11,7 @@ from typing import Any
 from django.core.cache import cache
 from django.utils import timezone
 
-from sentry import analytics, buffer, features
+from sentry import analytics, buffer
 from sentry.analytics.events.issue_alert_fired import IssueAlertFiredEvent
 from sentry.models.environment import Environment
 from sentry.models.group import Group
@@ -184,21 +184,6 @@ def activate_downstream_actions(
                 grouped_futures[key] = (future.callback, [rule_future])
             else:
                 grouped_futures[key][1].append(rule_future)
-
-    if features.has(
-        "organizations:workflow-engine-process-workflows",
-        rule.project.organization,
-    ):
-        if is_post_process:
-            logger_name = "post_process.process_rules.triggered_actions"
-        else:
-            logger_name = "post_process.delayed_processing.triggered_actions"
-
-        metrics.incr(
-            logger_name,
-            amount=instantiated_actions,
-            tags={"event_type": event.group.type},
-        )
 
     return grouped_futures
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1021,6 +1021,16 @@ def process_workflow_engine(job: PostProcessJob) -> None:
         return
 
 
+def _should_single_process_event(job: PostProcessJob) -> bool:
+    org = job["event"].project.organization
+
+    return (
+        features.has("organizations:workflow-engine-single-process-workflows", org)
+        and job["event"].group.type
+        in options.get("workflow_engine.issue_alert.group.type_id.rollout")
+    ) or job["event"].group.type in options.get("workflow_engine.issue_alert.group.type_id.ga")
+
+
 def process_workflow_engine_issue_alerts(job: PostProcessJob) -> None:
     """
     Call for process_workflow_engine with the issue alert feature flag
@@ -1028,12 +1038,8 @@ def process_workflow_engine_issue_alerts(job: PostProcessJob) -> None:
     if job["is_reprocessed"]:
         return
 
-    org = job["event"].project.organization
-
     # process workflow engine if we are single processing or dual processing for a specific org
-    if features.has("organizations:workflow-engine-single-process-workflows", org) or features.has(
-        "organizations:workflow-engine-process-workflows", org
-    ):
+    if _should_single_process_event(job):
         process_workflow_engine(job)
 
 
@@ -1058,14 +1064,8 @@ def process_rules(job: PostProcessJob) -> None:
     if job["is_reprocessed"]:
         return
 
-    org = job["event"].project.organization
-
-    if (
-        features.has("organizations:workflow-engine-single-process-workflows", org)
-        and job["event"].group.type
-        in options.get("workflow_engine.issue_alert.group.type_id.rollout")
-    ) or job["event"].group.type in options.get("workflow_engine.issue_alert.group.type_id.ga"):
-        # we are only processing through the workflow engine
+    if _should_single_process_event(job):
+        # we are only processing through workflow engine
         return
 
     metrics.incr(
@@ -1096,10 +1096,9 @@ def process_rules(job: PostProcessJob) -> None:
         # objects back and forth isn't super efficient
         callback_and_futures = rp.apply()
 
-        if not features.has("organizations:workflow-engine-trigger-actions", org):
-            for callback, futures in callback_and_futures:
-                has_alert = True
-                safe_execute(callback, group_event, futures)
+        for callback, futures in callback_and_futures:
+            has_alert = True
+            safe_execute(callback, group_event, futures)
 
     job["has_alert"] = has_alert
     return

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -415,9 +415,7 @@ class GetGroupToGroupEventTest(CreateEventTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.project = self.create_project()
-        self.log_config = LogConfig(
-            workflow_engine_process_workflows=True, num_events_issue_debugging=True
-        )
+        self.log_config = LogConfig(num_events_issue_debugging=True)
         self.rule = self.create_alert_rule(self.organization, [self.project])
 
         # Create some groups
@@ -1507,9 +1505,7 @@ class CleanupRedisBufferTest(CreateEventTestCase):
         self.project = self.create_project()
         self.group = self.create_group(self.project)
         self.rule = self.create_alert_rule()
-        self.log_config = LogConfig(
-            workflow_engine_process_workflows=True, num_events_issue_debugging=True
-        )
+        self.log_config = LogConfig(num_events_issue_debugging=True)
 
     def test_cleanup_redis(self) -> None:
         self.push_to_hash(self.project.id, self.rule.id, self.group.id)

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -17,6 +17,7 @@ from sentry.services.eventstore.processing import event_processing_store
 from sentry.tasks.post_process import post_process_group
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import Feature, with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.utils.cache import cache_key_for_event
 from sentry.workflow_engine import buffer
 from sentry.workflow_engine.models import Detector, DetectorWorkflow
@@ -215,10 +216,17 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
 
     @pytest.fixture(autouse=True)
     def with_feature_flags(self):
-        with Feature(
-            {
-                "organizations:workflow-engine-trigger-actions": True,
-            }
+        with (
+            Feature(
+                {
+                    "organizations:workflow-engine-single-process-workflows": True,
+                }
+            ),
+            override_options(
+                {
+                    "workflow_engine.issue_alert.group.type_id.rollout": [1],
+                }
+            ),
         ):
             yield
 

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -217,7 +217,6 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
     def with_feature_flags(self):
         with Feature(
             {
-                "organizations:workflow-engine-process-workflows": True,
                 "organizations:workflow-engine-trigger-actions": True,
             }
         ):


### PR DESCRIPTION
Use a single helper function to determine whether we send events through rules or workflow engine in post process (single processing).

Also removed checking organizations:workflow-engine-trigger-actions in post process as it was used to send notifications through workflow engine only while dual processing