### PR TITLE
chore(auth): reduce staff session length to 1 hour

### DIFF
--- a/src/sentry/auth/staff.py
+++ b/src/sentry/auth/staff.py
@@ -37,7 +37,7 @@ COOKIE_PATH = getattr(settings, "STAFF_COOKIE_PATH", settings.SESSION_COOKIE_PAT
 COOKIE_HTTPONLY = getattr(settings, "STAFF_COOKIE_HTTPONLY", True)
 
 # the maximum time the session can stay alive
-MAX_AGE = timedelta(hours=2)
+MAX_AGE = timedelta(hours=1)
 
 ALLOWED_IPS = frozenset(getattr(settings, "STAFF_ALLOWED_IPS", settings.INTERNAL_IPS) or ())
 


### PR DESCRIPTION
[ECO-983](https://linear.app/getsentry/issue/ECO-983/admin-does-not-reauth-after-20mins)