### PR TITLE
feat(prevent): Modify flake rate header based on branch

### DIFF
--- a/static/app/views/prevent/tests/testAnalyticsTable/tableHeader.tsx
+++ b/static/app/views/prevent/tests/testAnalyticsTable/tableHeader.tsx
@@ -10,6 +10,7 @@ import {RIGHT_ALIGNED_FIELDS} from 'sentry/views/prevent/tests/testAnalyticsTabl
 
 type TableHeaderParams = {
   column: Column;
+  isMainOrDefaultBranch: boolean;
   sort?: Sort;
 };
 
@@ -30,7 +31,11 @@ function FlakyTestsTooltip() {
   );
 }
 
-export const renderTableHeader = ({column, sort}: TableHeaderParams) => {
+export const renderTableHeader = ({
+  column,
+  isMainOrDefaultBranch,
+  sort,
+}: TableHeaderParams) => {
   const {key, name} = column;
 
   const alignment = RIGHT_ALIGNED_FIELDS.has(key) ? 'right' : 'left';
@@ -43,9 +48,10 @@ export const renderTableHeader = ({column, sort}: TableHeaderParams) => {
       fieldName={key}
       label={name}
       enableToggle={enableToggle}
-      {...(key === 'flakeRate' && {
-        tooltip: <FlakyTestsTooltip />,
-      })}
+      {...(key === 'flakeRate' &&
+        isMainOrDefaultBranch && {
+          tooltip: <FlakyTestsTooltip />,
+        })}
     />
   );
 };

--- a/static/app/views/prevent/tests/testAnalyticsTable/testAnalyticsTable.spec.tsx
+++ b/static/app/views/prevent/tests/testAnalyticsTable/testAnalyticsTable.spec.tsx
@@ -1,0 +1,121 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {PreventContext} from 'sentry/components/prevent/context/preventContext';
+import TestAnalyticsTable from 'sentry/views/prevent/tests/testAnalyticsTable/testAnalyticsTable';
+
+const mockTestResults = [
+  {
+    testName:
+      'tests.symbolicator.test_unreal_full.SymbolicatorUnrealIntegrationTest::test_unreal_crash_with_attachments',
+    averageDurationMs: 4,
+    flakeRate: 0.4,
+    isBrokenTest: false,
+    lastRun: '2025-04-17T22:26:19.486793+00:00',
+    totalFailCount: 1,
+    totalFlakyFailCount: 2,
+    totalPassCount: 0,
+    totalSkipCount: 3,
+    updatedAt: '2025-04-17T22:26:19.486793+00:00',
+  },
+];
+
+const mockResponse = {
+  data: {
+    testResults: mockTestResults,
+    defaultBranch: 'main',
+  },
+  isLoading: false,
+};
+
+const mockSort = {
+  field: 'averageDurationMs' as const,
+  kind: 'asc' as const,
+};
+
+const mockPreventContext = {
+  repository: 'test-repo',
+  changeContextValue: jest.fn(),
+  preventPeriod: '7d',
+  branch: 'main',
+  integratedOrgId: '123',
+  lastVisitedOrgId: '123',
+};
+
+describe('TestAnalyticsTable', () => {
+  describe('when selectedBranch is null', () => {
+    const nullBranchContext = {
+      ...mockPreventContext,
+      branch: null,
+    };
+
+    it('treats null branch as main/default branch and displays "Flake Rate"', () => {
+      render(
+        <PreventContext.Provider value={nullBranchContext}>
+          <TestAnalyticsTable response={mockResponse} sort={mockSort} />
+        </PreventContext.Provider>,
+        {
+          initialRouterConfig: {
+            location: {
+              pathname: '/prevent/tests',
+              query: {},
+            },
+          },
+        }
+      );
+
+      expect(screen.getByText('Flake Rate')).toBeInTheDocument();
+    });
+  });
+
+  describe('when selectedBranch matches defaultBranch', () => {
+    const matchingBranchContext = {
+      ...mockPreventContext,
+      branch: 'main',
+    };
+
+    it('treats matching branch as main/default branch and displays "Flake Rate"', () => {
+      render(
+        <PreventContext.Provider value={matchingBranchContext}>
+          <TestAnalyticsTable response={mockResponse} sort={mockSort} />
+        </PreventContext.Provider>,
+        {
+          initialRouterConfig: {
+            location: {
+              pathname: '/prevent/tests',
+              query: {},
+            },
+          },
+        }
+      );
+
+      expect(screen.getByText('Flake Rate')).toBeInTheDocument();
+    });
+  });
+
+  describe('when defaultBranch is undefined', () => {
+    const responseWithoutDefaultBranch = {
+      data: {
+        testResults: mockTestResults,
+      },
+      isLoading: false,
+    };
+
+    it('treats any branch as non-main when defaultBranch is undefined', () => {
+      render(
+        <PreventContext.Provider value={mockPreventContext}>
+          <TestAnalyticsTable response={responseWithoutDefaultBranch} sort={mockSort} />
+        </PreventContext.Provider>,
+        {
+          initialRouterConfig: {
+            location: {
+              pathname: '/prevent/tests',
+              query: {},
+            },
+          },
+        }
+      );
+
+      expect(screen.getByText('Failure Rate')).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/prevent/tests/testAnalyticsTable/testAnalyticsTable.tsx
+++ b/static/app/views/prevent/tests/testAnalyticsTable/testAnalyticsTable.tsx
@@ -1,6 +1,7 @@
 import {useSearchParams} from 'react-router-dom';
 import styled from '@emotion/styled';
 
+import {usePreventContext} from 'sentry/components/prevent/context/preventContext';
 import type {GridColumnHeader} from 'sentry/components/tables/gridEditable';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/tables/gridEditable';
 import {IconSearch} from 'sentry/icons';
@@ -42,13 +43,19 @@ export type ValidSort = Sort & {
   field: (typeof SORTABLE_FIELDS)[number];
 };
 
-const COLUMNS_ORDER: Column[] = [
-  {key: 'testName', name: t('Test Name'), width: COL_WIDTH_UNDEFINED},
-  {key: 'averageDurationMs', name: t('Avg. Duration'), width: COL_WIDTH_UNDEFINED},
-  {key: 'flakeRate', name: t('Flake Rate'), width: COL_WIDTH_UNDEFINED},
-  {key: 'totalFailCount', name: t('Runs Failed'), width: COL_WIDTH_UNDEFINED},
-  {key: 'lastRun', name: t('Last Run'), width: COL_WIDTH_UNDEFINED},
-];
+function getColumnsOrder(isMainOrDefaultBranch: boolean): Column[] {
+  return [
+    {key: 'testName', name: t('Test Name'), width: COL_WIDTH_UNDEFINED},
+    {key: 'averageDurationMs', name: t('Avg. Duration'), width: COL_WIDTH_UNDEFINED},
+    {
+      key: 'flakeRate',
+      name: isMainOrDefaultBranch ? t('Flake Rate') : t('Failure Rate'),
+      width: COL_WIDTH_UNDEFINED,
+    },
+    {key: 'totalFailCount', name: t('Runs Failed'), width: COL_WIDTH_UNDEFINED},
+    {key: 'lastRun', name: t('Last Run'), width: COL_WIDTH_UNDEFINED},
+  ];
+}
 
 export const RIGHT_ALIGNED_FIELDS = new Set([
   'averageDurationMs',
@@ -77,6 +84,7 @@ interface Props {
   response: {
     data: {
       testResults: Row[];
+      defaultBranch?: string;
     };
     isLoading: boolean;
   };
@@ -86,8 +94,13 @@ interface Props {
 export default function TestAnalyticsTable({response, sort}: Props) {
   const {data, isLoading} = response;
   const [searchParams] = useSearchParams();
+  const {branch: selectedBranch} = usePreventContext();
   const wrapToggleValue = searchParams.get('wrap') === 'true';
   const testResults = data.testResults;
+  const defaultBranch = response.data?.defaultBranch;
+  const isMainOrDefaultBranch =
+    selectedBranch === null || selectedBranch === defaultBranch;
+  const columnsOrder = getColumnsOrder(isMainOrDefaultBranch);
 
   const selectorEmptyMessage = (
     <MessageContainer>
@@ -107,7 +120,7 @@ export default function TestAnalyticsTable({response, sort}: Props) {
       isLoading={isLoading}
       data={testResults ?? []}
       emptyMessage={selectorEmptyMessage}
-      columnOrder={COLUMNS_ORDER}
+      columnOrder={columnsOrder}
       // TODO: This isn't used as per the docs but is still required. Test if
       // it affects sorting when backend is ready.
       columnSortBy={[
@@ -121,6 +134,7 @@ export default function TestAnalyticsTable({response, sort}: Props) {
           renderTableHeader({
             column,
             sort,
+            isMainOrDefaultBranch,
           }),
         renderBodyCell: (column, row) => renderTableBody({column, row, wrapToggleValue}),
       }}


### PR DESCRIPTION
- Change `flake rate` to `failure rate` when not the default or "All branches" selected
- remove the flake rate tooltip when it is "failure rate"
