### PR TITLE
ui(replay): fix the fast forward badge icon alignment & left margin with text

### DIFF
--- a/static/app/components/replays/player/fastForwardBadge.tsx
+++ b/static/app/components/replays/player/fastForwardBadge.tsx
@@ -31,11 +31,11 @@ const Badge = styled('div')`
 
 /* Badge layout and style */
 const FastForwardTooltip = styled(Tooltip)`
-  display: grid;
-  grid-template-columns: max-content max-content;
-  gap: ${space(0.5)};
+  display: flex;
   align-items: center;
-
+  > svg {
+    margin-left: ${p => p.theme.space.sm};
+  }
   background: ${p => p.theme.gray300};
   color: ${p => p.theme.white};
   padding: ${space(1.5)} ${space(2)};

--- a/static/app/components/replays/player/fastForwardBadge.tsx
+++ b/static/app/components/replays/player/fastForwardBadge.tsx
@@ -15,7 +15,7 @@ function FastForwardBadge({speed, className}: Props) {
     <Badge className={className}>
       <FastForwardTooltip title={t('Fast forwarding at %sx', speed)}>
         {t('Fast forwarding through inactivity')}
-        <IconArrow size="sm" direction="right" />
+        <StyledIconArrow size="sm" direction="right" />
       </FastForwardTooltip>
     </Badge>
   );
@@ -31,16 +31,16 @@ const Badge = styled('div')`
 
 /* Badge layout and style */
 const FastForwardTooltip = styled(Tooltip)`
-  display: flex;
-  align-items: center;
-  > svg {
-    margin-left: ${p => p.theme.space.sm};
-  }
   background: ${p => p.theme.gray300};
   color: ${p => p.theme.white};
   padding: ${space(1.5)} ${space(2)};
   border-top-right-radius: ${p => p.theme.borderRadius};
   z-index: ${p => p.theme.zIndex.initial};
+`;
+
+const StyledIconArrow = styled(IconArrow)`
+  margin-left: ${p => p.theme.space.sm};
+  vertical-align: text-top;
 `;
 
 export default FastForwardBadge;


### PR DESCRIPTION
- Fix the missing gap between the icon and text.
- Center the icon with the text.

Before:
<img width="298" height="74" alt="Screenshot 2025-09-23 at 2 59 10 PM" src="https://github.com/user-attachments/assets/1c355e82-252d-436a-b153-6e21abc8c288" />

After:
<img width="298" height="64" alt="Screenshot 2025-09-23 at 4 02 02 PM" src="https://github.com/user-attachments/assets/7db9a950-9663-468a-a8e3-b2d62359a83a" />
