### PR TITLE
fix(aci): Switch from chart ref to onChartReady

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
+import {mergeProps} from '@react-aria/utils';
 import type {YAXisComponentOption} from 'echarts';
 
 import {AreaChart} from 'sentry/components/charts/areaChart';
@@ -211,7 +212,6 @@ function MetricDetectorChart({
       yAxis={yAxes.length === 1 ? yAxes[0] : undefined}
       grid={grid}
       xAxis={openPeriodMarkerResult.incidentMarkerXAxis}
-      ref={openPeriodMarkerResult.connectIncidentMarkerChartRef}
       tooltip={{
         valueFormatter: getDetectorChartFormatters({
           detectionType,
@@ -219,6 +219,10 @@ function MetricDetectorChart({
         }).formatTooltipValue,
       }}
       {...chartZoomProps}
+      onChartReady={chart => {
+        chartZoomProps.onChartReady(chart);
+        openPeriodMarkerResult.onChartReady(chart);
+      }}
     />
   );
 }

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -1,6 +1,5 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
-import {mergeProps} from '@react-aria/utils';
 import type {YAXisComponentOption} from 'echarts';
 
 import {AreaChart} from 'sentry/components/charts/areaChart';

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -289,11 +289,7 @@ export function MetricDetectorChart({
           yAxis={yAxes.length === 1 ? yAxes[0] : undefined}
           grid={grid}
           xAxis={isAnomalyDetection ? anomalyMarkerResult.incidentMarkerXAxis : undefined}
-          ref={
-            isAnomalyDetection
-              ? anomalyMarkerResult.connectIncidentMarkerChartRef
-              : undefined
-          }
+          onChartReady={isAnomalyDetection ? anomalyMarkerResult.onChartReady : undefined}
           tooltip={{
             valueFormatter: getDetectorChartFormatters({detectionType, aggregate})
               .formatTooltipValue,

--- a/static/app/views/detectors/hooks/useIncidentMarkers.tsx
+++ b/static/app/views/detectors/hooks/useIncidentMarkers.tsx
@@ -16,9 +16,10 @@ import type {
 import MarkLine from 'sentry/components/charts/components/markLine';
 import {t} from 'sentry/locale';
 import type {
+  EChartChartReadyHandler,
   EChartMouseOutHandler,
   EChartMouseOverHandler,
-  ReactEchartsRef,
+  ECharts,
 } from 'sentry/types/echarts';
 import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 
@@ -224,7 +225,6 @@ interface UseIncidentMarkersProps {
 }
 
 interface UseIncidentMarkersResult {
-  connectIncidentMarkerChartRef: (ref: ReactEchartsRef | null) => void;
   incidentMarkerGrid: GridComponentOption;
   incidentMarkerSeries: CustomSeriesOption | null;
   incidentMarkerXAxis: {
@@ -232,6 +232,7 @@ interface UseIncidentMarkersResult {
     offset: number;
   };
   incidentMarkerYAxis: YAXisComponentOption | null;
+  onChartReady: EChartChartReadyHandler;
 }
 
 /**
@@ -244,7 +245,7 @@ export function useIncidentMarkers({
   seriesId = INCIDENT_MARKER_SERIES_ID,
 }: UseIncidentMarkersProps): UseIncidentMarkersResult {
   const theme = useTheme();
-  const chartRef = useRef<ReactEchartsRef | null>(null);
+  const chartRef = useRef<ECharts | null>(null);
 
   const incidentPeriods = useMemo(() => incidents || [], [incidents]);
 
@@ -302,11 +303,9 @@ export function useIncidentMarkers({
   }, [incidentPeriods.length, totalMarkerPaddingY]);
 
   // Chart ref handler
-  const connectIncidentMarkerChartRef = useCallback(
-    (ref: ReactEchartsRef | null) => {
-      chartRef.current = ref;
-
-      const echartsInstance = ref?.getEchartsInstance?.();
+  const onChartReady = useCallback<EChartChartReadyHandler>(
+    echartsInstance => {
+      chartRef.current = echartsInstance;
 
       const handleMouseOver = (params: Parameters<EChartMouseOverHandler>[0]) => {
         if (params.seriesId !== seriesId || !echartsInstance) {
@@ -391,7 +390,7 @@ export function useIncidentMarkers({
   }, [incidentPeriods, theme, yAxisIndex, seriesName, seriesId]);
 
   return {
-    connectIncidentMarkerChartRef,
+    onChartReady,
     incidentMarkerSeries,
     incidentMarkerYAxis,
     incidentMarkerGrid,


### PR DESCRIPTION
Uses onChartReady instead of the chart ref since the echarts instance can be created after the ref which would skip the binding of listeners.