### PR TITLE
fix(prevent): Match placeholders to content

### DIFF
--- a/static/app/views/prevent/tokens/repoTokenTable/repoTokenTable.tsx
+++ b/static/app/views/prevent/tokens/repoTokenTable/repoTokenTable.tsx
@@ -59,10 +59,10 @@ function Skeletons() {
             <Placeholder height="32px" />
           </SimpleTable.RowCell>
           <SimpleTable.RowCell>
-            <Placeholder height="32px" />
+            <Placeholder height="32px" width="368px" />
           </SimpleTable.RowCell>
           <SimpleTable.RowCell>
-            <Placeholder height="32px" />
+            <Placeholder height="32px" width="145px" />
           </SimpleTable.RowCell>
         </SimpleTable.Row>
       ))}


### PR DESCRIPTION
Sets widths on the placeholders in the repo tokens table so it matches
the content once loaded.