### PR TITLE
fix(eventstore): Prevent lazy loading of project.organization

### DIFF
--- a/src/sentry/services/eventstore/models.py
+++ b/src/sentry/services/eventstore/models.py
@@ -293,7 +293,9 @@ class BaseEvent(metaclass=abc.ABCMeta):
         from sentry.models.project import Project
 
         if not hasattr(self, "_project_cache"):
-            self._project_cache = Project.objects.get(id=self.project_id)
+            self._project_cache = Project.objects.select_related("organization").get(
+                id=self.project_id
+            )
         return self._project_cache
 
     @project.setter


### PR DESCRIPTION
Add `select_related('organization')` to `Event.project` property to avoid N+1 database queries when accessing `project.organization`.

Before: 2 queries (Project + lazy-loaded Organization)
After: 1 query with JOIN (Project + Organization together)

This eliminates Django lazy-loading without caching that was causing performance issues in code paths that access event.project.organization.