### PR TITLE
ref(prevent): Standardize selector menu footer styling

### DIFF
--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
@@ -1,55 +1,51 @@
-import {Fragment, useCallback, useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import type {SelectOption} from 'sentry/components/core/compactSelect';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
-import {Flex} from 'sentry/components/core/layout';
-import {ExternalLink} from 'sentry/components/core/link/link';
+import {Flex, Grid} from 'sentry/components/core/layout';
+import {ExternalLink} from 'sentry/components/core/link';
+import {Text} from 'sentry/components/core/text';
 import DropdownButton from 'sentry/components/dropdownButton';
 import {usePreventContext} from 'sentry/components/prevent/context/preventContext';
 import {integratedOrgIdToName} from 'sentry/components/prevent/utils';
 import {IconAdd, IconBuilding, IconInfo} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useGetActiveIntegratedOrgs} from 'sentry/views/prevent/tests/queries/useGetActiveIntegratedOrgs';
 
 const DEFAULT_ORG_LABEL = 'Select GitHub Org';
 
-function AddIntegratedOrgButton() {
-  return (
-    <LinkButton
-      href="https://github.com/apps/sentry-io/installations/select_target"
-      size="sm"
-      icon={<IconAdd size="sm" />}
-      priority="default"
-      external
-    >
-      {t('GitHub Organization')}
-    </LinkButton>
-  );
-}
-
 function OrgFooterMessage() {
   return (
-    <Fragment>
-      <AddIntegratedOrgButton />
-      <MenuFooterDivider />
-      <Flex justify="start" gap="md">
-        <IconInfo size="sm" style={{margin: '2px 0'}} />
-        <div>
-          <FooterInfoHeading>
-            Access{' '}
-            <ExternalLink href="https://github.com/apps/sentry-io">
-              GitHub Organization
-            </ExternalLink>
-          </FooterInfoHeading>
-          <FooterInfoSubheading>
-            Ensure admins approve the installation
-          </FooterInfoSubheading>
-        </div>
-      </Flex>
-    </Fragment>
+    <Flex gap="sm" direction="column" align="start">
+      <Grid columns="max-content 1fr" gap="sm">
+        {props => (
+          <Text variant="muted" size="sm" {...props}>
+            <IconInfo size="sm" />
+            <div>
+              {tct(
+                'Installing the [githubAppLink:GitHub Application] will require admin approval.',
+                {
+                  githubAppLink: (
+                    <ExternalLink openInNewTab href="https://github.com/apps/sentry-io" />
+                  ),
+                }
+              )}
+            </div>
+          </Text>
+        )}
+      </Grid>
+      <LinkButton
+        href="https://github.com/apps/sentry-io/installations/select_target"
+        size="xs"
+        icon={<IconAdd />}
+        external
+      >
+        {t('GitHub Organization')}
+      </LinkButton>
+    </Flex>
   );
 }
 
@@ -109,7 +105,7 @@ export function IntegratedOrgSelector() {
           </DropdownButton>
         );
       }}
-      menuWidth={'22em'}
+      menuWidth="280px"
       menuFooter={<OrgFooterMessage />}
     />
   );
@@ -132,32 +128,5 @@ const OptionLabel = styled('span')`
   remove SelectorItemLabel, we can delete this. */
   div {
     margin: 0;
-  }
-`;
-
-const FooterInfoHeading = styled('p')`
-  font-size: ${p => p.theme.fontSize.md};
-  line-height: 1.4;
-  margin: 0;
-`;
-
-const FooterInfoSubheading = styled('p')`
-  font-size: ${p => p.theme.fontSize.sm};
-  line-height: 1.2;
-  margin: 0;
-`;
-
-const MenuFooterDivider = styled('div')`
-  position: relative;
-  padding: ${p => p.theme.space.md} 0;
-  &:before {
-    display: block;
-    white-space: normal;
-    position: absolute;
-    content: '';
-    height: 1px;
-    left: 0;
-    right: 0;
-    background: ${p => p.theme.border};
   }
 `;

--- a/static/app/components/prevent/repoSelector/repoSelector.tsx
+++ b/static/app/components/prevent/repoSelector/repoSelector.tsx
@@ -5,42 +5,20 @@ import debounce from 'lodash/debounce';
 import {Button} from 'sentry/components/core/button';
 import type {SelectOption} from 'sentry/components/core/compactSelect';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {Grid} from 'sentry/components/core/layout';
 import {ExternalLink} from 'sentry/components/core/link';
+import {Text} from 'sentry/components/core/text';
 import DropdownButton from 'sentry/components/dropdownButton';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {usePreventContext} from 'sentry/components/prevent/context/preventContext';
 import {useInfiniteRepositories} from 'sentry/components/prevent/repoSelector/useInfiniteRepositories';
-import {IconInfo, IconSync} from 'sentry/icons';
+import {IconInfo} from 'sentry/icons';
 import {IconRepository} from 'sentry/icons/iconRepository';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import {useSyncRepos} from './useSyncRepos';
