### PR TITLE
fix(code mappings): Add handling for exception when deriving code mappings

### DIFF
--- a/src/sentry/issues/endpoints/organization_derive_code_mappings.py
+++ b/src/sentry/issues/endpoints/organization_derive_code_mappings.py
@@ -18,7 +18,7 @@ from sentry.issues.auto_source_code_config.derived_code_mappings_endpoint import
     get_code_mapping_from_request,
     get_file_and_repo_matches,
 )
-from sentry.issues.auto_source_code_config.errors import NeedsExtension
+from sentry.issues.auto_source_code_config.errors import NeedsExtension, UnsupportedFrameInfo
 from sentry.issues.auto_source_code_config.integration_utils import (
     InstallationCannotGetTreesError,
     InstallationNotFoundError,
@@ -82,6 +82,10 @@ class OrganizationDeriveCodeMappingsEndpoint(OrganizationEndpoint):
         except KeyError:
             return self.respond(
                 {"text": "Missing required parameters"}, status=status.HTTP_400_BAD_REQUEST
+            )
+        except UnsupportedFrameInfo:
+            return self.respond(
+                {"text": "Unsupported frame info"}, status=status.HTTP_400_BAD_REQUEST
             )
 
     def post(self, request: Request, organization: Organization) -> Response:

--- a/tests/sentry/api/endpoints/issues/test_organization_derive_code_mappings.py
+++ b/tests/sentry/api/endpoints/issues/test_organization_derive_code_mappings.py
@@ -180,6 +180,24 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
         response = self.client.get(self.url, data=config_data, format="json")
         assert response.status_code == 404, response.content
 
+    @patch("sentry.integrations.github.integration.GitHubIntegration.get_trees_for_org")
+    def test_get_unsupported_frame_info(self, mock_get_trees_for_org: Any) -> None:
+        config_data = {
+            "stacktraceFilename": "top_level_file.py",
+        }
+
+        mock_get_trees_for_org.return_value = {
+            "getsentry/codemap": RepoTree(
+                RepoAndBranch(
+                    name="getsentry/codemap",
+                    branch="master",
+                ),
+                files=["top_level_file.py"],
+            )
+        }
+        response = self.client.get(self.url, data=config_data, format="json")
+        assert response.status_code == 400, response.content
+
     def test_non_project_member_permissions(self) -> None:
         config_data = {
             "projectId": self.project.id,


### PR DESCRIPTION
Fixes [SENTRY-478G](https://sentry.sentry.io/issues/6742019081/?project=1&query=is%3Aunresolved%20unsupportedframeinfo&referrer=issue-stream).

Adds handling for the `UnsupportedFrameInfo` exception which can be raised in the GET handler for the `OrganizationDeriveCodeMappingsEndpoint`.