### PR TITLE
feat(dashboards): Remove discover from acceptance tests

### DIFF
--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -141,7 +141,7 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
             dashboard=self.dashboard,
             title="Existing Widget",
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
-            widget_type=DashboardWidgetTypes.DISCOVER,
+            widget_type=DashboardWidgetTypes.ERROR_EVENTS,
             interval="1d",
         )
         DashboardWidgetQuery.objects.create(
@@ -217,7 +217,7 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
             dashboard=self.dashboard,
             title="Existing Widget",
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
-            widget_type=DashboardWidgetTypes.DISCOVER,
+            widget_type=DashboardWidgetTypes.ERROR_EVENTS,
             interval="1d",
         )
         DashboardWidgetQuery.objects.create(
@@ -259,7 +259,7 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
             dashboard=self.dashboard,
             title="Existing Widget",
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
-            widget_type=DashboardWidgetTypes.DISCOVER,
+            widget_type=DashboardWidgetTypes.ERROR_EVENTS,
             interval="1d",
             detail={"layout": {"x": 0, "y": 0, "w": 2, "h": 2, "minH": 2}},
         )
@@ -335,7 +335,7 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
                     dashboard=self.dashboard,
                     title=f"Existing Widget {i}",
                     display_type=DashboardWidgetDisplayTypes.LINE_CHART,
-                    widget_type=DashboardWidgetTypes.DISCOVER,
+                    widget_type=DashboardWidgetTypes.ERROR_EVENTS,
                     interval="1d",
                 )
                 for i in range(4)
@@ -364,7 +364,7 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
             dashboard=self.dashboard,
             title="Big Number Widget",
             display_type=DashboardWidgetDisplayTypes.BIG_NUMBER,
-            widget_type=DashboardWidgetTypes.DISCOVER,
+            widget_type=DashboardWidgetTypes.ERROR_EVENTS,
             interval="1d",
         )
         DashboardWidgetQuery.objects.create(
@@ -521,7 +521,7 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
                     dashboard=self.dashboard,
                     title=f"Widget {i}",
                     display_type=display_type,
-                    widget_type=DashboardWidgetTypes.DISCOVER,
+                    widget_type=DashboardWidgetTypes.ERROR_EVENTS,
                     interval="1d",
                     detail={"layout": layout},
                 )
@@ -574,7 +574,7 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
             dashboard=self.dashboard,
             title="Originally Big Number - 3 rows",
             display_type=DashboardWidgetDisplayTypes.BIG_NUMBER,
-            widget_type=DashboardWidgetTypes.DISCOVER,
+            widget_type=DashboardWidgetTypes.ERROR_EVENTS,
             interval="1d",
             detail={"layout": {"x": 0, "y": 0, "w": 2, "h": 3, "minH": 1}},
         )
@@ -614,7 +614,7 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
             dashboard=self.dashboard,
             title="Originally Area Chart - 3 rows",
             display_type=DashboardWidgetDisplayTypes.AREA_CHART,
-            widget_type=DashboardWidgetTypes.DISCOVER,
+            widget_type=DashboardWidgetTypes.ERROR_EVENTS,
             interval="1d",
             detail={"layout": {"x": 0, "y": 0, "w": 2, "h": 3, "minH": 2}},
         )
@@ -662,14 +662,14 @@ class OrganizationDashboardsManageAcceptanceTest(AcceptanceTestCase):
             dashboard=self.dashboard,
             title="Widget 1",
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
-            widget_type=DashboardWidgetTypes.DISCOVER,
+            widget_type=DashboardWidgetTypes.ERROR_EVENTS,
             interval="1d",
         )
         self.widget_2 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
             title="Widget 2",
             display_type=DashboardWidgetDisplayTypes.TABLE,
-            widget_type=DashboardWidgetTypes.DISCOVER,
+            widget_type=DashboardWidgetTypes.ERROR_EVENTS,
             interval="1d",
         )
         self.login_as(self.user)
@@ -695,7 +695,7 @@ class OrganizationDashboardsManageAcceptanceTest(AcceptanceTestCase):
             dashboard=dashboard_with_layouts,
             title="Widget 1",
             display_type=DashboardWidgetDisplayTypes.BAR_CHART,
-            widget_type=DashboardWidgetTypes.DISCOVER,
+            widget_type=DashboardWidgetTypes.ERROR_EVENTS,
             interval="1d",
             detail={"layout": {"x": 1, "y": 0, "w": 3, "h": 3, "minH": 2}},
         )
@@ -706,7 +706,7 @@ class OrganizationDashboardsManageAcceptanceTest(AcceptanceTestCase):
             dashboard=dashboard_with_layouts,
             title="Widget 2",
             display_type=DashboardWidgetDisplayTypes.TABLE,
-            widget_type=DashboardWidgetTypes.DISCOVER,
+            widget_type=DashboardWidgetTypes.ERROR_EVENTS,
             interval="1d",
         )
 


### PR DESCRIPTION
Not needed anymore. We should be using a different dataset since this is deprecated