### PR TITLE
feat(billing): Improve alert button popup title

### DIFF
--- a/static/gsApp/components/productTrial/productTrialAlert.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.tsx
@@ -192,8 +192,8 @@ function ProductTrialAlert(props: ProductTrialAlertProps) {
         }}
         size="zero"
         borderless
-        title={t('Dismiss this period')}
-        aria-label={t('Dismiss this period')}
+        title={t('Dismiss')}
+        aria-label={t('Dismiss')}
       />
     </ButtonBar>
   );

--- a/static/gsApp/components/productTrial/productTrialAlert.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.tsx
@@ -193,7 +193,7 @@ function ProductTrialAlert(props: ProductTrialAlertProps) {
         size="zero"
         borderless
         title={t('Dismiss')}
-        aria-label={t('Dismiss')}
+        aria-label={t('Dismiss trial notice')}
       />
     </ButtonBar>
   );


### PR DESCRIPTION
`Dismiss this period` is a bit confusing for users, so just change it to `Dismiss`.