### PR TITLE
feat(insights): add to dashboard in specialized overview charts

### DIFF
--- a/static/app/views/insights/common/components/chartActionDropdown.tsx
+++ b/static/app/views/insights/common/components/chartActionDropdown.tsx
@@ -12,7 +12,6 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
-import {DEFAULT_WIDGET_NAME} from 'sentry/views/dashboards/types';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import type {ChartType} from 'sentry/views/insights/common/components/chart';
@@ -91,7 +90,7 @@ export function ChartActionDropdown({
   const addToDashboardOptions: AddToSpanDashboardOptions = {
     chartType,
     yAxes,
-    widgetName: title ?? DEFAULT_WIDGET_NAME,
+    widgetName: title,
     groupBy,
     search,
   };
@@ -137,24 +136,6 @@ export function BaseChartActionDropdown({
     },
   ];
 
-  if (alertMenuOptions.length > 0) {
-    menuOptions.push({
-      key: 'create-alert',
-      label: t('Create Alert for'),
-      isSubmenu: true,
-      children: alertMenuOptions.map(option => ({
-        ...option,
-        onAction: () => {
-          option.onAction?.();
-          trackAnalytics('insights.create_alert', {
-            organization,
-            referrer,
-          });
-        },
-      })),
-    });
-  }
-
   if (addToDashboardOptions) {
     menuOptions.push({
       key: 'add-to-dashboard',
@@ -173,6 +154,24 @@ export function BaseChartActionDropdown({
       },
       isSubmenu: false,
       disabled: !hasDashboardEdit,
+    });
+  }
+
+  if (alertMenuOptions.length > 0) {
+    menuOptions.push({
+      key: 'create-alert',
+      label: t('Create Alert for'),
+      isSubmenu: true,
+      children: alertMenuOptions.map(option => ({
+        ...option,
+        onAction: () => {
+          option.onAction?.();
+          trackAnalytics('insights.create_alert', {
+            organization,
+            referrer,
+          });
+        },
+      })),
     });
   }
 

--- a/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
@@ -26,6 +26,7 @@ import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
+import type {AddToSpanDashboardOptions} from 'sentry/views/insights/common/utils/useAddToSpanDashboard';
 import {useAlertsProject} from 'sentry/views/insights/common/utils/useAlertsProject';
 import {Referrer} from 'sentry/views/insights/pages/frontend/referrers';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
@@ -55,6 +56,8 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
   const totalTimeField = 'sum(span.duration)';
   const title = t('Assets by Time Spent');
   const interval = getIntervalForTimeSeriesQuery(yAxes, selection.datetime);
+  const chartType = ChartType.LINE;
+  const topEvents = 3;
 
   const {
     data: assetListData,
@@ -71,7 +74,7 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
       ],
       sorts: [{field: totalTimeField, kind: 'desc'}],
       search,
-      limit: 3,
+      limit: topEvents,
       noPagination: true,
     },
     referrer
@@ -87,7 +90,7 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
       fields: [groupBy, yAxes],
       yAxis: [yAxes],
       sort: {field: yAxes, kind: 'desc'},
-      topN: 3,
+      topN: topEvents,
       enabled: assetListData?.length > 0,
       interval,
     },
@@ -164,7 +167,7 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
     organization,
     visualize: [
       {
-        chartType: ChartType.LINE,
+        chartType,
         yAxes: [yAxes],
       },
     ],
@@ -176,6 +179,16 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
     interval,
     referrer,
   });
