### PR TITLE
 fix(dogstatsd): Fix crash when recording events 

### DIFF
--- a/src/sentry/metrics/dogstatsd.py
+++ b/src/sentry/metrics/dogstatsd.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from datadog import initialize
 from datadog.dogstatsd.base import statsd
+from datadog.util.hostname import get_hostname
 
 from .base import MetricsBackend, Tags
 
@@ -24,6 +25,10 @@ class DogStatsdMetricsBackend(MetricsBackend):
     def __init__(self, prefix: str | None = None, **kwargs: Any) -> None:
         # TODO(dcramer): it'd be nice if the initialize call wasn't a global
         self.tags = kwargs.pop("tags", None)
+        if "host" in kwargs:
+            self.host = kwargs.pop("host")
+        else:
+            self.host = get_hostname(hostname_from_config=True)
         kwargs["statsd_disable_buffering"] = False
 
         initialize(**kwargs)

--- a/src/sentry/metrics/precise_dogstatsd.py
+++ b/src/sentry/metrics/precise_dogstatsd.py
@@ -2,6 +2,7 @@ import atexit
 from typing import Any
 
 from datadog.dogstatsd.base import DogStatsd
+from datadog.util.hostname import get_hostname
 
 from .base import MetricsBackend, Tags
 
@@ -11,6 +12,10 @@ __all__ = ["PreciseDogStatsdMetricsBackend"]
 class PreciseDogStatsdMetricsBackend(MetricsBackend):
     def __init__(self, prefix: str | None = None, **kwargs: Any) -> None:
         self.tags = kwargs.pop("tags", None)
+        if "host" in kwargs:
+            self.host = kwargs.pop("host")
+        else:
+            self.host = get_hostname(hostname_from_config=True)
 
         instance_kwargs: dict[str, Any] = {
             "disable_telemetry": True,


### PR DESCRIPTION
found during INC-1413

error introduced by https://github.com/getsentry/sentry/commit/e2652bd26b3648f7631a162d254eeccde5237c32

code copied from other datadog backend

stacktrace ftr

```
"Traceback (most recent call last):
  File "/usr/src/sentry/src/sentry/utils/metrics.py", line 246, in event
    backend.event(
    ~~~~~~~~~~~~~^
        title,
        ^^^^^^
    ...<7 lines>...
        stacklevel + 1,
        ^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/sentry/src/sentry/metrics/middleware.py", line 209, in event
    return self.inner.event(
           ~~~~~~~~~~~~~~~~^
        title,
        ^^^^^^
    ...<7 lines>...
        stacklevel + 1,
        ^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/sentry/src/sentry/metrics/dualwrite.py", line 159, in event
    self._primary_backend.event(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        title,
        ^^^^^^
    ...<7 lines>...
        stacklevel + 1,
        ^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/sentry/src/sentry/metrics/dogstatsd.py", line 145, in event
    hostname=self.host,
             ^^^^^^^^^
AttributeError: 'DogStatsdMetricsBackend' object has no attribute 'host'"
```