### PR TITLE
fix(preprod): Some CSS polish for loading size

### DIFF
--- a/static/app/views/preprod/components/buildError.tsx
+++ b/static/app/views/preprod/components/buildError.tsx
@@ -20,9 +20,8 @@ export function BuildError({title, message, children}: BuildErrorProps) {
       gap="3xl"
       padding="md"
       minHeight="60vh"
-      maxWidth="500px"
     >
-      <Flex direction="column" align="center" gap="lg" padding="md">
+      <Flex maxWidth="500px" direction="column" align="center" gap="lg" padding="md">
         <AlertImage src={Missing} alt="Error image" />
         <Heading as="h2">{title}</Heading>
         <Text>{message}</Text>

--- a/static/app/views/preprod/components/buildProcessing.tsx
+++ b/static/app/views/preprod/components/buildProcessing.tsx
@@ -26,7 +26,7 @@ export function BuildProcessing({title, message, children}: BuildProcessingProps
           {title}
         </Heading>
         <Text align="center">{message}</Text>
-        <Flex gap="sm">
+        <Flex align="center" justify="center">
           <RotatingIcon>
             <IconSettings size="2xl" />
           </RotatingIcon>
@@ -40,23 +40,26 @@ export function BuildProcessing({title, message, children}: BuildProcessingProps
   );
 }
 
+// 22.5deg to offset icon by one tooth.
 const RotatingIcon = styled('span')`
   display: inline-block;
-  animation: spin 2s linear infinite;
+  animation: spin 3s linear infinite;
+  line-height: 0;
 
   @keyframes spin {
     0% {
-      transform: rotate(0deg);
+      transform: rotate(22.5deg);
     }
     100% {
-      transform: rotate(360deg);
+      transform: rotate(382.5deg);
     }
   }
 `;
 
 const RotatingIconReverse = styled('span')`
   display: inline-block;
-  animation: spin-reverse 2s linear infinite;
+  animation: spin-reverse 3s linear infinite;
+  line-height: 0;
 
   @keyframes spin-reverse {
     0% {


### PR DESCRIPTION
A number of small fixes for size CSS:
- Fix a bug where two loading texts could appear at once.
- Extract common loading CSS to a component
- Use grid to overlap elements rather than absolute + z-index
- Make build processing gears more 'geary'
  - Fix alignment so they don't rotate off-center
  - Offset one gear by one tooth so they mesh
- Add missing TODO reference
- Center build errors
