### PR TITLE
fix: Pin Spotlight to latest v3.x

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -454,7 +454,7 @@ services:
     labels:
       - orchestrator=devservices
   spotlight:
-    image: ghcr.io/getsentry/spotlight:latest
+    image: ghcr.io/getsentry/spotlight:7640f9ff4be79a934e5cac8b255d2a2055ceeb28
     healthcheck:
       interval: 1s
       timeout: 1s


### PR DESCRIPTION
Fixes inc-1406. Spotlight no longer supports the embedded UI mode since v4 which was released over the weekend.

Until we introduce a new flow for it, we are pinning it to the latest release in the 3.x line.
