### PR TITLE
fix(eco): Removes metadata field from RpcIntegration repr

### DIFF
--- a/src/sentry/integrations/services/integration/model.py
+++ b/src/sentry/integrations/services/integration/model.py
@@ -6,6 +6,8 @@
 from datetime import datetime
 from typing import Any
 
+from pydantic import Field
+
 from sentry.constants import ObjectStatus
 from sentry.hybridcloud.rpc import RpcModel
 from sentry.identity.services.identity.model import RpcIdentity, RpcIdentityProvider
@@ -22,7 +24,7 @@ class RpcIntegration(RpcModel):
     provider: str
     external_id: str
     name: str
-    metadata: dict[str, Any]
+    metadata: dict[str, Any] = Field(repr=False)
     status: int
 
     def __hash__(self) -> int:

--- a/tests/sentry/integrations/test_model.py
+++ b/tests/sentry/integrations/test_model.py
@@ -1,0 +1,21 @@
+from sentry.constants import ObjectStatus
+from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.testutils.cases import TestCase
+
+
+class TestRpcIntegration(TestCase):
+    def test_repr(self) -> None:
+        integration = RpcIntegration(
+            id=1,
+            name="Test Integration",
+            metadata={"secret": "shhhh"},
+            status=ObjectStatus.ACTIVE,
+            provider="test",
+            external_id="test-external-id",
+        )
+        assert (
+            repr(integration)
+            == "RpcIntegration(id=1, provider='test', external_id='test-external-id', name='Test Integration', status=0)"
+        )
+
+        assert "shhhh" not in str(integration)


### PR DESCRIPTION
Sets our RpcIntegration model's metadata field to `repr=False` to prevent this from being captured anywhere.