-
-function SyncRepoButton({searchValue}: {searchValue?: string}) {
-  const {triggerResync, isSyncing} = useSyncRepos({searchValue});
-
-  if (isSyncing) {
-    return <StyledLoadingIndicator size={12} />;
-  }
-
-  return (
-    <StyledButtonContainer>
-      <StyledButton
-        borderless
-        aria-label={t('Sync Now')}
-        onClick={() => triggerResync()}
-        size="xs"
-        icon={<IconSync />}
-      >
-        sync now
-      </StyledButton>
-    </StyledButtonContainer>
-  );
-}
 
 interface MenuFooterProps {
   repoAccessLink: string;
@@ -48,21 +26,21 @@ interface MenuFooterProps {
 
 function MenuFooter({repoAccessLink}: MenuFooterProps) {
   return (
-    <FooterTip>
-      <IconInfo size="xs" />
-      <span>
-        {tct(
-          "Sentry only displays repos you've authorized. Manage [repoAccessLink] in your GitHub settings.",
-          {
-            repoAccessLink: (
-              <ExternalLink openInNewTab href={repoAccessLink}>
-                repo access
-              </ExternalLink>
-            ),
-          }
-        )}
-      </span>
-    </FooterTip>
+    <Grid columns="max-content 1fr" gap="sm">
+      {props => (
+        <Text variant="muted" size="sm" {...props}>
+          <IconInfo size="sm" />
+          <div>
+            {tct(
+              "Sentry only displays repos you've authorized. Manage [repoAccessLink:repo access] in your GitHub settings.",
+              {
+                repoAccessLink: <ExternalLink openInNewTab href={repoAccessLink} />,
+              }
+            )}
+          </div>
+        </Text>
+      )}
+    </Grid>
   );
 }
 
@@ -77,6 +55,8 @@ export function RepoSelector() {
   const organization = useOrganization();
 
   const [searchValue, setSearchValue] = useState<string | undefined>();
+  const {isSyncing, triggerResync} = useSyncRepos({searchValue});
+
   const {
     data: repositories,
     isFetching,
@@ -134,8 +114,7 @@ export function RepoSelector() {
         // TODO: ideally this has a unique id, possibly adjust set to an
         // object when you have backend response
         value,
-        label: <OptionLabel>{value}</OptionLabel>,
-        textValue: value,
+        label: value,
       };
     });
   }, [displayedRepos, repository]);
@@ -161,7 +140,8 @@ export function RepoSelector() {
 
   return (
     <CompactSelect
-      loading={isLoading}
+      menuTitle={t('Select a Repository')}
+      loading={isLoading || isSyncing}
       onSearch={handleOnSearch}
       searchable
       disableSearchFilter
@@ -171,7 +151,16 @@ export function RepoSelector() {
       onChange={handleChange}
       onOpenChange={_ => setSearchValue(undefined)}
       menuWidth={'16rem'}
-      menuBody={<SyncRepoButton searchValue={searchValue} />}
+      menuHeaderTrailingItems={
+        <Syncbutton
+          disabled={isSyncing}
+          onClick={() => triggerResync()}
+          size="zero"
+          borderless
+        >
+          {t('Sync Repos')}
+        </Syncbutton>
+      }
       menuFooter={<MenuFooter repoAccessLink={currentOrgGHIntegrationRepoAccessLink} />}
       disabled={disabled}
       emptyMessage={getEmptyMessage()}
@@ -187,9 +176,7 @@ export function RepoSelector() {
             data-test-id="page-filter-prevent-repository-selector"
             {...triggerProps}
           >
-            <TriggerLabelWrap>
-              <TriggerLabel>{defaultLabel}</TriggerLabel>
-            </TriggerLabelWrap>
+            <TriggerLabel>{defaultLabel}</TriggerLabel>
           </DropdownButton>
         );
       }}
@@ -197,53 +184,15 @@ export function RepoSelector() {
   );
 }
 
-const StyledButton = styled(Button)`
-  display: inline-flex;
-  text-transform: uppercase;
-  color: ${p => p.theme.tokens.content.muted};
-  padding: ${space(1)};
-  &:hover * {
-    background-color: transparent;
-    border-color: transparent;
-  }
-`;
-
-const StyledButtonContainer = styled('div')`
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: ${space(0.5)};
-  margin: 0 ${space(0.5)} ${space(0.5)} 0;
-`;
-
-const FooterTip = styled('p')`
-  display: grid;
-  grid-auto-flow: column;
-  gap: ${space(0.5)};
-  color: ${p => p.theme.subText};
-  font-size: ${p => p.theme.fontSize.sm};
-  margin: 0;
-`;
-
-const TriggerLabelWrap = styled('span')`
-  position: relative;
-  min-width: 0;
+const TriggerLabel = styled('span')`
+  ${p => p.theme.overflowEllipsis}
   max-width: 200px;
 `;
 
-const TriggerLabel = styled('span')`
-  ${p => p.theme.overflowEllipsis}
-  width: auto;
-`;
-
-const OptionLabel = styled('span')`
-  div {
-    margin: 0;
-  }
-`;
-
-const StyledLoadingIndicator = styled(LoadingIndicator)`
-  && {
-    margin: ${p => p.theme.space.lg};
-  }
+const Syncbutton = styled(Button)`
+  font-size: inherit; /* Inherit font size from MenuHeader */
+  font-weight: ${p => p.theme.fontWeight.normal};
+  color: ${p => p.theme.subText};
+  padding: 0 ${p => p.theme.space.xs};
+  margin: -${p => p.theme.space['2xs']} -${p => p.theme.space.xs};
 `;


### PR DESCRIPTION
- Update integratedOrgSelector to match repoSelector layout and styling
- Replace custom styled components with consistent Text/Grid/Flex layout
- Remove divider and use smaller button/text sizes for visual
  consistency
- Consolidate both selectors to use same footer pattern with muted text
- Simplify repository selector trigger layout by removing wrapper
  elements

<img width="324" height="241" alt="image" src="https://github.com/user-attachments/assets/fb71dc7c-d01b-48eb-bca6-beecd10b2d3c" />

<img width="272" height="580" alt="image" src="https://github.com/user-attachments/assets/09930294-fc8a-4527-b437-d31c11bc7248" />

