### PR TITLE
ref(timeseries): Use `/events-timeseries/` on Insights span sample panels

### DIFF
--- a/static/app/views/insights/cache/components/charts/hitMissChart.tsx
+++ b/static/app/views/insights/cache/components/charts/hitMissChart.tsx
@@ -1,11 +1,11 @@
 // TODO(release-drawer): Only used in cache/components/samplePanel
 
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {Referrer} from 'sentry/views/insights/cache/referrers';
 // TODO(release-drawer): Only used in cache/components/samplePanel
 // eslint-disable-next-line no-restricted-imports
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
 
@@ -20,11 +20,10 @@ export function CacheHitMissChart({search}: Props) {
     data,
     isPending: isCacheHitRateLoading,
     error,
-  } = useSpanSeries(
+  } = useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: [`${SpanFunction.CACHE_MISS_RATE}()`],
-      transformAliasToInputFormat: true,
     },
     referrer
   );
@@ -41,7 +40,7 @@ export function CacheHitMissChart({search}: Props) {
     <InsightsLineChartWidget
       queryInfo={queryInfo}
       title={DataTitles[`cache_miss_rate()`]}
-      series={[data[`cache_miss_rate()`]]}
+      timeSeries={data?.timeSeries}
       showLegend="never"
       isLoading={isCacheHitRateLoading}
       error={error}

--- a/static/app/views/insights/cache/components/charts/transactionDurationChartWithSamples.tsx
+++ b/static/app/views/insights/cache/components/charts/transactionDurationChartWithSamples.tsx
@@ -1,5 +1,6 @@
 import {t} from 'sentry/locale';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import type {Samples} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/samples';
@@ -7,7 +8,6 @@ import {Referrer} from 'sentry/views/insights/cache/referrers';
 // TODO(release-drawer): Only used in cache/components/samplePanel
 // eslint-disable-next-line no-restricted-imports
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import type {SpanQueryFilters} from 'sentry/views/insights/types';
 import {SpanFields} from 'sentry/views/insights/types';
 
@@ -29,9 +29,9 @@ export function TransactionDurationChartWithSamples({samples}: Props) {
   } satisfies SpanQueryFilters);
   const referrer = Referrer.SAMPLES_CACHE_TRANSACTION_DURATION_CHART;
 
-  const {data, isPending, error} = useSpanSeries(
+  const {data, isPending, error} = useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: [`avg(${SpanFields.SPAN_DURATION})`],
     },
     Referrer.SAMPLES_CACHE_TRANSACTION_DURATION
@@ -44,7 +44,7 @@ export function TransactionDurationChartWithSamples({samples}: Props) {
       title={t('Average Transaction Duration')}
       isLoading={isPending}
       error={error}
-      series={[data['avg(span.duration)']]}
+      timeSeries={data?.timeSeries}
       samples={samples}
     />
   );

--- a/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
@@ -315,29 +315,6 @@ const setRequestMocks = (organization: Organization) => {
     },
   });
 
