### PR TITLE
fix(replay): fix vertical splitPanel resizing

### DIFF
--- a/static/app/components/layouts/fullViewport.tsx
+++ b/static/app/components/layouts/fullViewport.tsx
@@ -17,10 +17,6 @@ const FullViewport = styled('div')`
     display: none;
   }
 
-  @media (max-width: ${p => p.theme.breakpoints.md}) {
-    height: auto;
-  }
-
   /*
   TODO: Set \`body { overflow: hidden; }\` so that the body doesn't wiggle
   when you try to scroll something that is non-scrollable.

--- a/static/app/components/layouts/fullViewport.tsx
+++ b/static/app/components/layouts/fullViewport.tsx
@@ -17,6 +17,10 @@ const FullViewport = styled('div')`
     display: none;
   }
 
+  @media (max-width: ${p => p.theme.breakpoints.md}) {
+    height: auto;
+  }
+
   /*
   TODO: Set \`body { overflow: hidden; }\` so that the body doesn't wiggle
   when you try to scroll something that is non-scrollable.

--- a/static/app/components/replays/player/styles.tsx
+++ b/static/app/components/replays/player/styles.tsx
@@ -2,6 +2,7 @@ import {css, type Theme} from '@emotion/react';
 
 // Base styles, to make the Replayer instance work
 export const baseReplayerCss = css`
+  position: absolute;
   .replayer-wrapper {
     /* Videos have z-index, so we need a z-index here so user interactions is on top of the video */
     z-index: 1000000;

--- a/static/app/views/replays/detail/layout/replayLayout.tsx
+++ b/static/app/views/replays/detail/layout/replayLayout.tsx
@@ -128,7 +128,12 @@ export default function ReplayLayout({
             key={layout}
             availableSize={height}
             top={{
-              content: <PanelContainer>{video}</PanelContainer>,
+              content: (
+                <PanelContainer>
+                  {video}
+                  {controller}
+                </PanelContainer>
+              ),
               default: (height - DIVIDER_SIZE) * 0.5,
               min: MIN_VIDEO_HEIGHT,
               max: height - DIVIDER_SIZE - MIN_CONTENT_HEIGHT,
@@ -137,7 +142,6 @@ export default function ReplayLayout({
           />
         ) : null}
       </BodySlider>
-      {controller}
     </BodyGrid>
   );
 }
@@ -188,7 +192,10 @@ const VideoSection = styled('div')`
 const PanelContainer = styled('div')`
   position: relative;
   display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
   flex-grow: 1;
+  gap: 20px;
 
   &.disable-iframe-pointer iframe {
     pointer-events: none !important;

--- a/static/app/views/replays/detail/layout/replayLayout.tsx
+++ b/static/app/views/replays/detail/layout/replayLayout.tsx
@@ -128,12 +128,7 @@ export default function ReplayLayout({
             key={layout}
             availableSize={height}
             top={{
-              content: (
-                <PanelContainer>
-                  {video}
-                  {controller}
-                </PanelContainer>
-              ),
+              content: <PanelContainer>{video}</PanelContainer>,
               default: (height - DIVIDER_SIZE) * 0.5,
               min: MIN_VIDEO_HEIGHT,
               max: height - DIVIDER_SIZE - MIN_CONTENT_HEIGHT,
@@ -142,6 +137,7 @@ export default function ReplayLayout({
           />
         ) : null}
       </BodySlider>
+      {controller}
     </BodyGrid>
   );
 }
@@ -192,10 +188,7 @@ const VideoSection = styled('div')`
 const PanelContainer = styled('div')`
   position: relative;
   display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
   flex-grow: 1;
-  gap: 20px;
 
   &.disable-iframe-pointer iframe {
     pointer-events: none !important;


### PR DESCRIPTION
the `BasePlayerRoot` should be `position: absolute` since we're scaling it depending on it's parent component `height` and `width`. this fixes the split panel resizing issue. 

`position: absolute`
- Tested issue list replay preview 
- Tested main replay view 

`FullViewport`
- Tested User Feedback view
- Tested main replay view

before|after
--|--
![before](https://github.com/user-attachments/assets/8865c9f9-3bc2-42f3-a908-c948d093e8ee)|![after](https://github.com/user-attachments/assets/90df6048-b665-41aa-863b-cd3f665a5911)

relates to REPLAY-640
