### PR TITLE
fix(repo path parsing): Add handling for exception when parsing repo paths

### DIFF
--- a/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
+++ b/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
@@ -211,6 +211,15 @@ class ProjectStacktraceLinkGithubTest(BaseStacktraceLinkTest):
         assert resp.status_code == 400, resp.content
         assert resp.data == {"sourceUrl": ["Could not find repo"]}
 
+    def test_unsupported_frame_info(self) -> None:
+        source_url = (
+            "https://github.com/getsentry/sentry/blob/master/src/project_stacktrace_link.py"
+        )
+        stack_path = "project_stacktrace_link.py"
+        resp = self.make_post(source_url, stack_path)
+        assert resp.status_code == 400, resp.content
+        assert resp.data == {"detail": "Unsupported frame info"}
+
     def test_basic(self) -> None:
         source_url = "https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/project_stacktrace_link.py"
         stack_path = "sentry/api/endpoints/project_stacktrace_link.py"


### PR DESCRIPTION
Fixes [SENTRY-479W](https://sentry.sentry.io/issues/6744362113/?project=1&query=is%3Aunresolved%20unsupportedframeinfo&referrer=issue-stream).

Adds handling for the `UnsupportedFrameInfo` exception which can be raised in the POST handler for the `ProjectRepoPathParsingEndpoint`.