### PR TITLE
fix(replay): clear unread dot after viewing replay

### DIFF
--- a/static/app/utils/replays/hooks/useMarkReplayViewed.tsx
+++ b/static/app/utils/replays/hooks/useMarkReplayViewed.tsx
@@ -16,8 +16,11 @@ export default function useMarkReplayViewed() {
       return fetchMutation({method: 'POST', url});
     },
     onSuccess(_data, {projectSlug, replayId}) {
-      const url = `/projects/${organization.slug}/${projectSlug}/replays/${replayId}/viewed-by/`;
-      queryClient.refetchQueries({queryKey: [url]});
+      const viewedByUrl = `/projects/${organization.slug}/${projectSlug}/replays/${replayId}/viewed-by/`;
+      queryClient.refetchQueries({queryKey: [viewedByUrl]});
+
+      const replayListUrl = `/organizations/${organization.slug}/replays/`;
+      queryClient.refetchQueries({queryKey: [replayListUrl]});
     },
     retry: false,
   });


### PR DESCRIPTION
fixes REPLAY-721

On marking a replay as read, the original onSuccess only refetched the viewed-by list for the viewed replay. 