+
+  const addToDashboardOptions: AddToSpanDashboardOptions = {
+    chartType,
+    yAxes: [yAxes],
+    widgetName: title,
+    groupBy: [groupBy],
+    search,
+    sort: {field: totalTimeField, kind: 'desc'},
+    topEvents,
+  };
 
   return (
     <Widget
@@ -189,6 +202,7 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
                 key="slow assets widget"
                 exploreUrl={exploreUrl}
                 referrer={referrer}
+                addToDashboardOptions={addToDashboardOptions}
                 alertMenuOptions={assetSeriesData.map(series => ({
                   key: series.seriesName,
                   label: series.seriesName,

--- a/static/app/views/insights/common/components/widgets/overviewTimeConsumingQueriesWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewTimeConsumingQueriesWidget.tsx
@@ -25,6 +25,7 @@ import {TimeSpentCell} from 'sentry/views/insights/common/components/tableCells/
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
+import type {AddToSpanDashboardOptions} from 'sentry/views/insights/common/utils/useAddToSpanDashboard';
 import {useAlertsProject} from 'sentry/views/insights/common/utils/useAlertsProject';
 import {SupportedDatabaseSystem} from 'sentry/views/insights/database/utils/constants';
 import {Referrer} from 'sentry/views/insights/pages/backend/referrers';
@@ -181,6 +182,16 @@ export default function OverviewTimeConsumingQueriesWidget(
     referrer,
   });
 
+  const addToDashboardOptions: AddToSpanDashboardOptions = {
+    chartType: ChartType.LINE,
+    yAxes: [yAxes],
+    widgetName: title,
+    groupBy: [groupBy],
+    search,
+    sort: {field: totalTimeField, kind: 'desc'},
+    topEvents: 3,
+  };
+
   return (
     <Widget
       Title={<Widget.WidgetTitle title={title} />}
@@ -193,6 +204,7 @@ export default function OverviewTimeConsumingQueriesWidget(
                 key="time consuming queries widget"
                 exploreUrl={exploreUrl}
                 referrer={referrer}
+                addToDashboardOptions={addToDashboardOptions}
                 alertMenuOptions={plottables.map(plottable => ({
                   key: plottable.name,
                   label: ellipsize(plottable.name, 90),

--- a/static/app/views/insights/common/components/widgets/overviewTimeConsumingRequestsWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewTimeConsumingRequestsWidget.tsx
@@ -24,6 +24,7 @@ import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
+import type {AddToSpanDashboardOptions} from 'sentry/views/insights/common/utils/useAddToSpanDashboard';
 import {useAlertsProject} from 'sentry/views/insights/common/utils/useAlertsProject';
 import {DomainCell} from 'sentry/views/insights/http/components/tables/domainCell';
 import {Referrer} from 'sentry/views/insights/pages/frontend/referrers';
@@ -171,6 +172,16 @@ export default function OverviewTimeConsumingRequestsWidget(
     referrer,
   });
 
+  const addToDashboardOptions: AddToSpanDashboardOptions = {
+    chartType: ChartType.LINE,
+    yAxes: [yAxes],
+    widgetName: title,
+    groupBy: [groupBy],
+    search,
+    sort: {field: totalTimeField, kind: 'desc'},
+    topEvents: 3,
+  };
+
   return (
     <Widget
       Title={<Widget.WidgetTitle title={title} />}
@@ -183,6 +194,7 @@ export default function OverviewTimeConsumingRequestsWidget(
                 key="time consuming requests widget"
                 exploreUrl={exploreUrl}
                 referrer={referrer}
+                addToDashboardOptions={addToDashboardOptions}
                 alertMenuOptions={requestSeriesData.map(series => ({
                   key: series.seriesName,
                   label: aliases[series.seriesName],


### PR DESCRIPTION
1. Add `add to dashboard` feature in more specialized charts that don't work with the generic implementation
2. swap `add to dashboard` button and `create alert` button. The dropdown works better when the option with a submenu is at the bottom, because sometimes the submenu overlays the last item.
3. Add some extra config in the addToDashboard hook to make the chart match closer to the insights version
<img width="280" height="202" alt="image" src="https://github.com/user-attachments/assets/f6d5b6ce-60fb-4064-bcb2-f0010d1ec69f" />
<img width="662" height="652" alt="image" src="https://github.com/user-attachments/assets/daaa72a9-c897-4232-b03d-abd07a58074e" />
