### PR TITLE
chore(aci): RPC service for updating sentry app action status

### DIFF
--- a/src/sentry/deletions/defaults/sentry_app.py
+++ b/src/sentry/deletions/defaults/sentry_app.py
@@ -23,3 +23,8 @@ class SentryAppDeletionTask(ModelDeletionTask[SentryApp]):
             status = getattr(instance, "status", None)
             if status not in (SentryAppStatus.DELETION_IN_PROGRESS, None):
                 instance.update(status=SentryAppStatus.DELETION_IN_PROGRESS)
+
+    def delete_instance(self, instance: SentryApp) -> None:
+        # action service RPC goes here, iterating by region because children are deleted first
+
+        return super().delete_instance(instance)

--- a/src/sentry/deletions/defaults/sentry_app_installation.py
+++ b/src/sentry/deletions/defaults/sentry_app_installation.py
@@ -25,3 +25,8 @@ class SentryAppInstallationDeletionTask(ModelDeletionTask[SentryAppInstallation]
 
     def mark_deletion_in_progress(self, instance_list: Sequence[SentryAppInstallation]) -> None:
         pass
+
+    def delete_instance(self, instance: SentryAppInstallation) -> None:
+        # action_service RPC goes here
+
+        return super().delete_instance(instance)

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -44,7 +44,7 @@ class DatabaseBackedActionService(ActionService):
     def update_action_status_for_sentry_app_via_sentry_app_id(
         self,
         *,
-        organization_id: int,
+        region_name: str,
         status: int,
         sentry_app_id: int,
     ) -> None:

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -28,30 +28,28 @@ class DatabaseBackedActionService(ActionService):
             dataconditiongroupaction__condition_group__organization_id=organization_id,
         ).update(status=status)
 
-    def update_action_status_for_sentry_app(
+    def update_action_status_for_sentry_app_via_uuid(
         self,
         *,
         organization_id: int,
         status: int,
-        sentry_app_install_uuid: str | None = None,
-        sentry_app_id: int | None = None,
+        sentry_app_install_uuid: str,
     ) -> None:
-        if (not sentry_app_install_uuid and not sentry_app_id) or (
-            sentry_app_install_uuid and sentry_app_id
-        ):
-            raise ValueError("Either sentry_app_install_uuid or sentry_app_id must be provided")
-
-        sentry_app_identifier = (
-            SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID
-            if sentry_app_install_uuid
-            else SentryAppIdentifier.SENTRY_APP_ID
-        )
-        target_identifier = (
-            sentry_app_install_uuid if sentry_app_install_uuid else str(sentry_app_id)
-        )
-
         Action.objects.filter(
             type=Action.Type.SENTRY_APP,
-            config__sentry_app_identifier=sentry_app_identifier,
-            config__target_identifier=target_identifier,
+            config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+            config__target_identifier=sentry_app_install_uuid,
+        ).update(status=status)
+
+    def update_action_status_for_sentry_app_via_sentry_app_id(
+        self,
+        *,
+        organization_id: int,
+        status: int,
+        sentry_app_id: int,
+    ) -> None:
+        Action.objects.filter(
+            type=Action.Type.SENTRY_APP,
+            config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_ID,
+            config__target_identifier=str(sentry_app_id),
         ).update(status=status)

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -1,5 +1,6 @@
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.service.action.service import ActionService
+from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
 class DatabaseBackedActionService(ActionService):
@@ -25,4 +26,32 @@ class DatabaseBackedActionService(ActionService):
         Action.objects.filter(
             integration_id=integration_id,
             dataconditiongroupaction__condition_group__organization_id=organization_id,
+        ).update(status=status)
+
+    def update_action_status_for_sentry_app(
+        self,
+        *,
+        organization_id: int,
+        status: int,
+        sentry_app_install_uuid: str | None = None,
+        sentry_app_id: int | None = None,
+    ) -> None:
+        if (not sentry_app_install_uuid and not sentry_app_id) or (
+            sentry_app_install_uuid and sentry_app_id
+        ):
+            raise ValueError("Either sentry_app_install_uuid or sentry_app_id must be provided")
+
+        sentry_app_identifier = (
+            SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID
+            if sentry_app_install_uuid
+            else SentryAppIdentifier.SENTRY_APP_ID
+        )
+        target_identifier = (
+            sentry_app_install_uuid if sentry_app_install_uuid else str(sentry_app_id)
+        )
+
+        Action.objects.filter(
+            type=Action.Type.SENTRY_APP,
+            config__sentry_app_identifier=sentry_app_identifier,
+            config__target_identifier=target_identifier,
         ).update(status=status)

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -5,7 +5,7 @@
 
 import abc
 
-from sentry.hybridcloud.rpc.resolvers import ByOrganizationId
+from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByRegionName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.silo.base import SiloMode
 
@@ -45,12 +45,12 @@ class ActionService(RpcService):
     ) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByOrganizationId())
+    @regional_rpc_method(resolve=ByRegionName())
     @abc.abstractmethod
     def update_action_status_for_sentry_app_via_sentry_app_id(
         self,
         *,
-        organization_id: int,
+        region_name: str,
         status: int,
         sentry_app_id: int,
     ) -> None:

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -36,13 +36,23 @@ class ActionService(RpcService):
 
     @regional_rpc_method(resolve=ByOrganizationId())
     @abc.abstractmethod
