### PR TITLE
fix(dashboards): Table body contents rendering over table header

### DIFF
--- a/static/app/components/tables/gridEditable/index.tsx
+++ b/static/app/components/tables/gridEditable/index.tsx
@@ -500,7 +500,7 @@ class GridEditable<
               fit={fit}
             >
               <GridHead sticky={stickyHeader}>{this.renderGridHead()}</GridHead>
-              <GridBody>{this.renderGridBody()}</GridBody>
+              <GridBody stickyHeader={stickyHeader}>{this.renderGridBody()}</GridBody>
             </Grid>
           </Body>
         </Profiler>

--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -13,7 +13,7 @@ const GRID_STATUS_MESSAGE_HEIGHT = GRID_BODY_ROW_HEIGHT * 4;
  * Local z-index stacking context
  * https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
  */
-const Z_INDEX_STICKY_HEADER = 1;
+const Z_INDEX_STICKY_HEADER = 2;
 
 // Parent context is GridHeadCell
 const Z_INDEX_GRID_RESIZER = 1;
@@ -185,11 +185,15 @@ export const GridHeadCellStatic = styled('th')`
 /**
  * GridBody are the collection of elements that contains and display the data
  * of the Grid. They are rather simple.
+ *
+ * If the header is sticky, the body should be layered underneath it.
  */
-export const GridBody = styled('tbody')`
+export const GridBody = styled('tbody')<{stickyHeader?: boolean}>`
   display: grid;
   grid-template-columns: subgrid;
   grid-column: 1/-1;
+
+  ${p => (p.stickyHeader ? `z-index: ${Z_INDEX_STICKY_HEADER - 1}` : '')}
 `;
 
 export const GridRow = styled('tr')`


### PR DESCRIPTION
Noticed this:
<img width="389" height="242" alt="Screenshot 2025-09-24 at 3 33 56 PM" src="https://github.com/user-attachments/assets/2cc35dbc-27c4-494e-8042-317b86789106" />

This enforces that when the header is sticky, the body will render in the layer below the header z-index layer.