### PR TITLE
fix(insights): Fix insights overview pages erroring or displaying no data when user has no team projects

### DIFF
--- a/static/app/views/insights/agents/views/overview.tsx
+++ b/static/app/views/insights/agents/views/overview.tsx
@@ -52,6 +52,7 @@ import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import OverviewAgentsDurationChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsDurationChartWidget';
 import OverviewAgentsRunsChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsRunsChartWidget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useDefaultToAllProjects} from 'sentry/views/insights/common/utils/useDefaultToAllProjects';
 import {AgentsPageHeader} from 'sentry/views/insights/pages/agents/agentsPageHeader';
 import {getAIModuleTitle} from 'sentry/views/insights/pages/agents/settings';
 import {ModuleName} from 'sentry/views/insights/types';
@@ -75,6 +76,7 @@ function AgentsOverviewPage() {
   const showOnboarding = useShowOnboarding();
   const datePageFilterProps = limitMaxPickableDays(organization);
   const [searchQuery, setSearchQuery] = useLocationSyncedState('query', decodeScalar);
+  useDefaultToAllProjects();
 
   const {activeTable, onActiveTableChange} = useActiveTable();
 

--- a/static/app/views/insights/common/utils/useDefaultToAllProjects.spec.tsx
+++ b/static/app/views/insights/common/utils/useDefaultToAllProjects.spec.tsx
@@ -1,0 +1,66 @@
+import {PageFiltersFixture, PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {updateProjects} from 'sentry/actionCreators/pageFilters';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {useDefaultToAllProjects} from 'sentry/views/insights/common/utils/useDefaultToAllProjects';
+
+jest.mock('sentry/utils/usePageFilters');
+jest.mock('sentry/actionCreators/pageFilters');
+
+const pageFilterSelection = PageFiltersFixture({
+  projects: [],
+  datetime: {
+    period: '14d',
+    start: null,
+    end: null,
+    utc: false,
+  },
+});
+
+describe('useDefaultToAllProjects', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    ProjectsStore.reset();
+  });
+  it('should default to all projects when no projects are selected and user has no team projects', () => {
+    jest.mocked(usePageFilters).mockReturnValue(
+      PageFilterStateFixture({
+        selection: pageFilterSelection,
+      })
+    );
+    const nonMemberProject = ProjectFixture({isMember: false});
+    ProjectsStore.loadInitialData([nonMemberProject]);
+    renderHook(useDefaultToAllProjects);
+    expect(updateProjects).toHaveBeenCalledWith([-1], undefined, {
+      save: true,
+    });
+  });
+
+  it('should not update projects when there are no projects selected and user has team projects', () => {
+    jest.mocked(usePageFilters).mockReturnValue(
+      PageFilterStateFixture({
+        selection: pageFilterSelection,
+      })
+    );
+    ProjectsStore.loadInitialData([ProjectFixture()]);
+    renderHook(useDefaultToAllProjects);
+    expect(updateProjects).not.toHaveBeenCalled();
+  });
+
+  it('should not update projects when there are projects selected', () => {
+    jest.mocked(usePageFilters).mockReturnValue(
+      PageFilterStateFixture({
+        selection: {
+          ...pageFilterSelection,
+          projects: [1, 2],
+        },
+      })
+    );
+    renderHook(useDefaultToAllProjects);
+    expect(updateProjects).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/views/insights/common/utils/useDefaultToAllProjects.tsx
+++ b/static/app/views/insights/common/utils/useDefaultToAllProjects.tsx
@@ -1,0 +1,27 @@
+import {useEffect, useMemo} from 'react';
+
+import {updateProjects} from 'sentry/actionCreators/pageFilters';
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
+
+/**
+ * Defaults page filter selection to "All Projects" when no projects are selected and user has no team projects.
+ */
+export function useDefaultToAllProjects() {
+  const {selection} = usePageFilters();
+  const {projects} = useProjects();
+
+  const myProjects = useMemo(
+    () => projects.filter(project => project.isMember),
+    [projects]
+  );
+
+  useEffect(() => {
+    if (selection.projects.length === 0 && myProjects.length === 0) {
+      updateProjects([ALL_ACCESS_PROJECTS], undefined, {
+        save: true,
+      });
+    }
+  }, [selection.projects.length, myProjects.length]);
+}

--- a/static/app/views/insights/common/utils/useDefaultToAllProjects.tsx
+++ b/static/app/views/insights/common/utils/useDefaultToAllProjects.tsx
@@ -10,7 +10,7 @@ import useProjects from 'sentry/utils/useProjects';
  */
 export function useDefaultToAllProjects() {
   const {selection} = usePageFilters();
-  const {projects} = useProjects();
+  const {projects, initiallyLoaded} = useProjects();
 
   const myProjects = useMemo(
     () => projects.filter(project => project.isMember),
@@ -18,10 +18,10 @@ export function useDefaultToAllProjects() {
   );
 
   useEffect(() => {
-    if (selection.projects.length === 0 && myProjects.length === 0) {
+    if (initiallyLoaded && selection.projects.length === 0 && myProjects.length === 0) {
       updateProjects([ALL_ACCESS_PROJECTS], undefined, {
         save: true,
       });
     }
-  }, [selection.projects.length, myProjects.length]);
+  }, [selection.projects.length, myProjects.length, initiallyLoaded]);
 }

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -30,6 +30,7 @@ import OverviewRequestsChartWidget from 'sentry/views/insights/common/components
 import OverviewTimeConsumingQueriesWidget from 'sentry/views/insights/common/components/widgets/overviewTimeConsumingQueriesWidget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import {useDefaultToAllProjects} from 'sentry/views/insights/common/utils/useDefaultToAllProjects';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {Am1BackendOverviewPage} from 'sentry/views/insights/pages/backend/am1BackendOverviewPage';
@@ -84,6 +85,7 @@ function EAPBackendOverviewPage() {
   const navigate = useNavigate();
   const {selection} = usePageFilters();
   const cursor = decodeScalar(location.query?.[QueryParameterNames.PAGES_CURSOR]);
+  useDefaultToAllProjects();
 
   const {query: searchBarQuery} = useLocationQuery({
     fields: {

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -30,6 +30,7 @@ import OverviewTimeConsumingRequestsWidget from 'sentry/views/insights/common/co
 import OverviewTransactionDurationChartWidget from 'sentry/views/insights/common/components/widgets/overviewTransactionDurationChartWidget';
 import OverviewTransactionThroughputChartWidget from 'sentry/views/insights/common/components/widgets/overviewTransactionThroughputChartWidget';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import {useDefaultToAllProjects} from 'sentry/views/insights/common/utils/useDefaultToAllProjects';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {TripleRowWidgetWrapper} from 'sentry/views/insights/pages/backend/backendOverviewPage';
@@ -70,6 +71,8 @@ function FrontendOverviewPage() {
   const navigate = useNavigate();
   const {selection} = usePageFilters();
   const search = useFrontendQuery({includeWebVitalOps: true});
+
+  useDefaultToAllProjects();
 
   const cursor = decodeScalar(location.query?.[QueryParameterNames.PAGES_CURSOR]);
   const spanOp: PageSpanOps = getSpanOpFromQuery(

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -28,6 +28,7 @@ import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {STARRED_SEGMENT_TABLE_QUERY_KEY} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import {useDefaultToAllProjects} from 'sentry/views/insights/common/utils/useDefaultToAllProjects';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
@@ -72,6 +73,8 @@ function EAPMobileOverviewPage() {
   const mepSetting = useMEPSettingContext();
   const {selection} = usePageFilters();
   const cursor = decodeScalar(location.query?.[QueryParameterNames.PAGES_CURSOR]);
+
+  useDefaultToAllProjects();
 
   const withStaticFilters = canUseMetricsData(organization);
 


### PR DESCRIPTION
When a user has no team projects and does not have any page filter project selection saved in their local storage, the insights overview pages will error out or display no data (due to selecting 0 projects). This change defaults insights pages to select All Projects instead in this scenario, preventing the overview pages from erroring out or display empty data. Adds a new `useDefaultToAllProjects` hook to handle this.