### PR TITLE
fix(replay): fix old link to frontend pageloads

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbWebVital.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbWebVital.tsx
@@ -121,7 +121,7 @@ export function BreadcrumbWebVital({
         priority="link"
         size="xs"
         to={{
-          pathname: `/organizations/${organization.slug}/insights/frontend/pageloads/overview/`,
+          pathname: `/organizations/${organization.slug}/insights/frontend/pageloads/`,
           query: {
             projectId: replayReader?.getReplay().project_id,
           },


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/REPLAY-724/link-redirection-issue-with-all-web-vitals-in-sentry

https://github.com/user-attachments/assets/e283969f-37f1-4fd2-a76a-fff6856c36c9

