### PR TITLE
debug(onboarding): add sentry instrumentation for onboarding task cache misses

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3486,3 +3486,10 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "sentry.send_onboarding_task_metrics",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
Emit a metric everytime we have a cache miss and hit the database with this query. This will run only in S4S, so the cardinality will be low.
