### PR TITLE
fix(checkout): Padding for add a new card

### DIFF
--- a/static/gsApp/views/amCheckout/steps/addPaymentMethod.tsx
+++ b/static/gsApp/views/amCheckout/steps/addPaymentMethod.tsx
@@ -3,6 +3,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
+import {Container} from 'sentry/components/core/layout';
 import {Radio} from 'sentry/components/core/radio';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
@@ -91,7 +92,7 @@ function AddPaymentMethod({
             <CardDetails>{t('Add new card')}</CardDetails>
           </Label>
         </CreditCardOption>
-        {!useExisting && cardComponent}
+        {!useExisting && <Container padding="xl">{cardComponent}</Container>}
       </PanelBody>
     );
   }


### PR DESCRIPTION
I'm guessing this regressed in my panel changes.

# before 
<img width="837" height="430" alt="Screenshot 2025-09-23 at 1 51 56 PM" src="https://github.com/user-attachments/assets/a7bef5af-729a-4683-bd84-abc06a67f52b" />

# after 
<img width="823" height="375" alt="Screenshot 2025-09-23 at 1 51 37 PM" src="https://github.com/user-attachments/assets/79b9f8ae-6044-4097-90ca-c20a3de0eb8f" />
