### PR TITLE
chore(eco): Adds integrations throttled task namespace for larger batch jobs

### DIFF
--- a/src/sentry/integrations/github/tasks/codecov_account_link.py
+++ b/src/sentry/integrations/github/tasks/codecov_account_link.py
@@ -7,7 +7,6 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization import organization_service
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
-from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import (
     integrations_control_tasks,
     integrations_control_throttled_tasks,

--- a/src/sentry/integrations/github/tasks/codecov_account_link.py
+++ b/src/sentry/integrations/github/tasks/codecov_account_link.py
@@ -37,11 +37,9 @@ def codecov_account_link(
 @instrumented_task(
     name="sentry.integrations.github.tasks.backfill_codecov_account_link",
     silo_mode=SiloMode.CONTROL,
-    taskworker_config=TaskworkerConfig(
-        namespace=integrations_control_throttled_tasks,
-        retry=Retry(times=3),
-        processing_deadline_duration=60,
-    ),
+    namespace=integrations_control_throttled_tasks,
+    retry=Retry(times=3),
+    processing_deadline_duration=60,
 )
 @retry(exclude=(ConfigurationError,))
 def backfill_codecov_account_link(

--- a/src/sentry/integrations/github/tasks/codecov_account_link.py
+++ b/src/sentry/integrations/github/tasks/codecov_account_link.py
@@ -7,7 +7,11 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization import organization_service
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
-from sentry.taskworker.namespaces import integrations_control_tasks
+from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.namespaces import (
+    integrations_control_tasks,
+    integrations_control_throttled_tasks,
+)
 from sentry.taskworker.retry import Retry
 
 logger = logging.getLogger(__name__)
@@ -24,6 +28,32 @@ account_link_endpoint = "/sentry/internal/account/link/"
 )
 @retry(exclude=(ConfigurationError,))
 def codecov_account_link(
+    integration_id: int,
+    organization_id: int,
+) -> None:
+    link_codecov_account(integration_id, organization_id)
+
+
+@instrumented_task(
+    name="sentry.integrations.github.tasks.backfill_codecov_account_link",
+    queue="integrations.control.throttled",
+    max_retries=3,
+    silo_mode=SiloMode.CONTROL,
+    taskworker_config=TaskworkerConfig(
+        namespace=integrations_control_throttled_tasks,
+        retry=Retry(times=3),
+        processing_deadline_duration=60,
+    ),
+)
+@retry(exclude=(ConfigurationError,))
+def backfill_codecov_account_link(
+    integration_id: int,
+    organization_id: int,
+) -> None:
+    link_codecov_account(integration_id, organization_id)
+
+
+def link_codecov_account(
     integration_id: int,
     organization_id: int,
 ) -> None:

--- a/src/sentry/integrations/github/tasks/codecov_account_link.py
+++ b/src/sentry/integrations/github/tasks/codecov_account_link.py
@@ -36,8 +36,6 @@ def codecov_account_link(
 
 @instrumented_task(
     name="sentry.integrations.github.tasks.backfill_codecov_account_link",
-    queue="integrations.control.throttled",
-    max_retries=3,
     silo_mode=SiloMode.CONTROL,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_control_throttled_tasks,

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -115,6 +115,11 @@ integrations_control_tasks = app.taskregistry.create_namespace(
     app_feature="integrations",
 )
 
+integrations_control_throttled_tasks = app.taskregistry.create_namespace(
+    "integrations.control.throttled",
+    app_feature="integrations",
+)
+
 notifications_tasks = app.taskregistry.create_namespace(
     "notifications",
     app_feature="shared",


### PR DESCRIPTION
Adds a new task namespace for control integration tasks that need to be throttled. This will allow us to run larger backfill jobs with less impact on SaaS in the future. This namespace will be routed to the `taskworker-limited` in our config settings.
