### PR TITLE
ref(replay): temporary qparam patch for has_viewed

### DIFF
--- a/static/app/utils/replays/hooks/useReplayListQueryKey.tsx
+++ b/static/app/utils/replays/hooks/useReplayListQueryKey.tsx
@@ -40,7 +40,9 @@ export default function useReplayListQueryKey({
 
     // HACK!!! Because the sort field needs to be in the eventView, but I cannot
     // ask the server for compound fields like `os.name`.
-    const splitFields = REPLAY_LIST_FIELDS.map(field => field.split('.')[0]);
+    const splitFields = REPLAY_LIST_FIELDS.map(field => field.split('.')[0]).filter(
+      field => field !== 'has_viewed'
+    );
     const fields = uniq(splitFields);
 
     // when queryReferrer === 'issueReplays' we override the global view check on the backend
@@ -62,6 +64,7 @@ export default function useReplayListQueryKey({
           per_page: 50,
           ...query,
           fields,
+          field: ['has_viewed'],
           project,
           queryReferrer,
         },


### PR DESCRIPTION
Relates to https://linear.app/getsentry/issue/REPLAY-721/bug-replay-index-unread-dot-not-clearing-after-viewing-replay-session

tested in dev-ui