### PR TITLE
fix(api): Update endpoint URLs and response structure for AI consent status

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3408,12 +3408,12 @@ INTERNAL_URLS = [
     ),
     # Prevent AI (Overwatch) endpoints
     re_path(
-        r"^prevent/pr-review/configs/resolved$",
+        r"^prevent/pr-review/configs/resolved/$",
         PreventPrReviewResolvedConfigsEndpoint.as_view(),
         name="sentry-api-0-prevent-pr-review-configs-resolved",
     ),
     re_path(
-        r"^prevent/pr-review/github/sentry-org$",
+        r"^prevent/pr-review/github/sentry-org/$",
         PreventPrReviewSentryOrgEndpoint.as_view(),
         name="sentry-api-0-prevent-pr-review-github-sentry-org",
     ),

--- a/src/sentry/overwatch/endpoints/overwatch_rpc.py
+++ b/src/sentry/overwatch/endpoints/overwatch_rpc.py
@@ -157,7 +157,12 @@ class PreventPrReviewSentryOrgEndpoint(Endpoint):
 
         organizations = Organization.objects.filter(id__in=organization_ids)
 
-        # Filter out all orgs that didn't give us consent to use AI features
+        # Return all orgs with their consent status for AI features
         return Response(
-            data={"org_ids": [org.id for org in organizations if _can_use_prevent_ai_features(org)]}
+            data={
+                "organizations": [
+                    {"org_id": org.id, "has_consent": _can_use_prevent_ai_features(org)}
+                    for org in organizations
+                ]
+            }
         )


### PR DESCRIPTION
- Added trailing slashes to the URLs for PreventPrReviewResolvedConfigs and PreventPrReviewSentryOrg endpoints.
- Modified the response structure of the PreventPrReviewSentryOrg endpoint to return organizations with their consent status instead of just IDs.
- Updated tests to reflect the new response format and ensure correct functionality.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
