### PR TITLE
ref(api): remove option-based rate limiting for `organization_events`

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -88,9 +88,9 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
     rate_limits = RateLimitConfig(
         limit_overrides={
             "GET": {
-                RateLimitCategory.IP: RateLimit(limit=50, window=1, concurrent_limit=50),
-                RateLimitCategory.USER: RateLimit(limit=50, window=1, concurrent_limit=50),
-                RateLimitCategory.ORGANIZATION: RateLimit(limit=50, window=1, concurrent_limit=50),
+                RateLimitCategory.IP: RateLimit(limit=30, window=1, concurrent_limit=15),
+                RateLimitCategory.USER: RateLimit(limit=30, window=1, concurrent_limit=15),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=30, window=1, concurrent_limit=15),
             }
         }
     )

--- a/tests/sentry/api/test_organization_events.py
+++ b/tests/sentry/api/test_organization_events.py
@@ -1,22 +1,13 @@
 from unittest import mock
 
 import pytest
-from django.http import HttpRequest
 from django.test import override_settings
 from django.urls import reverse
-from rest_framework.request import Request
 
-from sentry.api.endpoints.organization_events import (
-    DEFAULT_INCREASED_RATE_LIMIT,
-    DEFAULT_REDUCED_RATE_LIMIT,
-    LEGACY_RATE_LIMIT,
-    rate_limit_events,
-)
+from sentry.api.endpoints.organization_events import LEGACY_RATE_LIMIT
 from sentry.search.events import constants
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import Feature, override_options, with_feature
 from sentry.testutils.helpers.datetime import before_now, freeze_time
-from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.snuba import QueryExecutionError, QueryIllegalTypeOfArgument, RateLimitExceeded
 
 MAX_QUERYABLE_TRANSACTION_THRESHOLDS = 1
@@ -187,124 +178,3 @@ class OrganizationEventsEndpointTest(APITestCase):
             frozen_time.shift(limit["window"] + 1)
             response = self.do_request(query)
             assert response.status_code == 200, response.content
