### PR TITLE
fix(prevent): Disable toggle for non-US

### DIFF
--- a/static/app/data/forms/organizationGeneralSettings.tsx
+++ b/static/app/data/forms/organizationGeneralSettings.tsx
@@ -1,4 +1,3 @@
-import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {ExternalLink} from 'sentry/components/core/link';
 import type {JsonFormObject} from 'sentry/components/forms/types';
 import {t, tct} from 'sentry/locale';
@@ -48,26 +47,6 @@ const formGroups: JsonFormObject[] = [
           ),
         }),
         visible: () => !ConfigStore.get('isSelfHostedErrorsOnly'),
-      },
-      {
-        name: 'enablePrReviewTestGeneration',
-        type: 'boolean',
-        label: tct('Enable AI Code Review [badge]', {
-          badge: <FeatureBadge type="beta" style={{marginBottom: '2px'}} />,
-        }),
-        help: tct(
-          'Use AI to review, find bugs, and generate tests in pull requests [link:Learn more]',
-          {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/sentry-prevent-ai/" />
-            ),
-          }
-        ),
-        visible: ({model}) => {
-          // Show field when AI features are enabled (hideAiFeatures is false)
-          const hideAiFeatures = model.getValue('hideAiFeatures');
-          return hideAiFeatures;
-        },
       },
     ],
   },

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -335,4 +335,50 @@ describe('OrganizationSettingsForm', () => {
     // PR Review field should be hidden again
     expect(screen.queryByText('Enable AI Code Review')).not.toBeInTheDocument();
   });
+
+  describe('AI Code Review field', () => {
+    it('is enabled when US region', () => {
+      jest.mocked(RegionUtils.getRegionDataFromOrganization).mockReturnValue({
+        name: 'us',
+        displayName: 'United States of America (US)',
+        url: 'https://sentry.de.example.com',
+      });
+
+      render(
+        <OrganizationSettingsForm
+          {...routerProps}
+          initialData={OrganizationFixture({hideAiFeatures: true})}
+          onSave={onSave}
+        />
+      );
+
+      const preventAiField = screen.getByRole('checkbox', {
+        name: /Enable AI Code Review/i,
+      });
+      expect(preventAiField).toBeInTheDocument();
+      expect(preventAiField).toBeEnabled();
+    });
+
+    it('is disabled when non US region', () => {
+      jest.mocked(RegionUtils.getRegionDataFromOrganization).mockReturnValue({
+        name: 'de',
+        displayName: 'Europe (Frankfurt)',
+        url: 'https://sentry.de.example.com',
+      });
+
+      render(
+        <OrganizationSettingsForm
+          {...routerProps}
+          initialData={OrganizationFixture({hideAiFeatures: true})}
+          onSave={onSave}
+        />
+      );
+
+      const preventAiField = screen.getByRole('checkbox', {
+        name: /Enable AI Code Review/i,
+      });
+      expect(preventAiField).toBeInTheDocument();
+      expect(preventAiField).toBeDisabled();
+    });
+  });
 });

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -23,6 +23,7 @@ import type {Organization} from 'sentry/types/organization';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeHideAiFeaturesField} from 'sentry/views/settings/organizationGeneralSettings/aiFeatureSettings';
+import {makePreventAiField} from 'sentry/views/settings/organizationGeneralSettings/preventAiSettings';
 
 const HookCodecovSettingsLink = HookOrDefault({
   hookName: 'component:codecov-integration-settings-link',
@@ -120,7 +121,7 @@ function OrganizationSettingsForm({initialData, onSave}: Props) {
           </PoweredByCodecov>
         ),
       },
-      ...formsConfig[0]!.fields.slice(3),
+      makePreventAiField(organization),
     ];
     return formsConfig;
   }, [access, organization]);

--- a/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
@@ -1,0 +1,36 @@
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import {ExternalLink} from 'sentry/components/core/link';
+import type {FieldObject} from 'sentry/components/forms/types';
+import {t, tct} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import {getRegionDataFromOrganization} from 'sentry/utils/regions';
+
+export const makePreventAiField = (organization: Organization): FieldObject => {
+  const regionData = getRegionDataFromOrganization(organization);
+  const isUSOrg = regionData?.name === 'us';
+
+  return {
+    name: 'enablePrReviewTestGeneration',
+    type: 'boolean',
+    label: tct('Enable AI Code Review [badge]', {
+      badge: <FeatureBadge type="beta" style={{marginBottom: '2px'}} />,
+    }),
+    help: tct(
+      'Use AI to review, find bugs, and generate tests in pull requests [link:Learn more]',
+      {
+        link: (
+          <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/sentry-prevent-ai/" />
+        ),
+      }
+    ),
+    visible: ({model}) => {
+      // Show field when AI features are enabled (hideAiFeatures is false)
+      const hideAiFeatures = model.getValue('hideAiFeatures');
+      return hideAiFeatures;
+    },
+    disabled: () => !isUSOrg,
+    disabledReason: isUSOrg
+      ? null
+      : t('AI Code Review is only available in the US region'),
+  };
+};


### PR DESCRIPTION
We do not offer Prevent AI Code Review for regions other than U.S. but we formerly allowed toggling it ON, leading to some user confusion. Disable the toggling if you are not in U.S. region.

Closes https://linear.app/getsentry/issue/PREVENT-316

Screenshot:
<img width="797" height="491" alt="Screenshot 2025-09-22 at 12 03 00 PM" src="https://github.com/user-attachments/assets/2ef69251-bf66-4039-9101-e2d57575acb7" />
