### PR TITLE
ref(timeseries): Use `/events-timeseries/` on Insights Overview pages

### DIFF
--- a/static/app/views/insights/common/components/widgets/overviewApiLatencyChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewApiLatencyChartWidget.tsx
@@ -2,6 +2,7 @@ import {useMemo} from 'react';
 
 import {openInsightChartModal} from 'sentry/actionCreators/modal';
 import {t} from 'sentry/locale';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
@@ -9,8 +10,6 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
-import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
@@ -29,22 +28,18 @@ export default function OverviewApiLatencyChartWidget(props: LoadableChartWidget
 
   const fullQuery = `span.op:http.server ${query}`.trim();
 
-  const {data, isLoading, error} = useSpanSeries(
+  const {data, isLoading, error} = useFetchSpanTimeSeries(
     {
       ...pageFilterChartParams,
-      search: fullQuery,
+      query: fullQuery,
       yAxis: ['avg(span.duration)', 'p95(span.duration)'],
-      referrer: Referrer.DURATION_CHART,
+      pageFilters: props.pageFilters,
     },
-    Referrer.DURATION_CHART,
-    props.pageFilters
+    Referrer.DURATION_CHART
   );
 
   const plottables = useMemo(() => {
-    return Object.keys(data).map(key => {
-      const series = data[key as keyof typeof data];
-      return new Line(convertSeriesToTimeseries(series));
-    });
+    return data?.timeSeries.map(timeSeries => new Line(timeSeries)) ?? [];
   }, [data]);
 
   const isEmpty = plottables.every(plottable => plottable.isEmpty);

--- a/static/app/views/insights/common/components/widgets/overviewTransactionDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewTransactionDurationChartWidget.tsx
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {Referrer} from 'sentry/views/insights/pages/frontend/referrers';
 import {useFrontendQuery} from 'sentry/views/insights/pages/frontend/useFrontendQuery';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -15,9 +15,9 @@ export default function OverviewTransactionDurationChartWidget(
   search.addFilterValue(SpanFields.IS_TRANSACTION, 'true');
   const referrer = Referrer.TRANSACTION_DURATION_CHART;
 
-  const {data, isLoading, error} = useSpanSeries(
+  const {data, isLoading, error} = useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: ['p50(span.duration)', 'p75(span.duration)', 'p95(span.duration)'],
     },
     referrer
@@ -32,11 +32,7 @@ export default function OverviewTransactionDurationChartWidget(
       height="100%"
       error={error}
       isLoading={isLoading}
-      series={[
-        data['p50(span.duration)'],
-        data['p75(span.duration)'],
-        data['p95(span.duration)'],
-      ]}
+      timeSeries={data?.timeSeries}
     />
   );
 }

--- a/static/app/views/insights/common/components/widgets/overviewTransactionThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewTransactionThroughputChartWidget.tsx
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {Referrer} from 'sentry/views/insights/pages/frontend/referrers';
 import {useFrontendQuery} from 'sentry/views/insights/pages/frontend/useFrontendQuery';
 import {SpanFields, type SpanProperty} from 'sentry/views/insights/types';
@@ -16,9 +16,9 @@ export default function OverviewTransactionThroughputChartWidget(
   const yAxis: SpanProperty = 'epm()';
   const referrer = Referrer.TRANSACTION_THROUGHPUT_CHART;
 
-  const {data, isPending, error} = useSpanSeries(
+  const {data, isPending, error} = useFetchSpanTimeSeries(
     {
-      search,
+      query: search,
       yAxis: [yAxis],
     },
     referrer
@@ -32,7 +32,7 @@ export default function OverviewTransactionThroughputChartWidget(
       height="100%"
       error={error}
       isLoading={isPending}
-      series={[data[yAxis]]}
+      timeSeries={data?.timeSeries}
       queryInfo={{search, referrer}}
     />
   );

--- a/static/app/views/insights/pages/platform/shared/baseTrafficWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/baseTrafficWidget.tsx
@@ -3,6 +3,8 @@ import {useTheme} from '@emotion/react';
 
 import {openInsightChartModal} from 'sentry/actionCreators/modal';
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
@@ -11,8 +13,6 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
-import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
 import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared/getReleaseBubbleProps';
@@ -42,14 +42,14 @@ export function BaseTrafficWidget({
 
   const theme = useTheme();
 
-  const {data, isLoading, error} = useSpanSeries(
+  const {data, isLoading, error} = useFetchSpanTimeSeries(
     {
       ...pageFilterChartParams,
-      search: query,
+      query,
       yAxis: ['trace_status_rate(internal_error)', 'count(span.duration)'],
+      pageFilters: props.pageFilters,
     },
-    referrer,
-    props.pageFilters
+    referrer
   );
 
   const aliases = {
@@ -58,16 +58,25 @@ export function BaseTrafficWidget({
   };
 
   const plottables = useMemo(() => {
+    const timeSeries = data?.timeSeries || [];
+
+    const countSeries = timeSeries.find(ts => ts.yAxis === 'count(span.duration)');
+    const errorRateSeries = timeSeries.find(
+      ts => ts.yAxis === 'trace_status_rate(internal_error)'
+    );
+
     return [
-      new Bars(convertSeriesToTimeseries(data['count(span.duration)']), {
-        alias: trafficSeriesName,
-        color: theme.chart.neutral,
-      }),
-      new Line(convertSeriesToTimeseries(data['trace_status_rate(internal_error)']), {
-        alias: t('Error Rate'),
-        color: theme.error,
-      }),
-    ];
+      countSeries &&
+        new Bars(countSeries, {
+          alias: trafficSeriesName,
+          color: theme.chart.neutral,
+        }),
+      errorRateSeries &&
+        new Line(errorRateSeries, {
+          alias: t('Error Rate'),
+          color: theme.error,
+        }),
+    ].filter(defined);
   }, [data, theme.error, theme.chart.neutral, trafficSeriesName]);
 
   const isEmpty = useMemo(


### PR DESCRIPTION
Continuing to replace usage of `/events-stats/` with `/events-timeseries/` This time, it's some usage on Insights landing pages, wherever we're not making an `groupBy` query. I had to make a few code changes to accommodate the new format, but for the most part things are a bit simpler now, with no need to convert data formats.
