### PR TITLE
fix(spans): More solid error logging for Span V2 format

### DIFF
--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -1,7 +1,7 @@
 import logging
 import types
 import uuid
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 import sentry_sdk
@@ -74,7 +74,7 @@ def process_segment(
     return spans
 
 
-def _verify_compatibility(spans: list[CompatibleSpan]) -> list[list[Any]]:
+def _verify_compatibility(spans: Sequence[Mapping[str, Any]]) -> list[list[Any]]:
     all_mismatches = []
     try:
         for span in spans:

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -2,7 +2,7 @@ import logging
 import types
 import uuid
 from collections.abc import Sequence
-from typing import cast
+from typing import Any, cast
 
 import sentry_sdk
 from django.core.exceptions import ValidationError
@@ -74,7 +74,7 @@ def process_segment(
     return spans
 
 
-def _verify_compatibility(spans: list[CompatibleSpan]):
+def _verify_compatibility(spans: list[CompatibleSpan]) -> list[list[Any]]:
     all_mismatches = []
     try:
         for span in spans:

--- a/src/sentry/spans/consumers/process_segments/types.py
+++ b/src/sentry/spans/consumers/process_segments/types.py
@@ -32,4 +32,5 @@ class CompatibleSpan(EnrichedSpan, total=True):
     # Added by `SpanGroupingResults.write_to_spans` in `_enrich_spans`
     hash: NotRequired[str]
 
-    attributes: NotRequired[dict[str, Any]]
+    # TODO: spec this in kafka schemas
+    attributes: NotRequired[None | dict[str, Any]]

--- a/src/sentry/spans/consumers/process_segments/types.py
+++ b/src/sentry/spans/consumers/process_segments/types.py
@@ -1,4 +1,4 @@
-from typing import Any, NotRequired
+from typing import NotRequired
 
 from sentry_kafka_schemas.schema_types.buffered_segments_v1 import SegmentSpan
 
@@ -31,6 +31,3 @@ class CompatibleSpan(EnrichedSpan, total=True):
 
     # Added by `SpanGroupingResults.write_to_spans` in `_enrich_spans`
     hash: NotRequired[str]
-
-    # TODO: spec this in kafka schemas
-    attributes: NotRequired[None | dict[str, Any]]

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -1,5 +1,6 @@
 import uuid
 from hashlib import md5
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -239,7 +240,7 @@ class TestSpansTask(TestCase):
 
 
 def test_verify_compatibility():
-    spans = [
+    spans: list[dict[str, Any]] = [
         {"data": {"foo": 1}, "attributes": {"foo": {"value": 1}}},
         {"data": {"foo": 1}},
         {"data": {"foo": 1}, "attributes": {"value": {"foo": 2}}},


### PR DESCRIPTION
Looks like the new compatibility spans have a less uniform format than expected, fix the verification code.

Fixes [SENTRY-55C7](https://sentry.sentry.io/issues/6897170327/).