-  requestMocks.missRateChart = MockApiClient.addMockResponse({
-    url: `/organizations/${organization.slug}/events-stats/`,
-    method: 'GET',
-    match: [
-      MockApiClient.matchQuery({
-        referrer: 'api.insights.cache.samples-cache-hit-miss-chart',
-      }),
-    ],
-    body: {
-      data: [
-        [1716379200, [{count: 0.5}]],
-        [1716393600, [{count: 0.75}]],
-      ],
-      meta: {
-        fields: {
-          time: 'date',
-          cache_miss_rate: 'percentage',
-        },
-        units: {},
-      },
-    },
-  });
-
   requestMocks.throughputChart = MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/events-timeseries/`,
     method: 'GET',
@@ -356,31 +333,6 @@ const setRequestMocks = (organization: Organization) => {
           ],
         }),
       ],
-    },
-  });
-
-  // Mock for the old useSpanSeries call in cache landing page that still uses events-stats
-  requestMocks.cacheMissRateError = MockApiClient.addMockResponse({
-    url: `/organizations/${organization.slug}/events-stats/`,
-    method: 'GET',
-    match: [
-      MockApiClient.matchQuery({
-        referrer: 'api.insights.cache.landing-cache-hit-miss-chart',
-        transformAliasToInputFormat: '1',
-      }),
-    ],
-    body: {
-      data: [
-        [1716379200, [{count: 0.5}]],
-        [1716393600, [{count: 0.75}]],
-      ],
-      meta: {
-        fields: {
-          time: 'date',
-          cache_miss_rate: 'percentage',
-        },
-        units: {},
-      },
     },
   });
 

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -3,14 +3,15 @@ import keyBy from 'lodash/keyBy';
 
 import {t} from 'sentry/locale';
 import {usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import type {TabularData} from 'sentry/views/dashboards/widgets/common/types';
 import {Samples} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/samples';
 // TODO(release-drawer): Used in spanSummarPage/samplelist and spanSamplesPanelContainer
 // eslint-disable-next-line no-restricted-imports
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import type {
   NonDefaultSpanSampleFields,
   SpanSample,
@@ -87,14 +88,13 @@ function DurationChart({
     isPending,
     data: spanMetricsSeriesData,
     error: spanMetricsSeriesError,
-  } = useSpanSeries(
+  } = useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: [`avg(${SPAN_SELF_TIME})`],
       enabled: Object.values({...filters, ...additionalFilters}).every(value =>
         Boolean(value)
       ),
-      transformAliasToInputFormat: true,
     },
     referrer
   );
@@ -178,7 +178,7 @@ function DurationChart({
       title={t('Average Duration')}
       isLoading={isPending}
       error={spanMetricsSeriesError}
-      series={[spanMetricsSeriesData[`avg(${SpanFields.SPAN_SELF_TIME})`]]}
+      timeSeries={spanMetricsSeriesData?.timeSeries}
       samples={samplesPlottable}
     />
   );

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -5,7 +5,6 @@ import {t} from 'sentry/locale';
 import {usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import type {TabularData} from 'sentry/views/dashboards/widgets/common/types';
 import {Samples} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/samples';
 // TODO(release-drawer): Used in spanSummarPage/samplelist and spanSamplesPanelContainer

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleTable/sampleTable.spec.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/sampleTable/sampleTable.spec.tsx
@@ -7,6 +7,7 @@ import {
 
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/tables/gridEditable';
 import type {PageFilters} from 'sentry/types/core';
+import {DurationUnit} from 'sentry/utils/discover/fields';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
 import SampleTable from './sampleTable';
@@ -199,21 +200,34 @@ const initializeMockRequests = () => {
     ],
   });
   MockApiClient.addMockResponse({
-    url: '/organizations/org-slug/events-stats/',
+    url: '/organizations/org-slug/events-timeseries/',
     body: {
-      data: [
-        [1689710400, [{count: 1.5}]],
-        [1689714000, [{count: 1.65}]],
+      timeSeries: [
+        {
+          yAxis: 'avg(span.self_time)',
+          meta: {
+            valueType: 'duration',
+            valueUnit: DurationUnit.MILLISECOND,
+          },
+          values: [
+            {
+              timestamp: 1689710400000,
+              value: 1.5,
+            },
+            {
+              timestamp: 1689714000000,
+              value: 1.65,
+            },
+          ],
+        },
       ],
-      end: 1690315200,
-      start: 1689710400,
     },
     match: [
       (_, options) => {
         const {query} = options;
         return (
           query?.referrer === 'api.insights.sidebar-span-metrics' &&
-          query?.yAxis === 'avg(span.self_time)'
+          query?.yAxis[0] === 'avg(span.self_time)'
         );
       },
     ],

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -37,7 +37,6 @@ import {ReadoutRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {SampleDrawerBody} from 'sentry/views/insights/common/components/sampleDrawerBody';
 import {SampleDrawerHeaderTransaction} from 'sentry/views/insights/common/components/sampleDrawerHeaderTransaction';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {
   DataTitles,

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
@@ -12,6 +12,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {DurationUnit, SizeUnit} from 'sentry/utils/discover/fields';
 import {PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -30,7 +31,6 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ReadoutRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {SampleDrawerBody} from 'sentry/views/insights/common/components/sampleDrawerBody';
 import {SampleDrawerHeaderTransaction} from 'sentry/views/insights/common/components/sampleDrawerHeaderTransaction';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getDurationChartTitle} from 'sentry/views/insights/common/views/spans/types';
 import {useSpanSamples} from 'sentry/views/insights/http/queries/useSpanSamples';
 import {InsightsSpanTagProvider} from 'sentry/views/insights/pages/insightsSpanTagProvider';
@@ -165,17 +165,32 @@ export function MessageSpanSamplesPanel() {
     isFetching: isDurationDataFetching,
     data: durationData,
     error: durationError,
-  } = useSpanSeries(
+  } = useFetchSpanTimeSeries(
     {
-      search: timeseriesFilters,
+      query: timeseriesFilters,
       yAxis: [`avg(span.duration)`],
       enabled: isPanelOpen,
-      transformAliasToInputFormat: true,
     },
     timeseriesReferrer
   );
 
-  const durationAxisMax = computeAxisMax([durationData?.[`avg(span.duration)`]]);
+  const timeSeries = durationData?.timeSeries || [];
+  const durationSeries = timeSeries.find(ts => ts.yAxis === 'avg(span.duration)');
+
+  const durationAxisMax = computeAxisMax([
+    durationSeries
+      ? {
+          seriesName: durationSeries.yAxis,
+          data: durationSeries.values.map(v => ({
+            name: v.timestamp,
+            value: v.value || 0,
+          })),
+        }
+      : {
+          seriesName: 'avg(span.duration)',
+          data: [],
+        },
+  ]);
 
   const {
     data: spanSamplesData,
@@ -312,7 +327,7 @@ export function MessageSpanSamplesPanel() {
                 title={getDurationChartTitle('queue')}
                 isLoading={isDurationDataFetching}
                 error={durationError}
-                series={[durationData[`avg(span.duration)`]]}
+                timeSeries={durationSeries ? [durationSeries] : []}
                 samples={samplesPlottable}
               />
             </ModuleLayout.Full>


### PR DESCRIPTION
Continuing to replace usage of `/events-stats/` inside Insights. This time, removing usage of the old endpoint from span sample panels. This leaves a bit of awkward code to calculate the Y axis max for the samples call, but I can clean that up in another PR. For now, adding some fallback empty series to calculate the axis max from.
