### PR TITLE
ref(workflow_engine): Pull legacy evaluation into a method and add metrics

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -742,8 +742,9 @@ class SubscriptionProcessor:
                         workflow_engine_results,
                     )
 
-                if workflow_engine_results or legacy_results:
-                    # If either the new or old system detect an issue, log the results for both systems
+                if not self._has_workflow_engine_processing_only and (
+                    workflow_engine_results or legacy_results
+                ):
                     logger.info(
                         metric_prefix,
                         extra={

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -123,6 +123,18 @@ class SubscriptionProcessor:
         self.orig_trigger_alert_counts = deepcopy(self.trigger_alert_counts)
         self.orig_trigger_resolve_counts = deepcopy(self.trigger_resolve_counts)
 
+        self._has_workflow_engine_processing_only = features.has(
+            "organizations:workflow-engine-single-process-metric-issues",
+            self.subscription.project.organization,
+        )
+        self._has_workflow_engine_processing = (
+            features.has(
+                "organizations:workflow-engine-metric-alert-processing",
+                self.subscription.project.organization,
+            )
+            or self._has_workflow_engine_processing_only
+        )
+
     @property
     def active_incident(self) -> Incident | None:
         """
@@ -492,6 +504,135 @@ class SubscriptionProcessor:
             )
         return results
 
+    def process_legacy_metric_alerts(
+        self,
+        subscription_update: QuerySubscriptionUpdate,
+        aggregation_value: float,
+        detector: Detector | None,
+        results: list[tuple[Detector, dict[DetectorGroupKey, DetectorEvaluationResult]]] | None,
+    ) -> None:
+        organization = self.subscription.project.organization
+        has_anomaly_detection = features.has("organizations:anomaly-detection-alerts", organization)
+        potential_anomalies = None
+
+        if (
+            has_anomaly_detection
+            and self.alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC
+            and not self._has_workflow_engine_processing
+        ):
+            with metrics.timer(
+                "incidents.subscription_processor.process_update.get_anomaly_data_from_seer_legacy"
+            ):
+                potential_anomalies = get_anomaly_data_from_seer_legacy(
+                    alert_rule=self.alert_rule,
+                    subscription=self.subscription,
+                    last_update=self.last_update.timestamp(),
+                    aggregation_value=aggregation_value,
+                )
+            if potential_anomalies is None:
+                return
+
+        fired_incident_triggers: list[IncidentTrigger] = []
+        with transaction.atomic(router.db_for_write(AlertRule)):
+            # Triggers is the threshold - NOT an instance of a trigger
+            metrics_incremented = False
+            for trigger in self.triggers:
+                # dual processing of anomaly detection alerts
+                if (
+                    has_anomaly_detection
+                    and self._has_workflow_engine_processing
+                    and self.alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC
+                ):
+                    if not detector or results is None:
+                        raise ResourceDoesNotExist("Detector not found, cannot evaluate anomaly")
+
+                    is_anomalous = get_anomaly_evaluation_from_workflow_engine(detector, results)
+                    logger.info(
+                        "dual processing anomaly detection alert",
+                        extra={
+                            "rule_id": self.alert_rule.id,
+                            "detector_id": detector.id,
+                            "anomaly_evaluation": is_anomalous,
+                        },
+                    )
+                    if is_anomalous is None:
+                        # we only care about True and False — None indicates no change
+                        continue
+
+                    assert isinstance(is_anomalous, bool)
+                    fired_incident_triggers, metrics_incremented = self.handle_trigger_anomalies(
+                        is_anomalous,
+                        trigger,
+                        aggregation_value,
+                        fired_incident_triggers,
+                        metrics_incremented,
+                        detector,
+                    )
+
+                elif potential_anomalies:
+                    # NOTE: There should only be one anomaly in the list
+                    for potential_anomaly in potential_anomalies:
+                        # check to see if we have enough data for the dynamic alert rule now
+                        if self.alert_rule.status == AlertRuleStatus.NOT_ENOUGH_DATA.value:
+                            if anomaly_has_confidence(potential_anomaly):
+                                # NOTE: this means "enabled," and it's the default alert rule status.
+                                # TODO: change these status labels to be less confusing
+                                self.alert_rule.status = AlertRuleStatus.PENDING.value
+                                self.alert_rule.save()
+                            else:
+                                # we don't need to check if the alert should fire if the alert can't fire yet
+                                continue
+
+                        is_anomalous = has_anomaly(potential_anomaly, trigger.label)
+                        fired_incident_triggers, metrics_incremented = (
+                            self.handle_trigger_anomalies(
+                                is_anomalous,
+                                trigger,
+                                aggregation_value,
+                                fired_incident_triggers,
+                                metrics_incremented,
+                                detector,
+                            )
+                        )
+                else:
+                    # ABOVE_AND_BELOW threshold type is only valid for dynamic detection with anomaly detection enabled
+                    if (
+                        self.alert_rule.threshold_type
+                        == AlertRuleThresholdType.ABOVE_AND_BELOW.value
+                    ):
+                        logger.info(
+                            "Skipping processing for ABOVE_AND_BELOW alert rule - anomaly detection likely disabled",
+                            extra={
+                                "rule_id": self.alert_rule.id,
+                                "detection_type": self.alert_rule.detection_type,
+                                "subscription_id": self.subscription.id,
+                                "organization_id": organization.id,
+                            },
+                        )
+                        return
+
+                    fired_incident_triggers, metrics_incremented = self.handle_trigger_alerts(
+                        trigger,
+                        aggregation_value,
+                        fired_incident_triggers,
+                        metrics_incremented,
+                        detector,
+                    )
+
+            if fired_incident_triggers:
+                # For all the newly created incidents
+                # handle the associated actions (eg. send an email/notification)
+                self.handle_trigger_actions(
+                    incident_triggers=fired_incident_triggers, metric_value=aggregation_value
+                )
+
+        # We update the rule stats here after we commit the transaction. This guarantees
+        # that we'll never miss an update, since we'll never roll back if the process
+        # is killed here. The trade-off is that we might process an update twice. Mostly
+        # this will have no effect, but if someone manages to close a triggered incident
+        # before the next one then we might alert twice.
+        self.update_alert_rule_stats()
+
     def process_update(self, subscription_update: QuerySubscriptionUpdate) -> None:
         """
         This is the core processing method utilized when Query Subscription Consumer fetches updates from kafka
@@ -546,172 +687,50 @@ class SubscriptionProcessor:
                     "result": subscription_update,
                 },
             )
