### PR TITLE
feat(billing): Display reserved PPE for billing plans

### DIFF
--- a/static/gsAdmin/views/billingPlans.spec.tsx
+++ b/static/gsAdmin/views/billingPlans.spec.tsx
@@ -63,8 +63,8 @@ const mockPlansResponse: BillingPlansResponse = {
         },
         price_tiers: {
           errors: [
-            {tier: 1, volume: 100000, monthly: 0, annual: 0, od_ppe: 0},
-            {tier: 2, volume: 1000000, monthly: 10000, annual: 100000, od_ppe: 200},
+            {tier: 1, volume: 100000, monthly: 0, annual: 0, od_ppe: 0, reserved_ppe: 0},
+            {tier: 2, volume: 1000000, monthly: 10000, annual: 100000, od_ppe: 200, reserved_ppe: 160},
           ],
         },
       },
@@ -157,12 +157,15 @@ describe('BillingPlans Component', () => {
 
     // Check that price tier information is displayed
     expect(await screen.findByText('Tier')).toBeInTheDocument();
+    expect(screen.getByText('Reserved PPE')).toBeInTheDocument();
+    expect(screen.getByText('PAYG PPE')).toBeInTheDocument();
     expect(screen.getByText('1')).toBeInTheDocument();
     expect(screen.getByText('100,000')).toBeInTheDocument();
-    expect(screen.getByText('$0.00')).toBeInTheDocument(); // od_ppe
+    expect(screen.getAllByText('$0.00')).toHaveLength(2); // Both reserved_ppe and od_ppe for tier 1
 
     expect(screen.getByText('2')).toBeInTheDocument();
     expect(screen.getByText('1,000,000')).toBeInTheDocument();
+    expect(screen.getByText('$1.60')).toBeInTheDocument(); // reserved_ppe
     expect(screen.getByText('$2.00')).toBeInTheDocument(); // od_ppe
   });
 
@@ -210,12 +213,12 @@ describe('BillingPlans Component', () => {
 
     // Perform assertions on the CSV content
     expect(blobText).toContain('AM9000');
-    expect(blobText).toContain('Am9000 Business, , , ,Errors,,,,,');
+    expect(blobText).toContain('Am9000 Business, , , ,Errors,,,,,,');
     expect(blobText).toContain(
-      'Monthly,Annual, , ,Tier,Volume (max),Monthly,Annual,OD PPE / PAYG PPE,'
+      'Monthly,Annual, , ,Tier,Volume (max),Monthly,Annual,Reserved PPE,PAYG PPE,'
     );
-    expect(blobText).toContain('$89,$960, , ,1,100000,$0,$0,$0.00,');
-    expect(blobText).toContain(' , , , ,2,1000000,$100,"$1,000",$2.00,');
+    expect(blobText).toContain('$89,$960, , ,1,100000,$0,$0,$0.00,$0.00,');
+    expect(blobText).toContain(' , , , ,2,1000000,$100,"$1,000",$1.60,$2.00,');
   });
 
   it('displays "NOT LIVE" badge for plans that are not live', async () => {
@@ -273,8 +276,8 @@ describe('BillingPlans Component', () => {
             },
             price_tiers: {
               errors: [
-                {tier: 1, volume: 100000, monthly: 0, annual: 0, od_ppe: 0},
-                {tier: 2, volume: 1000000, monthly: 10000, annual: 100000, od_ppe: 200},
+                {tier: 1, volume: 100000, monthly: 0, annual: 0, od_ppe: 0, reserved_ppe: 0},
+                {tier: 2, volume: 1000000, monthly: 10000, annual: 100000, od_ppe: 200, reserved_ppe: 160},
               ],
             },
           },

--- a/static/gsAdmin/views/billingPlans.spec.tsx
+++ b/static/gsAdmin/views/billingPlans.spec.tsx
@@ -64,7 +64,14 @@ const mockPlansResponse: BillingPlansResponse = {
         price_tiers: {
           errors: [
             {tier: 1, volume: 100000, monthly: 0, annual: 0, od_ppe: 0, reserved_ppe: 0},
-            {tier: 2, volume: 1000000, monthly: 10000, annual: 100000, od_ppe: 200, reserved_ppe: 160},
+            {
+              tier: 2,
+              volume: 1000000,
+              monthly: 10000,
+              annual: 100000,
+              od_ppe: 200,
+              reserved_ppe: 160,
+            },
           ],
         },
       },
@@ -276,8 +283,22 @@ describe('BillingPlans Component', () => {
             },
             price_tiers: {
               errors: [
-                {tier: 1, volume: 100000, monthly: 0, annual: 0, od_ppe: 0, reserved_ppe: 0},
-                {tier: 2, volume: 1000000, monthly: 10000, annual: 100000, od_ppe: 200, reserved_ppe: 160},
+                {
+                  tier: 1,
+                  volume: 100000,
+                  monthly: 0,
+                  annual: 0,
+                  od_ppe: 0,
+                  reserved_ppe: 0,
+                },
+                {
+                  tier: 2,
+                  volume: 1000000,
+                  monthly: 10000,
+                  annual: 100000,
+                  od_ppe: 200,
+                  reserved_ppe: 160,
+                },
               ],
             },
           },

--- a/static/gsAdmin/views/billingPlans.tsx
+++ b/static/gsAdmin/views/billingPlans.tsx
@@ -39,6 +39,7 @@ interface PriceTier {
   annual: number;
   monthly: number;
   od_ppe: number;
+  reserved_ppe: number;
   tier: number;
   volume: number;
 }
@@ -97,7 +98,8 @@ function BillingPlans() {
             '', // Volume (max)
             '', // Monthly
             '', // Annual
-            '', // OD PPE / PAYG PPE
+            '', // Reserved PPE
+            '', // PAYG PPE
             '' // empty column
           );
         });
