### PR TITLE
chore(aci): allow feedback issues through workflow engine

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1725,6 +1725,7 @@ GROUP_CATEGORY_POST_PROCESS_PIPELINE = {
         feedback_filter_decorator(process_snoozes),
         feedback_filter_decorator(process_inbox_adds),
         feedback_filter_decorator(process_rules),
+        feedback_filter_decorator(process_workflow_engine_issue_alerts),
         feedback_filter_decorator(process_resource_change_bounds),
     ],
     GroupCategory.METRIC_ALERT: [

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1738,6 +1738,7 @@ GENERIC_POST_PROCESS_PIPELINE = [
     process_inbox_adds,
     kick_off_seer_automation,
     process_rules,
+    process_workflow_engine_issue_alerts,
     process_resource_change_bounds,
     process_data_forwarding,
 ]

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -9,6 +9,7 @@ from sentry.eventstream.types import EventStreamEventType
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
+from sentry.issues.grouptype import FeedbackGroup
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.models.group import Group
 from sentry.rules.match import MatchType
@@ -524,3 +525,33 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
             )
             == {}
         )
+
+
+class TestWorkflowEngineIntegrationFromFeedbackPostProcess(BaseWorkflowIntegrationTest):
+    @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [6001]})
+    @with_feature("organizations:workflow-engine-single-process-workflows")
+    def test_workflow_engine(self) -> None:
+        occurrence_data = self.build_occurrence_data(
+            type=FeedbackGroup.type_id,
+            event_id=self.event.event_id,
+            project_id=self.project.id,
+            evidence_data={
+                "contact_email": "test@test.com",
+                "message": "test",
+                "name": "Name Test",
+                "source": "new_feedback_envelope",
+                "summary": "test",
+            },
+        )
+
+        self.occurrence, group_info = save_issue_occurrence(occurrence_data, self.event)
+        assert group_info is not None
+
+        self.group = Group.objects.get(grouphash__hash=self.occurrence.fingerprint[0])
+        assert self.group.type == FeedbackGroup.type_id
+
+        with mock.patch(
+            "sentry.workflow_engine.tasks.workflows.process_workflows_event.apply_async"
+        ) as mock_process_workflow:
+            self.call_post_process_group(self.group.id)
+            mock_process_workflow.assert_called_once()


### PR DESCRIPTION
Add `process_workflow_engine_issue_alerts` to the feedback post process pipeline