### PR TITLE
fix(prevent): Replace Pagination component with direct buttons in tests page

### DIFF
--- a/static/app/views/prevent/tests/tests.spec.tsx
+++ b/static/app/views/prevent/tests/tests.spec.tsx
@@ -7,12 +7,6 @@ import localStorageWrapper from 'sentry/utils/localStorage';
 import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import TestsPage from 'sentry/views/prevent/tests/tests';
 
-jest.mock('sentry/components/pagination', () => {
-  return function MockPagination() {
-    return <div>Pagination Component</div>;
-  };
-});
-
 jest.mock('sentry/utils/regions', () => ({
   getRegionDataFromOrganization: jest.fn(),
 }));
@@ -197,9 +191,8 @@ describe('CoveragePageWrapper', () => {
         expect(screen.getByRole('table')).toBeInTheDocument();
       });
 
-      await waitFor(() => {
-        expect(screen.getByText('Pagination Component')).toBeInTheDocument();
-      });
+      expect(await screen.findByRole('button', {name: 'Previous'})).toBeInTheDocument();
+      expect(await screen.findByRole('button', {name: 'Next'})).toBeInTheDocument();
     });
   });
   describe('when the organization is not in the US region', () => {

--- a/static/app/views/prevent/tests/tests.tsx
+++ b/static/app/views/prevent/tests/tests.tsx
@@ -1,8 +1,10 @@
 import {Fragment, useCallback, useEffect} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/core/button';
+import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import {Flex} from 'sentry/components/core/layout/flex';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import Pagination from 'sentry/components/pagination';
 import {BranchSelector} from 'sentry/components/prevent/branchSelector/branchSelector';
 import {usePreventContext} from 'sentry/components/prevent/context/preventContext';
 import {DateSelector} from 'sentry/components/prevent/dateSelector/dateSelector';
@@ -10,7 +12,7 @@ import {IntegratedOrgSelector} from 'sentry/components/prevent/integratedOrgSele
 import {RepoSelector} from 'sentry/components/prevent/repoSelector/repoSelector';
 import {TestSuiteDropdown} from 'sentry/components/prevent/testSuiteDropdown/testSuiteDropdown';
 import {getPreventParamsString} from 'sentry/components/prevent/utils';
-import {IconSearch} from 'sentry/icons';
+import {IconChevron, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {decodeSorts} from 'sentry/utils/queryString';
 import {getRegionDataFromOrganization} from 'sentry/utils/regions';
@@ -114,12 +116,7 @@ function Content({response}: TestResultsContentData) {
     selectedBranch === null || selectedBranch === defaultBranch;
 
   const handleCursor = useCallback(
-    (
-      _cursor: string | undefined,
-      path: string,
-      query: Record<string, any>,
-      delta: number
-    ) => {
+    (delta: number) => {
       // Without these guards, the pagination cursor can get stuck on an incorrect value.
       const navigation = delta === -1 ? 'prev' : 'next';
       const goPrevPage = navigation === 'prev' && response.hasPreviousPage;
@@ -133,9 +130,8 @@ function Content({response}: TestResultsContentData) {
       }
 
       navigate({
-        pathname: path,
         query: {
-          ...query,
+          ...location.query,
           cursor: goPrevPage
             ? response.startCursor
             : goNextPage
@@ -145,7 +141,7 @@ function Content({response}: TestResultsContentData) {
         },
       });
     },
-    [navigate, response]
+    [navigate, response, location.query]
   );
 
   return (
@@ -153,9 +149,24 @@ function Content({response}: TestResultsContentData) {
       {shouldDisplaySummaries && <Summaries />}
       <TestSearchBar testCount={response.totalCount} />
       <TestAnalyticsTable response={response} sort={sorts[0]} />
-      {/* We don't need to use the pageLinks prop because Codecov handles pagination using our own cursor implementation. But we need to
-          put a dummy value here because otherwise the component wouldn't render. */}
-      <StyledPagination pageLinks="showComponent" onCursor={handleCursor} />
+      <Flex justify="right">
+        <ButtonBar merged gap="0">
+          <Button
+            icon={<IconChevron direction="left" />}
+            aria-label={t('Previous')}
+            size="sm"
+            disabled={!response.hasPreviousPage}
+            onClick={() => handleCursor(-1)}
+          />
+          <Button
+            icon={<IconChevron direction="right" />}
+            aria-label={t('Next')}
+            size="sm"
+            disabled={!response.hasNextPage}
+            onClick={() => handleCursor(1)}
+          />
+        </ButtonBar>
+      </Flex>
     </Fragment>
   );
 }
@@ -188,8 +199,4 @@ const StyledIconSearch = styled(IconSearch)`
 const ControlsContainer = styled('div')`
   display: flex;
   gap: ${p => p.theme.space.xl};
-`;
-
-const StyledPagination = styled(Pagination)`
-  margin-top: 0px;
 `;


### PR DESCRIPTION
The prevent tests page was using the standard Pagination component with dummy props, which isn't appropriate for the different backend API used by prevent. This change replaces it with direct Previous/Next buttons that properly handle the hasNext/hasPrev states from the prevent API response, matching the pattern already used in the prevent tokens page.