### PR TITLE
ref(prevent): Replace panel summaries with card components

### DIFF
--- a/static/app/components/prevent/summary.tsx
+++ b/static/app/components/prevent/summary.tsx
@@ -1,15 +1,28 @@
-import {css} from '@emotion/react';
+import {Fragment, type ReactNode} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/core/button';
+import {Flex, Grid} from 'sentry/components/core/layout';
 import {Link} from 'sentry/components/core/link';
-import {IconFilter} from 'sentry/icons';
-import {space} from 'sentry/styles/space';
+import {Heading, Text} from 'sentry/components/core/text';
+import Placeholder from 'sentry/components/placeholder';
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import {IconClose, IconFilter} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
 import type {SummaryFilterKey} from 'sentry/views/prevent/tests/config';
 
 // exporting for testing purposes
-export function useCreateSummaryFilterLink(filterBy: SummaryFilterKey) {
+export function useCreateSummaryFilterLink(filterBy: SummaryFilterKey | undefined) {
   const location = useLocation();
+
+  if (!filterBy) {
+    return {
+      isFiltered: false,
+      filterLink: location,
+    };
+  }
+
   const isFiltered = location.query.filterBy === filterBy;
 
   const filterLink = {
@@ -34,92 +47,134 @@ export function useCreateSummaryFilterLink(filterBy: SummaryFilterKey) {
   };
 }
 
-const SummaryEntryBase = css`
-  display: flex;
-  align-items: center;
-  gap: ${space(0.5)};
-  font-size: 2.25rem;
-`;
+interface SummaryCardProps {
+  label: string;
+  tooltip: ReactNode;
+  extra?: ReactNode;
+  filterBy?: SummaryFilterKey;
+  value?: string | number;
+}
 
-export const SummaryEntryValue = styled('span')`
-  ${SummaryEntryBase}
-  color: ${p => p.theme.textColor};
-`;
-
-const StyledSummaryEntryValueLink = styled('span')`
-  font-variant-numeric: tabular-nums;
-  color: ${p => p.theme.linkColor};
-  font-size: 2.25rem;
-
-  /* This stops the text from jumping when becoming bold */
-  &::after {
-    content: attr(data-text);
-    height: 0;
-    visibility: hidden;
-    overflow: hidden;
-    pointer-events: none;
-    font-weight: ${p => p.theme.fontWeight.bold};
-    display: block;
-  }
-
-  &[data-is-filtered='true'] {
-    font-weight: ${p => p.theme.fontWeight.bold};
-  }
-
-  &:hover {
-    text-decoration: underline;
-  }
-`;
-
-type SummaryEntryValueLinkProps = {
-  children: React.ReactNode;
-  filterBy: SummaryFilterKey;
-};
-
-export function SummaryEntryValueLink({children, filterBy}: SummaryEntryValueLinkProps) {
+export function SummaryCard({label, tooltip, value, filterBy, extra}: SummaryCardProps) {
   const {filterLink, isFiltered} = useCreateSummaryFilterLink(filterBy);
 
+  const filterLabel = isFiltered
+    ? t('Clear filter')
+    : t('Filter the table to these tests');
+
+  const content = (
+    <Fragment>
+      <Flex align="center" gap="xs">
+        <Heading as="h4" size="sm">
+          {label}
+        </Heading>
+        <QuestionTooltip title={tooltip} size="xs" />
+      </Flex>
+      <Flex justify="between" align="center">
+        <Flex align="center" gap="sm">
+          <Text size="2xl" bold variant={filterBy ? 'accent' : undefined}>
+            {value ?? '-'}
+          </Text>
+          {extra}
+        </Flex>
+        {filterBy && (
+          <Button
+            size="zero"
+            borderless
+            icon={isFiltered ? <IconClose /> : <IconFilter />}
+            title={filterLabel}
+            aria-label={filterLabel}
+          />
+        )}
+      </Flex>
+    </Fragment>
+  );
+
   return (
-    <div style={{display: 'flex', alignItems: 'center', gap: space(0.5)}}>
-      <IconFilter />
-      <Link to={filterLink}>
-        <StyledSummaryEntryValueLink data-is-filtered={isFiltered}>
-          {children}
-        </StyledSummaryEntryValueLink>
-      </Link>
-    </div>
+    <SummaryCardContainer
+      direction="column"
+      padding="md"
+      gap="sm"
+      isFiltered={isFiltered}
+      isClickable={!!filterBy}
+    >
+      {props =>
+        filterBy ? (
+          <li>
+            <Link to={filterLink} {...props}>
+              {content}
+            </Link>
+          </li>
+        ) : (
+          <li {...props}> {content}</li>
+        )
+      }
+    </SummaryCardContainer>
   );
 }
 
-export const SummaryEntry = styled('div')<{columns?: number}>`
-  display: flex;
-  flex-direction: column;
-  align-items: start;
-  justify-content: space-between;
-  grid-column: span ${p => p.columns ?? 1};
+const SummaryCardContainer = styled(Flex)<{isClickable?: boolean; isFiltered?: boolean}>`
+  border: 1px solid ${p => (p.isFiltered ? p.theme.purple300 : p.theme.border)};
+  border-radius: ${p => p.theme.borderRadius};
+  background: ${p => (p.isFiltered ? p.theme.purple100 : p.theme.background)};
+
+  ${p =>
+    p.isClickable &&
+    `
+    &:hover {
+      background: ${p.theme.backgroundSecondary};
+    }
+  `}
 `;
 
-export const SummaryEntries = styled('div')<{
-  largeColumnSpan: number;
-  smallColumnSpan: number;
-}>`
-  display: grid;
-  align-items: start;
-  justify-content: space-between;
-  gap: ${p => p.theme.space.md};
-  padding-left: ${p => p.theme.space.xl};
-  padding-right: ${p => p.theme.space.xl};
-  padding-top: ${p => p.theme.space['2xl']};
-  padding-bottom: ${p => p.theme.space.sm};
-  grid-template-columns: repeat(${p => p.smallColumnSpan}, 1fr);
+interface SummaryCardGroupProps {
+  children: ReactNode;
+  isLoading: boolean;
+  placeholderCount: number;
+  title: string;
+  trailingHeaderItems?: ReactNode;
+}
 
-  @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    grid-template-columns: repeat(${p => p.largeColumnSpan}, 1fr);
-  }
-`;
+export function SummaryCardGroup({
+  title,
+  isLoading,
+  placeholderCount,
+  children,
+  trailingHeaderItems,
+}: SummaryCardGroupProps) {
+  return (
+    <Flex
+      gap="lg"
+      direction="column"
+      padding="xl"
+      background="secondary"
+      radius="md"
+      as="section"
+    >
+      <Flex justify="between" align="center" gap="md">
+        <Heading as="h4" size="lg">
+          {title}
+        </Heading>
+        {trailingHeaderItems}
+      </Flex>
+      <SummaryListGrid
+        columns="repeat(auto-fit, minmax(200px, 1fr))"
+        align="start"
+        gap="md"
+        as="ul"
+      >
+        {isLoading
+          ? Array.from({length: placeholderCount}, (_, index) => (
+              <Placeholder key={index} height="62px" />
+            ))
+          : children}
+      </SummaryListGrid>
+    </Flex>
+  );
+}
 
-export const SummaryContainer = styled('div')<{columns: number}>`
-  display: grid;
-  grid-template-columns: repeat(${p => p.columns}, 1fr);
-  gap: ${p => p.theme.space.md};
+const SummaryListGrid = styled(Grid)`
+  margin: 0;
+  padding: 0;
+  list-style: none;
 `;

--- a/static/app/views/prevent/coverage/commits/commitDetailSummary.tsx
+++ b/static/app/views/prevent/coverage/commits/commitDetailSummary.tsx
@@ -1,18 +1,10 @@
-import styled from '@emotion/styled';
+import {Fragment} from 'react';
 
+import {Grid} from 'sentry/components/core/layout';
 import {Link} from 'sentry/components/core/link';
-import {Tooltip} from 'sentry/components/core/tooltip';
-import Panel from 'sentry/components/panels/panel';
-import PanelBody from 'sentry/components/panels/panelBody';
-import PanelHeader from 'sentry/components/panels/panelHeader';
-import {
-  SummaryContainer,
-  SummaryEntries,
-  SummaryEntry,
-  SummaryEntryValue,
-  SummaryEntryValueLink,
-} from 'sentry/components/prevent/summary';
-import {t} from 'sentry/locale';
+import {Text} from 'sentry/components/core/text';
+import {SummaryCard, SummaryCardGroup} from 'sentry/components/prevent/summary';
+import {t, tct} from 'sentry/locale';
 
 const headCommit = {
   sha: '31b72ff64bd75326ea5e43bf8e93b415db56cb62',
@@ -26,106 +18,79 @@ const baseCommit = {
 
 export function CommitDetailSummary() {
   return (
-    <SummaryContainer columns={12}>
-      <SelectedCommitPanel>
-        <PanelHeader>{t('Coverage On Selected Commit')}</PanelHeader>
-        <PanelBody>
-          <SummaryEntries largeColumnSpan={6} smallColumnSpan={2}>
-            <SummaryEntry>
-              <Tooltip showUnderline title={t('Repository coverage tooltip')}>
-                {t('Repository coverage')}
-              </Tooltip>
-              <SummaryEntryValue>98.98%</SummaryEntryValue>
-              <StyledSubText>
-                {t('Head commit')}{' '}
-                <Link to={`/prevent/coverage/commits/${headCommit.sha}`}>
-                  {headCommit.shortSha}
-                </Link>
-              </StyledSubText>
-            </SummaryEntry>
-            <SummaryEntry>
-              <Tooltip showUnderline title={t('Patch coverage tooltip')}>
-                {t('Patch coverage')}
-              </Tooltip>
-              <SummaryEntryValue>100%</SummaryEntryValue>
-            </SummaryEntry>
-            <SummaryEntry>
-              <Tooltip showUnderline title={t('Uncovered lines tooltip')}>
-                {t('Uncovered lines')}
-              </Tooltip>
-              <SummaryEntryValueLink filterBy="uncoveredLines">5</SummaryEntryValueLink>
-            </SummaryEntry>
-            <SummaryEntry>
-              <Tooltip showUnderline title={t('Files changed tooltip')}>
-                {t('Files changed')}
-              </Tooltip>
-              <SummaryEntryValueLink filterBy="filesChanged">4</SummaryEntryValueLink>
-            </SummaryEntry>
-            <SummaryEntry>
-              <Tooltip showUnderline title={t('Indirect changes tooltip')}>
-                {t('Indirect changes')}
-              </Tooltip>
-              <SummaryEntryValueLink filterBy="indirectChanges">1</SummaryEntryValueLink>
-            </SummaryEntry>
-            <SourceEntry>
-              <Tooltip showUnderline title={t('Source tooltip')}>
-                {t('Source')}
-              </Tooltip>
-              <SourceText>
-                {t('This commit %s compared to', headCommit.shortSha)}{' '}
-                <Link to={`/prevent/coverage/commits/${baseCommit.sha}`}>
-                  {baseCommit.shortSha}
-                </Link>
-              </SourceText>
-            </SourceEntry>
-          </SummaryEntries>
-        </PanelBody>
-      </SelectedCommitPanel>
-      <UploadsPanel>
-        <PanelHeader>{t('Coverage Uploads - %s', headCommit.shortSha)}</PanelHeader>
-        <PanelBody>
-          <SummaryEntries largeColumnSpan={1} smallColumnSpan={1}>
-            <SummaryEntry>
-              <Tooltip showUnderline title={t('Uploads count tooltip')}>
-                {t('Uploads count')}
-              </Tooltip>
-              <SummaryEntryValueLink filterBy="uploadsCount">65</SummaryEntryValueLink>
-              <StyledSubText>{t('(%s processed, %s pending)', 65, 15)}</StyledSubText>
-            </SummaryEntry>
-          </SummaryEntries>
-        </PanelBody>
-      </UploadsPanel>
-    </SummaryContainer>
+    <Grid columns="4fr max-content" gap="xl">
+      <SummaryCardGroup
+        title={t('Coverage On Selected Commit')}
+        isLoading={false}
+        placeholderCount={5}
+        trailingHeaderItems={
+          <Text size="sm" variant="muted">
+            {t('This commit %s compared to', headCommit.shortSha)}{' '}
+            <Link to={`/prevent/coverage/commits/${baseCommit.sha}`}>
+              {baseCommit.shortSha}
+            </Link>
+          </Text>
+        }
+      >
+        <Fragment>
+          <SummaryCard
+            label={t('Repository coverage')}
+            tooltip={t('Repository coverage tooltip')}
+            value="98.98%"
+            extra={
+              <Text size="sm" variant="muted">
+                {tct('Head: [commitLink]', {
+                  commitLink: (
+                    <Link to={`/prevent/coverage/commits/${headCommit.sha}`}>
+                      {headCommit.shortSha}
+                    </Link>
+                  ),
+                })}
+              </Text>
+            }
+          />
+          <SummaryCard
+            label={t('Patch coverage')}
+            tooltip={t('Patch coverage tooltip')}
+            value="100%"
+          />
+          <SummaryCard
+            label={t('Uncovered lines')}
+            tooltip={t('Uncovered lines tooltip')}
+            value={5}
+            filterBy="uncoveredLines"
+          />
+          <SummaryCard
+            label={t('Files changed')}
+            tooltip={t('Files changed tooltip')}
+            value={4}
+            filterBy="filesChanged"
+          />
+          <SummaryCard
+            label={t('Indirect changes')}
+            tooltip={t('Indirect changes tooltip')}
+            value={1}
+            filterBy="indirectChanges"
+          />
+        </Fragment>
+      </SummaryCardGroup>
+      <SummaryCardGroup
+        title={t('Coverage Uploads - %s', headCommit.shortSha)}
+        isLoading={false}
+        placeholderCount={1}
+      >
+        <SummaryCard
+          label={t('Uploads count')}
+          tooltip={t('Uploads count tooltip')}
+          value={65}
+          filterBy="uploadsCount"
+          extra={
+            <Text size="sm" variant="muted">
+              {t('(%s processed, %s pending)', 65, 15)}
+            </Text>
+          }
+        />
+      </SummaryCardGroup>
+    </Grid>
   );
 }
-
-const StyledSubText = styled('p')`
-  font-size: ${p => p.theme.fontSize.sm};
-  color: ${p => p.theme.gray300};
-`;
-
-const SourceText = styled('p')`
-  font-size: ${p => p.theme.fontSize.sm};
-`;
-
-const SourceEntry = styled(SummaryEntry)`
-  word-break: break-word;
-  overflow-wrap: break-word;
-  max-width: 85%;
-`;
-
-const SelectedCommitPanel = styled(Panel)`
-  grid-column: span 12;
-
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
-    grid-column: span 9;
-  }
-`;
-
-const UploadsPanel = styled(Panel)`
-  grid-column: span 12;
-
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
-    grid-column: span 3;
-  }
-`;

--- a/static/app/views/prevent/tests/summaries/ciEfficiency.spec.tsx
+++ b/static/app/views/prevent/tests/summaries/ciEfficiency.spec.tsx
@@ -19,7 +19,7 @@ describe('CIEfficiency', () => {
   it('renders the slowest tests duration with a filter link', () => {
     render(<CIEfficiency {...testCIEfficiencyData} isLoading={false} />);
 
-    const formattedSlowestTests = screen.getByRole('link', {name: '10s'});
+    const formattedSlowestTests = screen.getByRole('link', {name: /Slowest Tests.*10s/});
     expect(formattedSlowestTests).toBeInTheDocument();
     expect(formattedSlowestTests).toHaveAttribute(
       'href',

--- a/static/app/views/prevent/tests/summaries/ciEfficiency.tsx
+++ b/static/app/views/prevent/tests/summaries/ciEfficiency.tsx
@@ -1,20 +1,10 @@
-import styled from '@emotion/styled';
+import {Fragment} from 'react';
 
 import {Tag} from 'sentry/components/core/badge/tag';
 import {Flex} from 'sentry/components/core/layout';
 import {Heading, Text} from 'sentry/components/core/text';
-import {Tooltip} from 'sentry/components/core/tooltip';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
-import Panel from 'sentry/components/panels/panel';
-import PanelBody from 'sentry/components/panels/panelBody';
-import PanelHeader from 'sentry/components/panels/panelHeader';
 import {usePreventContext} from 'sentry/components/prevent/context/preventContext';
-import {
-  SummaryEntries,
-  SummaryEntry,
-  SummaryEntryValue,
-  SummaryEntryValueLink,
-} from 'sentry/components/prevent/summary';
+import {SummaryCard, SummaryCardGroup} from 'sentry/components/prevent/summary';
 import {t, tct} from 'sentry/locale';
 import {formatPercentRate, formatTimeDuration} from 'sentry/utils/formatters';
 
@@ -85,44 +75,39 @@ function CIEfficiencyBody({
   slowestTestsDuration,
 }: CIEfficiencyBodyProps) {
   return (
-    <SummaryEntries largeColumnSpan={9} smallColumnSpan={1}>
-      <SummaryEntry columns={5}>
-        <Tooltip showUnderline title={<TotalTestsRunTimeTooltip />}>
-          {t('Total Tests Run Time')}
-        </Tooltip>
-        <SummaryEntryValue>
-          {totalTestsRunTime === undefined
-            ? '-'
-            : formatTimeDuration(totalTestsRunTime, 2)}
-          {typeof totalTestsRunTimeChange === 'number' &&
-            totalTestsRunTimeChange !== 0 && (
-              <Tag type={totalTestsRunTimeChange > 0 ? 'error' : 'success'}>
-                {formatPercentRate(totalTestsRunTimeChange)}
-              </Tag>
-            )}
-        </SummaryEntryValue>
-      </SummaryEntry>
-      <SummaryEntry columns={4}>
-        <Tooltip
-          showUnderline
-          title={
-            <SlowestTestsTooltip
-              slowestTests={slowestTests}
-              slowestTestsDuration={slowestTestsDuration}
-            />
-          }
-        >
-          {t('Slowest Tests (P95)')}
-        </Tooltip>
-        {slowestTestsDuration === undefined ? (
-          <SummaryEntryValue>-</SummaryEntryValue>
-        ) : (
-          <SummaryEntryValueLink filterBy="slowestTests">
-            {formatTimeDuration(slowestTestsDuration, 2)}
-          </SummaryEntryValueLink>
-        )}
-      </SummaryEntry>
-    </SummaryEntries>
+    <Fragment>
+      <SummaryCard
+        label={t('Total Tests Run Time')}
+        tooltip={<TotalTestsRunTimeTooltip />}
+        value={
+          totalTestsRunTime === undefined
+            ? undefined
+            : formatTimeDuration(totalTestsRunTime, 2)
+        }
+        extra={
+          totalTestsRunTimeChange ? (
+            <Tag type={totalTestsRunTimeChange > 0 ? 'error' : 'success'}>
+              {formatPercentRate(totalTestsRunTimeChange)}
+            </Tag>
+          ) : undefined
+        }
+      />
+      <SummaryCard
+        label={t('Slowest Tests (P95)')}
+        tooltip={
+          <SlowestTestsTooltip
+            slowestTests={slowestTests}
+            slowestTestsDuration={slowestTestsDuration}
+          />
+        }
+        value={
+          slowestTestsDuration === undefined
+            ? undefined
+            : formatTimeDuration(slowestTestsDuration, 2)
+        }
+        filterBy="slowestTests"
+      />
+    </Fragment>
   );
 }
 
@@ -132,19 +117,12 @@ interface CIEfficiencyProps extends CIEfficiencyBodyProps {
 
 export function CIEfficiency({isLoading, ...bodyProps}: CIEfficiencyProps) {
   return (
-    <CIEfficiencyPanel>
-      <PanelHeader>{t('CI Run Efficiency')}</PanelHeader>
-      <PanelBody>
-        {isLoading ? <LoadingIndicator /> : <CIEfficiencyBody {...bodyProps} />}
-      </PanelBody>
-    </CIEfficiencyPanel>
+    <SummaryCardGroup
+      title={t('CI Run Efficiency')}
+      isLoading={isLoading}
+      placeholderCount={2}
+    >
+      <CIEfficiencyBody {...bodyProps} />
+    </SummaryCardGroup>
   );
 }
-
-const CIEfficiencyPanel = styled(Panel)`
-  grid-column: span 24;
-
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
-    grid-column: span 9;
-  }
-`;

--- a/static/app/views/prevent/tests/summaries/summaries.tsx
+++ b/static/app/views/prevent/tests/summaries/summaries.tsx
@@ -1,4 +1,4 @@
-import {SummaryContainer} from 'sentry/components/prevent/summary';
+import {Grid} from 'sentry/components/core/layout';
 import {useTestResultsAggregates} from 'sentry/views/prevent/tests/queries/useTestResultsAggregates';
 import {CIEfficiency} from 'sentry/views/prevent/tests/summaries/ciEfficiency';
 import {TestPerformance} from 'sentry/views/prevent/tests/summaries/testPerformance';
@@ -10,9 +10,9 @@ export function Summaries() {
   const testPerformanceData = data?.testPerformance;
 
   return (
-    <SummaryContainer columns={24}>
+    <Grid columns="2fr 4fr" gap="xl">
       <CIEfficiency {...ciEfficiencyData} isLoading={isLoading} />
       <TestPerformance {...testPerformanceData} isLoading={isLoading} />
-    </SummaryContainer>
+    </Grid>
   );
 }

--- a/static/app/views/prevent/tests/summaries/testPerformance.spec.tsx
+++ b/static/app/views/prevent/tests/summaries/testPerformance.spec.tsx
@@ -17,12 +17,9 @@ describe('TestPerformance', () => {
   it('renders number of flaky tests with filter link', () => {
     render(<TestPerformance {...testPerformanceData} isLoading={false} />);
 
-    const flakyTestNumber = screen.getByRole('link', {name: '88'});
-    expect(flakyTestNumber).toBeInTheDocument();
-    expect(flakyTestNumber).toHaveAttribute(
-      'href',
-      '/mock-pathname/?filterBy=flakyTests'
-    );
+    const flakyTestCard = screen.getByRole('link', {name: /Flaky Tests.*88/});
+    expect(flakyTestCard).toBeInTheDocument();
+    expect(flakyTestCard).toHaveAttribute('href', '/mock-pathname/?filterBy=flakyTests');
   });
 
   it('renders average flake rate', () => {
@@ -35,7 +32,9 @@ describe('TestPerformance', () => {
   it('renders cumulative failures with filter link', () => {
     render(<TestPerformance {...testPerformanceData} isLoading={false} />);
 
-    const cumulativeFailures = screen.getByRole('link', {name: '356'});
+    const cumulativeFailures = screen.getByRole('link', {
+      name: /Cumulative Failures.*356/,
+    });
     expect(cumulativeFailures).toBeInTheDocument();
     expect(cumulativeFailures).toHaveAttribute(
       'href',
@@ -46,7 +45,7 @@ describe('TestPerformance', () => {
   it('renders skipped tests with filter link', () => {
     render(<TestPerformance {...testPerformanceData} isLoading={false} />);
 
-    const skippedTests = screen.getByRole('link', {name: '50'});
+    const skippedTests = screen.getByRole('link', {name: /Skipped Tests.*50/});
     expect(skippedTests).toBeInTheDocument();
     expect(skippedTests).toHaveAttribute('href', '/mock-pathname/?filterBy=skippedTests');
   });

--- a/static/app/views/prevent/tests/summaries/testPerformance.tsx
+++ b/static/app/views/prevent/tests/summaries/testPerformance.tsx
@@ -1,19 +1,9 @@
-import styled from '@emotion/styled';
+import {Fragment} from 'react';
 
 import {Tag} from 'sentry/components/core/badge/tag';
 import {Flex} from 'sentry/components/core/layout';
 import {Heading, Text} from 'sentry/components/core/text';
-import {Tooltip} from 'sentry/components/core/tooltip';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
-import Panel from 'sentry/components/panels/panel';
-import PanelBody from 'sentry/components/panels/panelBody';
-import PanelHeader from 'sentry/components/panels/panelHeader';
-import {
-  SummaryEntries,
-  SummaryEntry,
-  SummaryEntryValue,
-  SummaryEntryValueLink,
-} from 'sentry/components/prevent/summary';
+import {SummaryCard, SummaryCardGroup} from 'sentry/components/prevent/summary';
 import {t} from 'sentry/locale';
 import {formatPercentRate} from 'sentry/utils/formatters';
 
@@ -101,79 +91,61 @@ function TestPerformanceBody({
   skippedTestsChange,
 }: TestPerformanceBodyProps) {
   return (
-    <SummaryEntries largeColumnSpan={15} smallColumnSpan={1}>
-      <SummaryEntry columns={4}>
-        <Tooltip showUnderline title={<FlakyTestsTooltip />}>
-          {t('Flaky Tests')}
-        </Tooltip>
-        {flakyTests === undefined ? (
-          <SummaryEntryValue>-</SummaryEntryValue>
-        ) : (
-          <SummaryEntryValue>
-            <SummaryEntryValueLink filterBy="flakyTests">
-              {flakyTests}
-            </SummaryEntryValueLink>
-            {typeof flakyTestsChange === 'number' && flakyTestsChange !== 0 && (
-              <Tag type={flakyTestsChange > 0 ? 'error' : 'success'}>
-                {formatPercentRate(flakyTestsChange)}
-              </Tag>
-            )}
-          </SummaryEntryValue>
-        )}
-      </SummaryEntry>
-      <SummaryEntry columns={4}>
-        <Tooltip showUnderline title={<AverageFlakeTooltip />}>
-          {t('Avg. Flake Rate')}
-        </Tooltip>
-        <SummaryEntryValue>
-          {averageFlakeRate === undefined ? '-' : `${averageFlakeRate?.toFixed(2)}%`}
-          {typeof averageFlakeRateChange === 'number' && averageFlakeRateChange !== 0 && (
+    <Fragment>
+      <SummaryCard
+        label={t('Flaky Tests')}
+        tooltip={<FlakyTestsTooltip />}
+        value={flakyTests}
+        filterBy="flakyTests"
+        extra={
+          flakyTestsChange ? (
+            <Tag type={flakyTestsChange > 0 ? 'error' : 'success'}>
+              {formatPercentRate(flakyTestsChange)}
+            </Tag>
+          ) : undefined
+        }
+      />
+      <SummaryCard
+        label={t('Avg. Flake Rate')}
+        tooltip={<AverageFlakeTooltip />}
+        value={
+          averageFlakeRate === undefined ? undefined : `${averageFlakeRate?.toFixed(2)}%`
+        }
+        extra={
+          averageFlakeRateChange ? (
             <Tag type={averageFlakeRateChange > 0 ? 'error' : 'success'}>
               {formatPercentRate(averageFlakeRateChange)}
             </Tag>
-          )}
-        </SummaryEntryValue>
-      </SummaryEntry>
-      <SummaryEntry columns={4}>
-        <Tooltip showUnderline title={<CumulativeFailuresTooltip />}>
-          {t('Cumulative Failures')}
-        </Tooltip>
-        {cumulativeFailures === undefined ? (
-          <SummaryEntryValue>-</SummaryEntryValue>
-        ) : (
-          <SummaryEntryValue>
-            <SummaryEntryValueLink filterBy="failedTests">
-              {cumulativeFailures}
-            </SummaryEntryValueLink>
-            {typeof cumulativeFailuresChange === 'number' &&
-              cumulativeFailuresChange !== 0 && (
-                <Tag type={cumulativeFailuresChange > 0 ? 'error' : 'success'}>
-                  {formatPercentRate(cumulativeFailuresChange)}
-                </Tag>
-              )}
-          </SummaryEntryValue>
-        )}
-      </SummaryEntry>
-      <SummaryEntry columns={3}>
-        <Tooltip showUnderline title={<SkippedTestsTooltip />}>
-          {t('Skipped Tests')}
-        </Tooltip>
-        {skippedTests === undefined ? (
-          <SummaryEntryValue>-</SummaryEntryValue>
-        ) : (
-          <SummaryEntryValue>
-            <SummaryEntryValueLink filterBy="skippedTests">
-              {skippedTests}
-            </SummaryEntryValueLink>
-            {typeof skippedTestsChange === 'number' && skippedTestsChange !== 0 && (
-              <Tag type={skippedTestsChange > 0 ? 'error' : 'success'}>
-                {formatPercentRate(skippedTestsChange)}
-              </Tag>
-            )}
-          </SummaryEntryValue>
-        )}
-      </SummaryEntry>
-    </SummaryEntries>
+          ) : undefined
+        }
+      />
+      <SummaryCard
+        label={t('Cumulative Failures')}
+        tooltip={<CumulativeFailuresTooltip />}
+        value={cumulativeFailures?.toLocaleString()}
+        filterBy="failedTests"
+        extra={
+          cumulativeFailuresChange ? (
+            <Tag type={cumulativeFailuresChange > 0 ? 'error' : 'success'}>
+              {formatPercentRate(cumulativeFailuresChange)}
+            </Tag>
+          ) : undefined
+        }
+      />
+      <SummaryCard
+        label={t('Skipped Tests')}
+        tooltip={<SkippedTestsTooltip />}
+        value={skippedTests?.toLocaleString()}
+        filterBy="skippedTests"
+        extra={
+          skippedTestsChange ? (
+            <Tag type={skippedTestsChange > 0 ? 'error' : 'success'}>
+              {formatPercentRate(skippedTestsChange)}
+            </Tag>
+          ) : undefined
+        }
+      />
+    </Fragment>
   );
 }
 
@@ -183,19 +155,12 @@ interface TestPerformanceProps extends TestPerformanceBodyProps {
 
 export function TestPerformance({isLoading, ...bodyProps}: TestPerformanceProps) {
   return (
-    <TestPerformancePanel>
-      <PanelHeader>{t('Test Performance')}</PanelHeader>
-      <PanelBody>
-        {isLoading ? <LoadingIndicator /> : <TestPerformanceBody {...bodyProps} />}
-      </PanelBody>
-    </TestPerformancePanel>
+    <SummaryCardGroup
+      title={t('Test Performance')}
+      isLoading={isLoading}
+      placeholderCount={4}
+    >
+      <TestPerformanceBody {...bodyProps} />
+    </SummaryCardGroup>
   );
 }
-
-const TestPerformancePanel = styled(Panel)`
-  grid-column: span 24;
-
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
-    grid-column: span 15;
-  }
-`;


### PR DESCRIPTION
Modernizes the prevent summary system from panel-based layouts to a card-based approach:

- Replace old SummaryEntry/SummaryEntries components with new SummaryCard/SummaryCardGroup
- Remove complex CSS grid layouts in favor of flexible auto-fit grids
- Improve filter UI with clear visual states for active/inactive filters
- Use core layout components (Flex, Grid) instead of custom styled containers
- Standardize loading states with placeholder components
- Update tests to match new component structure and accessibility patterns

Benefits:
- More consistent visual design across prevent pages
- Better responsive behavior with auto-fit grids
- Cleaner component API with fewer layout props
- Enhanced accessibility with proper button labels
- Reduced code complexity (316 insertions, 372 deletions)

Before

<img alt="clipboard.png" width="1801" src="https://i.imgur.com/llSVoGy.png" />

After

<img width="1808" height="1492" alt="image" src="https://github.com/user-attachments/assets/a7b40e67-7e5c-47eb-a3c1-ea4d7b1bd5c3" />

Loading

<img width="1808" height="1492" alt="image" src="https://github.com/user-attachments/assets/ece6fd21-8925-477a-9859-b305e94fc780" />
