### PR TITLE
fix(eco): Reverts unset_option removal PR

### DIFF
--- a/src/sentry/plugins/base/v1.py
+++ b/src/sentry/plugins/base/v1.py
@@ -140,6 +140,18 @@ class IPlugin(local, PluggableViewMixin, PluginConfigMixin):
 
         set_option(self._get_option_key(key), value, project, user)
 
+    def unset_option(self, key, project=None, user=None) -> None:
+        """
+        Removes an option in your plugins keyspace.
+
+        If ``project`` is passed, it will limit the scope to that project's keyspace.
+
+        >>> plugin.unset_option('my_option')
+        """
+        from sentry.plugins.helpers import unset_option
+
+        unset_option(self._get_option_key(key), project, user)
+
     def enable(self, project=None, user=None):
         """Enable the plugin."""
         self.set_option("enabled", True, project, user)

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -145,6 +145,18 @@ class IPlugin2(local, PluginConfigMixin):
 
         set_option(self._get_option_key(key), value, project, user)
 
+    def unset_option(self, key, project=None, user=None) -> None:
+        """
+        Removes an option in your plugins keyspace.
+
+        If ``project`` is passed, it will limit the scope to that project's keyspace.
+
+        >>> plugin.unset_option('my_option')
+        """
+        from sentry.plugins.helpers import unset_option
+
+        unset_option(self._get_option_key(key), project, user)
+
     def enable(self, project=None, user=None):
         """Enable the plugin."""
         self.set_option("enabled", True, project, user)

--- a/src/sentry/plugins/helpers.py
+++ b/src/sentry/plugins/helpers.py
@@ -6,7 +6,7 @@ from sentry.models.project import Project
 from sentry.projects.services.project import RpcProject, project_service
 from sentry.users.models.user_option import UserOption
 
-__all__ = ("set_option", "get_option")
+__all__ = ("set_option", "get_option", "unset_option")
 
 
 def reset_options(prefix, project=None):
@@ -41,3 +41,12 @@ def get_option(key, project: Project | RpcProject | None = None, user=None):
         result = options.get(key)
 
     return result
+
+
+def unset_option(key, project=None, user=None) -> None:
+    if user:
+        UserOption.objects.unset_value(user, project, key)
+    elif project:
+        ProjectOption.objects.unset_value(project, key)
+    else:
+        raise NotImplementedError

--- a/src/sentry/users/models/user_option.py
+++ b/src/sentry/users/models/user_option.py
@@ -55,6 +55,21 @@ class UserOptionManager(OptionManager["UserOption"]):
             result = self.get_all_values(user, project)
         return result.get(key, default)
 
+    def unset_value(self, user: User, project: Project, key: str) -> None:
+        """
+        This isn't implemented for user-organization scoped options yet, because it hasn't been needed.
+        """
+        self.filter(user=user, project=project, key=key).delete()
+
+        if not hasattr(self, "_metadata"):
+            return
+
+        metakey = self._make_key(user, project=project)
+
+        if metakey not in self._option_cache:
+            return
+        self._option_cache[metakey].pop(key, None)
+
     def set_value(self, user: User | int, key: str, value: Any, **kwargs: Any) -> None:
         project = kwargs.get("project")
         organization = kwargs.get("organization")

--- a/tests/sentry/plugins/test_helpers.py
+++ b/tests/sentry/plugins/test_helpers.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from sentry.plugins.helpers import get_option, set_option
+from sentry.plugins.helpers import get_option, set_option, unset_option
 from sentry.testutils.cases import TestCase
 
 
@@ -20,3 +20,10 @@ class SentryPluginTest(TestCase):
             self.assertEqual(result, get_value.return_value)
 
             get_value.assert_called_once_with(project, "key", None)
+
+    def test_unset_option_with_project(self) -> None:
+        with mock.patch("sentry.models.ProjectOption.objects.unset_value") as unset_value:
+            project = mock.Mock()
+            unset_option("key", project)
+
+            unset_value.assert_called_once_with(project, "key")

--- a/tests/sentry_plugins/trello/test_plugin.py
+++ b/tests/sentry_plugins/trello/test_plugin.py
@@ -1,13 +1,9 @@
-from __future__ import annotations
-
 from functools import cached_property
 from urllib.parse import parse_qsl, urlparse
 
 import orjson
 import responses
 
-from sentry.models.options.project_option import ProjectOption
-from sentry.models.project import Project
 from sentry.testutils.cases import PluginTestCase
 from sentry.testutils.requests import drf_request_from_request
 from sentry_plugins.trello.plugin import TrelloPlugin
@@ -21,10 +17,6 @@ class TrelloPluginTestBase(PluginTestCase):
     @cached_property
     def plugin(self) -> TrelloPlugin:
         return TrelloPlugin()
-
-
-def _unset_org(project: Project) -> None:
-    ProjectOption.objects.filter(project_id=project.id, key="trello:organization").delete()
 
 
 class TrelloPluginTest(TrelloPluginTestBase):
@@ -63,7 +55,7 @@ class TrelloPluginApiTests(TrelloPluginTestBase):
         self.login_as(self.user)
 
     def test_get_config_no_org(self) -> None:
-        _unset_org(self.project)
+        self.plugin.unset_option("organization", self.project)
         out = self.plugin.get_config(self.project)
         assert out == [
             {
@@ -86,7 +78,7 @@ class TrelloPluginApiTests(TrelloPluginTestBase):
 
     @responses.activate
     def test_get_config_include_additional(self) -> None:
-        _unset_org(self.project)
+        self.plugin.unset_option("organization", self.project)
 
         responses.add(
             responses.GET,
@@ -239,7 +231,7 @@ class TrelloPluginApiTests(TrelloPluginTestBase):
 
     @responses.activate
     def test_view_autocomplete_no_org(self) -> None:
-        _unset_org(self.project)
+        self.plugin.unset_option("organization", self.project)
 
         responses.add(
             responses.GET,


### PR DESCRIPTION
These methods were removed last week, but our `ProjectPluginDetailsEndpoint` code still references `.unset()` for both V1 and V2 plugins. This reverts PR #99493
