### PR TITLE
fix(aci): filter cron detector detail timeline by env

### DIFF
--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -5,6 +5,8 @@ import {Alert} from 'sentry/components/core/alert';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {KeyValueTableRow} from 'sentry/components/keyValueTable';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import TimeSince from 'sentry/components/timeSince';
 import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
 import Section from 'sentry/components/workflowEngine/ui/section';
@@ -12,6 +14,7 @@ import {IconJson} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {CronDetector} from 'sentry/types/workflowEngine/detectors';
+import {useLocation} from 'sentry/utils/useLocation';
 import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details/common/assignee';
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
@@ -42,12 +45,22 @@ function hasLastCheckIn(envs: MonitorEnvironment[]) {
 }
 
 export function CronDetectorDetails({detector, project}: CronDetectorDetailsProps) {
+  const location = useLocation();
   const dataSource = detector.dataSources[0];
 
   const {failure_issue_threshold, recovery_threshold} = dataSource.queryObj.config;
 
+  // Filter monitor environments based on the selected environment from page filters
+  const selectedEnvironment = location.query.environment;
+  const filteredMonitor = {
+    ...dataSource.queryObj,
+    environments: selectedEnvironment
+      ? dataSource.queryObj.environments.filter(env => env.name === selectedEnvironment)
+      : dataSource.queryObj.environments,
+  };
+
   const monitorEnv = getLatestCronMonitorEnv(detector);
-  const hasCheckedIn = hasLastCheckIn(dataSource.queryObj.environments);
+  const hasCheckedIn = hasLastCheckIn(filteredMonitor.environments);
 
   function getIntervalSecondsFromEnv(env?: MonitorEnvironment): number | undefined {
     if (!env?.lastCheckIn || !env?.nextCheckIn) {
@@ -80,11 +93,14 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
       <DetectorDetailsHeader detector={detector} project={project} />
       <DetailLayout.Body>
         <DetailLayout.Main>
+          <PageFilterBar condensed>
+            <EnvironmentPageFilter />
+            <DatePageFilter />
+          </PageFilterBar>
           {hasCheckedIn ? (
             <Fragment>
-              <DatePageFilter />
               <DetailsTimeline
-                monitor={dataSource.queryObj}
+                monitor={filteredMonitor}
                 onStatsLoaded={checkHasUnknown}
               />
               <ErrorBoundary mini>
@@ -97,7 +113,7 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
                 <div>
                   <MonitorCheckIns
                     monitorSlug={dataSource.queryObj.slug}
-                    monitorEnvs={dataSource.queryObj.environments}
+                    monitorEnvs={filteredMonitor.environments}
                     project={project}
                   />
                 </div>

--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -52,11 +52,20 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
 
   // Filter monitor environments based on the selected environment from page filters
   const selectedEnvironment = location.query.environment;
+  const selectedEnvironments = Array.isArray(selectedEnvironment)
+    ? selectedEnvironment
+    : selectedEnvironment
+      ? [selectedEnvironment]
+      : [];
+
   const filteredMonitor = {
     ...dataSource.queryObj,
-    environments: selectedEnvironment
-      ? dataSource.queryObj.environments.filter(env => env.name === selectedEnvironment)
-      : dataSource.queryObj.environments,
+    environments:
+      selectedEnvironments.length > 0
+        ? dataSource.queryObj.environments.filter(env =>
+            selectedEnvironments.includes(env.name)
+          )
+        : dataSource.queryObj.environments,
   };
 
   const monitorEnv = getLatestCronMonitorEnv({

--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -14,6 +14,7 @@ import {IconJson} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {CronDetector} from 'sentry/types/workflowEngine/detectors';
+import toArray from 'sentry/utils/array/toArray';
 import {useLocation} from 'sentry/utils/useLocation';
 import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details/common/assignee';
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
@@ -51,13 +52,7 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
   const {failure_issue_threshold, recovery_threshold} = dataSource.queryObj.config;
 
   // Filter monitor environments based on the selected environment from page filters
-  const selectedEnvironment = location.query.environment;
-  const selectedEnvironments = Array.isArray(selectedEnvironment)
-    ? selectedEnvironment
-    : selectedEnvironment
-      ? [selectedEnvironment]
-      : [];
-
+  const selectedEnvironments = toArray(location.query.environment);
   const filteredMonitor = {
     ...dataSource.queryObj,
     environments:

--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -59,7 +59,15 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
       : dataSource.queryObj.environments,
   };
 
-  const monitorEnv = getLatestCronMonitorEnv(detector);
+  const monitorEnv = getLatestCronMonitorEnv({
+    ...detector,
+    dataSources: [
+      {
+        ...detector.dataSources[0],
+        queryObj: filteredMonitor,
+      },
+    ],
+  });
   const hasCheckedIn = hasLastCheckIn(filteredMonitor.environments);
 
   function getIntervalSecondsFromEnv(env?: MonitorEnvironment): number | undefined {

--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -52,7 +52,7 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
   const {failure_issue_threshold, recovery_threshold} = dataSource.queryObj.config;
 
   // Filter monitor environments based on the selected environment from page filters
-  const selectedEnvironments = toArray(location.query.environment);
+  const selectedEnvironments = toArray(location.query.environment).filter(Boolean);
   const filteredMonitor = {
     ...dataSource.queryObj,
     environments:


### PR DESCRIPTION
filtering by env previously was not working properly, and we were missing the environment selector

<img width="976" height="214" alt="Screenshot 2025-09-22 at 3 08 18 PM" src="https://github.com/user-attachments/assets/679d0216-ac01-47f9-ab13-2a7ca41ecf3e" />
