### PR TITLE
Fix null build title display

### DIFF
--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -47,12 +47,7 @@ export default function BuildDetails() {
   const buildNumber = buildDetails?.app_info?.build_number;
 
   let title = t('Build details');
-  if (
-    version !== undefined &&
-    version !== '' &&
-    buildNumber !== undefined &&
-    buildNumber !== ''
-  ) {
+  if (version && buildNumber) {
     title = t('Build details v%s (%s)', version, buildNumber);
   }
 

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -47,12 +47,7 @@ export default function BuildDetails() {
   const buildNumber = buildDetails?.app_info?.build_number;
 
   let title = t('Build details');
-  if (
-    version != null &&
-    version !== '' &&
-    buildNumber != null &&
-    buildNumber !== ''
-  ) {
+  if (version != null && version !== '' && buildNumber != null && buildNumber !== '') {
     title = t('Build details v%s (%s)', version, buildNumber);
   }
 

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -47,7 +47,12 @@ export default function BuildDetails() {
   const buildNumber = buildDetails?.app_info?.build_number;
 
   let title = t('Build details');
-  if (version && buildNumber) {
+  if (
+    version != null &&
+    version !== '' &&
+    buildNumber != null &&
+    buildNumber !== ''
+  ) {
     title = t('Build details v%s (%s)', version, buildNumber);
   }
 

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -9,16 +9,16 @@ export interface BuildDetailsApiResponse {
 }
 
 export interface BuildDetailsAppInfo {
-  app_id: string | null;
-  artifact_type: BuildDetailsArtifactType | null;
-  build_configuration: string | null;
-  build_number: string | null;
+  app_id: string | null | undefined;
+  artifact_type: BuildDetailsArtifactType | null | undefined;
+  build_configuration: string | null | undefined;
+  build_number: string | null | undefined;
   date_added: string; // Always present based on your example
-  date_built: string | null;
+  date_built: string | null | undefined;
   is_installable: boolean; // Always present based on your example
-  name: string | null;
-  platform: Platform | null;
-  version: string | null;
+  name: string | null | undefined;
+  platform: Platform | null | undefined;
+  version: string | null | undefined;
 }
 
 interface BuildDetailsVcsInfo {

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -1,5 +1,8 @@
 import type {Platform} from './sharedTypes';
 
+// Utility type for API fields that can be undefined or null
+type NullableOptional<T> = T | null | undefined;
+
 export interface BuildDetailsApiResponse {
   app_info: BuildDetailsAppInfo;
   id: string;
@@ -9,16 +12,16 @@ export interface BuildDetailsApiResponse {
 }
 
 export interface BuildDetailsAppInfo {
-  app_id?: string;
-  artifact_type?: BuildDetailsArtifactType;
-  build_configuration?: string;
-  build_number?: string;
-  date_added?: string;
-  date_built?: string;
-  is_installable?: boolean;
-  name?: string;
-  platform?: Platform;
-  version?: string;
+  app_id?: string | null;
+  artifact_type?: BuildDetailsArtifactType | null;
+  build_configuration?: string | null;
+  build_number?: string | null;
+  date_added?: string | null;
+  date_built?: string | null;
+  is_installable?: boolean | null;
+  name?: string | null;
+  platform?: Platform | null;
+  version?: string | null;
 }
 
 interface BuildDetailsVcsInfo {

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -1,8 +1,5 @@
 import type {Platform} from './sharedTypes';
 
-// Utility type for API fields that can be undefined or null
-type NullableOptional<T> = T | null | undefined;
-
 export interface BuildDetailsApiResponse {
   app_info: BuildDetailsAppInfo;
   id: string;
@@ -12,16 +9,16 @@ export interface BuildDetailsApiResponse {
 }
 
 export interface BuildDetailsAppInfo {
-  app_id?: string | null;
-  artifact_type?: BuildDetailsArtifactType | null;
-  build_configuration?: string | null;
-  build_number?: string | null;
-  date_added?: string | null;
-  date_built?: string | null;
-  is_installable?: boolean | null;
-  name?: string | null;
-  platform?: Platform | null;
-  version?: string | null;
+  app_id: string | null;
+  artifact_type: BuildDetailsArtifactType | null;
+  build_configuration: string | null;
+  build_number: string | null;
+  date_added: string; // Always present based on your example
+  date_built: string | null;
+  is_installable: boolean; // Always present based on your example
+  name: string | null;
+  platform: Platform | null;
+  version: string | null;
 }
 
 interface BuildDetailsVcsInfo {


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes an issue where the "Build details" title would display "vnull (null)" when `version` or `buildNumber` were `null`.

The previous condition did not correctly handle `null` values, allowing them to be stringified as "null". This change updates the condition to a simple truthy check (`if (version && buildNumber)`), ensuring that the version and build number are only included in the title when both are present and meaningful (i.e., not `null`, `undefined`, or empty strings).

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f2dc6a8-5ecc-4f1e-bdb5-92df5a8014c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f2dc6a8-5ecc-4f1e-bdb5-92df5a8014c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

