### PR TITLE
fix(spend-allocation): hide Firefox native number input steppers

### DIFF
--- a/static/gsApp/views/spendAllocations/components/allocationForm.tsx
+++ b/static/gsApp/views/spendAllocations/components/allocationForm.tsx
@@ -512,6 +512,11 @@ const FancyInput = styled('input')`
   ::-webkit-inner-spin-button {
     -webkit-appearance: none;
   }
+
+  /* Hide Firefox's native number input steppers to prevent duplicate UI with custom increment/decrement buttons */
+  &[type='number'] {
+    -moz-appearance: textfield;
+  }
 `;
 
 const Toggle = styled(NewBooleanField)`


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/88040
Closes https://linear.app/getsentry/issue/BIL-461/spend-allocation-input-styling-on-firefox-needs-to-be-overridden

Add CSS rule to hide Firefox's native number input steppers in the allocation form to prevent duplicate UI with custom increment/decrement buttons.

Verified with `pnpm dev-ui` on both Firefox and Chrome.

### Before 
<img width="637" height="500" alt="Screenshot 2025-09-22 at 4 29 18 PM" src="https://github.com/user-attachments/assets/eaa5fbd2-e6c4-425f-8881-2dcd4a395da0" />

### After

<img width="648" height="500" alt="Screenshot 2025-09-22 at 4 29 21 PM" src="https://github.com/user-attachments/assets/7a1f8a6e-0ce3-43b7-944a-63e6404ab31b" />

