### PR TITLE
fix(aci): query for all detectors at once to get automation project ids

### DIFF
--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -8,7 +8,7 @@ import {
 } from 'sentry/types/workflowEngine/dataConditions';
 import {AgeComparison} from 'sentry/views/automations/components/actionFilters/constants';
 import type {ConflictingConditions} from 'sentry/views/automations/components/automationBuilderConflictContext';
-import {useDetectorQueriesByIds} from 'sentry/views/detectors/hooks';
+import {useDetectorsQuery} from 'sentry/views/detectors/hooks';
 
 export function getAutomationActions(automation: Automation): ActionType[] {
   return [
@@ -53,9 +53,9 @@ export function getAutomationActionsWarning(
 }
 
 export function useAutomationProjectIds(automation: Automation): string[] {
-  const queries = useDetectorQueriesByIds(automation.detectorIds);
+  const {data: detectors} = useDetectorsQuery({ids: automation.detectorIds});
   return [
-    ...new Set(queries.map(query => query.data?.projectId).filter(x => x)),
+    ...new Set(detectors?.map(detector => detector.projectId).filter(x => x) ?? []),
   ] as string[];
 }
 

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -24,6 +24,12 @@ import AutomationsList from 'sentry/views/automations/list';
 
 describe('AutomationsList', () => {
   const organization = OrganizationFixture({features: ['workflow-engine-ui']});
+  const project = ProjectFixture({id: '1', slug: 'project-1'});
+  const detector = MetricDetectorFixture({
+    id: '1',
+    name: 'Detector 1',
+    projectId: project.id,
+  });
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -37,9 +43,19 @@ describe('AutomationsList', () => {
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/detectors/1/',
-      body: [MetricDetectorFixture({name: 'Detector 1'})],
+      body: detector,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      body: [detector],
+      match: [MockApiClient.matchQuery({id: ['1']})],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project],
     });
     PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [1]}), new Set());
+    ProjectsStore.loadInitialData([project]);
   });
 
   it('displays all automation info correctly', async () => {
@@ -61,19 +77,6 @@ describe('AutomationsList', () => {
       url: '/organizations/org-slug/workflows/',
       body: [AutomationFixture({id: '100', name: 'Automation 1', detectorIds: ['1']})],
     });
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/detectors/',
-      body: [
-        MetricDetectorFixture({
-          id: '1',
-          name: 'Detector 1',
-          workflowIds: ['100'],
-          projectId: '1',
-        }),
-      ],
-      match: [MockApiClient.matchQuery({id: ['1']})],
-    });
-    ProjectsStore.loadInitialData([ProjectFixture({id: '1', slug: 'project-1'})]);
 
     render(<AutomationsList />, {organization});
     const row = await screen.findByTestId('automation-list-row');
@@ -181,7 +184,6 @@ describe('AutomationsList', () => {
 
   describe('bulk actions', () => {
     beforeEach(() => {
-      MockApiClient.clearMockResponses();
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/users/1/',
         body: UserFixture(),
@@ -193,7 +195,7 @@ describe('AutomationsList', () => {
           AutomationFixture({
             id: '1',
             name: 'Enabled Automation',
-            detectorIds: [],
+            detectorIds: ['1'],
             enabled: true,
           }),
           AutomationFixture({
@@ -209,6 +211,10 @@ describe('AutomationsList', () => {
             enabled: true,
           }),
         ],
+      });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/detectors/',
+        body: [detector],
       });
       PageFiltersStore.onInitializeUrlState(
         PageFiltersFixture({projects: [1]}),
@@ -514,7 +520,7 @@ describe('AutomationsList', () => {
         within(row).queryByText('No Actions Automation')
       )!;
       expect(within(noActionsRow).getByText('Invalid')).toBeInTheDocument();
-      const noActionsIcon = within(noActionsRow).getByRole('img');
+      const noActionsIcon = within(noActionsRow).getAllByRole('img')[0]!; // Get the first img (warning icon)
       await userEvent.hover(noActionsIcon);
       expect(
         await screen.findByText('You must add an action for this automation to run.')
@@ -525,7 +531,7 @@ describe('AutomationsList', () => {
         within(row).queryByText('All Disabled Actions')
       )!;
       expect(within(allDisabledRow).getByText('Invalid')).toBeInTheDocument();
-      const allDisabledIcon = within(allDisabledRow).getByRole('img');
+      const allDisabledIcon = within(allDisabledRow).getAllByRole('img')[0]!; // Get the first img (warning icon)
       await userEvent.hover(allDisabledIcon);
       expect(
         await screen.findByText(
@@ -536,7 +542,7 @@ describe('AutomationsList', () => {
       // Test third automation (mixed) - should NOT show "Invalid" but show warning tooltip
       const mixedRow = rows.find(row => within(row).queryByText('Mixed Actions Status'))!;
       expect(within(mixedRow).queryByText('Invalid')).not.toBeInTheDocument();
-      const mixedIcon = within(mixedRow).getByRole('img');
+      const mixedIcon = within(mixedRow).getAllByRole('img')[0]!; // Get the first img (warning icon)
       await userEvent.hover(mixedIcon);
       expect(
         await screen.findByText(

--- a/static/app/views/detectors/hooks/index.ts
+++ b/static/app/views/detectors/hooks/index.ts
@@ -5,12 +5,7 @@ import {
   type Detector,
 } from 'sentry/types/workflowEngine/detectors';
 import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
-import {
-  useApiQueries,
-  useApiQuery,
-  useMutation,
-  useQueryClient,
-} from 'sentry/utils/queryClient';
+import {useApiQuery, useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -134,22 +129,4 @@ export function useDetectorQuery<T extends Detector = Detector>(
     retry: false,
     ...queryOptions,
   });
-}
-
-export function useDetectorQueriesByIds<T extends Detector = Detector>(
-  detectorId: string[],
-  queryOptions: Partial<UseApiQueryOptions<T>> = {}
-) {
-  const org = useOrganization();
-
-  return useApiQueries<T>(
-    detectorId.map(id =>
-      makeDetectorDetailsQueryKey({orgSlug: org.slug, detectorId: id})
-    ),
-    {
-      staleTime: 0,
-      retry: false,
-      ...queryOptions,
-    }
-  );
 }


### PR DESCRIPTION
replaces usage of `useDetectorQueriesByIds` hook with `useDetectorsQuery` so that we query for all detectors at once instead of one-by-one