-        has_metric_issue_single_processing = features.has(
-            "organizations:workflow-engine-single-process-metric-issues", organization
-        )
-        has_metric_alert_processing = (
-            features.has("organizations:workflow-engine-metric-alert-processing", organization)
-            or has_metric_issue_single_processing
-        )
-        has_anomaly_detection = features.has("organizations:anomaly-detection-alerts", organization)
 
         comparison_delta = None
         detector = None
         with (
             metrics.timer(
                 "incidents.alert_rules.process_update",
-                tags={"dual_processing": has_metric_alert_processing},
+                tags={"dual_processing": self._has_workflow_engine_processing},
             ),
             track_memory_usage(
                 "incidents.alert_rules.process_update_memory",
-                tags={"dual_processing": has_metric_alert_processing},
+                tags={"dual_processing": self._has_workflow_engine_processing},
             ),
         ):
-            detector = self.get_detector(has_metric_alert_processing)
+            detector = self.get_detector(self._has_workflow_engine_processing)
             comparison_delta = self.get_comparison_delta(detector)
             aggregation_value = self.get_aggregation_value(subscription_update, comparison_delta)
 
+            if aggregation_value is None:
+                metrics.incr("incidents.alert_rules.skipping_update_invalid_aggregation_value")
+                return
+
             if aggregation_value is not None:
