### PR TITLE
chore(releases): Add `PullRequest` to cleanup.py so that we can start deleting old rows.

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -451,6 +451,7 @@ def models_which_use_deletions_code_path() -> list[tuple[type[Model], str, str]]
     from sentry.models.artifactbundle import ArtifactBundle
     from sentry.models.eventattachment import EventAttachment
     from sentry.models.grouprulestatus import GroupRuleStatus
+    from sentry.models.pullrequest import PullRequest
     from sentry.models.release import Release
     from sentry.models.rulefirehistory import RuleFireHistory
     from sentry.monitors.models import MonitorCheckIn
@@ -464,6 +465,7 @@ def models_which_use_deletions_code_path() -> list[tuple[type[Model], str, str]]
         (ArtifactBundle, "date_added", "date_added"),
         (MonitorCheckIn, "date_added", "date_added"),
         (GroupRuleStatus, "date_added", "date_added"),
+        (PullRequest, "date_added", "date_added"),
         (RuleFireHistory, "date_added", "date_added"),
         (Release, "date_added", "date_added"),
     ]


### PR DESCRIPTION


Before we can set up a cron task to remove these we first need to add in this model so that cleanup.py knows what to do with it.

<!-- Describe your PR here. -->