### PR TITLE
[ft] Add region info banner to Prevent onboarding page

### DIFF
--- a/static/app/views/prevent/preventAI/onboarding.spec.tsx
+++ b/static/app/views/prevent/preventAI/onboarding.spec.tsx
@@ -30,6 +30,11 @@ describe('PreventAIOnboarding', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     configState = ConfigStore.getState();
+    // Set up default regions for tests
+    ConfigStore.set('regions', [
+      {url: 'https://us.sentry.io', name: 'us'},
+      {url: 'https://de.sentry.io', name: 'de'},
+    ]);
   });
 
   afterEach(() => {
@@ -266,11 +271,6 @@ describe('PreventAIOnboarding', () => {
   });
 
   it('shows EU data storage alert when organization region is EU', () => {
-    ConfigStore.set('regions', [
-      {url: 'https://us.sentry.io', name: 'us'},
-      {url: 'https://de.sentry.io', name: 'de'},
-    ]);
-
     const euOrg = OrganizationFixture({
       slug: 'eu-org',
       links: {
@@ -281,17 +281,14 @@ describe('PreventAIOnboarding', () => {
 
     render(<PreventAIOnboarding />, {organization: euOrg});
 
-    expect(screen.getByRole('alert')).toHaveTextContent(
-      'AI Code Review data is stored in the U.S. only and is not available in the EU. EU region support is coming soon.'
-    );
+    expect(
+      screen.getByText(
+        'AI Code Review data is stored in the U.S. only and is not available in the EU. EU region support is coming soon.'
+      )
+    ).toBeInTheDocument();
   });
 
   it('does not show region alert for US organizations', () => {
-    ConfigStore.set('regions', [
-      {url: 'https://us.sentry.io', name: 'us'},
-      {url: 'https://de.sentry.io', name: 'de'},
-    ]);
-
     const usOrg = OrganizationFixture({
       slug: 'us-org',
       links: {
@@ -302,6 +299,10 @@ describe('PreventAIOnboarding', () => {
 
     render(<PreventAIOnboarding />, {organization: usOrg});
 
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'AI Code Review data is stored in the U.S. only and is not available in the EU. EU region support is coming soon.'
+      )
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/prevent/preventAI/onboarding.tsx
+++ b/static/app/views/prevent/preventAI/onboarding.tsx
@@ -47,7 +47,9 @@ export default function PreventAIOnboarding() {
       {!isUSOrg && (
         <Alert.Container>
           <Alert type="info">
-            {t('AI Code Review is only available in the U.S. More regions coming soon.')}
+            {t(
+              'AI Code Review data is stored in the U.S. only and is not available in the EU. EU region support is coming soon.'
+            )}
           </Alert>
         </Alert.Container>
       )}

--- a/static/app/views/prevent/preventAI/onboarding.tsx
+++ b/static/app/views/prevent/preventAI/onboarding.tsx
@@ -45,13 +45,15 @@ export default function PreventAIOnboarding() {
   return (
     <Flex direction="column" gap="2xl">
       {!isUSOrg && (
-        <Alert.Container>
-          <Alert type="info">
-            {t(
-              'AI Code Review data is stored in the U.S. only and is not available in the EU. EU region support is coming soon.'
-            )}
-          </Alert>
-        </Alert.Container>
+        <Container maxWidth="1000px">
+          <Alert.Container>
+            <Alert type="info">
+              {t(
+                'AI Code Review data is stored in the U.S. only and is not available in the EU. EU region support is coming soon.'
+              )}
+            </Alert>
+          </Alert.Container>
+        </Container>
       )}
       <Flex
         direction="row"

--- a/static/app/views/prevent/preventAI/onboarding.tsx
+++ b/static/app/views/prevent/preventAI/onboarding.tsx
@@ -5,12 +5,14 @@ import preventHero from 'sentry-images/features/prevent-hero.svg';
 import preventPrCommentsDark from 'sentry-images/features/prevent-pr-comments-dark.svg';
 import preventPrCommentsLight from 'sentry-images/features/prevent-pr-comments-light.svg';
 
+import {Alert} from 'sentry/components/core/alert';
 import {Container, Flex} from 'sentry/components/core/layout';
 import {ExternalLink, Link} from 'sentry/components/core/link';
 import {Text} from 'sentry/components/core/text';
 import {Heading} from 'sentry/components/core/text/heading';
 import {IconInfo} from 'sentry/icons/iconInfo';
 import {t, tct} from 'sentry/locale';
+import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface OnboardingStepProps {
@@ -38,8 +40,17 @@ function OnboardingStep({step, title, description}: OnboardingStepProps) {
 export default function PreventAIOnboarding() {
   const organization = useOrganization();
   const theme = useTheme();
+  const regionData = getRegionDataFromOrganization(organization);
+  const isUSOrg = regionData?.name === 'us';
   return (
     <Flex direction="column" gap="2xl">
+      {!isUSOrg && (
+        <Alert.Container>
+          <Alert type="info">
+            {t('AI Code Review is only available in the U.S. More regions coming soon.')}
+          </Alert>
+        </Alert.Container>
+      )}
       <Flex
         direction="row"
         gap="md"

--- a/static/app/views/prevent/tests/onboarding.spec.tsx
+++ b/static/app/views/prevent/tests/onboarding.spec.tsx
@@ -718,7 +718,7 @@ describe('TestsOnboardingPage', () => {
 
       expect(
         screen.getByText(
-          'Test Analytics data is stored in the U.S. only is not available in the EU. EU region support is coming soon.'
+          'Test Analytics data is stored in the U.S. only and is not available in the EU. EU region support is coming soon.'
         )
       ).toBeInTheDocument();
       expect(

--- a/static/app/views/prevent/tests/onboarding.spec.tsx
+++ b/static/app/views/prevent/tests/onboarding.spec.tsx
@@ -718,7 +718,7 @@ describe('TestsOnboardingPage', () => {
 
       expect(
         screen.getByText(
-          'Test Analytics data is stored in the U.S. only. To use this feature, create a new Sentry organization with U.S. data storage.'
+          'Test Analytics data is stored in the U.S. only is not available in the EU. EU region support is coming soon.'
         )
       ).toBeInTheDocument();
       expect(

--- a/static/app/views/prevent/tests/preOnboarding.spec.tsx
+++ b/static/app/views/prevent/tests/preOnboarding.spec.tsx
@@ -29,7 +29,7 @@ describe('TestPreOnboardingPage', () => {
     // Check that the alert is displayed
     expect(
       screen.getByText(
-        'Test Analytics data is stored in the U.S. only. To use this feature, create a new Sentry organization with U.S. data storage.'
+        'Test Analytics data is stored in the U.S. only and therefore is not available in the EU. EU region support is coming soon.'
       )
     ).toBeInTheDocument();
   });
@@ -46,7 +46,7 @@ describe('TestPreOnboardingPage', () => {
 
     expect(
       screen.queryByText(
-        'Test Analytics data is stored in the U.S. only. To use this feature, create a new Sentry organization with U.S. data storage.'
+        'Test Analytics data is stored in the U.S. only and therefore is not available in the EU. EU region support is coming soon.'
       )
     ).not.toBeInTheDocument();
   });
@@ -60,7 +60,7 @@ describe('TestPreOnboardingPage', () => {
     // Check that the alert is displayed
     expect(
       screen.getByText(
-        'Test Analytics data is stored in the U.S. only. To use this feature, create a new Sentry organization with U.S. data storage.'
+        'Test Analytics data is stored in the U.S. only and therefore is not available in the EU. EU region support is coming soon.'
       )
     ).toBeInTheDocument();
   });
@@ -79,7 +79,7 @@ describe('TestPreOnboardingPage', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Test Analytics data is stored in the U.S. only. To use this feature, create a new Sentry organization with U.S. data storage.'
+        'Test Analytics data is stored in the U.S. only and therefore is not available in the EU. EU region support is coming soon.'
       )
     ).toBeInTheDocument();
   });

--- a/static/app/views/prevent/tests/preOnboarding.spec.tsx
+++ b/static/app/views/prevent/tests/preOnboarding.spec.tsx
@@ -29,7 +29,7 @@ describe('TestPreOnboardingPage', () => {
     // Check that the alert is displayed
     expect(
       screen.getByText(
-        'Test Analytics data is stored in the U.S. only and therefore is not available in the EU. EU region support is coming soon.'
+        'Test Analytics data is stored in the U.S. only and is not available in the EU. EU region support is coming soon.'
       )
     ).toBeInTheDocument();
   });
@@ -46,7 +46,7 @@ describe('TestPreOnboardingPage', () => {
 
     expect(
       screen.queryByText(
-        'Test Analytics data is stored in the U.S. only and therefore is not available in the EU. EU region support is coming soon.'
+        'Test Analytics data is stored in the U.S. only and is not available in the EU. EU region support is coming soon.'
       )
     ).not.toBeInTheDocument();
   });
@@ -60,7 +60,7 @@ describe('TestPreOnboardingPage', () => {
     // Check that the alert is displayed
     expect(
       screen.getByText(
-        'Test Analytics data is stored in the U.S. only and therefore is not available in the EU. EU region support is coming soon.'
+        'Test Analytics data is stored in the U.S. only and is not available in the EU. EU region support is coming soon.'
       )
     ).toBeInTheDocument();
   });
@@ -79,7 +79,7 @@ describe('TestPreOnboardingPage', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Test Analytics data is stored in the U.S. only and therefore is not available in the EU. EU region support is coming soon.'
+        'Test Analytics data is stored in the U.S. only and is not available in the EU. EU region support is coming soon.'
       )
     ).toBeInTheDocument();
   });

--- a/static/app/views/prevent/tests/preOnboarding.tsx
+++ b/static/app/views/prevent/tests/preOnboarding.tsx
@@ -36,7 +36,7 @@ export default function TestPreOnboardingPage() {
         <Alert.Container>
           <Alert type="info">
             {t(
-              'Test Analytics data is stored in the U.S. only. To use this feature, create a new Sentry organization with U.S. data storage.'
+              'Test Analytics data is stored in the U.S. only and therefore is not available in the EU. EU region support is coming soon.'
             )}
           </Alert>
         </Alert.Container>

--- a/static/app/views/prevent/tests/preOnboarding.tsx
+++ b/static/app/views/prevent/tests/preOnboarding.tsx
@@ -36,7 +36,7 @@ export default function TestPreOnboardingPage() {
         <Alert.Container>
           <Alert type="info">
             {t(
-              'Test Analytics data is stored in the U.S. only and therefore is not available in the EU. EU region support is coming soon.'
+              'Test Analytics data is stored in the U.S. only and is not available in the EU. EU region support is coming soon.'
             )}
           </Alert>
         </Alert.Container>


### PR DESCRIPTION
<!-- Describe your PR here. -->

Prevent is not currently available in EU. This PR includes adding an alert banner + updating copy to notify customers of that. 

<img width="1389" height="882" alt="Screenshot 2025-09-23 at 10 48 04 AM" src="https://github.com/user-attachments/assets/f87ce2b4-72fa-4485-908b-8b6de31b8a2c" />


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
