### PR TITLE
Fix github enterprise integration config retrieval error

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -501,6 +501,7 @@ from sentry.seer.endpoints.organization_seer_explorer_chat import (
 from sentry.seer.endpoints.organization_seer_setup_check import OrganizationSeerSetupCheck
 from sentry.seer.endpoints.organization_trace_summary import OrganizationTraceSummaryEndpoint
 from sentry.seer.endpoints.project_seer_preferences import ProjectSeerPreferencesEndpoint
+from sentry.seer.endpoints.github_enterprise_config import GitHubEnterpriseConfigEndpoint
 from sentry.seer.endpoints.seer_rpc import SeerRpcServiceEndpoint
 from sentry.seer.endpoints.trace_explorer_ai_query import TraceExplorerAIQuery
 from sentry.seer.endpoints.trace_explorer_ai_setup import TraceExplorerAISetup
@@ -3405,6 +3406,11 @@ INTERNAL_URLS = [
         r"^seer-rpc/(?P<method_name>\w+)/$",
         SeerRpcServiceEndpoint.as_view(),
         name="sentry-api-0-seer-rpc-service",
+    ),
+    re_path(
+        r"^github-enterprise-config/$",
+        GitHubEnterpriseConfigEndpoint.as_view(),
+        name="sentry-api-0-github-enterprise-config",
     ),
     # Prevent AI (Overwatch) endpoints
     re_path(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -490,6 +490,7 @@ from sentry.rules.history.endpoints.project_rule_group_history import (
     ProjectRuleGroupHistoryIndexEndpoint,
 )
 from sentry.rules.history.endpoints.project_rule_stats import ProjectRuleStatsIndexEndpoint
+from sentry.seer.endpoints.github_enterprise_config import GitHubEnterpriseConfigEndpoint
 from sentry.seer.endpoints.group_ai_autofix import GroupAutofixEndpoint
 from sentry.seer.endpoints.group_ai_summary import GroupAiSummaryEndpoint
 from sentry.seer.endpoints.group_autofix_setup_check import GroupAutofixSetupCheck
@@ -501,7 +502,6 @@ from sentry.seer.endpoints.organization_seer_explorer_chat import (
 from sentry.seer.endpoints.organization_seer_setup_check import OrganizationSeerSetupCheck
 from sentry.seer.endpoints.organization_trace_summary import OrganizationTraceSummaryEndpoint
 from sentry.seer.endpoints.project_seer_preferences import ProjectSeerPreferencesEndpoint
-from sentry.seer.endpoints.github_enterprise_config import GitHubEnterpriseConfigEndpoint
 from sentry.seer.endpoints.seer_rpc import SeerRpcServiceEndpoint
 from sentry.seer.endpoints.trace_explorer_ai_query import TraceExplorerAIQuery
 from sentry.seer.endpoints.trace_explorer_ai_setup import TraceExplorerAISetup

--- a/src/sentry/seer/endpoints/github_enterprise_config.py
+++ b/src/sentry/seer/endpoints/github_enterprise_config.py
@@ -42,12 +42,11 @@ class GitHubEnterpriseConfigEndpoint(Endpoint):
             if not organization_id or not integration_id:
                 return Response(
                     {"success": False, "error": "Missing organization_id or integration_id"},
-                    status=400
+                    status=400,
                 )
 
             result = get_github_enterprise_integration_config(
-                organization_id=organization_id,
-                integration_id=integration_id
+                organization_id=organization_id, integration_id=integration_id
             )
             return Response(result)
         except Exception as e:
@@ -73,7 +72,9 @@ def get_github_enterprise_integration_config(
             status=ObjectStatus.ACTIVE,
         )
         if integration is None:
-            logger.error("Integration %s does not exist for organization %s", integration_id, organization_id)
+            logger.error(
+                "Integration %s does not exist for organization %s", integration_id, organization_id
+            )
             return {"success": False, "error": "Integration not found"}
 
         logger.info("Successfully retrieved integration %s", integration.id)
@@ -84,7 +85,9 @@ def get_github_enterprise_integration_config(
             assert isinstance(installation, GitHubEnterpriseIntegration)
             logger.info("Successfully created installation for integration %s", integration.id)
         except Exception as e:
-            logger.exception("Failed to create installation for integration %s: %s", integration.id, e)
+            logger.exception(
+                "Failed to create installation for integration %s: %s", integration.id, e
+            )
             return {"success": False, "error": f"Failed to create installation: {e}"}
 
         # Step 3: Get the client
@@ -113,7 +116,9 @@ def get_github_enterprise_integration_config(
             encrypted_access_token = fernet.encrypt(access_token.encode("utf-8")).decode("utf-8")
             logger.info("Successfully encrypted access token for integration %s", integration.id)
         except Exception as e:
-            logger.exception("Failed to encrypt access token for integration %s: %s", integration.id, e)
+            logger.exception(
+                "Failed to encrypt access token for integration %s: %s", integration.id, e
+            )
             return {"success": False, "error": f"Failed to encrypt access token: {e}"}
 
         return {

--- a/src/sentry/seer/endpoints/github_enterprise_config.py
+++ b/src/sentry/seer/endpoints/github_enterprise_config.py
@@ -1,0 +1,128 @@
+import logging
+from typing import Any
+
+from cryptography.fernet import Fernet
+from django.conf import settings
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.authentication import AuthenticationSiloLimit
+from sentry.api.base import Endpoint, control_silo_endpoint
+from sentry.constants import ObjectStatus
+from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIntegration
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.seer.endpoints.seer_rpc import SeerRpcSignatureAuthentication
+
+logger = logging.getLogger(__name__)
+
+
+@control_silo_endpoint
+class GitHubEnterpriseConfigEndpoint(Endpoint):
+    """
+    Control silo endpoint for getting GitHub Enterprise integration configuration.
+    This is specifically for Seer to access integration data without RPC issues.
+    """
+
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ML_AI
+    authentication_classes = (SeerRpcSignatureAuthentication,)
+    permission_classes = ()
+
+    def post(self, request: Request) -> Response:
+        """Get GitHub Enterprise integration configuration."""
+        try:
+            organization_id = request.data.get("organization_id")
+            integration_id = request.data.get("integration_id")
+
+            if not organization_id or not integration_id:
+                return Response(
+                    {"success": False, "error": "Missing organization_id or integration_id"},
+                    status=400
+                )
+
+            result = get_github_enterprise_integration_config(
+                organization_id=organization_id,
+                integration_id=integration_id
+            )
+            return Response(result)
+        except Exception as e:
+            logger.exception("Error in GitHubEnterpriseConfigEndpoint: %s", e)
+            return Response({"success": False, "error": str(e)}, status=500)
+
+
+def get_github_enterprise_integration_config(
+    *, organization_id: int, integration_id: int
+) -> dict[str, Any]:
+    """Get GitHub Enterprise integration configuration for Seer."""
+    if not settings.SEER_GHE_ENCRYPT_KEY:
+        logger.error("Cannot encrypt access token without SEER_GHE_ENCRYPT_KEY")
+        return {"success": False, "error": "SEER_GHE_ENCRYPT_KEY not configured"}
+
+    try:
+        # Step 1: Get the integration directly (we're in CONTROL silo)
+        logger.info("Getting integration %s for organization %s", integration_id, organization_id)
+        integration = integration_service.get_integration(
+            integration_id=integration_id,
+            provider=IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
+            organization_id=organization_id,
+            status=ObjectStatus.ACTIVE,
+        )
+        if integration is None:
+            logger.error("Integration %s does not exist for organization %s", integration_id, organization_id)
+            return {"success": False, "error": "Integration not found"}
+
+        logger.info("Successfully retrieved integration %s", integration.id)
+
+        # Step 2: Create the installation
+        try:
+            installation = integration.get_installation(organization_id=organization_id)
+            assert isinstance(installation, GitHubEnterpriseIntegration)
+            logger.info("Successfully created installation for integration %s", integration.id)
+        except Exception as e:
+            logger.exception("Failed to create installation for integration %s: %s", integration.id, e)
+            return {"success": False, "error": f"Failed to create installation: {e}"}
+
+        # Step 3: Get the client
+        try:
+            client = installation.get_client()
+            logger.info("Successfully created client for integration %s", integration.id)
+        except Exception as e:
+            logger.exception("Failed to create client for integration %s: %s", integration.id, e)
+            return {"success": False, "error": f"Failed to create client: {e}"}
+
+        # Step 4: Get access token (this might make external API calls)
+        try:
+            access_token_data = client.get_access_token()
+            if not access_token_data:
+                logger.error("No access token found for integration %s", integration.id)
+                return {"success": False, "error": "No access token found"}
+            logger.info("Successfully retrieved access token for integration %s", integration.id)
+        except Exception as e:
+            logger.exception("Failed to get access token for integration %s: %s", integration.id, e)
+            return {"success": False, "error": f"Failed to get access token: {e}"}
+
+        # Step 5: Encrypt the access token
+        try:
+            fernet = Fernet(settings.SEER_GHE_ENCRYPT_KEY.encode("utf-8"))
+            access_token = access_token_data["access_token"]
+            encrypted_access_token = fernet.encrypt(access_token.encode("utf-8")).decode("utf-8")
+            logger.info("Successfully encrypted access token for integration %s", integration.id)
+        except Exception as e:
+            logger.exception("Failed to encrypt access token for integration %s: %s", integration.id, e)
+            return {"success": False, "error": f"Failed to encrypt access token: {e}"}
+
+        return {
+            "success": True,
+            "base_url": f"https://{installation.model.metadata['domain_name'].split('/')[0]}/api/v3",
+            "verify_ssl": installation.model.metadata["installation"]["verify_ssl"],
+            "encrypted_access_token": encrypted_access_token,
+            "permissions": access_token_data["permissions"],
+        }
+    except Exception as e:
+        logger.exception("Unexpected error getting GitHub Enterprise integration config: %s", e)
+        return {"success": False, "error": f"Unexpected error: {e}"}

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -825,7 +825,7 @@ def get_github_enterprise_integration_config(
 
     try:
         # Get the control silo address
-        control_address = getattr(settings, 'SENTRY_CONTROL_ADDRESS', None)
+        control_address = getattr(settings, "SENTRY_CONTROL_ADDRESS", None)
         if not control_address:
             logger.error("SENTRY_CONTROL_ADDRESS not configured")
             return {"success": False, "error": "SENTRY_CONTROL_ADDRESS not configured"}
@@ -834,16 +834,17 @@ def get_github_enterprise_integration_config(
         url = urljoin(control_address, "/api/0/github-enterprise-config/")
 
         # Prepare the request data
-        data = {
-            "organization_id": organization_id,
-            "integration_id": integration_id
-        }
+        data = {"organization_id": organization_id, "integration_id": integration_id}
 
         # Make the request to the control silo
-        logger.info("Making request to control silo for integration %s, org %s", integration_id, organization_id)
+        logger.info(
+            "Making request to control silo for integration %s, org %s",
+            integration_id,
+            organization_id,
+        )
 
         # Use the same authentication mechanism
-        body = json.dumps(data).encode('utf-8')
+        body = json.dumps(data).encode("utf-8")
         signature = generate_request_signature("/api/0/github-enterprise-config/", body)
 
         headers = {
@@ -855,11 +856,15 @@ def get_github_enterprise_integration_config(
         response.raise_for_status()
 
         result = response.json()
-        logger.info("Successfully got response from control silo for integration %s", integration_id)
+        logger.info(
+            "Successfully got response from control silo for integration %s", integration_id
+        )
         return result
 
     except requests.exceptions.RequestException as e:
-        logger.exception("HTTP error calling control silo for integration %s: %s", integration_id, e)
+        logger.exception(
+            "HTTP error calling control silo for integration %s: %s", integration_id, e
+        )
         return {"success": False, "error": f"HTTP error: {e}"}
     except Exception as e:
         logger.exception("Unexpected error getting GitHub Enterprise integration config: %s", e)


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes a silo boundary violation where the `get_github_enterprise_integration_config` function, called from a REGION silo, attempted to directly access CONTROL-plane `Integration` models.

**Changes:**
1.  Introduced a new `GitHubEnterpriseConfigEndpoint` in the CONTROL silo (`src/sentry/seer/endpoints/github_enterprise_config.py`). This endpoint has direct access to `Integration` models.
2.  Modified the existing `get_github_enterprise_integration_config` function in `src/sentry/seer/endpoints/seer_rpc.py` to make an authenticated HTTP request to this new CONTROL silo endpoint.
3.  Registered the new endpoint in `src/sentry/api/urls.py`.

This approach resolves the `SiloLimit.AvailabilityError` by ensuring that `Integration` model access occurs exclusively within the CONTROL silo, while still allowing the REGION silo to retrieve the necessary configuration via a proper inter-silo HTTP call.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-df9fe6f6-56d1-4300-9690-2e7fcbcd583f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-df9fe6f6-56d1-4300-9690-2e7fcbcd583f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

