### PR TITLE
chore(alerts): Remove GH repos page limit flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -571,8 +571,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
 
     # Enable using paginated projects endpoint for Jira integration
     manager.add("organizations:jira-paginated-projects", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable fetching first page of repositories for Github integration
-    manager.add("organizations:github-get-repos-page-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable single trace summary
     manager.add("organizations:single-trace-summary", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable users to connect many Sentry orgs to a single Github org


### PR DESCRIPTION
After https://github.com/getsentry/sentry/pull/100064 and https://github.com/getsentry/sentry-options-automator/pull/5267 are deployed we can remove this now unused flag.