### PR TITLE
ref(issues): remove `global-views` flag registration

### DIFF
--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -192,7 +192,6 @@ DETAILED_PROJECT = {
         "require2FA": False,
         "avatar": {"avatarType": "upload", "avatarUuid": "24f6f762f7a7473888b259c566da5adb"},
         "features": [
-            "global-views",
             "discover-basic",
             "incidents",
             "uptime",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -154,8 +154,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:gen-ai-consent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable disabling gitlab integrations when broken is detected
     manager.add("organizations:gitlab-disable-on-broken", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable multi project selection
-    manager.add("organizations:global-views", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     # Enable increased issue_owners rate limit for auto-assignment
     manager.add("organizations:increased-issue-owners-rate-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Starfish: extract metrics from the spans

--- a/src/sentry/replays/endpoints/organization_replay_events_meta.py
+++ b/src/sentry/replays/endpoints/organization_replay_events_meta.py
@@ -16,8 +16,8 @@ from sentry.models.organization import Organization
 
 @region_silo_endpoint
 class OrganizationReplayEventsMetaEndpoint(OrganizationEventsV2EndpointBase):
-    # TODO: now that global-views is enabled for all plans, we may be able to consolidate this with the generic OrganizationEventsV2Endpoint
-    """The generic Events endpoints require that the `organizations:global-views` feature
+    # TODO: now that cross-project selection is enabled for all plans, we may be able to consolidate this with the generic OrganizationEventsV2Endpoint
+    """The generic Events endpoints require that the cross-project selection feature
     be enabled before they return across multiple projects.
 
 


### PR DESCRIPTION
Removes `global-views` flag registration since it is no longer used anywhere. 

Closes https://linear.app/getsentry/issue/ID-927/deprecate-global-views-flag