### PR TITLE
fix(agent-insights): Trace error count

### DIFF
--- a/static/app/views/insights/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/agents/components/tracesTable.tsx
@@ -124,7 +124,7 @@ export function TracesTable() {
   const traceErrorRequest = useSpans(
     {
       // Get all generations and tool calls with status unknown
-      search: `!span.status:ok trace:[${tracesRequest.data?.data.map(span => span.trace).join(',')}]`,
+      search: `has:span.status !span.status:ok trace:[${tracesRequest.data?.data.map(span => span.trace).join(',')}]`,
       fields: ['trace', ...AI_AGENT_SUB_OPS],
       limit: tracesRequest.data?.data.length ?? 0,
       enabled: Boolean(tracesRequest.data && tracesRequest.data.data.length > 0),
@@ -294,7 +294,7 @@ const BodyCell = memo(function BodyCell({
         <ErrorCell
           value={dataRow.errors}
           target={getExploreUrl({
-            query: `${query} span.status:unknown trace:[${dataRow.traceId}]`,
+            query: `${query} has:span.status !span.status:ok trace:[${dataRow.traceId}]`,
             organization,
             selection,
             referrer: Referrer.TRACES_TABLE,


### PR DESCRIPTION
Exclude spans that do not have span.status