### PR TITLE
instr(spans): Verify that data are written as attributes

### DIFF
--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -74,7 +74,7 @@ def process_segment(
     return spans
 
 
-def _verify_compatibility(spans):
+def _verify_compatibility(spans: list[CompatibleSpan]) -> None:
     try:
         for span in spans:
             # As soon as compatibility spans are fully rolled out, we can assert that attributes exist here.

--- a/src/sentry/spans/consumers/process_segments/types.py
+++ b/src/sentry/spans/consumers/process_segments/types.py
@@ -32,4 +32,4 @@ class CompatibleSpan(EnrichedSpan, total=True):
     # Added by `SpanGroupingResults.write_to_spans` in `_enrich_spans`
     hash: NotRequired[str]
 
-    attributes: NotRequired[dict(str, Any)]
+    attributes: NotRequired[dict[str, Any]]

--- a/src/sentry/spans/consumers/process_segments/types.py
+++ b/src/sentry/spans/consumers/process_segments/types.py
@@ -1,4 +1,4 @@
-from typing import NotRequired
+from typing import Any, NotRequired
 
 from sentry_kafka_schemas.schema_types.buffered_segments_v1 import SegmentSpan
 
@@ -31,3 +31,5 @@ class CompatibleSpan(EnrichedSpan, total=True):
 
     # Added by `SpanGroupingResults.write_to_spans` in `_enrich_spans`
     hash: NotRequired[str]
+
+    attributes: NotRequired[dict(str, Any)]


### PR DESCRIPTION
Count the number of spans that have the new `attributes` field, and verify that every `data` item exists also as attribute.

ref: INGEST-531