### PR TITLE
chore(eco): record RestrictedIPAddress exceptions as halts

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -341,6 +341,11 @@ class IntegrationEventLifecycle(EventLifecycle):
         exc_value: BaseException | None,
         traceback: TracebackType,
     ) -> None:
+        if self._state != EventLifecycleOutcome.STARTED:
+            # The context called record_success or record_failure being closing,
+            # so we can just exit quietly.
+            return
+
         if exc_value is not None and isinstance(exc_value.__cause__, RestrictedIPAddress):
             # ApiHostError is raised from RestrictedIPAddress
             self.record_halt(exc_value)

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -314,13 +314,14 @@ class EventLifecycle:
             # The context called record_success or record_failure being closing,
             # so we can just exit quietly.
             return
-        if isinstance(exc_value.__cause__, RestrictedIPAddress):
-            # ApiHostError is raised from RestrictedIPAddress
-            self._terminate(EventLifecycleOutcome.HALTED, exc_value)
-        elif exc_value is not None:
-            # We were forced to exit the context by a raised exception.
-            # Default to creating a Sentry issue for unhandled exceptions
-            self.record_failure(exc_value, create_issue=True)
+        if exc_value is not None:
+            if isinstance(exc_value.__cause__, RestrictedIPAddress):
+                # ApiHostError is raised from RestrictedIPAddress
+                self._terminate(EventLifecycleOutcome.HALTED, exc_value)
+            else:
+                # We were forced to exit the context by a raised exception.
+                # Default to creating a Sentry issue for unhandled exceptions
+                self.record_failure(exc_value, create_issue=True)
         else:
             # We exited the context without record_success or record_failure being
             # called. Assume success if we were told to do so. Else, log a halt

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -314,7 +314,8 @@ class EventLifecycle:
             # The context called record_success or record_failure being closing,
             # so we can just exit quietly.
             return
-        if isinstance(exc_value, RestrictedIPAddress):
+        if isinstance(exc_value.__cause__, RestrictedIPAddress):
+            # ApiHostError is raised from RestrictedIPAddress
             self._terminate(EventLifecycleOutcome.HALTED, exc_value)
         elif exc_value is not None:
             # We were forced to exit the context by a raised exception.


### PR DESCRIPTION
We have an IP address blocklist. Requests that attempt to access the blocklist should be marked as halts because they're expected to fail. I also archived the associated error (SENTRY-54B4) which ends up bubbling up into `ApiHostError`.