### PR TITLE
ref(api): use `RateLimitConfig` in core endpoints

### DIFF
--- a/src/sentry/core/endpoints/organization_member_index.py
+++ b/src/sentry/core/endpoints/organization_member_index.py
@@ -35,6 +35,7 @@ from sentry.models.organization import Organization
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberinvite import OrganizationMemberInvite
 from sentry.models.team import Team, TeamStatus
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.roles import organization_roles, team_roles
 from sentry.search.utils import tokenize_query
 from sentry.signals import member_invited
@@ -168,18 +169,20 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
         "POST": ApiPublishStatus.PUBLIC,
     }
 
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=40, window=1),
-            RateLimitCategory.USER: RateLimit(limit=40, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=40, window=1),
+                RateLimitCategory.USER: RateLimit(limit=40, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
+            },
+            "POST": {
+                RateLimitCategory.IP: RateLimit(limit=40, window=1),
+                RateLimitCategory.USER: RateLimit(limit=40, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
+            },
         },
-        "POST": {
-            RateLimitCategory.IP: RateLimit(limit=40, window=1),
-            RateLimitCategory.USER: RateLimit(limit=40, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
-        },
-    }
+    )
 
     permission_classes = (MemberAndStaffPermission,)
     owner = ApiOwner.ENTERPRISE

--- a/src/sentry/core/endpoints/project_keys.py
+++ b/src/sentry/core/endpoints/project_keys.py
@@ -21,6 +21,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.loader.dynamic_sdk_options import get_default_loader_data
 from sentry.models.projectkey import ProjectKey, ProjectKeyStatus, UseCase
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -32,18 +33,20 @@ class ProjectKeysEndpoint(ProjectEndpoint):
         "POST": ApiPublishStatus.PUBLIC,
     }
 
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(limit=40, window=1),
-            RateLimitCategory.USER: RateLimit(limit=40, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=40, window=1),
+                RateLimitCategory.USER: RateLimit(limit=40, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
+            },
+            "POST": {
+                RateLimitCategory.IP: RateLimit(limit=40, window=1),
+                RateLimitCategory.USER: RateLimit(limit=40, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
+            },
         },
-        "POST": {
-            RateLimitCategory.IP: RateLimit(limit=40, window=1),
-            RateLimitCategory.USER: RateLimit(limit=40, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
-        },
-    }
+    )
 
     @extend_schema(
         operation_id="List a Project's Client Keys",

--- a/src/sentry/core/endpoints/project_transfer.py
+++ b/src/sentry/core/endpoints/project_transfer.py
@@ -14,6 +14,7 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.decorators import sudo_required
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organizationmember import OrganizationMember
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
@@ -36,13 +37,15 @@ class ProjectTransferEndpoint(ProjectEndpoint):
     permission_classes = (RelaxedProjectPermission,)
 
     enforce_rate_limit = True
-    rate_limits = {
-        "POST": {
-            RateLimitCategory.USER: RateLimit(
-                limit=3, window=60 * 60
-            ),  # 3 POST requests per hour per user
-        }
-    }
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "POST": {
+                RateLimitCategory.USER: RateLimit(
+                    limit=3, window=60 * 60
+                ),  # 3 POST requests per hour per user
+            },
+        },
+    )
 
     @sudo_required
     def post(self, request: Request, project) -> Response:

--- a/src/sentry/core/endpoints/project_users.py
+++ b/src/sentry/core/endpoints/project_users.py
@@ -9,6 +9,7 @@ from sentry.api.bases.project import ProjectAndStaffPermission, ProjectEndpoint
 from sentry.api.paginator import CallbackPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.eventuser import EventUserSerializer
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.eventuser import EventUser
 
@@ -18,11 +19,13 @@ class ProjectUsersEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=60),
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=60),
+            },
         },
-    }
+    )
     permission_classes = (ProjectAndStaffPermission,)
 
     def get(self, request: Request, project) -> Response:


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/99484, moving to RateLimitConfig instead of the rate limit dict.

turns out claude missed a few endpoints, this + relay should be the last ones that need updating before we can remove the dict logic