### PR TITLE
feat(aci): Delayed workflows cohort sharding

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3151,6 +3151,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "workflow_engine.num_cohorts",
+    type=Int,
+    default=1,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Restrict uptime issue creation for specific host provider identifiers. Items
 # in this list map to the `host_provider_id` column in the UptimeSubscription
 # table.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3158,6 +3158,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "workflow_engine.use_cohort_selection",
+    type=Bool,
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Restrict uptime issue creation for specific host provider identifiers. Items
 # in this list map to the `host_provider_id` column in the UptimeSubscription
 # table.

--- a/src/sentry/workflow_engine/buffer/batch_client.py
+++ b/src/sentry/workflow_engine/buffer/batch_client.py
@@ -16,9 +16,6 @@ if TYPE_CHECKING:
 class CohortUpdates(pydantic.BaseModel):
     values: dict[int, float]
 
-    def get_last_cohort_run(self, cohort_id: int) -> float:
-        return self.values.get(cohort_id, 0)
-
 
 class DelayedWorkflowClient:
     """

--- a/src/sentry/workflow_engine/buffer/redis_hash_sorted_set_buffer.py
+++ b/src/sentry/workflow_engine/buffer/redis_hash_sorted_set_buffer.py
@@ -6,8 +6,8 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, TypeAlias, TypeVar
 
-import rb
 import pydantic
+import rb
 from redis.client import Pipeline
 
 ClusterPipeline: TypeAlias = Any

--- a/src/sentry/workflow_engine/buffer/redis_hash_sorted_set_buffer.py
+++ b/src/sentry/workflow_engine/buffer/redis_hash_sorted_set_buffer.py
@@ -51,6 +51,8 @@ _NEED_EXPIRE = {
     "zrangebyscore": False,
     "zrem": True,
     "zremrangebyscore": True,
+    "set": True,
+    "get": False,
 }
 
 
@@ -420,8 +422,10 @@ class RedisHashSortedSetBuffer:
 
         return converted_results
 
-    def get_parsed_key[T: pydantic.BaseModel](self, key: str, model: type[T]) -> T:
+    def get_parsed_key[T: pydantic.BaseModel](self, key: str, model: type[T]) -> T | None:
         value = self._execute_redis_operation(key, "get")
+        if value is None:
+            return None
         return model.parse_raw(value)
 
     def put_parsed_key[T: pydantic.BaseModel](self, key: str, value: T) -> None:

--- a/src/sentry/workflow_engine/buffer/redis_hash_sorted_set_buffer.py
+++ b/src/sentry/workflow_engine/buffer/redis_hash_sorted_set_buffer.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, TypeAlias, TypeVar
 
 import rb
+import pydantic
 from redis.client import Pipeline
 
 ClusterPipeline: TypeAlias = Any
@@ -418,3 +419,10 @@ class RedisHashSortedSetBuffer:
             converted_results.update(host_parsed)
 
         return converted_results
+
+    def get_parsed_key[T: pydantic.BaseModel](self, key: str, model: type[T]) -> T:
+        value = self._execute_redis_operation(key, "get")
+        return model.parse_raw(value)
+
+    def put_parsed_key[T: pydantic.BaseModel](self, key: str, value: T) -> None:
+        self._execute_redis_operation(key, "set", value.json())

--- a/src/sentry/workflow_engine/processors/schedule.py
+++ b/src/sentry/workflow_engine/processors/schedule.py
@@ -6,7 +6,6 @@ from datetime import datetime, timezone
 from itertools import chain, islice
 from collections.abc import Generator
 from contextlib import contextmanager
-from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 from itertools import islice
 

--- a/src/sentry/workflow_engine/processors/schedule.py
+++ b/src/sentry/workflow_engine/processors/schedule.py
@@ -87,7 +87,7 @@ def process_in_batches(client: ProjectDelayedWorkflowClient) -> None:
 
 
 class ProjectChooser:
-    def __init__(self, buffer_client: DelayedWorkflowClient, num_cohorts):
+    def __init__(self, buffer_client: DelayedWorkflowClient, num_cohorts: int):
         self.client = buffer_client
         assert num_cohorts > 0 and num_cohorts <= 255
         self.num_cohorts = num_cohorts

--- a/src/sentry/workflow_engine/processors/schedule.py
+++ b/src/sentry/workflow_engine/processors/schedule.py
@@ -182,14 +182,15 @@ def mark_projects_processed(
     if not all_project_ids_and_timestamps:
         return
     with metrics.timer("workflow_engine.scheduler.mark_projects_processed"):
-        member_maxes = [
+        processed_member_maxes = [
             (project_id, max(timestamps))
             for project_id, timestamps in all_project_ids_and_timestamps.items()
+            if project_id in processed_project_ids
         ]
         deleted_project_ids = set[int]()
         # The conditional delete can be slow, so we break it into chunks that probably
         # aren't big enough to hold onto the main redis thread for too long.
-        for chunk in chunked(member_maxes, 500):
+        for chunk in chunked(processed_member_maxes, 500):
             with metrics.timer(
                 "workflow_engine.conditional_delete_from_sorted_sets.chunk_duration"
             ):

--- a/src/sentry/workflow_engine/processors/schedule.py
+++ b/src/sentry/workflow_engine/processors/schedule.py
@@ -105,9 +105,9 @@ class ProjectChooser:
         for co in range(self.num_cohorts):
             last_run = cohort_updates.get_last_cohort_run(co)
             elapsed = timedelta(seconds=now - last_run)
-            if elapsed > timedelta(minutes=1):
+            if elapsed >= timedelta(minutes=1):
                 must_process.add(co)
-            elif elapsed > timedelta(seconds=60 / self.num_cohorts):
+            elif elapsed >= timedelta(seconds=60 / self.num_cohorts):
                 may_process.add(co)
         if may_process and not must_process:
             choice = min(may_process, key=lambda c: (cohort_updates.get_last_cohort_run(c), c))
@@ -145,7 +145,9 @@ def process_buffered_workflows(buffer_client: DelayedWorkflowClient) -> None:
             max=fetch_time,
         )
 
-        project_chooser = ProjectChooser(buffer_client)
+        project_chooser = ProjectChooser(
+            buffer_client, num_cohorts=options.get("workflow_engine.num_cohorts", NUM_COHORTS)
+        )
         with chosen_projects(
             project_chooser, fetch_time, list(all_project_ids_and_timestamps.keys())
         ) as project_ids_to_process:

--- a/src/sentry/workflow_engine/processors/schedule.py
+++ b/src/sentry/workflow_engine/processors/schedule.py
@@ -5,7 +5,7 @@ import uuid
 from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
-from itertools import chain, islice
+from itertools import islice
 
 from sentry import options
 from sentry.utils import metrics
@@ -191,17 +191,3 @@ def mark_projects_processed(
                         "processed_project_ids": sorted(processed_project_ids),
                     },
                 )
-            except Exception:
-                logger.exception(
-                    "process_buffered_workflows.conditional_delete_from_sorted_sets_error"
-                )
-                # Fallback.
-                buffer_client.clear_project_ids(
-                    min=0,
-                    max=max_project_timestamp,
-                )
-        else:
-            buffer_client.clear_project_ids(
-                min=0,
-                max=max_project_timestamp,
-            )

--- a/src/sentry/workflow_engine/processors/schedule.py
+++ b/src/sentry/workflow_engine/processors/schedule.py
@@ -1,14 +1,11 @@
 import hashlib
-import itertools
 import logging
 import math
 import uuid
-from datetime import datetime, timezone
-from itertools import chain, islice
 from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
-from itertools import islice
+from itertools import chain, islice
 
 from sentry import options
 from sentry.utils import metrics
@@ -167,7 +164,7 @@ def process_buffered_workflows(buffer_client: DelayedWorkflowClient) -> None:
 
 def mark_projects_processed(
     buffer_client: DelayedWorkflowClient,
-    project_ids_to_process: list[int],
+    processed_project_ids: list[int],
     all_project_ids_and_timestamps: dict[int, list[float]],
 ) -> None:
     if not all_project_ids_and_timestamps:
@@ -191,7 +188,7 @@ def mark_projects_processed(
                     "process_buffered_workflows.project_ids_deleted",
                     extra={
                         "deleted_project_ids": sorted(deleted_project_ids),
-                        "processed_project_ids": sorted(project_ids_to_process),
+                        "processed_project_ids": sorted(processed_project_ids),
                     },
                 )
             except Exception:

--- a/tests/sentry/workflow_engine/buffer/test_batch_client.py
+++ b/tests/sentry/workflow_engine/buffer/test_batch_client.py
@@ -1,136 +1,9 @@
 from unittest.mock import Mock
 
 import pytest
-from sentry.testutils.cases import TestCase
+
 from sentry.workflow_engine.buffer.batch_client import CohortUpdates, DelayedWorkflowClient
 from sentry.workflow_engine.buffer.redis_hash_sorted_set_buffer import RedisHashSortedSetBuffer
-
-
-class TestDelayedWorkflowClient(TestCase):
-    def setUp(self) -> None:
-        self.mock_buffer = Mock()
-        self.buffer_keys = ["test_key_1", "test_key_2"]
-        self.workflow_client = DelayedWorkflowClient(
-            buf=self.mock_buffer, buffer_keys=self.buffer_keys
-        )
-
-    def test_mark_project_ids_as_processed(self) -> None:
-        """Test mark_project_ids_as_processed with mocked RedisHashSortedSetBuffer."""
-        # Mock the conditional_delete_from_sorted_sets return value
-        # Return value is dict[str, list[int]] where keys are buffer keys and values are deleted project IDs
-        mock_return_value = {
-            "test_key_1": [123, 456],
-            "test_key_2": [789],
-        }
-        self.mock_buffer.conditional_delete_from_sorted_sets.return_value = mock_return_value
-
-        # Input data: project_id -> max_timestamp mapping
-        project_id_max_timestamps = {
-            123: 1000.5,
-            456: 2000.0,
-            789: 1500.75,
-        }
-
-        # Call the method
-        result = self.workflow_client.mark_project_ids_as_processed(project_id_max_timestamps)
-
-        # Verify the mock was called with the correct arguments
-        self.mock_buffer.conditional_delete_from_sorted_sets.assert_called_once_with(
-            tuple(self.buffer_keys),  # DelayedWorkflowClient stores keys as tuple
-            [(123, 1000.5), (456, 2000.0), (789, 1500.75)],
-        )
-
-        # Verify the result is the union of all deleted project IDs
-        expected_result = [123, 456, 789]
-        assert sorted(result) == sorted(expected_result)
-
-    def test_mark_project_ids_as_processed_empty_input(self) -> None:
-        """Test mark_project_ids_as_processed with empty input."""
-        # Mock return value for empty input
-        self.mock_buffer.conditional_delete_from_sorted_sets.return_value = {
-            "test_key_1": [],
-            "test_key_2": [],
-        }
-
-        # Empty input
-        project_id_max_timestamps: dict[int, float] = {}
-
-        # Call the method
-        result = self.workflow_client.mark_project_ids_as_processed(project_id_max_timestamps)
-
-        # Verify the mock was called with empty member list
-        self.mock_buffer.conditional_delete_from_sorted_sets.assert_called_once_with(
-            tuple(self.buffer_keys),
-            [],
-        )
-
-        # Result should be empty
-        assert result == []
-
-    def test_mark_project_ids_as_processed_partial_deletion(self) -> None:
-        """Test mark_project_ids_as_processed when only some project IDs are deleted."""
-        # Mock return value where only some project IDs are actually deleted
-        mock_return_value = {
-            "test_key_1": [123],  # Only project 123 was deleted from this key
-            "test_key_2": [],  # No projects deleted from this key
-        }
-        self.mock_buffer.conditional_delete_from_sorted_sets.return_value = mock_return_value
-
-        # Input with multiple project IDs
-        project_id_max_timestamps = {
-            123: 1000.5,
-            456: 2000.0,  # This one won't be deleted (perhaps timestamp is too old)
-        }
-
-        # Call the method
-        result = self.workflow_client.mark_project_ids_as_processed(project_id_max_timestamps)
-
-        # Verify the mock was called with all input project IDs
-        self.mock_buffer.conditional_delete_from_sorted_sets.assert_called_once_with(
-            tuple(self.buffer_keys),
-            [(123, 1000.5), (456, 2000.0)],
-        )
-
-        # Result should only contain the actually deleted project IDs
-        assert result == [123]
-
-    def test_mark_project_ids_as_processed_deduplicates_results(self) -> None:
-        """Test that mark_project_ids_as_processed deduplicates project IDs from multiple keys."""
-        # Mock return value where the same project ID appears in multiple keys
-        mock_return_value = {
-            "test_key_1": [123, 456],
-            "test_key_2": [456, 789],  # 456 appears in both keys
-        }
-        self.mock_buffer.conditional_delete_from_sorted_sets.return_value = mock_return_value
-
-        # Input data
-        project_id_max_timestamps = {
-            123: 1000.5,
-            456: 2000.0,
-            789: 1500.75,
-        }
-
-        # Call the method
-        result = self.workflow_client.mark_project_ids_as_processed(project_id_max_timestamps)
-
-        # Verify the result deduplicates project ID 456
-        expected_result = [123, 456, 789]
-        assert sorted(result) == sorted(expected_result)
-        assert len(result) == 3  # Should have exactly 3 unique project IDs
-
-
-
-class TestCohortUpdates:
-    def test_get_last_cohort_run_existing(self):
-        """Test getting last run time for existing cohort."""
-        updates = CohortUpdates(values={1: 100.5, 2: 200.3})
-        assert updates.get_last_cohort_run(1) == 100.5
-        assert updates.get_last_cohort_run(2) == 200.3
-
-    def test_get_last_cohort_run_missing(self):
-        """Test getting last run time for non-existent cohort returns 0."""
-        updates = CohortUpdates(values={1: 100.5})
-        assert updates.get_last_cohort_run(999) == 0
 
 
 class TestDelayedWorkflowClient:
@@ -140,9 +13,131 @@ class TestDelayedWorkflowClient:
         return Mock(spec=RedisHashSortedSetBuffer)
 
     @pytest.fixture
+    def buffer_keys(self):
+        """Create test buffer keys."""
+        return ["test_key_1", "test_key_2"]
+
+    @pytest.fixture
     def delayed_workflow_client(self, mock_buffer):
         """Create a DelayedWorkflowClient with mocked buffer."""
         return DelayedWorkflowClient(buf=mock_buffer)
+
+    @pytest.fixture
+    def workflow_client_with_keys(self, mock_buffer, buffer_keys):
+        """Create a DelayedWorkflowClient with mocked buffer and specific keys."""
+        return DelayedWorkflowClient(buf=mock_buffer, buffer_keys=buffer_keys)
+
+    def test_mark_project_ids_as_processed(
+        self, workflow_client_with_keys, mock_buffer, buffer_keys
+    ):
+        """Test mark_project_ids_as_processed with mocked RedisHashSortedSetBuffer."""
+        # Mock the conditional_delete_from_sorted_sets return value
+        # Return value is dict[str, list[int]] where keys are buffer keys and values are deleted project IDs
+        mock_return_value = {
+            "test_key_1": [123, 456],
+            "test_key_2": [789],
+        }
+        mock_buffer.conditional_delete_from_sorted_sets.return_value = mock_return_value
+
+        # Input data: project_id -> max_timestamp mapping
+        project_id_max_timestamps = {
+            123: 1000.5,
+            456: 2000.0,
+            789: 1500.75,
+        }
+
+        # Call the method
+        result = workflow_client_with_keys.mark_project_ids_as_processed(project_id_max_timestamps)
+
+        # Verify the mock was called with the correct arguments
+        mock_buffer.conditional_delete_from_sorted_sets.assert_called_once_with(
+            tuple(buffer_keys),  # DelayedWorkflowClient stores keys as tuple
+            [(123, 1000.5), (456, 2000.0), (789, 1500.75)],
+        )
+
+        # Verify the result is the union of all deleted project IDs
+        expected_result = [123, 456, 789]
+        assert sorted(result) == sorted(expected_result)
+
+    def test_mark_project_ids_as_processed_empty_input(
+        self, workflow_client_with_keys, mock_buffer, buffer_keys
+    ):
+        """Test mark_project_ids_as_processed with empty input."""
+        # Mock return value for empty input
+        mock_buffer.conditional_delete_from_sorted_sets.return_value = {
+            "test_key_1": [],
+            "test_key_2": [],
+        }
+
+        # Empty input
+        project_id_max_timestamps: dict[int, float] = {}
+
+        # Call the method
+        result = workflow_client_with_keys.mark_project_ids_as_processed(project_id_max_timestamps)
+
+        # Verify the mock was called with empty member list
+        mock_buffer.conditional_delete_from_sorted_sets.assert_called_once_with(
+            tuple(buffer_keys),
+            [],
+        )
+
+        # Result should be empty
+        assert result == []
+
+    def test_mark_project_ids_as_processed_partial_deletion(
+        self, workflow_client_with_keys, mock_buffer, buffer_keys
+    ):
+        """Test mark_project_ids_as_processed when only some project IDs are deleted."""
+        # Mock return value where only some project IDs are actually deleted
+        mock_return_value = {
+            "test_key_1": [123],  # Only project 123 was deleted from this key
+            "test_key_2": [],  # No projects deleted from this key
+        }
+        mock_buffer.conditional_delete_from_sorted_sets.return_value = mock_return_value
+
+        # Input with multiple project IDs
+        project_id_max_timestamps = {
+            123: 1000.5,
+            456: 2000.0,  # This one won't be deleted (perhaps timestamp is too old)
+        }
+
+        # Call the method
+        result = workflow_client_with_keys.mark_project_ids_as_processed(project_id_max_timestamps)
+
+        # Verify the mock was called with all input project IDs
+        mock_buffer.conditional_delete_from_sorted_sets.assert_called_once_with(
+            tuple(buffer_keys),
+            [(123, 1000.5), (456, 2000.0)],
+        )
+
+        # Result should only contain the actually deleted project IDs
+        assert result == [123]
+
+    def test_mark_project_ids_as_processed_deduplicates_results(
+        self, workflow_client_with_keys, mock_buffer, buffer_keys
+    ):
+        """Test that mark_project_ids_as_processed deduplicates project IDs from multiple keys."""
+        # Mock return value where the same project ID appears in multiple keys
+        mock_return_value = {
+            "test_key_1": [123, 456],
+            "test_key_2": [456, 789],  # 456 appears in both keys
+        }
+        mock_buffer.conditional_delete_from_sorted_sets.return_value = mock_return_value
+
+        # Input data
+        project_id_max_timestamps = {
+            123: 1000.5,
+            456: 2000.0,
+            789: 1500.75,
+        }
+
+        # Call the method
+        result = workflow_client_with_keys.mark_project_ids_as_processed(project_id_max_timestamps)
+
+        # Verify the result deduplicates project ID 456
+        expected_result = [123, 456, 789]
+        assert sorted(result) == sorted(expected_result)
+        assert len(result) == 3  # Should have exactly 3 unique project IDs
 
     def test_fetch_updates(self, delayed_workflow_client, mock_buffer):
         """Test fetching cohort updates from buffer."""
@@ -201,7 +196,7 @@ class TestDelayedWorkflowClient:
         result = delayed_workflow_client.get_project_ids(min=0.0, max=300.0)
 
         mock_buffer.bulk_get_sorted_set.assert_called_once_with(
-            DelayedWorkflowClient._get_buffer_keys(),
+            tuple(DelayedWorkflowClient._get_buffer_keys()),
             min=0.0,
             max=300.0,
         )
@@ -212,7 +207,7 @@ class TestDelayedWorkflowClient:
         delayed_workflow_client.clear_project_ids(min=0.0, max=300.0)
 
         mock_buffer.delete_keys.assert_called_once_with(
-            DelayedWorkflowClient._get_buffer_keys(),
+            tuple(DelayedWorkflowClient._get_buffer_keys()),
             min=0.0,
             max=300.0,
         )

--- a/tests/sentry/workflow_engine/buffer/test_redis_hash_sorted_set_buffer.py
+++ b/tests/sentry/workflow_engine/buffer/test_redis_hash_sorted_set_buffer.py
@@ -65,7 +65,7 @@ class TestRedisHashSortedSetBuffer:
 
     @pytest.fixture(autouse=True)
     def setup_buffer(self, buffer, mock_time_provider):
-        self.buf = buffer
+        self.buf: RedisHashSortedSetBuffer = buffer
         self.mock_time = mock_time_provider
 
     def test_push_to_hash(self):

--- a/tests/sentry/workflow_engine/processors/test_schedule.py
+++ b/tests/sentry/workflow_engine/processors/test_schedule.py
@@ -1,6 +1,8 @@
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
+
+import pytest
 
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
@@ -8,7 +10,11 @@ from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
 from sentry.workflow_engine.processors.schedule import (
+    NUM_COHORTS,
+    CohortUpdates,
+    ProjectChooser,
     bucket_num_groups,
+    chosen_projects,
     process_buffered_workflows,
     process_in_batches,
 )
@@ -174,3 +180,298 @@ class FetchGroupToEventDataTest(CreateEventTestCase):
         assert f"{self.rule.id}:{self.group.id}" in result
         data = json.loads(result[f"{self.rule.id}:{self.group.id}"])
         assert data["event_id"] == "event-456"
+
+
+class TestCohortUpdates:
+    def test_get_last_cohort_run_existing(self):
+        """Test getting last run time for existing cohort."""
+        updates = CohortUpdates(values={1: 100.5, 2: 200.3})
+        assert updates.get_last_cohort_run(1) == 100.5
+        assert updates.get_last_cohort_run(2) == 200.3
+
+    def test_get_last_cohort_run_missing(self):
+        """Test getting last run time for non-existent cohort returns 0."""
+        updates = CohortUpdates(values={1: 100.5})
+        assert updates.get_last_cohort_run(999) == 0
+
+
+class TestProjectChooser:
+    @pytest.fixture
+    def mock_buffer(self):
+        """Create a mock buffer for testing."""
+        mock_buffer = Mock()
+        return mock_buffer
+
+    @pytest.fixture
+    def project_chooser(self, mock_buffer):
+        """Create a ProjectChooser with mocked buffer."""
+        return ProjectChooser(mock_buffer, num_cohorts=6)
+
+    def test_init_default_cohorts(self, mock_buffer):
+        chooser = ProjectChooser(mock_buffer)
+        assert chooser.num_cohorts == NUM_COHORTS
+
+    def test_fetch_updates(self, project_chooser, mock_buffer):
+        """Test fetching cohort updates from buffer."""
+        expected_updates = CohortUpdates(values={1: 100.0})
+        mock_buffer.get_parsed_key.return_value = expected_updates
+
+        result = project_chooser.fetch_updates()
+
+        mock_buffer.get_parsed_key.assert_called_once_with(
+            "WORKFLOW_ENGINE_COHORT_UPDATES", CohortUpdates
+        )
+        assert result == expected_updates
+
+    def test_persist_updates(self, project_chooser, mock_buffer):
+        """Test persisting cohort updates to buffer."""
+        updates = CohortUpdates(values={1: 100.0, 2: 200.0})
+
+        project_chooser.persist_updates(updates)
+
+        mock_buffer.put_parsed_key.assert_called_once_with(
+            "WORKFLOW_ENGINE_COHORT_UPDATES", updates
+        )
+
+    def test_fetch_updates_missing_key(self, project_chooser, mock_buffer):
+        """Test fetching cohort updates when key doesn't exist (returns None)."""
+        mock_buffer.get_parsed_key.return_value = None
+
+        result = project_chooser.fetch_updates()
+
+        mock_buffer.get_parsed_key.assert_called_once_with(
+            "WORKFLOW_ENGINE_COHORT_UPDATES", CohortUpdates
+        )
+        assert isinstance(result, CohortUpdates)
+        assert result.values == {}  # Should be default empty dict
+
+    def test_project_id_to_cohort_distribution(self, project_chooser):
+        """Test that project IDs are distributed across cohorts."""
+        project_ids = list(range(1, 1001))  # 1000 project IDs
+        cohorts = [project_chooser.project_id_to_cohort(pid) for pid in project_ids]
+
+        # Check all cohorts are used
+        assert set(cohorts) == set(range(6))
+
+        # Check distribution is reasonably even (each cohort gets some projects)
+        cohort_counts = [cohorts.count(i) for i in range(6)]
+        assert all(count > 0 for count in cohort_counts)
+        assert all(count < 1000 for count in cohort_counts)
+
+    def test_project_id_to_cohort_consistent(self, project_chooser):
+        """Test that same project ID always maps to same cohort."""
+        for project_id in [123, 999, 4, 193848493]:
+            cohort1 = project_chooser.project_id_to_cohort(project_id)
+            cohort2 = project_chooser.project_id_to_cohort(project_id)
+            cohort3 = project_chooser.project_id_to_cohort(project_id)
+
+            assert cohort1 == cohort2 == cohort3
+            assert 0 <= cohort1 < 6
+
+    def test_project_ids_to_process_must_process_over_minute(self, project_chooser):
+        """Test that cohorts not run for over a minute are marked as must_process."""
+        fetch_time = 1000.0
+        cohort_updates = CohortUpdates(
+            values={
+                0: 900.0,  # 100 seconds ago - must process
+                1: 950.0,  # 50 seconds ago - may process
+                2: 990.0,  # 10 seconds ago - no process
+            }
+        )
+        all_project_ids = [10, 11, 12, 13, 14, 15]  # Projects mapping to cohorts 0-5
+
+        result = project_chooser.project_ids_to_process(fetch_time, cohort_updates, all_project_ids)
+
+        # Should include projects from cohort 0 (over 1 minute old)
+        expected_cohort = project_chooser.project_id_to_cohort(10)
+        if expected_cohort == 0:
+            assert 10 in result
+
+        # cohort_updates should be updated with fetch_time for processed cohorts
+        assert 0 in cohort_updates.values
+
+    def test_project_ids_to_process_may_process_fallback(self, project_chooser):
+        """Test that when no must_process cohorts, oldest may_process is chosen."""
+        fetch_time = 1000.0
+        cohort_updates = CohortUpdates(
+            values={
+                0: 995.0,  # 5 seconds ago - may process (older)
+                1: 998.0,  # 2 seconds ago - may process (newer)
+                2: 999.0,  # 1 second ago - no process
+            }
+        )
+        all_project_ids = [10, 11, 12]
+
+        result = project_chooser.project_ids_to_process(fetch_time, cohort_updates, all_project_ids)
+
+        # Should choose the oldest from may_process cohorts (cohort 0)
+        # and update cohort_updates accordingly
+        assert len(result) > 0  # Should process something
+        processed_cohorts = {project_chooser.project_id_to_cohort(pid) for pid in result}
+
+        # The processed cohorts should be updated in cohort_updates
+        for cohort in processed_cohorts:
+            assert cohort_updates.values[cohort] == fetch_time
+
+    def test_project_ids_to_process_no_processing_needed(self, project_chooser):
+        """Test when no processing is needed (all cohorts recently processed)."""
+        fetch_time = 1000.0
+        cohort_updates = CohortUpdates(
+            values={
+                0: 999.0,  # 1 second ago
+                1: 998.0,  # 2 seconds ago
+                2: 997.0,  # 3 seconds ago
+                3: 996.0,  # 4 seconds ago
+                4: 995.0,  # 5 seconds ago
+                5: 994.0,  # 6 seconds ago
+            }
+        )
+        all_project_ids = [10, 11, 12, 13, 14, 15]
+
+        result = project_chooser.project_ids_to_process(fetch_time, cohort_updates, all_project_ids)
+
+        # No cohorts are old enough for must_process or may_process
+        assert len(result) == 0
+
+    def test_scenario_once_per_minute_6_cohorts(self, project_chooser):
+        """
+        Scenario test: Running once per minute with 6 cohorts.
+        Should converge to stable cycle where each cohort gets processed every 6 minutes.
+        """
+        # Find project IDs that map to each cohort to ensure even distribution
+        all_project_ids = []
+        used_cohorts: set[int] = set()
+        project_id = 1
+        while len(used_cohorts) < 6:
+            cohort = project_chooser.project_id_to_cohort(project_id)
+            if cohort not in used_cohorts:
+                all_project_ids.append(project_id)
+                used_cohorts.add(cohort)
+            project_id += 1
+
+        cohort_updates = CohortUpdates(values={})
+
+        # Track which cohorts get processed over time
+        processed_cohorts_over_time = []
+
+        # Simulate 20 minutes of processing (20 runs, once per minute)
+        for minute in range(20):
+            fetch_time = float(minute * 60)  # Every 60 seconds
+
+            processed_projects = project_chooser.project_ids_to_process(
+                fetch_time, cohort_updates, all_project_ids
+            )
+            processed_cohorts = {
+                project_chooser.project_id_to_cohort(pid) for pid in processed_projects
+            }
+            processed_cohorts_over_time.append(processed_cohorts)
+
+        # After initial ramp-up, should settle into stable cycle
+        # Check the last 12 runs (2 full cycles) for stability
+        stable_period = processed_cohorts_over_time[-12:]
+
+        # Each cohort should be processed at least once in 12 minutes
+        cohort_counts = {i: 0 for i in range(6)}
+        for processed_cohorts in stable_period:
+            for cohort in processed_cohorts:
+                cohort_counts[cohort] += 1
+
+        # Verify that all cohorts get processed (at least once in stable period)
+        for cohort in range(6):
+            assert cohort_counts[cohort] >= 1, f"Cohort {cohort} never processed in stable period"
+
+    def test_scenario_six_times_per_minute(self, project_chooser):
+        """
+        Scenario test: Running 6 times per minute (every 10 seconds).
+        Should process one cohort per run in stable cycle.
+        """
+        # Find project IDs that map to each cohort to ensure even distribution
+        all_project_ids = []
+        used_cohorts: set[int] = set()
+        project_id = 1
+        while len(used_cohorts) < 6:
+            cohort = project_chooser.project_id_to_cohort(project_id)
+            if cohort not in used_cohorts:
+                all_project_ids.append(project_id)
+                used_cohorts.add(cohort)
+            project_id += 1
+
+        cohort_updates = CohortUpdates(values={})
+
+        processed_cohorts_over_time = []
+
+        # Simulate 2 minutes of processing (12 runs, every 10 seconds)
+        for run in range(12):
+            fetch_time = float(run * 10)  # Every 10 seconds
+
+            processed_projects = project_chooser.project_ids_to_process(
+                fetch_time, cohort_updates, all_project_ids
+            )
+            processed_cohorts = {
+                project_chooser.project_id_to_cohort(pid) for pid in processed_projects
+            }
+            processed_cohorts_over_time.append(processed_cohorts)
+
+        # After initial period, check stable cycle behavior
+        # In the last 6 runs, each cohort should be processed at least once
+        stable_period = processed_cohorts_over_time[-6:]
+
+        cohort_counts = {i: 0 for i in range(6)}
+        for processed_cohorts in stable_period:
+            for cohort in processed_cohorts:
+                cohort_counts[cohort] += 1
+
+        # Each cohort should be processed at least once in the last 6 runs
+        for cohort in range(6):
+            assert cohort_counts[cohort] >= 1, f"Cohort {cohort} never processed in stable period"
+
+
+class TestChosenProjects:
+    @pytest.fixture
+    def mock_project_chooser(self):
+        """Create a mock ProjectChooser."""
+        return Mock()
+
+    def test_chosen_projects_context_manager(self, mock_project_chooser):
+        """Test chosen_projects as a context manager."""
+        # Setup mocks
+        mock_cohort_updates = Mock()
+        mock_project_chooser.fetch_updates.return_value = mock_cohort_updates
+        mock_project_chooser.project_ids_to_process.return_value = [1, 2, 3]
+
+        fetch_time = 1000.0
+        all_project_ids = [1, 2, 3, 4, 5]
+
+        # Use context manager
+        with chosen_projects(mock_project_chooser, fetch_time, all_project_ids) as result:
+            project_ids_to_process = result
+
+            # Verify fetch_updates was called
+            mock_project_chooser.fetch_updates.assert_called_once()
+
+            # Verify project_ids_to_process was called with correct args
+            mock_project_chooser.project_ids_to_process.assert_called_once_with(
+                fetch_time, mock_cohort_updates, all_project_ids
+            )
+
+            # Verify the result
+            assert project_ids_to_process == [1, 2, 3]
+
+        # Verify persist_updates was called after context exit
+        mock_project_chooser.persist_updates.assert_called_once_with(mock_cohort_updates)
+
+    def test_chosen_projects_fetch_updates_exception(self, mock_project_chooser):
+        """Test that exception during fetch_updates is properly handled."""
+        # Make fetch_updates raise an exception (e.g. key doesn't exist)
+        mock_project_chooser.fetch_updates.side_effect = Exception("Key not found")
+
+        fetch_time = 1000.0
+        all_project_ids = [1, 2, 3, 4, 5]
+
+        # Should raise the exception from fetch_updates
+        with pytest.raises(Exception, match="Key not found"):
+            with chosen_projects(mock_project_chooser, fetch_time, all_project_ids):
+                pass
+
+        # persist_updates should not be called if fetch_updates fails
+        mock_project_chooser.persist_updates.assert_not_called()

