### PR TITLE
feat(otlp): Rename otlp logs endpoint

### DIFF
--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -19,7 +19,7 @@ KEY_RATE_LIMIT = {
         "minidump": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/minidump/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "playstation": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/playstation/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "otlp_traces": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/otlp/v1/traces",
-        "otlp_logs": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/otlp/v1/logs",
+        "otlp_logs": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/integration/otlp/v1/logs",
         "nel": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/nel/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "unreal": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/unreal/a785682ddda719b7a8a4011110d75598/",
         "cdn": "https://js.sentry-cdn.com/a785682ddda719b7a8a4011110d75598.min.js",

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -275,7 +275,7 @@ class ProjectKey(Model):
     def otlp_logs_endpoint(self):
         endpoint = self.get_endpoint()
 
-        return f"{endpoint}/api/{self.project_id}/otlp/v1/logs"
+        return f"{endpoint}/api/{self.project_id}/integration/otlp/v1/logs"
 
     @property
     def unreal_endpoint(self) -> str:

--- a/tests/sentry/core/endpoints/test_project_keys.py
+++ b/tests/sentry/core/endpoints/test_project_keys.py
@@ -69,6 +69,7 @@ class ListProjectKeysTest(APITestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         assert response.data[0]["dsn"]["otlp_logs"] == key.otlp_logs_endpoint
+        assert "integration/otlp/v1/logs" in response.data[0]["dsn"]["otlp_logs"]
 
     def test_use_case(self) -> None:
         """Regular user can access user DSNs but not internal DSNs"""


### PR DESCRIPTION
In https://www.notion.so/sentry/Log-Drains-and-other-Integrations-2778b10e4b5d806995e2dac749a323db we decided to move to a new endpoint, `/api/{project_id}/integration/{integration}/{...}` for integrations with other platforms, like OTLP.

This PR updates the sentry project settings based on https://github.com/getsentry/relay/pull/5176.

It does not update the traces endpoint, which can be done at another time.