### PR TITLE
ref(tests): remove global-views from frontend tests

### DIFF
--- a/static/app/components/organizations/environmentPageFilter/index.spec.tsx
+++ b/static/app/components/organizations/environmentPageFilter/index.spec.tsx
@@ -8,7 +8,7 @@ import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
 const {organization, projects, router} = initializeOrg({
-  organization: {features: ['global-views', 'open-membership']},
+  organization: {features: ['open-membership']},
   projects: [
     {id: '1', slug: 'project-1', environments: ['prod', 'staging']},
     {id: '2', slug: 'project-2', environments: ['prod', 'stage']},
@@ -136,7 +136,7 @@ describe('EnvironmentPageFilter', () => {
 
   it('displays a desynced state message', async () => {
     const {organization: desyncOrganization, router: desyncRouter} = initializeOrg({
-      organization: {features: ['global-views', 'open-membership']},
+      organization: {features: ['open-membership']},
       projects: [
         {id: '1', slug: 'project-1', environments: ['prod', 'staging']},
         {id: '2', slug: 'project-2', environments: ['prod', 'stage']},

--- a/static/app/components/organizations/projectPageFilter/index.spec.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.spec.tsx
@@ -15,7 +15,7 @@ import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
 const {organization, projects, router} = initializeOrg({
-  organization: {features: ['global-views', 'open-membership']},
+  organization: {features: ['open-membership']},
   projects: [
     {id: '1', slug: 'project-1', isMember: true},
     {id: '2', slug: 'project-2', isMember: true},
@@ -213,7 +213,7 @@ describe('ProjectPageFilter', () => {
 
   it('displays a desynced state message', async () => {
     const {organization: desyncOrganization, router: desyncRouter} = initializeOrg({
-      organization: {features: ['global-views', 'open-membership']},
+      organization: {features: ['open-membership']},
       projects: [
         {id: '1', slug: 'project-1', isMember: true},
         {id: '2', slug: 'project-2', isMember: true},

--- a/static/app/components/timeRangeSelector/index.spec.tsx
+++ b/static/app/components/timeRangeSelector/index.spec.tsx
@@ -8,7 +8,7 @@ import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
 import ConfigStore from 'sentry/stores/configStore';
 
 const {organization} = initializeOrg({
-  organization: {features: ['global-views', 'open-membership']},
+  organization: {features: ['open-membership']},
   projects: [
     {id: '1', slug: 'project-1', isMember: true},
     {id: '2', slug: 'project-2', isMember: true},

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -77,7 +77,7 @@ class MockIntersectionObserver {
 
 describe('Dashboards > Detail', () => {
   const organization = OrganizationFixture({
-    features: ['global-views', 'dashboards-basic', 'dashboards-edit', 'discover-query'],
+    features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
   });
   const projects = [ProjectFixture()];
   window.IntersectionObserver = MockIntersectionObserver as any;
@@ -205,7 +205,7 @@ describe('Dashboards > Detail', () => {
       });
       initialData = initializeOrg({
         organization: OrganizationFixture({
-          features: ['global-views', 'dashboards-basic', 'discover-query'],
+          features: ['dashboards-basic', 'discover-query'],
         }),
       });
 
@@ -601,12 +601,7 @@ describe('Dashboards > Detail', () => {
 
       initialData = initializeOrg({
         organization: OrganizationFixture({
-          features: [
-            'global-views',
-            'dashboards-basic',
-            'dashboards-edit',
-            'discover-query',
-          ],
+          features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
         }),
       });
 
@@ -1214,12 +1209,7 @@ describe('Dashboards > Detail', () => {
       });
       const testData = initializeOrg({
         organization: OrganizationFixture({
-          features: [
-            'global-views',
-            'dashboards-basic',
-            'dashboards-edit',
-            'discover-query',
-          ],
+          features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
         }),
         router: {
           location: {
@@ -1291,12 +1281,7 @@ describe('Dashboards > Detail', () => {
       });
       const testData = initializeOrg({
         organization: OrganizationFixture({
-          features: [
-            'global-views',
-            'dashboards-basic',
-            'dashboards-edit',
-            'discover-query',
-          ],
+          features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
         }),
         router: {
           location: {
@@ -1354,12 +1339,7 @@ describe('Dashboards > Detail', () => {
       });
       const testData = initializeOrg({
         organization: OrganizationFixture({
-          features: [
-            'global-views',
-            'dashboards-basic',
-            'dashboards-edit',
-            'discover-query',
-          ],
+          features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
         }),
         router: {
           location: {
@@ -1424,12 +1404,7 @@ describe('Dashboards > Detail', () => {
       });
       const testData = initializeOrg({
         organization: OrganizationFixture({
-          features: [
-            'global-views',
-            'dashboards-basic',
-            'dashboards-edit',
-            'discover-query',
-          ],
+          features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
         }),
         router: {
           location: {
@@ -1499,7 +1474,6 @@ describe('Dashboards > Detail', () => {
       const testData = initializeOrg({
         organization: OrganizationFixture({
           features: [
-            'global-views',
             'dashboards-basic',
             'dashboards-edit',
             'discover-basic',
@@ -1569,12 +1543,7 @@ describe('Dashboards > Detail', () => {
 
       const testData = initializeOrg({
         organization: OrganizationFixture({
-          features: [
-            'global-views',
-            'dashboards-basic',
-            'dashboards-edit',
-            'discover-query',
-          ],
+          features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
         }),
         router: {
           location: {
@@ -1629,12 +1598,7 @@ describe('Dashboards > Detail', () => {
       });
       const testData = initializeOrg({
         organization: OrganizationFixture({
-          features: [
-            'global-views',
-            'dashboards-basic',
-            'dashboards-edit',
-            'discover-query',
-          ],
+          features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
         }),
         router: {
           location: {
@@ -1688,12 +1652,7 @@ describe('Dashboards > Detail', () => {
       });
       const testData = initializeOrg({
         organization: OrganizationFixture({
-          features: [
-            'global-views',
-            'dashboards-basic',
-            'dashboards-edit',
-            'discover-query',
-          ],
+          features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
         }),
         router: {
           location: {
@@ -1754,12 +1713,7 @@ describe('Dashboards > Detail', () => {
       });
       const testData = initializeOrg({
         organization: OrganizationFixture({
-          features: [
-            'global-views',
-            'dashboards-basic',
-            'dashboards-edit',
-            'discover-query',
-          ],
+          features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
         }),
         router: {
           location: LocationFixture(),
@@ -1826,7 +1780,6 @@ describe('Dashboards > Detail', () => {
       const testData = initializeOrg({
         organization: OrganizationFixture({
           features: [
-            'global-views',
             'dashboards-basic',
             'dashboards-edit',
             'discover-basic',
@@ -2335,12 +2288,7 @@ describe('Dashboards > Detail', () => {
       beforeEach(() => {
         initialData = initializeOrg({
           organization: OrganizationFixture({
-            features: [
-              'global-views',
-              'dashboards-basic',
-              'dashboards-edit',
-              'discover-query',
-            ],
+            features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
           }),
         });
 

--- a/static/app/views/dashboards/manage/dashboardGrid.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.spec.tsx
@@ -22,7 +22,7 @@ describe('Dashboards - DashboardGrid', () => {
   let dashboardUpdateMock: jest.Mock;
   let createMock: jest.Mock;
   const organization = OrganizationFixture({
-    features: ['global-views', 'dashboards-basic', 'dashboards-edit', 'discover-query'],
+    features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
   });
 
   const {router} = initializeOrg();

--- a/static/app/views/dashboards/manage/dashboardTable.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.spec.tsx
@@ -22,7 +22,7 @@ describe('Dashboards - DashboardTable', () => {
   let dashboardUpdateMock: jest.Mock;
   let createMock: jest.Mock;
   const organization = OrganizationFixture({
-    features: ['global-views', 'dashboards-basic', 'dashboards-edit', 'discover-query'],
+    features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
   });
 
   const {router} = initializeOrg();
@@ -280,7 +280,7 @@ describe('Dashboards - DashboardTable', () => {
 
   it('renders access column', async () => {
     const organizationWithEditAccess = OrganizationFixture({
-      features: ['global-views', 'dashboards-basic', 'dashboards-edit', 'discover-query'],
+      features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
     });
 
     render(
@@ -306,7 +306,7 @@ describe('Dashboards - DashboardTable', () => {
     });
 
     const organizationWithFavorite = OrganizationFixture({
-      features: ['global-views', 'dashboards-basic', 'dashboards-edit', 'discover-query'],
+      features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
     });
 
     render(

--- a/static/app/views/dashboards/manage/index.spec.tsx
+++ b/static/app/views/dashboards/manage/index.spec.tsx
@@ -15,12 +15,7 @@ import {getPaginationPageLink} from 'sentry/views/organizationStats/utils';
 
 jest.mock('sentry/utils/localStorage');
 
-const FEATURES = [
-  'global-views',
-  'dashboards-basic',
-  'dashboards-edit',
-  'discover-query',
-];
+const FEATURES = ['dashboards-basic', 'dashboards-edit', 'discover-query'];
 
 jest.mock('sentry/utils/useNavigate', () => ({
   useNavigate: jest.fn(),
@@ -33,7 +28,7 @@ const mockUseLocation = jest.mocked(useLocation);
 
 describe('Dashboards > Detail', () => {
   const mockUnauthorizedOrg = OrganizationFixture({
-    features: ['global-views', 'dashboards-basic', 'discover-query'],
+    features: ['dashboards-basic', 'discover-query'],
   });
 
   const mockAuthorizedOrg = OrganizationFixture({

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -11,7 +11,7 @@ import WidgetBuilderV2 from 'sentry/views/dashboards/widgetBuilder/components/ne
 
 const {organization, projects, router} = initializeOrg({
   organization: {
-    features: ['global-views', 'open-membership', 'visibility-explore-view'],
+    features: ['open-membership', 'visibility-explore-view'],
   },
   projects: [
     {id: '1', slug: 'project-1', isMember: true},

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
@@ -25,7 +25,7 @@ describe('WidgetBuilderSortBySelector', () => {
   beforeEach(() => {
     const setupOrg = initializeOrg({
       organization: {
-        features: ['global-views', 'open-membership', 'visibility-explore-view'],
+        features: ['open-membership', 'visibility-explore-view'],
       },
       projects: [],
       router: {
@@ -249,7 +249,7 @@ describe('WidgetBuilderSortBySelector', () => {
 
     const setupOrg = initializeOrg({
       organization: {
-        features: ['global-views', 'open-membership', 'visibility-explore-view'],
+        features: ['open-membership', 'visibility-explore-view'],
       },
       projects: [],
       router: {

--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -21,7 +21,7 @@ import {DEFAULT_EVENT_VIEW} from 'sentry/views/discover/results/data';
 import Homepage from './homepage';
 
 describe('Discover > Homepage', () => {
-  const features = ['global-views', 'discover-query'];
+  const features = ['discover-query'];
   let initialData: ReturnType<typeof initializeOrg>;
   let organization: ReturnType<typeof OrganizationFixture>;
   let mockHomepage: jest.Mock;

--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -882,7 +882,7 @@ describe('Results', () => {
 
     it('respects pinned filters for prebuilt queries', async () => {
       const organization = OrganizationFixture({
-        features: [...features, 'global-views'],
+        features: [...features],
       });
 
       const {router} = initializeOrg({

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -43,7 +43,6 @@ const {organization, projects, router} = initializeOrg({
   organization: {
     id: '1337',
     slug: 'org-slug',
-    features: ['global-views'],
     access: [],
   },
   router: {

--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -28,7 +28,7 @@ describe('OrganizationStats', () => {
   };
   const projects = ['1', '2', '3'].map(id => ProjectFixture({id, slug: `proj-${id}`}));
   const {organization, router} = initializeOrg({
-    organization: {features: ['global-views', 'team-insights']},
+    organization: {features: ['team-insights']},
     projects,
     router: undefined,
   });
@@ -252,22 +252,9 @@ describe('OrganizationStats', () => {
   /**
    * Project Selection
    */
-  it('renders single project without global-views', async () => {
+  it('renders default projects', async () => {
     const newOrg = initializeOrg();
     newOrg.organization.features = ['team-insights'];
-
-    render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
-      organization: newOrg.organization,
-    });
-
-    expect(await screen.findByTestId('usage-stats-chart')).toBeInTheDocument();
-    expect(screen.queryByText('My Projects')).not.toBeInTheDocument();
-    expect(screen.queryByText('usage-stats-table')).not.toBeInTheDocument();
-  });
-
-  it('renders default projects with global-views', async () => {
-    const newOrg = initializeOrg();
-    newOrg.organization.features = ['global-views', 'team-insights'];
     OrganizationStore.onUpdate(newOrg.organization, {replace: true});
     render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
       organization: newOrg.organization,
@@ -289,7 +276,7 @@ describe('OrganizationStats', () => {
 
   it('renders with multiple projects selected', async () => {
     const newOrg = initializeOrg();
-    newOrg.organization.features = ['global-views', 'team-insights'];
+    newOrg.organization.features = ['team-insights'];
 
     const selectedProjects = [1, 2];
     const newSelection = {
@@ -330,7 +317,7 @@ describe('OrganizationStats', () => {
 
   it('renders with a single project selected', async () => {
     const newOrg = initializeOrg();
-    newOrg.organization.features = ['global-views', 'team-insights'];
+    newOrg.organization.features = ['team-insights'];
     const selectedProject = [1];
     const newSelection = {
       ...defaultSelection,
@@ -371,7 +358,7 @@ describe('OrganizationStats', () => {
 
   it('renders a project when its graph icon is clicked', async () => {
     const newOrg = initializeOrg();
-    newOrg.organization.features = ['global-views', 'team-insights'];
+    newOrg.organization.features = ['team-insights'];
     render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
       organization: newOrg.organization,
     });
@@ -417,7 +404,7 @@ describe('OrganizationStats', () => {
   it('shows only profile duration category with continuous-profiling-stats feature', async () => {
     const newOrg = initializeOrg({
       organization: {
-        features: ['global-views', 'team-insights', 'continuous-profiling-stats'],
+        features: ['team-insights', 'continuous-profiling-stats'],
       },
     });
 
@@ -436,7 +423,7 @@ describe('OrganizationStats', () => {
   it('shows both profile hours and profiles categories with continuous-profiling feature', async () => {
     const newOrg = initializeOrg({
       organization: {
-        features: ['global-views', 'team-insights', 'continuous-profiling'],
+        features: ['team-insights', 'continuous-profiling'],
       },
     });
 
@@ -455,7 +442,7 @@ describe('OrganizationStats', () => {
   it('shows both profile hours without continuous-profiling feature', async () => {
     const newOrg = initializeOrg({
       organization: {
-        features: ['global-views', 'team-insights'],
+        features: ['team-insights'],
       },
     });
 
@@ -478,12 +465,7 @@ describe('OrganizationStats', () => {
   it('shows only profile duration category when both profiling features are enabled', async () => {
     const newOrg = initializeOrg({
       organization: {
-        features: [
-          'global-views',
-          'team-insights',
-          'continuous-profiling-stats',
-          'continuous-profiling',
-        ],
+        features: ['team-insights', 'continuous-profiling-stats', 'continuous-profiling'],
       },
     });
 
@@ -502,7 +484,7 @@ describe('OrganizationStats', () => {
   it('shows only Profiles category without profiling features', async () => {
     const newOrg = initializeOrg({
       organization: {
-        features: ['global-views', 'team-insights'],
+        features: ['team-insights'],
       },
     });
 
@@ -521,7 +503,7 @@ describe('OrganizationStats', () => {
   it('shows Seer categories when seer-billing feature flag is enabled', async () => {
     const newOrg = initializeOrg({
       organization: {
-        features: ['global-views', 'team-insights', 'seer-billing'],
+        features: ['team-insights', 'seer-billing'],
       },
     });
 
@@ -535,7 +517,7 @@ describe('OrganizationStats', () => {
   it('does not show Seer categories when seer-billing feature flag is disabled', async () => {
     const newOrg = initializeOrg({
       organization: {
-        features: ['global-views', 'team-insights'],
+        features: ['team-insights'],
       },
     });
 
@@ -559,12 +541,7 @@ describe('OrganizationStats', () => {
   it('shows estimation text when profile duration category is selected', async () => {
     const newOrg = initializeOrg({
       organization: {
-        features: [
-          'global-views',
-          'team-insights',
-          'continuous-profiling-stats',
-          'continuous-profiling',
-        ],
+        features: ['team-insights', 'continuous-profiling-stats', 'continuous-profiling'],
       },
     });
 

--- a/static/gsApp/components/upsellModal/details.spec.tsx
+++ b/static/gsApp/components/upsellModal/details.spec.tsx
@@ -149,7 +149,6 @@ describe('Upsell Modal Details', () => {
     expect(await screen.findByText('Features Include')).toBeInTheDocument();
 
     // Check that the source feature is highlighted.
-    expect(screen.queryByTestId('global-views')).not.toBeInTheDocument();
     expect(screen.getByTestId('tracing')).toHaveAttribute('aria-selected');
   });
 

--- a/static/gsApp/components/upsellModal/details.tsx
+++ b/static/gsApp/components/upsellModal/details.tsx
@@ -190,7 +190,6 @@ const TEAM_FEATURES = selectFeatures(['extended-data-retention']).filter(Boolean
 const INSIGHTS_FEATURES = selectFeatures(['insights-modules']).filter(Boolean);
 
 const BUSINESS_FEATURES = selectFeatures([
-  'global-views',
   'discover-query',
   'change-alerts',
   'event-volume',

--- a/static/gsApp/views/spikeProtection/spikeProtectionProjects.spec.tsx
+++ b/static/gsApp/views/spikeProtection/spikeProtectionProjects.spec.tsx
@@ -47,7 +47,6 @@ describe('project renders and toggles', () => {
     const newData = initializeOrg({
       projects,
       organization: {
-        features: ['global-views'],
         openMembership: true,
         access: ['org:write'],
       },

--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -28,7 +28,6 @@ FEATURE_NAMES = [
     "organizations:discover-basic",
     "organizations:discover-query",
     "organizations:dashboards-basic",
-    "organizations:global-views",
 ]
 
 EDIT_FEATURE = ["organizations:dashboards-edit"]


### PR DESCRIPTION
Refs https://linear.app/getsentry/issue/ID-927/deprecate-global-views-flag. Removes `global-views` flag from a bunch of frontend tests, since it has been rolled out to all plans. This should be the second-to-last real `global-views` deprecation change.

See https://github.com/getsentry/sentry/pull/99450