-    def update_action_status_for_sentry_app(
+    def update_action_status_for_sentry_app_via_uuid(
         self,
         *,
         organization_id: int,
         status: int,
-        sentry_app_install_uuid: str | None = None,
-        sentry_app_id: int | None = None,
+        sentry_app_install_uuid: str,
+    ) -> None:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abc.abstractmethod
+    def update_action_status_for_sentry_app_via_sentry_app_id(
+        self,
+        *,
+        organization_id: int,
+        status: int,
+        sentry_app_id: int,
     ) -> None:
         pass
 

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -34,5 +34,17 @@ class ActionService(RpcService):
     ) -> None:
         pass
 
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abc.abstractmethod
+    def update_action_status_for_sentry_app(
+        self,
+        *,
+        organization_id: int,
+        status: int,
+        sentry_app_install_uuid: str | None = None,
+        sentry_app_id: int | None = None,
+    ) -> None:
+        pass
+
 
 action_service = ActionService.create_delegation()

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -1,5 +1,3 @@
-import pytest
-
 from sentry.constants import ObjectStatus
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.silo.base import SiloMode
@@ -252,21 +250,6 @@ class TestActionService(TestCase):
             assert action is not None
             assert action.status == ObjectStatus.DISABLED
 
-    def test_update_action_status_for_sentry_app__invalid_params(self) -> None:
-        with pytest.raises(Exception):
-            action_service.update_action_status_for_sentry_app(
-                organization_id=self.organization.id,
-                sentry_app_install_uuid="asdf",
-                sentry_app_id=self.sentry_app.id,
-                status=ObjectStatus.DISABLED,
-            )
-
-        with pytest.raises(Exception):
-            action_service.update_action_status_for_sentry_app(
-                organization_id=self.organization.id,
-                status=ObjectStatus.DISABLED,
-            )
-
     def test_update_action_status_for_sentry_app__installation_uuid(self) -> None:
         sentry_app_installation = self.create_sentry_app_installation(
             slug=self.sentry_app.slug,
@@ -281,7 +264,7 @@ class TestActionService(TestCase):
             },
         )
 
-        action_service.update_action_status_for_sentry_app(
+        action_service.update_action_status_for_sentry_app_via_uuid(
             organization_id=self.organization.id,
             sentry_app_install_uuid=sentry_app_installation.uuid,
             status=ObjectStatus.DISABLED,
@@ -291,7 +274,7 @@ class TestActionService(TestCase):
             action.refresh_from_db()
             assert action.status == ObjectStatus.DISABLED
 
-    def test_update_action_status_for_sentry_app__id(self) -> None:
+    def test_update_action_status_for_sentry_app__via_sentry_app_id(self) -> None:
         action = self.create_action(
             type=Action.Type.SENTRY_APP,
             config={
@@ -300,7 +283,7 @@ class TestActionService(TestCase):
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
-        action_service.update_action_status_for_sentry_app(
+        action_service.update_action_status_for_sentry_app_via_sentry_app_id(
             organization_id=self.organization.id,
             sentry_app_id=self.sentry_app.id,
             status=ObjectStatus.DISABLED,

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -284,7 +284,7 @@ class TestActionService(TestCase):
             },
         )
         action_service.update_action_status_for_sentry_app_via_sentry_app_id(
-            organization_id=self.organization.id,
+            region_name="us",
             sentry_app_id=self.sentry_app.id,
             status=ObjectStatus.DISABLED,
         )

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.constants import ObjectStatus
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.silo.base import SiloMode
@@ -248,4 +250,62 @@ class TestActionService(TestCase):
 
             action = Action.objects.filter(id=sentry_app_action.id).first()
             assert action is not None
+            assert action.status == ObjectStatus.DISABLED
+
+    def test_update_action_status_for_sentry_app__invalid_params(self) -> None:
+        with pytest.raises(Exception):
+            action_service.update_action_status_for_sentry_app(
+                organization_id=self.organization.id,
+                sentry_app_install_uuid="asdf",
+                sentry_app_id=self.sentry_app.id,
+                status=ObjectStatus.DISABLED,
+            )
+
+        with pytest.raises(Exception):
+            action_service.update_action_status_for_sentry_app(
+                organization_id=self.organization.id,
+                status=ObjectStatus.DISABLED,
+            )
+
+    def test_update_action_status_for_sentry_app__installation_uuid(self) -> None:
+        sentry_app_installation = self.create_sentry_app_installation(
+            slug=self.sentry_app.slug,
+            organization=self.organization,
+        )
+        action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": sentry_app_installation.uuid,
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+
+        action_service.update_action_status_for_sentry_app(
+            organization_id=self.organization.id,
+            sentry_app_install_uuid=sentry_app_installation.uuid,
+            status=ObjectStatus.DISABLED,
+        )
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            action.refresh_from_db()
+            assert action.status == ObjectStatus.DISABLED
+
+    def test_update_action_status_for_sentry_app__id(self) -> None:
+        action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": str(self.sentry_app.id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+        action_service.update_action_status_for_sentry_app(
+            organization_id=self.organization.id,
+            sentry_app_id=self.sentry_app.id,
+            status=ObjectStatus.DISABLED,
+        )
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            action.refresh_from_db()
             assert action.status == ObjectStatus.DISABLED


### PR DESCRIPTION
Part 1 of quieting SENTRY-494A (cannot find installation with specific sentry app installation uuid to fire an Action because it was deleted)

We can either mass update the action status given a sentry app id or sentry app installation uuid (2 RPC functions).