### PR TITLE
feat(feedback): always suggest has_linked_error search

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2956,7 +2956,9 @@ const FEEDBACK_FIELD_DEFINITIONS: Record<FeedbackFieldKey, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   [FeedbackFieldKey.HAS_LINKED_ERROR]: {
-    desc: t('Whether the feedback is explicitly linked to a Sentry error.'),
+    desc: t(
+      'Whether the feedback is explicitly linked to a Sentry error (associated_event_id).'
+    ),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.BOOLEAN,
   },

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2957,7 +2957,7 @@ const FEEDBACK_FIELD_DEFINITIONS: Record<FeedbackFieldKey, FieldDefinition> = {
   },
   [FeedbackFieldKey.HAS_LINKED_ERROR]: {
     desc: t(
-      'Whether the feedback is explicitly linked to a Sentry error (associated_event_id).'
+      'Whether the feedback is explicitly linked to a Sentry error (has associated_event_id).'
     ),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.BOOLEAN,

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2906,6 +2906,7 @@ const REPLAY_CLICK_FIELD_DEFINITIONS: Record<ReplayClickFieldKey, FieldDefinitio
 
 export enum FeedbackFieldKey {
   BROWSER_NAME = 'browser.name',
+  HAS_LINKED_ERROR = 'has_linked_error',
   LOCALE_LANG = 'locale.lang',
   LOCALE_TIMEZONE = 'locale.timezone',
   MESSAGE = 'message',
@@ -2927,6 +2928,7 @@ export const FEEDBACK_FIELDS = [
   FieldKey.GEO_REGION,
   FieldKey.GEO_SUBDIVISION,
   FieldKey.HAS,
+  FeedbackFieldKey.HAS_LINKED_ERROR,
   FieldKey.ID,
   FieldKey.IS,
   FieldKey.LEVEL,
@@ -2952,6 +2954,11 @@ const FEEDBACK_FIELD_DEFINITIONS: Record<FeedbackFieldKey, FieldDefinition> = {
     desc: t('Name of the browser'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+  },
+  [FeedbackFieldKey.HAS_LINKED_ERROR]: {
+    desc: t('Whether the feedback is explicitly linked to a Sentry error.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.BOOLEAN,
   },
   [FeedbackFieldKey.LOCALE_LANG]: {
     desc: t('Language preference of the user'),


### PR DESCRIPTION
Sentry attaches this tag to every feedback, and I thought it'd be good to always show it in the "suggested" section. The tag suggestions can be flaky, but the value is always either true or false

<img width="1141" height="467" alt="Screenshot 2025-09-22 at 12 07 46 PM" src="https://github.com/user-attachments/assets/ffd72be5-7659-4cf9-abdf-e88881e10920" />

Before:
<img width="494" height="171" alt="Screenshot 2025-09-22 at 12 09 31 PM" src="https://github.com/user-attachments/assets/53753049-7755-4c48-b8d7-81291f5256b1" />

no suggestions
<img width="201" height="72" alt="Screenshot 2025-09-22 at 12 09 46 PM" src="https://github.com/user-attachments/assets/2079363f-da2a-4acc-823f-56a2423b2795" />
