### PR TITLE
fix(slack): allow empty response content

### DIFF
--- a/src/sentry/middleware/integrations/tasks.py
+++ b/src/sentry/middleware/integrations/tasks.py
@@ -110,9 +110,9 @@ class _AsyncSlackDispatcher(_AsyncRegionDispatcher):
         return IntegrationProviderSlug.SLACK.value
 
     def unpack_payload(self, response: Response) -> Any:
-        if response.content:
+        if response.content != b"":
             return orjson.loads(response.content)
-        return {}
+        return None
 
 
 @instrumented_task(

--- a/src/sentry/middleware/integrations/tasks.py
+++ b/src/sentry/middleware/integrations/tasks.py
@@ -93,7 +93,7 @@ class _AsyncRegionDispatcher(ABC):
             return None
         else:
             logger.info(
-                "discord.async_integration_response",
+                "integration.async_integration_response",
                 extra={
                     "path": self.request_payload["path"],
                     "region": result.region.name,
@@ -110,7 +110,9 @@ class _AsyncSlackDispatcher(_AsyncRegionDispatcher):
         return IntegrationProviderSlug.SLACK.value
 
     def unpack_payload(self, response: Response) -> Any:
-        return orjson.loads(response.content)
+        if response.content:
+            return orjson.loads(response.content)
+        return {}
 
 
 @instrumented_task(

--- a/src/sentry/middleware/integrations/tasks.py
+++ b/src/sentry/middleware/integrations/tasks.py
@@ -110,7 +110,7 @@ class _AsyncSlackDispatcher(_AsyncRegionDispatcher):
         return IntegrationProviderSlug.SLACK.value
 
     def unpack_payload(self, response: Response) -> Any:
-        if response.content != b"":
+        if response.content:
             return orjson.loads(response.content)
         return None
 

--- a/tests/sentry/middleware/integrations/test_tasks.py
+++ b/tests/sentry/middleware/integrations/test_tasks.py
@@ -125,7 +125,6 @@ class AsyncSlackResponseTest(TestCase):
             responses.POST,
             "https://us.testserver/extensions/slack/action/",
             status=404,
-            json={},
         )
         responses.add(
             responses.POST,


### PR DESCRIPTION
We used to gracefully handle empty response content here https://github.com/getsentry/sentry/pull/73998/files#diff-b2cbbebe9bbbe1cbfe72cb721b6efdd7c8fa211e0df2da77b39a5ecbccaf7947L64-L81

Resolves SENTRY-42M5 

Fixes https://linear.app/getsentry/issue/ECO-872/slack-jsondecodeerror-input-is-a-zero-length-empty-document-line-1