### PR TITLE
feat(checkout v3): Add billing info step

### DIFF
--- a/static/gsApp/components/billingDetails/panel.tsx
+++ b/static/gsApp/components/billingDetails/panel.tsx
@@ -13,6 +13,7 @@ import PanelHeader from 'sentry/components/panels/panelHeader';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 
 import {openEditBillingDetails} from 'getsentry/actionCreators/modal';
 import BillingDetailsForm from 'getsentry/components/billingDetails/form';
@@ -191,7 +192,8 @@ function BillingDetailsPanel({
             }
             analyticsEvent={analyticsEvent}
           />
-        ) : billingDetails ? (
+        ) : billingDetails &&
+          Object.values(billingDetails).some(value => defined(value)) ? (
           <Fragment>
             {billingDetails.billingEmail && <Text>{billingDetails.billingEmail}</Text>}
             {billingDetails.companyName && <Text>{billingDetails.companyName}</Text>}

--- a/static/gsApp/components/billingDetails/panel.tsx
+++ b/static/gsApp/components/billingDetails/panel.tsx
@@ -13,12 +13,12 @@ import PanelHeader from 'sentry/components/panels/panelHeader';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
-import {defined} from 'sentry/utils';
 
 import {openEditBillingDetails} from 'getsentry/actionCreators/modal';
 import BillingDetailsForm from 'getsentry/components/billingDetails/form';
 import {useBillingDetails} from 'getsentry/hooks/useBillingDetails';
 import type {Subscription} from 'getsentry/types';
+import {hasSomeBillingDetails} from 'getsentry/utils/billing';
 import formatCurrency from 'getsentry/utils/formatCurrency';
 import {getCountryByCode} from 'getsentry/utils/ISO3166codes';
 import {countryHasSalesTax, getTaxFieldInfo} from 'getsentry/utils/salesTax';
@@ -192,8 +192,7 @@ function BillingDetailsPanel({
             }
             analyticsEvent={analyticsEvent}
           />
-        ) : billingDetails &&
-          Object.values(billingDetails).some(value => defined(value)) ? (
+        ) : billingDetails && hasSomeBillingDetails(billingDetails) ? (
           <Fragment>
             {billingDetails.billingEmail && <Text>{billingDetails.billingEmail}</Text>}
             {billingDetails.companyName && <Text>{billingDetails.companyName}</Text>}

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -719,5 +719,16 @@ export function partnerPlanEndingModalIsDismissed(
  * Returns true if some billing details are set.
  */
 export function hasSomeBillingDetails(billingDetails: BillingDetails | undefined) {
-  return billingDetails && Object.values(billingDetails).some(value => defined(value));
+  if (!billingDetails) {
+    return false;
+  }
+  return (
+    billingDetails &&
+    Object.entries(billingDetails)
+      .filter(
+        ([key, _]) =>
+          key !== 'billingEmail' && key !== 'companyName' && key !== 'taxNumber'
+      )
+      .some(([_, value]) => defined(value))
+  );
 }

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -20,6 +20,7 @@ import {
 } from 'getsentry/constants';
 import type {
   BillingConfig,
+  BillingDetails,
   BillingMetricHistory,
   BillingStatTotal,
   EventBucket,
@@ -712,4 +713,11 @@ export function partnerPlanEndingModalIsDismissed(
     default:
       return true;
   }
+}
+
+/**
+ * Returns true if some billing details are set.
+ */
+export function hasSomeBillingDetails(billingDetails: BillingDetails | undefined) {
+  return billingDetails && Object.values(billingDetails).some(value => defined(value));
 }

--- a/static/gsApp/views/amCheckout/cart.spec.tsx
+++ b/static/gsApp/views/amCheckout/cart.spec.tsx
@@ -74,6 +74,10 @@ describe('Cart', () => {
         invoiceItems: [],
       },
     });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-details/`,
+      method: 'GET',
+    });
   });
 
   afterEach(() => {
@@ -102,7 +106,6 @@ describe('Cart', () => {
     expect(cart).toHaveTextContent('Pay-as-you-go spend limit$0-$300/mo');
     expect(cart).toHaveTextContent('Plan Total$89/mo');
     expect(cart).toHaveTextContent('Default Amount');
-    expect(within(cart).getByRole('button', {name: 'Confirm and pay'})).toBeEnabled();
   });
 
   it('renders form data', async () => {
@@ -129,7 +132,6 @@ describe('Cart', () => {
         activePlan={teamPlanAnnual}
         formData={formData}
         formDataForPreview={getFormDataForPreview(formData)}
-        hasCompleteBillingDetails
         organization={organization}
         subscription={subscription}
         onSuccess={jest.fn()}
@@ -187,7 +189,6 @@ describe('Cart', () => {
         activePlan={legacyTeamPlan}
         formData={formData}
         formDataForPreview={getFormDataForPreview(formData)}
-        hasCompleteBillingDetails
         organization={organization}
         subscription={subscription}
         onSuccess={jest.fn()}
@@ -240,7 +241,6 @@ describe('Cart', () => {
         activePlan={businessPlan}
         formData={defaultFormData}
         formDataForPreview={getFormDataForPreview(defaultFormData)}
-        hasCompleteBillingDetails
         organization={organization}
         subscription={subscription}
         onSuccess={jest.fn()}
@@ -281,7 +281,6 @@ describe('Cart', () => {
         activePlan={businessPlan}
         formData={defaultFormData}
         formDataForPreview={getFormDataForPreview(defaultFormData)}
-        hasCompleteBillingDetails
         organization={organization}
         subscription={subscription}
         onSuccess={jest.fn()}
@@ -294,21 +293,6 @@ describe('Cart', () => {
     expect(
       screen.getByText(/Your changes will apply on Jun 7, 2023/)
     ).toBeInTheDocument();
-  });
-
-  it('disables confirm and pay button for incomplete billing details', async () => {
-    render(
-      <Cart
-        activePlan={businessPlan}
-        formData={defaultFormData}
-        formDataForPreview={getFormDataForPreview(defaultFormData)}
-        hasCompleteBillingDetails={false}
-        organization={organization}
-        subscription={subscription}
-        onSuccess={jest.fn()}
-      />
-    );
-    expect(await screen.findByRole('button', {name: 'Confirm and pay'})).toBeDisabled();
   });
 
   it('renders buttons and subtext for migrating partner customers', async () => {
@@ -333,7 +317,6 @@ describe('Cart', () => {
         activePlan={businessPlan}
         formData={defaultFormData}
         formDataForPreview={getFormDataForPreview(defaultFormData)}
-        hasCompleteBillingDetails
         organization={partnerOrg}
         subscription={partnerSub}
         onSuccess={jest.fn()}
@@ -374,7 +357,6 @@ describe('Cart', () => {
         activePlan={businessPlan}
         formData={defaultFormData}
         formDataForPreview={getFormDataForPreview(defaultFormData)}
-        hasCompleteBillingDetails
         organization={organization}
         subscription={partnerSub}
         onSuccess={jest.fn()}
@@ -416,7 +398,6 @@ describe('Cart', () => {
         activePlan={teamPlanAnnual}
         formData={formData}
         formDataForPreview={getFormDataForPreview(formData)}
-        hasCompleteBillingDetails
         organization={organization}
         subscription={paidSub}
         onSuccess={jest.fn()}
@@ -448,7 +429,6 @@ describe('Cart', () => {
         activePlan={businessPlan}
         formData={defaultFormData}
         formDataForPreview={getFormDataForPreview(defaultFormData)}
-        hasCompleteBillingDetails
         organization={organization}
         subscription={paidSub}
         onSuccess={jest.fn()}

--- a/static/gsApp/views/amCheckout/cart.tsx
+++ b/static/gsApp/views/amCheckout/cart.tsx
@@ -590,7 +590,7 @@ function Cart({
   const [changesIsOpen, setChangesIsOpen] = useState(true);
   const api = useApi();
   const {data: billingDetails} = useBillingDetails();
-  const hasCompleteBillingInfo = utils.hasSomeBillingInfo(billingDetails, subscription);
+  const hasCompleteBillingInfo = utils.hasBillingInfo(billingDetails, subscription, true);
 
   const resetPreviewState = () => setPreviewState(NULL_PREVIEW_STATE);
 

--- a/static/gsApp/views/amCheckout/cart.tsx
+++ b/static/gsApp/views/amCheckout/cart.tsx
@@ -19,6 +19,7 @@ import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 import useApi from 'sentry/utils/useApi';
 
 import {PAYG_BUSINESS_DEFAULT, PAYG_TEAM_DEFAULT} from 'getsentry/constants';
+import {useBillingDetails} from 'getsentry/hooks/useBillingDetails';
 import {useStripeInstance} from 'getsentry/hooks/useStripeInstance';
 import {
   InvoiceItemType,
@@ -55,7 +56,6 @@ interface CartProps {
   activePlan: Plan;
   formData: CheckoutFormData;
   formDataForPreview: CheckoutFormData;
-  hasCompleteBillingDetails: boolean;
   onSuccess: ({
     invoice,
     nextQueryParams,
@@ -580,7 +580,6 @@ function Cart({
   organization,
   referrer,
   formDataForPreview,
-  hasCompleteBillingDetails,
   onSuccess,
 }: CartProps) {
   const [previewState, setPreviewState] = useState<CartPreviewState>(NULL_PREVIEW_STATE);
@@ -590,6 +589,8 @@ function Cart({
   const [summaryIsOpen, setSummaryIsOpen] = useState(true);
   const [changesIsOpen, setChangesIsOpen] = useState(true);
   const api = useApi();
+  const {data: billingDetails} = useBillingDetails();
+  const hasCompleteBillingInfo = billingDetails && subscription.paymentSource;
 
   const resetPreviewState = () => setPreviewState(NULL_PREVIEW_STATE);
 
@@ -751,7 +752,7 @@ function Cart({
       <TotalSummary
         activePlan={activePlan}
         billedTotal={previewState.billedTotal}
-        buttonDisabled={!hasCompleteBillingDetails}
+        buttonDisabled={!hasCompleteBillingInfo}
         formData={formData}
         isSubmitting={isSubmitting}
         originalBilledTotal={previewState.originalBilledTotal}

--- a/static/gsApp/views/amCheckout/cart.tsx
+++ b/static/gsApp/views/amCheckout/cart.tsx
@@ -590,7 +590,7 @@ function Cart({
   const [changesIsOpen, setChangesIsOpen] = useState(true);
   const api = useApi();
   const {data: billingDetails} = useBillingDetails();
-  const hasCompleteBillingInfo = billingDetails && subscription.paymentSource;
+  const hasCompleteBillingInfo = utils.hasSomeBillingInfo(billingDetails, subscription);
 
   const resetPreviewState = () => setPreviewState(NULL_PREVIEW_STATE);
 

--- a/static/gsApp/views/amCheckout/index.spec.tsx
+++ b/static/gsApp/views/amCheckout/index.spec.tsx
@@ -24,6 +24,20 @@ import AMCheckout from 'getsentry/views/amCheckout';
 import {getCheckoutAPIData} from 'getsentry/views/amCheckout/utils';
 import {hasOnDemandBudgetsFeature} from 'getsentry/views/onDemandBudgets/utils';
 
+function assertCheckoutV3Steps(tier: PlanTier) {
+  expect(screen.getByTestId('checkout-steps')).toBeInTheDocument();
+  [
+    'Build your plan',
+    [PlanTier.AM1, PlanTier.AM2].includes(tier)
+      ? /Set your on-demand limit/
+      : /Set your pay-as-you-go limit/,
+    'Billing cycle',
+    'Edit billing information',
+  ].forEach(step => {
+    expect(screen.getByText(step)).toBeInTheDocument();
+  });
+}
+
 describe('AM1 Checkout', () => {
   let mockResponse: any;
   const api = new MockApiClient();
@@ -84,6 +98,41 @@ describe('AM1 Checkout', () => {
         })
       );
     });
+  });
+
+  it('renders for checkout v3', async () => {
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-details/`,
+      method: 'GET',
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/subscription/preview/`,
+      method: 'GET',
+    });
+
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        checkoutTier={PlanTier.AM1}
+        navigate={jest.fn()}
+        api={api}
+        onToggleLegacy={jest.fn()}
+        isNewCheckout
+      />,
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(mockResponse).toHaveBeenCalledWith(
+        `/customers/${organization.slug}/billing-config/`,
+        expect.objectContaining({
+          method: 'GET',
+          data: {tier: 'am1'},
+        })
+      );
+    });
+
+    assertCheckoutV3Steps(PlanTier.AM1);
   });
 
   it('can skip to step and continue', async () => {
@@ -664,6 +713,41 @@ describe('AM2 Checkout', () => {
       method: 'GET',
       body: {},
     });
+  });
+
+  it('renders for checkout v3', async () => {
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-details/`,
+      method: 'GET',
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/subscription/preview/`,
+      method: 'GET',
+    });
+
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        checkoutTier={PlanTier.AM2}
+        navigate={jest.fn()}
+        api={api}
+        onToggleLegacy={jest.fn()}
+        isNewCheckout
+      />,
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(mockResponse).toHaveBeenCalledWith(
+        `/customers/${organization.slug}/billing-config/`,
+        expect.objectContaining({
+          method: 'GET',
+          data: {tier: 'am2'},
+        })
+      );
+    });
+
+    assertCheckoutV3Steps(PlanTier.AM2);
   });
 
   it('renders for am1 team plan', async () => {
@@ -1370,6 +1454,46 @@ describe('AM3 Checkout', () => {
       method: 'GET',
       body: {},
     });
+  });
+
+  it('renders for checkout v3', async () => {
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-details/`,
+      method: 'GET',
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/subscription/preview/`,
+      method: 'GET',
+    });
+    const mockResponse = MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-config/`,
+      method: 'GET',
+      body: BillingConfigFixture(PlanTier.AM3),
+    });
+
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        checkoutTier={PlanTier.AM3}
+        navigate={jest.fn()}
+        api={api}
+        onToggleLegacy={jest.fn()}
+        isNewCheckout
+      />,
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(mockResponse).toHaveBeenCalledWith(
+        `/customers/${organization.slug}/billing-config/`,
+        expect.objectContaining({
+          method: 'GET',
+          data: {tier: 'am3'},
+        })
+      );
+    });
+
+    assertCheckoutV3Steps(PlanTier.AM3);
   });
 
   it('renders for new customers (AM3 free plan)', async () => {

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -74,6 +74,7 @@ import CheckoutSuccess from 'getsentry/views/amCheckout/checkoutSuccess';
 import AddBillingDetails from 'getsentry/views/amCheckout/steps/addBillingDetails';
 import AddDataVolume from 'getsentry/views/amCheckout/steps/addDataVolume';
 import AddPaymentMethod from 'getsentry/views/amCheckout/steps/addPaymentMethod';
+import AddBillingInformation from 'getsentry/views/amCheckout/steps/checkoutV3/addBillingInfo';
 import BillingCycle from 'getsentry/views/amCheckout/steps/checkoutV3/billingCycle';
 import BuildYourPlan from 'getsentry/views/amCheckout/steps/checkoutV3/buildYourPlan';
 import ContractSelect from 'getsentry/views/amCheckout/steps/contractSelect';
@@ -296,7 +297,7 @@ class AMCheckout extends Component<Props, State> {
       : OnDemandSpend;
 
     if (isNewCheckout) {
-      return [BuildYourPlan, SetSpendLimit, BillingCycle];
+      return [BuildYourPlan, SetSpendLimit, BillingCycle, AddBillingInformation];
     }
 
     const preAM3Tiers = [PlanTier.AM1, PlanTier.AM2];
@@ -903,7 +904,6 @@ class AMCheckout extends Component<Props, State> {
               <Cart
                 {...overviewProps}
                 referrer={this.referrer}
-                hasCompleteBillingDetails={!!subscription.paymentSource?.last4}
                 formDataForPreview={formDataForPreview}
                 onSuccess={params => {
                   this.setState(prev => ({...prev, ...params}));

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.spec.tsx
@@ -1,0 +1,129 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
+
+import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
+import {BillingDetailsFixture} from 'getsentry-test/fixtures/billingDetails';
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import SubscriptionStore from 'getsentry/stores/subscriptionStore';
+import {PlanTier} from 'getsentry/types';
+import AMCheckout from 'getsentry/views/amCheckout/';
+
+describe('AddBillingInformation', () => {
+  const api = new MockApiClient();
+  const organization = OrganizationFixture();
+  const subscription = SubscriptionFixture({organization, plan: 'am3_f'});
+
+  beforeEach(() => {
+    api.clear();
+    MockApiClient.clearMockResponses();
+    SubscriptionStore.set(organization.slug, subscription);
+
+    MockApiClient.addMockResponse({
+      url: `/subscriptions/${organization.slug}/`,
+      method: 'GET',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-config/`,
+      method: 'GET',
+      body: BillingConfigFixture(PlanTier.AM3),
+    });
+    MockApiClient.addMockResponse({
+      method: 'POST',
+      url: '/_experiment/log_exposure/',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/promotions/trigger-check/`,
+      method: 'POST',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/plan-migrations/?applied=0`,
+      method: 'GET',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/subscription/preview/`,
+      method: 'GET',
+      body: {
+        invoiceItems: [],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-details/`,
+      method: 'GET',
+    });
+  });
+
+  it('renders heading with complete existing billing info', async () => {
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-details/`,
+      method: 'GET',
+      body: BillingDetailsFixture(),
+    });
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        api={api}
+        onToggleLegacy={jest.fn()}
+        checkoutTier={PlanTier.AM3}
+        isNewCheckout
+        navigate={jest.fn()}
+      />,
+      {organization}
+    );
+
+    expect(await screen.findByText('Edit billing information')).toBeInTheDocument();
+    expect(screen.getByText('Business address')).toBeInTheDocument();
+    expect(screen.getByText('Payment method')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Confirm and pay'})).toBeEnabled();
+  });
+
+  it('renders heading with some existing billing info', async () => {
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        api={api}
+        onToggleLegacy={jest.fn()}
+        checkoutTier={PlanTier.AM3}
+        isNewCheckout
+        navigate={jest.fn()}
+      />,
+      {organization}
+    );
+
+    expect(await screen.findByText('Edit billing information')).toBeInTheDocument();
+    expect(screen.getByText('Business address')).toBeInTheDocument();
+    expect(screen.getByText('Payment method')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Confirm and pay'})).toBeDisabled();
+  });
+
+  it('renders heading with no existing billing info', async () => {
+    const newSubscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_f',
+      paymentSource: null,
+    });
+    SubscriptionStore.set(organization.slug, newSubscription);
+
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        api={api}
+        onToggleLegacy={jest.fn()}
+        checkoutTier={PlanTier.AM3}
+        isNewCheckout
+        navigate={jest.fn()}
+      />,
+      {organization}
+    );
+
+    expect(await screen.findByText('Add billing information')).toBeInTheDocument();
+    expect(screen.getByText('Business address')).toBeInTheDocument();
+    expect(screen.getByText('Payment method')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Confirm and pay'})).toBeDisabled();
+  });
+});

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.tsx
@@ -2,7 +2,6 @@ import {Fragment, useState} from 'react';
 
 import {Flex} from 'sentry/components/core/layout';
 import {t} from 'sentry/locale';
-import {defined} from 'sentry/utils';
 import {useLocation} from 'sentry/utils/useLocation';
 
 import BillingDetailsPanel from 'getsentry/components/billingDetails/panel';
@@ -11,6 +10,7 @@ import {useBillingDetails} from 'getsentry/hooks/useBillingDetails';
 import {FTCConsentLocation} from 'getsentry/types';
 import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
 import type {CheckoutV3StepProps} from 'getsentry/views/amCheckout/types';
+import {hasSomeBillingInfo} from 'getsentry/views/amCheckout/utils';
 
 function AddBillingInformation({
   subscription,
@@ -22,9 +22,7 @@ function AddBillingInformation({
   const [isOpen, setIsOpen] = useState(true);
   const location = useLocation();
   const {data: billingDetails} = useBillingDetails();
-  const hasSomeBillingInfo =
-    (billingDetails && Object.values(billingDetails).some(value => defined(value))) ||
-    subscription.paymentSource;
+  const showEditBillingInfo = hasSomeBillingInfo(billingDetails, subscription);
 
   return (
     <Flex direction="column" gap="xl">
@@ -36,7 +34,7 @@ function AddBillingInformation({
         isOpen={isOpen}
         stepNumber={stepNumber}
         title={
-          hasSomeBillingInfo
+          showEditBillingInfo
             ? t('Edit billing information')
             : t('Add billing information')
         }

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.tsx
@@ -2,6 +2,7 @@ import {Fragment, useState} from 'react';
 
 import {Flex} from 'sentry/components/core/layout';
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import {useLocation} from 'sentry/utils/useLocation';
 
 import BillingDetailsPanel from 'getsentry/components/billingDetails/panel';
@@ -21,7 +22,9 @@ function AddBillingInformation({
   const [isOpen, setIsOpen] = useState(true);
   const location = useLocation();
   const {data: billingDetails} = useBillingDetails();
-  const hasSomeBillingInfo = billingDetails || subscription.paymentSource;
+  const hasSomeBillingInfo =
+    (billingDetails && Object.values(billingDetails).some(value => defined(value))) ||
+    subscription.paymentSource;
 
   return (
     <Flex direction="column" gap="xl">

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.tsx
@@ -1,0 +1,65 @@
+import {Fragment, useState} from 'react';
+
+import {Flex} from 'sentry/components/core/layout';
+import {t} from 'sentry/locale';
+import {useLocation} from 'sentry/utils/useLocation';
+
+import BillingDetailsPanel from 'getsentry/components/billingDetails/panel';
+import CreditCardPanel from 'getsentry/components/creditCardEdit/panel';
+import {useBillingDetails} from 'getsentry/hooks/useBillingDetails';
+import {FTCConsentLocation} from 'getsentry/types';
+import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
+import type {CheckoutV3StepProps} from 'getsentry/views/amCheckout/types';
+
+function AddBillingInformation({
+  subscription,
+  onEdit,
+  stepNumber,
+  organization,
+  activePlan,
+}: CheckoutV3StepProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const location = useLocation();
+  const {data: billingDetails} = useBillingDetails();
+  const hasSomeBillingInfo = billingDetails || subscription.paymentSource;
+
+  return (
+    <Flex direction="column" gap="xl">
+      <StepHeader
+        isActive
+        isCompleted={false}
+        onEdit={onEdit}
+        onToggleStep={setIsOpen}
+        isOpen={isOpen}
+        stepNumber={stepNumber}
+        title={
+          hasSomeBillingInfo
+            ? t('Edit billing information')
+            : t('Add billing information')
+        }
+        isNewCheckout
+      />
+      {isOpen && (
+        <Fragment>
+          <BillingDetailsPanel
+            organization={organization}
+            subscription={subscription}
+            isNewBillingUI
+            analyticsEvent="checkout.updated_billing_details"
+          />
+          <CreditCardPanel
+            organization={organization}
+            subscription={subscription}
+            isNewBillingUI
+            location={location}
+            ftcLocation={FTCConsentLocation.CHECKOUT}
+            budgetTerm={activePlan.budgetTerm}
+            analyticsEvent="checkout.updated_cc"
+          />
+        </Fragment>
+      )}
+    </Flex>
+  );
+}
+
+export default AddBillingInformation;

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.tsx
@@ -10,7 +10,7 @@ import {useBillingDetails} from 'getsentry/hooks/useBillingDetails';
 import {FTCConsentLocation} from 'getsentry/types';
 import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
 import type {CheckoutV3StepProps} from 'getsentry/views/amCheckout/types';
-import {hasSomeBillingInfo} from 'getsentry/views/amCheckout/utils';
+import {hasBillingInfo} from 'getsentry/views/amCheckout/utils';
 
 function AddBillingInformation({
   subscription,
@@ -22,7 +22,7 @@ function AddBillingInformation({
   const [isOpen, setIsOpen] = useState(true);
   const location = useLocation();
   const {data: billingDetails} = useBillingDetails();
-  const showEditBillingInfo = hasSomeBillingInfo(billingDetails, subscription);
+  const showEditBillingInfo = hasBillingInfo(billingDetails, subscription, false);
 
   return (
     <Flex direction="column" gap="xl">

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/billingCycle.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/billingCycle.spec.tsx
@@ -55,6 +55,10 @@ describe('BillingCycle', () => {
         invoiceItems: [],
       },
     });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-details/`,
+      method: 'GET',
+    });
   });
 
   afterEach(() => {

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.spec.tsx
@@ -52,6 +52,10 @@ describe('BuildYourPlan', () => {
         invoiceItems: [],
       },
     });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-details/`,
+      method: 'GET',
+    });
   });
 
   function assertAllSubsteps(isNewCheckout: boolean) {

--- a/static/gsApp/views/amCheckout/steps/productSelect.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/productSelect.spec.tsx
@@ -52,6 +52,10 @@ describe('ProductSelect', () => {
       method: 'GET',
       body: {},
     });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-details/`,
+      method: 'GET',
+    });
   });
 
   it('renders', async () => {

--- a/static/gsApp/views/amCheckout/steps/setSpendLimit.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/setSpendLimit.spec.tsx
@@ -39,6 +39,10 @@ describe('SetSpendLimit', () => {
         invoiceItems: [],
       },
     });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-details/`,
+      method: 'GET',
+    });
   });
   it('renders for checkout v3 on AM3 tier', async () => {
     MockApiClient.addMockResponse({

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -992,9 +992,13 @@ export function hasNewCheckout(organization: Organization) {
 /**
  * Returns true if the subscription has either a payment source or some billing details set.
  */
-export function hasSomeBillingInfo(
+export function hasBillingInfo(
   billingDetails: BillingDetails | undefined,
-  subscription: Subscription
+  subscription: Subscription,
+  isComplete: boolean
 ) {
-  return subscription.paymentSource || hasSomeBillingDetails(billingDetails);
+  if (isComplete) {
+    return !!subscription.paymentSource && hasSomeBillingDetails(billingDetails);
+  }
+  return !!subscription.paymentSource || hasSomeBillingDetails(billingDetails);
 }

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -30,6 +30,7 @@ import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 import {
   InvoiceItemType,
   PlanTier,
+  type BillingDetails,
   type EventBucket,
   type InvoiceItem,
   type OnDemandBudgets,
@@ -43,6 +44,7 @@ import {
   getAmPlanTier,
   getSlot,
   hasPartnerMigrationFeature,
+  hasSomeBillingDetails,
   isBizPlanFamily,
   isTeamPlanFamily,
   isTrialPlan,
@@ -985,4 +987,14 @@ export function getCreditApplied({
 // TODO(isabella): clean this up after GA
 export function hasNewCheckout(organization: Organization) {
   return organization.features.includes('checkout-v3');
+}
+
+/**
+ * Returns true if the subscription has either a payment source or some billing details set.
+ */
+export function hasSomeBillingInfo(
+  billingDetails: BillingDetails | undefined,
+  subscription: Subscription
+) {
+  return subscription.paymentSource || hasSomeBillingDetails(billingDetails);
 }


### PR DESCRIPTION
Final split from #99976

when the customer already has billing info:
<img width="1050" height="447" alt="Screenshot 2025-09-23 at 1 09 35 PM" src="https://github.com/user-attachments/assets/8a2c6d27-f642-4f06-9964-4c2a80d7637c" />

when the customer has no pre-existing billing info:
<img width="1050" height="262" alt="Screenshot 2025-09-23 at 1 14 25 PM" src="https://github.com/user-attachments/assets/daa30fdb-91a3-426d-8de9-306c71406d6f" />
