### PR TITLE
fix: Remove test name sort behavior

### DIFF
--- a/static/app/views/prevent/tests/config.tsx
+++ b/static/app/views/prevent/tests/config.tsx
@@ -3,7 +3,6 @@ export const TABLE_FIELD_NAME_TO_SORT_KEY = {
   flakeRate: 'FLAKE_RATE',
   totalFailCount: 'RUNS_FAILED',
   lastRun: 'UPDATED_AT',
-  testName: 'NAME',
 };
 
 export const SUMMARY_TO_TA_TABLE_FILTER_KEY = {

--- a/static/app/views/prevent/tests/queries/useGetTestResults.spec.tsx
+++ b/static/app/views/prevent/tests/queries/useGetTestResults.spec.tsx
@@ -265,7 +265,7 @@ describe('useInfiniteTestResults', () => {
     };
 
     const mockSearchParams = new URLSearchParams(
-      'term=integration&filterBy=slowestTests&sort=testName'
+      'term=integration&filterBy=slowestTests&sort=totalFailCount'
     );
     jest.requireMock('react-router-dom').useSearchParams = () => [
       mockSearchParams,
@@ -278,7 +278,7 @@ describe('useInfiniteTestResults', () => {
       match: [
         MockApiClient.matchQuery({
           interval: 'INTERVAL_1_DAY', // from preventPeriod: '24h'
-          sortBy: 'NAME', // from sort: 'testName' (no '-' prefix means ascending)
+          sortBy: 'RUNS_FAILED', // from sort: 'totalFailCount' (no '-' prefix means ascending)
           branch: 'feature-branch', // from context
           term: 'integration', // from search params
           filterBy: 'SLOWEST_TESTS', // from filterBy: 'slowestTests'

--- a/static/app/views/prevent/tests/testAnalyticsTable/sortableHeader.spec.tsx
+++ b/static/app/views/prevent/tests/testAnalyticsTable/sortableHeader.spec.tsx
@@ -1,0 +1,145 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import SortableHeader from './sortableHeader';
+
+const mockLocation = {
+  pathname: '/prevent/tests/',
+  query: {},
+  search: '',
+  hash: '',
+  state: undefined,
+  action: 'POP' as const,
+  key: 'test',
+};
+
+jest.mock('sentry/utils/useLocation', () => ({
+  useLocation: () => mockLocation,
+}));
+
+describe('SortableHeader', () => {
+  const defaultProps = {
+    fieldName: 'averageDurationMs',
+    label: 'Avg. Duration',
+    alignment: 'right',
+    enableToggle: false,
+    sort: undefined,
+  };
+
+  const renderHeader = (props = {}) => {
+    return render(<SortableHeader {...defaultProps} {...props} />);
+  };
+
+  beforeEach(() => {
+    mockLocation.query = {};
+  });
+
+  describe('sortable fields', () => {
+    it('renders with correct label and as clickable link', () => {
+      renderHeader({fieldName: 'flakeRate', label: 'Flake Rate'});
+
+      const link = screen.getByRole('columnheader');
+      expect(link).toBeInTheDocument();
+      expect(link.tagName).toBe('A');
+      expect(screen.getByText('Flake Rate')).toBeInTheDocument();
+    });
+
+    it('shows no sort arrow when not sorted', () => {
+      renderHeader({fieldName: 'flakeRate', sort: undefined});
+
+      expect(screen.queryByRole('img')).not.toBeInTheDocument();
+      expect(screen.getByRole('columnheader')).toHaveAttribute('aria-sort', 'none');
+    });
+
+    it('shows ascending arrow when sorted ascending', () => {
+      renderHeader({
+        fieldName: 'totalFailCount',
+        sort: {field: 'totalFailCount', kind: 'asc'},
+      });
+
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(screen.getByRole('columnheader')).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    it('shows descending arrow when sorted descending', () => {
+      renderHeader({
+        fieldName: 'lastRun',
+        sort: {field: 'lastRun', kind: 'desc'},
+      });
+
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(screen.getByRole('columnheader')).toHaveAttribute('aria-sort', 'descending');
+    });
+
+    it('generates correct link for first click (no sort → descending)', () => {
+      renderHeader({fieldName: 'flakeRate'});
+
+      const link = screen.getByRole('columnheader');
+      expect(link).toHaveAttribute('href', '/prevent/tests/?sort=-flakeRate');
+    });
+
+    it('generates correct link for second click (descending → ascending)', () => {
+      renderHeader({
+        fieldName: 'flakeRate',
+        sort: {field: 'flakeRate', kind: 'desc'},
+      });
+
+      const link = screen.getByRole('columnheader');
+      expect(link).toHaveAttribute('href', '/prevent/tests/?sort=flakeRate');
+    });
+  });
+
+  describe('non-sortable fields', () => {
+    it('renders as plain text without link functionality', () => {
+      renderHeader({
+        fieldName: 'testName',
+        label: 'Test Name',
+      });
+
+      const header = screen.getByRole('columnheader');
+      expect(header).toBeInTheDocument();
+      expect(header.tagName).toBe('SPAN');
+      expect(header).not.toHaveAttribute('href');
+      expect(screen.getByText('Test Name')).toBeInTheDocument();
+    });
+  });
+
+  describe('query parameter handling', () => {
+    it('preserves other query parameters when changing sort', () => {
+      mockLocation.query = {
+        cursor: 'abc123',
+        integratedOrgId: 'org-123',
+        repository: 'test-repo',
+        branch: 'main',
+      };
+
+      renderHeader({fieldName: 'flakeRate'});
+
+      const link = screen.getByRole('columnheader');
+      const href = link.getAttribute('href');
+      expect(href).toContain('integratedOrgId=org-123');
+      expect(href).toContain('repository=test-repo');
+      expect(href).toContain('branch=main');
+      expect(href).toContain('sort=-flakeRate');
+    });
+
+    it('removes cursor and navigation params when sorting', () => {
+      mockLocation.query = {
+        cursor: 'abc123',
+        navigation: 'next',
+        integratedOrgId: 'org-123',
+        sort: '-flakeRate',
+      };
+
+      renderHeader({
+        fieldName: 'flakeRate',
+        sort: {field: 'flakeRate', kind: 'desc'},
+      });
+
+      const link = screen.getByRole('columnheader');
+      const href = link.getAttribute('href');
+      expect(href).not.toContain('cursor');
+      expect(href).not.toContain('navigation');
+      expect(href).toContain('integratedOrgId=org-123');
+    });
+  });
+});

--- a/static/app/views/prevent/tests/testAnalyticsTable/sortableHeader.tsx
+++ b/static/app/views/prevent/tests/testAnalyticsTable/sortableHeader.tsx
@@ -9,6 +9,7 @@ import {IconArrow} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
+import {SORTABLE_FIELDS} from 'sentry/views/prevent/tests/testAnalyticsTable/testAnalyticsTable';
 
 type HeaderParams = {
   alignment: string;
@@ -63,31 +64,37 @@ function SortableHeader({
     ...queryWithoutPagination
   } = location.query;
 
+  const isSortable = SORTABLE_FIELDS.includes(fieldName as any);
+
   return (
     <HeaderCell alignment={alignment}>
-      <StyledLink
-        role="columnheader"
-        aria-sort={
-          sort?.field.endsWith(fieldName)
-            ? sort?.kind === 'asc'
-              ? 'ascending'
-              : 'descending'
-            : 'none'
-        }
-        to={{
-          pathname: location.pathname,
-          query: {
-            ...queryWithoutPagination,
-            sort: sort?.field.endsWith(fieldName)
-              ? sort?.kind === 'desc'
-                ? fieldName
-                : '-' + fieldName
-              : '-' + fieldName,
-          },
-        }}
-      >
-        {label} {sort?.field === fieldName && sortArrow}
-      </StyledLink>
+      {isSortable ? (
+        <StyledLink
+          role="columnheader"
+          aria-sort={
+            sort?.field.endsWith(fieldName)
+              ? sort?.kind === 'asc'
+                ? 'ascending'
+                : 'descending'
+              : 'none'
+          }
+          to={{
+            pathname: location.pathname,
+            query: {
+              ...queryWithoutPagination,
+              sort: sort?.field.endsWith(fieldName)
+                ? sort?.kind === 'desc'
+                  ? fieldName
+                  : '-' + fieldName
+                : '-' + fieldName,
+            },
+          }}
+        >
+          {label} {sort?.field === fieldName && sortArrow}
+        </StyledLink>
+      ) : (
+        <NonSortableHeader role="columnheader">{label}</NonSortableHeader>
+      )}
       {enableToggle ? <WrapToggle /> : null}
       {tooltip ? (
         <span>
@@ -121,6 +128,10 @@ const StyledLink = styled(Link)`
 
 const WrapText = styled('span')`
   margin-left: ${space(0.5)};
+`;
+
+const NonSortableHeader = styled('span')`
+  color: inherit;
 `;
 
 export default SortableHeader;

--- a/static/app/views/prevent/tests/testAnalyticsTable/testAnalyticsTable.tsx
+++ b/static/app/views/prevent/tests/testAnalyticsTable/testAnalyticsTable.tsx
@@ -57,14 +57,12 @@ export const RIGHT_ALIGNED_FIELDS = new Set([
 ]);
 
 export type SortableTAOptions =
-  | 'testName'
   | 'averageDurationMs'
   | 'flakeRate'
   | 'totalFailCount'
   | 'lastRun';
 
 export const SORTABLE_FIELDS: SortableTAOptions[] = [
-  'testName',
   'averageDurationMs',
   'flakeRate',
   'totalFailCount',


### PR DESCRIPTION
This PR removes the sort behavior for the test name field on the test analytics table because that's not a field the backend currently supports.

Also creates a test file for the test analytics header with some basic tests.

**Crappy video of not being able to click test name anymore**


https://github.com/user-attachments/assets/846cb3be-a1b6-406c-8611-020debf2b609






<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
