### PR TITLE
bug(preprod): Fix size analysis comparisons

### DIFF
--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -385,33 +385,17 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
             )
             return Response(body.dict(), status=200)
 
-        head_metrics_map = build_size_metrics_map(head_size_metrics)
-        base_metrics_map = build_size_metrics_map(base_size_metrics)
-
         logger.info(
-            "preprod.size_analysis.compare.api.post.running_comparisons",
-            extra={"head_metrics_map": head_metrics_map, "base_metrics_map": base_metrics_map},
+            "preprod.size_analysis.compare.api.post.running_comparison",
+            extra={"head_artifact_id": head_artifact.id, "base_artifact_id": base_artifact.id},
         )
 
-        for key, head_metric in head_metrics_map.items():
-            base_metric = base_metrics_map.get(key)
-            if not base_metric:
-                logger.info(
-                    "preprod.size_analysis.compare.api.no_matching_base_metric",
-                    extra={"head_metric_id": head_metric.id},
-                )
-                continue
-
-            logger.info(
-                "preprod.size_analysis.compare.api.post.running_comparison",
-                extra={"head_metric_id": head_metric.id, "base_metric_id": base_metric.id},
-            )
-            manual_size_analysis_comparison.apply_async(
-                kwargs={
-                    "head_size_metric_id": head_metric.id,
-                    "base_size_metric_id": base_metric.id,
-                }
-            )
+        manual_size_analysis_comparison.apply_async(
+            kwargs={
+                "head_artifact_id": head_artifact.id,
+                "base_artifact_id": base_artifact.id,
+            }
+        )
 
         logger.info(
             "preprod.size_analysis.compare.api.post.success",

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -392,6 +392,8 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
 
         manual_size_analysis_comparison.apply_async(
             kwargs={
+                "project_id": project.id,
+                "org_id": project.organization_id,
                 "head_artifact_id": head_artifact.id,
                 "base_artifact_id": base_artifact.id,
             }

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
@@ -361,6 +361,8 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
         mock_apply_async.assert_called_once_with(
             kwargs={
+                "project_id": self.project.id,
+                "org_id": self.organization.id,
                 "head_artifact_id": self.head_artifact.id,
                 "base_artifact_id": self.base_artifact.id,
             }
@@ -532,7 +534,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
     def test_post_comparison_multiple_metrics(self, mock_apply_async):
         """Test POST endpoint handles multiple size metrics correctly"""
         # Create additional size metrics
-        head_watch_metric = PreprodArtifactSizeMetrics.objects.create(
+        PreprodArtifactSizeMetrics.objects.create(
             preprod_artifact=self.head_artifact,
             analysis_file_id=self.head_analysis_file.id,
             metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
@@ -540,7 +542,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         )
 
-        base_watch_metric = PreprodArtifactSizeMetrics.objects.create(
+        PreprodArtifactSizeMetrics.objects.create(
             preprod_artifact=self.base_artifact,
             analysis_file_id=self.base_analysis_file.id,
             metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
@@ -551,31 +553,15 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         response = self.client.post(self._get_url())
 
         assert response.status_code == 200
-        # Should be called twice - once for main artifact, once for watch artifact
-        assert mock_apply_async.call_count == 2
 
-        # Check the calls
-        calls = mock_apply_async.call_args_list
-        call_kwargs = [call[1]["kwargs"] for call in calls]
-
-        # Should have calls for both main and watch metrics
-        main_call = next(
-            (
-                call
-                for call in call_kwargs
-                if call["head_size_metric_id"] == self.head_size_metric.id
-            ),
-            None,
+        mock_apply_async.assert_called_once_with(
+            kwargs={
+                "project_id": self.project.id,
+                "org_id": self.organization.id,
+                "head_artifact_id": self.head_artifact.id,
+                "base_artifact_id": self.base_artifact.id,
+            }
         )
-        watch_call = next(
-            (call for call in call_kwargs if call["head_size_metric_id"] == head_watch_metric.id),
-            None,
-        )
-
-        assert main_call is not None
-        assert watch_call is not None
-        assert main_call["base_size_metric_id"] == self.base_size_metric.id
-        assert watch_call["base_size_metric_id"] == base_watch_metric.id
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_no_matching_base_metric(self):

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
@@ -361,8 +361,8 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
         mock_apply_async.assert_called_once_with(
             kwargs={
-                "head_size_metric_id": self.head_size_metric.id,
-                "base_size_metric_id": self.base_size_metric.id,
+                "head_artifact_id": self.head_artifact.id,
+                "base_artifact_id": self.base_artifact.id,
             }
         )
 


### PR DESCRIPTION
Was calling the manual_size_comparison task with metric IDs, when it needs artifact IDs.