### PR TITLE
chore(eco): Silences errors from 400 responses when creating Jira issues

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -991,7 +991,7 @@ class JiraIntegration(IssueSyncIntegration):
                 "sentry.jira.raise_error.api_invalid_request_error",
                 extra={
                     "exception_type": type(exc).__name__,
-                    "request_body": str(exc.text),
+                    "request_body": str(exc.json),
                 },
             )
             raise IntegrationConfigurationError(exc.text) from exc

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -986,6 +986,14 @@ class JiraIntegration(IssueSyncIntegration):
                 error_fields = self.error_fields_from_json(exc.json)
                 if error_fields is not None:
                     raise IntegrationFormError(error_fields).with_traceback(sys.exc_info()[2])
+
+            logger.warning(
+                "sentry.jira.raise_error.api_invalid_request_error",
+                extra={
+                    "exception_type": type(exc).__name__,
+                    "exception_message": str(exc),
+                },
+            )
             raise IntegrationConfigurationError(exc.text) from exc
         super().raise_error(exc, identity=identity)
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -52,6 +52,7 @@ from sentry.shared_integrations.exceptions import (
     IntegrationFormError,
 )
 from sentry.silo.base import all_silo_function
+from sentry.users.models.identity import Identity
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
@@ -971,7 +972,7 @@ class JiraIntegration(IssueSyncIntegration):
         # Immediately fetch and return the created issue.
         return self.get_issue(issue_key)
 
