### PR TITLE
chore(checkout v3): First round of feedback

### DIFF
--- a/static/gsApp/views/amCheckout/billingCycleSelectCard.tsx
+++ b/static/gsApp/views/amCheckout/billingCycleSelectCard.tsx
@@ -52,24 +52,21 @@ function BillingCycleSelectCard({
   let cycleInfo: ReactNode;
   if (isPartnerMigration) {
     if (isAnnual) {
-      cycleInfo = t('Billed every 12 months from your selected start date on submission');
+      cycleInfo = t('Billed annually from your selected start date on submission');
     } else {
       cycleInfo = t('Billed monthly starting on your selected start date on submission');
     }
   } else if (isAnnual) {
-    cycleInfo = tct('Billed every 12 months on the [day] of [month]', {
-      day: contractStartDate.format('Do'),
-      month: contractStartDate.format('MMMM'),
-    });
+    cycleInfo = t('Billed annually');
   } else {
-    cycleInfo = tct('Billed monthly starting on [contractStartDate]', {
-      contractStartDate: contractStartDate.format('MMMM DD'),
+    cycleInfo = tct('Billed on the [day] of each month', {
+      day: contractStartDate.format('Do'),
     });
   }
 
   const additionalInfo = isAnnual
-    ? tct("Discount doesn't apply to [budgetTerm] usage", {
-        budgetTerm: plan.budgetTerm,
+    ? tct('[budgetTerm] usage billed monthly, discount does not apply', {
+        budgetTerm: plan.budgetTerm === 'pay-as-you-go' ? 'PAYG' : plan.budgetTerm,
       })
     : t('Cancel anytime');
 

--- a/static/gsApp/views/amCheckout/cart.spec.tsx
+++ b/static/gsApp/views/amCheckout/cart.spec.tsx
@@ -146,7 +146,7 @@ describe('Cart', () => {
 
     // PAYG-only categories are also shown for paid plans
     expect(planItem).toHaveTextContent('Continuous profile hours');
-    expect(planItem).toHaveTextContent('Available with pay-as-you-go');
+    expect(planItem).toHaveTextContent('Available with PAYG');
 
     const seerItem = screen.getByTestId('summary-item-product-seer');
     expect(seerItem).toHaveTextContent('Seer');
@@ -413,7 +413,7 @@ describe('Cart', () => {
     expect(reservedChanges).toHaveTextContent('Reserved volume');
 
     const sharedSpendCapChanges = within(changes).getByTestId('shared-spend-limit-diff');
-    expect(sharedSpendCapChanges).toHaveTextContent('Shared spend limit');
+    expect(sharedSpendCapChanges).toHaveTextContent('PAYG spend limit');
   });
 
   it('can toggle changes and plan summary', async () => {

--- a/static/gsApp/views/amCheckout/cart.tsx
+++ b/static/gsApp/views/amCheckout/cart.tsx
@@ -203,20 +203,6 @@ function ItemsSummary({activePlan, formData}: ItemsSummaryProps) {
                     </div>
                   ) : (
                     isPaygOnly &&
-                    // <Tag
-                    //   icon={
-                    //     hasPaygForCategory ? undefined : <IconLock locked size="xs" />
-                    //   }
-                    // >
-                    //   {hasPaygForCategory
-                    //     ? tct('Available with [budgetTerm]', {
-                    //         budgetTerm:
-                    //           activePlan.budgetTerm === 'pay-as-you-go'
-                    //             ? t('PAYG')
-                    //             : activePlan.budgetTerm,
-                    //       })
-                    //     : t('Product not available')}
-                    // </Tag>
                     (hasPaygForCategory ? (
                       <Tag>
                         {tct('Available with [budgetTerm]', {

--- a/static/gsApp/views/amCheckout/cart.tsx
+++ b/static/gsApp/views/amCheckout/cart.tsx
@@ -8,6 +8,7 @@ import {Tag} from 'sentry/components/core/badge/tag';
 import {Button} from 'sentry/components/core/button';
 import {Container, Flex} from 'sentry/components/core/layout';
 import {Heading, Text} from 'sentry/components/core/text';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import Placeholder from 'sentry/components/placeholder';
 import {IconChevron, IconLightning, IconLock, IconSentry} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -175,6 +176,10 @@ function ItemsSummary({activePlan, formData}: ItemsSummaryProps) {
                 cents: price,
               });
               const formattedReserved = formatReservedWithUnits(reserved, category);
+              const hasPaygForCategory =
+                formData.onDemandBudget?.budgetMode === OnDemandBudgetMode.PER_CATEGORY
+                  ? (formData.onDemandBudget?.budgets?.[category] ?? 0) > 0
+                  : (formData.onDemandBudget?.sharedMaxBudget ?? 0) > 0;
 
               return (
                 <ItemFlex key={category}>
@@ -197,13 +202,39 @@ function ItemsSummary({activePlan, formData}: ItemsSummaryProps) {
                       {formattedPrice}/{shortInterval}
                     </div>
                   ) : (
-                    isPaygOnly && (
+                    isPaygOnly &&
+                    // <Tag
+                    //   icon={
+                    //     hasPaygForCategory ? undefined : <IconLock locked size="xs" />
+                    //   }
+                    // >
+                    //   {hasPaygForCategory
+                    //     ? tct('Available with [budgetTerm]', {
+                    //         budgetTerm:
+                    //           activePlan.budgetTerm === 'pay-as-you-go'
+                    //             ? t('PAYG')
+                    //             : activePlan.budgetTerm,
+                    //       })
+                    //     : t('Product not available')}
+                    // </Tag>
+                    (hasPaygForCategory ? (
                       <Tag>
                         {tct('Available with [budgetTerm]', {
-                          budgetTerm: activePlan.budgetTerm,
+                          budgetTerm:
+                            activePlan.budgetTerm === 'pay-as-you-go'
+                              ? t('PAYG')
+                              : activePlan.budgetTerm,
                         })}
                       </Tag>
-                    )
+                    ) : (
+                      <Tooltip
+                        title={t('This product is only available with a PAYG budget.')}
+                      >
+                        <Tag icon={<IconLock locked size="xs" />}>
+                          {t('Product not available')}
+                        </Tag>
+                      </Tooltip>
+                    ))
                   )}
                 </ItemFlex>
               );
@@ -290,6 +321,29 @@ function SubtotalSummary({
   return (
     <Container borderTop="primary">
       <Flex direction="column" padding="2xl xl" gap="md">
+        <Item data-test-id="summary-item-plan-total">
+          <ItemFlex>
+            <strong>{t('Plan Total')}</strong>
+            {previewDataLoading ? (
+              <Placeholder height="16px" width={PRICE_PLACEHOLDER_WIDTH} />
+            ) : (
+              <span>
+                {utils.displayPrice({cents: recurringSubtotal})}/{shortInterval}
+              </span>
+            )}
+          </ItemFlex>
+          {previewDataLoading ? (
+            <Placeholder height="14px" width="200px" />
+          ) : (
+            renewalDate && (
+              <RenewalDate>
+                {tct('Renews [date]', {
+                  date: moment(renewalDate).format('MMM D, YYYY'),
+                })}
+              </RenewalDate>
+            )
+          )}
+        </Item>
         {formData.onDemandBudget?.budgetMode === OnDemandBudgetMode.SHARED &&
           !!formData.onDemandMaxSpend && (
             <Item data-test-id="summary-item-spend-limit">
@@ -359,29 +413,6 @@ function SubtotalSummary({
                 </Item>
               );
             })}
-        <Item data-test-id="summary-item-plan-total">
-          <ItemFlex>
-            <strong>{t('Plan Total')}</strong>
-            {previewDataLoading ? (
-              <Placeholder height="16px" width={PRICE_PLACEHOLDER_WIDTH} />
-            ) : (
-              <span>
-                {utils.displayPrice({cents: recurringSubtotal})}/{shortInterval}
-              </span>
-            )}
-          </ItemFlex>
-          {previewDataLoading ? (
-            <Placeholder height="14px" width="200px" />
-          ) : (
-            renewalDate && (
-              <RenewalDate>
-                {tct('Renews [date]', {
-                  date: moment(renewalDate).format('MMM D, YYYY'),
-                })}
-              </RenewalDate>
-            )
-          )}
-        </Item>
       </Flex>
     </Container>
   );
@@ -865,8 +896,9 @@ const Credit = styled('div')`
 
 const StyledButton = styled(Button)`
   display: flex;
-  gap: ${p => p.theme.space.xl};
   flex-grow: 1;
+  align-items: center;
+  justify-content: center;
 `;
 
 const Subtext = styled('div')`

--- a/static/gsApp/views/amCheckout/index.spec.tsx
+++ b/static/gsApp/views/amCheckout/index.spec.tsx
@@ -31,7 +31,7 @@ function assertCheckoutV3Steps(tier: PlanTier) {
     [PlanTier.AM1, PlanTier.AM2].includes(tier)
       ? /Set your on-demand limit/
       : /Set your pay-as-you-go limit/,
-    'Choose your billing cycle',
+    'Pay monthly or yearly, your choice',
     'Edit billing information',
   ].forEach(step => {
     expect(screen.getByText(step)).toBeInTheDocument();

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -922,11 +922,21 @@ class AMCheckout extends Component<Props, State> {
             <SupportPrompt>
               {t('Have a question?')}
               <TextOverflow>
-                {tct('[help:Find an Answer] or [contact:Ask Support]', {
+                {tct('[help:Find an answer] or [contact]', {
                   help: (
                     <ExternalLink href="https://sentry.zendesk.com/hc/en-us/categories/17135853065755-Account-Billing" />
                   ),
-                  contact: <ZendeskLink subject="Billing Question" source="checkout" />,
+                  contact: (
+                    <ZendeskLink
+                      subject="Billing Question"
+                      source="checkout"
+                      Component={({href, onClick}) => (
+                        <LinkButton href={href ?? ''} onClick={onClick}>
+                          {t('ask Support')}
+                        </LinkButton>
+                      )}
+                    />
+                  ),
                 })}
               </TextOverflow>
             </SupportPrompt>

--- a/static/gsApp/views/amCheckout/planFeatures.tsx
+++ b/static/gsApp/views/amCheckout/planFeatures.tsx
@@ -24,14 +24,14 @@ const FEATURES: Array<{features: string[]; plan: string}> = [
     plan: 'developer',
     features: [
       t('1 user'),
-      t('5k Errors'),
-      t('5GB of Logs'),
-      t('5M Spans'),
-      t('50 Replays'),
+      t('5K errors'),
+      t('5GB of logs'),
+      t('5M spans'),
+      t('50 replays'),
       t('10 custom dashboards'),
-      t('1 Cron Monitor'),
-      t('1 Uptime Monitor'),
-      t('1GB of Attachments'),
+      t('1 cron monitor'),
+      t('1 uptime monitor'),
+      t('1GB of attachments'),
       t('20 metric alerts'),
     ],
   },
@@ -39,7 +39,7 @@ const FEATURES: Array<{features: string[]; plan: string}> = [
     plan: 'team',
     features: [
       t('Unlimited users'),
-      t('50K Errors'),
+      t('50K errors'),
       t('Access to UI and Continuous Profiling'),
       t('Can add event volume to subscription'),
       t('Third-party integrations'),
@@ -87,16 +87,27 @@ function PlanFeatures({
 }) {
   const planToFeatures: PlanFeatureInfo[] = [];
   let activePlanIndex = 0;
-  planOptions.forEach((planOption, index) => {
+  // XXX(isabella): this is a hacky way to show the free features
+  // without free plan being surfaced in the UI
+  // (will be removed when free is surfaced)
+  const planOptionsWithFree = [
+    {
+      ...planOptions[0],
+      name: 'Developer',
+    } as Plan,
+    ...planOptions,
+  ];
+
+  planOptionsWithFree.forEach((planOption, index) => {
     const planName = planOption.name.toLowerCase();
-    const priorPlan = index > 0 ? planOptions[index - 1] : null;
+    const priorPlan = index > 0 ? planOptionsWithFree[index - 1] : null;
     const featureList = FEATURES.filter(({plan}) => planName.includes(plan)).flatMap(
       ({features}) => features
     );
     const perUnitPriceDiffs =
       !priorPlan || priorPlan?.basePrice === 0
         ? {}
-        : Object.entries(planOption.planCategories).reduce(
+        : Object.entries(planOption.planCategories ?? {}).reduce(
             (acc, [category, eventBuckets]) => {
               const priorPlanEventBuckets =
                 priorPlan?.planCategories[category as DataCategory];
@@ -130,7 +141,10 @@ function PlanFeatures({
           planName: <Text underline>{activePlan.name}</Text>,
         })}
       </Heading>
-      <Grid columns={{xs: '1fr', sm: `repeat(${planOptions.length}, 1fr)`}} gap="md xl">
+      <Grid
+        columns={{xs: '1fr', sm: `repeat(${planOptionsWithFree.length}, 1fr)`}}
+        gap="md xl"
+      >
         {planToFeatures.map(({plan, features, perUnitPriceDiffs}, index) => {
           const planName = plan.name;
           const lowerCasePlanName = planName.toLowerCase();
@@ -147,7 +161,7 @@ function PlanFeatures({
                 <FeatureItem key={feature} feature={feature} isIncluded={isIncluded} />
               ))}
               {Object.keys(perUnitPriceDiffs).length > 0 && (
-                <EventPriceWarning align="center" gap="sm">
+                <EventPriceWarning isIncluded={isIncluded} align="center" gap="sm">
                   <IconWarning size="sm" color="yellow300" />
                   <Tooltip
                     title={tct('Starting at [priceDiffs].', {
@@ -188,7 +202,8 @@ function PlanFeatures({
 
 export default PlanFeatures;
 
-const EventPriceWarning = styled(Flex)`
+const EventPriceWarning = styled(Flex)<{isIncluded: boolean}>`
+  opacity: ${p => (p.isIncluded ? 1 : 0.5)};
   > span {
     text-decoration: underline dotted;
     text-decoration-color: ${p => p.theme.subText};

--- a/static/gsApp/views/amCheckout/planFeatures.tsx
+++ b/static/gsApp/views/amCheckout/planFeatures.tsx
@@ -90,13 +90,16 @@ function PlanFeatures({
   // XXX(isabella): this is a hacky way to show the free features
   // without free plan being surfaced in the UI
   // (will be removed when free is surfaced)
-  const planOptionsWithFree = [
-    {
-      ...planOptions[0],
-      name: 'Developer',
-    } as Plan,
-    ...planOptions,
-  ];
+  const planOptionsWithFree =
+    planOptions.length >= 3
+      ? planOptions
+      : [
+          {
+            ...planOptions[0],
+            name: 'Developer',
+          } as Plan,
+          ...planOptions,
+        ];
 
   planOptionsWithFree.forEach((planOption, index) => {
     const planName = planOption.name.toLowerCase();

--- a/static/gsApp/views/amCheckout/planFeatures.tsx
+++ b/static/gsApp/views/amCheckout/planFeatures.tsx
@@ -167,7 +167,7 @@ function PlanFeatures({
                 <EventPriceWarning isIncluded={isIncluded} align="center" gap="sm">
                   <IconWarning size="sm" color="yellow300" />
                   <Tooltip
-                    title={tct('Starting at [priceDiffs].', {
+                    title={tct('Starting at [priceDiffs] on [planName].', {
                       priceDiffs: oxfordizeArray(
                         Object.entries(perUnitPriceDiffs).map(([category, diff]) => {
                           const formattedDiff = displayUnitPrice({cents: diff});
@@ -179,6 +179,7 @@ function PlanFeatures({
                           return `+${formattedDiff} / ${formattedCategory}`;
                         })
                       ),
+                      planName,
                     })}
                   >
                     {/* TODO(checkout v3): verify tooltip copy */}

--- a/static/gsApp/views/amCheckout/reserveAdditionalVolume.tsx
+++ b/static/gsApp/views/amCheckout/reserveAdditionalVolume.tsx
@@ -73,7 +73,7 @@ function ReserveAdditionalVolume({
   );
 
   return (
-    <Flex direction="column" gap="xl">
+    <Flex direction="column" gap="md">
       <Flex gap="md" align="center" justify="between" width="100%" height="28px">
         <Flex align="center" gap="md">
           <Button
@@ -104,19 +104,24 @@ function ReserveAdditionalVolume({
         )}
       </Flex>
       {showSliders && (
-        <Flex direction="column" gap="md">
-          <Separator orientation="horizontal" border="primary" />
-          <VolumeSliders
-            checkoutTier={checkoutTier}
-            activePlan={activePlan}
-            organization={organization}
-            onUpdate={onUpdate}
-            formData={formData}
-            subscription={subscription}
-            isLegacy={isLegacy}
-            isNewCheckout
-            onReservedChange={debouncedReservedChange}
-          />
+        <Flex direction="column" gap="xl">
+          <Text variant="muted">
+            {t('Prepay for usage by reserving volumes and save up to 20%')}
+          </Text>
+          <Flex direction="column" gap="md">
+            <Separator orientation="horizontal" border="primary" />
+            <VolumeSliders
+              checkoutTier={checkoutTier}
+              activePlan={activePlan}
+              organization={organization}
+              onUpdate={onUpdate}
+              formData={formData}
+              subscription={subscription}
+              isLegacy={isLegacy}
+              isNewCheckout
+              onReservedChange={debouncedReservedChange}
+            />
+          </Flex>
         </Flex>
       )}
     </Flex>

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/buildYourPlan.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
-import cloneDeep from 'lodash/cloneDeep';
 import moment from 'moment-timezone';
 
 import {Tag} from 'sentry/components/core/badge/tag';
@@ -18,7 +17,6 @@ import {
   isTrialPlan,
 } from 'getsentry/utils/billing';
 import PlanFeatures from 'getsentry/views/amCheckout/planFeatures';
-import {getHighlightedFeatures} from 'getsentry/views/amCheckout/steps/planSelect';
 import PlanSelectCard from 'getsentry/views/amCheckout/steps/planSelectCard';
 import ProductSelect from 'getsentry/views/amCheckout/steps/productSelect';
 import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
@@ -39,7 +37,6 @@ interface PlanSubstepProps extends BaseSubstepProps {
   organization: Organization;
   subscription: Subscription;
   checkoutTier?: PlanTier;
-  referrer?: string;
 }
 
 interface AdditionalProductsSubstepProps extends BaseSubstepProps {}
@@ -50,7 +47,6 @@ function PlanSubstep({
   formData,
   subscription,
   organization,
-  referrer,
   onUpdate,
 }: PlanSubstepProps) {
   const planOptions = useMemo(() => {
@@ -106,17 +102,7 @@ function PlanSubstep({
           );
           const basePrice = utils.formatPrice({cents: plan.basePrice}); // TODO(isabella): confirm discountInfo is no longer used
 
-          let planContent = utils.getContentForPlan(plan);
-          const highlightedFeatures = getHighlightedFeatures(referrer);
-
-          // Additional members is available on any paid plan
-          // but it's so impactful it doesn't hurt to add it in for the business plan
-          // if the user is coming from a deactivated member header CTA
-          if (isBizPlanFamily(plan) && referrer === 'deactivated_member_header') {
-            highlightedFeatures.push('deactivated_member_header');
-            planContent = cloneDeep(planContent);
-            planContent.features.deactivated_member_header = t('Unlimited members');
-          }
+          const planContent = utils.getContentForPlan(plan, true);
 
           const planIcon = getPlanIcon(plan);
           const badge = getBadge(plan);
@@ -131,7 +117,6 @@ function PlanSubstep({
               planName={plan.name}
               price={basePrice}
               planContent={planContent}
-              highlightedFeatures={highlightedFeatures}
               planIcon={planIcon}
               shouldShowDefaultPayAsYouGo={shouldShowDefaultPayAsYouGo}
               badge={badge}
@@ -170,7 +155,6 @@ function BuildYourPlan({
   organization,
   subscription,
   formData,
-  referrer,
   onEdit,
   onUpdate,
   stepNumber,
@@ -198,7 +182,6 @@ function BuildYourPlan({
             formData={formData}
             onUpdate={onUpdate}
             organization={organization}
-            referrer={referrer}
             subscription={subscription}
             checkoutTier={checkoutTier}
           />

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/chooseYourBillingCycle.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/chooseYourBillingCycle.spec.tsx
@@ -88,7 +88,7 @@ describe('ChooseYourBillingCycle', () => {
     expect(within(yearlyOption).getByText('save 10%')).toBeInTheDocument();
     expect(within(yearlyOption).getByText(yearlyInfo)).toBeInTheDocument();
     expect(
-      within(yearlyOption).getByText("Discount doesn't apply to pay-as-you-go usage")
+      within(yearlyOption).getByText('PAYG usage billed monthly, discount does not apply')
     ).toBeInTheDocument();
   }
 
@@ -118,8 +118,8 @@ describe('ChooseYourBillingCycle', () => {
   it('renders for coterm upgrade', async () => {
     renderCheckout(true);
     await assertCycleText({
-      monthlyInfo: /Billed monthly starting on August 13/,
-      yearlyInfo: /Billed every 12 months on the 13th of August/,
+      monthlyInfo: /Billed on the 13th of each month/,
+      yearlyInfo: /Billed annually/,
     });
   });
 
@@ -133,8 +133,8 @@ describe('ChooseYourBillingCycle', () => {
     SubscriptionStore.set(organization.slug, annualSub);
     renderCheckout(true);
     await assertCycleText({
-      monthlyInfo: /Billed monthly starting on July 16/,
-      yearlyInfo: /Billed every 12 months on the 13th of August/, // annual can be applied immediately
+      monthlyInfo: /Billed on the 16th of each month/,
+      yearlyInfo: /Billed annually/,
     });
   });
 
@@ -158,7 +158,7 @@ describe('ChooseYourBillingCycle', () => {
     renderCheckout(true);
     await assertCycleText({
       monthlyInfo: /Billed monthly starting on your selected start date on submission/,
-      yearlyInfo: /Billed every 12 months from your selected start date on submission/,
+      yearlyInfo: /Billed annually from your selected start date on submission/,
     });
   });
 

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/chooseYourBillingCycle.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/chooseYourBillingCycle.spec.tsx
@@ -73,7 +73,9 @@ describe('ChooseYourBillingCycle', () => {
     monthlyInfo: string | RegExp;
     yearlyInfo: string | RegExp;
   }) {
-    expect(await screen.findByText('Choose your billing cycle')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Pay monthly or yearly, your choice')
+    ).toBeInTheDocument();
 
     const monthlyOption = screen.getByTestId('billing-cycle-option-monthly');
     expect(within(monthlyOption).getByText('Monthly')).toBeInTheDocument();

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/chooseYourBillingCycle.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/chooseYourBillingCycle.tsx
@@ -1,7 +1,6 @@
 import {useMemo, useState} from 'react';
 
 import {Flex, Grid} from 'sentry/components/core/layout';
-import {Text} from 'sentry/components/core/text';
 import {t} from 'sentry/locale';
 
 import {ANNUAL} from 'getsentry/constants';
@@ -32,7 +31,7 @@ function ChooseYourBillingCycle({
 
   let previousPlanPrice = 0;
   return (
-    <Flex direction="column" gap="sm">
+    <Flex direction="column" gap="xl">
       <StepHeader
         isActive
         isCompleted={false}
@@ -40,51 +39,46 @@ function ChooseYourBillingCycle({
         onToggleStep={setIsOpen}
         isOpen={isOpen}
         stepNumber={stepNumber}
-        title={t('Choose your billing cycle')}
+        title={t('Pay monthly or yearly, your choice')}
         isNewCheckout
       />
       {isOpen && (
-        <Flex direction="column" gap="xl">
-          <Text as="div" variant="muted">
-            {t('Additional usage is billed separately, at the start of the next cycle')}
-          </Text>
-          <Grid
-            columns={{xs: '1fr', md: `repeat(${intervalOptions.length}, 1fr)`}}
-            gap="xl"
-          >
-            {intervalOptions.map(plan => {
-              const isSelected = plan.id === formData.plan;
-              const isAnnual = plan.contractInterval === ANNUAL;
-              const priceAfterDiscount = utils.getReservedPriceCents({
-                plan,
-                reserved: formData.reserved,
-                selectedProducts: formData.selectedProducts,
-              });
-              const formattedPriceAfterDiscount = utils.formatPrice({
-                cents: priceAfterDiscount,
-              });
+        <Grid
+          columns={{xs: '1fr', md: `repeat(${intervalOptions.length}, 1fr)`}}
+          gap="xl"
+        >
+          {intervalOptions.map(plan => {
+            const isSelected = plan.id === formData.plan;
+            const isAnnual = plan.contractInterval === ANNUAL;
+            const priceAfterDiscount = utils.getReservedPriceCents({
+              plan,
+              reserved: formData.reserved,
+              selectedProducts: formData.selectedProducts,
+            });
+            const formattedPriceAfterDiscount = utils.formatPrice({
+              cents: priceAfterDiscount,
+            });
 
-              const priceBeforeDiscount = isAnnual ? previousPlanPrice * 12 : 0;
-              const formattedPriceBeforeDiscount = previousPlanPrice
-                ? utils.formatPrice({cents: priceBeforeDiscount})
-                : '';
-              previousPlanPrice = priceAfterDiscount;
+            const priceBeforeDiscount = isAnnual ? previousPlanPrice * 12 : 0;
+            const formattedPriceBeforeDiscount = previousPlanPrice
+              ? utils.formatPrice({cents: priceBeforeDiscount})
+              : '';
+            previousPlanPrice = priceAfterDiscount;
 
-              return (
-                <BillingCycleSelectCard
-                  key={plan.id}
-                  plan={plan}
-                  isSelected={isSelected}
-                  onUpdate={onUpdate}
-                  subscription={subscription}
-                  formattedPriceAfterDiscount={formattedPriceAfterDiscount}
-                  formattedPriceBeforeDiscount={formattedPriceBeforeDiscount}
-                  priceAfterDiscount={priceAfterDiscount}
-                />
-              );
-            })}
-          </Grid>
-        </Flex>
+            return (
+              <BillingCycleSelectCard
+                key={plan.id}
+                plan={plan}
+                isSelected={isSelected}
+                onUpdate={onUpdate}
+                subscription={subscription}
+                formattedPriceAfterDiscount={formattedPriceAfterDiscount}
+                formattedPriceBeforeDiscount={formattedPriceBeforeDiscount}
+                priceAfterDiscount={priceAfterDiscount}
+              />
+            );
+          })}
+        </Grid>
       )}
     </Flex>
   );

--- a/static/gsApp/views/amCheckout/steps/planSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelect.tsx
@@ -51,7 +51,7 @@ const REFERRER_FEATURE_HIGHLIGHTS = {
   'upsell-discover2': ['discover'],
 };
 
-export function getHighlightedFeatures(referrer?: string): string[] {
+function getHighlightedFeatures(referrer?: string): string[] {
   return referrer
     ? (REFERRER_FEATURE_HIGHLIGHTS[
         referrer as keyof typeof REFERRER_FEATURE_HIGHLIGHTS

--- a/static/gsApp/views/amCheckout/steps/planSelectCard.tsx
+++ b/static/gsApp/views/amCheckout/steps/planSelectCard.tsx
@@ -21,6 +21,7 @@ interface PlanSelectCardProps
     | 'planWarning'
     | 'priceHeader'
     | 'shouldShowEventPrice'
+    | 'highlightedFeatures'
   > {
   /**
    * Icon to use for the plan

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -867,12 +867,12 @@ export function getToggleTier(checkoutTier: PlanTier | undefined) {
   return SUPPORTED_TIERS[tierIndex + 1];
 }
 
-export function getContentForPlan(plan: Plan): PlanContent {
+export function getContentForPlan(plan: Plan, isNewCheckout?: boolean): PlanContent {
   if (isBizPlanFamily(plan)) {
     return {
-      description: t(
-        'Everything in the Team plan + deeper insight into your application health.'
-      ),
+      description: isNewCheckout
+        ? t('For teams that need more powerful debugging')
+        : t('Everything in the Team plan + deeper insight into your application health.'),
       features: {
         discover: t('Advanced analytics with Discover'),
         enhanced_priority_alerts: t('Enhanced issue priority and alerting'),
@@ -889,7 +889,9 @@ export function getContentForPlan(plan: Plan): PlanContent {
 
   if (isTeamPlanFamily(plan)) {
     return {
-      description: t('Resolve errors and track application performance as a team.'),
+      description: isNewCheckout
+        ? t('Everything to monitor your application as it scales')
+        : t('Resolve errors and track application performance as a team.'),
       features: {
         unlimited_members: t('Unlimited members'),
         integrations: t('Third-party integrations'),

--- a/static/gsApp/views/spendLimits/spendLimitSettings.tsx
+++ b/static/gsApp/views/spendLimits/spendLimitSettings.tsx
@@ -185,7 +185,7 @@ function SharedSpendLimitPriceTable({
       radius="md"
       padding="lg xl"
     >
-      <Grid gap="sm" columns={{xs: '1fr', md: 'repeat(2, 1fr)'}}>
+      <Grid gap="lg" columns={{xs: '1fr', md: 'repeat(2, 1fr)'}}>
         {baseCategories.map(category => {
           const categoryInfo = getCategoryInfoFromPlural(category);
           const reserved = currentReserved[category] ?? 0;


### PR DESCRIPTION
Based off https://www.notion.so/sentry/Checkout-Improvements-18f8b10e4b5d80288f95fb37e9547392?source=copy_link#2708b10e4b5d808caa26e926c046cfee

Changes:
- Updated plan descriptions
- Fixed casing in features list
- Added Developer features to feature list regardless of available plan options
- Updated copy for excess usage price warning
- Greyed out excess usage price warning when Business is not selected
- Shortened pay-as-you-go to PAYG in some places
- "Locked" PAYG-only categories in cart if PAYG is set to $0
- Moved billing cycle changes to bottom of plan changes in cart diff
- Moved PAYG limit to be after Plan Total in cart
- Some UI1 styling fixes
- Increased spacing between columns in PAYG categories table
- Added description to `Reserve additional volume` substep
- Updated billing cycle step title, removed step description, and updated choice descriptions 
- Fixed casing on `Find an answer or ask Support` footer
- Changed `ask Support` link to open Zendesk widget instead of mail app