### PR TITLE
ref(grouping): Use "ignored because" everywhere in hints

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -342,9 +342,9 @@ def _get_variants_from_strategies(
                             if component.contributes
                         )
                     )
-                    precedence_hint = "{} take{} precedence".format(
+                    precedence_hint = "ignored because {} take{} precedence".format(
                         (
-                            f"{strategy.name} of {variant_descriptor}"
+                            f"{variant_descriptor} {strategy.name}"
                             if variant_name != "default"
                             else strategy.name
                         ),
@@ -446,7 +446,7 @@ def get_grouping_variants_for_event(
             )
             fingerprint_source = "custom server" if matched_rule else "custom client"
 
-        hint = f"{fingerprint_source} fingerprint takes precedence"
+        hint = f"ignored because {fingerprint_source} fingerprint takes precedence"
 
         for variant in strategy_component_variants.values():
             variant.component.update(contributes=False, hint=hint)

--- a/src/sentry/grouping/strategies/security.py
+++ b/src/sentry/grouping/strategies/security.py
@@ -89,11 +89,13 @@ def csp_v1(
         violation_component.update(values=["'%s'" % interface.local_script_violation_type])
         uri_component.update(
             contributes=False,
-            hint="violation takes precedence",
+            hint="ignored because violation takes precedence",
             values=[interface.normalized_blocked_uri],
         )
     else:
-        violation_component.update(contributes=False, hint="not a local script violation")
+        violation_component.update(
+            contributes=False, hint="ignored because it's not a local script violation"
+        )
         uri_component.update(values=[interface.normalized_blocked_uri])
 
     return {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.678855+00:00'
+created: '2025-09-19T05:53:38.392514+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -110,7 +110,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -145,7 +145,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -180,7 +180,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -215,7 +215,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -250,7 +250,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -285,7 +285,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -320,7 +320,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -355,7 +355,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -390,7 +390,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -425,7 +425,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -460,7 +460,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -495,7 +495,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -530,7 +530,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -565,7 +565,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -600,7 +600,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -635,7 +635,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -670,7 +670,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -705,7 +705,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -740,7 +740,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -775,7 +775,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -810,7 +810,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -845,7 +845,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -880,7 +880,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -915,7 +915,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -950,7 +950,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -985,7 +985,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1020,7 +1020,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1055,7 +1055,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1090,7 +1090,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1125,7 +1125,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1160,7 +1160,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1195,7 +1195,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1230,7 +1230,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1265,7 +1265,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1300,7 +1300,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1335,7 +1335,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1370,7 +1370,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1405,7 +1405,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1440,7 +1440,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1475,7 +1475,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1510,7 +1510,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1545,7 +1545,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1580,7 +1580,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1615,7 +1615,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1650,7 +1650,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1685,7 +1685,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1720,7 +1720,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1755,7 +1755,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1790,7 +1790,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1825,7 +1825,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1860,7 +1860,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1895,7 +1895,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1930,7 +1930,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1965,7 +1965,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2000,7 +2000,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2035,7 +2035,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2070,7 +2070,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2105,7 +2105,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2140,7 +2140,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2175,7 +2175,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2210,7 +2210,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2245,7 +2245,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2280,7 +2280,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2315,7 +2315,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2350,7 +2350,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2385,7 +2385,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2420,7 +2420,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2455,7 +2455,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2490,7 +2490,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2525,7 +2525,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2560,7 +2560,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2595,7 +2595,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2630,7 +2630,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2665,7 +2665,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2700,7 +2700,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2735,7 +2735,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2770,7 +2770,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2805,7 +2805,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2840,7 +2840,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2875,7 +2875,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2910,7 +2910,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2945,7 +2945,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2980,7 +2980,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3015,7 +3015,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3050,7 +3050,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3085,7 +3085,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3120,7 +3120,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3155,7 +3155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3190,7 +3190,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3225,7 +3225,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3260,7 +3260,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3295,7 +3295,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3330,7 +3330,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3365,7 +3365,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3400,7 +3400,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3435,7 +3435,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3470,7 +3470,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3505,7 +3505,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3540,7 +3540,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3575,7 +3575,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3610,7 +3610,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3645,7 +3645,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3680,7 +3680,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3715,7 +3715,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3750,7 +3750,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3785,7 +3785,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3854,7 +3854,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3889,7 +3889,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3974,7 +3974,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4009,7 +4009,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4044,7 +4044,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4079,7 +4079,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4114,7 +4114,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4149,7 +4149,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4184,7 +4184,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4219,7 +4219,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4254,7 +4254,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4289,7 +4289,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4324,7 +4324,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4359,7 +4359,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4394,7 +4394,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4429,7 +4429,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4464,7 +4464,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4499,7 +4499,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4534,7 +4534,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4569,7 +4569,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4604,7 +4604,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4639,7 +4639,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4674,7 +4674,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4709,7 +4709,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4744,7 +4744,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4779,7 +4779,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4814,7 +4814,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4849,7 +4849,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4884,7 +4884,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4919,7 +4919,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4954,7 +4954,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -4989,7 +4989,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5024,7 +5024,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5059,7 +5059,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5094,7 +5094,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5129,7 +5129,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5164,7 +5164,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5199,7 +5199,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5234,7 +5234,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5269,7 +5269,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5304,7 +5304,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5339,7 +5339,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5374,7 +5374,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5409,7 +5409,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5444,7 +5444,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5479,7 +5479,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5514,7 +5514,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5549,7 +5549,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5584,7 +5584,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5619,7 +5619,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5654,7 +5654,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5689,7 +5689,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5724,7 +5724,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5759,7 +5759,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5794,7 +5794,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5829,7 +5829,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5864,7 +5864,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5899,7 +5899,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5934,7 +5934,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -5969,7 +5969,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6004,7 +6004,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6039,7 +6039,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6074,7 +6074,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6109,7 +6109,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6144,7 +6144,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6179,7 +6179,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6214,7 +6214,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6249,7 +6249,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6284,7 +6284,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6319,7 +6319,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6354,7 +6354,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6389,7 +6389,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6424,7 +6424,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6459,7 +6459,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6494,7 +6494,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6529,7 +6529,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6564,7 +6564,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6599,7 +6599,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6634,7 +6634,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6669,7 +6669,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6704,7 +6704,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6739,7 +6739,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6774,7 +6774,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6809,7 +6809,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6844,7 +6844,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6879,7 +6879,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6914,7 +6914,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6949,7 +6949,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -6984,7 +6984,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7019,7 +7019,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7054,7 +7054,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7089,7 +7089,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7124,7 +7124,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7159,7 +7159,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7194,7 +7194,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7229,7 +7229,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7264,7 +7264,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7299,7 +7299,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7334,7 +7334,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7369,7 +7369,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7404,7 +7404,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7439,7 +7439,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7474,7 +7474,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7509,7 +7509,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7544,7 +7544,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7579,7 +7579,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7614,7 +7614,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7649,7 +7649,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7684,7 +7684,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7719,7 +7719,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7761,7 +7761,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         },
         {
           "contributes": false,
-          "hint": "exception of system takes precedence",
+          "hint": "ignored because system exception takes precedence",
           "id": "threads",
           "name": "thread",
           "values": [
@@ -7788,7 +7788,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -7823,7 +7823,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.699428+00:00'
+created: '2025-09-19T05:53:38.413154+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1030,7 +1030,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1100,13 +1100,13 @@ source: tests/sentry/grouping/test_grouping_info.py
   "default": {
     "component": {
       "contributes": false,
-      "hint": "exception of app/system takes precedence",
+      "hint": "ignored because app/system exception takes precedence",
       "id": "default",
       "name": null,
       "values": [
         {
           "contributes": false,
-          "hint": "exception of app/system takes precedence",
+          "hint": "ignored because app/system exception takes precedence",
           "id": "message",
           "name": "message",
           "values": [
@@ -2166,7 +2166,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.718058+00:00'
+created: '2025-09-19T05:53:38.431494+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -150,13 +150,13 @@ source: tests/sentry/grouping/test_grouping_info.py
   "default": {
     "component": {
       "contributes": false,
-      "hint": "threads of app take precedence",
+      "hint": "ignored because app threads take precedence",
       "id": "default",
       "name": null,
       "values": [
         {
           "contributes": false,
-          "hint": "threads of app take precedence",
+          "hint": "ignored because app threads take precedence",
           "id": "message",
           "name": "message",
           "values": [
@@ -193,7 +193,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "system": {
     "component": {
       "contributes": false,
-      "hint": "threads of app take precedence",
+      "hint": "ignored because app threads take precedence",
       "id": "system",
       "name": null,
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.738658+00:00'
+created: '2025-09-19T05:53:38.450228+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.780253+00:00'
+created: '2025-09-19T05:53:38.483900+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "built-in fingerprint takes precedence",
+      "hint": "ignored because built-in fingerprint takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -120,7 +120,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "system": {
     "component": {
       "contributes": false,
-      "hint": "built-in fingerprint takes precedence",
+      "hint": "ignored because built-in fingerprint takes precedence",
       "id": "system",
       "name": null,
       "values": [
@@ -153,7 +153,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.760978+00:00'
+created: '2025-09-19T05:53:38.467530+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "built-in fingerprint takes precedence",
+      "hint": "ignored because built-in fingerprint takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -124,7 +124,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "system": {
     "component": {
       "contributes": false,
-      "hint": "built-in fingerprint takes precedence",
+      "hint": "ignored because built-in fingerprint takes precedence",
       "id": "system",
       "name": null,
       "values": [
@@ -157,7 +157,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.855667+00:00'
+created: '2025-09-19T05:53:38.550733+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -522,13 +522,13 @@ source: tests/sentry/grouping/test_grouping_info.py
   "default": {
     "component": {
       "contributes": false,
-      "hint": "threads of app/system take precedence",
+      "hint": "ignored because app/system threads take precedence",
       "id": "default",
       "name": null,
       "values": [
         {
           "contributes": false,
-          "hint": "threads of app/system take precedence",
+          "hint": "ignored because app/system threads take precedence",
           "id": "message",
           "name": "message",
           "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.149180+00:00'
+created: '2025-09-19T05:53:38.570796+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -128,7 +128,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -172,7 +172,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -216,7 +216,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -304,7 +304,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -348,7 +348,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -392,7 +392,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -436,7 +436,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -480,7 +480,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -559,13 +559,13 @@ source: tests/sentry/grouping/test_grouping_info.py
   "default": {
     "component": {
       "contributes": false,
-      "hint": "exception of app/system takes precedence",
+      "hint": "ignored because app/system exception takes precedence",
       "id": "default",
       "name": null,
       "values": [
         {
           "contributes": false,
-          "hint": "exception of app/system takes precedence",
+          "hint": "ignored because app/system exception takes precedence",
           "id": "message",
           "name": "message",
           "values": [
@@ -635,7 +635,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -679,7 +679,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -723,7 +723,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -767,7 +767,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -811,7 +811,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -855,7 +855,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -899,7 +899,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -943,7 +943,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -987,7 +987,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1031,7 +1031,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1075,7 +1075,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.190016+00:00'
+created: '2025-09-19T05:53:38.601794+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.320093+00:00'
+created: '2025-09-19T05:53:38.718855+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -28,7 +28,7 @@ source: tests/sentry/grouping/test_grouping_info.py
             },
             {
               "contributes": false,
-              "hint": "not a local script violation",
+              "hint": "ignored because it's not a local script violation",
               "id": "violation",
               "name": "violation",
               "values": []
@@ -46,7 +46,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         },
         {
           "contributes": false,
-          "hint": "csp takes precedence",
+          "hint": "ignored because csp takes precedence",
           "id": "message",
           "name": "message",
           "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_img_src.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_img_src.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.977707+00:00'
+created: '2025-09-19T05:53:38.617046+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -28,7 +28,7 @@ source: tests/sentry/grouping/test_grouping_info.py
             },
             {
               "contributes": false,
-              "hint": "not a local script violation",
+              "hint": "ignored because it's not a local script violation",
               "id": "violation",
               "name": "violation",
               "values": []

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.023787+00:00'
+created: '2025-09-19T05:53:38.631545+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -28,7 +28,7 @@ source: tests/sentry/grouping/test_grouping_info.py
             },
             {
               "contributes": false,
-              "hint": "not a local script violation",
+              "hint": "ignored because it's not a local script violation",
               "id": "violation",
               "name": "violation",
               "values": []

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_data_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_data_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.086630+00:00'
+created: '2025-09-19T05:53:38.646142+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -28,7 +28,7 @@ source: tests/sentry/grouping/test_grouping_info.py
             },
             {
               "contributes": false,
-              "hint": "not a local script violation",
+              "hint": "ignored because it's not a local script violation",
               "id": "violation",
               "name": "violation",
               "values": []

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.118899+00:00'
+created: '2025-09-19T05:53:38.661439+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -37,7 +37,7 @@ source: tests/sentry/grouping/test_grouping_info.py
             },
             {
               "contributes": false,
-              "hint": "violation takes precedence",
+              "hint": "ignored because violation takes precedence",
               "id": "uri",
               "name": "URL",
               "values": [
@@ -48,7 +48,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         },
         {
           "contributes": false,
-          "hint": "csp takes precedence",
+          "hint": "ignored because csp takes precedence",
           "id": "message",
           "name": "message",
           "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.159463+00:00'
+created: '2025-09-19T05:53:38.676251+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -37,7 +37,7 @@ source: tests/sentry/grouping/test_grouping_info.py
             },
             {
               "contributes": false,
-              "hint": "violation takes precedence",
+              "hint": "ignored because violation takes precedence",
               "id": "uri",
               "name": "URL",
               "values": [
@@ -48,7 +48,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         },
         {
           "contributes": false,
-          "hint": "csp takes precedence",
+          "hint": "ignored because csp takes precedence",
           "id": "message",
           "name": "message",
           "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.211727+00:00'
+created: '2025-09-19T05:53:38.690638+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -28,7 +28,7 @@ source: tests/sentry/grouping/test_grouping_info.py
             },
             {
               "contributes": false,
-              "hint": "not a local script violation",
+              "hint": "ignored because it's not a local script violation",
               "id": "violation",
               "name": "violation",
               "values": []

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_style_src_elem.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_style_src_elem.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.282621+00:00'
+created: '2025-09-19T05:53:38.704585+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -28,7 +28,7 @@ source: tests/sentry/grouping/test_grouping_info.py
             },
             {
               "contributes": false,
-              "hint": "not a local script violation",
+              "hint": "ignored because it's not a local script violation",
               "id": "violation",
               "name": "violation",
               "values": []
@@ -46,7 +46,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         },
         {
           "contributes": false,
-          "hint": "csp takes precedence",
+          "hint": "ignored because csp takes precedence",
           "id": "message",
           "name": "message",
           "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.392787+00:00'
+created: '2025-09-19T05:53:38.750035+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "custom client fingerprint takes precedence",
+      "hint": "ignored because custom client fingerprint takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -128,7 +128,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -172,7 +172,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -216,7 +216,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -304,7 +304,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -348,7 +348,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -392,7 +392,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -436,7 +436,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -480,7 +480,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -524,7 +524,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -568,7 +568,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -612,7 +612,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -656,7 +656,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -700,7 +700,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -744,7 +744,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -839,7 +839,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "system": {
     "component": {
       "contributes": false,
-      "hint": "custom client fingerprint takes precedence",
+      "hint": "ignored because custom client fingerprint takes precedence",
       "id": "system",
       "name": null,
       "values": [
@@ -872,7 +872,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -916,7 +916,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -960,7 +960,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1004,7 +1004,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1048,7 +1048,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1092,7 +1092,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1136,7 +1136,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1180,7 +1180,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1224,7 +1224,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1268,7 +1268,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1312,7 +1312,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1356,7 +1356,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1400,7 +1400,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1444,7 +1444,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1488,7 +1488,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1532,7 +1532,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1576,7 +1576,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.371465+00:00'
+created: '2025-09-19T05:53:38.734440+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "custom server fingerprint takes precedence",
+      "hint": "ignored because custom server fingerprint takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -128,7 +128,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -172,7 +172,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -216,7 +216,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -304,7 +304,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -348,7 +348,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -392,7 +392,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -436,7 +436,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -480,7 +480,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -524,7 +524,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -568,7 +568,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -612,7 +612,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -656,7 +656,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -700,7 +700,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -744,7 +744,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -838,7 +838,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "system": {
     "component": {
       "contributes": false,
-      "hint": "custom server fingerprint takes precedence",
+      "hint": "ignored because custom server fingerprint takes precedence",
       "id": "system",
       "name": null,
       "values": [
@@ -871,7 +871,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -915,7 +915,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -959,7 +959,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1003,7 +1003,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1047,7 +1047,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1091,7 +1091,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1135,7 +1135,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1179,7 +1179,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1223,7 +1223,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1267,7 +1267,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1311,7 +1311,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1355,7 +1355,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1399,7 +1399,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1443,7 +1443,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1487,7 +1487,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1531,7 +1531,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1575,7 +1575,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.413269+00:00'
+created: '2025-09-19T05:53:38.765781+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "custom server fingerprint takes precedence",
+      "hint": "ignored because custom server fingerprint takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -128,7 +128,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -172,7 +172,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -216,7 +216,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -304,7 +304,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -348,7 +348,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -392,7 +392,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -436,7 +436,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -480,7 +480,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -524,7 +524,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -568,7 +568,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -612,7 +612,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -656,7 +656,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -700,7 +700,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -744,7 +744,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -833,7 +833,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "system": {
     "component": {
       "contributes": false,
-      "hint": "custom server fingerprint takes precedence",
+      "hint": "ignored because custom server fingerprint takes precedence",
       "id": "system",
       "name": null,
       "values": [
@@ -866,7 +866,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -910,7 +910,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -954,7 +954,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -998,7 +998,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1042,7 +1042,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1086,7 +1086,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1130,7 +1130,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1174,7 +1174,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1218,7 +1218,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1262,7 +1262,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1306,7 +1306,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1350,7 +1350,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1394,7 +1394,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1438,7 +1438,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1482,7 +1482,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1526,7 +1526,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1570,7 +1570,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.452681+00:00'
+created: '2025-09-19T05:53:38.797768+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -72,7 +72,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         },
         {
           "contributes": false,
-          "hint": "exception of app takes precedence",
+          "hint": "ignored because app exception takes precedence",
           "id": "threads",
           "name": "thread",
           "values": [
@@ -829,13 +829,13 @@ source: tests/sentry/grouping/test_grouping_info.py
   "system": {
     "component": {
       "contributes": false,
-      "hint": "exception of app takes precedence",
+      "hint": "ignored because app exception takes precedence",
       "id": "system",
       "name": null,
       "values": [
         {
           "contributes": false,
-          "hint": "exception of app takes precedence",
+          "hint": "ignored because app exception takes precedence",
           "id": "threads",
           "name": "thread",
           "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.633877+00:00'
+created: '2025-09-19T05:53:38.813011+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -106,7 +106,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "system": {
     "component": {
       "contributes": false,
-      "hint": "exception of app takes precedence",
+      "hint": "ignored because app exception takes precedence",
       "id": "system",
       "name": null,
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.497094+00:00'
+created: '2025-09-19T05:53:38.827909+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -179,7 +179,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "system": {
     "component": {
       "contributes": false,
-      "hint": "exception of app takes precedence",
+      "hint": "ignored because app exception takes precedence",
       "id": "system",
       "name": null,
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.894510+00:00'
+created: '2025-09-19T05:53:39.104080+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -82,7 +82,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -194,7 +194,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -236,7 +236,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.502094+00:00'
+created: '2025-09-19T05:53:39.237302+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.531883+00:00'
+created: '2025-09-19T05:53:39.255229+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.585921+00:00'
+created: '2025-09-19T05:53:39.284132+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.613494+00:00'
+created: '2025-09-19T05:53:39.298158+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.636905+00:00'
+created: '2025-09-19T05:53:39.313035+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.679117+00:00'
+created: '2025-09-19T05:53:39.341558+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.702591+00:00'
+created: '2025-09-19T05:53:39.355376+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.725160+00:00'
+created: '2025-09-19T05:53:39.369708+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:18.284752+00:00'
+created: '2025-09-19T05:53:39.383782+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -132,7 +132,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "discarded because from URL origin and no function",
+                  "hint": "ignored because file path is a URL and function name is missing",
                   "id": "context_line",
                   "name": null,
                   "values": [
@@ -298,7 +298,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "discarded because from URL origin and no function",
+                  "hint": "ignored because file path is a URL and function name is missing",
                   "id": "context_line",
                   "name": null,
                   "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.765332+00:00'
+created: '2025-09-19T05:53:39.397503+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:18.352722+00:00'
+created: '2025-09-19T05:53:39.429888+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:18.374156+00:00'
+created: '2025-09-19T05:53:39.446056+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.865120+00:00'
+created: '2025-09-19T05:53:39.461313+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.895134+00:00'
+created: '2025-09-19T05:53:39.475720+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.924130+00:00'
+created: '2025-09-19T05:53:39.489688+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.946226+00:00'
+created: '2025-09-19T05:53:39.504663+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.016831+00:00'
+created: '2025-09-19T05:53:39.549069+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.971131+00:00'
+created: '2025-09-19T05:53:39.519356+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.992577+00:00'
+created: '2025-09-19T05:53:39.533642+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.037191+00:00'
+created: '2025-09-19T05:53:39.563552+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.079401+00:00'
+created: '2025-09-19T05:53:39.591943+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -32,7 +32,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "native code indicated by filename",
+                  "hint": "ignored because filename suggests native code",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -107,7 +107,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "native code indicated by filename",
+                  "hint": "ignored because filename suggests native code",
                   "id": "filename",
                   "name": null,
                   "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.192599+00:00'
+created: '2025-09-19T05:53:39.667420+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.169909+00:00'
+created: '2025-09-19T05:53:39.652562+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.215155+00:00'
+created: '2025-09-19T05:53:39.683584+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.235904+00:00'
+created: '2025-09-19T05:53:39.698703+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.259052+00:00'
+created: '2025-09-19T05:53:39.713036+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.333873+00:00'
+created: '2025-09-19T05:53:39.741968+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.296092+00:00'
+created: '2025-09-19T05:53:39.727915+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:18.826716+00:00'
+created: '2025-09-19T05:53:39.756484+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.398495+00:00'
+created: '2025-09-19T05:53:39.770300+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -34,7 +34,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -109,7 +109,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.431152+00:00'
+created: '2025-09-19T05:53:39.784386+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.458104+00:00'
+created: '2025-09-19T05:53:39.799842+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -178,7 +178,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -213,7 +213,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.497625+00:00'
+created: '2025-09-19T05:53:39.824431+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.523117+00:00'
+created: '2025-09-19T05:53:39.842691+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.552958+00:00'
+created: '2025-09-19T05:53:39.861197+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.577784+00:00'
+created: '2025-09-19T05:53:39.878189+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.600961+00:00'
+created: '2025-09-19T05:53:39.896208+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.626523+00:00'
+created: '2025-09-19T05:53:39.914201+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.649517+00:00'
+created: '2025-09-19T05:53:39.929828+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.672705+00:00'
+created: '2025-09-19T05:53:39.945687+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.698657+00:00'
+created: '2025-09-19T05:53:39.965846+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.724219+00:00'
+created: '2025-09-19T05:53:39.985232+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.749885+00:00'
+created: '2025-09-19T05:53:40.004951+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.772318+00:00'
+created: '2025-09-19T05:53:40.021578+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.796852+00:00'
+created: '2025-09-19T05:53:40.040038+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.821255+00:00'
+created: '2025-09-19T05:53:40.058753+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.846681+00:00'
+created: '2025-09-19T05:53:40.077939+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:19.308138+00:00'
+created: '2025-09-19T05:53:40.127693+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -45,7 +45,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -89,7 +89,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -133,7 +133,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -177,7 +177,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -221,7 +221,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -265,7 +265,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -309,7 +309,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -353,7 +353,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -397,7 +397,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -441,7 +441,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -485,7 +485,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -529,7 +529,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -573,7 +573,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -617,7 +617,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -661,7 +661,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -705,7 +705,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -749,7 +749,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -871,7 +871,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -915,7 +915,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -959,7 +959,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1003,7 +1003,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1047,7 +1047,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1091,7 +1091,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1135,7 +1135,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1179,7 +1179,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1223,7 +1223,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1267,7 +1267,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1311,7 +1311,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1355,7 +1355,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1399,7 +1399,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1443,7 +1443,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1487,7 +1487,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1531,7 +1531,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1575,7 +1575,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:19.331104+00:00'
+created: '2025-09-19T05:53:40.144547+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "custom server fingerprint takes precedence",
+      "hint": "ignored because custom server fingerprint takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -128,7 +128,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -172,7 +172,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -216,7 +216,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -304,7 +304,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -348,7 +348,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -392,7 +392,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -436,7 +436,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -480,7 +480,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -524,7 +524,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -568,7 +568,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -612,7 +612,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -656,7 +656,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -700,7 +700,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -744,7 +744,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -838,7 +838,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "system": {
     "component": {
       "contributes": false,
-      "hint": "custom server fingerprint takes precedence",
+      "hint": "ignored because custom server fingerprint takes precedence",
       "id": "system",
       "name": null,
       "values": [
@@ -871,7 +871,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -915,7 +915,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -959,7 +959,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1003,7 +1003,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1047,7 +1047,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1091,7 +1091,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1135,7 +1135,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1179,7 +1179,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1223,7 +1223,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1267,7 +1267,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1311,7 +1311,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1355,7 +1355,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1399,7 +1399,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1443,7 +1443,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1487,7 +1487,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1531,7 +1531,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1575,7 +1575,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:19.425210+00:00'
+created: '2025-09-19T05:53:40.215420+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -46,7 +46,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -81,7 +81,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -116,7 +116,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -151,7 +151,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -186,7 +186,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -221,7 +221,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -256,7 +256,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -291,7 +291,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -326,7 +326,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -361,7 +361,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -396,7 +396,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -431,7 +431,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -466,7 +466,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -501,7 +501,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -536,7 +536,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -571,7 +571,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -606,7 +606,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -641,7 +641,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -676,7 +676,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -711,7 +711,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -746,7 +746,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -781,7 +781,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -816,7 +816,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -885,7 +885,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -920,7 +920,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -955,7 +955,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -990,7 +990,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1025,7 +1025,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1060,7 +1060,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1095,7 +1095,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1130,7 +1130,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1165,7 +1165,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1200,7 +1200,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1235,7 +1235,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1270,7 +1270,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1305,7 +1305,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1340,7 +1340,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1375,7 +1375,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1444,7 +1444,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1479,7 +1479,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1514,7 +1514,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1549,7 +1549,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1584,7 +1584,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1619,7 +1619,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1654,7 +1654,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1689,7 +1689,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1724,7 +1724,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1759,7 +1759,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1794,7 +1794,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1829,7 +1829,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1864,7 +1864,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1899,7 +1899,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -1971,13 +1971,13 @@ source: tests/sentry/grouping/test_grouping_info.py
   "default": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "default",
       "name": null,
       "values": [
         {
           "contributes": false,
-          "hint": "exception of system takes precedence",
+          "hint": "ignored because system exception takes precedence",
           "id": "message",
           "name": "message",
           "values": [
@@ -2053,7 +2053,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2088,7 +2088,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2123,7 +2123,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2158,7 +2158,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2193,7 +2193,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2228,7 +2228,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2263,7 +2263,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2298,7 +2298,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2333,7 +2333,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2368,7 +2368,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2403,7 +2403,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2438,7 +2438,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2473,7 +2473,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2508,7 +2508,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2543,7 +2543,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2578,7 +2578,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2613,7 +2613,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2648,7 +2648,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2683,7 +2683,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2718,7 +2718,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2753,7 +2753,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2788,7 +2788,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2823,7 +2823,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2892,7 +2892,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2927,7 +2927,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2962,7 +2962,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -2997,7 +2997,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3032,7 +3032,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3067,7 +3067,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3102,7 +3102,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3137,7 +3137,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3172,7 +3172,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3207,7 +3207,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3242,7 +3242,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3277,7 +3277,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3312,7 +3312,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3347,7 +3347,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3382,7 +3382,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3451,7 +3451,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3486,7 +3486,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3521,7 +3521,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3556,7 +3556,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3591,7 +3591,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3626,7 +3626,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3661,7 +3661,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3696,7 +3696,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3731,7 +3731,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3766,7 +3766,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3801,7 +3801,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3836,7 +3836,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3871,7 +3871,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [
@@ -3906,7 +3906,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                         },
                         {
                           "contributes": false,
-                          "hint": "module takes precedence",
+                          "hint": "ignored because module takes precedence",
                           "id": "filename",
                           "name": null,
                           "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.121797+00:00'
+created: '2025-09-19T05:53:40.236287+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -110,7 +110,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -145,7 +145,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -180,7 +180,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -215,7 +215,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -250,7 +250,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -285,7 +285,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -320,7 +320,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -355,7 +355,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -390,7 +390,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -425,7 +425,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -460,7 +460,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -495,7 +495,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -530,7 +530,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -565,7 +565,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -600,7 +600,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -635,7 +635,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -670,7 +670,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -705,7 +705,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -740,7 +740,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -775,7 +775,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -810,7 +810,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -845,7 +845,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -880,7 +880,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -915,7 +915,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -950,7 +950,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -985,7 +985,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1020,7 +1020,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1055,7 +1055,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1090,7 +1090,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1125,7 +1125,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1160,7 +1160,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1195,7 +1195,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1230,7 +1230,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1265,7 +1265,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1300,7 +1300,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1335,7 +1335,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1370,7 +1370,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1405,7 +1405,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1440,7 +1440,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1475,7 +1475,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1510,7 +1510,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1545,7 +1545,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1580,7 +1580,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1615,7 +1615,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1650,7 +1650,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1685,7 +1685,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1720,7 +1720,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1755,7 +1755,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1790,7 +1790,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1825,7 +1825,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1860,7 +1860,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1895,7 +1895,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1930,7 +1930,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2000,13 +2000,13 @@ source: tests/sentry/grouping/test_grouping_info.py
   "default": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "default",
       "name": null,
       "values": [
         {
           "contributes": false,
-          "hint": "exception of system takes precedence",
+          "hint": "ignored because system exception takes precedence",
           "id": "message",
           "name": "message",
           "values": [
@@ -2076,7 +2076,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2111,7 +2111,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2146,7 +2146,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2181,7 +2181,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2216,7 +2216,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2251,7 +2251,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2286,7 +2286,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2321,7 +2321,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2356,7 +2356,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2391,7 +2391,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2426,7 +2426,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2461,7 +2461,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2496,7 +2496,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2531,7 +2531,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2566,7 +2566,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2601,7 +2601,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2636,7 +2636,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2671,7 +2671,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2706,7 +2706,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2741,7 +2741,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2776,7 +2776,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2811,7 +2811,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2846,7 +2846,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2881,7 +2881,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2916,7 +2916,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2951,7 +2951,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -2986,7 +2986,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3021,7 +3021,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3056,7 +3056,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3091,7 +3091,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3126,7 +3126,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3161,7 +3161,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3196,7 +3196,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3231,7 +3231,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3266,7 +3266,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3301,7 +3301,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3336,7 +3336,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3371,7 +3371,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3406,7 +3406,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3441,7 +3441,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3476,7 +3476,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3511,7 +3511,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3546,7 +3546,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3581,7 +3581,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3616,7 +3616,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3651,7 +3651,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3686,7 +3686,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3721,7 +3721,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3756,7 +3756,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3791,7 +3791,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3826,7 +3826,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3861,7 +3861,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3896,7 +3896,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3931,7 +3931,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -3966,7 +3966,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.203271+00:00'
+created: '2025-09-19T05:53:40.281712+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.264782+00:00'
+created: '2025-09-19T05:53:40.322962+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -174,7 +174,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "system": {
     "component": {
       "contributes": false,
-      "hint": "exception of app takes precedence",
+      "hint": "ignored because app exception takes precedence",
       "id": "system",
       "name": null,
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.286350+00:00'
+created: '2025-09-19T05:53:40.337301+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.309781+00:00'
+created: '2025-09-19T05:53:40.351986+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -201,7 +201,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "anonymous filename discarded",
+                      "hint": "ignored because filename is anonymous",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -595,7 +595,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "anonymous filename discarded",
+                      "hint": "ignored because filename is anonymous",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.333413+00:00'
+created: '2025-09-19T05:53:40.366761+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.362533+00:00'
+created: '2025-09-19T05:53:40.381518+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.383414+00:00'
+created: '2025-09-19T05:53:40.395876+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -211,7 +211,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "anonymous filename discarded",
+                      "hint": "ignored because filename is anonymous",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -623,7 +623,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "anonymous filename discarded",
+                      "hint": "ignored because filename is anonymous",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.404445+00:00'
+created: '2025-09-19T05:53:40.410519+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -213,7 +213,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -629,7 +629,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.426864+00:00'
+created: '2025-09-19T05:53:40.424944+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.449522+00:00'
+created: '2025-09-19T05:53:40.442475+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -141,7 +141,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "native code indicated by filename",
+                      "hint": "ignored because filename suggests native code",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -209,7 +209,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "native code indicated by filename",
+                      "hint": "ignored because filename suggests native code",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -345,7 +345,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "native code indicated by filename",
+                      "hint": "ignored because filename suggests native code",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -584,7 +584,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "native code indicated by filename",
+                      "hint": "ignored because filename suggests native code",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -652,7 +652,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "native code indicated by filename",
+                      "hint": "ignored because filename suggests native code",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -788,7 +788,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "native code indicated by filename",
+                      "hint": "ignored because filename suggests native code",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.469432+00:00'
+created: '2025-09-19T05:53:40.459261+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -135,7 +135,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "native code indicated by filename",
+                      "hint": "ignored because filename suggests native code",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -201,7 +201,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "native code indicated by filename",
+                      "hint": "ignored because filename suggests native code",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -331,7 +331,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "native code indicated by filename",
+                      "hint": "ignored because filename suggests native code",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -562,7 +562,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "native code indicated by filename",
+                      "hint": "ignored because filename suggests native code",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -628,7 +628,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "native code indicated by filename",
+                      "hint": "ignored because filename suggests native code",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -758,7 +758,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "native code indicated by filename",
+                      "hint": "ignored because filename suggests native code",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:19.792155+00:00'
+created: '2025-09-19T05:53:40.478305+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -128,7 +128,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -172,7 +172,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -216,7 +216,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -304,7 +304,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -348,7 +348,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -392,7 +392,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -436,7 +436,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -454,7 +454,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -480,7 +480,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -498,7 +498,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -524,7 +524,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -542,7 +542,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -568,7 +568,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -586,7 +586,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -612,7 +612,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -630,7 +630,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -656,7 +656,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -674,7 +674,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -700,7 +700,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -744,7 +744,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -788,7 +788,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -900,7 +900,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -944,7 +944,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -988,7 +988,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1032,7 +1032,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1076,7 +1076,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1120,7 +1120,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1164,7 +1164,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1208,7 +1208,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1252,7 +1252,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1296,7 +1296,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1314,7 +1314,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1340,7 +1340,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1358,7 +1358,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1384,7 +1384,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1402,7 +1402,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1428,7 +1428,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1446,7 +1446,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1472,7 +1472,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1490,7 +1490,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1516,7 +1516,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1534,7 +1534,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1560,7 +1560,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1604,7 +1604,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1648,7 +1648,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:19.817288+00:00'
+created: '2025-09-19T05:53:40.495800+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -38,7 +38,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "native code indicated by filename",
+                      "hint": "ignored because filename suggests native code",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -73,7 +73,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -117,7 +117,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -161,7 +161,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -205,7 +205,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -249,7 +249,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -293,7 +293,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -311,7 +311,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -337,7 +337,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -355,7 +355,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -381,7 +381,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -399,7 +399,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -425,7 +425,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -443,7 +443,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -469,7 +469,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -487,7 +487,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -513,7 +513,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -531,7 +531,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -557,7 +557,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -601,7 +601,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -645,7 +645,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -755,7 +755,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "native code indicated by filename",
+                      "hint": "ignored because filename suggests native code",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -790,7 +790,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -834,7 +834,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -878,7 +878,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -922,7 +922,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -966,7 +966,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1010,7 +1010,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1028,7 +1028,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1054,7 +1054,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1072,7 +1072,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1098,7 +1098,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1116,7 +1116,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1142,7 +1142,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1160,7 +1160,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1186,7 +1186,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1204,7 +1204,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1230,7 +1230,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1248,7 +1248,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1274,7 +1274,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1318,7 +1318,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1362,7 +1362,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.624352+00:00'
+created: '2025-09-19T05:53:40.574385+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.650767+00:00'
+created: '2025-09-19T05:53:40.592657+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.677336+00:00'
+created: '2025-09-19T05:53:40.609372+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:20.042661+00:00'
+created: '2025-09-19T05:53:40.673115+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -58,7 +58,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -102,7 +102,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -146,7 +146,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -190,7 +190,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -234,7 +234,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -278,7 +278,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -322,7 +322,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -366,7 +366,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -410,7 +410,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -454,7 +454,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -498,7 +498,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -542,7 +542,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -586,7 +586,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -630,7 +630,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -674,7 +674,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -718,7 +718,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -762,7 +762,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -806,7 +806,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -850,7 +850,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -894,7 +894,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -938,7 +938,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -982,7 +982,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1092,7 +1092,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1136,7 +1136,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1180,7 +1180,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1224,7 +1224,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1268,7 +1268,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1312,7 +1312,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1356,7 +1356,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1400,7 +1400,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1444,7 +1444,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1488,7 +1488,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1532,7 +1532,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1576,7 +1576,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1620,7 +1620,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1664,7 +1664,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1708,7 +1708,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1752,7 +1752,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1796,7 +1796,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1840,7 +1840,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1884,7 +1884,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1928,7 +1928,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -1972,7 +1972,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [
@@ -2016,7 +2016,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "discarded because line too long",
+                      "hint": "ignored because line is too long",
                       "id": "context_line",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.777244+00:00'
+created: '2025-09-19T05:53:40.688214+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.796922+00:00'
+created: '2025-09-19T05:53:40.703152+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.816378+00:00'
+created: '2025-09-19T05:53:40.717691+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.836373+00:00'
+created: '2025-09-19T05:53:40.732822+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.857853+00:00'
+created: '2025-09-19T05:53:40.747252+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.879965+00:00'
+created: '2025-09-19T05:53:40.762578+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.921748+00:00'
+created: '2025-09-19T05:53:40.791546+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.942563+00:00'
+created: '2025-09-19T05:53:40.806026+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.965661+00:00'
+created: '2025-09-19T05:53:40.821594+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -179,7 +179,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         },
         {
           "contributes": false,
-          "hint": "thread has no stacktrace",
+          "hint": "ignored because thread has no stacktrace",
           "id": "threads",
           "name": "thread",
           "values": []

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:20.256685+00:00'
+created: '2025-09-19T05:53:40.836796+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -119,7 +119,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -163,7 +163,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -207,7 +207,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -251,7 +251,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -295,7 +295,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -339,7 +339,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -383,7 +383,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -427,7 +427,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -530,7 +530,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -574,7 +574,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -609,7 +609,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -653,7 +653,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -697,7 +697,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -741,7 +741,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -785,7 +785,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -829,7 +829,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -873,7 +873,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -917,7 +917,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.008054+00:00'
+created: '2025-09-19T05:53:40.851398+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -143,7 +143,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "system": {
     "component": {
       "contributes": false,
-      "hint": "exception of app takes precedence",
+      "hint": "ignored because app exception takes precedence",
       "id": "system",
       "name": null,
       "values": [
@@ -176,7 +176,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:20.313532+00:00'
+created: '2025-09-19T05:53:40.880201+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -128,7 +128,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -172,7 +172,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -216,7 +216,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -304,7 +304,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -348,7 +348,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -392,7 +392,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -436,7 +436,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -548,7 +548,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -592,7 +592,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -636,7 +636,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -680,7 +680,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -724,7 +724,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -768,7 +768,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -812,7 +812,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -856,7 +856,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -900,7 +900,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -944,7 +944,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:20.332587+00:00'
+created: '2025-09-19T05:53:40.894966+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -128,7 +128,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -172,7 +172,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -216,7 +216,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -304,7 +304,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -348,7 +348,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -392,7 +392,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -436,7 +436,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -548,7 +548,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -592,7 +592,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -636,7 +636,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -680,7 +680,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -724,7 +724,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -768,7 +768,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -812,7 +812,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -856,7 +856,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -900,7 +900,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -944,7 +944,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:20.353456+00:00'
+created: '2025-09-19T05:53:40.909751+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -128,7 +128,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -207,13 +207,13 @@ source: tests/sentry/grouping/test_grouping_info.py
   "default": {
     "component": {
       "contributes": false,
-      "hint": "exception of app/system takes precedence",
+      "hint": "ignored because app/system exception takes precedence",
       "id": "default",
       "name": null,
       "values": [
         {
           "contributes": false,
-          "hint": "exception of app/system takes precedence",
+          "hint": "ignored because app/system exception takes precedence",
           "id": "message",
           "name": "message",
           "values": [
@@ -283,7 +283,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -327,7 +327,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -371,7 +371,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:20.429390+00:00'
+created: '2025-09-19T05:53:40.970501+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -40,7 +40,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -128,7 +128,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -172,7 +172,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -216,7 +216,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -260,7 +260,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -304,7 +304,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -348,7 +348,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -392,7 +392,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -436,7 +436,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -511,7 +511,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -555,7 +555,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -599,7 +599,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -643,7 +643,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -687,7 +687,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -731,7 +731,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -775,7 +775,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -819,7 +819,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -863,7 +863,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -907,7 +907,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -951,7 +951,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1063,7 +1063,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1107,7 +1107,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1151,7 +1151,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1195,7 +1195,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1239,7 +1239,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1283,7 +1283,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1327,7 +1327,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1371,7 +1371,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1415,7 +1415,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1459,7 +1459,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1534,7 +1534,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1578,7 +1578,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1622,7 +1622,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1666,7 +1666,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1710,7 +1710,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1754,7 +1754,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1798,7 +1798,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1842,7 +1842,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1886,7 +1886,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1930,7 +1930,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [
@@ -1974,7 +1974,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                     },
                     {
                       "contributes": false,
-                      "hint": "module takes precedence",
+                      "hint": "ignored because module takes precedence",
                       "id": "filename",
                       "name": null,
                       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.301922+00:00'
+created: '2025-09-19T05:53:40.999128+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -34,7 +34,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -69,7 +69,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -104,7 +104,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -139,7 +139,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -174,7 +174,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -209,7 +209,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -244,7 +244,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -321,7 +321,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -356,7 +356,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -391,7 +391,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -426,7 +426,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -461,7 +461,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -496,7 +496,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -531,7 +531,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "module takes precedence",
+                  "hint": "ignored because module takes precedence",
                   "id": "filename",
                   "name": null,
                   "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.372958+00:00'
+created: '2025-09-19T05:53:41.040675+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.418050+00:00'
+created: '2025-09-19T05:53:41.070184+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.443358+00:00'
+created: '2025-09-19T05:53:41.084515+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.469372+00:00'
+created: '2025-09-19T05:53:41.098796+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -111,7 +111,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "system": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of app takes precedence",
+      "hint": "ignored because app stacktrace takes precedence",
       "id": "system",
       "name": null,
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.500540+00:00'
+created: '2025-09-19T05:53:41.113543+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "stacktrace of system takes precedence",
+      "hint": "ignored because system stacktrace takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [
@@ -32,7 +32,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "anonymous filename discarded",
+                  "hint": "ignored because filename is anonymous",
                   "id": "filename",
                   "name": null,
                   "values": [
@@ -171,7 +171,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                 },
                 {
                   "contributes": false,
-                  "hint": "anonymous filename discarded",
+                  "hint": "ignored because filename is anonymous",
                   "id": "filename",
                   "name": null,
                   "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.522057+00:00'
+created: '2025-09-19T05:53:41.129056+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "app": {
     "component": {
       "contributes": false,
-      "hint": "exception of system takes precedence",
+      "hint": "ignored because system exception takes precedence",
       "id": "app",
       "name": "in-app",
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.634807+00:00'
+created: '2025-09-19T05:53:41.201895+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -90,7 +90,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "system": {
     "component": {
       "contributes": false,
-      "hint": "threads of app take precedence",
+      "hint": "ignored because app threads take precedence",
       "id": "system",
       "name": null,
       "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.768626+00:00'
+created: '2025-09-19T05:53:41.298127+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1430,7 +1430,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         },
         {
           "contributes": false,
-          "hint": "exception of app/system takes precedence",
+          "hint": "ignored because app/system exception takes precedence",
           "id": "threads",
           "name": "thread",
           "values": [
@@ -4280,7 +4280,7 @@ source: tests/sentry/grouping/test_grouping_info.py
         },
         {
           "contributes": false,
-          "hint": "exception of app/system takes precedence",
+          "hint": "ignored because app/system exception takes precedence",
           "id": "threads",
           "name": "thread",
           "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.813399+00:00'
+created: '2025-09-19T05:53:41.338300+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1328,13 +1328,13 @@ source: tests/sentry/grouping/test_grouping_info.py
   "default": {
     "component": {
       "contributes": false,
-      "hint": "threads of app/system take precedence",
+      "hint": "ignored because app/system threads take precedence",
       "id": "default",
       "name": null,
       "values": [
         {
           "contributes": false,
-          "hint": "threads of app/system take precedence",
+          "hint": "ignored because app/system threads take precedence",
           "id": "message",
           "name": "message",
           "values": [

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:16.010337+00:00'
+created: '2025-09-24T19:48:24.169382+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -13,7 +13,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: built-in fingerprint takes precedence
+      hint: ignored because built-in fingerprint takes precedence
     type: component
   built_in_fingerprint:
     matched_rule: family:"javascript" type:"ChunkLoadError" -> "chunkloaderror"
@@ -23,5 +23,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: built-in fingerprint takes precedence
+      hint: ignored because built-in fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_abs_path.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_abs_path.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:16.351532+00:00'
+created: '2025-09-24T19:48:24.204370+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,7 +20,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" -> "{{ stack.abs_path }}"
@@ -30,5 +30,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:17.269318+00:00'
+created: '2025-09-24T19:48:24.325058+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -28,5 +28,5 @@ variants:
   default:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:15.728454+00:00'
+created: '2025-09-24T19:48:24.126367+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,7 +20,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     client_values:
@@ -33,5 +33,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:17.957455+00:00'
+created: '2025-09-24T19:48:24.418290+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,7 +22,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     client_values:
@@ -35,5 +35,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-06T19:45:37.706347+00:00'
+created: '2025-09-24T19:48:23.969226+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -37,7 +37,7 @@ variants:
     - '{{ default }}'
     component:
       contributes: false
-      hint: exception of app takes precedence
+      hint: ignored because app exception takes precedence
     type: salted_component
     values:
     - my-route

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:14.719522+00:00'
+created: '2025-09-24T19:48:24.006948+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,7 +22,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     client_values:
@@ -35,5 +35,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-06T19:45:39.610879+00:00'
+created: '2025-09-24T19:48:24.290070+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -37,7 +37,7 @@ variants:
     - '{{ default }}'
     component:
       contributes: false
-      hint: exception of app takes precedence
+      hint: ignored because app exception takes precedence
     type: salted_component
     values:
     - my-route

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:17.697024+00:00'
+created: '2025-09-24T19:48:24.381487+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,7 +22,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: value:"*went wrong*" -> "something-went-wrong{{ error.value }}"
@@ -33,5 +33,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:14.090880+00:00'
+created: '2025-09-24T19:48:23.933938+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,7 +25,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
@@ -37,5 +37,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:17.404401+00:00'
+created: '2025-09-24T19:48:24.343846+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -28,5 +28,5 @@ variants:
   default:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:14.857909+00:00'
+created: '2025-09-24T19:48:24.024728+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,7 +22,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: message:"*love*" -> "what-is-love{{ message }}"
@@ -33,5 +33,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:15.891338+00:00'
+created: '2025-09-24T19:48:24.152189+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,7 +22,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"SymCacheError" function:"symbolicator::actors::symcaches::*"
@@ -33,5 +33,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:15.323823+00:00'
+created: '2025-09-24T19:48:24.084533+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,7 +22,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: function:"symbolicator::actors::symcaches::*" app:"true" -> "symcache-error"
@@ -32,5 +32,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:18.092628+00:00'
+created: '2025-09-24T19:48:24.436876+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,7 +25,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
@@ -37,5 +37,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-06T19:45:40.127492+00:00'
+created: '2025-09-24T19:48:24.399568+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -37,7 +37,7 @@ variants:
     - '{{ default }}'
     component:
       contributes: false
-      hint: exception of app takes precedence
+      hint: ignored because app exception takes precedence
     type: salted_component
     values:
     - my-route

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:14.552335+00:00'
+created: '2025-09-24T19:48:23.988697+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,7 +20,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" -> "{{ package }}"
@@ -30,5 +30,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:15.158256+00:00'
+created: '2025-09-24T19:48:24.059149+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,7 +25,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
@@ -37,5 +37,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:13.727464+00:00'
+created: '2025-09-24T19:48:23.864423+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -24,7 +24,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: function:"main" -> "{{ type }}{{ module }}{{ function }}"
@@ -36,5 +36,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:17.133621+00:00'
+created: '2025-09-24T19:48:24.307087+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -36,5 +36,5 @@ variants:
   default:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:15.008448+00:00'
+created: '2025-09-24T19:48:24.041473+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,5 +25,5 @@ variants:
   default:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:16.845801+00:00'
+created: '2025-09-24T19:48:24.272566+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -28,5 +28,5 @@ variants:
   default:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:14.231203+00:00'
+created: '2025-09-24T19:48:23.951264+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,5 +27,5 @@ variants:
   default:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:16.489072+00:00'
+created: '2025-09-24T19:48:24.221657+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,7 +20,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" -> "{{ package }}"
@@ -30,5 +30,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:13.953461+00:00'
+created: '2025-09-24T19:48:23.913583+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,7 +23,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"ReadTimeout" path:"**/requests/adapters.py" -> "timeout-in-requests"
@@ -33,5 +33,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:16.610349+00:00'
+created: '2025-09-24T19:48:24.238693+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,7 +20,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     client_values:
@@ -33,5 +33,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:17.561266+00:00'
+created: '2025-09-24T19:48:24.362823+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -26,7 +26,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
@@ -38,5 +38,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_two_threads.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_two_threads.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:16.156321+00:00'
+created: '2025-09-24T19:48:24.186835+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,7 +20,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: function:"main" -> "in-main"
@@ -30,5 +30,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-23T19:43:16.724367+00:00'
+created: '2025-09-24T19:48:24.256043+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,7 +25,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "{{ type
@@ -37,5 +37,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom server fingerprint takes precedence
+      hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:21:47.696063+00:00'
+created: '2025-09-19T05:52:36.171245+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,762 +7,762 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
               "com.android.internal.os.ZygoteInit"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "zygoteinit.java"
             function*
               "main"
           frame (marked out of app by the client)
             module*
               "com.android.internal.os.ZygoteInit$MethodAndArgsCaller"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "zygoteinit.java"
             function*
               "run"
           frame (marked out of app by the client)
             module*
               "java.lang.reflect.Method"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "method.java"
             function*
               "invoke"
           frame (marked out of app by the client)
             module*
               "java.lang.reflect.Method"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "method.java"
             function*
               "invoke"
           frame (marked out of app by the client)
             module*
               "android.app.ActivityThread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "activitythread.java"
             function*
               "main"
           frame (marked out of app by the client)
             module*
               "android.os.Looper"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "looper.java"
             function*
               "loop"
           frame (marked out of app by the client)
             module*
               "android.os.Handler"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "handler.java"
             function*
               "dispatchMessage"
           frame (marked out of app by the client)
             module*
               "android.os.Handler"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "handler.java"
             function*
               "handleCallback"
           frame (marked out of app by the client)
             module*
               "android.view.Choreographer$FrameDisplayEventReceiver"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "run"
           frame (marked out of app by the client)
             module*
               "android.view.Choreographer"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "doFrame"
           frame (marked out of app by the client)
             module*
               "android.view.Choreographer"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "doCallbacks"
           frame (marked out of app by the client)
             module*
               "android.view.Choreographer$CallbackRecord"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "run"
           frame (marked out of app by the client)
             module*
               "android.view.ViewRootImpl$TraversalRunnable"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "run"
           frame (marked out of app by the client)
             module*
               "android.view.ViewRootImpl"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "doTraversal"
           frame (marked out of app by the client)
             module*
               "android.view.ViewRootImpl"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "performTraversals"
           frame (marked out of app by the client)
             module*
               "android.view.ViewRootImpl"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "performLayout"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
           frame (marked out of app by the client)
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (marked out of app by the client)
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "onLayout"
           frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "dispatchLayout"
           frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "dispatchLayoutStep1"
           frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "processAdapterUpdatesAndSetAnimationFlags"
           frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.AdapterHelper"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "consumeUpdatesInOnePass"
           frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView$6"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "offsetPositionsForAdd"
           frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "offsetPositionRecordsForInsert"
           frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.ChildHelper"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "getUnfilteredChildAt"
           frame (marked out of app by the client)
             module*
               "androidx.recyclerview.widget.RecyclerView$5"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "getChildAt"
@@ -775,14 +775,14 @@ app:
           frame (marked out of app by the client)
             module*
               "java.lang.Thread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "thread.java"
             function*
               "getStackTrace"
           frame (marked out of app by the client)
             module*
               "dalvik.system.VMStack"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "vmstack.java"
             function*
               "getThreadStackTrace"
@@ -797,756 +797,756 @@ system:
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "com.android.internal.os.ZygoteInit"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "zygoteinit.java"
             function*
               "main"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "com.android.internal.os.ZygoteInit$MethodAndArgsCaller"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "zygoteinit.java"
             function*
               "run"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "java.lang.reflect.Method"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "method.java"
             function*
               "invoke"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "java.lang.reflect.Method"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "method.java"
             function*
               "invoke"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.app.ActivityThread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "activitythread.java"
             function*
               "main"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.os.Looper"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "looper.java"
             function*
               "loop"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.os.Handler"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "handler.java"
             function*
               "dispatchMessage"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.os.Handler"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "handler.java"
             function*
               "handleCallback"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer$FrameDisplayEventReceiver"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "run"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "doFrame"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "doCallbacks"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer$CallbackRecord"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "choreographer.java"
             function*
               "run"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl$TraversalRunnable"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "run"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "doTraversal"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "performTraversals"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewrootimpl.java"
             function*
               "performLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "viewgroup.java"
             function*
               "layout"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "view.java"
             function*
               "layout"
           frame*
             module*
               "androidx.recyclerview.widget.RecyclerView"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "onLayout"
           frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "dispatchLayout"
           frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "dispatchLayoutStep1"
           frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "processAdapterUpdatesAndSetAnimationFlags"
           frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.AdapterHelper"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "consumeUpdatesInOnePass"
           frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView$6"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "offsetPositionsForAdd"
           frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "offsetPositionRecordsForInsert"
           frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.ChildHelper"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "getUnfilteredChildAt"
           frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView$5"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "sourcefile"
             function*
               "getChildAt"
@@ -1554,19 +1554,19 @@ system:
           "ApplicationNotResponding"
         value (ignored because stacktrace takes precedence)
           "Application Not Responding for at least <int> ms."
-      threads (exception of system takes precedence)
+      threads (ignored because system exception takes precedence)
         stacktrace*
           frame*
             module*
               "java.lang.Thread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "thread.java"
             function*
               "getStackTrace"
           frame (ignored by stack trace rule (category:internals -group))
             module*
               "dalvik.system.VMStack"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "vmstack.java"
             function*
               "getThreadStackTrace"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:21:47.907164+00:00'
+created: '2025-09-19T05:52:36.190962+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -163,7 +163,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "SentryTest2.Controllers.ValuesController"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "valuescontroller.cs"
             function*
               "Get"
@@ -176,8 +176,8 @@ default:
   hash: null
   contributing component: null
   component:
-    default (exception of app/system takes precedence)
-      message (exception of app/system takes precedence)
+    default (ignored because app/system exception takes precedence)
+      message (ignored because app/system exception takes precedence)
         "An unhandled exception has occurred while executing the request."
 --------------------------------------------------------------------------
 system:
@@ -340,7 +340,7 @@ system:
           frame*
             module*
               "SentryTest2.Controllers.ValuesController"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "valuescontroller.cs"
             function*
               "Get"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:21:48.052430+00:00'
+created: '2025-09-19T05:52:36.209410+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,15 +24,15 @@ default:
   hash: null
   contributing component: null
   component:
-    default (threads of app take precedence)
-      message (threads of app take precedence)
+    default (ignored because app threads take precedence)
+      message (ignored because app threads take precedence)
         "Foo"
 --------------------------------------------------------------------------
 system:
   hash: null
   contributing component: null
   component:
-    system (threads of app take precedence)
+    system (ignored because app threads take precedence)
       threads (ignored because hash matches app variant)
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:21:48.170589+00:00'
+created: '2025-09-19T05:52:36.227606+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-07-18T18:34:02.043165+00:00'
+created: '2025-09-19T05:52:36.260507+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,13 +7,13 @@ app:
   hash: null
   contributing component: null
   component:
-    app (built-in fingerprint takes precedence)
+    app (ignored because built-in fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
               "foo.bar"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "bar.tsx"
             function*
               "main"
@@ -31,13 +31,13 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (built-in fingerprint takes precedence)
+    system (ignored because built-in fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
             module*
               "foo.bar"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "bar.tsx"
             function*
               "main"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-07-18T18:34:01.624671+00:00'
+created: '2025-09-19T05:52:36.245071+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,13 +7,13 @@ app:
   hash: null
   contributing component: null
   component:
-    app (built-in fingerprint takes precedence)
+    app (ignored because built-in fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
               "bar.bar"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "foo.tsx"
             function*
               "main"
@@ -31,13 +31,13 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (built-in fingerprint takes precedence)
+    system (ignored because built-in fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
             module*
               "bar.bar"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "foo.tsx"
             function*
               "main"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:40:58.548136+00:00'
+created: '2025-09-19T05:52:36.324340+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -60,8 +60,8 @@ default:
   hash: null
   contributing component: null
   component:
-    default (threads of app/system take precedence)
-      message (threads of app/system take precedence)
+    default (ignored because app/system threads take precedence)
+      message (ignored because app/system threads take precedence)
         "Foo"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:49.425980+00:00'
+created: '2025-09-19T05:52:36.341355+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.utils.safe"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "safe.py"
             function*
               "safe_execute"
@@ -22,7 +22,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.utils.services"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "services.py"
             function*
               "<lambda>"
@@ -31,7 +31,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "getsentry.quotas"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "quotas.py"
             function*
               "is_rate_limited"
@@ -40,7 +40,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.quotas.redis"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "redis.py"
             function*
               "is_rate_limited"
@@ -49,7 +49,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.utils.redis"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "redis.py"
             function*
               "call_script"
@@ -58,7 +58,7 @@ app:
           frame (marked out of app by the client)
             module*
               "redis.client"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "client.py"
             function*
               "__call__"
@@ -67,7 +67,7 @@ app:
           frame (marked out of app by the client)
             module*
               "redis.client"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "client.py"
             function*
               "evalsha"
@@ -76,7 +76,7 @@ app:
           frame (marked out of app by the client)
             module*
               "redis.client"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "client.py"
             function*
               "execute_command"
@@ -85,7 +85,7 @@ app:
           frame (marked out of app by the client)
             module*
               "redis.client"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "client.py"
             function*
               "parse_response"
@@ -94,7 +94,7 @@ app:
           frame (marked out of app by the client)
             module*
               "redis.connection"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "connection.py"
             function*
               "read_response"
@@ -103,7 +103,7 @@ app:
           frame (marked out of app by the client)
             module*
               "redis.connection"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "connection.py"
             function*
               "read_response"
@@ -118,8 +118,8 @@ default:
   hash: null
   contributing component: null
   component:
-    default (exception of app/system takes precedence)
-      message (exception of app/system takes precedence)
+    default (ignored because app/system exception takes precedence)
+      message (ignored because app/system exception takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:
@@ -132,7 +132,7 @@ system:
           frame*
             module*
               "sentry.utils.safe"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "safe.py"
             function*
               "safe_execute"
@@ -141,7 +141,7 @@ system:
           frame*
             module*
               "sentry.utils.services"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "services.py"
             function*
               "<lambda>"
@@ -150,7 +150,7 @@ system:
           frame*
             module*
               "getsentry.quotas"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "quotas.py"
             function*
               "is_rate_limited"
@@ -159,7 +159,7 @@ system:
           frame*
             module*
               "sentry.quotas.redis"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "redis.py"
             function*
               "is_rate_limited"
@@ -168,7 +168,7 @@ system:
           frame*
             module*
               "sentry.utils.redis"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "redis.py"
             function*
               "call_script"
@@ -177,7 +177,7 @@ system:
           frame*
             module*
               "redis.client"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "client.py"
             function*
               "__call__"
@@ -186,7 +186,7 @@ system:
           frame*
             module*
               "redis.client"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "client.py"
             function*
               "evalsha"
@@ -195,7 +195,7 @@ system:
           frame*
             module*
               "redis.client"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "client.py"
             function*
               "execute_command"
@@ -204,7 +204,7 @@ system:
           frame*
             module*
               "redis.client"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "client.py"
             function*
               "parse_response"
@@ -213,7 +213,7 @@ system:
           frame*
             module*
               "redis.connection"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "connection.py"
             function*
               "read_response"
@@ -222,7 +222,7 @@ system:
           frame*
             module*
               "redis.connection"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "connection.py"
             function*
               "read_response"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:49.476934+00:00'
+created: '2025-09-19T05:52:36.372477+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no contributing frames)
           frame (marked out of app by stack trace rule (function:runApp -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:09.976338+00:00'
+created: '2025-09-19T05:52:36.489890+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,8 +11,8 @@ default:
       csp*
         salt* (a static salt)
           "script-src"
-        violation (not a local script violation)
+        violation (ignored because it's not a local script violation)
         uri*
           "YYY"
-      message (csp takes precedence)
+      message (ignored because csp takes precedence)
         "Blocked 'script' from 'YYY'"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_img_src.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_img_src.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:09.407680+00:00'
+created: '2025-09-19T05:52:36.387193+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,6 +11,6 @@ default:
       csp*
         salt* (a static salt)
           "img-src"
-        violation (not a local script violation)
+        violation (ignored because it's not a local script violation)
         uri*
           "ftp://example.com"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:09.585767+00:00'
+created: '2025-09-19T05:52:36.402011+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,6 +11,6 @@ default:
       csp*
         salt* (a static salt)
           "script-src"
-        violation (not a local script violation)
+        violation (ignored because it's not a local script violation)
         uri*
           "'self'"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_data_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_data_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:09.675166+00:00'
+created: '2025-09-19T05:52:36.417038+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,6 +11,6 @@ default:
       csp*
         salt* (a static salt)
           "img-src"
-        violation (not a local script violation)
+        violation (ignored because it's not a local script violation)
         uri*
           "data:"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:09.745696+00:00'
+created: '2025-09-19T05:52:36.431885+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ default:
           "script-src"
         violation*
           "'unsafe-eval'"
-        uri (violation takes precedence)
+        uri (ignored because violation takes precedence)
           "'self'"
-      message (csp takes precedence)
+      message (ignored because csp takes precedence)
         "Blocked unsafe eval() 'script'"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:09.815198+00:00'
+created: '2025-09-19T05:52:36.446268+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ default:
           "script-src"
         violation*
           "'unsafe-inline'"
-        uri (violation takes precedence)
+        uri (ignored because violation takes precedence)
           "'self'"
-      message (csp takes precedence)
+      message (ignored because csp takes precedence)
         "Blocked unsafe inline 'script'"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:09.871501+00:00'
+created: '2025-09-19T05:52:36.461062+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,6 +11,6 @@ default:
       csp*
         salt* (a static salt)
           "script-src"
-        violation (not a local script violation)
+        violation (ignored because it's not a local script violation)
         uri*
           "example.com"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_style_src_elem.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_style_src_elem.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:09.926990+00:00'
+created: '2025-09-19T05:52:36.475387+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,8 +11,8 @@ default:
       csp*
         salt* (a static salt)
           "style-src-elem"
-        violation (not a local script violation)
+        violation (ignored because it's not a local script violation)
         uri*
           "use.fontawesome.com"
-      message (csp takes precedence)
+      message (ignored because csp takes precedence)
         "Blocked 'style' from '<hostname>'"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:49.689064+00:00'
+created: '2025-09-19T05:52:36.521394+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,13 +7,13 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom client fingerprint takes precedence)
+    app (ignored because custom client fingerprint takes precedence)
       exception*
         stacktrace*
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "_wrapped"
@@ -22,7 +22,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "process_event"
@@ -31,7 +31,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "_do_process_event"
@@ -40,7 +40,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "stacktraces.py"
             function*
               "process_stacktraces"
@@ -49,7 +49,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "plugin.py"
             function*
               "preprocess_step"
@@ -58,7 +58,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "symbolizer.py"
             function*
               "__init__"
@@ -67,7 +67,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "get_symcaches"
@@ -76,7 +76,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
@@ -85,7 +85,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "save_to"
@@ -94,7 +94,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_get_chunked_blob"
@@ -103,7 +103,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "__init__"
@@ -112,7 +112,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_prefetch"
@@ -121,7 +121,7 @@ app:
           frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "_base.py"
             function*
               "__exit__"
@@ -130,7 +130,7 @@ app:
           frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "thread.py"
             function*
               "shutdown"
@@ -139,7 +139,7 @@ app:
           frame (marked out of app by the client)
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "join"
@@ -148,7 +148,7 @@ app:
           frame (marked out of app by the client)
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "wait"
@@ -157,7 +157,7 @@ app:
           frame (marked out of app by the client)
             module*
               "billiard.pool"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "pool.py"
             function*
               "soft_timeout_sighandler"
@@ -177,13 +177,13 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom client fingerprint takes precedence)
+    system (ignored because custom client fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
             module*
               "sentry.tasks.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "_wrapped"
@@ -192,7 +192,7 @@ system:
           frame*
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "process_event"
@@ -201,7 +201,7 @@ system:
           frame*
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "_do_process_event"
@@ -210,7 +210,7 @@ system:
           frame*
             module*
               "sentry.stacktraces"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "stacktraces.py"
             function*
               "process_stacktraces"
@@ -219,7 +219,7 @@ system:
           frame*
             module*
               "sentry.lang.native.plugin"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "plugin.py"
             function*
               "preprocess_step"
@@ -228,7 +228,7 @@ system:
           frame*
             module*
               "sentry.lang.native.symbolizer"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "symbolizer.py"
             function*
               "__init__"
@@ -237,7 +237,7 @@ system:
           frame*
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "get_symcaches"
@@ -246,7 +246,7 @@ system:
           frame*
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
@@ -255,7 +255,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "save_to"
@@ -264,7 +264,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_get_chunked_blob"
@@ -273,7 +273,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "__init__"
@@ -282,7 +282,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_prefetch"
@@ -291,7 +291,7 @@ system:
           frame*
             module*
               "concurrent.futures._base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "_base.py"
             function*
               "__exit__"
@@ -300,7 +300,7 @@ system:
           frame*
             module*
               "concurrent.futures.thread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "thread.py"
             function*
               "shutdown"
@@ -309,7 +309,7 @@ system:
           frame*
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "join"
@@ -318,7 +318,7 @@ system:
           frame*
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "wait"
@@ -327,7 +327,7 @@ system:
           frame*
             module*
               "billiard.pool"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "pool.py"
             function*
               "soft_timeout_sighandler"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:49.666332+00:00'
+created: '2025-09-19T05:52:36.505379+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,13 +7,13 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom server fingerprint takes precedence)
+    app (ignored because custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "_wrapped"
@@ -22,7 +22,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "process_event"
@@ -31,7 +31,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "_do_process_event"
@@ -40,7 +40,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "stacktraces.py"
             function*
               "process_stacktraces"
@@ -49,7 +49,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "plugin.py"
             function*
               "preprocess_step"
@@ -58,7 +58,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "symbolizer.py"
             function*
               "__init__"
@@ -67,7 +67,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "get_symcaches"
@@ -76,7 +76,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
@@ -85,7 +85,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "save_to"
@@ -94,7 +94,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_get_chunked_blob"
@@ -103,7 +103,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "__init__"
@@ -112,7 +112,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_prefetch"
@@ -121,7 +121,7 @@ app:
           frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "_base.py"
             function*
               "__exit__"
@@ -130,7 +130,7 @@ app:
           frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "thread.py"
             function*
               "shutdown"
@@ -139,7 +139,7 @@ app:
           frame (marked out of app by the client)
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "join"
@@ -148,7 +148,7 @@ app:
           frame (marked out of app by the client)
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "wait"
@@ -157,7 +157,7 @@ app:
           frame (marked out of app by the client)
             module*
               "billiard.pool"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "pool.py"
             function*
               "soft_timeout_sighandler"
@@ -177,13 +177,13 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom server fingerprint takes precedence)
+    system (ignored because custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
             module*
               "sentry.tasks.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "_wrapped"
@@ -192,7 +192,7 @@ system:
           frame*
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "process_event"
@@ -201,7 +201,7 @@ system:
           frame*
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "_do_process_event"
@@ -210,7 +210,7 @@ system:
           frame*
             module*
               "sentry.stacktraces"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "stacktraces.py"
             function*
               "process_stacktraces"
@@ -219,7 +219,7 @@ system:
           frame*
             module*
               "sentry.lang.native.plugin"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "plugin.py"
             function*
               "preprocess_step"
@@ -228,7 +228,7 @@ system:
           frame*
             module*
               "sentry.lang.native.symbolizer"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "symbolizer.py"
             function*
               "__init__"
@@ -237,7 +237,7 @@ system:
           frame*
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "get_symcaches"
@@ -246,7 +246,7 @@ system:
           frame*
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
@@ -255,7 +255,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "save_to"
@@ -264,7 +264,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_get_chunked_blob"
@@ -273,7 +273,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "__init__"
@@ -282,7 +282,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_prefetch"
@@ -291,7 +291,7 @@ system:
           frame*
             module*
               "concurrent.futures._base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "_base.py"
             function*
               "__exit__"
@@ -300,7 +300,7 @@ system:
           frame*
             module*
               "concurrent.futures.thread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "thread.py"
             function*
               "shutdown"
@@ -309,7 +309,7 @@ system:
           frame*
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "join"
@@ -318,7 +318,7 @@ system:
           frame*
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "wait"
@@ -327,7 +327,7 @@ system:
           frame*
             module*
               "billiard.pool"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "pool.py"
             function*
               "soft_timeout_sighandler"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:49.713489+00:00'
+created: '2025-09-19T05:52:36.538337+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,13 +7,13 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom server fingerprint takes precedence)
+    app (ignored because custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "_wrapped"
@@ -22,7 +22,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "process_event"
@@ -31,7 +31,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "_do_process_event"
@@ -40,7 +40,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "stacktraces.py"
             function*
               "process_stacktraces"
@@ -49,7 +49,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "plugin.py"
             function*
               "preprocess_step"
@@ -58,7 +58,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "symbolizer.py"
             function*
               "__init__"
@@ -67,7 +67,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "get_symcaches"
@@ -76,7 +76,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
@@ -85,7 +85,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "save_to"
@@ -94,7 +94,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_get_chunked_blob"
@@ -103,7 +103,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "__init__"
@@ -112,7 +112,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_prefetch"
@@ -121,7 +121,7 @@ app:
           frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "_base.py"
             function*
               "__exit__"
@@ -130,7 +130,7 @@ app:
           frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "thread.py"
             function*
               "shutdown"
@@ -139,7 +139,7 @@ app:
           frame (marked out of app by the client)
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "join"
@@ -148,7 +148,7 @@ app:
           frame (marked out of app by the client)
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "wait"
@@ -157,7 +157,7 @@ app:
           frame (marked out of app by the client)
             module*
               "billiard.pool"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "pool.py"
             function*
               "soft_timeout_sighandler"
@@ -177,13 +177,13 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom server fingerprint takes precedence)
+    system (ignored because custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
             module*
               "sentry.tasks.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "_wrapped"
@@ -192,7 +192,7 @@ system:
           frame*
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "process_event"
@@ -201,7 +201,7 @@ system:
           frame*
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "_do_process_event"
@@ -210,7 +210,7 @@ system:
           frame*
             module*
               "sentry.stacktraces"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "stacktraces.py"
             function*
               "process_stacktraces"
@@ -219,7 +219,7 @@ system:
           frame*
             module*
               "sentry.lang.native.plugin"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "plugin.py"
             function*
               "preprocess_step"
@@ -228,7 +228,7 @@ system:
           frame*
             module*
               "sentry.lang.native.symbolizer"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "symbolizer.py"
             function*
               "__init__"
@@ -237,7 +237,7 @@ system:
           frame*
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "get_symcaches"
@@ -246,7 +246,7 @@ system:
           frame*
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
@@ -255,7 +255,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "save_to"
@@ -264,7 +264,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_get_chunked_blob"
@@ -273,7 +273,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "__init__"
@@ -282,7 +282,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_prefetch"
@@ -291,7 +291,7 @@ system:
           frame*
             module*
               "concurrent.futures._base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "_base.py"
             function*
               "__exit__"
@@ -300,7 +300,7 @@ system:
           frame*
             module*
               "concurrent.futures.thread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "thread.py"
             function*
               "shutdown"
@@ -309,7 +309,7 @@ system:
           frame*
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "join"
@@ -318,7 +318,7 @@ system:
           frame*
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "wait"
@@ -327,7 +327,7 @@ system:
           frame*
             module*
               "billiard.pool"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "pool.py"
             function*
               "soft_timeout_sighandler"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:34.961238+00:00'
+created: '2025-09-19T05:52:36.568903+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,7 +18,7 @@ app:
             0
         value (ignored because ns-error info takes precedence)
           "Code=<int> Description=The operation couldn’t be completed. (iOS_Swift.SampleError error <int>.)"
-      threads (exception of app takes precedence)
+      threads (ignored because app exception takes precedence)
         stacktrace*
           frame (marked out of app by the client)
             function*
@@ -94,8 +94,8 @@ system:
   hash: null
   contributing component: null
   component:
-    system (exception of app takes precedence)
-      threads (exception of app takes precedence)
+    system (ignored because app exception takes precedence)
+      threads (ignored because app exception takes precedence)
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:21:51.359658+00:00'
+created: '2025-09-19T05:52:36.583167+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ system:
   hash: null
   contributing component: null
   component:
-    system (exception of app takes precedence)
+    system (ignored because app exception takes precedence)
       exception (ignored because hash matches app variant)
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:49.804766+00:00'
+created: '2025-09-19T05:52:36.598596+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -32,7 +32,7 @@ system:
   hash: null
   contributing component: null
   component:
-    system (exception of app takes precedence)
+    system (ignored because app exception takes precedence)
       chained_exception (ignored because hash matches app variant)
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:50.158076+00:00'
+created: '2025-09-19T05:52:36.867031+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,20 +7,20 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
               "app/components/modals/createTeamModal"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "createteammodal.jsx"
             context_line*
               "onError(err);"
           frame (marked out of app by the client)
             module*
               "app/views/settings/components/forms/form"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "form.jsx"
             function (ignored because sourcemap used and context line available)
               "onError"
@@ -41,14 +41,14 @@ system:
           frame*
             module*
               "app/components/modals/createTeamModal"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "createteammodal.jsx"
             context_line*
               "onError(err);"
           frame*
             module*
               "app/views/settings/components/forms/form"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "form.jsx"
             function (ignored because sourcemap used and context line available)
               "onError"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:21:54.336775+00:00'
+created: '2025-09-19T05:52:37.000051+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:11.393020+00:00'
+created: '2025-09-19T05:52:37.015885+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:11.492237+00:00'
+created: '2025-09-19T05:52:37.046357+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:11.538650+00:00'
+created: '2025-09-19T05:52:37.062339+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:11.582816+00:00'
+created: '2025-09-19T05:52:37.080471+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:11.676678+00:00'
+created: '2025-09-19T05:52:37.119770+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:11.743494+00:00'
+created: '2025-09-19T05:52:37.140342+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:11.830568+00:00'
+created: '2025-09-19T05:52:37.160828+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:50.541271+00:00'
+created: '2025-09-19T05:52:37.181499+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
@@ -26,7 +26,7 @@ app:
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo.js"
-          context_line (discarded because from URL origin and no function)
+          context_line (ignored because file path is a URL and function name is missing)
             "hello world"
 --------------------------------------------------------------------------
 system:
@@ -52,5 +52,5 @@ system:
         frame
           filename (ignored because frame points to a URL)
             "foo.js"
-          context_line (discarded because from URL origin and no function)
+          context_line (ignored because file path is a URL and function name is missing)
             "hello world"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:11.932427+00:00'
+created: '2025-09-19T05:52:37.201631+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:50.598554+00:00'
+created: '2025-09-19T05:52:37.241874+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:50.617321+00:00'
+created: '2025-09-19T05:52:37.261326+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:02.567005+00:00'
+created: '2025-09-19T05:52:37.281269+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (family:javascript module:**/packages/flutter/** -app))
           module*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.194519+00:00'
+created: '2025-09-19T05:52:37.300187+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.238346+00:00'
+created: '2025-09-19T05:52:37.320208+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.280239+00:00'
+created: '2025-09-19T05:52:37.339159+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module (ignored java lambda)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.427765+00:00'
+created: '2025-09-19T05:52:37.396724+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.333885+00:00'
+created: '2025-09-19T05:52:37.359193+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.380625+00:00'
+created: '2025-09-19T05:52:37.378261+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename* (cleaned javassist parts)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.490795+00:00'
+created: '2025-09-19T05:52:37.415761+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module (ignored bad javascript module)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.604576+00:00'
+created: '2025-09-19T05:52:37.451616+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,10 +7,10 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
-          filename (native code indicated by filename)
+          filename (ignored because filename suggests native code)
             "[native code]"
           function*
             "forEach"
@@ -22,7 +22,7 @@ system:
     system*
       stacktrace*
         frame*
-          filename (native code indicated by filename)
+          filename (ignored because filename suggests native code)
             "[native code]"
           function*
             "forEach"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-07T18:37:31.787929+00:00'
+created: '2025-09-19T05:52:37.546284+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (category:framework -app))
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-07T18:37:31.505448+00:00'
+created: '2025-09-19T05:52:37.528830+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (category:framework -app))
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-07T18:37:32.081584+00:00'
+created: '2025-09-19T05:52:37.563323+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (category:framework -app))
           module* (removed reflection marker)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:12.976442+00:00'
+created: '2025-09-19T05:52:37.581578+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:13.018734+00:00'
+created: '2025-09-19T05:52:37.599687+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:13.104174+00:00'
+created: '2025-09-19T05:52:37.636893+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:13.060242+00:00'
+created: '2025-09-19T05:52:37.619636+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:51.004639+00:00'
+created: '2025-09-19T05:52:37.653240+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:13.355422+00:00'
+created: '2025-09-19T05:52:37.668491+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,12 +7,12 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "foo"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "foo.py"
 --------------------------------------------------------------------------
 system:
@@ -24,5 +24,5 @@ system:
         frame*
           module*
             "foo"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "foo.py"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:13.439929+00:00'
+created: '2025-09-19T05:52:37.683032+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:03.909577+00:00'
+created: '2025-09-19T05:52:37.698144+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,14 +13,14 @@ app:
           frame (marked out of app by stack trace rule (path:**/go/pkg/mod/** -app))
             module*
               "github.com/robfig/cron/v3"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "cron.go"
             function*
               "FuncJob.Run"
           frame* (marked in-app by the client)
             module*
               "main"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "main.go"
             function*
               "background.func2"
@@ -39,14 +39,14 @@ system:
           frame*
             module*
               "github.com/robfig/cron/v3"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "cron.go"
             function*
               "FuncJob.Run"
           frame*
             module*
               "main"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "main.go"
             function*
               "background.func2"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:05.380716+00:00'
+created: '2025-09-19T05:52:37.715889+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:05.494750+00:00'
+created: '2025-09-19T05:52:37.732684+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:13.656262+00:00'
+created: '2025-09-19T05:52:37.749874+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:05.707221+00:00'
+created: '2025-09-19T05:52:37.766577+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:05.871975+00:00'
+created: '2025-09-19T05:52:37.784409+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:06.011222+00:00'
+created: '2025-09-19T05:52:37.802387+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:13.892599+00:00'
+created: '2025-09-19T05:52:37.817682+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:06.203034+00:00'
+created: '2025-09-19T05:52:37.833387+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:06.338424+00:00'
+created: '2025-09-19T05:52:37.852802+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:06.460061+00:00'
+created: '2025-09-19T05:52:37.872104+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:06.608710+00:00'
+created: '2025-09-19T05:52:37.890944+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:14.218173+00:00'
+created: '2025-09-19T05:52:37.906257+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:14.288342+00:00'
+created: '2025-09-19T05:52:37.923852+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:14.340610+00:00'
+created: '2025-09-19T05:52:37.940947+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:07.049436+00:00'
+created: '2025-09-19T05:52:37.959860+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:51.453339+00:00'
+created: '2025-09-19T05:52:38.006637+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "_wrapped"
@@ -22,7 +22,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "process_event"
@@ -31,7 +31,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "_do_process_event"
@@ -40,7 +40,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "stacktraces.py"
             function*
               "process_stacktraces"
@@ -49,7 +49,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "plugin.py"
             function*
               "preprocess_step"
@@ -58,7 +58,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "symbolizer.py"
             function*
               "__init__"
@@ -67,7 +67,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "get_symcaches"
@@ -76,7 +76,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
@@ -85,7 +85,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "save_to"
@@ -94,7 +94,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_get_chunked_blob"
@@ -103,7 +103,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "__init__"
@@ -112,7 +112,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_prefetch"
@@ -121,7 +121,7 @@ app:
           frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "_base.py"
             function*
               "__exit__"
@@ -130,7 +130,7 @@ app:
           frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "thread.py"
             function*
               "shutdown"
@@ -139,7 +139,7 @@ app:
           frame (marked out of app by the client)
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "join"
@@ -148,7 +148,7 @@ app:
           frame (marked out of app by the client)
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "wait"
@@ -157,7 +157,7 @@ app:
           frame (marked out of app by the client)
             module*
               "billiard.pool"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "pool.py"
             function*
               "soft_timeout_sighandler"
@@ -180,7 +180,7 @@ system:
           frame*
             module*
               "sentry.tasks.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "_wrapped"
@@ -189,7 +189,7 @@ system:
           frame*
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "process_event"
@@ -198,7 +198,7 @@ system:
           frame*
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "_do_process_event"
@@ -207,7 +207,7 @@ system:
           frame*
             module*
               "sentry.stacktraces"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "stacktraces.py"
             function*
               "process_stacktraces"
@@ -216,7 +216,7 @@ system:
           frame*
             module*
               "sentry.lang.native.plugin"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "plugin.py"
             function*
               "preprocess_step"
@@ -225,7 +225,7 @@ system:
           frame*
             module*
               "sentry.lang.native.symbolizer"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "symbolizer.py"
             function*
               "__init__"
@@ -234,7 +234,7 @@ system:
           frame*
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "get_symcaches"
@@ -243,7 +243,7 @@ system:
           frame*
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
@@ -252,7 +252,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "save_to"
@@ -261,7 +261,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_get_chunked_blob"
@@ -270,7 +270,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "__init__"
@@ -279,7 +279,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_prefetch"
@@ -288,7 +288,7 @@ system:
           frame*
             module*
               "concurrent.futures._base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "_base.py"
             function*
               "__exit__"
@@ -297,7 +297,7 @@ system:
           frame*
             module*
               "concurrent.futures.thread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "thread.py"
             function*
               "shutdown"
@@ -306,7 +306,7 @@ system:
           frame*
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "join"
@@ -315,7 +315,7 @@ system:
           frame*
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "wait"
@@ -324,7 +324,7 @@ system:
           frame*
             module*
               "billiard.pool"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "pool.py"
             function*
               "soft_timeout_sighandler"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:51.472839+00:00'
+created: '2025-09-19T05:52:38.026762+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,13 +7,13 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom server fingerprint takes precedence)
+    app (ignored because custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "_wrapped"
@@ -22,7 +22,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "process_event"
@@ -31,7 +31,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "_do_process_event"
@@ -40,7 +40,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.stacktraces"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "stacktraces.py"
             function*
               "process_stacktraces"
@@ -49,7 +49,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.lang.native.plugin"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "plugin.py"
             function*
               "preprocess_step"
@@ -58,7 +58,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.lang.native.symbolizer"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "symbolizer.py"
             function*
               "__init__"
@@ -67,7 +67,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "get_symcaches"
@@ -76,7 +76,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
@@ -85,7 +85,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "save_to"
@@ -94,7 +94,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_get_chunked_blob"
@@ -103,7 +103,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "__init__"
@@ -112,7 +112,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_prefetch"
@@ -121,7 +121,7 @@ app:
           frame (marked out of app by the client)
             module*
               "concurrent.futures._base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "_base.py"
             function*
               "__exit__"
@@ -130,7 +130,7 @@ app:
           frame (marked out of app by the client)
             module*
               "concurrent.futures.thread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "thread.py"
             function*
               "shutdown"
@@ -139,7 +139,7 @@ app:
           frame (marked out of app by the client)
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "join"
@@ -148,7 +148,7 @@ app:
           frame (marked out of app by the client)
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "wait"
@@ -157,7 +157,7 @@ app:
           frame (marked out of app by the client)
             module*
               "billiard.pool"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "pool.py"
             function*
               "soft_timeout_sighandler"
@@ -177,13 +177,13 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom server fingerprint takes precedence)
+    system (ignored because custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
             module*
               "sentry.tasks.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "_wrapped"
@@ -192,7 +192,7 @@ system:
           frame*
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "process_event"
@@ -201,7 +201,7 @@ system:
           frame*
             module*
               "sentry.tasks.store"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "store.py"
             function*
               "_do_process_event"
@@ -210,7 +210,7 @@ system:
           frame*
             module*
               "sentry.stacktraces"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "stacktraces.py"
             function*
               "process_stacktraces"
@@ -219,7 +219,7 @@ system:
           frame*
             module*
               "sentry.lang.native.plugin"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "plugin.py"
             function*
               "preprocess_step"
@@ -228,7 +228,7 @@ system:
           frame*
             module*
               "sentry.lang.native.symbolizer"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "symbolizer.py"
             function*
               "__init__"
@@ -237,7 +237,7 @@ system:
           frame*
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "get_symcaches"
@@ -246,7 +246,7 @@ system:
           frame*
             module*
               "sentry.models.debugfile"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "debugfile.py"
             function*
               "_load_cachefiles_via_fs"
@@ -255,7 +255,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "save_to"
@@ -264,7 +264,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_get_chunked_blob"
@@ -273,7 +273,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "__init__"
@@ -282,7 +282,7 @@ system:
           frame*
             module*
               "sentry.models.file"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "file.py"
             function*
               "_prefetch"
@@ -291,7 +291,7 @@ system:
           frame*
             module*
               "concurrent.futures._base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "_base.py"
             function*
               "__exit__"
@@ -300,7 +300,7 @@ system:
           frame*
             module*
               "concurrent.futures.thread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "thread.py"
             function*
               "shutdown"
@@ -309,7 +309,7 @@ system:
           frame*
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "join"
@@ -318,7 +318,7 @@ system:
           frame*
             module*
               "threading"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threading.py"
             function*
               "wait"
@@ -327,7 +327,7 @@ system:
           frame*
             module*
               "billiard.pool"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "pool.py"
             function*
               "soft_timeout_sighandler"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:51.571589+00:00'
+created: '2025-09-19T05:52:38.093786+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,168 +7,168 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       chained_exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         exception*
           stacktrace (ignored because it contains no in-app frames)
             frame (marked out of app by the client)
               module*
                 "io.sentry.example.Application"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "application.java"
               function*
                 "main"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "refreshContext"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "refresh"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "refresh"
             frame (marked out of app by the client)
               module*
                 "org.springframework.context.support.AbstractApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "abstractapplicationcontext.java"
               function*
                 "refresh"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "finishRefresh"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "startEmbeddedServletContainer"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "start"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "addPreviouslyRemovedConnectors"
             frame (marked out of app by the client)
               module*
                 "org.apache.catalina.core.StandardService"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "standardservice.java"
               function*
                 "addConnector"
             frame (marked out of app by the client)
               module*
                 "org.apache.catalina.util.LifecycleBase"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "lifecyclebase.java"
               function*
                 "start"
             frame (marked out of app by the client)
               module*
                 "org.apache.catalina.connector.Connector"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "connector.java"
               function*
                 "startInternal"
             frame (marked out of app by the client)
               module*
                 "org.apache.coyote.AbstractProtocol"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "abstractprotocol.java"
               function*
                 "start"
             frame (marked out of app by the client)
               module*
                 "org.apache.tomcat.util.net.AbstractEndpoint"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "abstractendpoint.java"
               function*
                 "start"
             frame (marked out of app by the client)
               module*
                 "org.apache.tomcat.util.net.NioEndpoint"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "nioendpoint.java"
               function*
                 "bind"
             frame (marked out of app by the client)
               module*
                 "sun.nio.ch.ServerSocketAdaptor"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "serversocketadaptor.java"
               function*
                 "bind"
             frame (marked out of app by the client)
               module*
                 "sun.nio.ch.ServerSocketChannelImpl"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "serversocketchannelimpl.java"
               function*
                 "bind"
             frame (marked out of app by the client)
               module*
                 "sun.nio.ch.Net"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "net.java"
               function*
                 "bind"
             frame (marked out of app by the client)
               module*
                 "sun.nio.ch.Net"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "net.java"
               function*
                 "bind"
             frame (marked out of app by the client)
               module*
                 "sun.nio.ch.Net"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "net.java"
               function*
                 "bind0"
@@ -181,105 +181,105 @@ app:
             frame (marked out of app by the client)
               module*
                 "io.sentry.example.Application"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "application.java"
               function*
                 "main"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "refreshContext"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "refresh"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "refresh"
             frame (marked out of app by the client)
               module*
                 "org.springframework.context.support.AbstractApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "abstractapplicationcontext.java"
               function*
                 "refresh"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "finishRefresh"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "startEmbeddedServletContainer"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "start"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "addPreviouslyRemovedConnectors"
             frame (marked out of app by the client)
               module*
                 "org.apache.catalina.core.StandardService"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "standardservice.java"
               function*
                 "addConnector"
             frame (marked out of app by the client)
               module*
                 "org.apache.catalina.util.LifecycleBase"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "lifecyclebase.java"
               function*
                 "start"
             frame (marked out of app by the client)
               module*
                 "org.apache.catalina.connector.Connector"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "connector.java"
               function*
                 "startInternal"
@@ -292,98 +292,98 @@ app:
             frame (marked out of app by stack trace rule (category:framework -app))
               module*
                 "io.sentry.example.Application"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "application.java"
               function*
                 "main"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "refreshContext"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "refresh"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "refresh"
             frame (marked out of app by the client)
               module*
                 "org.springframework.context.support.AbstractApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "abstractapplicationcontext.java"
               function*
                 "refresh"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "finishRefresh"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "startEmbeddedServletContainer"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "start"
             frame (marked out of app by the client)
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "addPreviouslyRemovedConnectors"
             frame (marked out of app by the client)
               module*
                 "org.apache.catalina.core.StandardService"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "standardservice.java"
               function*
                 "addConnector"
             frame (marked out of app by the client)
               module*
                 "org.apache.catalina.util.LifecycleBase"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "lifecyclebase.java"
               function*
                 "start"
@@ -396,8 +396,8 @@ default:
   hash: null
   contributing component: null
   component:
-    default (exception of system takes precedence)
-      message (exception of system takes precedence)
+    default (ignored because system exception takes precedence)
+      message (ignored because system exception takes precedence)
         "Failed to start connector [Connector[HTTP/<float><int>]]"
 --------------------------------------------------------------------------
 system:
@@ -411,161 +411,161 @@ system:
             frame (ignored by stack trace rule (module:io.sentry.* -group))
               module*
                 "io.sentry.example.Application"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "application.java"
               function*
                 "main"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "refreshContext"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "refresh"
             frame*
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "refresh"
             frame*
               module*
                 "org.springframework.context.support.AbstractApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "abstractapplicationcontext.java"
               function*
                 "refresh"
             frame*
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "finishRefresh"
             frame*
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "startEmbeddedServletContainer"
             frame*
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "start"
             frame*
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "addPreviouslyRemovedConnectors"
             frame*
               module*
                 "org.apache.catalina.core.StandardService"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "standardservice.java"
               function*
                 "addConnector"
             frame*
               module*
                 "org.apache.catalina.util.LifecycleBase"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "lifecyclebase.java"
               function*
                 "start"
             frame*
               module*
                 "org.apache.catalina.connector.Connector"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "connector.java"
               function*
                 "startInternal"
             frame*
               module*
                 "org.apache.coyote.AbstractProtocol"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "abstractprotocol.java"
               function*
                 "start"
             frame*
               module*
                 "org.apache.tomcat.util.net.AbstractEndpoint"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "abstractendpoint.java"
               function*
                 "start"
             frame*
               module*
                 "org.apache.tomcat.util.net.NioEndpoint"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "nioendpoint.java"
               function*
                 "bind"
             frame*
               module*
                 "sun.nio.ch.ServerSocketAdaptor"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "serversocketadaptor.java"
               function*
                 "bind"
             frame*
               module*
                 "sun.nio.ch.ServerSocketChannelImpl"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "serversocketchannelimpl.java"
               function*
                 "bind"
             frame*
               module*
                 "sun.nio.ch.Net"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "net.java"
               function*
                 "bind"
             frame*
               module*
                 "sun.nio.ch.Net"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "net.java"
               function*
                 "bind"
             frame*
               module*
                 "sun.nio.ch.Net"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "net.java"
               function*
                 "bind0"
@@ -578,105 +578,105 @@ system:
             frame (ignored by stack trace rule (module:io.sentry.* -group))
               module*
                 "io.sentry.example.Application"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "application.java"
               function*
                 "main"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "refreshContext"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "refresh"
             frame*
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "refresh"
             frame*
               module*
                 "org.springframework.context.support.AbstractApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "abstractapplicationcontext.java"
               function*
                 "refresh"
             frame*
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "finishRefresh"
             frame*
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "startEmbeddedServletContainer"
             frame*
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "start"
             frame*
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "addPreviouslyRemovedConnectors"
             frame*
               module*
                 "org.apache.catalina.core.StandardService"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "standardservice.java"
               function*
                 "addConnector"
             frame*
               module*
                 "org.apache.catalina.util.LifecycleBase"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "lifecyclebase.java"
               function*
                 "start"
             frame*
               module*
                 "org.apache.catalina.connector.Connector"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "connector.java"
               function*
                 "startInternal"
@@ -689,98 +689,98 @@ system:
             frame (ignored by stack trace rule (module:io.sentry.* -group))
               module*
                 "io.sentry.example.Application"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "application.java"
               function*
                 "main"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "run"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "refreshContext"
             frame*
               module*
                 "org.springframework.boot.SpringApplication"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "springapplication.java"
               function*
                 "refresh"
             frame*
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "refresh"
             frame*
               module*
                 "org.springframework.context.support.AbstractApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "abstractapplicationcontext.java"
               function*
                 "refresh"
             frame*
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "finishRefresh"
             frame*
               module*
                 "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "embeddedwebapplicationcontext.java"
               function*
                 "startEmbeddedServletContainer"
             frame*
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "start"
             frame*
               module*
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "tomcatembeddedservletcontainer.java"
               function*
                 "addPreviouslyRemovedConnectors"
             frame*
               module*
                 "org.apache.catalina.core.StandardService"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "standardservice.java"
               function*
                 "addConnector"
             frame*
               module*
                 "org.apache.catalina.util.LifecycleBase"
-              filename (module takes precedence)
+              filename (ignored because module takes precedence)
                 "lifecyclebase.java"
               function*
                 "start"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:41:14.689837+00:00'
+created: '2025-09-19T05:52:38.114811+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,391 +7,391 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
             module*
               "java.lang.Thread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "thread.java"
             function*
               "run"
           frame (marked out of app by the client)
             module*
               "org.apache.tomcat.util.threads.TaskThread$WrappingRunnable"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "taskthread.java"
             function*
               "run"
           frame (marked out of app by the client)
             module*
               "java.util.concurrent.ThreadPoolExecutor$Worker"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threadpoolexecutor.java"
             function*
               "run"
           frame (marked out of app by the client)
             module*
               "java.util.concurrent.ThreadPoolExecutor"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threadpoolexecutor.java"
             function*
               "runWorker"
           frame (marked out of app by the client)
             module*
               "org.apache.tomcat.util.net.SocketProcessorBase"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "socketprocessorbase.java"
             function*
               "run"
           frame (marked out of app by the client)
             module*
               "org.apache.tomcat.util.net.NioEndpoint$SocketProcessor"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "nioendpoint.java"
             function*
               "doRun"
           frame (marked out of app by the client)
             module*
               "org.apache.coyote.AbstractProtocol$ConnectionHandler"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "abstractprotocol.java"
             function*
               "process"
           frame (marked out of app by the client)
             module*
               "org.apache.coyote.AbstractProcessorLight"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "abstractprocessorlight.java"
             function*
               "process"
           frame (marked out of app by the client)
             module*
               "org.apache.coyote.http11.Http11Processor"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "http11processor.java"
             function*
               "service"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.connector.CoyoteAdapter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "coyoteadapter.java"
             function*
               "service"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.StandardEngineValve"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "standardenginevalve.java"
             function*
               "invoke"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.valves.ErrorReportValve"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "errorreportvalve.java"
             function*
               "invoke"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.StandardHostValve"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "standardhostvalve.java"
             function*
               "invoke"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.authenticator.AuthenticatorBase"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "authenticatorbase.java"
             function*
               "invoke"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.StandardContextValve"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "standardcontextvalve.java"
             function*
               "invoke"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.StandardWrapperValve"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "standardwrappervalve.java"
             function*
               "invoke"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.CharacterEncodingFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "characterencodingfilter.java"
             function*
               "doFilterInternal"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.HiddenHttpMethodFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "hiddenhttpmethodfilter.java"
             function*
               "doFilterInternal"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.HttpPutFormContentFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "httpputformcontentfilter.java"
             function*
               "doFilterInternal"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.filter.RequestContextFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "requestcontextfilter.java"
             function*
               "doFilterInternal"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
           frame (marked out of app by the client)
             module*
               "org.apache.tomcat.websocket.server.WsFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "wsfilter.java"
             function*
               "doFilter"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
           frame (marked out of app by the client)
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
           frame (marked out of app by the client)
             module*
               "javax.servlet.http.HttpServlet"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "httpservlet.java"
             function*
               "service"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.FrameworkServlet"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "frameworkservlet.java"
             function*
               "service"
           frame (marked out of app by the client)
             module*
               "javax.servlet.http.HttpServlet"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "httpservlet.java"
             function*
               "service"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.FrameworkServlet"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "frameworkservlet.java"
             function*
               "doGet"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.FrameworkServlet"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "frameworkservlet.java"
             function*
               "processRequest"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.DispatcherServlet"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "dispatcherservlet.java"
             function*
               "doService"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.DispatcherServlet"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "dispatcherservlet.java"
             function*
               "doDispatch"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "abstracthandlermethodadapter.java"
             function*
               "handle"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "requestmappinghandleradapter.java"
             function*
               "handleInternal"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "requestmappinghandleradapter.java"
             function*
               "invokeHandlerMethod"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "servletinvocablehandlermethod.java"
             function*
               "invokeAndHandle"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.method.support.InvocableHandlerMethod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "invocablehandlermethod.java"
             function*
               "invokeForRequest"
           frame (marked out of app by the client)
             module*
               "org.springframework.web.method.support.InvocableHandlerMethod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "invocablehandlermethod.java"
             function*
               "doInvoke"
           frame (marked out of app by the client)
             module*
               "java.lang.reflect.Method"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "method.java"
             function*
               "invoke"
           frame (marked out of app by the client)
             module*
               "jdk.internal.reflect.DelegatingMethodAccessorImpl"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "delegatingmethodaccessorimpl.java"
             function*
               "invoke"
           frame (marked out of app by the client)
             module*
               "jdk.internal.reflect.NativeMethodAccessorImpl"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "nativemethodaccessorimpl.java"
             function*
               "invoke"
           frame (marked out of app by the client)
             module*
               "jdk.internal.reflect.NativeMethodAccessorImpl"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "nativemethodaccessorimpl.java"
             function*
               "invoke0"
           frame (marked out of app by the client)
             module*
               "io.sentry.example.Application"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "application.java"
             function*
               "home"
@@ -404,8 +404,8 @@ default:
   hash: null
   contributing component: null
   component:
-    default (exception of system takes precedence)
-      message (exception of system takes precedence)
+    default (ignored because system exception takes precedence)
+      message (ignored because system exception takes precedence)
         "Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.ArithmeticException: / by zero] with root cause"
 --------------------------------------------------------------------------
 system:
@@ -418,385 +418,385 @@ system:
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "java.lang.Thread"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "thread.java"
             function*
               "run"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "org.apache.tomcat.util.threads.TaskThread$WrappingRunnable"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "taskthread.java"
             function*
               "run"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "java.util.concurrent.ThreadPoolExecutor$Worker"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threadpoolexecutor.java"
             function*
               "run"
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "java.util.concurrent.ThreadPoolExecutor"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "threadpoolexecutor.java"
             function*
               "runWorker"
           frame*
             module*
               "org.apache.tomcat.util.net.SocketProcessorBase"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "socketprocessorbase.java"
             function*
               "run"
           frame*
             module*
               "org.apache.tomcat.util.net.NioEndpoint$SocketProcessor"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "nioendpoint.java"
             function*
               "doRun"
           frame*
             module*
               "org.apache.coyote.AbstractProtocol$ConnectionHandler"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "abstractprotocol.java"
             function*
               "process"
           frame*
             module*
               "org.apache.coyote.AbstractProcessorLight"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "abstractprocessorlight.java"
             function*
               "process"
           frame*
             module*
               "org.apache.coyote.http11.Http11Processor"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "http11processor.java"
             function*
               "service"
           frame*
             module*
               "org.apache.catalina.connector.CoyoteAdapter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "coyoteadapter.java"
             function*
               "service"
           frame*
             module*
               "org.apache.catalina.core.StandardEngineValve"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "standardenginevalve.java"
             function*
               "invoke"
           frame*
             module*
               "org.apache.catalina.valves.ErrorReportValve"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "errorreportvalve.java"
             function*
               "invoke"
           frame*
             module*
               "org.apache.catalina.core.StandardHostValve"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "standardhostvalve.java"
             function*
               "invoke"
           frame*
             module*
               "org.apache.catalina.authenticator.AuthenticatorBase"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "authenticatorbase.java"
             function*
               "invoke"
           frame*
             module*
               "org.apache.catalina.core.StandardContextValve"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "standardcontextvalve.java"
             function*
               "invoke"
           frame*
             module*
               "org.apache.catalina.core.StandardWrapperValve"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "standardwrappervalve.java"
             function*
               "invoke"
           frame*
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
           frame*
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
           frame*
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
           frame*
             module*
               "org.springframework.web.filter.CharacterEncodingFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "characterencodingfilter.java"
             function*
               "doFilterInternal"
           frame*
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
           frame*
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
           frame*
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
           frame*
             module*
               "org.springframework.web.filter.HiddenHttpMethodFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "hiddenhttpmethodfilter.java"
             function*
               "doFilterInternal"
           frame*
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
           frame*
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
           frame*
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
           frame*
             module*
               "org.springframework.web.filter.HttpPutFormContentFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "httpputformcontentfilter.java"
             function*
               "doFilterInternal"
           frame*
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
           frame*
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
           frame*
             module*
               "org.springframework.web.filter.OncePerRequestFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "onceperrequestfilter.java"
             function*
               "doFilter"
           frame*
             module*
               "org.springframework.web.filter.RequestContextFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "requestcontextfilter.java"
             function*
               "doFilterInternal"
           frame*
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
           frame*
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
           frame*
             module*
               "org.apache.tomcat.websocket.server.WsFilter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "wsfilter.java"
             function*
               "doFilter"
           frame*
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "doFilter"
           frame*
             module*
               "org.apache.catalina.core.ApplicationFilterChain"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "applicationfilterchain.java"
             function*
               "internalDoFilter"
           frame*
             module*
               "javax.servlet.http.HttpServlet"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "httpservlet.java"
             function*
               "service"
           frame*
             module*
               "org.springframework.web.servlet.FrameworkServlet"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "frameworkservlet.java"
             function*
               "service"
           frame*
             module*
               "javax.servlet.http.HttpServlet"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "httpservlet.java"
             function*
               "service"
           frame*
             module*
               "org.springframework.web.servlet.FrameworkServlet"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "frameworkservlet.java"
             function*
               "doGet"
           frame*
             module*
               "org.springframework.web.servlet.FrameworkServlet"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "frameworkservlet.java"
             function*
               "processRequest"
           frame*
             module*
               "org.springframework.web.servlet.DispatcherServlet"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "dispatcherservlet.java"
             function*
               "doService"
           frame*
             module*
               "org.springframework.web.servlet.DispatcherServlet"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "dispatcherservlet.java"
             function*
               "doDispatch"
           frame*
             module*
               "org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "abstracthandlermethodadapter.java"
             function*
               "handle"
           frame*
             module*
               "org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "requestmappinghandleradapter.java"
             function*
               "handleInternal"
           frame*
             module*
               "org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "requestmappinghandleradapter.java"
             function*
               "invokeHandlerMethod"
           frame*
             module*
               "org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "servletinvocablehandlermethod.java"
             function*
               "invokeAndHandle"
           frame*
             module*
               "org.springframework.web.method.support.InvocableHandlerMethod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "invocablehandlermethod.java"
             function*
               "invokeForRequest"
           frame*
             module*
               "org.springframework.web.method.support.InvocableHandlerMethod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "invocablehandlermethod.java"
             function*
               "doInvoke"
           frame (ignored by stack trace rule (category:indirection -group))
             module*
               "java.lang.reflect.Method"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "method.java"
             function*
               "invoke"
           frame*
             module*
               "jdk.internal.reflect.DelegatingMethodAccessorImpl"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "delegatingmethodaccessorimpl.java"
             function*
               "invoke"
           frame*
             module*
               "jdk.internal.reflect.NativeMethodAccessorImpl"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "nativemethodaccessorimpl.java"
             function*
               "invoke"
           frame*
             module*
               "jdk.internal.reflect.NativeMethodAccessorImpl"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "nativemethodaccessorimpl.java"
             function*
               "invoke0"
           frame (ignored by stack trace rule (module:io.sentry.* -group))
             module*
               "io.sentry.example.Application"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "application.java"
             function*
               "home"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:08.287079+00:00'
+created: '2025-09-19T05:52:38.164944+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:41:15.722000+00:00'
+created: '2025-09-19T05:52:38.210845+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -34,7 +34,7 @@ system:
   hash: null
   contributing component: null
   component:
-    system (exception of app takes precedence)
+    system (ignored because app exception takes precedence)
       exception (ignored because hash matches app variant)
         stacktrace (ignored because it contains no contributing frames)
           frame (ignored by stack trace rule (module:@babel/** -group))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:09.069606+00:00'
+created: '2025-09-19T05:52:38.227470+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (path:**https://unpkg.com/** -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:08.768980+00:00'
+created: '2025-09-19T05:52:38.244084+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
@@ -34,7 +34,7 @@ app:
             function*
               "test"
           frame (marked out of app by the client)
-            filename (anonymous filename discarded)
+            filename (ignored because filename is anonymous)
               "<anonymous>"
             function* (trimmed javascript function)
               "map"
@@ -92,7 +92,7 @@ system:
             function*
               "test"
           frame (ignored low quality javascript frame)
-            filename (anonymous filename discarded)
+            filename (ignored because filename is anonymous)
               "<anonymous>"
             function* (trimmed javascript function)
               "map"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:08.885692+00:00'
+created: '2025-09-19T05:52:38.263302+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:08.995269+00:00'
+created: '2025-09-19T05:52:38.284263+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:09.130154+00:00'
+created: '2025-09-19T05:52:38.301712+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
@@ -44,7 +44,7 @@ app:
             function*
               "test"
           frame (marked out of app by the client)
-            filename (anonymous filename discarded)
+            filename (ignored because filename is anonymous)
               "<anonymous>"
             function* (trimmed javascript function)
               "map"
@@ -120,7 +120,7 @@ system:
             function*
               "test"
           frame (ignored low quality javascript frame)
-            filename (anonymous filename discarded)
+            filename (ignored because filename is anonymous)
               "<anonymous>"
             function* (trimmed javascript function)
               "map"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:09.242170+00:00'
+created: '2025-09-19T05:52:38.317768+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
@@ -46,7 +46,7 @@ app:
           frame (marked out of app by the client)
             module*
               "test"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "native code"
             function* (trimmed javascript function)
               "map"
@@ -126,7 +126,7 @@ system:
           frame (ignored low quality javascript frame)
             module*
               "test"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "native code"
             function* (trimmed javascript function)
               "map"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:09.356012+00:00'
+created: '2025-09-19T05:52:38.333508+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:09.470253+00:00'
+created: '2025-09-19T05:52:38.352907+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
@@ -30,7 +30,7 @@ app:
             function*
               "aha"
           frame (marked out of app by the client)
-            filename (native code indicated by filename)
+            filename (ignored because filename suggests native code)
               "[native code]"
             function*
               "eval"
@@ -42,7 +42,7 @@ app:
             function*
               "test"
           frame (marked out of app by the client)
-            filename (native code indicated by filename)
+            filename (ignored because filename suggests native code)
               "[native code]"
             function*
               "map"
@@ -66,7 +66,7 @@ app:
             function*
               "callAnotherThing"
           frame (marked out of app by the client)
-            filename (native code indicated by filename)
+            filename (ignored because filename suggests native code)
               "[native code]"
             function*
               "aha"
@@ -109,7 +109,7 @@ system:
             function*
               "aha"
           frame (ignored low quality javascript frame)
-            filename (native code indicated by filename)
+            filename (ignored because filename suggests native code)
               "[native code]"
             function*
               "eval"
@@ -121,7 +121,7 @@ system:
             function*
               "test"
           frame (ignored low quality javascript frame)
-            filename (native code indicated by filename)
+            filename (ignored because filename suggests native code)
               "[native code]"
             function*
               "map"
@@ -145,7 +145,7 @@ system:
             function*
               "callAnotherThing"
           frame (ignored low quality javascript frame)
-            filename (native code indicated by filename)
+            filename (ignored because filename suggests native code)
               "[native code]"
             function*
               "aha"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:09.621261+00:00'
+created: '2025-09-19T05:52:38.368120+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
@@ -24,7 +24,7 @@ app:
             function*
               "aha"
           frame (marked out of app by the client)
-            filename (native code indicated by filename)
+            filename (ignored because filename suggests native code)
               "[native code]"
             function*
               "eval"
@@ -34,7 +34,7 @@ app:
             function*
               "test"
           frame (marked out of app by the client)
-            filename (native code indicated by filename)
+            filename (ignored because filename suggests native code)
               "[native code]"
             function*
               "map"
@@ -52,7 +52,7 @@ app:
             function*
               "callAnotherThing"
           frame (marked out of app by the client)
-            filename (native code indicated by filename)
+            filename (ignored because filename suggests native code)
               "[native code]"
             function*
               "aha"
@@ -87,7 +87,7 @@ system:
             function*
               "aha"
           frame (ignored low quality javascript frame)
-            filename (native code indicated by filename)
+            filename (ignored because filename suggests native code)
               "[native code]"
             function*
               "eval"
@@ -97,7 +97,7 @@ system:
             function*
               "test"
           frame (ignored low quality javascript frame)
-            filename (native code indicated by filename)
+            filename (ignored because filename suggests native code)
               "[native code]"
             function*
               "map"
@@ -115,7 +115,7 @@ system:
             function*
               "callAnotherThing"
           frame (ignored low quality javascript frame)
-            filename (native code indicated by filename)
+            filename (ignored because filename suggests native code)
               "[native code]"
             function*
               "aha"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:52.013439+00:00'
+created: '2025-09-19T05:52:38.385798+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/core-js/modules/_microtask"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "_microtask.js"
             function (ignored because sourcemap used and context line available)
               "M"
@@ -22,7 +22,7 @@ app:
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "es6.promise.js"
             function (ignored because sourcemap used and context line available)
               "fn"
@@ -31,7 +31,7 @@ app:
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "es6.promise.js"
             function (ignored because sourcemap used and context line available)
               "run"
@@ -40,7 +40,7 @@ app:
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "_next"
@@ -49,7 +49,7 @@ app:
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "asyncGeneratorStep"
@@ -58,7 +58,7 @@ app:
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "key"
@@ -67,7 +67,7 @@ app:
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "this"
@@ -76,7 +76,7 @@ app:
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "tryCatch"
@@ -85,7 +85,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "app/components/lazyLoad"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "lazyload.jsx"
             function (ignored because sourcemap used and context line available)
               "fn"
@@ -94,61 +94,61 @@ app:
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react/cjs/react.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react.production.min.js"
             function*
               "this"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} !==typeof a&&\"function\"!==typeof a&&null!=a?B(\"85\"):void 0;this.updater.enqueueSetState(this,a,b,\"setState\")};E.prototype.forceUpdate=functi {snip}"
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "this"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} );e.payload=b;void 0!==c&&null!==c&&(e.callback=c);ff(a,e);If(a,d)},enqueueReplaceState:function(a,b,c){a=a._reactInternalFiber;var d=Gf();d {snip}"
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "If"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} );else if(c=b.expirationTime,0===c||a<c)b.expirationTime=a;V||(W?Wg&&(Y=b,Z=1,Xg(b,1,!0)):1===a?Yg(1,null):Zg(b,a))}$g>ah&&($g=0,t(\"185\"))}} {snip}"
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "Yg"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} ),qh(),oh(),lh=kh;else for(;null!==Y&&0!==Z&&(0===a||a>=Z);)Xg(Y,Z,!0),qh();null!==hh&&(ch=0,dh=null);0!==Z&&Zg(Y,Z);hh=null;eh=!1;$g=0;mh=n {snip}"
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "Xg"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finishedWork,null!==d&&rh( {snip}"
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "rh"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} nate;q=Q;p=y;switch(q.tag){case 2:case 3:var X=q.stateNode;if(q.effectTag&4)if(null===oc)X.props=q.memoizedProps,X.state=q.memoizedState,X.c {snip}"
           frame* (marked in-app by the client)
             module*
               "app/views/groupDetails/shared/groupEventDetails"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "X"
@@ -157,7 +157,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "app/views/groupDetails/shared/groupEventDetails"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "this"
@@ -166,7 +166,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "app/api"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "api.jsx"
             function (ignored because sourcemap used and context line available)
               "fetchGroupEventAndMarkSeen"
@@ -187,7 +187,7 @@ system:
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/core-js/modules/_microtask"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "_microtask.js"
             function (ignored because sourcemap used and context line available)
               "M"
@@ -196,7 +196,7 @@ system:
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "es6.promise.js"
             function (ignored because sourcemap used and context line available)
               "fn"
@@ -205,7 +205,7 @@ system:
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "es6.promise.js"
             function (ignored because sourcemap used and context line available)
               "run"
@@ -214,7 +214,7 @@ system:
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "_next"
@@ -223,7 +223,7 @@ system:
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "asyncGeneratorStep"
@@ -232,7 +232,7 @@ system:
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "key"
@@ -241,7 +241,7 @@ system:
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "this"
@@ -250,7 +250,7 @@ system:
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "tryCatch"
@@ -259,7 +259,7 @@ system:
           frame*
             module*
               "app/components/lazyLoad"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "lazyload.jsx"
             function (ignored because sourcemap used and context line available)
               "fn"
@@ -268,61 +268,61 @@ system:
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/react/cjs/react.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react.production.min.js"
             function*
               "this"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} !==typeof a&&\"function\"!==typeof a&&null!=a?B(\"85\"):void 0;this.updater.enqueueSetState(this,a,b,\"setState\")};E.prototype.forceUpdate=functi {snip}"
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "this"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} );e.payload=b;void 0!==c&&null!==c&&(e.callback=c);ff(a,e);If(a,d)},enqueueReplaceState:function(a,b,c){a=a._reactInternalFiber;var d=Gf();d {snip}"
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "If"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} );else if(c=b.expirationTime,0===c||a<c)b.expirationTime=a;V||(W?Wg&&(Y=b,Z=1,Xg(b,1,!0)):1===a?Yg(1,null):Zg(b,a))}$g>ah&&($g=0,t(\"185\"))}} {snip}"
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "Yg"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} ),qh(),oh(),lh=kh;else for(;null!==Y&&0!==Z&&(0===a||a>=Z);)Xg(Y,Z,!0),qh();null!==hh&&(ch=0,dh=null);0!==Z&&Zg(Y,Z);hh=null;eh=!1;$g=0;mh=n {snip}"
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "Xg"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finishedWork,null!==d&&rh( {snip}"
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "rh"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} nate;q=Q;p=y;switch(q.tag){case 2:case 3:var X=q.stateNode;if(q.effectTag&4)if(null===oc)X.props=q.memoizedProps,X.state=q.memoizedState,X.c {snip}"
           frame*
             module*
               "app/views/groupDetails/shared/groupEventDetails"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "X"
@@ -331,7 +331,7 @@ system:
           frame*
             module*
               "app/views/groupDetails/shared/groupEventDetails"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "this"
@@ -340,7 +340,7 @@ system:
           frame*
             module*
               "app/api"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "api.jsx"
             function (ignored because sourcemap used and context line available)
               "fetchGroupEventAndMarkSeen"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:52.035654+00:00'
+created: '2025-09-19T05:52:38.403134+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,14 +11,14 @@ app:
       exception*
         stacktrace*
           frame (marked in-app by the client but ignored low quality javascript frame)
-            filename (native code indicated by filename)
+            filename (ignored because filename suggests native code)
               "[native code]"
             function*
               "promiseReactionJob"
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "_next"
@@ -27,7 +27,7 @@ app:
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "asyncGeneratorStep"
@@ -36,7 +36,7 @@ app:
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "key"
@@ -45,7 +45,7 @@ app:
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "tryCatch"
@@ -54,7 +54,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "app/components/lazyLoad"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "lazyload.jsx"
             function (ignored because sourcemap used and context line available)
               "call"
@@ -63,61 +63,61 @@ app:
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react/cjs/react.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react.production.min.js"
             function*
               "setState"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} ructor=G;m(H,E.prototype);H.isPureReactComponent=!0;var I={current:null,currentDispatcher:null},J=Object.prototype.hasOwnProperty,K={key:!0, {snip}"
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "enqueueSetState"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} &(e.callback=c);ff(a,e);If(a,d)},enqueueForceUpdate:function(a,b){a=a._reactInternalFiber;var c=Gf();c=Hf(c,a);var d=df(c);d.tag=2;void 0!=="
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "tag"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "var U=null,T=null,ch=0,dh=void 0,V=!1,Y=null,Z=0,Vg=0,eh=!1,fh=!1,gh=null,hh=null,W=!1,Wg=!1,Ug=!1,ih=null,jh=ba.unstable_now(),kh=(jh/10|0) {snip}"
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "Yg"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "function Xg(a,b,c){V?t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finis {snip}"
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "Xg"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "function rh(a,b,c){var d=a.firstBatch;if(null!==d&&d._expirationTime<=c&&(null===ih?ih=[d]:ih.push(d),d._defer)){a.finishedWork=b;a.expirati {snip}"
           frame (marked out of app by the client)
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "ih"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} .__reactInternalSnapshotBeforeUpdate)}var kg=q.updateQueue;null!==kg&&(X.props=q.memoizedProps,X.state=q.memoizedState,lf(q,kg,X,p));break;c {snip}"
           frame* (marked in-app by the client)
             module*
               "app/views/groupDetails/shared/groupEventDetails"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "q"
@@ -126,7 +126,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "app/views/groupDetails/shared/groupEventDetails"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "fetchData"
@@ -135,7 +135,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "app/api"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "api.jsx"
             function (ignored because sourcemap used and context line available)
               "fetchGroupEventAndMarkSeen"
@@ -154,14 +154,14 @@ system:
       exception*
         stacktrace*
           frame (ignored low quality javascript frame)
-            filename (native code indicated by filename)
+            filename (ignored because filename suggests native code)
               "[native code]"
             function*
               "promiseReactionJob"
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "_next"
@@ -170,7 +170,7 @@ system:
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "asynctogenerator.js"
             function (ignored because sourcemap used and context line available)
               "asyncGeneratorStep"
@@ -179,7 +179,7 @@ system:
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "key"
@@ -188,7 +188,7 @@ system:
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "runtime.js"
             function (ignored because sourcemap used and context line available)
               "tryCatch"
@@ -197,7 +197,7 @@ system:
           frame*
             module*
               "app/components/lazyLoad"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "lazyload.jsx"
             function (ignored because sourcemap used and context line available)
               "call"
@@ -206,61 +206,61 @@ system:
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/react/cjs/react.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react.production.min.js"
             function*
               "setState"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} ructor=G;m(H,E.prototype);H.isPureReactComponent=!0;var I={current:null,currentDispatcher:null},J=Object.prototype.hasOwnProperty,K={key:!0, {snip}"
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "enqueueSetState"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} &(e.callback=c);ff(a,e);If(a,d)},enqueueForceUpdate:function(a,b){a=a._reactInternalFiber;var c=Gf();c=Hf(c,a);var d=df(c);d.tag=2;void 0!=="
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "tag"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "var U=null,T=null,ch=0,dh=void 0,V=!1,Y=null,Z=0,Vg=0,eh=!1,fh=!1,gh=null,hh=null,W=!1,Wg=!1,Ug=!1,ih=null,jh=ba.unstable_now(),kh=(jh/10|0) {snip}"
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "Yg"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "function Xg(a,b,c){V?t(\"245\"):void 0;V=!0;if(null===hh||c){var d=a.finishedWork;null!==d?rh(a,d,b):(a.finishedWork=null,Sg(a,!1,c),d=a.finis {snip}"
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "Xg"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "function rh(a,b,c){var d=a.firstBatch;if(null!==d&&d._expirationTime<=c&&(null===ih?ih=[d]:ih.push(d),d._defer)){a.finishedWork=b;a.expirati {snip}"
           frame*
             module*
               "usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "react-dom.production.min.js"
             function*
               "ih"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} .__reactInternalSnapshotBeforeUpdate)}var kg=q.updateQueue;null!==kg&&(X.props=q.memoizedProps,X.state=q.memoizedState,lf(q,kg,X,p));break;c {snip}"
           frame*
             module*
               "app/views/groupDetails/shared/groupEventDetails"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "q"
@@ -269,7 +269,7 @@ system:
           frame*
             module*
               "app/views/groupDetails/shared/groupEventDetails"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "groupeventdetails.jsx"
             function (ignored because sourcemap used and context line available)
               "fetchData"
@@ -278,7 +278,7 @@ system:
           frame*
             module*
               "app/api"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "api.jsx"
             function (ignored because sourcemap used and context line available)
               "fetchGroupEventAndMarkSeen"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:10.510211+00:00'
+created: '2025-09-19T05:52:38.484967+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:10.612905+00:00'
+created: '2025-09-19T05:52:38.503668+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:10.692332+00:00'
+created: '2025-09-19T05:52:38.521295+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:52.318428+00:00'
+created: '2025-09-19T05:52:38.590451+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
@@ -17,7 +17,7 @@ app:
               "vendor.js"
             function*
               "M"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} o,r;for(b&&(o=i.domain)&&o.exit();t;){r=t.fn,t=t.next;try{r()}catch(o){throw t?n():e=void 0,o}}e=void 0,o&&o.enter()};if(b)n=function(){i.n {snip}"
           frame (marked out of app by the client)
             module*
@@ -26,7 +26,7 @@ app:
               "vendor.js"
             function (ignored unknown function name)
               "S/<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} ,M):b(n)):M(o)}catch(t){a&&!i&&a.exit(),M(t)}};n.length>p;)i(n[p++]);t._c=[],t._n=!1,e&&!t._h&&x(t)})}},x=function(t){d.call(b,function(){va {snip}"
           frame (marked out of app by the client)
             module*
@@ -35,7 +35,7 @@ app:
               "vendor.js"
             function*
               "i"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} ry{c?(r||(2==t._h&&T(t),t._h=1),!0===c?n=o:(a&&a.enter(),n=c(o),a&&(a.exit(),i=!0)),n===e.promise?M(y(\"Promise-chain cycle\")):(p=N(n))?p.cal {snip}"
           frame (marked out of app by the client)
             module*
@@ -44,7 +44,7 @@ app:
               "vendor.js"
             function*
               "b"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} ply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.lo {snip}"
           frame (marked out of app by the client)
             module*
@@ -53,7 +53,7 @@ app:
               "vendor.js"
             function*
               "n"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
           frame (marked out of app by the client)
             module*
@@ -62,7 +62,7 @@ app:
               "vendor.js"
             function*
               "g/</t[e]"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
           frame (marked out of app by the client)
             module*
@@ -71,7 +71,7 @@ app:
               "vendor.js"
             function (ignored unknown function name)
               "_invoke</<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
           frame (marked out of app by the client)
             module*
@@ -80,7 +80,7 @@ app:
               "vendor.js"
             function*
               "W"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
           frame (marked out of app by the client)
             module*
@@ -89,7 +89,7 @@ app:
               "app.js"
             function (ignored unknown function name)
               "e/<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} (e.t0)&&n<I)){e.next=12;break}return n++,e.abrupt(\"return\",a());case 12:throw e.t0;case 13:case\"end\":return e.stop()}},e,this,[[0,7]])}));re {snip}"
           frame (marked out of app by the client)
             module*
@@ -98,7 +98,7 @@ app:
               "app.js"
             function (ignored unknown function name)
               "e/</a</<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} urn e.stop()}},e,this,[[0,7]])}));return function(){return e.apply(this,arguments)}}(),e.abrupt(\"return\",a());case 3:case\"end\":return e.stop {snip}"
           frame (marked out of app by the client)
             module*
@@ -107,7 +107,7 @@ app:
               "vendor.js"
             function (ignored unknown function name)
               "exports/<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} unction(t){return function(){var e=this,o=arguments;return new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)} {snip}"
           frame (marked out of app by the client)
             module*
@@ -116,7 +116,7 @@ app:
               "vendor.js"
             function*
               "L"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} function(t){O(this,L,\"Promise\",\"_h\"),s(t),o.call(this);try{t(M(H,this,1),M(C,this,1))}catch(t){C.call(this,t)}},(o=function(t){this._c=[],th {snip}"
           frame (marked out of app by the client)
             module*
@@ -125,7 +125,7 @@ app:
               "vendor.js"
             function (ignored unknown function name)
               "exports/</<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.load(n(1467))},,function( {snip}"
           frame (marked out of app by the client)
             module*
@@ -134,7 +134,7 @@ app:
               "vendor.js"
             function*
               "c"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,funct {snip}"
           frame (marked out of app by the client)
             module*
@@ -143,7 +143,7 @@ app:
               "vendor.js"
             function*
               "n"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
           frame (marked out of app by the client)
             module*
@@ -152,7 +152,7 @@ app:
               "vendor.js"
             function*
               "g/</t[e]"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
           frame (marked out of app by the client)
             module*
@@ -161,7 +161,7 @@ app:
               "vendor.js"
             function (ignored unknown function name)
               "_invoke</<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
           frame (marked out of app by the client)
             module*
@@ -170,7 +170,7 @@ app:
               "vendor.js"
             function*
               "W"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
           frame (marked out of app by the client)
             module*
@@ -179,7 +179,7 @@ app:
               "app.js"
             function (ignored unknown function name)
               "e/<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} r(;;)switch(e.prev=e.next){case 0:return e.prev=0,e.next=3,t();case 3:return r=e.sent,e.abrupt(\"return\",r.default||r);case 7:if(e.prev=7,e.t {snip}"
           frame (marked out of app by the client)
             module*
@@ -188,7 +188,7 @@ app:
               "app.js"
             function*
               "componentPromise"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} orgId/issues/:groupId/\",componentPromise:function(){return n.e(75).then(n.bind(null,2497))},component:Object(cs.default)(Zt.a)},b.a.createEl {snip}"
           frame (marked out of app by the client)
             module*
@@ -197,7 +197,7 @@ app:
               "app.js"
             function* (trimmed javascript function)
               "e"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} \"+i+\")\");o.type=a,o.request=i,n[1](o)}r[e]=void 0}};var c=setTimeout(function(){i({type:\"timeout\",target:s})},12e4);s.onerror=s.onload=i,do {snip}"
           frame (marked out of app by the client)
             module*
@@ -206,7 +206,7 @@ app:
               "vendor.js"
             function (ignored unknown function name)
               "wrapTimeFunction/<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} ism:{data:{function:Dt(t)},handled:!0,type:\"instrument\"}}),t.apply(this,e)}},t.prototype.wrapRAF=function(t){return function(e){return t(Et( {snip}"
         type*
           "NS_ERROR_NOT_INITIALIZED"
@@ -225,7 +225,7 @@ system:
               "vendor.js"
             function*
               "M"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} o,r;for(b&&(o=i.domain)&&o.exit();t;){r=t.fn,t=t.next;try{r()}catch(o){throw t?n():e=void 0,o}}e=void 0,o&&o.enter()};if(b)n=function(){i.n {snip}"
           frame*
             module*
@@ -234,7 +234,7 @@ system:
               "vendor.js"
             function (ignored unknown function name)
               "S/<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} ,M):b(n)):M(o)}catch(t){a&&!i&&a.exit(),M(t)}};n.length>p;)i(n[p++]);t._c=[],t._n=!1,e&&!t._h&&x(t)})}},x=function(t){d.call(b,function(){va {snip}"
           frame*
             module*
@@ -243,7 +243,7 @@ system:
               "vendor.js"
             function*
               "i"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} ry{c?(r||(2==t._h&&T(t),t._h=1),!0===c?n=o:(a&&a.enter(),n=c(o),a&&(a.exit(),i=!0)),n===e.promise?M(y(\"Promise-chain cycle\")):(p=N(n))?p.cal {snip}"
           frame*
             module*
@@ -252,7 +252,7 @@ system:
               "vendor.js"
             function*
               "b"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} ply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.lo {snip}"
           frame*
             module*
@@ -261,7 +261,7 @@ system:
               "vendor.js"
             function*
               "n"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
           frame*
             module*
@@ -270,7 +270,7 @@ system:
               "vendor.js"
             function*
               "g/</t[e]"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
           frame*
             module*
@@ -279,7 +279,7 @@ system:
               "vendor.js"
             function (ignored unknown function name)
               "_invoke</<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
           frame*
             module*
@@ -288,7 +288,7 @@ system:
               "vendor.js"
             function*
               "W"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
           frame*
             module*
@@ -297,7 +297,7 @@ system:
               "app.js"
             function (ignored unknown function name)
               "e/<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} (e.t0)&&n<I)){e.next=12;break}return n++,e.abrupt(\"return\",a());case 12:throw e.t0;case 13:case\"end\":return e.stop()}},e,this,[[0,7]])}));re {snip}"
           frame*
             module*
@@ -306,7 +306,7 @@ system:
               "app.js"
             function (ignored unknown function name)
               "e/</a</<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} urn e.stop()}},e,this,[[0,7]])}));return function(){return e.apply(this,arguments)}}(),e.abrupt(\"return\",a());case 3:case\"end\":return e.stop {snip}"
           frame*
             module*
@@ -315,7 +315,7 @@ system:
               "vendor.js"
             function (ignored unknown function name)
               "exports/<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} unction(t){return function(){var e=this,o=arguments;return new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)} {snip}"
           frame*
             module*
@@ -324,7 +324,7 @@ system:
               "vendor.js"
             function*
               "L"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} function(t){O(this,L,\"Promise\",\"_h\"),s(t),o.call(this);try{t(M(H,this,1),M(C,this,1))}catch(t){C.call(this,t)}},(o=function(t){this._c=[],th {snip}"
           frame*
             module*
@@ -333,7 +333,7 @@ system:
               "vendor.js"
             function (ignored unknown function name)
               "exports/</<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,function(t,e,n){(t.exports=n(1466)).tz.load(n(1467))},,function( {snip}"
           frame*
             module*
@@ -342,7 +342,7 @@ system:
               "vendor.js"
             function*
               "c"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} new Promise(function(r,p){var i=t.apply(e,o);function c(t){n(i,r,p,c,b,\"next\",t)}function b(t){n(i,r,p,c,b,\"throw\",t)}c(void 0)})}}},,,funct {snip}"
           frame*
             module*
@@ -351,7 +351,7 @@ system:
               "vendor.js"
             function*
               "n"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} e)}},function(t,e){function n(t,e,n,o,r,p,i){try{var c=t[p](i),b=c.value}catch(t){return void n(t)}c.done?e(b):Promise.resolve(b).then(o,r)} {snip}"
           frame*
             module*
@@ -360,7 +360,7 @@ system:
               "vendor.js"
             function*
               "g/</t[e]"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} row\",\"return\"].forEach(function(e){t[e]=function(t){return this._invoke(e,t)}})}function R(t){var e;this._invoke=function(n,o){function p(){ {snip}"
           frame*
             module*
@@ -369,7 +369,7 @@ system:
               "vendor.js"
             function (ignored unknown function name)
               "_invoke</<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} lse\"return\"===n.method&&n.abrupt(\"return\",n.arg);o=s;var b=W(t,e,n);if(\"normal\"===b.type){if(o=n.done?O:z,b.arg===l)continue;return{value:b. {snip}"
           frame*
             module*
@@ -378,7 +378,7 @@ system:
               "vendor.js"
             function*
               "W"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} }}(t,n,i),p}function W(t,e,n){try{return{type:\"normal\",arg:t.call(e,n)}}catch(t){return{type:\"throw\",arg:t}}}function v(){}function y(){}fun {snip}"
           frame*
             module*
@@ -387,7 +387,7 @@ system:
               "app.js"
             function (ignored unknown function name)
               "e/<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} r(;;)switch(e.prev=e.next){case 0:return e.prev=0,e.next=3,t();case 3:return r=e.sent,e.abrupt(\"return\",r.default||r);case 7:if(e.prev=7,e.t {snip}"
           frame*
             module*
@@ -396,7 +396,7 @@ system:
               "app.js"
             function*
               "componentPromise"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} orgId/issues/:groupId/\",componentPromise:function(){return n.e(75).then(n.bind(null,2497))},component:Object(cs.default)(Zt.a)},b.a.createEl {snip}"
           frame*
             module*
@@ -405,7 +405,7 @@ system:
               "app.js"
             function* (trimmed javascript function)
               "e"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} \"+i+\")\");o.type=a,o.request=i,n[1](o)}r[e]=void 0}};var c=setTimeout(function(){i({type:\"timeout\",target:s})},12e4);s.onerror=s.onload=i,do {snip}"
           frame*
             module*
@@ -414,7 +414,7 @@ system:
               "vendor.js"
             function (ignored unknown function name)
               "wrapTimeFunction/<"
-            context_line (discarded because line too long)
+            context_line (ignored because line is too long)
               "{snip} ism:{data:{function:Dt(t)},handled:!0,type:\"instrument\"}}),t.apply(this,e)}},t.prototype.wrapRAF=function(t){return function(e){return t(Et( {snip}"
         type*
           "NS_ERROR_NOT_INITIALIZED"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:11.400931+00:00'
+created: '2025-09-19T05:52:38.606779+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:11.550057+00:00'
+created: '2025-09-19T05:52:38.623263+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:11.681430+00:00'
+created: '2025-09-19T05:52:38.639852+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:11.795630+00:00'
+created: '2025-09-19T05:52:38.656032+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:11.924203+00:00'
+created: '2025-09-19T05:52:38.670993+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:12.050592+00:00'
+created: '2025-09-19T05:52:38.686928+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:12.278502+00:00'
+created: '2025-09-19T05:52:38.717735+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:12.392747+00:00'
+created: '2025-09-19T05:52:38.732304+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:12.501597+00:00'
+created: '2025-09-19T05:52:38.747202+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
@@ -34,7 +34,7 @@ app:
           "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
         value*
           "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
-      threads (thread has no stacktrace)
+      threads (ignored because thread has no stacktrace)
 --------------------------------------------------------------------------
 system:
   hash: "c29439027eafcf7642f641554ab0f0ef"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:52.612791+00:00'
+created: '2025-09-19T05:52:38.762502+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "hub"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "hub.js"
             function* (trimmed javascript function)
               "withScope"
@@ -22,14 +22,14 @@ app:
           frame* (marked in-app by the client)
             module*
               "onunhandledrejection.ts"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "onunhandledrejection.ts"
             function (ignored unknown function name)
               "<anonymous>"
           frame (marked out of app by the client)
             module*
               "jest-mock.build:index"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "index.js"
             function* (trimmed javascript function)
               "mockConstructor [as captureException]"
@@ -38,7 +38,7 @@ app:
           frame (marked out of app by the client)
             module*
               "jest-mock.build:index"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "index.js"
             function (ignored unknown function name)
               "<anonymous>"
@@ -47,7 +47,7 @@ app:
           frame (marked out of app by the client)
             module*
               "jest-mock.build:index"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "index.js"
             function*
               "finalReturnValue"
@@ -56,7 +56,7 @@ app:
           frame (marked out of app by the client)
             module*
               "jest-mock.build:index"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "index.js"
             function (ignored unknown function name)
               "<anonymous>"
@@ -65,7 +65,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "hub.ts"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "hub.ts"
             function* (trimmed javascript function)
               "captureException"
@@ -74,7 +74,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "hub"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "hub.js"
             function* (trimmed javascript function)
               "invokeClient"
@@ -83,7 +83,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "baseclient.ts"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "baseclient.ts"
             function* (trimmed javascript function)
               "captureException"
@@ -92,7 +92,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "backend.ts"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "backend.ts"
             function* (trimmed javascript function)
               "eventFromException"
@@ -111,7 +111,7 @@ system:
           frame*
             module*
               "hub"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "hub.js"
             function* (trimmed javascript function)
               "withScope"
@@ -120,14 +120,14 @@ system:
           frame*
             module*
               "onunhandledrejection.ts"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "onunhandledrejection.ts"
             function (ignored unknown function name)
               "<anonymous>"
           frame*
             module*
               "jest-mock.build:index"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "index.js"
             function* (trimmed javascript function)
               "mockConstructor [as captureException]"
@@ -136,7 +136,7 @@ system:
           frame*
             module*
               "jest-mock.build:index"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "index.js"
             function (ignored unknown function name)
               "<anonymous>"
@@ -145,7 +145,7 @@ system:
           frame*
             module*
               "jest-mock.build:index"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "index.js"
             function*
               "finalReturnValue"
@@ -154,7 +154,7 @@ system:
           frame*
             module*
               "jest-mock.build:index"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "index.js"
             function (ignored unknown function name)
               "<anonymous>"
@@ -163,7 +163,7 @@ system:
           frame*
             module*
               "hub.ts"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "hub.ts"
             function* (trimmed javascript function)
               "captureException"
@@ -172,7 +172,7 @@ system:
           frame*
             module*
               "hub"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "hub.js"
             function* (trimmed javascript function)
               "invokeClient"
@@ -181,7 +181,7 @@ system:
           frame*
             module*
               "baseclient.ts"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "baseclient.ts"
             function* (trimmed javascript function)
               "captureException"
@@ -190,7 +190,7 @@ system:
           frame*
             module*
               "backend.ts"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "backend.ts"
             function* (trimmed javascript function)
               "eventFromException"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:41:21.896373+00:00'
+created: '2025-09-19T05:52:38.777257+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
           frame (marked out of app by stack trace rule (function:processTicksAndRejections -app))
             module*
               "task_queues"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "task_queues"
             function*
               "processTicksAndRejections"
@@ -31,13 +31,13 @@ system:
   hash: null
   contributing component: null
   component:
-    system (exception of app takes precedence)
+    system (ignored because app exception takes precedence)
       exception (ignored because hash matches app variant)
         stacktrace (ignored because it contains no contributing frames)
           frame (ignored by stack trace rule (function:processTicksAndRejections -group))
             module*
               "task_queues"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "task_queues"
             function*
               "processTicksAndRejections"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:52.713142+00:00'
+created: '2025-09-19T05:52:38.808556+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
           frame (marked out of app by the client)
             module*
               "django.core.handlers.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "get_response"
@@ -22,7 +22,7 @@ app:
           frame (marked out of app by the client)
             module*
               "django.views.generic.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "view"
@@ -31,7 +31,7 @@ app:
           frame (marked out of app by the client)
             module*
               "django.utils.decorators"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "decorators.py"
             function*
               "_wrapper"
@@ -40,7 +40,7 @@ app:
           frame (marked out of app by the client)
             module*
               "django.views.decorators.csrf"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "csrf.py"
             function*
               "wrapped_view"
@@ -49,7 +49,7 @@ app:
           frame (marked out of app by the client)
             module*
               "django.utils.decorators"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "decorators.py"
             function*
               "bound_func"
@@ -58,7 +58,7 @@ app:
           frame (marked in-app by the client but ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
               "sentry.web.frontend.release_webhook"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "release_webhook.py"
             function*
               "dispatch"
@@ -67,7 +67,7 @@ app:
           frame (marked out of app by the client)
             module*
               "django.views.generic.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "dispatch"
@@ -76,7 +76,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.web.frontend.release_webhook"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "release_webhook.py"
             function*
               "post"
@@ -85,7 +85,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry_plugins.heroku.plugin"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "plugin.py"
             function*
               "handle"
@@ -94,7 +94,7 @@ app:
           frame (marked out of app by the client)
             module*
               "django.utils.datastructures"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "datastructures.py"
             function*
               "__getitem__"
@@ -115,7 +115,7 @@ system:
           frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
               "django.core.handlers.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "get_response"
@@ -124,7 +124,7 @@ system:
           frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
               "django.views.generic.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "view"
@@ -133,7 +133,7 @@ system:
           frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
               "django.utils.decorators"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "decorators.py"
             function*
               "_wrapper"
@@ -142,7 +142,7 @@ system:
           frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
               "django.views.decorators.csrf"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "csrf.py"
             function*
               "wrapped_view"
@@ -151,7 +151,7 @@ system:
           frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
               "django.utils.decorators"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "decorators.py"
             function*
               "bound_func"
@@ -160,7 +160,7 @@ system:
           frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
               "sentry.web.frontend.release_webhook"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "release_webhook.py"
             function*
               "dispatch"
@@ -169,7 +169,7 @@ system:
           frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
             module*
               "django.views.generic.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "dispatch"
@@ -178,7 +178,7 @@ system:
           frame*
             module*
               "sentry.web.frontend.release_webhook"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "release_webhook.py"
             function*
               "post"
@@ -187,7 +187,7 @@ system:
           frame*
             module*
               "sentry_plugins.heroku.plugin"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "plugin.py"
             function*
               "handle"
@@ -196,7 +196,7 @@ system:
           frame*
             module*
               "django.utils.datastructures"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "datastructures.py"
             function*
               "__getitem__"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:52.741934+00:00'
+created: '2025-09-19T05:52:38.824301+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,13 +7,13 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no contributing frames)
           frame (marked out of app by the client)
             module*
               "django.core.handlers.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "get_response"
@@ -22,7 +22,7 @@ app:
           frame (marked out of app by the client)
             module*
               "django.views.generic.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "view"
@@ -31,7 +31,7 @@ app:
           frame (marked out of app by the client)
             module*
               "django.utils.decorators"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "decorators.py"
             function*
               "_wrapper"
@@ -40,7 +40,7 @@ app:
           frame (marked out of app by the client)
             module*
               "django.views.decorators.csrf"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "csrf.py"
             function*
               "wrapped_view"
@@ -49,7 +49,7 @@ app:
           frame (marked out of app by the client)
             module*
               "django.utils.decorators"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "decorators.py"
             function*
               "bound_func"
@@ -58,7 +58,7 @@ app:
           frame (marked in-app by the client but ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
               "sentry.web.frontend.release_webhook"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "release_webhook.py"
             function*
               "dispatch"
@@ -67,7 +67,7 @@ app:
           frame (marked out of app by the client)
             module*
               "django.views.generic.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "dispatch"
@@ -76,7 +76,7 @@ app:
           frame (marked in-app by the client but ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
               "sentry.web.frontend.release_webhook"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "release_webhook.py"
             function*
               "post"
@@ -85,7 +85,7 @@ app:
           frame (marked in-app by the client but ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
               "sentry_plugins.heroku.plugin"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "plugin.py"
             function*
               "handle"
@@ -94,7 +94,7 @@ app:
           frame (marked out of app by the client)
             module*
               "django.utils.datastructures"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "datastructures.py"
             function*
               "__getitem__"
@@ -115,7 +115,7 @@ system:
           frame*
             module*
               "django.core.handlers.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "get_response"
@@ -124,7 +124,7 @@ system:
           frame*
             module*
               "django.views.generic.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "view"
@@ -133,7 +133,7 @@ system:
           frame*
             module*
               "django.utils.decorators"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "decorators.py"
             function*
               "_wrapper"
@@ -142,7 +142,7 @@ system:
           frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
               "django.views.decorators.csrf"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "csrf.py"
             function*
               "wrapped_view"
@@ -151,7 +151,7 @@ system:
           frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
               "django.utils.decorators"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "decorators.py"
             function*
               "bound_func"
@@ -160,7 +160,7 @@ system:
           frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
               "sentry.web.frontend.release_webhook"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "release_webhook.py"
             function*
               "dispatch"
@@ -169,7 +169,7 @@ system:
           frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
               "django.views.generic.base"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "base.py"
             function*
               "dispatch"
@@ -178,7 +178,7 @@ system:
           frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
               "sentry.web.frontend.release_webhook"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "release_webhook.py"
             function*
               "post"
@@ -187,7 +187,7 @@ system:
           frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
               "sentry_plugins.heroku.plugin"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "plugin.py"
             function*
               "handle"
@@ -196,7 +196,7 @@ system:
           frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
             module*
               "django.utils.datastructures"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "datastructures.py"
             function*
               "__getitem__"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:52.769061+00:00'
+created: '2025-09-19T05:52:38.840352+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.utils.safe"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "safe.py"
             function*
               "safe_execute"
@@ -22,7 +22,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "sentry.integrations.slack.notify_action"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "notify_action.py"
             function*
               "send_notification"
@@ -31,7 +31,7 @@ app:
           frame (marked out of app by the client)
             module*
               "requests.models"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "models.py"
             function*
               "raise_for_status"
@@ -46,8 +46,8 @@ default:
   hash: null
   contributing component: null
   component:
-    default (exception of app/system takes precedence)
-      message (exception of app/system takes precedence)
+    default (ignored because app/system exception takes precedence)
+      message (ignored because app/system exception takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:
@@ -60,7 +60,7 @@ system:
           frame*
             module*
               "sentry.utils.safe"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "safe.py"
             function*
               "safe_execute"
@@ -69,7 +69,7 @@ system:
           frame*
             module*
               "sentry.integrations.slack.notify_action"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "notify_action.py"
             function*
               "send_notification"
@@ -78,7 +78,7 @@ system:
           frame*
             module*
               "requests.models"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "models.py"
             function*
               "raise_for_status"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:38:52.880659+00:00'
+created: '2025-09-19T05:52:38.902505+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "value"
@@ -22,7 +22,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "flushedQueue"
@@ -31,7 +31,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "_inCall"
@@ -40,7 +40,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "flushedQueue"
@@ -49,7 +49,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "_lastFlush"
@@ -58,7 +58,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "_receiveRootNodeIDEvent"
@@ -67,7 +67,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "batchedUpdates"
@@ -76,7 +76,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "_batchedUpdates"
@@ -85,7 +85,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "fn"
@@ -94,7 +94,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "forEachAccumulated"
@@ -106,7 +106,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "D"
@@ -115,7 +115,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "executeDispatch"
@@ -124,7 +124,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "invokeGuardedCallbackAndCatchFirstError"
@@ -133,7 +133,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "apply"
@@ -142,7 +142,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "apply"
@@ -151,7 +151,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Components/Touchable/Touchable"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "touchable.js"
             function (ignored because sourcemap used and context line available)
               "arguments"
@@ -160,7 +160,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Components/Touchable/Touchable"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "touchable.js"
             function (ignored because sourcemap used and context line available)
               "_receiveSignal"
@@ -169,7 +169,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Components/Touchable/Touchable"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "touchable.js"
             function (ignored because sourcemap used and context line available)
               "_performSideEffectsForTransition"
@@ -178,7 +178,7 @@ app:
           frame (marked out of app by the client)
             module*
               "react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "touchablenativefeedback.android.js"
             function (ignored because sourcemap used and context line available)
               "this"
@@ -187,7 +187,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "App"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "app.js"
             function (ignored because sourcemap used and context line available)
               "onPress"
@@ -196,7 +196,7 @@ app:
           frame* (marked in-app by the client)
             module*
               "App"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "app.js"
             function (ignored because sourcemap used and context line available)
               "Button"
@@ -217,7 +217,7 @@ system:
           frame*
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "value"
@@ -226,7 +226,7 @@ system:
           frame*
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "flushedQueue"
@@ -235,7 +235,7 @@ system:
           frame*
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "_inCall"
@@ -244,7 +244,7 @@ system:
           frame*
             module*
               "react-native/Libraries/BatchedBridge/MessageQueue"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "messagequeue.js"
             function (ignored because sourcemap used and context line available)
               "flushedQueue"
@@ -253,7 +253,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "_lastFlush"
@@ -262,7 +262,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "_receiveRootNodeIDEvent"
@@ -271,7 +271,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "batchedUpdates"
@@ -280,7 +280,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "_batchedUpdates"
@@ -289,7 +289,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "fn"
@@ -298,7 +298,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "forEachAccumulated"
@@ -310,7 +310,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "D"
@@ -319,7 +319,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "executeDispatch"
@@ -328,7 +328,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "invokeGuardedCallbackAndCatchFirstError"
@@ -337,7 +337,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "apply"
@@ -346,7 +346,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Renderer/ReactNativeRenderer-prod"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "reactnativerenderer-prod.js"
             function (ignored because sourcemap used and context line available)
               "apply"
@@ -355,7 +355,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Components/Touchable/Touchable"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "touchable.js"
             function (ignored because sourcemap used and context line available)
               "arguments"
@@ -364,7 +364,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Components/Touchable/Touchable"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "touchable.js"
             function (ignored because sourcemap used and context line available)
               "_receiveSignal"
@@ -373,7 +373,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Components/Touchable/Touchable"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "touchable.js"
             function (ignored because sourcemap used and context line available)
               "_performSideEffectsForTransition"
@@ -382,7 +382,7 @@ system:
           frame*
             module*
               "react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "touchablenativefeedback.android.js"
             function (ignored because sourcemap used and context line available)
               "this"
@@ -391,7 +391,7 @@ system:
           frame*
             module*
               "App"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "app.js"
             function (ignored because sourcemap used and context line available)
               "onPress"
@@ -400,7 +400,7 @@ system:
           frame*
             module*
               "App"
-            filename (module takes precedence)
+            filename (ignored because module takes precedence)
               "app.js"
             function (ignored because sourcemap used and context line available)
               "Button"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:13.604760+00:00'
+created: '2025-09-19T05:52:38.932580+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,54 +7,54 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by the client)
           module*
             "com.example.Application"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "application.java"
           function*
             "main"
         frame (marked out of app by the client)
           module*
             "com.example.Application"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "application.java"
           function*
             "normalFunc"
         frame (marked out of app by the client)
           module*
             "com.example.Application"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (marked out of app by the client)
           module*
             "com.example.Application"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (marked out of app by the client)
           module*
             "com.example.Application"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (marked out of app by the client)
           module*
             "com.example.Application"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (marked out of app by the client)
           module*
             "com.example.Application"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "application.java"
           function*
             "throwError"
@@ -68,49 +68,49 @@ system:
         frame*
           module*
             "com.example.Application"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "application.java"
           function*
             "main"
         frame*
           module*
             "com.example.Application"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "application.java"
           function*
             "normalFunc"
         frame*
           module*
             "com.example.Application"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (ignored due to recursion)
           module*
             "com.example.Application"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (ignored due to recursion)
           module*
             "com.example.Application"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
             "com.example.Application"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
             "com.example.Application"
-          filename (module takes precedence)
+          filename (ignored because module takes precedence)
             "application.java"
           function*
             "throwError"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:18.335738+00:00'
+created: '2025-09-19T05:52:38.976968+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:34:14.852322+00:00'
+created: '2025-09-19T05:52:39.006694+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (discarded because stack trace only contains 1 frame which is under the configured threshold by stack trace rule (family:native min-frames=2))
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:18.492868+00:00'
+created: '2025-09-19T05:52:39.020881+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-08-08T18:50:29.285229+00:00'
+created: '2025-09-19T05:52:39.034608+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -20,7 +20,7 @@ system:
   hash: null
   contributing component: null
   component:
-    system (stacktrace of app takes precedence)
+    system (ignored because app stacktrace takes precedence)
       stacktrace (ignored because hash matches app variant)
         frame*
           filename*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:14.552509+00:00'
+created: '2025-09-19T05:52:39.049079+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,10 +7,10 @@ app:
   hash: null
   contributing component: null
   component:
-    app (stacktrace of system takes precedence)
+    app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by the client)
-          filename (anonymous filename discarded)
+          filename (ignored because filename is anonymous)
             "<anonymous>"
         frame (marked out of app by the client)
           filename*
@@ -30,7 +30,7 @@ system:
     system*
       stacktrace*
         frame (ignored low quality javascript frame)
-          filename (anonymous filename discarded)
+          filename (ignored because filename is anonymous)
             "<anonymous>"
         frame*
           filename*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:47:18.681218+00:00'
+created: '2025-09-19T05:52:39.064063+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (exception of system takes precedence)
+    app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:15.234636+00:00'
+created: '2025-09-19T05:52:39.140060+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -20,7 +20,7 @@ system:
   hash: null
   contributing component: null
   component:
-    system (threads of app take precedence)
+    system (ignored because app threads take precedence)
       threads (ignored because hash matches app variant)
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:41:30.548327+00:00'
+created: '2025-09-19T05:52:39.242134+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -137,7 +137,7 @@ app:
           "Ensure failed"
         value (ignored because stacktrace takes precedence)
           "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
-      threads (exception of app/system takes precedence)
+      threads (ignored because app/system exception takes precedence)
         stacktrace*
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
@@ -397,7 +397,7 @@ system:
           "Ensure failed"
         value (ignored because stacktrace takes precedence)
           "Ensure condition failed: ensurePtr != nullptr [File:/Users/tustanivsky/Work/sentry-unreal/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp] [Line: <int>]"
-      threads (exception of app/system takes precedence)
+      threads (ignored because app/system exception takes precedence)
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-05-12T23:41:31.153786+00:00'
+created: '2025-09-19T05:52:39.277764+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -138,8 +138,8 @@ default:
   hash: null
   contributing component: null
   component:
-    default (threads of app/system take precedence)
-      message (threads of app/system take precedence)
+    default (ignored because app/system threads take precedence)
+      message (ignored because app/system threads take precedence)
         "Message for scoped event"
 --------------------------------------------------------------------------
 system:


### PR DESCRIPTION
This changes the wording of our grouping info hints to be more consistent, so that when we ignore a component, we always use "ignored <description of component>" or "ignored because <reason>." In a few cases this also required a slight rewording of the hints.