### PR TITLE
ref(ui): reset all state with a key instead of an effect

### DIFF
--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useMemo, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
@@ -93,16 +93,9 @@ function OrganizationMemberDetailContent({member}: {member: Member}) {
   const organization = useOrganization();
   const navigate = useNavigate();
 
-  const [orgRole, setOrgRole] = useState<Member['orgRole']>('');
-  const [teamRoles, setTeamRoles] = useState<Member['teamRoles']>([]);
+  const [orgRole, setOrgRole] = useState<Member['orgRole']>(member.orgRole);
+  const [teamRoles, setTeamRoles] = useState<Member['teamRoles']>(member.teamRoles);
   const hasTeamRoles = organization.features.includes('team-roles');
-
-  useEffect(() => {
-    if (member) {
-      setOrgRole(member.orgRole);
-      setTeamRoles(member.teamRoles);
-    }
-  }, [member]);
 
   const {mutate: updatedMember, isPending: isSaving} = useMutation<Member, RequestError>({
     mutationFn: () => {
@@ -417,7 +410,7 @@ function OrganizationMemberDetail() {
     return <NotFound />;
   }
 
-  return <OrganizationMemberDetailContent member={member} />;
+  return <OrganizationMemberDetailContent member={member} key={member.id} />;
 }
 
 export default OrganizationMemberDetail;


### PR DESCRIPTION
when all state of a component should be reset upon a change, it’s best to use a `key` for that instead of syncing with effects. see: https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes
