### PR TITLE
feat(prevent): Improve help tooltip text layouts

### DIFF
--- a/static/app/components/prevent/summary.tsx
+++ b/static/app/components/prevent/summary.tsx
@@ -2,7 +2,6 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Link} from 'sentry/components/core/link';
-import {Hovercard} from 'sentry/components/hovercard';
 import {IconFilter} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -33,24 +32,6 @@ export function useCreateSummaryFilterLink(filterBy: SummaryFilterKey) {
     isFiltered,
     filterLink: isFiltered ? revertFilterLink : filterLink,
   };
-}
-
-const StyledSummaryEntryLabel = styled('span')`
-  font-size: ${p => p.theme.fontSize.lg};
-  font-weight: ${p => p.theme.fontWeight.bold};
-  color: ${p => p.theme.subText};
-`;
-
-interface SummaryEntryLabelProps extends React.ComponentProps<typeof Hovercard> {
-  children: React.ReactNode;
-}
-
-export function SummaryEntryLabel({children, ...props}: SummaryEntryLabelProps) {
-  return (
-    <Hovercard {...props}>
-      <StyledSummaryEntryLabel>{children}</StyledSummaryEntryLabel>
-    </Hovercard>
-  );
 }
 
 const SummaryEntryBase = css`

--- a/static/app/views/prevent/coverage/commits/commitDetailSummary.tsx
+++ b/static/app/views/prevent/coverage/commits/commitDetailSummary.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import {Link} from 'sentry/components/core/link';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
@@ -8,7 +9,6 @@ import {
   SummaryContainer,
   SummaryEntries,
   SummaryEntry,
-  SummaryEntryLabel,
   SummaryEntryValue,
   SummaryEntryValueLink,
 } from 'sentry/components/prevent/summary';
@@ -32,12 +32,9 @@ export function CommitDetailSummary() {
         <PanelBody>
           <SummaryEntries largeColumnSpan={6} smallColumnSpan={2}>
             <SummaryEntry>
-              <SummaryEntryLabel
-                showUnderline
-                body={<p>{t('Repository coverage tooltip')}</p>}
-              >
+              <Tooltip showUnderline title={t('Repository coverage tooltip')}>
                 {t('Repository coverage')}
-              </SummaryEntryLabel>
+              </Tooltip>
               <SummaryEntryValue>98.98%</SummaryEntryValue>
               <StyledSubText>
                 {t('Head commit')}{' '}
@@ -47,42 +44,33 @@ export function CommitDetailSummary() {
               </StyledSubText>
             </SummaryEntry>
             <SummaryEntry>
-              <SummaryEntryLabel
-                showUnderline
-                body={<p>{t('Patch coverage tooltip')}</p>}
-              >
+              <Tooltip showUnderline title={t('Patch coverage tooltip')}>
                 {t('Patch coverage')}
-              </SummaryEntryLabel>
+              </Tooltip>
               <SummaryEntryValue>100%</SummaryEntryValue>
             </SummaryEntry>
             <SummaryEntry>
-              <SummaryEntryLabel
-                showUnderline
-                body={<p>{t('Uncovered lines tooltip')}</p>}
-              >
+              <Tooltip showUnderline title={t('Uncovered lines tooltip')}>
                 {t('Uncovered lines')}
-              </SummaryEntryLabel>
+              </Tooltip>
               <SummaryEntryValueLink filterBy="uncoveredLines">5</SummaryEntryValueLink>
             </SummaryEntry>
             <SummaryEntry>
-              <SummaryEntryLabel showUnderline body={<p>{t('Files changed tooltip')}</p>}>
+              <Tooltip showUnderline title={t('Files changed tooltip')}>
                 {t('Files changed')}
-              </SummaryEntryLabel>
+              </Tooltip>
               <SummaryEntryValueLink filterBy="filesChanged">4</SummaryEntryValueLink>
             </SummaryEntry>
             <SummaryEntry>
-              <SummaryEntryLabel
-                showUnderline
-                body={<p>{t('Indirect changes tooltip')}</p>}
-              >
+              <Tooltip showUnderline title={t('Indirect changes tooltip')}>
                 {t('Indirect changes')}
-              </SummaryEntryLabel>
+              </Tooltip>
               <SummaryEntryValueLink filterBy="indirectChanges">1</SummaryEntryValueLink>
             </SummaryEntry>
             <SourceEntry>
-              <SummaryEntryLabel showUnderline body={<p>{t('Source tooltip')}</p>}>
+              <Tooltip showUnderline title={t('Source tooltip')}>
                 {t('Source')}
-              </SummaryEntryLabel>
+              </Tooltip>
               <SourceText>
                 {t('This commit %s compared to', headCommit.shortSha)}{' '}
                 <Link to={`/prevent/coverage/commits/${baseCommit.sha}`}>
@@ -98,9 +86,9 @@ export function CommitDetailSummary() {
         <PanelBody>
           <SummaryEntries largeColumnSpan={1} smallColumnSpan={1}>
             <SummaryEntry>
-              <SummaryEntryLabel showUnderline body={<p>{t('Uploads count tooltip')}</p>}>
+              <Tooltip showUnderline title={t('Uploads count tooltip')}>
                 {t('Uploads count')}
-              </SummaryEntryLabel>
+              </Tooltip>
               <SummaryEntryValueLink filterBy="uploadsCount">65</SummaryEntryValueLink>
               <StyledSubText>{t('(%s processed, %s pending)', 65, 15)}</StyledSubText>
             </SummaryEntry>

--- a/static/app/views/prevent/tests/summaries/ciEfficiency.tsx
+++ b/static/app/views/prevent/tests/summaries/ciEfficiency.tsx
@@ -1,7 +1,9 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Tag} from 'sentry/components/core/badge/tag';
+import {Flex} from 'sentry/components/core/layout';
+import {Heading, Text} from 'sentry/components/core/text';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
@@ -10,29 +12,30 @@ import {usePreventContext} from 'sentry/components/prevent/context/preventContex
 import {
   SummaryEntries,
   SummaryEntry,
-  SummaryEntryLabel,
   SummaryEntryValue,
   SummaryEntryValueLink,
 } from 'sentry/components/prevent/summary';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {formatPercentRate, formatTimeDuration} from 'sentry/utils/formatters';
 
 function TotalTestsRunTimeTooltip() {
   const {preventPeriod} = usePreventContext();
 
   return (
-    <Fragment>
-      <p>
-        <ToolTipTitle>Impact:</ToolTipTitle>
-        {/* TODO: this is a dynamic value based on the selector */}
-        The cumulative CI time spent running tests over the last{' '}
-        <strong>{preventPeriod}</strong>.
-      </p>
-      <p>
-        <ToolTipTitle>What is it:</ToolTipTitle>
-        The total time it takes to run all your tests.
-      </p>
-    </Fragment>
+    <Flex direction="column" gap="sm">
+      {props => (
+        <Text {...props} align="left">
+          <Heading as="h5">{t('Impact:')}</Heading>
+          <Text>
+            {tct('The cumulative CI time spent running tests over the last [period].', {
+              period: <strong>{preventPeriod}</strong>,
+            })}
+          </Text>
+          <Heading as="h5">{t('What is it:')}</Heading>
+          <Text>{t('The total time it takes to run all your tests.')}</Text>
+        </Text>
+      )}
+    </Flex>
   );
 }
 
@@ -46,25 +49,27 @@ function SlowestTestsTooltip({
   slowestTestsDuration,
 }: SlowestTestsTooltipProps) {
   return (
-    <Fragment>
-      {/* TODO: add t/tct for these tooltips */}
-      <p>
-        <ToolTipTitle>Impact:</ToolTipTitle>
-        The slowest <strong>{slowestTests}</strong> tests take{' '}
-        <strong>{formatTimeDuration(slowestTestsDuration, 2)}</strong> to run.
-      </p>
-      <p>
-        <ToolTipTitle>What is it:</ToolTipTitle>
-        Lists the tests that take more than the 95th percentile run time to complete.
-        Showing a max of 100 tests.
-      </p>
-    </Fragment>
+    <Flex direction="column" gap="sm">
+      {props => (
+        <Text {...props} align="left">
+          <Heading as="h5">{t('Impact:')}</Heading>
+          <Text>
+            {tct('The slowest [count] tests take [duration] to run.', {
+              count: <strong>{slowestTests}</strong>,
+              duration: <strong>{formatTimeDuration(slowestTestsDuration, 2)}</strong>,
+            })}
+          </Text>
+          <Heading as="h5">{t('What is it:')}</Heading>
+          <Text>
+            {t(
+              'Lists the tests that take more than the 95th percentile run time to complete. Showing a max of 100 tests.'
+            )}
+          </Text>
+        </Text>
+      )}
+    </Flex>
   );
 }
-
-const ToolTipTitle = styled('strong')`
-  display: block;
-`;
 
 interface CIEfficiencyBodyProps {
   slowestTests?: number;
@@ -82,9 +87,9 @@ function CIEfficiencyBody({
   return (
     <SummaryEntries largeColumnSpan={9} smallColumnSpan={1}>
       <SummaryEntry columns={5}>
-        <SummaryEntryLabel showUnderline body={<TotalTestsRunTimeTooltip />}>
+        <Tooltip showUnderline title={<TotalTestsRunTimeTooltip />}>
           {t('Total Tests Run Time')}
-        </SummaryEntryLabel>
+        </Tooltip>
         <SummaryEntryValue>
           {totalTestsRunTime === undefined
             ? '-'
@@ -98,9 +103,9 @@ function CIEfficiencyBody({
         </SummaryEntryValue>
       </SummaryEntry>
       <SummaryEntry columns={4}>
-        <SummaryEntryLabel
+        <Tooltip
           showUnderline
-          body={
+          title={
             <SlowestTestsTooltip
               slowestTests={slowestTests}
               slowestTestsDuration={slowestTestsDuration}
@@ -108,7 +113,7 @@ function CIEfficiencyBody({
           }
         >
           {t('Slowest Tests (P95)')}
-        </SummaryEntryLabel>
+        </Tooltip>
         {slowestTestsDuration === undefined ? (
           <SummaryEntryValue>-</SummaryEntryValue>
         ) : (

--- a/static/app/views/prevent/tests/summaries/testPerformance.tsx
+++ b/static/app/views/prevent/tests/summaries/testPerformance.tsx
@@ -1,7 +1,9 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Tag} from 'sentry/components/core/badge/tag';
+import {Flex} from 'sentry/components/core/layout';
+import {Heading, Text} from 'sentry/components/core/text';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
@@ -9,7 +11,6 @@ import PanelHeader from 'sentry/components/panels/panelHeader';
 import {
   SummaryEntries,
   SummaryEntry,
-  SummaryEntryLabel,
   SummaryEntryValue,
   SummaryEntryValueLink,
 } from 'sentry/components/prevent/summary';
@@ -18,60 +19,65 @@ import {formatPercentRate} from 'sentry/utils/formatters';
 
 function FlakyTestsTooltip() {
   return (
-    <Fragment>
-      <p>
-        <ToolTipTitle>What is it:</ToolTipTitle>
-        The number of tests that transition from fail to pass or pass to fail.
-      </p>
-    </Fragment>
+    <Flex direction="column" gap="sm">
+      {props => (
+        <Text {...props} align="left">
+          <Heading as="h5">{t('What is it:')}</Heading>
+          <Text>
+            {t('The number of tests that transition from fail to pass or pass to fail.')}
+          </Text>
+        </Text>
+      )}
+    </Flex>
   );
 }
 
 function AverageFlakeTooltip() {
   return (
-    <Fragment>
-      <p>
-        <ToolTipTitle>Impact:</ToolTipTitle>
-        The average flake rate on your selected branch.
-      </p>
-      <p>
-        <ToolTipTitle>What is it:</ToolTipTitle>
-        The percentage of tests that flake, based on how many times a test transitions
-        from fail to pass or pass to fail on a given branch and commit.
-      </p>
-    </Fragment>
+    <Flex direction="column" gap="sm">
+      {props => (
+        <Text {...props} align="left">
+          <Heading as="h5">{t('Impact:')}</Heading>
+          <Text>{t('The average flake rate on your selected branch.')}</Text>
+          <Heading as="h5">{t('What is it:')}</Heading>
+          <Text>
+            {t(
+              'The percentage of tests that flake, based on how many times a test transitions from fail to pass or pass to fail on a given branch and commit.'
+            )}
+          </Text>
+        </Text>
+      )}
+    </Flex>
   );
 }
 
 function CumulativeFailuresTooltip() {
   return (
-    <Fragment>
-      <p>
-        <ToolTipTitle>Impact:</ToolTipTitle>
-        The number of test failures on your default branch.
-      </p>
-      <p>
-        <ToolTipTitle>What is it:</ToolTipTitle>
-        The number of individual runs of tests that failed.
-      </p>
-    </Fragment>
+    <Flex direction="column" gap="sm">
+      {props => (
+        <Text {...props} align="left">
+          <Heading as="h5">{t('Impact:')}</Heading>
+          <Text>{t('The number of test failures on your default branch.')}</Text>
+          <Heading as="h5">{t('What is it:')}</Heading>
+          <Text>{t('The number of individual runs of tests that failed.')}</Text>
+        </Text>
+      )}
+    </Flex>
   );
 }
 
 function SkippedTestsTooltip() {
   return (
-    <Fragment>
-      <p>
-        <ToolTipTitle>What is it:</ToolTipTitle>
-        The number of individual runs of tests that were skipped.
-      </p>
-    </Fragment>
+    <Flex direction="column" gap="sm">
+      {props => (
+        <Text {...props} align="left">
+          <Heading as="h5">{t('What is it:')}</Heading>
+          <Text>{t('The number of individual runs of tests that were skipped.')}</Text>
+        </Text>
+      )}
+    </Flex>
   );
 }
-
-const ToolTipTitle = styled('strong')`
-  display: block;
-`;
 
 interface TestPerformanceBodyProps {
   averageFlakeRate?: number;
@@ -97,9 +103,9 @@ function TestPerformanceBody({
   return (
     <SummaryEntries largeColumnSpan={15} smallColumnSpan={1}>
       <SummaryEntry columns={4}>
-        <SummaryEntryLabel showUnderline body={<FlakyTestsTooltip />}>
+        <Tooltip showUnderline title={<FlakyTestsTooltip />}>
           {t('Flaky Tests')}
-        </SummaryEntryLabel>
+        </Tooltip>
         {flakyTests === undefined ? (
           <SummaryEntryValue>-</SummaryEntryValue>
         ) : (
@@ -116,9 +122,9 @@ function TestPerformanceBody({
         )}
       </SummaryEntry>
       <SummaryEntry columns={4}>
-        <SummaryEntryLabel showUnderline body={<AverageFlakeTooltip />}>
+        <Tooltip showUnderline title={<AverageFlakeTooltip />}>
           {t('Avg. Flake Rate')}
-        </SummaryEntryLabel>
+        </Tooltip>
         <SummaryEntryValue>
           {averageFlakeRate === undefined ? '-' : `${averageFlakeRate?.toFixed(2)}%`}
           {typeof averageFlakeRateChange === 'number' && averageFlakeRateChange !== 0 && (
@@ -129,9 +135,9 @@ function TestPerformanceBody({
         </SummaryEntryValue>
       </SummaryEntry>
       <SummaryEntry columns={4}>
-        <SummaryEntryLabel showUnderline body={<CumulativeFailuresTooltip />}>
+        <Tooltip showUnderline title={<CumulativeFailuresTooltip />}>
           {t('Cumulative Failures')}
-        </SummaryEntryLabel>
+        </Tooltip>
         {cumulativeFailures === undefined ? (
           <SummaryEntryValue>-</SummaryEntryValue>
         ) : (
@@ -149,9 +155,9 @@ function TestPerformanceBody({
         )}
       </SummaryEntry>
       <SummaryEntry columns={3}>
-        <SummaryEntryLabel showUnderline body={<SkippedTestsTooltip />}>
+        <Tooltip showUnderline title={<SkippedTestsTooltip />}>
           {t('Skipped Tests')}
-        </SummaryEntryLabel>
+        </Tooltip>
         {skippedTests === undefined ? (
           <SummaryEntryValue>-</SummaryEntryValue>
         ) : (

--- a/static/app/views/prevent/tests/testAnalyticsTable/sortableHeader.tsx
+++ b/static/app/views/prevent/tests/testAnalyticsTable/sortableHeader.tsx
@@ -96,11 +96,7 @@ function SortableHeader({
         <NonSortableHeader role="columnheader">{label}</NonSortableHeader>
       )}
       {enableToggle ? <WrapToggle /> : null}
-      {tooltip ? (
-        <span>
-          <QuestionTooltip size="xs" title={tooltip} isHoverable />
-        </span>
-      ) : null}
+      {tooltip ? <QuestionTooltip size="xs" title={tooltip} isHoverable /> : null}
     </HeaderCell>
   );
 }


### PR DESCRIPTION
Before

<img alt="clipboard.png" width="360" src="https://i.imgur.com/gdfHRlB.png" />

Note the extraneous margin at the bottom of the page, the unneeded
ability to hover into the tooltip, and the inconsistent sizing of text
compared to help tooltips elsewhere in the app.

After

<img alt="clipboard.png" width="334" src="https://i.imgur.com/YqUt6ZT.png" />