### PR TITLE
test(spans): Log full redacted span to find mismatches

### DIFF
--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -102,13 +102,9 @@ def _verify_compatibility(spans: Sequence[Mapping[str, Any]]) -> list[None | dic
 
 def _redact(data: Any) -> Any:
     if isinstance(data, list):
-        for i, item in enumerate(data):
-            data[i] = _redact(item)
-        return data
+        return [_redact(item) for item in data]
     elif isinstance(data, dict):
-        for key, value in data.items():
-            data[key] = _redact(value)
-        return data
+        return {key: _redact(value) for key, value in data.items()}
     elif isinstance(data, str):
         return "[redacted]"
     else:

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -74,18 +74,16 @@ def process_segment(
     return spans
 
 
-def _verify_compatibility(spans: Sequence[Mapping[str, Any]]) -> list[list[Any]]:
-    all_mismatches = []
+def _verify_compatibility(spans: Sequence[Mapping[str, Any]]) -> list[None | dict[str, Any]]:
+    result: list[None | dict[str, Any]] = [None for span in spans]
     try:
-        for span in spans:
+        for i, span in enumerate(spans):
             # As soon as compatibility spans are fully rolled out, we can assert that attributes exist here.
             if "attributes" in span:
-                attributes = span["attributes"]
-                if attributes is None:
-                    logger.warning("Empty attributes")
-                    continue
                 metrics.incr("spans.consumers.process_segments.span_v2")
-                data = span.get("data", {})
+
+                attributes = span.get("attributes") or {}
+                data = span.get("data") or {}
                 # Verify that all data exist also in attributes.
                 mismatches = [
                     (key, data_value, attribute_value)
@@ -93,11 +91,28 @@ def _verify_compatibility(spans: Sequence[Mapping[str, Any]]) -> list[list[Any]]
                     if data_value != (attribute_value := (attributes.get(key) or {}).get("value"))
                 ]
                 if mismatches:
-                    logger.warning("Attribute mismatch", extra={"mismatches": mismatches})
-                all_mismatches.append(mismatches)
+                    redacted = _redact(span)
+                    logger.warning("Attribute mismatch", extra={"span": redacted})
+                    result[i] = redacted
     except Exception as e:
         sentry_sdk.capture_exception(e)
-    return all_mismatches
+
+    return result
+
+
+def _redact(data: Any) -> Any:
+    if isinstance(data, list):
+        for i, item in enumerate(data):
+            data[i] = _redact(item)
+        return data
+    elif isinstance(data, dict):
+        for key, value in data.items():
+            data[key] = _redact(value)
+        return data
+    elif isinstance(data, str):
+        return "[redacted]"
+    else:
+        return data
 
 
 @metrics.wraps("spans.consumers.process_segments.enrich_spans")

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -241,18 +241,17 @@ class TestSpansTask(TestCase):
 
 def test_verify_compatibility():
     spans: list[dict[str, Any]] = [
-        {"data": {"foo": 1}, "attributes": {"foo": {"value": 1}}},
+        # regular span:
         {"data": {"foo": 1}},
-        {"data": {"foo": 1}, "attributes": {"value": {"foo": 2}}},
+        # valid compat span:
+        {"data": {"foo": 1}, "attributes": {"foo": {"value": 1}}},
+        # invalid compat spans:
+        {"data": {"foo": 1}, "attributes": {"value": {"foo": "2"}}},
         {"data": {"bar": 1}, "attributes": None},
         {"data": {"baz": 1}, "attributes": {}},
-        {"data": {"zap": 1}, "attributes": {"zap": {"no_value": 1}}},
+        {"data": {"zap": 1}, "attributes": {"zap": {"no_value": "1"}}},
         {"data": {"abc": 1}, "attributes": {"abc": None}},
     ]
-    assert _verify_compatibility(spans) == [
-        [],
-        [("foo", 1, None)],
-        [("baz", 1, None)],
-        [("zap", 1, None)],
-        [("abc", 1, None)],
-    ]
+    result = _verify_compatibility(spans)
+    assert len(result) == len(spans)
+    assert [v is None for v in result] == [True, True, False, False, False, False, False]


### PR DESCRIPTION
Another attempt at understanding mismatches between `span.attributes` and `span.data` in backward-compatible spans: Attach the full (redacted) span to the log.

ref: INGEST-531