### PR TITLE
fix(dashboards): move disabled fields to bottom of visualize dropdown

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -120,6 +120,16 @@ function _sortFn(
     return 0;
   }
 
+  if (a.disabled && b.disabled) {
+    return a.label.localeCompare(b.label);
+  }
+  if (a.disabled) {
+    return 1;
+  }
+  if (b.disabled) {
+    return -1;
+  }
+
   return a.label.localeCompare(b.label);
 }
 


### PR DESCRIPTION
part one of a two part fix for the visualize dropdown in the widget builder. I've moved the disabled fields to the end of the list. I'll get to part two when I have a little more time :)

contributes to https://linear.app/getsentry/issue/DAIN-389/changes-to-visualize-dropdowns
