### PR TITLE
feat(overwatch): add PreventPrReviewSentryOrgEndpoint and update routing

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -419,7 +419,10 @@ from sentry.notifications.api.endpoints.user_notification_settings_providers imp
     UserNotificationSettingsProvidersEndpoint,
 )
 from sentry.notifications.platform.api.endpoints import urls as notification_platform_urls
-from sentry.overwatch.endpoints.overwatch_rpc import PreventPrReviewResolvedConfigsEndpoint
+from sentry.overwatch.endpoints.overwatch_rpc import (
+    PreventPrReviewResolvedConfigsEndpoint,
+    PreventPrReviewSentryOrgEndpoint,
+)
 from sentry.preprod.api.endpoints import urls as preprod_urls
 from sentry.releases.endpoints.organization_release_assemble import (
     OrganizationReleaseAssembleEndpoint,
@@ -3408,6 +3411,11 @@ INTERNAL_URLS = [
         r"^prevent/pr-review/configs/resolved$",
         PreventPrReviewResolvedConfigsEndpoint.as_view(),
         name="sentry-api-0-prevent-pr-review-configs-resolved",
+    ),
+    re_path(
+        r"^prevent/pr-review/github/sentry-org$",
+        PreventPrReviewSentryOrgEndpoint.as_view(),
+        name="sentry-api-0-prevent-pr-review-github-sentry-org",
     ),
     re_path(
         r"^check-am2-compatibility/$",

--- a/src/sentry/overwatch/endpoints/overwatch_rpc.py
+++ b/src/sentry/overwatch/endpoints/overwatch_rpc.py
@@ -15,6 +15,13 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import AuthenticationSiloLimit, StandardAuthentication
 from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.constants import (
+    ENABLE_PR_REVIEW_TEST_GENERATION_DEFAULT,
+    HIDE_AI_FEATURES_DEFAULT,
+    ObjectStatus,
+)
+from sentry.models.organization import Organization
+from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
 
 logger = logging.getLogger(__name__)
@@ -74,6 +81,18 @@ class OverwatchRpcSignatureAuthentication(StandardAuthentication):
         return (AnonymousUser(), token)
 
 
+def _can_use_prevent_ai_features(org: Organization) -> bool:
+    """Check if organization has opted in to Prevent AI features."""
+    hide_ai_features = org.get_option("sentry:hide_ai_features", HIDE_AI_FEATURES_DEFAULT)
+    pr_review_test_generation_enabled = bool(
+        org.get_option(
+            "sentry:enable_pr_review_test_generation",
+            ENABLE_PR_REVIEW_TEST_GENERATION_DEFAULT,
+        )
+    )
+    return not hide_ai_features and pr_review_test_generation_enabled
+
+
 @region_silo_endpoint
 class PreventPrReviewResolvedConfigsEndpoint(Endpoint):
     """
@@ -101,3 +120,43 @@ class PreventPrReviewResolvedConfigsEndpoint(Endpoint):
             raise ParseError("Missing required query parameters: ghOrg, repo")
         # Stub: return empty dict for now
         return Response(data={})
+
+
+@region_silo_endpoint
+class PreventPrReviewSentryOrgEndpoint(Endpoint):
+    """
+    Get Sentry organization IDs for a GitHub repository.
+
+    GET /prevent/pr-review/github/sentry-org?ghOrgId={orgId}&repoId={repoId}
+    """
+
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.CODECOV
+    authentication_classes = (OverwatchRpcSignatureAuthentication,)
+    permission_classes = ()
+    enforce_rate_limit = False
+
+    def get(self, request: Request) -> Response:
+        if not request.auth or not isinstance(
+            request.successful_authenticator, OverwatchRpcSignatureAuthentication
+        ):
+            raise PermissionDenied
+
+        gh_org_id = request.GET.get("ghOrgId")
+        repo_id = request.GET.get("repoId")
+
+        if not gh_org_id or not repo_id:
+            raise ParseError("Missing required query parameters: ghOrgId, repoId")
+
+        organization_ids = Repository.objects.filter(
+            external_id=repo_id, provider="integrations:github", status=ObjectStatus.ACTIVE
+        ).values_list("organization_id", flat=True)
+
+        organizations = Organization.objects.filter(id__in=organization_ids)
+
+        # Filter out all orgs that didn't give us consent to use AI features
+        return Response(
+            data={"org_ids": [org.id for org in organizations if _can_use_prevent_ai_features(org)]}
+        )

--- a/src/sentry/overwatch/endpoints/overwatch_rpc.py
+++ b/src/sentry/overwatch/endpoints/overwatch_rpc.py
@@ -127,7 +127,7 @@ class PreventPrReviewSentryOrgEndpoint(Endpoint):
     """
     Get Sentry organization IDs for a GitHub repository.
 
-    GET /prevent/pr-review/github/sentry-org?ghOrgId={orgId}&repoId={repoId}
+    GET /prevent/pr-review/github/sentry-org?fullRepoName={fullRepoName}&repoId={repoId}
     """
 
     publish_status = {
@@ -144,14 +144,17 @@ class PreventPrReviewSentryOrgEndpoint(Endpoint):
         ):
             raise PermissionDenied
 
-        gh_org_id = request.GET.get("ghOrgId")
+        full_repo_name = request.GET.get("fullRepoName")
         repo_id = request.GET.get("repoId")
 
-        if not gh_org_id or not repo_id:
-            raise ParseError("Missing required query parameters: ghOrgId, repoId")
+        if not full_repo_name or not repo_id:
+            raise ParseError("Missing required query parameters: fullRepoName, repoId")
 
         organization_ids = Repository.objects.filter(
-            external_id=repo_id, provider="integrations:github", status=ObjectStatus.ACTIVE
+            name=full_repo_name,
+            external_id=repo_id,
+            provider="integrations:github",
+            status=ObjectStatus.ACTIVE,
         ).values_list("organization_id", flat=True)
 
         organizations = Organization.objects.filter(id__in=organization_ids)

--- a/src/sentry/overwatch/endpoints/overwatch_rpc.py
+++ b/src/sentry/overwatch/endpoints/overwatch_rpc.py
@@ -127,7 +127,7 @@ class PreventPrReviewSentryOrgEndpoint(Endpoint):
     """
     Get Sentry organization IDs for a GitHub repository.
 
-    GET /prevent/pr-review/github/sentry-org?fullRepoName={fullRepoName}&repoId={repoId}
+    GET /prevent/pr-review/github/sentry-org?repoId={repoId}
     """
 
     publish_status = {
@@ -144,14 +144,12 @@ class PreventPrReviewSentryOrgEndpoint(Endpoint):
         ):
             raise PermissionDenied
 
-        full_repo_name = request.GET.get("fullRepoName")
         repo_id = request.GET.get("repoId")
 
-        if not full_repo_name or not repo_id:
-            raise ParseError("Missing required query parameters: fullRepoName, repoId")
+        if not repo_id:
+            raise ParseError("Missing required query parameter: repoId")
 
         organization_ids = Repository.objects.filter(
-            name=full_repo_name,
             external_id=repo_id,
             provider="integrations:github",
             status=ObjectStatus.ACTIVE,

--- a/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
+++ b/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from django.urls import reverse
 
+from sentry.constants import ObjectStatus
 from sentry.testutils.cases import APITestCase
 
 
@@ -50,3 +51,117 @@ class TestPreventPrReviewResolvedConfigsEndpoint(APITestCase):
         assert resp.status_code == 200
         assert resp.data == {}
         assert "Link" not in resp
+
+
+class TestPreventPrReviewSentryOrgEndpoint(APITestCase):
+    def _auth_header_for_get(self, url: str, params: dict[str, str], b64_secret: str) -> str:
+        secret_bytes = base64.b64decode(b64_secret)
+        message = b"[]"
+        signature = hmac.new(secret_bytes, message, hashlib.sha256).hexdigest()
+        return f"Rpcsignature rpc0:{signature}"
+
+    @patch(
+        "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
+        [base64.b64encode(b"test-secret").decode()],
+    )
+    def test_requires_auth(self):
+        url = reverse("sentry-api-0-prevent-pr-review-github-sentry-org")
+        resp = self.client.get(url, {"ghOrgId": "123", "repoId": "456"})
+        assert resp.status_code == 403
+
+    @patch(
+        "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
+        [base64.b64encode(b"test-secret").decode()],
+    )
+    def test_missing_required_params_returns_400(self):
+        url = reverse("sentry-api-0-prevent-pr-review-github-sentry-org")
+        b64_secret = base64.b64encode(b"test-secret").decode()
+        auth = self._auth_header_for_get(url, {}, b64_secret)
+
+        resp = self.client.get(url, HTTP_AUTHORIZATION=auth)
+        assert resp.status_code == 400
+
+        resp = self.client.get(url, {"ghOrgId": "123"}, HTTP_AUTHORIZATION=auth)
+        assert resp.status_code == 400
+
+        resp = self.client.get(url, {"repoId": "456"}, HTTP_AUTHORIZATION=auth)
+        assert resp.status_code == 400
+
+    @patch(
+        "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
+        [base64.b64encode(b"test-secret").decode()],
+    )
+    def test_returns_empty_list_when_no_repos_found(self):
+        url = reverse("sentry-api-0-prevent-pr-review-github-sentry-org")
+        params = {"ghOrgId": "123", "repoId": "456"}
+        b64_secret = base64.b64encode(b"test-secret").decode()
+        auth = self._auth_header_for_get(url, params, b64_secret)
+
+        resp = self.client.get(url, params, HTTP_AUTHORIZATION=auth)
+        assert resp.status_code == 200
+        assert resp.data == {"org_ids": []}
+
+    @patch(
+        "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
+        [base64.b64encode(b"test-secret").decode()],
+    )
+    def test_returns_org_ids_with_consent(self):
+
+        org_with_consent = self.create_organization()
+        org_with_consent.update_option("sentry:hide_ai_features", False)
+        org_with_consent.update_option("sentry:enable_pr_review_test_generation", True)
+
+        org_without_consent = self.create_organization()
+        org_without_consent.update_option("sentry:hide_ai_features", True)
+
+        repo_id = "12345"
+        self.create_repository(
+            organization=org_with_consent,
+            external_id=repo_id,
+            provider="integrations:github",
+            status=ObjectStatus.ACTIVE,
+        )
+        self.create_repository(
+            organization=org_without_consent,
+            external_id=repo_id,
+            provider="integrations:github",
+            status=ObjectStatus.ACTIVE,
+        )
+
+        url = reverse("sentry-api-0-prevent-pr-review-github-sentry-org")
+        params = {"ghOrgId": "123", "repoId": repo_id}
+        b64_secret = base64.b64encode(b"test-secret").decode()
+        auth = self._auth_header_for_get(url, params, b64_secret)
+
+        resp = self.client.get(url, params, HTTP_AUTHORIZATION=auth)
+        assert resp.status_code == 200
+        # Should only return the org with consent
+        assert resp.data == {"org_ids": [org_with_consent.id]}
+
+    @patch(
+        "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
+        [base64.b64encode(b"test-secret").decode()],
+    )
+    def test_filters_inactive_repositories(self):
+        org = self.create_organization()
+        org.update_option("sentry:hide_ai_features", False)
+        org.update_option("sentry:enable_pr_review_test_generation", True)
+
+        repo_id = "12345"
+
+        self.create_repository(
+            organization=org,
+            external_id=repo_id,
+            provider="integrations:github",
+            status=ObjectStatus.DISABLED,
+        )
+
+        url = reverse("sentry-api-0-prevent-pr-review-github-sentry-org")
+        params = {"ghOrgId": "123", "repoId": repo_id}
+        b64_secret = base64.b64encode(b"test-secret").decode()
+        auth = self._auth_header_for_get(url, params, b64_secret)
+
+        resp = self.client.get(url, params, HTTP_AUTHORIZATION=auth)
+        assert resp.status_code == 200
+        # Should return empty list as the repository is inactive
+        assert resp.data == {"org_ids": []}

--- a/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
+++ b/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
@@ -67,7 +67,7 @@ class TestPreventPrReviewSentryOrgEndpoint(APITestCase):
     )
     def test_requires_auth(self):
         url = reverse("sentry-api-0-prevent-pr-review-github-sentry-org")
-        resp = self.client.get(url, {"fullRepoName": "org/repo", "repoId": "456"})
+        resp = self.client.get(url, {"repoId": "456"})
         assert resp.status_code == 403
 
     @patch(
@@ -82,19 +82,13 @@ class TestPreventPrReviewSentryOrgEndpoint(APITestCase):
         resp = self.client.get(url, HTTP_AUTHORIZATION=auth)
         assert resp.status_code == 400
 
-        resp = self.client.get(url, {"fullRepoName": "org/repo"}, HTTP_AUTHORIZATION=auth)
-        assert resp.status_code == 400
-
-        resp = self.client.get(url, {"repoId": "456"}, HTTP_AUTHORIZATION=auth)
-        assert resp.status_code == 400
-
     @patch(
         "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
         [base64.b64encode(b"test-secret").decode()],
     )
     def test_returns_empty_list_when_no_repos_found(self):
         url = reverse("sentry-api-0-prevent-pr-review-github-sentry-org")
-        params = {"fullRepoName": "org/repo", "repoId": "456"}
+        params = {"repoId": "456"}
         b64_secret = base64.b64encode(b"test-secret").decode()
         auth = self._auth_header_for_get(url, params, b64_secret)
 
@@ -132,7 +126,7 @@ class TestPreventPrReviewSentryOrgEndpoint(APITestCase):
         )
 
         url = reverse("sentry-api-0-prevent-pr-review-github-sentry-org")
-        params = {"fullRepoName": "org/repo", "repoId": repo_id}
+        params = {"repoId": repo_id}
         b64_secret = base64.b64encode(b"test-secret").decode()
         auth = self._auth_header_for_get(url, params, b64_secret)
 
@@ -161,7 +155,7 @@ class TestPreventPrReviewSentryOrgEndpoint(APITestCase):
         )
 
         url = reverse("sentry-api-0-prevent-pr-review-github-sentry-org")
-        params = {"fullRepoName": "org/repo", "repoId": repo_id}
+        params = {"repoId": repo_id}
         b64_secret = base64.b64encode(b"test-secret").decode()
         auth = self._auth_header_for_get(url, params, b64_secret)
 


### PR DESCRIPTION
This commit introduces the PreventPrReviewSentryOrgEndpoint to retrieve Sentry organization IDs for a specified GitHub repository. It also updates the API routing in urls.py to include this new endpoint, ensuring proper handling of organization consent for AI features.




### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
