### PR TITLE
fix(onboarding): don't attempt to record onboarding tasks if onboardi…

### DIFF
--- a/src/sentry/models/options/organization_option.py
+++ b/src/sentry/models/options/organization_option.py
@@ -36,7 +36,7 @@ class OrganizationOptionManager(OptionManager["OrganizationOption"]):
 
     def get_value(
         self,
-        organization: Organization,
+        organization: Organization | int,
         key: str,
         default: Any | None = None,
         validate: Callable[[object], bool] | None = None,

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -71,7 +71,7 @@ class OrganizationOnboardingTaskManager(BaseManager["OrganizationOnboardingTask"
             )
 
         if options.get("sentry:skip-record-onboarding-tasks-if-complete"):
-            onboarding_complete_option = OrganizationOption.get_value(
+            onboarding_complete_option = OrganizationOption.objects.get_value(
                 organization_id, "onboarding:complete", None
             )
             if onboarding_complete_option:

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -21,6 +21,7 @@ from sentry.db.models import (
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.fields.jsonfield import LegacyTextJSONField
 from sentry.db.models.manager.base import BaseManager
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.utils import metrics
 
 
@@ -68,6 +69,13 @@ class OrganizationOnboardingTaskManager(BaseManager["OrganizationOnboardingTask"
             raise ValueError(
                 f"status={status} unsupported must be {OnboardingTaskStatus.COMPLETE}."
             )
+
+        if options.get("sentry:skip-record-onboarding-tasks-if-complete"):
+            onboarding_complete_option = OrganizationOption.get_value(
+                organization_id, "onboarding:complete", None
+            )
+            if onboarding_complete_option:
+                return False
 
         cache_key = f"organizationonboardingtask:{organization_id}:{task}"
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3493,3 +3493,11 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Skip recording onboarding tasks if organization onboarding is already complete
+register(
+    "sentry:skip-record-onboarding-tasks-if-complete",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
- We currently try to record onboarding tasks forever, even if onboarding has been marked as complete
- This PR adds a check to the org option that is set when onboarding has been marked as complete to prevent these calls from occuring