-    def raise_error(self, exc: Exception) -> NoReturn:
+    def raise_error(self, exc: Exception, identity: Identity | None = None) -> NoReturn:
         """
         Overrides the base `raise_error` method to treat ApiInvalidRequestErrors
         as configuration errors when we don't have error field handling for the
@@ -986,7 +987,7 @@ class JiraIntegration(IssueSyncIntegration):
                 if error_fields is not None:
                     raise IntegrationFormError(error_fields).with_traceback(sys.exc_info()[2])
             raise IntegrationConfigurationError(exc.text) from exc
-        super().raise_error(exc)
+        super().raise_error(exc, identity=identity)
 
     def sync_assignee_outbound(
         self,

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -991,7 +991,7 @@ class JiraIntegration(IssueSyncIntegration):
                 "sentry.jira.raise_error.api_invalid_request_error",
                 extra={
                     "exception_type": type(exc).__name__,
-                    "exception_message": str(exc),
+                    "request_body": str(exc.text),
                 },
             )
             raise IntegrationConfigurationError(exc.text) from exc

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -73,7 +73,7 @@ class LegacyRegistryHandler(ABC):
 
 
 EXCEPTION_IGNORE_LIST = (IntegrationFormError, IntegrationConfigurationError, InvalidIdentity)
-RETRIABLE_EXCEPTIONS = (ApiError,)
+RETRYABLE_EXCEPTIONS = (ApiError,)
 
 
 def invoke_future_with_error_handling(
@@ -96,7 +96,7 @@ def invoke_future_with_error_handling(
         # We need to reraise ProcessingDeadlineExceeded for workflow engine to
         # monitor and potentially retry this action.
         raise
-    except RETRIABLE_EXCEPTIONS as e:
+    except RETRYABLE_EXCEPTIONS as e:
         raise RetryError from e
     except Exception as e:
         # This is just a redefinition of the safe_execute util function, as we

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -101,7 +101,6 @@ def invoke_future_with_error_handling(
     except Exception as e:
         # This is just a redefinition of the safe_execute util function, as we
         # still want to report any unhandled exceptions.
-        logger.exception("Failed to execute future", extra={"future": future})
         if hasattr(callback, "im_class"):
             cls = callback.im_class
         else:
@@ -109,9 +108,9 @@ def invoke_future_with_error_handling(
 
         func_name = getattr(callback, "__name__", str(callback))
         cls_name = cls.__name__
-        localized_logger = logging.getLogger(f"sentry.safe.{cls_name.lower()}")
+        local_logger = logging.getLogger(f"sentry.safe_action.{cls_name.lower()}")
 
-        localized_logger.exception("%s.process_error", func_name, extra={"exception": e})
+        local_logger.exception("%s.process_error", func_name, extra={"exception": e})
         return None
 
 

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -48,7 +48,7 @@ from sentry.workflow_engine.typings.notification_action import (
 
 logger = logging.getLogger(__name__)
 
-FutureCallback = Callable[[GroupEvent, Sequence[RuleFuture]], None]
+FutureCallback = Callable[[GroupEvent, Sequence[RuleFuture]], Any]
 
 
 class RuleData(TypedDict):
@@ -79,7 +79,7 @@ RETRIABLE_EXCEPTIONS = (ApiError,)
 def invoke_future_with_error_handling(
     event_data: WorkflowEventData,
     callback: FutureCallback,
-    future: list[RuleFuture],
+    future: Sequence[RuleFuture],
 ) -> None:
     # WorkflowEventData should only ever be a GroupEvent in this context, so we
     # narrow the type here to keep mypy happy.

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -18,7 +18,6 @@ from sentry.integrations.project_management.metrics import (
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
 from sentry.models.grouplink import GroupLink
-from sentry.notifications.types import TEST_NOTIFICATION_ID
 from sentry.notifications.utils.links import create_link_to_workflow
 from sentry.services.eventstore.models import GroupEvent
 from sentry.shared_integrations.exceptions import (
@@ -187,10 +186,8 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
             ) as e:
                 # Most of the time, these aren't explicit failures, they're
                 # some misconfiguration of an issue field - typically Jira.
-                # We only want to raise if the rule_id is -1 because that means we're testing the action
                 lifecycle.record_halt(e)
-                if rule_id == TEST_NOTIFICATION_ID:
-                    raise
+                raise
             # If we successfully created the issue, we want to create the link
             else:
                 create_link(integration, installation, event, response)

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -19,7 +19,11 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.services.integration import integration_service
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupmeta import GroupMeta
-from sentry.shared_integrations.exceptions import IntegrationConfigurationError, IntegrationError
+from sentry.shared_integrations.exceptions import (
+    IntegrationConfigurationError,
+    IntegrationError,
+    IntegrationFormError,
+)
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, IntegrationTestCase
 from sentry.testutils.factories import EventType
@@ -710,6 +714,59 @@ class RegionJiraIntegrationTest(APITestCase):
                 "description": "example bug report",
                 "key": "APP-123",
             }
+
+    @responses.activate
+    def test_create_issue_with_form_error(self) -> None:
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/issue/createmeta",
+            body=StubService.get_stub_json("jira", "createmeta_response.json"),
+            content_type="json",
+        )
+        responses.add(
+            responses.POST,
+            "https://example.atlassian.net/rest/api/2/issue",
+            status=400,
+            body=json.dumps({"errors": {"issuetype": ["Issue type is required."]}}),
+            content_type="json",
+        )
+
+        installation = self.integration.get_installation(self.organization.id)
+        with pytest.raises(IntegrationFormError):
+            installation.create_issue(
+                {
+                    "title": "example summary",
+                    "description": "example bug report",
+                    "issuetype": "1",
+                    "project": "10000",
+                }
+            )
+
+    @responses.activate
+    def test_create_issue_with_configuration_error(self) -> None:
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/issue/createmeta",
+            body=StubService.get_stub_json("jira", "createmeta_response.json"),
+            content_type="json",
+        )
+        responses.add(
+            responses.POST,
+            "https://example.atlassian.net/rest/api/2/issue",
+            status=400,
+            body=json.dumps({"error": "Jira had an oopsie"}),
+            content_type="json",
+        )
+        installation = self.integration.get_installation(self.organization.id)
+        with pytest.raises(IntegrationConfigurationError):
+            installation.create_issue(
+                {
+                    "title": "example summary",
+                    "description": "example bug report",
+                    "issuetype": "1",
+                    "project": "10000",
+                }
+            )
 
     @responses.activate
     def test_create_issue_labels_and_option(self) -> None:

--- a/tests/sentry/integrations/jira/test_ticket_action.py
+++ b/tests/sentry/integrations/jira/test_ticket_action.py
@@ -208,7 +208,8 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
             rule_object = Rule.objects.get(id=response.data["id"])
             event = self.get_event()
 
-            self.trigger(event, rule_object)
+            with pytest.raises(IntegrationFormError):
+                self.trigger(event, rule_object)
 
             assert mock_record_event.call_count == 2
             start, halt = mock_record_event.call_args_list
@@ -230,7 +231,8 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
             rule_object = Rule.objects.get(id=response.data["id"])
             event = self.get_event()
 
-            self.trigger(event, rule_object)
+            with pytest.raises(IntegrationConfigurationError):
+                self.trigger(event, rule_object)
 
             assert mock_record_event.call_count == 2
             start, halt = mock_record_event.call_args_list

--- a/tests/sentry/integrations/jira/test_ticket_action.py
+++ b/tests/sentry/integrations/jira/test_ticket_action.py
@@ -13,10 +13,9 @@ from sentry.services.eventstore.models import GroupEvent
 from sentry.shared_integrations.exceptions import (
     ApiInvalidRequestError,
     IntegrationConfigurationError,
-    IntegrationError,
     IntegrationFormError,
 )
-from sentry.testutils.asserts import assert_failure_metric, assert_halt_metric
+from sentry.testutils.asserts import assert_halt_metric
 from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.skips import requires_snuba
 from sentry.types.rules import RuleFuture
@@ -143,18 +142,16 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
             rule_object = Rule.objects.get(id=response.data["id"])
             event = self.get_event()
 
-            with pytest.raises(IntegrationError):
-                # Trigger its `after`, but with a broken client which should raise
-                # an ApiInvalidRequestError, which is reraised as an IntegrationError.
+            with pytest.raises(IntegrationConfigurationError):
                 self.trigger(event, rule_object)
 
             assert mock_record_event.call_count == 2
-            start, failure = mock_record_event.call_args_list
+            start, halt = mock_record_event.call_args_list
             assert start.args == (EventLifecycleOutcome.STARTED,)
 
-            assert_failure_metric(
+            assert_halt_metric(
                 mock_record_event,
-                IntegrationError("Error Communicating with Jira (HTTP 400): unknown error"),
+                IntegrationConfigurationError(),
             )
 
     def test_fails_validation(self) -> None:

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -250,11 +250,11 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         assert rule.status == ObjectStatus.ACTIVE
         assert rule.source == RuleSource.ISSUE
 
-    @mock.patch("sentry.notifications.notification_action.types.safe_execute")
+    @mock.patch("sentry.notifications.notification_action.types.invoke_future_with_error_handling")
     @mock.patch("sentry.notifications.notification_action.types.activate_downstream_actions")
     @mock.patch("uuid.uuid4")
     def test_invoke_legacy_registry(
-        self, mock_uuid, mock_activate_downstream_actions, mock_safe_execute
+        self, mock_uuid, mock_activate_downstream_actions, mock_invoke_future_with_error_handling
     ):
         # Test that invoke_legacy_registry correctly processes the action
         mock_uuid.return_value = uuid.UUID("12345678-1234-5678-1234-567812345678")
@@ -272,8 +272,8 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         )
 
         # Verify callback execution
-        mock_safe_execute.assert_called_once_with(
-            mock_callback, self.event_data.event, mock_futures
+        mock_invoke_future_with_error_handling.assert_called_once_with(
+            self.event_data, mock_callback, mock_futures
         )
 
 

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -821,3 +821,185 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
 
         # Both orgs should have different sentry app installations
         assert action_1_uuid != action_2_uuid
+
+
+class TestInvokeFutureWithErrorHandling(BaseWorkflowTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.project = self.create_project()
+        self.group, self.event, self.group_event = self.create_group_event()
+        self.event_data = WorkflowEventData(
+            event=self.group_event, workflow_env=self.environment, group=self.group
+        )
+
+        self.mock_callback = mock.Mock()
+        self.mock_futures = [mock.Mock()]
+
+    def test_happy_path(self):
+        from sentry.notifications.notification_action.types import invoke_future_with_error_handling
+
+        result = invoke_future_with_error_handling(
+            self.event_data, self.mock_callback, self.mock_futures
+        )
+
+        self.mock_callback.assert_called_once_with(self.group_event, self.mock_futures)
+        assert result is None
+
+    def test_invalid_event_data(self):
+        from sentry.notifications.notification_action.types import invoke_future_with_error_handling
+        from sentry.workflow_engine.types import WorkflowEventData
+
+        invalid_event_data = WorkflowEventData(
+            event=mock.Mock(), workflow_env=self.environment, group=self.group
+        )
+
+        with pytest.raises(AssertionError) as excinfo:
+            invoke_future_with_error_handling(
+                invalid_event_data, self.mock_callback, self.mock_futures
+            )
+
+        assert "Expected a GroupEvent" in str(excinfo.value)
+
+    def test_ignores_integration_form_error(self):
+        from sentry.notifications.notification_action.types import invoke_future_with_error_handling
+        from sentry.shared_integrations.exceptions import IntegrationFormError
+
+        self.mock_callback.side_effect = IntegrationFormError("Test form error")
+
+        result = invoke_future_with_error_handling(
+            self.event_data, self.mock_callback, self.mock_futures
+        )
+
+        assert result is None
+        self.mock_callback.assert_called_once()
+
+    def test_ignores_integration_configuration_error(self):
+        from sentry.notifications.notification_action.types import invoke_future_with_error_handling
+        from sentry.shared_integrations.exceptions import IntegrationConfigurationError
+
+        self.mock_callback.side_effect = IntegrationConfigurationError("Test config error")
+
+        result = invoke_future_with_error_handling(
+            self.event_data, self.mock_callback, self.mock_futures
+        )
+
+        assert result is None
+        self.mock_callback.assert_called_once()
+
+    def test_reraises_processing_deadline_exceeded(self):
+        from sentry.notifications.notification_action.types import invoke_future_with_error_handling
+        from sentry.taskworker.workerchild import ProcessingDeadlineExceeded
+
+        self.mock_callback.side_effect = ProcessingDeadlineExceeded("Deadline exceeded")
+
+        with pytest.raises(ProcessingDeadlineExceeded):
+            invoke_future_with_error_handling(
+                self.event_data, self.mock_callback, self.mock_futures
+            )
+
+        self.mock_callback.assert_called_once()
+
+    def test_raises_retry_error_for_api_error(self):
+        from sentry.notifications.notification_action.types import invoke_future_with_error_handling
+        from sentry.shared_integrations.exceptions import ApiError
+        from sentry.taskworker.retry import RetryError
+
+        self.mock_callback.side_effect = ApiError("API error", 500)
+
+        with pytest.raises(RetryError) as excinfo:
+            invoke_future_with_error_handling(
+                self.event_data, self.mock_callback, self.mock_futures
+            )
+
+        assert isinstance(excinfo.value.__cause__, ApiError)
+        self.mock_callback.assert_called_once()
+
+    @mock.patch("logging.getLogger")
+    def test_safe_execute_exception_handling(self, mock_get_logger):
+        from sentry.notifications.notification_action.types import invoke_future_with_error_handling
+
+        mock_localized_logger = mock.Mock()
+        mock_get_logger.return_value = mock_localized_logger
+
+        test_exception = ValueError("Generic test error")
+
+        class TestCallbackClass:
+            def __call__(self, event, futures):  # noqa: ARG002
+                raise test_exception
+
+            @property
+            def __name__(self):
+                return "test_callback"
+
+        failing_callback = TestCallbackClass()
+
+        result = invoke_future_with_error_handling(
+            self.event_data, failing_callback, self.mock_futures
+        )
+
+        assert result is None
+
+        mock_get_logger.assert_called_once_with("sentry.safe_action.testcallbackclass")
+
+        mock_localized_logger.exception.assert_called_once_with(
+            "%s.process_error", "test_callback", extra={"exception": test_exception}
+        )
+
+    @mock.patch("logging.getLogger")
+    def test_generic_exception_with_im_class_attribute(self, mock_get_logger):
+        from sentry.notifications.notification_action.types import invoke_future_with_error_handling
+
+        mock_localized_logger = mock.Mock()
+        mock_get_logger.return_value = mock_localized_logger
+
+        test_exception = RuntimeError("Test runtime error")
+
+        def failing_callback_with_im_class(event, futures):  # noqa: ARG001
+            raise test_exception
+
+        class MockImClass:
+            __name__ = "ImClassTest"
+
+        failing_callback_with_im_class.im_class = MockImClass()
+        failing_callback_with_im_class.__name__ = "old_style_method"
+
+        result = invoke_future_with_error_handling(
+            self.event_data, failing_callback_with_im_class, self.mock_futures
+        )
+
+        assert result is None
+
+        mock_get_logger.assert_called_once_with("sentry.safe_action.imclasstest")
+
+        mock_localized_logger.exception.assert_called_once_with(
+            "%s.process_error", "old_style_method", extra={"exception": test_exception}
+        )
+
+    @mock.patch("logging.getLogger")
+    def test_generic_exception_with_no_name_attribute(self, mock_get_logger):
+        from sentry.notifications.notification_action.types import invoke_future_with_error_handling
+
+        mock_localized_logger = mock.Mock()
+        mock_get_logger.return_value = mock_localized_logger
+
+        test_exception = Exception("Test error")
+
+        class CallableWithoutName:
+            def __call__(self, event, futures):  # noqa: ARG002
+                raise test_exception
+
+        callback_without_name = CallableWithoutName()
+        callback_without_name.__class__.__name__ = "CallbackWithoutName"
+
+        result = invoke_future_with_error_handling(
+            self.event_data, callback_without_name, self.mock_futures
+        )
+
+        assert result is None
+
+        mock_get_logger.assert_called_once_with("sentry.safe_action.callbackwithoutname")
+
+        expected_func_name = str(callback_without_name)
+        mock_localized_logger.exception.assert_called_once_with(
+            "%s.process_error", expected_func_name, extra={"exception": test_exception}
+        )


### PR DESCRIPTION
Our current ticket creation errors are noisy. The majority of them are the result of strict configuration on the Jira site rejecting the ticket creation. These messages tend to vary greatly in content, and are generally unhelpful in triaging failing ticket creations.

This PR overrides the default error handling, and reraises the issues as `IntegrationConfigurationError`s, which records them as halts instead of failures.