--- a/tests/sentry/workflow_engine/processors/test_schedule.py
+++ b/tests/sentry/workflow_engine/processors/test_schedule.py
@@ -10,7 +10,6 @@ from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 from sentry.workflow_engine.buffer.batch_client import CohortUpdates, DelayedWorkflowClient
 from sentry.workflow_engine.processors.schedule import (
-    NUM_COHORTS,
     ProjectChooser,
     bucket_num_groups,
     chosen_projects,
@@ -203,10 +202,6 @@ class TestProjectChooser:
                 used_cohorts.add(cohort)
             project_id += 1
         return all_project_ids
-
-    def test_init_default_cohorts(self, mock_buffer):
-        chooser = ProjectChooser(mock_buffer)
-        assert chooser.num_cohorts == NUM_COHORTS
 
     def test_project_id_to_cohort_distribution(self, project_chooser):
         project_ids = list(range(1, 1001))  # 1000 project IDs

--- a/tests/sentry/workflow_engine/processors/test_schedule.py
+++ b/tests/sentry/workflow_engine/processors/test_schedule.py
@@ -198,7 +198,7 @@ class TestProjectChooser:
         used_cohorts: set[int] = set()
         project_id = 1
         while len(used_cohorts) < num_cohorts:
-            cohort = chooser.project_id_to_cohort(project_id)
+            cohort = chooser._project_id_to_cohort(project_id)
             if cohort not in used_cohorts:
                 all_project_ids.append(project_id)
                 used_cohorts.add(cohort)
@@ -207,7 +207,7 @@ class TestProjectChooser:
 
     def test_project_id_to_cohort_distribution(self, project_chooser):
         project_ids = list(range(1, 1001))  # 1000 project IDs
-        cohorts = [project_chooser.project_id_to_cohort(pid) for pid in project_ids]
+        cohorts = [project_chooser._project_id_to_cohort(pid) for pid in project_ids]
 
         # Check all cohorts are used
         assert set(cohorts) == set(range(6))
@@ -219,9 +219,9 @@ class TestProjectChooser:
 
     def test_project_id_to_cohort_consistent(self, project_chooser):
         for project_id in [123, 999, 4, 193848493]:
-            cohort1 = project_chooser.project_id_to_cohort(project_id)
-            cohort2 = project_chooser.project_id_to_cohort(project_id)
-            cohort3 = project_chooser.project_id_to_cohort(project_id)
+            cohort1 = project_chooser._project_id_to_cohort(project_id)
+            cohort2 = project_chooser._project_id_to_cohort(project_id)
+            cohort3 = project_chooser._project_id_to_cohort(project_id)
 
             assert cohort1 == cohort2 == cohort3
             assert 0 <= cohort1 < 6
@@ -240,7 +240,7 @@ class TestProjectChooser:
         result = project_chooser.project_ids_to_process(fetch_time, cohort_updates, all_project_ids)
 
         # Should include projects from cohort 0 (over 1 minute old)
-        expected_cohort = project_chooser.project_id_to_cohort(10)
+        expected_cohort = project_chooser._project_id_to_cohort(10)
         if expected_cohort == 0:
             assert 10 in result
 
@@ -263,7 +263,7 @@ class TestProjectChooser:
         # Should choose the oldest from may_process cohorts (cohort 0)
         # and update cohort_updates accordingly
         assert len(result) > 0  # Should process something
-        processed_cohorts = {project_chooser.project_id_to_cohort(pid) for pid in result}
+        processed_cohorts = {project_chooser._project_id_to_cohort(pid) for pid in result}
 
         # The processed cohorts should be updated in cohort_updates
         for cohort in processed_cohorts:
@@ -306,7 +306,7 @@ class TestProjectChooser:
                 fetch_time, cohort_updates, all_project_ids
             )
             processed_cohorts = {
-                project_chooser.project_id_to_cohort(pid) for pid in processed_projects
+                project_chooser._project_id_to_cohort(pid) for pid in processed_projects
             }
 
             # Every run should process all 6 cohorts.
