### PR TITLE
fix: Cursor page reset when updating term value

### DIFF
--- a/static/app/views/prevent/tests/testSearchBar/testSearchBar.tsx
+++ b/static/app/views/prevent/tests/testSearchBar/testSearchBar.tsx
@@ -36,13 +36,20 @@ export function TestSearchBar({testCount}: TestSearchBarProps) {
         setSearchParams(prev => {
           const currentParams = Object.fromEntries(prev.entries());
 
+          // Remove cursor and navigation params when searching to start from first page
+          const {
+            cursor: _cursor,
+            navigation: _navigation,
+            ...paramsWithoutPagination
+          } = currentParams;
+
           if (newValue) {
-            currentParams.term = newValue;
+            paramsWithoutPagination.term = newValue;
           } else {
-            delete currentParams.term;
+            delete paramsWithoutPagination.term;
           }
 
-          return currentParams;
+          return paramsWithoutPagination;
         });
       }, 500),
     [setSearchParams]


### PR DESCRIPTION
This PR aims to fix a bug where the cursor wasn't being reset upon updating the value in the term search bar. Just uses the same implementation as in other places in the table / token table


https://github.com/user-attachments/assets/89db5b74-03ea-481c-99de-44194c805202




<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
