### PR TITLE
fix(alerts): Limit GH repo page limit results to 1

### DIFF
--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -29,6 +29,8 @@ from sentry.users.services.user import RpcUser
 from sentry.utils.http import absolute_uri
 from sentry.utils.strings import truncatechars
 
+PAGE_NUMBER_LIMIT = 1
+
 
 class GitHubIssuesSpec(SourceCodeIssueIntegration):
     def raise_error(self, exc: Exception, identity: Identity | None = None) -> NoReturn:
@@ -172,8 +174,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
             org = org_context.organization
 
         params = kwargs.pop("params", {})
-        page_number_limit = 1
-        default_repo, repo_choices = self.get_repository_choices(group, params, page_number_limit)
+        default_repo, repo_choices = self.get_repository_choices(group, params, PAGE_NUMBER_LIMIT)
 
         assignees = self.get_allowed_assignees(default_repo) if default_repo else []
         labels: Sequence[tuple[str, str]] = []

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -7,7 +7,6 @@ from typing import Any, NoReturn
 
 from django.urls import reverse
 
-from sentry import features
 from sentry.integrations.mixins.issues import MAX_CHAR
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
@@ -173,9 +172,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
             org = org_context.organization
 
         params = kwargs.pop("params", {})
-        page_number_limit = (
-            features.has("organizations:github-get-repos-page-limit", org) and 1 or None
-        )
+        page_number_limit = 1
         default_repo, repo_choices = self.get_repository_choices(group, params, page_number_limit)
 
         assignees = self.get_allowed_assignees(default_repo) if default_repo else []


### PR DESCRIPTION
After successfully rolling the flag out internally and to an affected customer we can safely default the page limit to 1. I'll remove the flag reference in options automator next and finally remove the flag from this repo entirely.