@@ -340,7 +340,7 @@ class TestProjectChooser:
                 fetch_time, cohort_updates, all_project_ids
             )
             processed_cohorts = {
-                project_chooser.project_id_to_cohort(pid) for pid in processed_projects
+                project_chooser._project_id_to_cohort(pid) for pid in processed_projects
             }
             if run == 0:
                 assert (
@@ -371,7 +371,7 @@ class TestProjectChooser:
 
         # Verify all projects map to cohort 0
         for project_id in all_project_ids:
-            cohort = chooser.project_id_to_cohort(project_id)
+            cohort = chooser._project_id_to_cohort(project_id)
             assert cohort == 0, f"Project {project_id} should map to cohort 0, got {cohort}"
 
         cohort_updates = CohortUpdates(values={})
@@ -383,7 +383,7 @@ class TestProjectChooser:
             processed_projects = chooser.project_ids_to_process(
                 fetch_time, cohort_updates, all_project_ids
             )
-            processed_cohorts = {chooser.project_id_to_cohort(pid) for pid in processed_projects}
+            processed_cohorts = {chooser._project_id_to_cohort(pid) for pid in processed_projects}
 
             # With cohort count = 1, should always process cohort 0
             assert processed_cohorts == {

--- a/tests/sentry/workflow_engine/processors/test_schedule.py
+++ b/tests/sentry/workflow_engine/processors/test_schedule.py
@@ -8,10 +8,9 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
-from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
+from sentry.workflow_engine.buffer.batch_client import CohortUpdates, DelayedWorkflowClient
 from sentry.workflow_engine.processors.schedule import (
     NUM_COHORTS,
-    CohortUpdates,
     ProjectChooser,
     bucket_num_groups,
     chosen_projects,


### PR DESCRIPTION
Delayed workflows tasks are currently all scheduled every minute.
This frequency (60s) is what we want, but running them all at once makes our load bursty, and causes some rate limits to be frequently hit in Snuba querying.

This change establishes "cohorts" and schedules one cohort at a time, allowing us to smoothly transition to N groups of `delayed_workflow` tasks per minute, one every 1/Nth of a minute, smoothing out our workload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce cohort-sharded scheduling for delayed workflows, persisting cohort run timestamps in Redis and refactoring processing/cleanup; add pydantic-based Redis helpers and a new num_cohorts option.
> 
> - **Workflow Engine (Scheduling & Processing)**
>   - Introduce cohort-sharded scheduling via `ProjectChooser` and `chosen_projects`, selecting projects per run based on `workflow_engine.num_cohorts`.
>   - Persist cohort run timestamps in Redis as `CohortUpdates` using `DelayedWorkflowClient.fetch_updates/persist_updates`.
>   - Refactor cleanup into `mark_projects_processed`; compute `max_project_timestamp` and use conditional delete or range clear accordingly.
> - **Buffer Layer**
>   - Add `RedisHashSortedSetBuffer.get_parsed_key/put_parsed_key` for pydantic models; extend supported ops and expiry handling.
>   - Extend `DelayedWorkflowClient` with `_COHORT_UPDATES_KEY` and cohort update helpers.
> - **Options**
>   - Add `workflow_engine.num_cohorts` (Int, default `1`).
> - **Tests**
>   - Convert to pytest-style and add coverage for cohort selection, Redis parsed key helpers, and new scheduling/cleanup flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87a09d029031fe6c2c895d819ecb22435f2ff8dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->