### PR TITLE
chore: Update fixtures for otlp_logs in js project key tests

### DIFF
--- a/static/app/views/settings/project/loaderScript.spec.tsx
+++ b/static/app/views/settings/project/loaderScript.spec.tsx
@@ -101,7 +101,7 @@ describe('LoaderScript', () => {
           playstation:
             'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
           otlp_traces: 'http://dev.getsentry.net:8000/api/1/otlp/v1/traces',
-          otlp_logs: 'http://dev.getsentry.net:8000/api/1/otlp/v1/logs',
+          otlp_logs: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/logs',
         },
         public: '188ee45a58094d939428d8585aa6f662',
         secret: 'a33bf9aba64c4bbdaf873bb9023b6d2c',
@@ -243,7 +243,7 @@ describe('LoaderScript', () => {
           playstation:
             'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
           otlp_traces: 'http://dev.getsentry.net:8000/api/1/otlp/v1/traces',
-          otlp_logs: 'http://dev.getsentry.net:8000/api/1/otlp/v1/logs',
+          otlp_logs: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/logs',
         },
         public: '188ee45a58094d939428d8585aa6f662',
         secret: 'a33bf9aba64c4bbdaf873bb9023b6d2c',

--- a/static/app/views/settings/project/projectKeys/list/index.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.tsx
@@ -164,7 +164,7 @@ describe('ProjectKeys', () => {
           playstation:
             'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
           otlp_traces: 'http://dev.getsentry.net:8000/api/1/otlp/v1/traces',
-          otlp_logs: 'http://dev.getsentry.net:8000/api/1/otlp/v1/logs',
+          otlp_logs: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/logs',
         },
         dateCreated: '2018-02-28T07:13:51.087Z',
         public: '188ee45a58094d939428d8585aa6f662',

--- a/tests/js/fixtures/projectKeys.ts
+++ b/tests/js/fixtures/projectKeys.ts
@@ -18,7 +18,7 @@ export function ProjectKeysFixture(params: ProjectKey[] = []): ProjectKey[] {
         playstation:
           'http://dev.getsentry.net:8000/api/1/playstation/?sentry_key=188ee45a58094d939428d8585aa6f661',
         otlp_traces: 'http://dev.getsentry.net:8000/api/1/otlp/v1/traces',
-        otlp_logs: 'http://dev.getsentry.net:8000/api/1/otlp/v1/logs',
+        otlp_logs: 'http://dev.getsentry.net:8000/api/1/integration/otlp/v1/logs',
       },
       public: '188ee45a58094d939428d8585aa6f661',
       secret: 'a33bf9aba64c4bbdaf873bb9023b6d2d',


### PR DESCRIPTION
This makes the FE test changes that map to https://github.com/getsentry/sentry/issues/100107