-
-    def test_rate_limit_events_without_rollout(self) -> None:
-        slug = self.organization.slug
-        request = Request(HttpRequest())
-
-        assert rate_limit_events(request, slug)["GET"][RateLimitCategory.IP] == RateLimit(
-            **LEGACY_RATE_LIMIT
-        )
-
-    @with_feature("organizations:api-organization_events-rate-limit-reduced-rollout")
-    def test_rate_limit_events_with_rollout(self) -> None:
-        slug = self.organization.slug
-        request = Request(HttpRequest())
-
-        assert rate_limit_events(request, slug)["GET"][RateLimitCategory.IP] == RateLimit(
-            **DEFAULT_REDUCED_RATE_LIMIT
-        )
-
-        with override_options(
-            {
-                "api.organization_events.rate-limit-reduced.limits": {
-                    "limit": 123,
-                    "window": 456,
-                },
-            },
-        ):
-            assert rate_limit_events(request, slug)["GET"][RateLimitCategory.IP] == RateLimit(
-                limit=123,
-                window=456,
-            )
-
-    def test_rate_limit_events_increased(self) -> None:
-        slug = self.organization.slug
-        request = Request(HttpRequest())
-
-        with override_options(
-            {"api.organization_events.rate-limit-increased.orgs": [self.organization.id]}
-        ):
-            assert rate_limit_events(request, slug)["GET"][RateLimitCategory.IP] == RateLimit(
-                **DEFAULT_INCREASED_RATE_LIMIT
-            )
-
-        # when both reduced rollout and increased rate limit for org, increased rate limit should take precedence
-        with (
-            Feature("organizations:api-organization_events-rate-limit-reduced-rollout"),
-            override_options(
-                {"api.organization_events.rate-limit-increased.orgs": [self.organization.id]}
-            ),
-        ):
-            assert rate_limit_events(request, slug)["GET"][RateLimitCategory.IP] == RateLimit(
-                **DEFAULT_INCREASED_RATE_LIMIT
-            )
-
-        with override_options(
-            {
-                "api.organization_events.rate-limit-increased.orgs": [self.organization.id],
-                "api.organization_events.rate-limit-increased.limits": {
-                    "limit": 123,
-                    "window": 456,
-                },
-            },
-        ):
-            assert rate_limit_events(request, slug)["GET"][RateLimitCategory.IP] == RateLimit(
-                limit=123,
-                window=456,
-            )
-
-    def test_rate_limit_events_invalid_options(self) -> None:
-        slug = self.organization.slug
-        request = Request(HttpRequest())
-
-        with override_options(
-            {
-                "api.organization_events.rate-limit-increased.orgs": [self.organization.id],
-                "api.organization_events.rate-limit-increased.limits": {
-                    "limit": "invalid",
-                    "window": 123,
-                },
-            },
-        ):
-            assert rate_limit_events(request, slug)["GET"][RateLimitCategory.IP] == RateLimit(
-                **DEFAULT_INCREASED_RATE_LIMIT
-            )
-
-        with override_options(
-            {
-                "api.organization_events.rate-limit-increased.orgs": [self.organization.id],
-                "api.organization_events.rate-limit-increased.limits": {
-                    "leemeet": 123,
-                    "window": 123,
-                },
-            },
-        ):
-            assert rate_limit_events(request, slug)["GET"][RateLimitCategory.IP] == RateLimit(
-                **DEFAULT_INCREASED_RATE_LIMIT
-            )
-
-        with (
-            Feature("organizations:api-organization_events-rate-limit-reduced-rollout"),
-            override_options(
-                {
-                    "api.organization_events.rate-limit-reduced.limits": {
-                        "limit": 123,
-                        "window": 456,
-                        "concurrent_limit": 789,
-                        "unexpected_key": 0xBAD,
-                    },
-                }
-            ),
-        ):
-            assert rate_limit_events(request, slug)["GET"][RateLimitCategory.IP] == RateLimit(
-                **DEFAULT_REDUCED_RATE_LIMIT
-            )
-
-    def test_rate_limit_events_bad_slug(self) -> None:
-        slug = "ucsc-banana-slugs-go-sammy"
-        request = Request(HttpRequest())
-
-        assert rate_limit_events(request, slug)["GET"][RateLimitCategory.IP] == RateLimit(
-            **LEGACY_RATE_LIMIT
-        )


### PR DESCRIPTION
Remove the custom option-based rate limit determining for the `organization_events` endpoint, setting it to the old default  rate limit. There were a few orgs that had increased rate limits with this, I'll be monitoring [the dashboards](https://redash.getsentry.net/dashboards/364-rate-limiting-overview?p_w2720_day=d_now&p_w2725_from_days_ago=7&p_w2725_sort_by=percentage&p_w2726_from_days_ago=7&p_w2726_sort_by=percentage) to make sure they aren't being affected. I'd like to go with the lower rate limits since this option hasn't been touched in a while, and I suspect the orgs with higher rate limits no longer need them + some spot checking indicates this endpoint isn't hit even close to the rate limit amounts (see [metric](https://app.datadoghq.com/metric/explorer?fromUser=false&start=1758059148080&end=1758663948080&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKHsTIWiIFWAB0AG56YHV2DiJawKIaCBgi2VVwNXF1GPIQdUNQDqIWdW4wfRAAXp6SIk5wDUNzTXBgPAAEAEZYh8DVtU5GMOs8oxrXnnAAFACUIDwAulSu7niYULhP6qAEYGKleKfH4gHpYNA5UDyDAIhAIHJJHAwJyZQEaCCZRJoURwJxyRTKdLEqBEklOehMZQiNweNCffgQeyYLBkhQY4kiJTfHh8WHyYkIADCUmEMBQIgBaB4QA))

Next step is to remove the options.