### PR TITLE
fix(prevent): TA onboarding US region only and snippet changes

### DIFF
--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
@@ -20,7 +20,7 @@ const DEFAULT_ORG_LABEL = 'Select Integrated Org';
 function AddIntegratedOrgButton() {
   return (
     <LinkButton
-      href="https://github.com/apps/sentry/installations/select_target"
+      href="https://github.com/apps/sentry-io/installations/select_target"
       size="sm"
       icon={<IconAdd size="sm" />}
       priority="default"

--- a/static/app/views/prevent/tests/onboarding.spec.tsx
+++ b/static/app/views/prevent/tests/onboarding.spec.tsx
@@ -53,7 +53,7 @@ const mockRepoData = {
 
 describe('TestsOnboardingPage', () => {
   beforeEach(() => {
-    mockGetRegionData.mockReset();
+    jest.clearAllMocks();
     mockGetRegionData.mockReturnValue({
       name: 'us',
       displayName: 'United States',
@@ -695,15 +695,13 @@ describe('TestsOnboardingPage', () => {
   });
 
   describe('when the organization is not in the US region', () => {
-    beforeEach(() => {
+    it('renders the pre-onboarding page with alert and header text', () => {
       mockGetRegionData.mockReturnValue({
         name: 'eu',
         displayName: 'European Union (EU)',
         url: 'https://eu.sentry.io',
       });
-    });
 
-    it('renders the pre-onboarding page with alert and header text', () => {
       render(
         <PreventContext.Provider value={mockPreventContext}>
           <TestsOnboardingPage />

--- a/static/app/views/prevent/tests/onboarding.spec.tsx
+++ b/static/app/views/prevent/tests/onboarding.spec.tsx
@@ -1,7 +1,14 @@
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PreventContext} from 'sentry/components/prevent/context/preventContext';
+import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import TestsOnboardingPage from 'sentry/views/prevent/tests/onboarding';
+
+jest.mock('sentry/utils/regions', () => ({
+  getRegionDataFromOrganization: jest.fn(),
+}));
+
+const mockGetRegionData = jest.mocked(getRegionDataFromOrganization);
 
 const mockPreventContext = {
   repository: 'test-repo',
@@ -46,6 +53,13 @@ const mockRepoData = {
 
 describe('TestsOnboardingPage', () => {
   beforeEach(() => {
+    mockGetRegionData.mockReset();
+    mockGetRegionData.mockReturnValue({
+      name: 'us',
+      displayName: 'United States',
+      url: 'https://sentry.io',
+    });
+
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/integrations/',
       body: [mockGitHubIntegration],
@@ -677,6 +691,41 @@ describe('TestsOnboardingPage', () => {
 
       expect(await screen.findByText('SENTRY_PREVENT_TOKEN')).toBeInTheDocument();
       expect(screen.getByText('new-generated-token-12345')).toBeInTheDocument();
+    });
+  });
+
+  describe('when the organization is not in the US region', () => {
+    beforeEach(() => {
+      mockGetRegionData.mockReturnValue({
+        name: 'eu',
+        displayName: 'European Union (EU)',
+        url: 'https://eu.sentry.io',
+      });
+    });
+
+    it('renders the pre-onboarding page with alert and header text', () => {
+      render(
+        <PreventContext.Provider value={mockPreventContext}>
+          <TestsOnboardingPage />
+        </PreventContext.Provider>,
+        {
+          initialRouterConfig: {
+            location: {
+              pathname: '/prevent/tests/new',
+              query: {},
+            },
+          },
+        }
+      );
+
+      expect(
+        screen.getByText(
+          'Test Analytics data is stored in the U.S. only. To use this feature, create a new Sentry organization with U.S. data storage.'
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('Keep Test Problems From Slowing You Down')
+      ).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/prevent/tests/onboarding.tsx
+++ b/static/app/views/prevent/tests/onboarding.tsx
@@ -18,6 +18,7 @@ import {getPreventParamsString} from 'sentry/components/prevent/utils';
 import {t, tct} from 'sentry/locale';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AddScriptToYamlStep} from 'sentry/views/prevent/tests/onboardingSteps/addScriptToYamlStep';
@@ -76,6 +77,17 @@ export default function TestsOnboardingPage() {
     ],
     {staleTime: 0}
   );
+
+  const regionData = getRegionDataFromOrganization(organization);
+  const isUSStorage = regionData?.name === 'us';
+
+  if (!isUSStorage) {
+    return (
+      <LayoutGap>
+        <TestPreOnboardingPage />
+      </LayoutGap>
+    );
+  }
 
   if (isPending) {
     return (

--- a/static/app/views/prevent/tests/onboardingSteps/GHAWorkflowExpandable.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/GHAWorkflowExpandable.tsx
@@ -34,7 +34,7 @@ jobs:
       # Copy and paste the getsentry/prevent-action here
       - name: Upload test results to Sentry Prevent
         if: \${{ !cancelled() }}
-        uses: getsentry/prevent-action@latest
+        uses: getsentry/prevent-action@v0
 `;
 
 export function GHAWorkflowExpandable() {

--- a/static/app/views/prevent/tests/onboardingSteps/addScriptToYamlStep.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/addScriptToYamlStep.tsx
@@ -12,7 +12,7 @@ interface AddScriptToYamlStepProps {
 
 const SNIPPET = `- name: Upload test results to Sentry Prevent
   if: \${{ !cancelled() }}
-  uses: getsentry/prevent-action@latest
+  uses: getsentry/prevent-action@v0
   with:
     token: \${{ secrets.SENTRY_PREVENT_TOKEN }}
 `;

--- a/static/app/views/prevent/tests/onboardingSteps/editGHAWorkflowStep.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/editGHAWorkflowStep.tsx
@@ -17,7 +17,7 @@ const PERMISSIONS_SNIPPET = `permissions:
 
 const ACTION_SNIPPET = `- name: Upload test results to Sentry Prevent
   if: \${{ !cancelled() }}
-  uses: getsentry/prevent-action@latest
+  uses: getsentry/prevent-action@v0
 `;
 
 export function EditGHAWorkflowStep({step}: EditGHAWorkflowStepProps) {

--- a/static/app/views/prevent/tests/onboardingSteps/outputCoverageFileStep.spec.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/outputCoverageFileStep.spec.tsx
@@ -42,9 +42,9 @@ describe('OutputCoverageFileStep component', () => {
     expect(screen.getByText('Pytest')).toBeInTheDocument();
 
     // Check Pytest installation snippet
-    expect(screen.getByText('pip install pytest pytest-cov')).toBeInTheDocument();
+    expect(screen.getByText('pip install pytest')).toBeInTheDocument();
     expect(
-      screen.getByText('pytest --cov --junitxml=junit.xml -o junit_family=legacy')
+      screen.getByText('pytest --junitxml=junit.xml -o junit_family=legacy')
     ).toBeInTheDocument();
   });
 

--- a/static/app/views/prevent/tests/onboardingSteps/outputCoverageFileStep.tsx
+++ b/static/app/views/prevent/tests/onboardingSteps/outputCoverageFileStep.tsx
@@ -17,14 +17,14 @@ type Frameworks = 'jest' | 'vitest' | 'pytest' | 'phpunit';
 const INSTALL_REQUIREMENTS_SNIPPETS: Record<Frameworks, string> = {
   jest: 'npm install --save-dev jest',
   vitest: 'npm install --save-dev vitest @vitest/coverage-v8',
-  pytest: 'pip install pytest pytest-cov',
+  pytest: 'pip install pytest',
   phpunit: 'composer require --dev phpunit/phpunit',
 };
 
 const GENERATE_FILE_SNIPPETS: Record<Frameworks, string> = {
   jest: `JEST_JUNIT_CLASSNAME="{filepath}" jest --reporters=jest-junit`,
   vitest: 'vitest --reporter=junit --outputFile=test-report.junit.xml',
-  pytest: 'pytest --cov --junitxml=junit.xml -o junit_family=legacy',
+  pytest: 'pytest --junitxml=junit.xml -o junit_family=legacy',
   phpunit: './vendor/bin/phpunit --log-junit junit.xml',
 };
 

--- a/static/app/views/prevent/tests/preOnboarding.spec.tsx
+++ b/static/app/views/prevent/tests/preOnboarding.spec.tsx
@@ -64,4 +64,23 @@ describe('TestPreOnboardingPage', () => {
       )
     ).toBeInTheDocument();
   });
+
+  it('displays the feature is only allowed in US messaging when isUSstorage is false', () => {
+    mockGetRegionData.mockReturnValue({
+      name: 'eu',
+      displayName: 'European Union (EU)',
+      url: 'https://eu.sentry.io',
+    });
+
+    render(<TestPreOnboardingPage />, {organization: org});
+
+    expect(
+      screen.getByText('Keep Test Problems From Slowing You Down')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Test Analytics data is stored in the U.S. only. To use this feature, create a new Sentry organization with U.S. data storage.'
+      )
+    ).toBeInTheDocument();
+  });
 });

--- a/static/app/views/prevent/tests/preOnboarding.tsx
+++ b/static/app/views/prevent/tests/preOnboarding.tsx
@@ -47,7 +47,7 @@ export default function TestPreOnboardingPage() {
             <img src={isDarkMode ? testsAnalyticsSummaryDark : testsAnalyticsSummary} />
           </ImgContainer>
           <StyledDiv>
-            <h2>{t('Keep test problems from slowing you down')}</h2>
+            <h2>{t('Keep Test Problems From Slowing You Down')}</h2>
             <SpacedParagraph>
               {t('Get testing data that keeps your CI running smoothly')}
             </SpacedParagraph>

--- a/static/app/views/prevent/tests/tests.spec.tsx
+++ b/static/app/views/prevent/tests/tests.spec.tsx
@@ -146,32 +146,28 @@ const mockApiCall = () => {
 
 describe('CoveragePageWrapper', () => {
   beforeEach(() => {
-    mockGetRegionData.mockReset();
+    jest.clearAllMocks();
+
+    localStorageWrapper.clear();
+    localStorageWrapper.setItem(
+      'prevent-selection:org-slug',
+      JSON.stringify({
+        'test-integration': {
+          integratedOrgId: '123',
+        },
+      })
+    );
+    mockApiCall();
   });
 
   describe('when the wrapper is used', () => {
-    beforeEach(() => {
-      localStorageWrapper.clear();
-
-      localStorageWrapper.setItem(
-        'prevent-selection:org-slug',
-        JSON.stringify({
-          'test-integration': {
-            integratedOrgId: '123',
-          },
-        })
-      );
-
-      // Mock US region by default
+    it('renders the passed children', async () => {
       mockGetRegionData.mockReturnValue({
         name: 'us',
         displayName: 'United States',
         url: 'https://sentry.io',
       });
-    });
 
-    mockApiCall();
-    it('renders the passed children', async () => {
       render(
         <PreventQueryParamsProvider>
           <TestsPage />
@@ -207,27 +203,13 @@ describe('CoveragePageWrapper', () => {
     });
   });
   describe('when the organization is not in the US region', () => {
-    beforeEach(() => {
-      localStorageWrapper.clear();
-
-      localStorageWrapper.setItem(
-        'prevent-selection:org-slug',
-        JSON.stringify({
-          'test-integration': {
-            integratedOrgId: '123',
-          },
-        })
-      );
-
+    it('renders the pre-onboarding page', () => {
       mockGetRegionData.mockReturnValue({
         name: 'eu',
         displayName: 'European Union (EU)',
         url: 'https://eu.sentry.io',
       });
 
-      mockApiCall();
-    });
-    it('renders the pre-onboarding page', () => {
       render(
         <PreventQueryParamsProvider>
           <TestsPage />

--- a/static/app/views/prevent/tests/tests.spec.tsx
+++ b/static/app/views/prevent/tests/tests.spec.tsx
@@ -1,7 +1,10 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import PreventQueryParamsProvider from 'sentry/components/prevent/container/preventParamsProvider';
 import localStorageWrapper from 'sentry/utils/localStorage';
+import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import TestsPage from 'sentry/views/prevent/tests/tests';
 
 jest.mock('sentry/components/pagination', () => {
@@ -9,6 +12,12 @@ jest.mock('sentry/components/pagination', () => {
     return <div>Pagination Component</div>;
   };
 });
+
+jest.mock('sentry/utils/regions', () => ({
+  getRegionDataFromOrganization: jest.fn(),
+}));
+
+const mockGetRegionData = jest.mocked(getRegionDataFromOrganization);
 
 // TODO: Make these fixtures
 const mockTestResultsData = [
@@ -136,6 +145,10 @@ const mockApiCall = () => {
 };
 
 describe('CoveragePageWrapper', () => {
+  beforeEach(() => {
+    mockGetRegionData.mockReset();
+  });
+
   describe('when the wrapper is used', () => {
     beforeEach(() => {
       localStorageWrapper.clear();
@@ -148,6 +161,13 @@ describe('CoveragePageWrapper', () => {
           },
         })
       );
+
+      // Mock US region by default
+      mockGetRegionData.mockReturnValue({
+        name: 'us',
+        displayName: 'United States',
+        url: 'https://sentry.io',
+      });
     });
 
     mockApiCall();
@@ -184,6 +204,53 @@ describe('CoveragePageWrapper', () => {
       await waitFor(() => {
         expect(screen.getByText('Pagination Component')).toBeInTheDocument();
       });
+    });
+  });
+  describe('when the organization is not in the US region', () => {
+    beforeEach(() => {
+      localStorageWrapper.clear();
+
+      localStorageWrapper.setItem(
+        'prevent-selection:org-slug',
+        JSON.stringify({
+          'test-integration': {
+            integratedOrgId: '123',
+          },
+        })
+      );
+
+      mockGetRegionData.mockReturnValue({
+        name: 'eu',
+        displayName: 'European Union (EU)',
+        url: 'https://eu.sentry.io',
+      });
+
+      mockApiCall();
+    });
+    it('renders the pre-onboarding page', () => {
+      render(
+        <PreventQueryParamsProvider>
+          <TestsPage />
+        </PreventQueryParamsProvider>,
+        {
+          initialRouterConfig: {
+            location: {
+              pathname: '/prevent/tests',
+              query: {
+                preventPeriod: '7d',
+                integratedOrgName: 'test-integration',
+                repository: 'some-repository',
+                branch: 'some-branch',
+              },
+            },
+          },
+          organization: OrganizationFixture({features: ['test-analytics']}),
+        }
+      );
+
+      expect(
+        screen.getByText('Keep Test Problems From Slowing You Down')
+      ).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/prevent/tests/tests.tsx
+++ b/static/app/views/prevent/tests/tests.tsx
@@ -13,8 +13,11 @@ import {getPreventParamsString} from 'sentry/components/prevent/utils';
 import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {decodeSorts} from 'sentry/utils/queryString';
+import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import TestsPreOnboardingPage from 'sentry/views/prevent/tests/preOnboarding';
 import {
   useInfiniteTestResults,
   type UseInfiniteTestResultsResult,
@@ -49,8 +52,19 @@ export default function TestsPage() {
   });
   const defaultBranch = response.data?.defaultBranch;
   const shouldDisplayTestSuiteDropdown = branch === null || branch === defaultBranch;
-
+  const organization = useOrganization();
   const shouldDisplayContent = integratedOrgId && repository && preventPeriod;
+
+  const regionData = getRegionDataFromOrganization(organization);
+  const isUSStorage = regionData?.name === 'us';
+
+  if (!isUSStorage) {
+    return (
+      <LayoutGap>
+        <TestsPreOnboardingPage />
+      </LayoutGap>
+    );
+  }
 
   return (
     <LayoutGap>


### PR DESCRIPTION
Fixes:
- Seeing repos on EU shouldn’t happen
- Update the app to be sentry-io for +Integrated Organization
- Only need `pip install pytest and pytest –junitxml… ` in pip install snippets
- Fix `getsentry/prevent-action@latest` should be `prevent-action@v0` in snippets