-                if has_metric_alert_processing:
-                    results = self.process_results_workflow_engine(
+                workflow_engine_results = None
+                if self._has_workflow_engine_processing:
+                    workflow_engine_results = self.process_results_workflow_engine(
                         subscription_update, aggregation_value, organization
                     )
-            else:
-                # XXX: after we fully migrate to single processing we can return early here
-                # this just preserves test functionality for now
-                metrics.incr("incidents.alert_rules.skipping_update_invalid_aggregation_value")
 
-            if has_metric_issue_single_processing:
-                # don't go through the legacy system
-                return
+                if not self._has_workflow_engine_processing_only:
+                    """
+                    TODO - Remove this and related code once workflow_engine rollout is complete.
 
-            potential_anomalies = None
-            if (
-                has_anomaly_detection
-                and self.alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC
-                and not has_metric_alert_processing
-            ):
-                with metrics.timer(
-                    "incidents.subscription_processor.process_update.get_anomaly_data_from_seer_legacy"
-                ):
-                    potential_anomalies = get_anomaly_data_from_seer_legacy(
-                        alert_rule=self.alert_rule,
-                        subscription=self.subscription,
-                        last_update=self.last_update.timestamp(),
-                        aggregation_value=aggregation_value,
+                    The detector / results are required for the legacy system now,
+                    because anomaly detection can only be executed on the data set once.
+
+                    This allows us to process the anomaly detection results in
+                    workflow engine "and" metric alerts.
+                    """
+                    self.process_legacy_metric_alerts(
+                        subscription_update,
+                        aggregation_value,
+                        detector,
+                        workflow_engine_results,
                     )
-                if potential_anomalies is None:
-                    return
-
-            if aggregation_value is None:
-                return
-
-            fired_incident_triggers: list[IncidentTrigger] = []
-            with transaction.atomic(router.db_for_write(AlertRule)):
-                # Triggers is the threshold - NOT an instance of a trigger
-                metrics_incremented = False
-                for trigger in self.triggers:
-                    # dual processing of anomaly detection alerts
-                    if (
-                        has_anomaly_detection
-                        and has_metric_alert_processing
-                        and self.alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC
-                    ):
-                        if not detector:
-                            raise ResourceDoesNotExist(
-                                "Detector not found, cannot evaluate anomaly"
-                            )
-
-                        is_anomalous = get_anomaly_evaluation_from_workflow_engine(
-                            detector, results
-                        )
-                        logger.info(
-                            "dual processing anomaly detection alert",
-                            extra={
-                                "rule_id": self.alert_rule.id,
-                                "detector_id": detector.id,
-                                "anomaly_evaluation": is_anomalous,
-                            },
-                        )
-                        if is_anomalous is None:
-                            # we only care about True and False — None indicates no change
-                            continue
-
-                        assert isinstance(is_anomalous, bool)
-                        fired_incident_triggers, metrics_incremented = (
-                            self.handle_trigger_anomalies(
-                                is_anomalous,
-                                trigger,
-                                aggregation_value,
-                                fired_incident_triggers,
-                                metrics_incremented,
-                                detector,
-                            )
-                        )
-
-                    elif potential_anomalies:
-                        # NOTE: There should only be one anomaly in the list
-                        for potential_anomaly in potential_anomalies:
-                            # check to see if we have enough data for the dynamic alert rule now
-                            if self.alert_rule.status == AlertRuleStatus.NOT_ENOUGH_DATA.value:
-                                if anomaly_has_confidence(potential_anomaly):
-                                    # NOTE: this means "enabled," and it's the default alert rule status.
-                                    # TODO: change these status labels to be less confusing
-                                    self.alert_rule.status = AlertRuleStatus.PENDING.value
-                                    self.alert_rule.save()
-                                else:
-                                    # we don't need to check if the alert should fire if the alert can't fire yet
-                                    continue
-
-                            is_anomalous = has_anomaly(potential_anomaly, trigger.label)
-                            fired_incident_triggers, metrics_incremented = (
-                                self.handle_trigger_anomalies(
-                                    is_anomalous,
-                                    trigger,
-                                    aggregation_value,
-                                    fired_incident_triggers,
-                                    metrics_incremented,
-                                    detector,
-                                )
-                            )
-                    else:
-                        # ABOVE_AND_BELOW threshold type is only valid for dynamic detection with anomaly detection enabled
-                        if (
-                            self.alert_rule.threshold_type
-                            == AlertRuleThresholdType.ABOVE_AND_BELOW.value
-                        ):
-                            logger.info(
-                                "Skipping processing for ABOVE_AND_BELOW alert rule - anomaly detection likely disabled",
-                                extra={
-                                    "rule_id": self.alert_rule.id,
-                                    "detection_type": self.alert_rule.detection_type,
-                                    "subscription_id": self.subscription.id,
-                                    "organization_id": organization.id,
-                                },
-                            )
-                            return
-
-                        fired_incident_triggers, metrics_incremented = self.handle_trigger_alerts(
-                            trigger,
-                            aggregation_value,
-                            fired_incident_triggers,
-                            metrics_incremented,
-                            detector,
-                        )
-
-                if fired_incident_triggers:
-                    # For all the newly created incidents
-                    # handle the associated actions (eg. send an email/notification)
-                    self.handle_trigger_actions(
-                        incident_triggers=fired_incident_triggers, metric_value=aggregation_value
-                    )
-
-            # We update the rule stats here after we commit the transaction. This guarantees
-            # that we'll never miss an update, since we'll never roll back if the process
-            # is killed here. The trade-off is that we might process an update twice. Mostly
-            # this will have no effect, but if someone manages to close a triggered incident
-            # before the next one then we might alert twice.
-            self.update_alert_rule_stats()
 
     def trigger_alert_threshold(
         self, trigger: AlertRuleTrigger, metric_value: float

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -69,7 +69,7 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         )
         value = trigger.alert_threshold + 1
         self.send_update(rule, value)
-        assert mock_logger.info.call_count == 2
+
         mock_logger.info.assert_any_call(
             "dual processing results for alert rule",
             extra={
@@ -79,6 +79,7 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
                 "rule_id": rule.id,
             },
         )
+
         mock_logger.info.assert_any_call(
             "subscription_processor.alert_triggered",
             extra={
@@ -129,7 +130,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         create_alert_rule_trigger(self.rule, WARNING_TRIGGER_LABEL, trigger.alert_threshold - 1)
         self.snooze_rule(owner_id=self.user.id, alert_rule=rule)
         self.send_update(rule, trigger.alert_threshold + 1)
-        assert mock_logger.info.call_count == 1
         mock_logger.info.assert_any_call(
             "dual processing results for alert rule",
             extra={
@@ -184,7 +184,7 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
                 call("incidents.alert_rules.trigger", tags={"type": "resolve"}),
             ]
         )
-        assert mock_logger.info.call_count == 2
+
         mock_logger.info.assert_any_call(
             "dual processing results for alert rule",
             extra={
@@ -236,7 +236,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
                 call("incidents.alert_rules.trigger", tags={"type": "resolve"}),
             ]
         )
-        assert mock_logger.info.call_count == 1
         mock_logger.info.assert_any_call(
             "dual processing results for alert rule",
             extra={
@@ -648,7 +647,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
                 call("incidents.alert_rules.trigger", tags={"type": "fire"}),
             ],
         )
-        assert mock_logger.info.call_count == 4
         mock_logger.info.assert_any_call(
             "subscription_processor.alert_triggered",
             extra={
@@ -718,7 +716,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
                 call("incidents.alert_rules.trigger", tags={"type": "fire"}),
             ],
         )
-        assert mock_logger.info.call_count == 3
 
         # this one gets called twice, once per trigger
         mock_logger.info.assert_any_call(
@@ -794,7 +791,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
                 call("incidents.alert_rules.trigger", tags={"type": "resolve"}),
             ],
         )
-        assert mock_logger.info.call_count == 4
 
         mock_logger.info.assert_any_call(
             "dual processing results for alert rule",
@@ -877,7 +873,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
                 call("incidents.alert_rules.trigger", tags={"type": "resolve"}),
             ],
         )
-        assert mock_logger.info.call_count == 3
 
         # this one gets called twice, once per trigger
         mock_logger.info.assert_any_call(


### PR DESCRIPTION
# Description
This PR accomplishes a few goals:
- Pulls the legacy evaluation into a method, cleaning up the `process_update` method a bit
- Introduces a metric for single processing, so we can see that more data is being evaluated after changing the feature flag
- Adds an info log if we're not in single processing _and_ one of the systems is in a triggered state; then it will log the results from both evaluations.