### PR TITLE
fix(preprod): Move builds content to preprod index

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2445,7 +2445,7 @@ function buildRoutes(): RouteObject[] {
 
   const preprodChildren: SentryRouteObject[] = [
     {
-      path: 'builds/',
+      index: true,
       component: make(() => import('sentry/views/preprod/buildList/buildList')),
     },
     {


### PR DESCRIPTION
Previously /organizations/my-org/preprod/my-project/builds/ showed
the list of builds and /organizations/my-org/preprod/my-project/ was
empty which was a bit odd.

Rename:
/organizations/my-org/preprod/my-project/builds/
to:
/organizations/my-org/preprod/my-project/

Resolves EME-331