### PR TITLE
chore(suspect commits): remove GH comment reactions task

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1768,10 +1768,6 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "issues:sentry.tasks.schedule_auto_transition_to_ongoing",
         "schedule": task_crontab("*/5", "*", "*", "*", "*"),
     },
-    "github_comment_reactions": {
-        "task": "integrations:sentry.integrations.github.tasks.github_comment_reactions",
-        "schedule": task_crontab("0", "4", "*", "*", "*"),
-    },
     "statistical-detectors-detect-regressions": {
         "task": "performance:sentry.tasks.statistical_detectors.run_detection",
         "schedule": task_crontab("0", "*/1", "*", "*", "*"),

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -394,9 +394,7 @@ MERGED_PR_COMMENT_BODY_TEMPLATE = """\
 ## Issues attributed to commits in this pull request
 This pull request was merged and Sentry observed the following issues:
 
-{issue_list}
-
-<sub>Did you find this useful? React with a 👍 or 👎</sub>"""
+{issue_list}""".rstrip()
 
 
 class GitHubPRCommentWorkflow(PRCommentWorkflow):
@@ -458,10 +456,7 @@ OPEN_PR_COMMENT_BODY_TEMPLATE = """\
 ## 🔍 Existing Issues For Review
 Your pull request is modifying functions with the following pre-existing issues:
 
-{issue_tables}
----
-
-<sub>Did you find this useful? React with a 👍 or 👎</sub>"""
+{issue_tables}""".rstrip()
 
 OPEN_PR_ISSUE_TABLE_TEMPLATE = """\
 📄 File: **{filename}**

--- a/src/sentry/integrations/github/tasks/__init__.py
+++ b/src/sentry/integrations/github/tasks/__init__.py
@@ -2,13 +2,12 @@ from .codecov_account_link import codecov_account_link
 from .codecov_account_unlink import codecov_account_unlink
 from .link_all_repos import link_all_repos
 from .open_pr_comment import open_pr_comment_workflow
-from .pr_comment import github_comment_reactions, github_comment_workflow
+from .pr_comment import github_comment_workflow
 
 __all__ = (
     "codecov_account_link",
     "codecov_account_unlink",
     "open_pr_comment_workflow",
-    "github_comment_reactions",
     "github_comment_workflow",
     "link_all_repos",
 )

--- a/src/sentry/integrations/github/tasks/pr_comment.py
+++ b/src/sentry/integrations/github/tasks/pr_comment.py
@@ -1,24 +1,12 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta, timezone
 
-import sentry_sdk
-
-from sentry.constants import ObjectStatus
-from sentry.integrations.github.constants import RATE_LIMITED_MESSAGE
-from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.tasks import pr_comment_workflow
-from sentry.integrations.types import IntegrationProviderSlug
-from sentry.models.pullrequest import PullRequestComment
-from sentry.models.repository import Repository
-from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import integrations_tasks
-from sentry.utils import metrics
-from sentry.utils.query import RangeQuerySetWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -34,79 +22,3 @@ def github_comment_workflow(pullrequest_id: int, project_id: int) -> None:
     # TODO(jianyuan): Using `sentry.integrations.source_code_management.tasks.pr_comment_workflow` now.
     # Keep this task temporarily to avoid breaking changes.
     pr_comment_workflow(pr_id=pullrequest_id, project_id=project_id)
-
-
-@instrumented_task(
-    name="sentry.integrations.github.tasks.github_comment_reactions",
-    silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(
-        namespace=integrations_tasks,
-        processing_deadline_duration=1800,  # 30 minutes
-        at_most_once=True,
-    ),
-)
-def github_comment_reactions() -> None:
-    logger.info("github.pr_comment.reactions_task")
-
-    comments = PullRequestComment.objects.filter(
-        created_at__gte=datetime.now(tz=timezone.utc) - timedelta(days=7),
-    ).select_related("pull_request")
-
-    logger.info("pr_comment.comment_reactions.count", extra={"count": comments.count()})
-
-    comment_count = 0
-
-    for comment in RangeQuerySetWrapper(comments):
-        pr = comment.pull_request
-        try:
-            repo = Repository.objects.get(id=pr.repository_id)
-        except Repository.DoesNotExist:
-            metrics.incr("pr_comment.comment_reactions.missing_repo")
-            continue
-
-        # Add check for GitHub provider before proceeding
-        # TODO: nuke comment reactions or implement for all providers
-        if repo.provider not in (IntegrationProviderSlug.GITHUB.value, "integrations:github"):
-            metrics.incr("pr_comment.comment_reactions.skipped_non_github")
-            continue
-
-        integration = integration_service.get_integration(
-            integration_id=repo.integration_id, status=ObjectStatus.ACTIVE
-        )
-        if not integration:
-            logger.info(
-                "pr_comment.comment_reactions.integration_missing",
-                extra={
-                    "organization_id": pr.organization_id,
-                },
-            )
-            metrics.incr("pr_comment.comment_reactions.missing_integration")
-            continue
-
-        installation = integration.get_installation(organization_id=pr.organization_id)
-
-        # GitHubApiClient
-        # TODO(cathy): create helper function to fetch client for repo
-        client = installation.get_client()
-
-        try:
-            reactions = client.get_comment_reactions(repo=repo.name, comment_id=comment.external_id)
-            if reactions or comment.reactions:
-                comment.reactions = reactions
-                comment.save()
-        except ApiError as e:
-            if e.json and RATE_LIMITED_MESSAGE in e.json.get("message", ""):
-                metrics.incr("pr_comment.comment_reactions.rate_limited_error")
-                break
-
-            if e.code == 404:
-                metrics.incr("pr_comment.comment_reactions.not_found_error")
-            else:
-                metrics.incr("pr_comment.comment_reactions.api_error")
-                sentry_sdk.capture_exception(e)
-            continue
-
-        comment_count += 1
-        metrics.incr("pr_comment.comment_reactions.success")
-
-    logger.info("pr_comment.comment_reactions.total_collected", extra={"count": comment_count})

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -230,7 +230,7 @@ MERGED_PR_COMMENT_BODY_TEMPLATE = """\
 ## Issues attributed to commits in this merge request
 The following issues were detected after merging:
 
-{issue_list}"""
+{issue_list}""".rstrip()
 
 
 class GitlabPRCommentWorkflow(PRCommentWorkflow):
@@ -281,7 +281,7 @@ OPEN_PR_COMMENT_BODY_TEMPLATE = """\
 ## 🔍 Existing Issues For Review
 Your merge request is modifying functions with the following pre-existing issues:
 
-{issue_tables}"""
+{issue_tables}""".rstrip()
 
 OPEN_PR_ISSUE_TABLE_TEMPLATE = """\
 📄 File: **{filename}**

--- a/tests/sentry/integrations/github/tasks/test_open_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_open_pr_comment.py
@@ -841,10 +841,7 @@ Your pull request is modifying functions with the following pre-existing issues:
 | :------- | :----- |
 | **`function_0`** | [**SoftTimeLimitExceeded 0**](http://testserver/organizations/{self.organization.slug}/issues/5/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **20k** |
 | **`function_1`** | [**SoftTimeLimitExceeded 1**](http://testserver/organizations/{self.organization.slug}/issues/6/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **10k** |
-</details>
----
-
-<sub>Did you find this useful? React with a 👍 or 👎</sub>"""
+</details>"""
         )
 
     def test_comment_format_javascript(self) -> None:
@@ -906,10 +903,7 @@ Your pull request is modifying functions with the following pre-existing issues:
 | :------- | :----- |
 | **`function_0`** | [**SoftTimeLimitExceeded 0**](http://testserver/organizations/{self.organization.slug}/issues/5/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **20k** `Affected Users:` **20k** |
 | **`function_1`** | [**SoftTimeLimitExceeded 1**](http://testserver/organizations/{self.organization.slug}/issues/6/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **10k** `Affected Users:` **10k** |
-</details>
----
-
-<sub>Did you find this useful? React with a 👍 or 👎</sub>"""
+</details>"""
         )
 
     def test_comment_format_missing_language(self) -> None:
@@ -1022,9 +1016,7 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
             "| :------- | :----- |\n"
             f"| **`function_1`** | [**Error**](http://testserver/organizations/baz/issues/{self.group_id_2}/?referrer=github-open-pr-bot) issue2 <br> `Event Count:` **2k** |\n"
             f"| **`function_0`** | [**Error**](http://testserver/organizations/baz/issues/{self.group_id_1}/?referrer=github-open-pr-bot) issue1 <br> `Event Count:` **1k** |\n"
-            "</details>\n"
-            "---\n\n"
-            "<sub>Did you find this useful? React with a 👍 or 👎</sub>"
+            "</details>"
         )
 
         assert orjson.loads(responses.calls[0].request.body.decode())["body"] == expected_body


### PR DESCRIPTION
This task is not functional in its current state, needs significant reworking. Removing for now.

Removed the subtitle on GH comment templates encouraging users to leave reactions. Seems like there was an extra newline on the end of GH and GL comments, removed that as well.