### PR TITLE
fix(insights): Fix Laravel overview tables not properly using transaction search filter

### DIFF
--- a/static/app/views/insights/pages/platform/laravel/jobsTable.tsx
+++ b/static/app/views/insights/pages/platform/laravel/jobsTable.tsx
@@ -20,6 +20,7 @@ import {ErrorRateCell} from 'sentry/views/insights/pages/platform/shared/table/E
 import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
 import {useSpanTableData} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
 import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
+import {SpanFields} from 'sentry/views/insights/types';
 
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
   {
@@ -54,10 +55,10 @@ const rightAlignColumns = new Set([
 export function JobsTable() {
   const {query} = useTransactionNameQuery();
   const mutableQuery = new MutableSearch(query);
-  mutableQuery.addFilterValue('span.op', 'queue.process');
+  mutableQuery.addFilterValue(SpanFields.SPAN_OP, 'queue.process');
 
   const tableDataRequest = useSpanTableData({
-    query: mutableQuery.formatString(),
+    query: mutableQuery,
     fields: [
       'count()',
       'project.id',

--- a/static/app/views/insights/pages/platform/laravel/jobsTable.tsx
+++ b/static/app/views/insights/pages/platform/laravel/jobsTable.tsx
@@ -8,6 +8,7 @@ import {
   type GridColumnOrder,
 } from 'sentry/components/tables/gridEditable';
 import {t} from 'sentry/locale';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {HeadSortCell} from 'sentry/views/insights/agents/components/headSortCell';
 import {TimeSpentCell} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
@@ -52,8 +53,11 @@ const rightAlignColumns = new Set([
 
 export function JobsTable() {
   const {query} = useTransactionNameQuery();
+  const mutableQuery = new MutableSearch(query);
+  mutableQuery.addFilterValue('span.op', 'queue.process');
+
   const tableDataRequest = useSpanTableData({
-    query: `span.op:queue.process ${query ?? ''}`.trim(),
+    query: mutableQuery.formatString(),
     fields: [
       'count()',
       'project.id',

--- a/static/app/views/insights/pages/platform/laravel/pathsTable.tsx
+++ b/static/app/views/insights/pages/platform/laravel/pathsTable.tsx
@@ -10,6 +10,7 @@ import {
   type GridColumnOrder,
 } from 'sentry/components/tables/gridEditable';
 import {t} from 'sentry/locale';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {HeadSortCell} from 'sentry/views/insights/agents/components/headSortCell';
 import {TimeSpentCell} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
@@ -23,6 +24,7 @@ import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/Numb
 import {TransactionCell} from 'sentry/views/insights/pages/platform/shared/table/TransactionCell';
 import {UserCell} from 'sentry/views/insights/pages/platform/shared/table/UserCell';
 import {useTableDataWithController} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 
 const getP95Threshold = (avg: number) => {
   return {
@@ -52,8 +54,13 @@ const rightAlignColumns = new Set([
 ]);
 
 export function PathsTable() {
+  const {query} = useTransactionNameQuery();
+  const mutableQuery = new MutableSearch(query);
+  mutableQuery.addFilterValue('transaction.op', 'http.server');
+  mutableQuery.addFilterValue('is_transaction', 'true');
+
   const tableDataRequest = useTableDataWithController({
-    query: 'transaction.op:http.server is_transaction:True',
+    query: mutableQuery.formatString(),
     fields: [
       'project.id',
       'transaction',

--- a/static/app/views/insights/pages/platform/laravel/pathsTable.tsx
+++ b/static/app/views/insights/pages/platform/laravel/pathsTable.tsx
@@ -25,6 +25,7 @@ import {TransactionCell} from 'sentry/views/insights/pages/platform/shared/table
 import {UserCell} from 'sentry/views/insights/pages/platform/shared/table/UserCell';
 import {useTableDataWithController} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
 import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
+import {SpanFields} from 'sentry/views/insights/types';
 
 const getP95Threshold = (avg: number) => {
   return {
@@ -56,11 +57,11 @@ const rightAlignColumns = new Set([
 export function PathsTable() {
   const {query} = useTransactionNameQuery();
   const mutableQuery = new MutableSearch(query);
-  mutableQuery.addFilterValue('transaction.op', 'http.server');
-  mutableQuery.addFilterValue('is_transaction', 'true');
+  mutableQuery.addFilterValue(SpanFields.TRANSACTION_OP, 'http.server');
+  mutableQuery.addFilterValue(SpanFields.IS_TRANSACTION, 'true');
 
   const tableDataRequest = useTableDataWithController({
-    query: mutableQuery.formatString(),
+    query: mutableQuery,
     fields: [
       'project.id',
       'transaction',

--- a/static/app/views/insights/pages/platform/shared/table/useTableData.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/useTableData.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 
+import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useTableSortParams} from 'sentry/views/insights/agents/components/headSortCell';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
@@ -15,7 +16,7 @@ export function useSpanTableData<Fields extends SpanProperty>({
 }: {
   cursorParamName: string;
   fields: Fields[];
-  query: string;
+  query: string | MutableSearch;
   referrer: string;
 }) {
   const location = useLocation();
@@ -47,7 +48,7 @@ export function useTableDataWithController<Fields extends SpanProperty>({
 }: {
   cursorParamName: string;
   fields: Fields[];
-  query: string;
+  query: string | MutableSearch;
   referrer: string;
 }) {
   const transactionsRequest = useSpanTableData({


### PR DESCRIPTION
- Fixes the `PathsTable` not properly utilizing transaction search filters
- Small refactor to `JobsTable` to use `MutableSearch`.


No changes to `CommandsTable` since that table does not query `transaction` field anyways. Maybe we should remove transaction filtering on this table?