### PR TITLE
fix(dashboards): Legends on dashboards cannot be toggled

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -41,6 +41,7 @@ import type {
   EChartEventHandler,
   EChartFinishedHandler,
   EChartHighlightHandler,
+  EChartLegendSelectChangeHandler,
   EChartMouseOutHandler,
   EChartMouseOverHandler,
   EChartRenderedHandler,
@@ -219,11 +220,7 @@ export interface BaseChartProps {
   onDownplay?: EChartDownplayHandler;
   onFinished?: EChartFinishedHandler;
   onHighlight?: EChartHighlightHandler;
-  onLegendSelectChanged?: EChartEventHandler<{
-    name: string;
-    selected: Record<string, boolean>;
-    type: 'legendselectchanged';
-  }>;
+  onLegendSelectChanged?: EChartLegendSelectChangeHandler;
   onMouseOut?: EChartMouseOutHandler;
   onMouseOver?: EChartMouseOverHandler;
   onRendered?: EChartRenderedHandler;

--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -38,7 +38,6 @@ import type {
   EChartClickHandler,
   EChartDataZoomHandler,
   EChartDownplayHandler,
-  EChartEventHandler,
   EChartFinishedHandler,
   EChartHighlightHandler,
   EChartLegendSelectChangeHandler,

--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -67,6 +67,18 @@ export type EChartHighlightHandler = EChartEventHandler<EChartsHighlightEventPar
 
 export type EChartDownplayHandler = EChartEventHandler<EChartsHighlightEventParam>;
 
+/**
+ * Incomplete type for the "legendselectchanged" event handler in ECharts. This is extracted from types we were using in the app at one time.
+ */
+interface EChartsLegendSelectChangeEventParam {
+  name: string;
+  selected: Record<string, boolean>;
+  type: 'legendselectchanged';
+}
+
+export type EChartLegendSelectChangeHandler =
+  EChartEventHandler<EChartsLegendSelectChangeEventParam>;
+
 type EChartMouseEventData = string | number | Record<string, any>;
 /**
  * XXX: These are incomplete types and can also vary depending on the component type

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -159,7 +159,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
       // N.B. Always use `onChartReady` for this, rather than `ref`, since
       // `onChartReady` correctly fires async when the instance becomes
       // available, unlike `ref`!
-      instance.group = props.chartGroup;
+      if (props.chartGroup) instance.group = props.chartGroup;
     },
     [props.chartGroup]
   );

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -7,6 +7,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {
   EChartDataZoomHandler,
   EChartEventHandler,
+  EChartLegendSelectChangeHandler,
   Series,
 } from 'sentry/types/echarts';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
@@ -84,14 +85,9 @@ export function WidgetCardChartContainer({
   onWidgetTableResizeColumn,
   disableTableActions,
 }: Props) {
-  function keepLegendState({
-    selected,
-  }: {
-    selected: Record<string, boolean>;
-    type: 'legendselectchanged';
-  }) {
+  const keepLegendState: EChartLegendSelectChangeHandler = ({selected}) => {
     widgetLegendState.setWidgetSelectionState(selected, widget);
-  }
+  };
 
   function getErrorOrEmptyMessage(
     errorMessage: string | undefined,


### PR DESCRIPTION
Closes DAIN-957. The symptom of the bug is that toggling legends on and off on a dashboard with multiple widgets doesn't work. Legends cannot be toggled, and the URL can be seen to thrash as its gets updated in a loop. The full root cause of this is not clear to me. The bug was introduced in https://github.com/getsentry/sentry/pull/97885, but it actually masked a _previous_ bug!

Roughly speaking, here's what happened on the page when a Dashboard rendered:

- a helper function runs `echarts.connect` on the dashboard group
- charts mount, the `ref` callback fires, and adds a `.group` property to every chart instance
- chart actions are synchronized
- when a legend is toggled on any chart, this causes a re-mount of the chart, which destroys the synchronization

The end result is that legends are working correctly (i.e.,, toggling a series on one chart doesn't toggle the others), but only because the sync is destroyed! The cursors lost sync. Bug! After the PR that "broke things", the situation was different. The timing of the registration changed slightly, and the sync started working correctly.

The fix is annoying but makes sense

1. Use `onChartReady` instead of `ref` to attach `.group` to charts. Especially as of ECharts 6.0, `ref` is _not_ a reliable way to wait for the chart, because the chart _component_ is ready, but the instance might not be. Anything that requires an instance needs to use `onChartReady`. This ensures that sync is working correctly
2. Manually prevent legend events from propagating to other charts. This is exactly the approach we already use for tooltips, I just did the same thing for legends

There are still gaps! One is that charts are remounted oddly too often, we should track that down. Another is that we should probably use `WidgetSyncContext` for this, rather than the helper.

In any case, this PR fixes the current bug, and we can make improvements in the future.