@@ -117,7 +119,8 @@ function BillingPlans() {
             'Volume (max)',
             'Monthly',
             'Annual',
-            'OD PPE / PAYG PPE',
+            'Reserved PPE',
+            'PAYG PPE',
             ' ' // empty column
           );
         });
@@ -148,7 +151,8 @@ function BillingPlans() {
                 tier.volume.toString(), // Volume (max)
                 formatCurrency(tier.monthly), // Monthly
                 formatCurrency(tier.annual), // Annual
-                displayUnitPrice({cents: tier.od_ppe, minDigits: 2, maxDigits: 10}), // OD PPE / PAYG PPE
+                displayUnitPrice({cents: tier.reserved_ppe, minDigits: 2, maxDigits: 10}), // Reserved PPE
+                displayUnitPrice({cents: tier.od_ppe, minDigits: 2, maxDigits: 10}), // PAYG PPE
                 ' ' // empty column
               );
             } else {
@@ -158,7 +162,8 @@ function BillingPlans() {
                 ' ', // Volume (max)
                 ' ', // Monthly
                 ' ', // Annual
-                ' ', // OD PPE / PAYG PPE
+                ' ', // Reserved PPE
+                ' ', // PAYG PPE
                 ' ' // empty column
               );
             }
@@ -397,7 +402,8 @@ function PriceTiersTable({
               <th>Volume</th>
               <th>Monthly</th>
               <th>Annual</th>
-              <th>OD PPE / PAYG PPE</th>
+              <th>Reserved PPE</th>
+              <th>PAYG PPE</th>
             </tr>
           </thead>
           <tbody>
@@ -407,6 +413,9 @@ function PriceTiersTable({
                 <td>{Number(tier.volume).toLocaleString('en-US')}</td>
                 <td>{formatCurrency(tier.monthly)}</td>
                 <td>{formatCurrency(tier.annual)}</td>
+                <td>
+                  {displayUnitPrice({cents: tier.reserved_ppe, minDigits: 2, maxDigits: 10})}
+                </td>
                 <td>
                   {displayUnitPrice({cents: tier.od_ppe, minDigits: 2, maxDigits: 10})}
                 </td>

--- a/static/gsAdmin/views/billingPlans.tsx
+++ b/static/gsAdmin/views/billingPlans.tsx
@@ -414,7 +414,11 @@ function PriceTiersTable({
                 <td>{formatCurrency(tier.monthly)}</td>
                 <td>{formatCurrency(tier.annual)}</td>
                 <td>
-                  {displayUnitPrice({cents: tier.reserved_ppe, minDigits: 2, maxDigits: 10})}
+                  {displayUnitPrice({
+                    cents: tier.reserved_ppe,
+                    minDigits: 2,
+                    maxDigits: 10,
+                  })}
                 </td>
                 <td>
                   {displayUnitPrice({cents: tier.od_ppe, minDigits: 2, maxDigits: 10})}


### PR DESCRIPTION
Expose reserved PPE for debugging pricing discrepancies. 

Depends on https://github.com/getsentry/getsentry/pull/18479

<img width="1223" height="870" alt="Screenshot 2025-09-24 at 2 37 42 PM" src="https://github.com/user-attachments/assets/a7b29413-a90d-4a00-b71d-7306dc122130" />
