### PR TITLE
chore(local dev): Allow for custom GRPC port to be specified

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -785,6 +785,10 @@ SENTRY_MONOLITH_REGION: str = "--monolith--"
 SENTRY_SUBNET_SECRET = os.environ.get("SENTRY_SUBNET_SECRET", None)
 
 
+DEVSERVICES_TASKBROKER_GRPC_PORT = 50051
+if SILO_DEVSERVER or IS_DEV:
+    DEVSERVICES_TASKBROKER_GRPC_PORT = 50055
+
 # Queue configuration
 from kombu import Exchange, Queue
 
@@ -2963,7 +2967,9 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
     "taskbroker": lambda settings, options: (
         {
             "image": "ghcr.io/getsentry/taskbroker:latest",
-            "ports": {"50051/tcp": 50051},
+            "ports": {
+                f"{settings.DEVSERVICES_TASKBROKER_GRPC_PORT}/tcp": settings.DEVSERVICES_TASKBROKER_GRPC_PORT
+            },
             "environment": {
                 "TASKBROKER_KAFKA_CLUSTER": (
                     "sentry_kafka"


### PR DESCRIPTION
I and some other coworkers had an issue where colima was using port 50051, which is the port that taskbroker also wants to use. Changing the port that taskbroker uses caused tasks to start flowing again

This is an attempt to use port 50055 solely in the devservices/local development environment

corresponding taskbroker PR: https://github.com/getsentry/taskbroker/pull/492