### PR TITLE
feat(insights): add "add to dashboards" to most specialized module charts

### DIFF
--- a/static/app/views/insights/common/components/chartActionDropdown.tsx
+++ b/static/app/views/insights/common/components/chartActionDropdown.tsx
@@ -109,7 +109,7 @@ type BaseProps = {
   alertMenuOptions: MenuItemProps[];
   exploreUrl: LocationDescriptor;
   referrer: string;
-  addToDashboardOptions?: AddToSpanDashboardOptions;
+  addToDashboardOptions?: AddToSpanDashboardOptions | AddToSpanDashboardOptions[];
 };
 
 export function BaseChartActionDropdown({
@@ -137,7 +137,7 @@ export function BaseChartActionDropdown({
   ];
 
   if (addToDashboardOptions) {
-    menuOptions.push({
+    const menuOption: MenuItemProps = {
       key: 'add-to-dashboard',
       label: (
         <Feature
@@ -149,12 +149,25 @@ export function BaseChartActionDropdown({
         </Feature>
       ),
       textValue: t('Add to Dashboard'),
-      onAction: () => {
-        addToSpanDashboard(addToDashboardOptions);
-      },
-      isSubmenu: false,
       disabled: !hasDashboardEdit,
-    });
+    };
+    if (Array.isArray(addToDashboardOptions)) {
+      menuOption.isSubmenu = true;
+      menuOption.children = addToDashboardOptions.map((option, idx) => ({
+        ...option,
+        key: `${option.chartType}-${idx}-${option.yAxes}`,
+        label: option.widgetName,
+        onAction: () => {
+          addToSpanDashboard(option);
+        },
+      }));
+    } else {
+      menuOption.isSubmenu = false;
+      menuOption.onAction = () => {
+        addToSpanDashboard(addToDashboardOptions);
+      };
+    }
+    menuOptions.push(menuOption);
   }
 
   if (alertMenuOptions.length > 0) {

--- a/static/app/views/insights/common/components/chartActionDropdown.tsx
+++ b/static/app/views/insights/common/components/chartActionDropdown.tsx
@@ -154,7 +154,6 @@ export function BaseChartActionDropdown({
     if (Array.isArray(addToDashboardOptions)) {
       menuOption.isSubmenu = true;
       menuOption.children = addToDashboardOptions.map((option, idx) => ({
-        ...option,
         key: `${option.chartType}-${idx}-${option.yAxes}`,
         label: option.widgetName,
         onAction: () => {

--- a/static/app/views/insights/common/components/widgets/httpDomainSummaryResponseCodesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpDomainSummaryResponseCodesChartWidget.tsx
@@ -12,6 +12,7 @@ import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/i
 import {useHttpDomainSummaryChartFilter} from 'sentry/views/insights/common/components/widgets/hooks/useHttpDomainSummaryChartFilter';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
+import type {AddToSpanDashboardOptions} from 'sentry/views/insights/common/utils/useAddToSpanDashboard';
 import {useAlertsProject} from 'sentry/views/insights/common/utils/useAlertsProject';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {Referrer} from 'sentry/views/insights/http/referrers';
@@ -44,20 +45,21 @@ export default function HttpDomainSummaryResponseCodesChartWidget(
 
   const responseRateField = 'tags[http.response.status_code,number]';
   const stringifiedSearch = search.formatString();
+  const yAxis = 'count()';
 
   const queries = [
     {
-      yAxes: ['count()'],
+      yAxes: [yAxis],
       label: '3xx',
       query: `${stringifiedSearch} ${responseRateField}:>=300 ${responseRateField}:<=399`,
     },
     {
-      yAxes: ['count()'],
+      yAxes: [yAxis],
       label: '4xx',
       query: `${stringifiedSearch} ${responseRateField}:>=400 ${responseRateField}:<=499`,
     },
     {
-      yAxes: ['count()'],
+      yAxes: [yAxis],
       label: '5xx',
       query: `${stringifiedSearch} ${responseRateField}:>=500 ${responseRateField}:<=599`,
     },
@@ -74,10 +76,19 @@ export default function HttpDomainSummaryResponseCodesChartWidget(
     referrer,
   });
 
+  const addToDashboardOptions: AddToSpanDashboardOptions[] = queries.map(query => ({
+    chartType: ChartType.LINE,
+    yAxes: query.yAxes,
+    widgetName: query.label,
+    groupBy: [],
+    search: new MutableSearch(query.query),
+  }));
+
   const extraActions = [
     <BaseChartActionDropdown
       key="http response chart widget"
       exploreUrl={exploreUrl}
+      addToDashboardOptions={addToDashboardOptions}
       referrer={referrer}
       alertMenuOptions={queries.map(query => ({
         key: query.label,

--- a/static/app/views/insights/common/components/widgets/httpResponseCodesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpResponseCodesChartWidget.tsx
@@ -12,6 +12,7 @@ import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/i
 import {useHttpLandingChartFilter} from 'sentry/views/insights/common/components/widgets/hooks/useHttpLandingChartFilter';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
+import type {AddToSpanDashboardOptions} from 'sentry/views/insights/common/utils/useAddToSpanDashboard';
 import {useAlertsProject} from 'sentry/views/insights/common/utils/useAlertsProject';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {Referrer} from 'sentry/views/insights/http/referrers';
@@ -42,20 +43,21 @@ export default function HttpResponseCodesChartWidget(props: LoadableChartWidgetP
 
   const responseRateField = 'tags[http.response.status_code,number]';
   const stringifiedSearch = search.formatString();
+  const yAxis = 'count()';
 
   const queries = [
     {
-      yAxes: ['count()'],
+      yAxes: [yAxis],
       label: '3xx',
       query: `${stringifiedSearch} ${responseRateField}:>=300 ${responseRateField}:<=399`,
     },
     {
-      yAxes: ['count()'],
+      yAxes: [yAxis],
       label: '4xx',
       query: `${stringifiedSearch} ${responseRateField}:>=400 ${responseRateField}:<=499`,
     },
     {
-      yAxes: ['count()'],
+      yAxes: [yAxis],
       label: '5xx',
       query: `${stringifiedSearch} ${responseRateField}:>=500 ${responseRateField}:<=599`,
     },
@@ -72,10 +74,19 @@ export default function HttpResponseCodesChartWidget(props: LoadableChartWidgetP
     referrer,
   });
 
+  const addToDashboardOptions: AddToSpanDashboardOptions[] = queries.map(query => ({
+    chartType: ChartType.LINE,
+    yAxes: query.yAxes,
+    widgetName: query.label,
+    groupBy: [],
+    search: new MutableSearch(query.query),
+  }));
+
   const extraActions = [
     <BaseChartActionDropdown
       key="http response chart widget"
       exploreUrl={exploreUrl}
+      addToDashboardOptions={addToDashboardOptions}
       referrer={referrer}
       alertMenuOptions={queries.map(query => ({
         key: query.label,

--- a/static/app/views/insights/common/components/widgets/overviewApiLatencyChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewApiLatencyChartWidget.tsx
@@ -73,6 +73,7 @@ export default function OverviewApiLatencyChartWidget(props: LoadableChartWidget
         !isEmpty && (
           <Toolbar
             showCreateAlert
+            showAddToDashboard
             exploreParams={{
               mode: Mode.SAMPLES,
               visualize: [

--- a/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
+++ b/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
@@ -12,6 +12,7 @@ import {BaseChartActionDropdown} from 'sentry/views/insights/common/components/c
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
+import type {AddToSpanDashboardOptions} from 'sentry/views/insights/common/utils/useAddToSpanDashboard';
 import {useAlertsProject} from 'sentry/views/insights/common/utils/useAlertsProject';
 import {SpanFields} from 'sentry/views/insights/types';
 
@@ -96,11 +97,22 @@ export function ResponseCodeCountChart({
     referrer,
   });
 
+  const addToDashboardOptions: AddToSpanDashboardOptions = {
+    chartType: ChartType.LINE,
+    yAxes: [yAxis],
+    widgetName: title,
+    groupBy,
+    search,
+    sort: {field: yAxis, kind: 'desc'},
+    topEvents: 5,
+  };
+
   const extraActions = [
     <BaseChartActionDropdown
       key="http response chart widget"
       exploreUrl={exploreUrl}
       referrer={referrer}
+      addToDashboardOptions={addToDashboardOptions}
       alertMenuOptions={queries.map(query => ({
         key: query.label,
         label: query.label,

--- a/static/app/views/insights/pages/platform/shared/toolbar.tsx
+++ b/static/app/views/insights/pages/platform/shared/toolbar.tsx
@@ -75,7 +75,7 @@ export function Toolbar({
     if (visualize[0] && visualize.length === 1) {
       addToDashboardOptions = {
         chartType: visualize[0].chartType || ChartType.LINE,
-        yAxes: [...visualize[0].yAxes],
+        yAxes,
         groupBy: (exploreParams?.groupBy as SpanFields[]) ?? [],
         search: new MutableSearch(exploreParams?.query || ''),
         sort: decodeSorts(exploreParams?.sort).at(0),

--- a/static/app/views/insights/pages/platform/shared/toolbar.tsx
+++ b/static/app/views/insights/pages/platform/shared/toolbar.tsx
@@ -1,15 +1,20 @@
 import {Button} from 'sentry/components/core/button';
 import {IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {decodeSorts} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {getExploreUrl} from 'sentry/views/explore/utils';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {BaseChartActionDropdown} from 'sentry/views/insights/common/components/chartActionDropdown';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
+import type {AddToSpanDashboardOptions} from 'sentry/views/insights/common/utils/useAddToSpanDashboard';
 import {useAlertsProject} from 'sentry/views/insights/common/utils/useAlertsProject';
+import type {SpanFields} from 'sentry/views/insights/types';
 
 type ExploreParams = Parameters<typeof getExploreUrl>[0];
 
@@ -19,7 +24,8 @@ interface ToolbarProps {
   exploreParams?: Omit<ExploreParams, 'organization' | 'selection'>;
   loaderSource?: LoadableChartWidgetProps['loaderSource'];
   referrer?: string;
-  // TODO: this is temporary so we can slowly add create alert functionality, in the future all charts that can open in explore can be alerted
+  // TODO: this is temporary so we can slowly add create alert/dashboard functionality, in the future all charts that can open in explore can be alerted
+  showAddToDashboard?: boolean;
   showCreateAlert?: boolean;
 }
 
@@ -29,6 +35,7 @@ export function Toolbar({
   loaderSource,
   aliases,
   showCreateAlert = false,
+  showAddToDashboard = false,
   referrer: referrerProp,
 }: ToolbarProps) {
   const organization = useOrganization();
@@ -59,11 +66,40 @@ export function Toolbar({
     };
   });
 
+  let addToDashboardOptions:
+    | AddToSpanDashboardOptions
+    | AddToSpanDashboardOptions[]
+    | undefined = undefined;
+  const visualize = exploreParams?.visualize;
+  if (showAddToDashboard && visualize) {
+    if (visualize[0] && visualize.length === 1) {
+      addToDashboardOptions = {
+        chartType: visualize[0].chartType || ChartType.LINE,
+        yAxes: [...visualize[0].yAxes],
+        groupBy: (exploreParams?.groupBy as SpanFields[]) ?? [],
+        search: new MutableSearch(exploreParams?.query || ''),
+        sort: decodeSorts(exploreParams?.sort).at(0),
+        widgetName: exploreParams?.title,
+      } satisfies AddToSpanDashboardOptions;
+    }
+    if (visualize.length > 1) {
+      addToDashboardOptions = visualize.map(v => ({
+        chartType: v.chartType || ChartType.LINE,
+        yAxes: [...v.yAxes],
+        groupBy: (exploreParams?.groupBy as SpanFields[]) ?? [],
+        search: new MutableSearch(exploreParams?.query || ''),
+        sort: decodeSorts(exploreParams?.sort).at(0),
+        widgetName: v.yAxes[0],
+      })) satisfies AddToSpanDashboardOptions[];
+    }
+  }
+
   return (
     <Widget.WidgetToolbar>
       {exploreUrl ? (
         <BaseChartActionDropdown
           exploreUrl={exploreUrl}
+          addToDashboardOptions={addToDashboardOptions}
           alertMenuOptions={showCreateAlert ? alertsUrls : []}
           referrer={referrer}
         />

--- a/static/app/views/insights/queues/charts/throughputChart.tsx
+++ b/static/app/views/insights/queues/charts/throughputChart.tsx
@@ -18,6 +18,7 @@ import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDisco
 import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 import {renameDiscoverSeries} from 'sentry/views/insights/common/utils/renameDiscoverSeries';
+import type {AddToSpanDashboardOptions} from 'sentry/views/insights/common/utils/useAddToSpanDashboard';
 import {useAlertsProject} from 'sentry/views/insights/common/utils/useAlertsProject';
 import type {Referrer} from 'sentry/views/insights/queues/referrers';
 import {FIELD_ALIASES} from 'sentry/views/insights/queues/settings';
@@ -95,9 +96,20 @@ export function ThroughputChart({id, error, destination, pageFilters, referrer}:
     referrer,
   });
 
+  const addToDashboardOptions: AddToSpanDashboardOptions = {
+    chartType: ChartType.LINE,
+    yAxes: [yAxis],
+    widgetName: title,
+    groupBy: [groupBy],
+    search,
+    topEvents: 2,
+    sort: {field: yAxis, kind: 'desc'},
+  };
+
   const extraActions = [
     <BaseChartActionDropdown
       key="throughput-chart-action"
+      addToDashboardOptions={addToDashboardOptions}
       alertMenuOptions={[
         {
           key: 'publish',


### PR DESCRIPTION
Adds the `add to dashboards` insight chart feature to some specialized insight charts.