### PR TITLE
fix(insights): Fixes an issue with links in insights tables being non clickable

### DIFF
--- a/static/app/views/insights/browser/resources/components/tables/resourceSummaryTable.tsx
+++ b/static/app/views/insights/browser/resources/components/tables/resourceSummaryTable.tsx
@@ -109,7 +109,7 @@ function ResourceSummaryTable() {
       }
 
       const link = (
-        <Link
+        <TransactionLink
           to={{
             pathname: location.pathname,
             query: {
@@ -120,7 +120,7 @@ function ResourceSummaryTable() {
           }}
         >
           {row[key]}
-        </Link>
+        </TransactionLink>
       );
 
       return (
@@ -207,6 +207,10 @@ const DescriptionWrapper = styled('div')`
   .inline-flex {
     display: inline-flex;
   }
+`;
+
+const TransactionLink = styled(Link)`
+  min-width: ${p => p.theme.space['2xl']};
 `;
 
 export default ResourceSummaryTable;

--- a/static/app/views/insights/common/components/spanGroupDetailsLink.tsx
+++ b/static/app/views/insights/common/components/spanGroupDetailsLink.tsx
@@ -1,6 +1,7 @@
+import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
-import {Link} from 'sentry/components/core/link';
+import {Link, type LinkProps} from 'sentry/components/core/link';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {OverflowEllipsisTextContainer} from 'sentry/views/insights/common/components/textAlign';
@@ -41,16 +42,21 @@ export function SpanGroupDetailsLink({
   return (
     <OverflowEllipsisTextContainer>
       {group ? (
-        <Link
+        <StyledLink
           to={normalizeUrl(
             `${moduleURL}/spans/span/${group}/?${qs.stringify(queryString)}`
           )}
         >
           {description}
-        </Link>
+        </StyledLink>
       ) : (
         description
       )}
     </OverflowEllipsisTextContainer>
   );
 }
+
+const StyledLink = styled(Link)`
+  display: inline-block;
+  min-width: ${p => p.theme.space['2xl']};
+`;

--- a/static/app/views/insights/common/components/spanGroupDetailsLink.tsx
+++ b/static/app/views/insights/common/components/spanGroupDetailsLink.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
-import {Link, type LinkProps} from 'sentry/components/core/link';
+import {Link} from 'sentry/components/core/link';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {OverflowEllipsisTextContainer} from 'sentry/views/insights/common/components/textAlign';


### PR DESCRIPTION
Fixes an issue where tooltips boundaries overlap insights table links, preventing them from being clickable. Adds a minimum width to link elements.
<img width="322" height="91" alt="image" src="https://github.com/user-attachments/assets/0c9cb64e-8acb-4a60-bcf8-b1b5cbe62d37" />
