### PR TITLE
fix(aci): Center align plugin icon

### DIFF
--- a/static/app/components/workflowEngine/ui/actionMetadata.tsx
+++ b/static/app/components/workflowEngine/ui/actionMetadata.tsx
@@ -2,12 +2,16 @@ import styled from '@emotion/styled';
 
 import {IconMail} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
+import {PluginIcon, type PluginIconProps} from 'sentry/plugins/components/pluginIcon';
 import {ActionType} from 'sentry/types/workflowEngine/actions';
 
 const ICON_SIZE = 20;
 
-const StyledPluginIcon = styled(PluginIcon)`
+const StyledPluginIcon = styled(({className, ...props}: PluginIconProps) => (
+  <div className={className}>
+    <PluginIcon {...props} />
+  </div>
+))`
   display: inline-block;
   vertical-align: middle;
 `;


### PR DESCRIPTION
display: inline-block affects the alignment of the icon, add a wrapper

before 

<img width="93" height="38" alt="image" src="https://github.com/user-attachments/assets/1343c971-0547-4c05-9dc9-b3fd88c62bb6" />
