### PR TITLE
fix(Prevent) - adjust codecov context to use integrated org name instead

### DIFF
--- a/static/app/components/prevent/branchSelector/branchSelector.tsx
+++ b/static/app/components/prevent/branchSelector/branchSelector.tsx
@@ -16,8 +16,14 @@ import {space} from 'sentry/styles/space';
 const ALL_BRANCHES = 'All Branches';
 
 export function BranchSelector() {
-  const {branch, integratedOrgId, repository, preventPeriod, changeContextValue} =
-    usePreventContext();
+  const {
+    branch,
+    integratedOrgId,
+    integratedOrgName,
+    repository,
+    preventPeriod,
+    changeContextValue,
+  } = usePreventContext();
   const [searchValue, setSearchValue] = useState<string | undefined>();
 
   const {data, isFetching, isLoading} = useInfiniteRepositoryBranches({
@@ -30,13 +36,14 @@ export function BranchSelector() {
       const newBranch =
         selectedOption.value === ALL_BRANCHES ? null : selectedOption.value;
       changeContextValue({
+        integratedOrgName,
         integratedOrgId,
         repository,
         preventPeriod,
         branch: newBranch,
       });
     },
-    [changeContextValue, integratedOrgId, repository, preventPeriod]
+    [changeContextValue, integratedOrgName, integratedOrgId, repository, preventPeriod]
   );
 
   const handleOnSearch = useMemo(

--- a/static/app/components/prevent/container/preventParamsProvider.tsx
+++ b/static/app/components/prevent/container/preventParamsProvider.tsx
@@ -146,7 +146,7 @@ export default function PreventQueryParamsProvider({
             ...newState[integratedOrgName],
             repository: currentParams.repository,
             branch: currentParams?.branch || newState[integratedOrgName]?.branch || null,
-            integratedOrgId: newState[integratedOrgName]?.integratedOrgId || '',
+            integratedOrgId: newState[integratedOrgName]?.integratedOrgId || null,
           };
           newState.lastVisitedOrgName = integratedOrgName;
         }

--- a/static/app/components/prevent/container/preventParamsProvider.tsx
+++ b/static/app/components/prevent/container/preventParamsProvider.tsx
@@ -48,9 +48,7 @@ export default function PreventQueryParamsProvider({
     const integratedOrgId =
       (integratedOrgName
         ? localStorageState?.[integratedOrgName]?.integratedOrgId
-        : null) ||
-      currentParams?.integratedOrgName ||
-      undefined;
+        : null) || undefined;
     const repository =
       (integratedOrgName ? localStorageState?.[integratedOrgName]?.repository : null) ||
       currentParams?.repository ||

--- a/static/app/components/prevent/context/preventContext.tsx
+++ b/static/app/components/prevent/context/preventContext.tsx
@@ -5,6 +5,7 @@ export type PreventContextData = {
   preventPeriod: string;
   branch?: string | null;
   integratedOrgId?: string;
+  integratedOrgName?: string;
   lastVisitedOrgId?: string;
   repository?: string;
 };

--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.spec.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.spec.tsx
@@ -27,10 +27,10 @@ describe('IntegratedOrgSelector', () => {
     localStorageWrapper.setItem(
       'prevent-selection:org-slug',
       JSON.stringify({
-        MOCK_INTEGRATED_ORG_NAME: {
+        [MOCK_INTEGRATED_ORG_NAME]: {
           integratedOrgId: '1',
         },
-        MOCK_INTEGRATED_ORG_NAME_2: {
+        [MOCK_INTEGRATED_ORG_NAME_2]: {
           integratedOrgId: '2',
         },
       })

--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.spec.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.spec.tsx
@@ -2,10 +2,14 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import PreventQueryParamsProvider from 'sentry/components/prevent/container/preventParamsProvider';
 import {IntegratedOrgSelector} from 'sentry/components/prevent/integratedOrgSelector/integratedOrgSelector';
+import localStorageWrapper from 'sentry/utils/localStorage';
+
+const MOCK_INTEGRATED_ORG_NAME = 'my-other-org-with-a-super-long-name';
+const MOCK_INTEGRATED_ORG_NAME_2 = 'other-org';
 
 const mockIntegrations = [
-  {name: 'my-other-org-with-a-super-long-name', id: '1', status: 'active'},
-  {name: 'my-other-org-with-a-super-long-name', id: '2', status: 'active'},
+  {name: MOCK_INTEGRATED_ORG_NAME, id: '1', status: 'active'},
+  {name: MOCK_INTEGRATED_ORG_NAME_2, id: '2', status: 'active'},
 ];
 
 const mockApiCall = () => {
@@ -17,6 +21,22 @@ const mockApiCall = () => {
 };
 
 describe('IntegratedOrgSelector', () => {
+  beforeEach(() => {
+    localStorageWrapper.clear();
+
+    localStorageWrapper.setItem(
+      'prevent-selection:org-slug',
+      JSON.stringify({
+        MOCK_INTEGRATED_ORG_NAME: {
+          integratedOrgId: '1',
+        },
+        MOCK_INTEGRATED_ORG_NAME_2: {
+          integratedOrgId: '2',
+        },
+      })
+    );
+  });
+
   it('renders when given integrated org', async () => {
     mockApiCall();
     render(
@@ -27,13 +47,15 @@ describe('IntegratedOrgSelector', () => {
         initialRouterConfig: {
           location: {
             pathname: '/',
-            query: {integratedOrgId: '1'},
+            query: {
+              integratedOrgName: MOCK_INTEGRATED_ORG_NAME,
+            },
           },
         },
       }
     );
     expect(
-      await screen.findByRole('button', {name: 'my-other-org-with-a-super-long-name'})
+      await screen.findByRole('button', {name: MOCK_INTEGRATED_ORG_NAME})
     ).toBeInTheDocument();
   });
 
@@ -47,17 +69,19 @@ describe('IntegratedOrgSelector', () => {
         initialRouterConfig: {
           location: {
             pathname: '/',
-            query: {integratedOrgId: '2'},
+            query: {
+              integratedOrgName: MOCK_INTEGRATED_ORG_NAME_2,
+            },
           },
         },
       }
     );
 
     const button = await screen.findByRole('button', {
-      name: 'my-other-org-with-a-super-long-name',
+      name: MOCK_INTEGRATED_ORG_NAME_2,
     });
     await userEvent.click(button);
     const options = await screen.findAllByRole('option');
-    expect(options[0]).toHaveTextContent('my-other-org-with-a-super-long-name');
+    expect(options[0]).toHaveTextContent(MOCK_INTEGRATED_ORG_NAME_2);
   });
 });

--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
@@ -55,14 +55,19 @@ function OrgFooterMessage() {
 }
 
 export function IntegratedOrgSelector() {
-  const {integratedOrgId, preventPeriod, changeContextValue} = usePreventContext();
+  const {integratedOrgId, integratedOrgName, preventPeriod, changeContextValue} =
+    usePreventContext();
   const organization = useOrganization();
 
   const {data: integrations = []} = useGetActiveIntegratedOrgs({organization});
 
   const handleChange = useCallback(
     (selectedOption: SelectOption<string>) => {
-      changeContextValue({preventPeriod, integratedOrgId: selectedOption.value});
+      changeContextValue({
+        preventPeriod,
+        integratedOrgId: selectedOption.value,
+        integratedOrgName: selectedOption.textValue,
+      });
     },
     [changeContextValue, preventPeriod]
   );
@@ -74,11 +79,11 @@ export function IntegratedOrgSelector() {
     ]);
 
     const makeOption = (value: string): SelectOption<string> => {
-      const integratedOrgName = integratedOrgIdToName(value, integrations);
+      const integratedOrgNameFromId = integratedOrgIdToName(value, integrations);
       return {
         value,
-        label: <OptionLabel>{integratedOrgName ?? DEFAULT_ORG_LABEL}</OptionLabel>,
-        textValue: integratedOrgName ?? DEFAULT_ORG_LABEL,
+        label: <OptionLabel>{integratedOrgNameFromId ?? DEFAULT_ORG_LABEL}</OptionLabel>,
+        textValue: integratedOrgNameFromId ?? DEFAULT_ORG_LABEL,
       };
     };
 
@@ -103,10 +108,7 @@ export function IntegratedOrgSelector() {
                 <IconContainer>
                   <IconIntegratedOrg />
                 </IconContainer>
-                <TriggerLabel>
-                  {integratedOrgIdToName(integratedOrgId, integrations) ??
-                    DEFAULT_ORG_LABEL}
-                </TriggerLabel>
+                <TriggerLabel>{integratedOrgName ?? DEFAULT_ORG_LABEL}</TriggerLabel>
               </Flex>
             </TriggerLabelWrap>
           </DropdownButton>

--- a/static/app/components/prevent/repoSelector/repoSelector.tsx
+++ b/static/app/components/prevent/repoSelector/repoSelector.tsx
@@ -68,8 +68,13 @@ function MenuFooter({repoAccessLink}: MenuFooterProps) {
 }
 
 export function RepoSelector() {
-  const {repository, integratedOrgId, preventPeriod, changeContextValue} =
-    usePreventContext();
+  const {
+    repository,
+    integratedOrgId,
+    integratedOrgName,
+    preventPeriod,
+    changeContextValue,
+  } = usePreventContext();
   const organization = useOrganization();
 
   const [searchValue, setSearchValue] = useState<string | undefined>();
@@ -101,11 +106,12 @@ export function RepoSelector() {
     (selectedOption: SelectOption<string>) => {
       changeContextValue({
         integratedOrgId,
+        integratedOrgName,
         preventPeriod,
         repository: selectedOption.value,
       });
     },
-    [changeContextValue, integratedOrgId, preventPeriod]
+    [changeContextValue, integratedOrgName, integratedOrgId, preventPeriod]
   );
 
   const handleOnSearch = useMemo(

--- a/static/app/views/prevent/tests/tests.spec.tsx
+++ b/static/app/views/prevent/tests/tests.spec.tsx
@@ -1,6 +1,7 @@
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import PreventQueryParamsProvider from 'sentry/components/prevent/container/preventParamsProvider';
+import localStorageWrapper from 'sentry/utils/localStorage';
 import TestsPage from 'sentry/views/prevent/tests/tests';
 
 jest.mock('sentry/components/pagination', () => {
@@ -136,6 +137,19 @@ const mockApiCall = () => {
 
 describe('CoveragePageWrapper', () => {
   describe('when the wrapper is used', () => {
+    beforeEach(() => {
+      localStorageWrapper.clear();
+
+      localStorageWrapper.setItem(
+        'prevent-selection:org-slug',
+        JSON.stringify({
+          'test-integration': {
+            integratedOrgId: '123',
+          },
+        })
+      );
+    });
+
     mockApiCall();
     it('renders the passed children', async () => {
       render(
@@ -148,7 +162,7 @@ describe('CoveragePageWrapper', () => {
               pathname: '/prevent/tests',
               query: {
                 preventPeriod: '7d',
-                integratedOrgId: '123',
+                integratedOrgName: 'test-integration',
                 repository: 'some-repository',
                 branch: 'some-branch',
               },

--- a/static/app/views/prevent/tokens/repoTokenTable/repoTokenTable.spec.tsx
+++ b/static/app/views/prevent/tokens/repoTokenTable/repoTokenTable.spec.tsx
@@ -8,6 +8,7 @@ import {
 
 import {openTokenRegenerationConfirmationModal} from 'sentry/actionCreators/modal';
 import PreventQueryParamsProvider from 'sentry/components/prevent/container/preventParamsProvider';
+import localStorageWrapper from 'sentry/utils/localStorage';
 
 import RepoTokenTable, {type ValidSort} from './repoTokenTable';
 
@@ -51,6 +52,17 @@ describe('RepoTokenTable', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     jest.clearAllMocks();
+
+    localStorageWrapper.clear();
+
+    localStorageWrapper.setItem(
+      'prevent-selection:org-slug',
+      JSON.stringify({
+        'integrated-name': {
+          integratedOrgId: 'integrated-123',
+        },
+      })
+    );
   });
 
   const renderWithContext = (props = defaultProps) => {
@@ -63,7 +75,7 @@ describe('RepoTokenTable', () => {
           location: {
             pathname: '/prevent/tokens/',
             query: {
-              integratedOrgId: 'integrated-123',
+              integratedOrgName: 'integrated-name',
             },
           },
         },

--- a/static/app/views/prevent/tokens/tokens.spec.tsx
+++ b/static/app/views/prevent/tokens/tokens.spec.tsx
@@ -7,6 +7,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import PreventQueryParamsProvider from 'sentry/components/prevent/container/preventParamsProvider';
+import localStorageWrapper from 'sentry/utils/localStorage';
 import TokensPage from 'sentry/views/prevent/tokens/tokens';
 
 jest.mock('sentry/components/pagination', () => {
@@ -62,6 +63,21 @@ const mockApiCall = () => {
 
 describe('TokensPage', () => {
   describe('when the wrapper is used', () => {
+    beforeEach(() => {
+      localStorageWrapper.clear();
+
+      localStorageWrapper.setItem(
+        'prevent-selection:org-slug',
+        JSON.stringify({
+          'test-integration': {
+            integratedOrgId: '1',
+          },
+          'test-integration-2': {
+            integratedOrgId: '2',
+          },
+        })
+      );
+    });
     it('renders the header', async () => {
       mockApiCall();
       render(
@@ -73,7 +89,7 @@ describe('TokensPage', () => {
             location: {
               pathname: '/prevent/tokens/',
               query: {
-                integratedOrgId: '1',
+                integratedOrgName: 'test-integration',
               },
             },
           },
@@ -93,7 +109,7 @@ describe('TokensPage', () => {
             location: {
               pathname: '/prevent/tokens/',
               query: {
-                integratedOrgId: '2',
+                integratedOrgName: 'test-integration-2',
               },
             },
           },
@@ -128,7 +144,7 @@ describe('TokensPage', () => {
             location: {
               pathname: '/prevent/tokens/',
               query: {
-                integratedOrgId: '1',
+                integratedOrgName: 'test-integration',
               },
             },
           },
@@ -149,7 +165,7 @@ describe('TokensPage', () => {
             location: {
               pathname: '/prevent/tokens/',
               query: {
-                integratedOrgId: '1',
+                integratedOrgName: 'test-integration',
               },
             },
           },
@@ -170,7 +186,7 @@ describe('TokensPage', () => {
             location: {
               pathname: '/prevent/tokens/',
               query: {
-                integratedOrgId: '1',
+                integratedOrgName: 'test-integration',
               },
             },
           },
@@ -204,7 +220,7 @@ describe('TokensPage', () => {
             location: {
               pathname: '/prevent/tokens/',
               query: {
-                integratedOrgId: '1',
+                integratedOrgName: 'test-integration',
               },
             },
           },
@@ -246,7 +262,7 @@ describe('TokensPage', () => {
               location: {
                 pathname: '/prevent/tokens/',
                 query: {
-                  integratedOrgId: '1',
+                  integratedOrgName: 'test-integration',
                   sort: 'name', // ascending sort
                 },
               },
@@ -272,7 +288,7 @@ describe('TokensPage', () => {
               location: {
                 pathname: '/prevent/tokens/',
                 query: {
-                  integratedOrgId: '1',
+                  integratedOrgName: 'test-integration',
                   sort: '-name', // descending sort
                 },
               },
@@ -298,7 +314,7 @@ describe('TokensPage', () => {
               location: {
                 pathname: '/prevent/tokens/',
                 query: {
-                  integratedOrgId: '1',
+                  integratedOrgName: 'test-integration',
                   // no sort parameter
                 },
               },
@@ -335,7 +351,7 @@ describe('TokensPage', () => {
               location: {
                 pathname: '/prevent/tokens/',
                 query: {
-                  integratedOrgId: '1',
+                  integratedOrgName: 'test-integration',
                   sort: '-name', // descending name sort
                 },
               },


### PR DESCRIPTION
This PR adjusts the behavior of the prevent context to use the integrated org's name for the FE instead of the integrated org's id. This enables the Codecov/Sentry PR comment to create a link to the TA page.

This also adjusts an issue where selecting a different org didn't clear the previous selection.

https://github.com/user-attachments/assets/f3c8433a-f4d3-4886-b397-3545df8e46f7

# Notes
- Adjust the preventParamsProvider to save data using the integratedOrgName. Data used to look like this `{['integratedOrgId': {repository: <value>, branch: <value>}, lastVisitedOrg: <value?}`, now it looks like this `{['integratedOrgName': {integratedOrgId: <value>. repository: <value>, branch: <value>}, lastVisitedOrg: <value?}`. The integratedOrgId is no longer saved/exposed via the query params, just from local storage; we still need to save this because it's needed for our backend communications. While we could fetch it via the `useGetActiveIntegratedOrgs` hook, I opted to store it once we get it to avoid unnecessary API calls.
- Adjusted the integratedOrgSelector to also pass/store the orgName
- Adjust selectors to include the newly added integratedOrgName
- Adjusts tests to reflect this change - since the orgId is not gotten from the query params anymore, I added a local storage wrapper to get the data from there