### PR TITLE
fix(preprod): adjust null check for artifact type

### DIFF
--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -84,7 +84,10 @@ class BuildDetailsApiResponse(BaseModel):
     size_analysis_state: PreprodArtifactSizeMetrics.SizeAnalysisState | None = None
 
 
-def platform_from_artifact_type(artifact_type: PreprodArtifact.ArtifactType) -> Platform:
+def platform_from_artifact_type(artifact_type: PreprodArtifact.ArtifactType | int) -> Platform:
+    if isinstance(artifact_type, int):
+        artifact_type = PreprodArtifact.ArtifactType(artifact_type)
+
     match artifact_type:
         case PreprodArtifact.ArtifactType.XCARCHIVE:
             return Platform.IOS
@@ -144,7 +147,9 @@ def transform_preprod_artifact_to_build_details(
         date_built=(artifact.date_built.isoformat() if artifact.date_built else None),
         artifact_type=artifact.artifact_type,
         platform=(
-            platform_from_artifact_type(artifact.artifact_type) if artifact.artifact_type else None
+            platform_from_artifact_type(artifact.artifact_type)
+            if artifact.artifact_type is not None
+            else None
         ),
         is_installable=is_installable_artifact(artifact),
         build_configuration=(

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -84,10 +84,7 @@ class BuildDetailsApiResponse(BaseModel):
     size_analysis_state: PreprodArtifactSizeMetrics.SizeAnalysisState | None = None
 
 
-def platform_from_artifact_type(artifact_type: PreprodArtifact.ArtifactType | int) -> Platform:
-    if isinstance(artifact_type, int):
-        artifact_type = PreprodArtifact.ArtifactType(artifact_type)
-
+def platform_from_artifact_type(artifact_type: PreprodArtifact.ArtifactType) -> Platform:
     match artifact_type:
         case PreprodArtifact.ArtifactType.XCARCHIVE:
             return Platform.IOS


### PR DESCRIPTION
iOS builds are `artifact_type: 0`, but this was being interpreted as null so the platform icon wouldn't show. Fix to show platform icon


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
