### PR TITLE
feat(ourlogs): Add message.template to body when message scrubbed

### DIFF
--- a/static/app/views/explore/components/table.tsx
+++ b/static/app/views/explore/components/table.tsx
@@ -66,7 +66,7 @@ export function useTableStyles(
   options?: {
     minimumColumnWidth?: number;
     prefixColumnWidth?: 'min-content' | number;
-    staticColumnWidths?: Record<string, number | '1fr'>;
+    staticColumnWidths?: Record<string, number | 'minmax(90px,1fr)'>;
   }
 ) {
   const minimumColumnWidth = options?.minimumColumnWidth ?? MINIMUM_COLUMN_WIDTH;

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -32,6 +32,7 @@ export const AlwaysPresentLogFields: OurLogFieldKey[] = [
   OurLogKnownFieldKey.TIMESTAMP,
   OurLogKnownFieldKey.TIMESTAMP_PRECISE,
   OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE,
+  OurLogKnownFieldKey.TEMPLATE,
 ] as const;
 
 const AlwaysHiddenLogFields: OurLogFieldKey[] = [

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -41,6 +41,7 @@ import {
   ColoredLogText,
   LogBasicRendererContainer,
   LogDate,
+  LogsFilteredHelperText,
   LogsHighlight,
   WrappingText,
   type getLogColors,
@@ -72,6 +73,7 @@ export interface RendererExtra extends RenderFunctionBaggage {
   highlightTerms: string[];
   logColors: ReturnType<typeof getLogColors>;
   align?: 'left' | 'center' | 'right';
+  canAppendTemplateToBody?: boolean;
   meta?: EventsMetaType;
   onReplayTimeClick?: (fieldName: string) => void;
   project?: Project;
@@ -322,19 +324,45 @@ function FilteredTooltip({
   value,
   children,
   extra,
+  isAppendingTemplate,
 }: {
   children: React.ReactNode;
   extra: RendererExtra;
   value: string | number | null;
+  isAppendingTemplate?: boolean;
 }) {
   if (
     !value ||
     typeof value !== 'string' ||
-    !value.includes('[Filtered]') ||
+    value.trim() !== '[Filtered]' ||
     !extra.projectSlug
   ) {
     return <React.Fragment>{children}</React.Fragment>;
   }
+
+  if (isAppendingTemplate) {
+    return (
+      <Tooltip
+        title={tct(
+          `The log message was entirely filtered by a data scrubbing rule, its template is also been shown to help identify what was filtered. If necessary, you can turn data scrubbing off in your [settings].`,
+          {
+            settings: (
+              <Link
+                to={normalizeUrl(
+                  `/settings/${extra.organization.slug}/projects/${extra.projectSlug}/security-and-privacy/`
+                )}
+              >
+                {'Settings, under Security & Privacy'}
+              </Link>
+            ),
+          }
+        )}
+      >
+        {children}
+      </Tooltip>
+    );
+  }
+
   return (
     <Tooltip
       title={tct(
@@ -402,11 +430,26 @@ function ReleaseRenderer(props: LogFieldRendererProps) {
 export function LogBodyRenderer(props: LogFieldRendererProps) {
   const attribute_value = props.item.value as string;
   const highlightTerm = props.extra?.highlightTerms[0] ?? '';
-  // TODO: Allow more than one highlight term to be highlighted at once.
+  const template = props.extra.attributes?.[OurLogKnownFieldKey.TEMPLATE];
+  const templateText =
+    props.extra.canAppendTemplateToBody && template ? template : undefined;
+
   return (
-    <FilteredTooltip value={props.item.value} extra={props.extra}>
+    <FilteredTooltip
+      value={props.item.value}
+      extra={props.extra}
+      isAppendingTemplate={!!templateText}
+    >
       <WrappingText wrapText={props.extra.wrapBody}>
         <LogsHighlight text={highlightTerm}>{stripAnsi(attribute_value)}</LogsHighlight>
+        {templateText && (
+          <FieldReplacementHelper
+            original={attribute_value}
+            replacement={templateText as string}
+            extra={props.extra}
+            item={props.item}
+          />
+        )}
       </WrappingText>
     </FilteredTooltip>
   );
@@ -500,6 +543,12 @@ function AnnotatedAttributeWrapper(props: {
 
 function ProjectRenderer(props: LogFieldRendererProps) {
   return <span>{props.item.value}</span>;
+}
+
+function FieldReplacementHelper(
+  props: {original: string; replacement: string} & LogFieldRendererProps
+) {
+  return <LogsFilteredHelperText>{props.replacement}</LogsFilteredHelperText>;
 }
 
 /**

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -232,6 +232,13 @@ export const LogsHighlight = styled(HighlightComponent)`
   margin-left: 2px;
 `;
 
+export const LogsFilteredHelperText = styled('span')`
+  margin-left: 4px;
+  font-size: ${p => p.theme.fontSize.sm};
+  color: ${p => p.theme.subText};
+  background-color: ${p => p.theme.gray200};
+`;
+
 export const WrappingText = styled('div')<{wrapText?: boolean}>`
   white-space: ${p => (p.wrapText ? 'pre-wrap' : 'nowrap')};
   overflow: hidden;

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -138,7 +138,7 @@ export function LogsInfiniteTable({
       minimumColumnWidth: 50,
       prefixColumnWidth: 'min-content',
       staticColumnWidths: {
-        [OurLogKnownFieldKey.MESSAGE]: '1fr',
+        [OurLogKnownFieldKey.MESSAGE]: 'minmax(90px,1fr)',
       },
     }
   );

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -344,6 +344,7 @@ export const LogRowContent = memo(function LogRowContent({
               meta={meta}
               extra={{
                 ...rendererExtra,
+                canAppendTemplateToBody: true,
                 unit: meta?.units?.[field],
               }}
             />


### PR DESCRIPTION
### Summary
When the body gets fully scrubbed (due to a default object PII rule eg. password) it shows entirely as `[Filtered]`, this also appends the template, since template is `Pii::Maybe` as per sentry conventions, it should be less restrictive. Template should only be sent from the sdks when a formatted message is added.

#### Screenshots
<img width="733" height="284" alt="Screenshot 2025-09-23 at 11 03 11 AM" src="https://github.com/user-attachments/assets/4978571a-beb5-4abc-9fcd-479d97844516" />
