### PR TITLE
fix(aci): Don't assume conditionGroup is in BaseDetectorTypeValidator.create

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -150,13 +150,14 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
                 source_id=data_source.id,
                 type=validated_data["data_source"]["data_source_type"],
             )
-            for condition in validated_data["condition_group"]["conditions"]:
-                DataCondition.objects.create(
-                    comparison=condition["comparison"],
-                    condition_result=condition["condition_result"],
-                    type=condition["type"],
-                    condition_group=condition_group,
-                )
+            if "condition_group" in validated_data:
+                for condition in validated_data["condition_group"]["conditions"]:
+                    DataCondition.objects.create(
+                        comparison=condition["comparison"],
+                        condition_result=condition["condition_result"],
+                        type=condition["type"],
+                        condition_group=condition_group,
+                    )
 
             owner = validated_data.get("owner")
             owner_user_id = None

--- a/tests/sentry/monitors/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_detector_index.py
@@ -107,16 +107,6 @@ class OrganizationDetectorIndexPostTest(APITestCase):
                     "scheduleType": "crontab",
                 },
             },
-            "conditionGroup": {
-                "logicType": "any",
-                "conditions": [
-                    {
-                        "comparison": 1,
-                        "type": "gt",
-                        "conditionResult": "low",
-                    }
-                ],
-            },
         }
         data.update(overrides)
         return data


### PR DESCRIPTION
The validator lists the field as option, and the `update` method ignores it if absent; ignoring if absent in `create` is consistent.

Fixes ACI-462.
