### PR TITLE
ref(grouping): Rename `ComponentVariant.component` to `root_component`

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -380,7 +380,7 @@ def _get_variants_from_strategies(
         )
 
         variants[variant_name] = ComponentVariant(
-            component=root_component,
+            root_component=root_component,
             contributing_component=contributing_component,
             strategy_config=context.config,
         )
@@ -449,7 +449,7 @@ def get_grouping_variants_for_event(
         hint = f"ignored because {fingerprint_source} fingerprint takes precedence"
 
         for variant in strategy_component_variants.values():
-            variant.component.update(contributes=False, hint=hint)
+            variant.root_component.update(contributes=False, hint=hint)
 
     elif fingerprint_type == "hybrid":
         for variant_name, variant in strategy_component_variants.items():

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -531,19 +531,19 @@ def _get_fallback_hashing_metadata(
 
     if (
         "app" in variants
-        and variants["app"].component.values[0].hint == "ignored because it contains no frames"
+        and variants["app"].root_component.values[0].hint == "ignored because it contains no frames"
     ):
         reason = "no_frames"
 
     elif (
         "system" in variants
-        and variants["system"].component.values[0].hint
+        and variants["system"].root_component.values[0].hint
         == "ignored because it contains no contributing frames"
     ):
         reason = "no_contributing_frames"
 
     elif "system" in variants and "min-frames" in (
-        variants["system"].component.values[0].hint or ""
+        variants["system"].root_component.values[0].hint or ""
     ):
         reason = "insufficient_contributing_frames"
 

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:24.179882+00:00'
+created: '2025-09-24T20:28:33.803099+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "738e7d2503464bc264b4f791286f5122"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -273,7 +273,7 @@ contributing variants:
   system*
     hash: "19a96e0438d28e48355653def82f887a"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:27.585766+00:00'
+created: '2025-09-24T20:28:33.866785+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "2552498cfe69a6ddf1dcdde5440ce9c3"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:24.436583+00:00'
+created: '2025-09-24T20:28:33.893515+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "228c649a3aa0901622c0a0e66ab0522c"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -45,7 +45,7 @@ contributing variants:
   system*
     hash: "4ccd0f1953483581ba360c7518f90332"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:24.541096+00:00'
+created: '2025-09-24T20:28:33.915264+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
     contributing component: threads
-    component:
+    root_component:
       app*
         threads*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:27.750560+00:00'
+created: '2025-09-24T20:28:33.933450+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "d9c9b0f9ba46e32fddd7cd1512fad235"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:11.825571+00:00'
+created: '2025-09-24T20:28:33.999226+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "4ef1fb44d656c3be2a146971f2a222dc"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -49,7 +49,7 @@ contributing variants:
   system*
     hash: "47481871aa8d5ab5729cf2db78ce3032"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:25.252502+00:00'
+created: '2025-09-24T20:28:34.052475+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "7c8a196d16b94be382add324be2605ee"
     contributing component: threads
-    component:
+    root_component:
       app*
         threads*
           stacktrace*
@@ -45,7 +45,7 @@ contributing variants:
   system*
     hash: "cd7f51d716fd57adc1a5ce1c112e538f"
     contributing component: threads
-    component:
+    root_component:
       system*
         threads*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:11.901214+00:00'
+created: '2025-09-24T20:28:34.070744+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "6b059b9febc815ac18ac4d2082e38a9b"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -70,7 +70,7 @@ contributing variants:
   system*
     hash: "013d3477a774fe20c468dc8accd516f1"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:11.921846+00:00'
+created: '2025-09-24T20:28:34.092367+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "161ce02ecc5d6685a72e8e520ab726b3"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -42,7 +42,7 @@ contributing variants:
   system*
     hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:11.948664+00:00'
+created: '2025-09-24T20:28:34.113882+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:28.517549+00:00'
+created: '2025-09-24T20:28:34.269006+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   default*
     hash: "666766514295bb52812324097cdaf53e"
     contributing component: csp
-    component:
+    root_component:
       default*
         csp*
           salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_img_src.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_img_src.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:28.164949+00:00'
+created: '2025-09-24T20:28:34.135583+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   default*
     hash: "1742101e08eb1608f569751dfedd0062"
     contributing component: csp
-    component:
+    root_component:
       default*
         csp*
           salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:28.211783+00:00'
+created: '2025-09-24T20:28:34.154815+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   default*
     hash: "efddf1cde918097259aa7d4904fb1942"
     contributing component: csp
-    component:
+    root_component:
       default*
         csp*
           salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_data_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_data_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:28.258600+00:00'
+created: '2025-09-24T20:28:34.176273+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   default*
     hash: "4e6f2bce9d121aa89f4dc5e5da08afb5"
     contributing component: csp
-    component:
+    root_component:
       default*
         csp*
           salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:28.302380+00:00'
+created: '2025-09-24T20:28:34.199596+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -25,7 +25,7 @@ contributing variants:
   default*
     hash: "56c6520f35bce2f89ed2c4e725ccef65"
     contributing component: csp
-    component:
+    root_component:
       default*
         csp*
           salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:28.351573+00:00'
+created: '2025-09-24T20:28:34.218236+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -25,7 +25,7 @@ contributing variants:
   default*
     hash: "d346ee37d19a2be6587e609075ca2d57"
     contributing component: csp
-    component:
+    root_component:
       default*
         csp*
           salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:28.405407+00:00'
+created: '2025-09-24T20:28:34.235616+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   default*
     hash: "223cdacfe5b4b830dc700b5c18cc21b4"
     contributing component: csp
-    component:
+    root_component:
       default*
         csp*
           salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_style_src_elem.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_style_src_elem.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:28.470712+00:00'
+created: '2025-09-24T20:28:34.252686+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   default*
     hash: "537a973f594c364842893e9a72af62a5"
     contributing component: csp
-    component:
+    root_component:
       default*
         csp*
           salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:12.271965+00:00'
+created: '2025-09-24T20:28:34.361728+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "029f3b967068b1539f96957b7c0451d7"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:30.102806+00:00'
+created: '2025-09-24T20:28:34.414962+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "b23ee1963904c2ca87b145febf94b66c"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:27.170117+00:00'
+created: '2025-09-24T20:28:34.378793+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "9509e122c6175606d52862fa4f64853c"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:13:34.911117+00:00'
+created: '2025-09-24T20:28:34.396686+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "669cb6664e0f5fed38665da04e464f7e"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:12.356006+00:00'
+created: '2025-09-24T20:28:34.434023+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "e2bf1e0628b7b1824a9b63dec7a079a3"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:12.397134+00:00'
+created: '2025-09-24T20:28:34.472715+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "93b26686d00504b4e5aa1cb0244d8b37"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:12.377006+00:00'
+created: '2025-09-24T20:28:34.450358+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "93b26686d00504b4e5aa1cb0244d8b37"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:30.451327+00:00'
+created: '2025-09-24T20:28:34.492943+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "a4f16891fa438620699cb2d9af5cc827"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:12.433749+00:00'
+created: '2025-09-24T20:28:34.509709+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "028157fe357e4592e39eacb32eafa2db"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:12.451453+00:00'
+created: '2025-09-24T20:28:34.543791+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "f0078a82f351095ba595daa7d493aa3c"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:12.470733+00:00'
+created: '2025-09-24T20:28:34.560700+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "93b26686d00504b4e5aa1cb0244d8b37"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-18T22:16:41.777611+00:00'
+created: '2025-09-24T20:28:34.584084+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "0809098f9f613b63467605dd1739cc9b"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:30.752309+00:00'
+created: '2025-09-24T20:28:34.603776+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "0809098f9f613b63467605dd1739cc9b"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_exception.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_exception.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:30.830766+00:00'
+created: '2025-09-24T20:28:34.621967+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "a4f16891fa438620699cb2d9af5cc827"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:30.907294+00:00'
+created: '2025-09-24T20:28:34.639391+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "a4f16891fa438620699cb2d9af5cc827"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:12.591762+00:00'
+created: '2025-09-24T20:28:34.656595+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "17022e0561e9b6e6351723a08aa81b18"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:31.134838+00:00'
+created: '2025-09-24T20:28:34.691063+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "a4f16891fa438620699cb2d9af5cc827"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:12.610912+00:00'
+created: '2025-09-24T20:28:34.673808+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "f0078a82f351095ba595daa7d493aa3c"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:13:35.237698+00:00'
+created: '2025-09-24T20:28:34.709389+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "d505dfb9059ac63c11955233323a9100"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*
@@ -60,7 +60,7 @@ contributing variants:
   system*
     hash: "4f9cc6a81f4eb34f9e917374f281b9dc"
     contributing component: chained_exception
-    component:
+    root_component:
       system*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_types.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_types.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:12.707275+00:00'
+created: '2025-09-24T20:28:34.744863+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "bca604b98cb4637167eb6190a92e8933"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:12.683636+00:00'
+created: '2025-09-24T20:28:34.727422+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "fca0fd23f09e8da4481304ef2a531100"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:12.730331+00:00'
+created: '2025-09-24T20:28:34.762529+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "26552f86ca2368e708afa1df6effc1c5"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_without_type.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_without_type.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:31.585212+00:00'
+created: '2025-09-24T20:28:34.785230+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "5eb63bbbe01eeed093cb22bb8f5acdc3"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           value*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_without_value.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_without_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:31.683152+00:00'
+created: '2025-09-24T20:28:34.807479+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "5a2cfd89b7b171fd7b4794b08023d04f"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/expectct.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/expectct.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:12.890172+00:00'
+created: '2025-09-24T20:28:34.894316+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,7 +23,7 @@ contributing variants:
   default*
     hash: "3d2933f4b5ec459ec8d569a398fd328c"
     contributing component: expect_ct
-    component:
+    root_component:
       default*
         expect_ct*
           salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:31.865839+00:00'
+created: '2025-09-24T20:28:34.930109+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "87497299851e09febfecf4e84e0d45ba"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:31.946715+00:00'
+created: '2025-09-24T20:28:34.955671+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "526b64456c48836a46ec1a89544fd412"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:32.164960+00:00'
+created: '2025-09-24T20:28:35.001380+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "7d2cc7acbf90328200d960bf78a26234"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:32.241026+00:00'
+created: '2025-09-24T20:28:35.024616+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "465d672b2d322bf6a1b44499f6dabc1f"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:32.314907+00:00'
+created: '2025-09-24T20:28:35.044835+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "45c0b0a8c777e7a7040d7c39233a08a5"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:32.464870+00:00'
+created: '2025-09-24T20:28:35.087744+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "353e05904b48bd3ae4fa9623934a70d0"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:32.529829+00:00'
+created: '2025-09-24T20:28:35.104473+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "0094f39fc617031afb6c655419f4a9f2"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:32.605542+00:00'
+created: '2025-09-24T20:28:35.121696+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "be15ca3d511b96918e087c4f42503ca2"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:13.131406+00:00'
+created: '2025-09-24T20:28:35.143424+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "e04dce7550635e05dbd7f656102cf304"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:32.784229+00:00'
+created: '2025-09-24T20:28:35.162742+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "098f6bcd4621d373cade4e832627b4f6"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:13.192010+00:00'
+created: '2025-09-24T20:28:35.203923+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "64a0e0a34d99dce03a8c5a4c237a4b5a"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:13.211297+00:00'
+created: '2025-09-24T20:28:35.223164+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "64a0e0a34d99dce03a8c5a4c237a4b5a"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:08.758780+00:00'
+created: '2025-09-24T20:28:35.246212+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "e0e7c4713e9092dc77635d5a0d5db31d"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:33.450199+00:00'
+created: '2025-09-24T20:28:35.267025+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "c32a94349d9e9b72d31a46610c6c9589"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:33.550925+00:00'
+created: '2025-09-24T20:28:35.293812+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "be7f1b8b4014de623c533a8218dba5bd"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:33.667461+00:00'
+created: '2025-09-24T20:28:35.314547+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "53b9e9679a8ea25880376080b76f98ad"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_javassist.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:33.955214+00:00'
+created: '2025-09-24T20:28:35.373054+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "538bdfd8d7bb2495d0d6429c3689a420"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:33.756196+00:00'
+created: '2025-09-24T20:28:35.331627+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "538bdfd8d7bb2495d0d6429c3689a420"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:33.843690+00:00'
+created: '2025-09-24T20:28:35.351906+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "dc3d511120ce04996b1eef3496516e5c"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:34.097465+00:00'
+created: '2025-09-24T20:28:35.392974+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "0cc175b9c0f1b6a831c399e269772661"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:34.271532+00:00'
+created: '2025-09-24T20:28:35.433267+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "30eb5001914d29dd8461898b5b8094fe"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:09.949432+00:00'
+created: '2025-09-24T20:28:35.525977+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "07d1a8e5728b3c4c7aa8b8273fd0e753"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:09.859524+00:00'
+created: '2025-09-24T20:28:35.507441+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "09e0efcab18f545166318118ed4e0292"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:10.033910+00:00'
+created: '2025-09-24T20:28:35.547821+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "9bc326575875422d0d4ced3c35d9f916"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:34.972855+00:00'
+created: '2025-09-24T20:28:35.565695+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "27eed4125fc13d42163ddb0b8f357b48"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:35.072534+00:00'
+created: '2025-09-24T20:28:35.584416+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "4067a71d7098866f87c746a57a77b2bb"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:35.249862+00:00'
+created: '2025-09-24T20:28:35.623327+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "2f908c015ad77a50595512fcf65d344c"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:35.155305+00:00'
+created: '2025-09-24T20:28:35.602641+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "2f908c015ad77a50595512fcf65d344c"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:13.644431+00:00'
+created: '2025-09-24T20:28:35.643838+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "60e0a667027bef0d0b7c4882891df7e8"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:35.662197+00:00'
+created: '2025-09-24T20:28:35.661191+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "acbd18db4cc2f85cedef654fccc4a4d8"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:35.910248+00:00'
+created: '2025-09-24T20:28:35.678382+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "1effb24729ae4c43efa36b460511136a"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:33.279634+00:00'
+created: '2025-09-24T20:28:35.695692+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "4b8bbc500bd2cabfcadc1f1be867e0bb"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -40,7 +40,7 @@ contributing variants:
   system*
     hash: "348fc4026c9fa11ffba8fbfa80a134c9"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:11.512656+00:00'
+created: '2025-09-24T20:28:35.716252+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "3da34e8c72dbcd4a490ac36eb7130638"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:11.603758+00:00'
+created: '2025-09-24T20:28:35.742332+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "ca733a48a19d237df8577d09449095d9"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:36.398165+00:00'
+created: '2025-09-24T20:28:35.762816+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "2c1bbd635b64d5adccdb64a620044075"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:11.817120+00:00'
+created: '2025-09-24T20:28:35.781916+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "9c336f632f6764c0f082a6a66edbf22d"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:11.909576+00:00'
+created: '2025-09-24T20:28:35.802998+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "49b6f72b6635cb43190c57ee56b026b0"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:12.004668+00:00'
+created: '2025-09-24T20:28:35.823678+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "49b6f72b6635cb43190c57ee56b026b0"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:36.905369+00:00'
+created: '2025-09-24T20:28:35.842651+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "aeed765d29d1a60cb094f66d2cd8efb2"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:37.082795+00:00'
+created: '2025-09-24T20:28:35.861486+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "aeed765d29d1a60cb094f66d2cd8efb2"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:12.312636+00:00'
+created: '2025-09-24T20:28:35.882174+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "8be5979a334287a1b47457228f1d4612"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:12.445192+00:00'
+created: '2025-09-24T20:28:35.903630+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "8be5979a334287a1b47457228f1d4612"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:12.566413+00:00'
+created: '2025-09-24T20:28:35.924593+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "7e64037e487c78ce0439f750a2ef503f"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:37.494215+00:00'
+created: '2025-09-24T20:28:35.942908+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "aeed765d29d1a60cb094f66d2cd8efb2"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:37.588354+00:00'
+created: '2025-09-24T20:28:35.962923+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "6148c73af04344a8597354711f5951ea"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:37.684154+00:00'
+created: '2025-09-24T20:28:35.982325+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "1056f62d72ff8b4d0c3842d696dbb10a"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:13.559138+00:00'
+created: '2025-09-24T20:28:36.002465+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "15526a7b64e9b5dc6d89e7ebec864260"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hpkp.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hpkp.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:37.994068+00:00'
+created: '2025-09-24T20:28:36.020202+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,7 +23,7 @@ contributing variants:
   default*
     hash: "1e37a374cb33572622d02ff7a6237c44"
     contributing component: hpkp
-    component:
+    root_component:
       default*
         hpkp*
           salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-07-18T18:37:27.160196+00:00'
+created: '2025-09-24T20:28:36.037911+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -28,12 +28,12 @@ contributing variants:
   app*
     hash: "e3d593b4335190212ca7c18b8e967fb1"
     contributing component: exception
-    component:
+    fingerprint_info: {"client_fingerprint":["{{ default }}","dogs are great"]}
+    root_component:
       app*
         exception*
           type*
             "FailedToFetchError"
           value*
             "FailedToFetchError: Charlie didn't bring the ball back!"
-    fingerprint_info: {"client_fingerprint":["{{ default }}","dogs are great"]}
     values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:14.091144+00:00'
+created: '2025-09-24T20:28:36.056103+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -31,7 +31,8 @@ contributing variants:
   app*
     hash: "19163f3ca34f5995c69d85351ce3d697"
     contributing component: exception
-    component:
+    fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
+    root_component:
       app*
         exception*
           stacktrace*
@@ -121,12 +122,12 @@ contributing variants:
                 "exe.submit(fetch_file, idx.offset, idx.blob.getfile)"
           type*
             "SoftTimeLimitExceeded"
-    fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
     values: ["{{ default }}","soft-timelimit-exceeded"]
   system*
     hash: "847950eb44d280e6758d136c763d6ddc"
     contributing component: exception
-    component:
+    fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
+    root_component:
       system*
         exception*
           stacktrace*
@@ -251,5 +252,4 @@ contributing variants:
                 "raise SoftTimeLimitExceeded()"
           type*
             "SoftTimeLimitExceeded"
-    fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
     values: ["{{ default }}","soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-07-18T18:37:27.657035+00:00'
+created: '2025-09-24T20:28:36.091930+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -28,12 +28,12 @@ contributing variants:
   app*
     hash: "5b5ad5a0fbb4deb5e3fc631ce42681ae"
     contributing component: exception
-    component:
+    fingerprint_info: {"client_fingerprint":["{{ default }}","adopt don't shop"]}
+    root_component:
       app*
         exception*
           type*
             "FailedToFetchError"
           value*
             "FailedToFetchError: Charlie didn't bring the ball back!"
-    fingerprint_info: {"client_fingerprint":["{{ default }}","adopt don't shop"]}
     values: ["{{ default }}","adopt don't shop"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-07-18T18:37:27.829828+00:00'
+created: '2025-09-24T20:28:36.109779+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -28,12 +28,12 @@ contributing variants:
   app*
     hash: "c5578778212497f1ff3435405e2a4a98"
     contributing component: exception
-    component:
+    fingerprint_info: {"client_fingerprint":["{{ default }}","dogs are great"]}
+    root_component:
       app*
         exception*
           type*
             "FailedToFetchError"
           value*
             "FailedToFetchError: Maisey can't see the ball anymore :-("
-    fingerprint_info: {"client_fingerprint":["{{ default }}","dogs are great"]}
     values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:35.815206+00:00'
+created: '2025-09-24T20:28:36.130571+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "5b032559156688c9eabe4e4bd5ae6bd4"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -93,7 +93,7 @@ contributing variants:
   system*
     hash: "1921b991270e24c19ea1ed6863892d71"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:13:36.940819+00:00'
+created: '2025-09-24T20:28:36.152116+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "1959b227a7cf6acf7f3fd401b5d9f09b"
     contributing component: chained_exception
-    component:
+    root_component:
       system*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:38.811522+00:00'
+created: '2025-09-24T20:28:36.173079+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "ef2555bf7958ada8eefafbfdaed1c409"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:38.984446+00:00'
+created: '2025-09-24T20:28:36.210428+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "10dfd81e2df31e96fae451b9e205ad81"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:38.902308+00:00'
+created: '2025-09-24T20:28:36.189136+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "b8e2a347e75266ca7bb565e2b3c0722e"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:39.076175+00:00'
+created: '2025-09-24T20:28:36.227579+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "c0f3f7d6deb17aec9d07259ac684fad0"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:39.248563+00:00'
+created: '2025-09-24T20:28:36.266002+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   default*
     hash: "4119639092e62c55ea8be348e4d9260d"
     contributing component: message
-    component:
+    root_component:
       default*
         message*
           "event"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_message_parameterization.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:39.144829+00:00'
+created: '2025-09-24T20:28:36.245112+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   default*
     hash: "f9e47f16e3b9770b440157179c47bf7a"
     contributing component: message
-    component:
+    root_component:
       default*
         message* (stripped event-specific values)
           "testing testing <int>, <int>, <int>"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:39.445707+00:00'
+created: '2025-09-24T20:28:36.283947+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "be36642f41f047346396f018f62375d3"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:17.258843+00:00'
+created: '2025-09-24T20:28:36.304845+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "6ab78545e13144405fb21dadb9045b91"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:39.595523+00:00'
+created: '2025-09-24T20:28:36.324721+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "c63e8727af1a8fe75872b6a762797113"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:39.677590+00:00'
+created: '2025-09-24T20:28:36.344638+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "c63e8727af1a8fe75872b6a762797113"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:39.770204+00:00'
+created: '2025-09-24T20:28:36.367676+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "c63e8727af1a8fe75872b6a762797113"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:39.872332+00:00'
+created: '2025-09-24T20:28:36.389924+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "b2602ad455472dede8e4c340d8a7eaba"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:39.983796+00:00'
+created: '2025-09-24T20:28:36.413818+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "b2602ad455472dede8e4c340d8a7eaba"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:40.097495+00:00'
+created: '2025-09-24T20:28:36.437098+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "b2602ad455472dede8e4c340d8a7eaba"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:40.183768+00:00'
+created: '2025-09-24T20:28:36.457925+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "b2602ad455472dede8e4c340d8a7eaba"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:40.295521+00:00'
+created: '2025-09-24T20:28:36.478168+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "c63e8727af1a8fe75872b6a762797113"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:14.533348+00:00'
+created: '2025-09-24T20:28:36.501830+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "4a3cf3893b6485428dd02da116c8370e"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -55,7 +55,7 @@ contributing variants:
   system*
     hash: "d5456487ea8dccfe96c1968b19870978"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:14.552908+00:00'
+created: '2025-09-24T20:28:36.523919+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "4a3cf3893b6485428dd02da116c8370e"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -55,7 +55,7 @@ contributing variants:
   system*
     hash: "0b81da6ea3d7cc82b1d4825b7aac0b8d"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:14.592678+00:00'
+created: '2025-09-24T20:28:36.567826+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "4665d486184740231357ab63f4543a8d"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -54,7 +54,7 @@ contributing variants:
   system*
     hash: "107ed03036d901157372f260bc3df446"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:14.571273+00:00'
+created: '2025-09-24T20:28:36.543481+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "a728cdf5d62c8e017c35c3fe04051b6e"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -40,7 +40,7 @@ contributing variants:
   system*
     hash: "63c67781779781d9b0a442a5b2bdb976"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/logentry_prefers_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/logentry_prefers_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:40.875625+00:00'
+created: '2025-09-24T20:28:36.585809+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   default*
     hash: "8ec8bbc71eb6e2af7fbe5076a8534f96"
     contributing component: message
-    component:
+    root_component:
       default*
         message*
           "Hello there %s!"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/logentry_uses_formatted.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/logentry_uses_formatted.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:40.978341+00:00'
+created: '2025-09-24T20:28:36.606428+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   default*
     hash: "329b29efcf1f77067a063e34f56e7791"
     contributing component: message
-    component:
+    root_component:
       default*
         message*
           "Hello there world!"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:19.517204+00:00'
+created: '2025-09-24T20:28:36.630101+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "b8baf791d22ac902d5f59a7eedd844fd"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:19.613014+00:00'
+created: '2025-09-24T20:28:36.655154+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "36be6e0b6123ef6ecfbef62f5cb88406"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:41.336121+00:00'
+created: '2025-09-24T20:28:36.678821+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "70b7b816193e06eb5d6649989fbaf605"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/message_prefers_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/message_prefers_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:41.434397+00:00'
+created: '2025-09-24T20:28:36.699098+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   default*
     hash: "8ec8bbc71eb6e2af7fbe5076a8534f96"
     contributing component: message
-    component:
+    root_component:
       default*
         message*
           "Hello there %s!"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/message_uses_formatted.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/message_uses_formatted.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:41.480162+00:00'
+created: '2025-09-24T20:28:36.719381+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   default*
     hash: "d3f5e52d24e9c1eae5abe6c866cced63"
     contributing component: message
-    component:
+    root_component:
       default*
         message*
           "Hello there Peter!"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/message_with_key_pair_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:41.534351+00:00'
+created: '2025-09-24T20:28:36.741054+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   default*
     hash: "d2ab1028e9cb44352a824e878951f412"
     contributing component: message
-    component:
+    root_component:
       default*
         message* (stripped event-specific values)
           "Error key1=<quoted_str> key2=<int> key3=<bool> key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:41.591718+00:00'
+created: '2025-09-24T20:28:36.767035+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "dcfcd48a02c100bbe4023cbc783054f0"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:41.644202+00:00'
+created: '2025-09-24T20:28:36.786550+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:20.717367+00:00'
+created: '2025-09-24T20:28:36.808653+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "2e0d26cae5986fcda5edf66612a78268"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:20.842525+00:00'
+created: '2025-09-24T20:28:36.827681+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "c85e23e804b52ea4b9f290ba838e77a0"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:20.975620+00:00'
+created: '2025-09-24T20:28:36.847843+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "784442a33bd16c15013bb8f69f68e7d6"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:41.919971+00:00'
+created: '2025-09-24T20:28:36.867771+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "8f4c7709e4af98d3c47ce3519690e6d9"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:21.509341+00:00'
+created: '2025-09-24T20:28:36.889774+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "3ff01ce959249abecc6bc8a8f1432b0b"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:39.699520+00:00'
+created: '2025-09-24T20:28:36.912883+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "418120a66f7031923031f5c52aca0724"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -45,7 +45,7 @@ contributing variants:
   system*
     hash: "bbcdb2e1d8df09ffe0fffd30fb361d4b"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:42.110455+00:00'
+created: '2025-09-24T20:28:36.933204+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:42.222768+00:00'
+created: '2025-09-24T20:28:36.952368+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "46b84e4da51648cc9f9741abd2bdad51"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:42.292602+00:00'
+created: '2025-09-24T20:28:36.984710+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "c29439027eafcf7642f641554ab0f0ef"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:14.965913+00:00'
+created: '2025-09-24T20:28:37.009912+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "a20509269752c9a1bea6078851e4d39c"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -71,7 +71,7 @@ contributing variants:
   system*
     hash: "252dc79eb5653bf822e2684d90734cb8"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:42.536533+00:00'
+created: '2025-09-24T20:28:37.028808+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "be36642f41f047346396f018f62375d3"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:13:37.800606+00:00'
+created: '2025-09-24T20:28:37.048764+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "c52ebcc2d9d0780a23c7d99831678830"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*
@@ -44,7 +44,7 @@ contributing variants:
   system*
     hash: "669cb6664e0f5fed38665da04e464f7e"
     contributing component: chained_exception
-    component:
+    root_component:
       system*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:15.033167+00:00'
+created: '2025-09-24T20:28:37.067180+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "121caa876de75ec51bf72ed4c852cd75"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -49,7 +49,7 @@ contributing variants:
   system*
     hash: "a5af2577d4caca8f983657c5d1919e14"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:15.058271+00:00'
+created: '2025-09-24T20:28:37.086546+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "90888e813b09fa25061af2883c0fb9bd"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:15.078945+00:00'
+created: '2025-09-24T20:28:37.104527+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "d59239f5aad3304d60beb1fde3369b78"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -49,7 +49,7 @@ contributing variants:
   system*
     hash: "133db3f366b1327dab4e661f66dfb961"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:15.157158+00:00'
+created: '2025-09-24T20:28:37.158390+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "11e6467c8358a9366c6538f95dcd7bd4"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-20T20:36:08.028421+00:00'
+created: '2025-09-24T20:28:37.122468+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "70dd09f56349dcce62a74137b00bb571"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:15.125491+00:00'
+created: '2025-09-24T20:28:37.140286+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,7 +24,7 @@ contributing variants:
   app*
     hash: "5f209162115f576bedbaf6f0ad30e5aa"
     contributing component: chained_exception
-    component:
+    root_component:
       app*
         chained_exception*
           exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:15.179434+00:00'
+created: '2025-09-24T20:28:37.179419+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "73470e545e51eea9cff8a6c006f68f57"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -45,7 +45,7 @@ contributing variants:
   system*
     hash: "ecd413627f0d90a5a25cb28d1ba9c39f"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_cocoa.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:40.715654+00:00'
+created: '2025-09-24T20:28:37.196696+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "eb416f98479efa56a77c524602dc9979"
     contributing component: stacktrace
-    component:
+    root_component:
       app*
         stacktrace*
           frame* (marked in-app by the client)
@@ -35,7 +35,7 @@ contributing variants:
   system*
     hash: "1df786c8c266506e1acb6669c8df5154"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:43.046182+00:00'
+created: '2025-09-24T20:28:37.214875+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "9bdadae4fa003cef6cf460ff1325e54b"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:40.887229+00:00'
+created: '2025-09-24T20:28:37.231994+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "1effb24729ae4c43efa36b460511136a"
     contributing component: stacktrace
-    component:
+    root_component:
       app*
         stacktrace*
           frame* (marked in-app by the client)
@@ -35,7 +35,7 @@ contributing variants:
   system*
     hash: "659ad79e2e70c822d30a53d7d889529e"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:43.186747+00:00'
+created: '2025-09-24T20:28:37.266001+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "acbd18db4cc2f85cedef654fccc4a4d8"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:23.838955+00:00'
+created: '2025-09-24T20:28:37.302589+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:43.332530+00:00'
+created: '2025-09-24T20:28:37.319630+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "cd2a9fd0cdaa8cd55ed22b101fc65882"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-08-11T23:13:51.203046+00:00'
+created: '2025-09-24T20:28:37.337256+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "659ad79e2e70c822d30a53d7d889529e"
     contributing component: stacktrace
-    component:
+    root_component:
       app*
         stacktrace*
           frame* (marked in-app by the client)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:43.427960+00:00'
+created: '2025-09-24T20:28:37.354908+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "c5da56c71b31f34c5880d734cbc8f5bb"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:50:43.482286+00:00'
+created: '2025-09-24T20:28:37.373563+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   system*
     hash: "eb87c1031dba55b67df86fb9fff59dc6"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:24.290677+00:00'
+created: '2025-09-24T20:28:37.391805+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "eb87c1031dba55b67df86fb9fff59dc6"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -38,7 +38,7 @@ contributing variants:
   system*
     hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:24.398457+00:00'
+created: '2025-09-24T20:28:37.410565+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "eb87c1031dba55b67df86fb9fff59dc6"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -38,7 +38,7 @@ contributing variants:
   system*
     hash: "0817e4e604fbe88c4534eff166df1db9"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:42.036118+00:00'
+created: '2025-09-24T20:28:37.428074+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "1effb24729ae4c43efa36b460511136a"
     contributing component: stacktrace
-    component:
+    root_component:
       app*
         stacktrace*
           frame* (marked in-app by the client)
@@ -35,7 +35,7 @@ contributing variants:
   system*
     hash: "659ad79e2e70c822d30a53d7d889529e"
     contributing component: stacktrace
-    component:
+    root_component:
       system*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/template_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/template_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T18:40:15.471979+00:00'
+created: '2025-09-24T20:28:37.446112+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -20,7 +20,7 @@ contributing variants:
   default*
     hash: "1f5bdebe3c9f414c7dbb4296a8353245"
     contributing component: template
-    component:
+    root_component:
       default*
         template*
           filename*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:42.442507+00:00'
+created: '2025-09-24T20:28:37.463442+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "1a11687556cf74559f0ae90b1c87e2fd"
     contributing component: threads
-    component:
+    root_component:
       app*
         threads*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unity.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:24:42.687609+00:00'
+created: '2025-09-24T20:28:37.498286+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "a12d579fed7636c2a5d2fae110c95ce5"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -40,7 +40,7 @@ contributing variants:
   system*
     hash: "c0dbeebf0430b3310ad1f7ceb48553a6"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unknown_variant.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unknown_variant.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:49:55.671362+00:00'
+created: '2025-09-24T20:28:39.412221+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -16,5 +16,5 @@ contributing variants:
   dogs*
     hash: "d41d8cd98f00b204e9800998ecf8427e"
     contributing component: null
-    component:
+    root_component:
       not_a_known_component_type*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:24.945789+00:00'
+created: '2025-09-24T20:28:37.517909+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "ecb890e5cd60dec2b626d500cc866de4"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -110,7 +110,7 @@ contributing variants:
   system*
     hash: "57493ac3e558feffb778cf170a7fd986"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:25.041637+00:00'
+created: '2025-09-24T20:28:37.536183+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "8c134ce2a43a0b2c55654902491307c2"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -78,7 +78,7 @@ contributing variants:
   system*
     hash: "f203e9bc12df86bb01fbd92a45643f86"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:25.147539+00:00'
+created: '2025-09-24T20:28:37.556638+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "c246c95d4a435b3d601044aebae72a38"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -124,7 +124,7 @@ contributing variants:
   system*
     hash: "d0669f63f03ddaec66ac8b9f4e3e449d"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-28T13:16:30.843887+00:00'
+created: '2025-09-24T20:28:37.578915+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "e7a1be23aff9a117598bb893ed4bedb4"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -104,7 +104,7 @@ contributing variants:
   system*
     hash: "1bba3ace796a07d167af26959c6039c9"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-28T13:16:31.191865+00:00'
+created: '2025-09-24T20:28:37.599698+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "4717aeb08ff642726ef6ea8f1ce55cdf"
     contributing component: exception
-    component:
+    root_component:
       app*
         exception*
           stacktrace*
@@ -126,7 +126,7 @@ contributing variants:
   system*
     hash: "65244b22630821cacd0be603ebcef671"
     contributing component: exception
-    component:
+    root_component:
       system*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:32:25.363317+00:00'
+created: '2025-09-24T20:28:37.620023+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,7 +26,7 @@ contributing variants:
   app*
     hash: "54e8028fb2526cf31b12dd66c01ad9e2"
     contributing component: threads
-    component:
+    root_component:
       app*
         threads*
           stacktrace*
@@ -111,7 +111,7 @@ contributing variants:
   system*
     hash: "9e04decaf79ecba9dc0314dc0edd3993"
     contributing component: threads
-    component:
+    root_component:
       system*
         threads*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/actix.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-05-12T23:40:57.034736+00:00'
+created: '2025-09-24T20:27:05.406039+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "738e7d2503464bc264b4f791286f5122"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -399,7 +399,7 @@ app:
 system:
   hash: "19a96e0438d28e48355653def82f887a"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/android_anr.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.171245+00:00'
+created: '2025-09-24T20:27:05.460952+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -790,7 +790,7 @@ app:
 system:
   hash: "2552498cfe69a6ddf1dcdde5440ce9c3"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/aspnetcore.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.190962+00:00'
+created: '2025-09-24T20:27:05.489841+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "228c649a3aa0901622c0a0e66ab0522c"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -175,7 +175,7 @@ app:
 default:
   hash: null
   contributing component: null
-  component:
+  root_component:
     default (ignored because app/system exception takes precedence)
       message (ignored because app/system exception takes precedence)
         "An unhandled exception has occurred while executing the request."
@@ -183,7 +183,7 @@ default:
 system:
   hash: "4ccd0f1953483581ba360c7518f90332"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.209410+00:00'
+created: '2025-09-24T20:27:05.512364+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
   contributing component: threads
-  component:
+  root_component:
     app*
       threads*
         stacktrace*
@@ -23,7 +23,7 @@ app:
 default:
   hash: null
   contributing component: null
-  component:
+  root_component:
     default (ignored because app threads take precedence)
       message (ignored because app threads take precedence)
         "Foo"
@@ -31,7 +31,7 @@ default:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system (ignored because app threads take precedence)
       threads (ignored because hash matches app variant)
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/bugly.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.227606+00:00'
+created: '2025-09-24T20:27:05.537722+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -32,7 +32,7 @@ app:
 system:
   hash: "d9c9b0f9ba46e32fddd7cd1512fad235"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.260507+00:00'
+created: '2025-09-24T20:27:05.583626+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because built-in fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -30,7 +30,7 @@ built_in_fingerprint:
 system:
   hash: null
   contributing component: exception
-  component:
+  root_component:
     system (ignored because built-in fingerprint takes precedence)
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.245071+00:00'
+created: '2025-09-24T20:27:05.561124+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because built-in fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -30,7 +30,7 @@ built_in_fingerprint:
 system:
   hash: null
   contributing component: exception
-  component:
+  root_component:
     system (ignored because built-in fingerprint takes precedence)
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:49.335294+00:00'
+created: '2025-09-24T20:27:05.607190+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "4ef1fb44d656c3be2a146971f2a222dc"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -132,7 +132,7 @@ app:
 system:
   hash: "47481871aa8d5ab5729cf2db78ce3032"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.324340+00:00'
+created: '2025-09-24T20:27:05.667696+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "7c8a196d16b94be382add324be2605ee"
   contributing component: threads
-  component:
+  root_component:
     app*
       threads*
         stacktrace*
@@ -59,7 +59,7 @@ app:
 default:
   hash: null
   contributing component: null
-  component:
+  root_component:
     default (ignored because app/system threads take precedence)
       message (ignored because app/system threads take precedence)
         "Foo"
@@ -67,7 +67,7 @@ default:
 system:
   hash: "cd7f51d716fd57adc1a5ce1c112e538f"
   contributing component: threads
-  component:
+  root_component:
     system*
       threads*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/connection_error.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.341355+00:00'
+created: '2025-09-24T20:27:05.692871+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "6b059b9febc815ac18ac4d2082e38a9b"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -117,7 +117,7 @@ app:
 default:
   hash: null
   contributing component: null
-  component:
+  root_component:
     default (ignored because app/system exception takes precedence)
       message (ignored because app/system exception takes precedence)
         "%s.process_error"
@@ -125,7 +125,7 @@ default:
 system:
   hash: "013d3477a774fe20c468dc8accd516f1"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:49.449922+00:00'
+created: '2025-09-24T20:27:05.715124+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "161ce02ecc5d6685a72e8e520ab726b3"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -46,7 +46,7 @@ app:
 system:
   hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.372477+00:00'
+created: '2025-09-24T20:27:05.733302+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no contributing frames)
@@ -39,7 +39,7 @@ app:
 system:
   hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.489890+00:00'
+created: '2025-09-24T20:27:05.899791+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "666766514295bb52812324097cdaf53e"
   contributing component: csp
-  component:
+  root_component:
     default*
       csp*
         salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_img_src.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_img_src.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.387193+00:00'
+created: '2025-09-24T20:27:05.753938+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "1742101e08eb1608f569751dfedd0062"
   contributing component: csp
-  component:
+  root_component:
     default*
       csp*
         salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.402011+00:00'
+created: '2025-09-24T20:27:05.775893+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "efddf1cde918097259aa7d4904fb1942"
   contributing component: csp
-  component:
+  root_component:
     default*
       csp*
         salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_data_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_data_uri.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.417038+00:00'
+created: '2025-09-24T20:27:05.796578+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "4e6f2bce9d121aa89f4dc5e5da08afb5"
   contributing component: csp
-  component:
+  root_component:
     default*
       csp*
         salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.431885+00:00'
+created: '2025-09-24T20:27:05.818199+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "56c6520f35bce2f89ed2c4e725ccef65"
   contributing component: csp
-  component:
+  root_component:
     default*
       csp*
         salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.446268+00:00'
+created: '2025-09-24T20:27:05.840011+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "d346ee37d19a2be6587e609075ca2d57"
   contributing component: csp
-  component:
+  root_component:
     default*
       csp*
         salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_uri.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.461062+00:00'
+created: '2025-09-24T20:27:05.860538+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "223cdacfe5b4b830dc700b5c18cc21b4"
   contributing component: csp
-  component:
+  root_component:
     default*
       csp*
         salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_style_src_elem.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_style_src_elem.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.475387+00:00'
+created: '2025-09-24T20:27:05.880589+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "537a973f594c364842893e9a72af62a5"
   contributing component: csp
-  component:
+  root_component:
     default*
       csp*
         salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.521394+00:00'
+created: '2025-09-24T20:27:05.943655+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: exception
-  component:
+  root_component:
     app (ignored because custom client fingerprint takes precedence)
       exception*
         stacktrace*
@@ -176,7 +176,7 @@ custom_fingerprint:
 system:
   hash: null
   contributing component: exception
-  component:
+  root_component:
     system (ignored because custom client fingerprint takes precedence)
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.505379+00:00'
+created: '2025-09-24T20:27:05.922502+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: exception
-  component:
+  root_component:
     app (ignored because custom server fingerprint takes precedence)
       exception*
         stacktrace*
@@ -176,7 +176,7 @@ custom_fingerprint:
 system:
   hash: null
   contributing component: exception
-  component:
+  root_component:
     system (ignored because custom server fingerprint takes precedence)
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.538337+00:00'
+created: '2025-09-24T20:27:05.963002+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: exception
-  component:
+  root_component:
     app (ignored because custom server fingerprint takes precedence)
       exception*
         stacktrace*
@@ -176,7 +176,7 @@ custom_fingerprint:
 system:
   hash: null
   contributing component: exception
-  component:
+  root_component:
     system (ignored because custom server fingerprint takes precedence)
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.568903+00:00'
+created: '2025-09-24T20:27:06.000378+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "029f3b967068b1539f96957b7c0451d7"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         type*
@@ -93,7 +93,7 @@ app:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system (ignored because app exception takes precedence)
       threads (ignored because app exception takes precedence)
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:10.395244+00:00'
+created: '2025-09-24T20:27:06.053202+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "b23ee1963904c2ca87b145febf94b66c"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.583167+00:00'
+created: '2025-09-24T20:27:06.018498+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "9509e122c6175606d52862fa4f64853c"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -21,7 +21,7 @@ app:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system (ignored because app exception takes precedence)
       exception (ignored because hash matches app variant)
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.598596+00:00'
+created: '2025-09-24T20:27:06.036292+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "669cb6664e0f5fed38665da04e464f7e"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*
@@ -31,7 +31,7 @@ app:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system (ignored because app exception takes precedence)
       chained_exception (ignored because hash matches app variant)
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:49.843764+00:00'
+created: '2025-09-24T20:27:06.069350+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "e2bf1e0628b7b1824a9b63dec7a079a3"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:49.881067+00:00'
+created: '2025-09-24T20:27:06.102607+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "93b26686d00504b4e5aa1cb0244d8b37"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:49.862805+00:00'
+created: '2025-09-24T20:27:06.085815+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "93b26686d00504b4e5aa1cb0244d8b37"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:10.493459+00:00'
+created: '2025-09-24T20:27:06.119275+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "a4f16891fa438620699cb2d9af5cc827"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:49.917508+00:00'
+created: '2025-09-24T20:27:06.136326+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "028157fe357e4592e39eacb32eafa2db"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:49.935660+00:00'
+created: '2025-09-24T20:27:06.155706+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "f0078a82f351095ba595daa7d493aa3c"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:49.954009+00:00'
+created: '2025-09-24T20:27:06.173794+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "93b26686d00504b4e5aa1cb0244d8b37"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-06-18T22:05:57.923494+00:00'
+created: '2025-09-24T20:27:06.190688+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "0809098f9f613b63467605dd1739cc9b"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:10.640807+00:00'
+created: '2025-09-24T20:27:06.208119+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "0809098f9f613b63467605dd1739cc9b"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_exception.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_exception.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:10.691743+00:00'
+created: '2025-09-24T20:27:06.225091+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "a4f16891fa438620699cb2d9af5cc827"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:10.742275+00:00'
+created: '2025-09-24T20:27:06.248379+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "a4f16891fa438620699cb2d9af5cc827"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:50.045629+00:00'
+created: '2025-09-24T20:27:06.269469+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "17022e0561e9b6e6351723a08aa81b18"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:10.874065+00:00'
+created: '2025-09-24T20:27:06.310766+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "a4f16891fa438620699cb2d9af5cc827"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:50.064214+00:00'
+created: '2025-09-24T20:27:06.290283+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "f0078a82f351095ba595daa7d493aa3c"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:50.101609+00:00'
+created: '2025-09-24T20:27:06.335316+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "d505dfb9059ac63c11955233323a9100"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*
@@ -50,7 +50,7 @@ app:
 system:
   hash: "4f9cc6a81f4eb34f9e917374f281b9dc"
   contributing component: chained_exception
-  component:
+  root_component:
     system*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_types.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_types.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:50.138740+00:00'
+created: '2025-09-24T20:27:06.373150+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "bca604b98cb4637167eb6190a92e8933"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:50.119782+00:00'
+created: '2025-09-24T20:27:06.355156+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "fca0fd23f09e8da4481304ef2a531100"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:36.867031+00:00'
+created: '2025-09-24T20:27:06.390623+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -34,7 +34,7 @@ app:
 system:
   hash: "26552f86ca2368e708afa1df6effc1c5"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_without_type.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_without_type.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:11.122087+00:00'
+created: '2025-09-24T20:27:06.413857+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "5eb63bbbe01eeed093cb22bb8f5acdc3"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         value*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_without_value.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_without_value.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:11.171155+00:00'
+created: '2025-09-24T20:27:06.434197+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "5a2cfd89b7b171fd7b4794b08023d04f"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/expectct.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/expectct.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:50.290562+00:00'
+created: '2025-09-24T20:27:06.521328+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "3d2933f4b5ec459ec8d569a398fd328c"
   contributing component: expect_ct
-  component:
+  root_component:
     default*
       expect_ct*
         salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.000051+00:00'
+created: '2025-09-24T20:27:06.552254+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -34,7 +34,7 @@ app:
 system:
   hash: "87497299851e09febfecf4e84e0d45ba"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.015885+00:00'
+created: '2025-09-24T20:27:06.592455+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "526b64456c48836a46ec1a89544fd412"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_empty_list.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:11.444360+00:00'
+created: '2025-09-24T20:27:06.610346+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app
       stacktrace (ignored because it contains no frames)
 --------------------------------------------------------------------------
@@ -16,6 +16,6 @@ fallback:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system
       stacktrace (ignored because it contains no frames)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.046357+00:00'
+created: '2025-09-24T20:27:06.627584+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "7d2cc7acbf90328200d960bf78a26234"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.062339+00:00'
+created: '2025-09-24T20:27:06.648158+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "465d672b2d322bf6a1b44499f6dabc1f"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.080471+00:00'
+created: '2025-09-24T20:27:06.664430+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "45c0b0a8c777e7a7040d7c39233a08a5"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-05-12T23:41:05.183677+00:00'
+created: '2025-09-24T20:27:06.685492+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (family:javascript path:org-dartlang-sdk:///** -app))
@@ -21,7 +21,7 @@ fallback:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
         frame (ignored by stack trace rule (family:javascript path:org-dartlang-sdk:///** -group))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.119770+00:00'
+created: '2025-09-24T20:27:06.705075+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "353e05904b48bd3ae4fa9623934a70d0"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.140342+00:00'
+created: '2025-09-24T20:27:06.729318+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "0094f39fc617031afb6c655419f4a9f2"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.160828+00:00'
+created: '2025-09-24T20:27:06.751252+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "be15ca3d511b96918e087c4f42503ca2"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.181499+00:00'
+created: '2025-09-24T20:27:06.767792+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -32,7 +32,7 @@ app:
 system:
   hash: "e04dce7550635e05dbd7f656102cf304"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.201631+00:00'
+created: '2025-09-24T20:27:06.785006+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "098f6bcd4621d373cade4e832627b4f6"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:12.008984+00:00'
+created: '2025-09-24T20:27:06.805423+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -19,7 +19,7 @@ fallback:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
         frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.241874+00:00'
+created: '2025-09-24T20:27:06.826274+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -20,7 +20,7 @@ app:
 system:
   hash: "64a0e0a34d99dce03a8c5a4c237a4b5a"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.261326+00:00'
+created: '2025-09-24T20:27:06.843189+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -20,7 +20,7 @@ app:
 system:
   hash: "64a0e0a34d99dce03a8c5a4c237a4b5a"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.281269+00:00'
+created: '2025-09-24T20:27:06.860895+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (family:javascript module:**/packages/flutter/** -app))
@@ -20,7 +20,7 @@ app:
 system:
   hash: "e0e7c4713e9092dc77635d5a0d5db31d"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.300187+00:00'
+created: '2025-09-24T20:27:06.882868+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "c32a94349d9e9b72d31a46610c6c9589"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.320208+00:00'
+created: '2025-09-24T20:27:06.901174+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "be7f1b8b4014de623c533a8218dba5bd"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.339159+00:00'
+created: '2025-09-24T20:27:06.918683+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "53b9e9679a8ea25880376080b76f98ad"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.396724+00:00'
+created: '2025-09-24T20:27:06.976927+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "538bdfd8d7bb2495d0d6429c3689a420"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.359193+00:00'
+created: '2025-09-24T20:27:06.938113+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "538bdfd8d7bb2495d0d6429c3689a420"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.378261+00:00'
+created: '2025-09-24T20:27:06.957645+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "dc3d511120ce04996b1eef3496516e5c"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_module_if_page_url.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:12.545283+00:00'
+created: '2025-09-24T20:27:07.015528+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -21,7 +21,7 @@ fallback:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
         frame (ignored single non-URL JavaScript frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.415761+00:00'
+created: '2025-09-24T20:27:06.995494+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -20,7 +20,7 @@ app:
 system:
   hash: "0cc175b9c0f1b6a831c399e269772661"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.451616+00:00'
+created: '2025-09-24T20:27:07.032008+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "30eb5001914d29dd8461898b5b8094fe"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-05-12T23:41:07.871940+00:00'
+created: '2025-09-24T20:27:07.048882+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (path:package:sentry_logging/** -app))
@@ -51,7 +51,7 @@ fallback:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
         frame (ignored by stack trace rule (path:package:sentry_logging/** -group))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-05-12T23:41:08.021063+00:00'
+created: '2025-09-24T20:27:07.065031+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (path:package:sentry/** -app))
@@ -21,7 +21,7 @@ fallback:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
         frame (ignored by stack trace rule (path:package:sentry/** -group))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-05-12T23:41:08.168621+00:00'
+created: '2025-09-24T20:27:07.080863+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (path:package:sentry_flutter/** -app))
@@ -21,7 +21,7 @@ fallback:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
         frame (ignored by stack trace rule (path:package:sentry_flutter/** -group))

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.546284+00:00'
+created: '2025-09-24T20:27:07.115228+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (category:framework -app))
@@ -18,7 +18,7 @@ app:
 system:
   hash: "07d1a8e5728b3c4c7aa8b8273fd0e753"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.528830+00:00'
+created: '2025-09-24T20:27:07.097832+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (category:framework -app))
@@ -18,7 +18,7 @@ app:
 system:
   hash: "09e0efcab18f545166318118ed4e0292"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.563323+00:00'
+created: '2025-09-24T20:27:07.132295+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (category:framework -app))
@@ -23,7 +23,7 @@ app:
 system:
   hash: "9bc326575875422d0d4ced3c35d9f916"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.581578+00:00'
+created: '2025-09-24T20:27:07.149247+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "27eed4125fc13d42163ddb0b8f357b48"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.599687+00:00'
+created: '2025-09-24T20:27:07.165847+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "4067a71d7098866f87c746a57a77b2bb"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.636893+00:00'
+created: '2025-09-24T20:27:07.199282+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -16,7 +16,7 @@ app:
 system:
   hash: "2f908c015ad77a50595512fcf65d344c"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.619636+00:00'
+created: '2025-09-24T20:27:07.182818+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -16,7 +16,7 @@ app:
 system:
   hash: "2f908c015ad77a50595512fcf65d344c"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.653240+00:00'
+created: '2025-09-24T20:27:07.216058+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -20,7 +20,7 @@ app:
 system:
   hash: "60e0a667027bef0d0b7c4882891df7e8"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.668491+00:00'
+created: '2025-09-24T20:27:07.231937+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "acbd18db4cc2f85cedef654fccc4a4d8"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.683032+00:00'
+created: '2025-09-24T20:27:07.248318+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -16,7 +16,7 @@ app:
 system:
   hash: "1effb24729ae4c43efa36b460511136a"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.698144+00:00'
+created: '2025-09-24T20:27:07.264460+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "4b8bbc500bd2cabfcadc1f1be867e0bb"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -32,7 +32,7 @@ app:
 system:
   hash: "348fc4026c9fa11ffba8fbfa80a134c9"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.715889+00:00'
+created: '2025-09-24T20:27:07.284456+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -146,7 +146,7 @@ app:
 system:
   hash: "3da34e8c72dbcd4a490ac36eb7130638"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.732684+00:00'
+created: '2025-09-24T20:27:07.304065+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -90,7 +90,7 @@ app:
 system:
   hash: "ca733a48a19d237df8577d09449095d9"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.749874+00:00'
+created: '2025-09-24T20:27:07.324543+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -106,7 +106,7 @@ app:
 system:
   hash: "2c1bbd635b64d5adccdb64a620044075"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.766577+00:00'
+created: '2025-09-24T20:27:07.345396+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -98,7 +98,7 @@ app:
 system:
   hash: "9c336f632f6764c0f082a6a66edbf22d"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.784409+00:00'
+created: '2025-09-24T20:27:07.368496+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -147,7 +147,7 @@ app:
 system:
   hash: "49b6f72b6635cb43190c57ee56b026b0"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.802387+00:00'
+created: '2025-09-24T20:27:07.390428+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -162,7 +162,7 @@ app:
 system:
   hash: "49b6f72b6635cb43190c57ee56b026b0"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.817682+00:00'
+created: '2025-09-24T20:27:07.408995+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -66,7 +66,7 @@ app:
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.833387+00:00'
+created: '2025-09-24T20:27:07.427715+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -61,7 +61,7 @@ app:
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.852802+00:00'
+created: '2025-09-24T20:27:07.448942+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -195,7 +195,7 @@ app:
 system:
   hash: "8be5979a334287a1b47457228f1d4612"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.872104+00:00'
+created: '2025-09-24T20:27:07.469860+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -200,7 +200,7 @@ app:
 system:
   hash: "8be5979a334287a1b47457228f1d4612"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.890944+00:00'
+created: '2025-09-24T20:27:07.490925+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -198,7 +198,7 @@ app:
 system:
   hash: "7e64037e487c78ce0439f750a2ef503f"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.906257+00:00'
+created: '2025-09-24T20:27:07.508401+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -48,7 +48,7 @@ app:
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.923852+00:00'
+created: '2025-09-24T20:27:07.528322+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -132,7 +132,7 @@ app:
 system:
   hash: "6148c73af04344a8597354711f5951ea"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.940947+00:00'
+created: '2025-09-24T20:27:07.549224+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -132,7 +132,7 @@ app:
 system:
   hash: "1056f62d72ff8b4d0c3842d696dbb10a"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:37.959860+00:00'
+created: '2025-09-24T20:27:07.570190+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -153,7 +153,7 @@ app:
 system:
   hash: "15526a7b64e9b5dc6d89e7ebec864260"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hpkp.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hpkp.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:14.452884+00:00'
+created: '2025-09-24T20:27:07.587556+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "1e37a374cb33572622d02ff7a6237c44"
   contributing component: hpkp
-  component:
+  root_component:
     default*
       hpkp*
         salt* (a static salt)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
@@ -1,17 +1,17 @@
 ---
-created: '2025-07-18T18:34:35.038828+00:00'
+created: '2025-09-24T20:27:07.604966+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "e3d593b4335190212ca7c18b8e967fb1"
   contributing component: exception
-  component:
+  fingerprint_info: {"client_fingerprint":["{{ default }}","dogs are great"]}
+  root_component:
     app*
       exception*
         type*
           "FailedToFetchError"
         value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
-  fingerprint_info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,12 +1,13 @@
 ---
-created: '2025-09-19T05:52:38.006637+00:00'
+created: '2025-09-24T20:27:07.624541+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "19163f3ca34f5995c69d85351ce3d697"
   contributing component: exception
-  component:
+  fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
+  root_component:
     app*
       exception*
         stacktrace*
@@ -167,13 +168,13 @@ app:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
-  fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
   values: ["{{ default }}","soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
   hash: "847950eb44d280e6758d136c763d6ddc"
   contributing component: exception
-  component:
+  fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
+  root_component:
     system*
       exception*
         stacktrace*
@@ -334,5 +335,4 @@ system:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
-  fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
   values: ["{{ default }}","soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.026762+00:00'
+created: '2025-09-24T20:27:07.649154+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: exception
-  component:
+  root_component:
     app (ignored because custom server fingerprint takes precedence)
       exception*
         stacktrace*
@@ -176,7 +176,7 @@ custom_fingerprint:
 system:
   hash: null
   contributing component: exception
-  component:
+  root_component:
     system (ignored because custom server fingerprint takes precedence)
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -1,17 +1,17 @@
 ---
-created: '2025-07-18T18:34:36.147527+00:00'
+created: '2025-09-24T20:27:07.665248+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "5b5ad5a0fbb4deb5e3fc631ce42681ae"
   contributing component: exception
-  component:
+  fingerprint_info: {"client_fingerprint":["{{ default }}","adopt don't shop"]}
+  root_component:
     app*
       exception*
         type*
           "FailedToFetchError"
         value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
-  fingerprint_info: {"client_fingerprint":["{{ default }}","adopt don't shop"]}
   values: ["{{ default }}","adopt don't shop"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -1,17 +1,17 @@
 ---
-created: '2025-07-18T18:34:36.529709+00:00'
+created: '2025-09-24T20:27:07.686450+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "c5578778212497f1ff3435405e2a4a98"
   contributing component: exception
-  component:
+  fingerprint_info: {"client_fingerprint":["{{ default }}","dogs are great"]}
+  root_component:
     app*
       exception*
         type*
           "FailedToFetchError"
         value*
           "FailedToFetchError: Maisey can't see the ball anymore :-("
-  fingerprint_info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-05-12T23:41:14.019436+00:00'
+created: '2025-09-24T20:27:07.714893+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "5b032559156688c9eabe4e4bd5ae6bd4"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -152,7 +152,7 @@ app:
 system:
   hash: "1921b991270e24c19ea1ed6863892d71"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_chained.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.093786+00:00'
+created: '2025-09-24T20:27:07.740635+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       chained_exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         exception*
@@ -395,7 +395,7 @@ app:
 default:
   hash: null
   contributing component: null
-  component:
+  root_component:
     default (ignored because system exception takes precedence)
       message (ignored because system exception takes precedence)
         "Failed to start connector [Connector[HTTP/<float><int>]]"
@@ -403,7 +403,7 @@ default:
 system:
   hash: "1959b227a7cf6acf7f3fd401b5d9f09b"
   contributing component: chained_exception
-  component:
+  root_component:
     system*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.114811+00:00'
+created: '2025-09-24T20:27:07.764920+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -403,7 +403,7 @@ app:
 default:
   hash: null
   contributing component: null
-  component:
+  root_component:
     default (ignored because system exception takes precedence)
       message (ignored because system exception takes precedence)
         "Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.ArithmeticException: / by zero] with root cause"
@@ -411,7 +411,7 @@ default:
 system:
   hash: "ef2555bf7958ada8eefafbfdaed1c409"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:15.111326+00:00'
+created: '2025-09-24T20:27:07.802891+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "10dfd81e2df31e96fae451b9e205ad81"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:15.057122+00:00'
+created: '2025-09-24T20:27:07.786157+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "b8e2a347e75266ca7bb565e2b3c0722e"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.164944+00:00'
+created: '2025-09-24T20:27:07.824693+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -78,7 +78,7 @@ app:
 system:
   hash: "c0f3f7d6deb17aec9d07259ac684fad0"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_message.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_message.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:15.372837+00:00'
+created: '2025-09-24T20:27:07.862236+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "4119639092e62c55ea8be348e4d9260d"
   contributing component: message
-  component:
+  root_component:
     default*
       message*
         "event"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_message_parameterization.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:15.236626+00:00'
+created: '2025-09-24T20:27:07.841279+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "f9e47f16e3b9770b440157179c47bf7a"
   contributing component: message
-  component:
+  root_component:
     default*
       message* (stripped event-specific values)
         "testing testing <int>, <int>, <int>"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.210845+00:00'
+created: '2025-09-24T20:27:07.888908+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "be36642f41f047346396f018f62375d3"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace (ignored because it contains no in-app frames)
@@ -33,7 +33,7 @@ app:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system (ignored because app exception takes precedence)
       exception (ignored because hash matches app variant)
         stacktrace (ignored because it contains no contributing frames)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.227470+00:00'
+created: '2025-09-24T20:27:07.911115+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -40,7 +40,7 @@ app:
 system:
   hash: "6ab78545e13144405fb21dadb9045b91"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.244084+00:00'
+created: '2025-09-24T20:27:07.929567+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -64,7 +64,7 @@ app:
 system:
   hash: "c63e8727af1a8fe75872b6a762797113"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.263302+00:00'
+created: '2025-09-24T20:27:07.952726+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -68,7 +68,7 @@ app:
 system:
   hash: "c63e8727af1a8fe75872b6a762797113"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.284263+00:00'
+created: '2025-09-24T20:27:07.977468+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -61,7 +61,7 @@ app:
 system:
   hash: "c63e8727af1a8fe75872b6a762797113"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.301712+00:00'
+created: '2025-09-24T20:27:07.998179+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -82,7 +82,7 @@ app:
 system:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.317768+00:00'
+created: '2025-09-24T20:27:08.018602+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -86,7 +86,7 @@ app:
 system:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.333508+00:00'
+created: '2025-09-24T20:27:08.035641+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -79,7 +79,7 @@ app:
 system:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.352907+00:00'
+created: '2025-09-24T20:27:08.053353+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -85,7 +85,7 @@ app:
 system:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.368120+00:00'
+created: '2025-09-24T20:27:08.070832+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -69,7 +69,7 @@ app:
 system:
   hash: "c63e8727af1a8fe75872b6a762797113"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.385798+00:00'
+created: '2025-09-24T20:27:08.090526+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "4a3cf3893b6485428dd02da116c8370e"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -180,7 +180,7 @@ app:
 system:
   hash: "d5456487ea8dccfe96c1968b19870978"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.403134+00:00'
+created: '2025-09-24T20:27:08.110241+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "4a3cf3893b6485428dd02da116c8370e"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -149,7 +149,7 @@ app:
 system:
   hash: "0b81da6ea3d7cc82b1d4825b7aac0b8d"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/laravel.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:52.081424+00:00'
+created: '2025-09-24T20:27:08.153145+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "4665d486184740231357ab63f4543a8d"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -366,7 +366,7 @@ app:
 system:
   hash: "107ed03036d901157372f260bc3df446"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/laravel_anonymous.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:52.056738+00:00'
+created: '2025-09-24T20:27:08.128878+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "a728cdf5d62c8e017c35c3fe04051b6e"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -37,7 +37,7 @@ app:
 system:
   hash: "63c67781779781d9b0a442a5b2bdb976"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/logentry_prefers_message.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/logentry_prefers_message.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:16.309956+00:00'
+created: '2025-09-24T20:27:08.174876+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "8ec8bbc71eb6e2af7fbe5076a8534f96"
   contributing component: message
-  component:
+  root_component:
     default*
       message*
         "Hello there %s!"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/logentry_uses_formatted.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/logentry_uses_formatted.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:16.370777+00:00'
+created: '2025-09-24T20:27:08.196405+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "329b29efcf1f77067a063e34f56e7791"
   contributing component: message
-  component:
+  root_component:
     default*
       message*
         "Hello there world!"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.484967+00:00'
+created: '2025-09-24T20:27:08.217008+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -161,7 +161,7 @@ app:
 system:
   hash: "b8baf791d22ac902d5f59a7eedd844fd"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.503668+00:00'
+created: '2025-09-24T20:27:08.243615+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -189,7 +189,7 @@ app:
 system:
   hash: "36be6e0b6123ef6ecfbef62f5cb88406"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.521295+00:00'
+created: '2025-09-24T20:27:08.269029+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -102,7 +102,7 @@ app:
 system:
   hash: "70b7b816193e06eb5d6649989fbaf605"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/message_prefers_message.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/message_prefers_message.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:16.765850+00:00'
+created: '2025-09-24T20:27:08.295222+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "8ec8bbc71eb6e2af7fbe5076a8534f96"
   contributing component: message
-  component:
+  root_component:
     default*
       message*
         "Hello there %s!"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/message_uses_formatted.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/message_uses_formatted.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:16.813552+00:00'
+created: '2025-09-24T20:27:08.332190+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "d3f5e52d24e9c1eae5abe6c866cced63"
   contributing component: message
-  component:
+  root_component:
     default*
       message*
         "Hello there Peter!"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/message_with_key_pair_values.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:16.866274+00:00'
+created: '2025-09-24T20:27:08.352257+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "d2ab1028e9cb44352a824e878951f412"
   contributing component: message
-  component:
+  root_component:
     default*
       message* (stripped event-specific values)
         "Error key1=<quoted_str> key2=<int> key3=<bool> key4=<date> key5=<quoted_str> other_date=datetime.datetime(<int>, <int>, <int>, <int>, <int>, tzinfo=d..."

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.590451+00:00'
+created: '2025-09-24T20:27:08.375908+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -214,7 +214,7 @@ app:
 system:
   hash: "dcfcd48a02c100bbe4023cbc783054f0"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.606779+00:00'
+created: '2025-09-24T20:27:08.397848+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -27,7 +27,7 @@ app:
 system:
   hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.623263+00:00'
+created: '2025-09-24T20:27:08.425438+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -37,7 +37,7 @@ app:
 system:
   hash: "2e0d26cae5986fcda5edf66612a78268"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.639852+00:00'
+created: '2025-09-24T20:27:08.452178+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -32,7 +32,7 @@ app:
 system:
   hash: "c85e23e804b52ea4b9f290ba838e77a0"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.656032+00:00'
+created: '2025-09-24T20:27:08.483625+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -38,7 +38,7 @@ app:
 system:
   hash: "784442a33bd16c15013bb8f69f68e7d6"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.670993+00:00'
+created: '2025-09-24T20:27:08.506714+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -27,7 +27,7 @@ app:
 system:
   hash: "8f4c7709e4af98d3c47ce3519690e6d9"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.686928+00:00'
+created: '2025-09-24T20:27:08.531031+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -36,7 +36,7 @@ app:
 system:
   hash: "3ff01ce959249abecc6bc8a8f1432b0b"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_no_filenames.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-04-25T21:22:12.168925+00:00'
+created: '2025-09-24T20:27:08.549425+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "418120a66f7031923031f5c52aca0724"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -60,7 +60,7 @@ app:
 system:
   hash: "bbcdb2e1d8df09ffe0fffd30fb361d4b"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.717735+00:00'
+created: '2025-09-24T20:27:08.575464+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -27,7 +27,7 @@ app:
 system:
   hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.732304+00:00'
+created: '2025-09-24T20:27:08.596751+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -43,7 +43,7 @@ app:
 system:
   hash: "46b84e4da51648cc9f9741abd2bdad51"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_with_function_name.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.747202+00:00'
+created: '2025-09-24T20:27:08.617701+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -39,7 +39,7 @@ app:
 system:
   hash: "c29439027eafcf7642f641554ab0f0ef"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.762502+00:00'
+created: '2025-09-24T20:27:08.637402+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "a20509269752c9a1bea6078851e4d39c"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -104,7 +104,7 @@ app:
 system:
   hash: "252dc79eb5653bf822e2684d90734cb8"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.777257+00:00'
+created: '2025-09-24T20:27:08.656302+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "be36642f41f047346396f018f62375d3"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace (ignored because it contains no in-app frames)
@@ -30,7 +30,7 @@ app:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system (ignored because app exception takes precedence)
       exception (ignored because hash matches app variant)
         stacktrace (ignored because it contains no contributing frames)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:52.682946+00:00'
+created: '2025-09-24T20:27:08.674545+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "c52ebcc2d9d0780a23c7d99831678830"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*
@@ -31,7 +31,7 @@ app:
 system:
   hash: "669cb6664e0f5fed38665da04e464f7e"
   contributing component: chained_exception
-  component:
+  root_component:
     system*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.808556+00:00'
+created: '2025-09-24T20:27:08.695052+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "121caa876de75ec51bf72ed4c852cd75"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -108,7 +108,7 @@ app:
 system:
   hash: "a5af2577d4caca8f983657c5d1919e14"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.824301+00:00'
+created: '2025-09-24T20:27:08.713939+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no contributing frames)
@@ -108,7 +108,7 @@ app:
 system:
   hash: "90888e813b09fa25061af2883c0fb9bd"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.840352+00:00'
+created: '2025-09-24T20:27:08.732319+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "d59239f5aad3304d60beb1fde3369b78"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -45,7 +45,7 @@ app:
 default:
   hash: null
   contributing component: null
-  component:
+  root_component:
     default (ignored because app/system exception takes precedence)
       message (ignored because app/system exception takes precedence)
         "%s.process_error"
@@ -53,7 +53,7 @@ default:
 system:
   hash: "133db3f366b1327dab4e661f66dfb961"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:52.848113+00:00'
+created: '2025-09-24T20:27:08.785618+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "11e6467c8358a9366c6538f95dcd7bd4"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-06-20T20:34:12.234791+00:00'
+created: '2025-09-24T20:27:08.750026+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "70dd09f56349dcce62a74137b00bb571"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:52.820525+00:00'
+created: '2025-09-24T20:27:08.768376+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "5f209162115f576bedbaf6f0ad30e5aa"
   contributing component: chained_exception
-  component:
+  root_component:
     app*
       chained_exception*
         exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_native.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.902505+00:00'
+created: '2025-09-24T20:27:08.805605+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "73470e545e51eea9cff8a6c006f68f57"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -210,7 +210,7 @@ app:
 system:
   hash: "ecd413627f0d90a5a25cb28d1ba9c39f"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_cocoa.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-04-25T21:22:13.498456+00:00'
+created: '2025-09-24T20:27:08.823174+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "eb416f98479efa56a77c524602dc9979"
   contributing component: stacktrace
-  component:
+  root_component:
     app*
       stacktrace*
         frame* (marked in-app by the client)
@@ -19,7 +19,7 @@ app:
 system:
   hash: "1df786c8c266506e1acb6669c8df5154"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.932580+00:00'
+created: '2025-09-24T20:27:08.841287+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by the client)
@@ -62,7 +62,7 @@ app:
 system:
   hash: "9bdadae4fa003cef6cf460ff1325e54b"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-04-25T21:22:13.737660+00:00'
+created: '2025-09-24T20:27:08.858034+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "1effb24729ae4c43efa36b460511136a"
   contributing component: stacktrace
-  component:
+  root_component:
     app*
       stacktrace*
         frame* (marked in-app by the client)
@@ -19,7 +19,7 @@ app:
 system:
   hash: "659ad79e2e70c822d30a53d7d889529e"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_discards_seemingly_useless_stack.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_discards_seemingly_useless_stack.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:18.279612+00:00'
+created: '2025-09-24T20:27:08.875474+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -19,7 +19,7 @@ fallback:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
         frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:38.976968+00:00'
+created: '2025-09-24T20:27:08.892024+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -16,7 +16,7 @@ app:
 system:
   hash: "acbd18db4cc2f85cedef654fccc4a4d8"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_does_not_group_different_js_errors.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_does_not_group_different_js_errors.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-12-17T22:47:18.387663+00:00'
+created: '2025-09-24T20:27:08.909598+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -19,7 +19,7 @@ fallback:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system
       stacktrace (ignored because it contains no contributing frames)
         frame

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:39.006694+00:00'
+created: '2025-09-24T20:27:08.927379+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (discarded because stack trace only contains 1 frame which is under the configured threshold by stack trace rule (family:native min-frames=2))
@@ -39,7 +39,7 @@ app:
 system:
   hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:39.020881+00:00'
+created: '2025-09-24T20:27:08.944621+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
@@ -18,7 +18,7 @@ app:
 system:
   hash: "cd2a9fd0cdaa8cd55ed22b101fc65882"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:39.034608+00:00'
+created: '2025-09-24T20:27:08.960999+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "659ad79e2e70c822d30a53d7d889529e"
   contributing component: stacktrace
-  component:
+  root_component:
     app*
       stacktrace*
         frame* (marked in-app by the client)
@@ -19,7 +19,7 @@ app:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system (ignored because app stacktrace takes precedence)
       stacktrace (ignored because hash matches app variant)
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:39.049079+00:00'
+created: '2025-09-24T20:27:08.978201+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by the client)
@@ -26,7 +26,7 @@ app:
 system:
   hash: "c5da56c71b31f34c5880d734cbc8f5bb"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame (ignored low quality javascript frame)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:39.064063+00:00'
+created: '2025-09-24T20:27:08.995932+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
@@ -39,7 +39,7 @@ app:
 system:
   hash: "eb87c1031dba55b67df86fb9fff59dc6"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-02-26T00:34:15.407981+00:00'
+created: '2025-09-24T20:27:09.016742+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "eb87c1031dba55b67df86fb9fff59dc6"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -39,7 +39,7 @@ app:
 system:
   hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-02-26T00:34:15.546061+00:00'
+created: '2025-09-24T20:27:09.036587+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "eb87c1031dba55b67df86fb9fff59dc6"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -39,7 +39,7 @@ app:
 system:
   hash: "0817e4e604fbe88c4534eff166df1db9"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-04-25T21:22:15.001608+00:00'
+created: '2025-09-24T20:27:09.054457+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "1effb24729ae4c43efa36b460511136a"
   contributing component: stacktrace
-  component:
+  root_component:
     app*
       stacktrace*
         frame* (marked in-app by the client)
@@ -49,7 +49,7 @@ app:
 system:
   hash: "659ad79e2e70c822d30a53d7d889529e"
   contributing component: stacktrace
-  component:
+  root_component:
     system*
       stacktrace*
         frame*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/template_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/template_compute_hashes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-11T18:38:53.254274+00:00'
+created: '2025-09-24T20:27:09.071278+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "1f5bdebe3c9f414c7dbb4296a8353245"
   contributing component: template
-  component:
+  root_component:
     default*
       template*
         filename*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:39.140060+00:00'
+created: '2025-09-24T20:27:09.089493+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "1a11687556cf74559f0ae90b1c87e2fd"
   contributing component: threads
-  component:
+  root_component:
     app*
       threads*
         stacktrace*
@@ -19,7 +19,7 @@ app:
 system:
   hash: null
   contributing component: null
-  component:
+  root_component:
     system (ignored because app threads take precedence)
       threads (ignored because hash matches app variant)
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/threads_no_hash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/threads_no_hash.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-02-25T04:21:43.518732+00:00'
+created: '2025-09-24T20:27:09.106846+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
-  component:
+  root_component:
     app
       threads (ignored because it contains neither a single thread nor multiple threads with exactly one crashing or current thread; instead contains 0 crashing, 2 current, and 2 total threads)
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unity.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-04-25T21:22:15.466823+00:00'
+created: '2025-09-24T20:27:09.126995+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "a12d579fed7636c2a5d2fae110c95ce5"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -58,7 +58,7 @@ app:
 system:
   hash: "c0dbeebf0430b3310ad1f7ceb48553a6"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-05-12T23:41:29.503478+00:00'
+created: '2025-09-24T20:27:09.146880+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "ecb890e5cd60dec2b626d500cc866de4"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -114,7 +114,7 @@ app:
 system:
   hash: "57493ac3e558feffb778cf170a7fd986"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-05-12T23:41:29.747451+00:00'
+created: '2025-09-24T20:27:09.166505+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "8c134ce2a43a0b2c55654902491307c2"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -86,7 +86,7 @@ app:
 system:
   hash: "f203e9bc12df86bb01fbd92a45643f86"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-05-12T23:41:30.148944+00:00'
+created: '2025-09-24T20:27:09.186630+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "c246c95d4a435b3d601044aebae72a38"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -157,7 +157,7 @@ app:
 system:
   hash: "d0669f63f03ddaec66ac8b9f4e3e449d"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:39.242134+00:00'
+created: '2025-09-24T20:27:09.208856+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "e7a1be23aff9a117598bb893ed4bedb4"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -266,7 +266,7 @@ app:
 system:
   hash: "1bba3ace796a07d167af26959c6039c9"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-05-12T23:41:30.796928+00:00'
+created: '2025-09-24T20:27:09.229616+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "4717aeb08ff642726ef6ea8f1ce55cdf"
   contributing component: exception
-  component:
+  root_component:
     app*
       exception*
         stacktrace*
@@ -186,7 +186,7 @@ app:
 system:
   hash: "65244b22630821cacd0be603ebcef671"
   contributing component: exception
-  component:
+  root_component:
     system*
       exception*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-09-19T05:52:39.277764+00:00'
+created: '2025-09-24T20:27:09.251707+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "54e8028fb2526cf31b12dd66c01ad9e2"
   contributing component: threads
-  component:
+  root_component:
     app*
       threads*
         stacktrace*
@@ -137,7 +137,7 @@ app:
 default:
   hash: null
   contributing component: null
-  component:
+  root_component:
     default (ignored because app/system threads take precedence)
       message (ignored because app/system threads take precedence)
         "Message for scoped event"
@@ -145,7 +145,7 @@ default:
 system:
   hash: "9e04decaf79ecba9dc0314dc0edd3993"
   contributing component: threads
-  component:
+  root_component:
     system*
       threads*
         stacktrace*

--- a/tests/sentry/grouping/test_components.py
+++ b/tests/sentry/grouping/test_components.py
@@ -105,7 +105,7 @@ class ComponentTest(TestCase):
         variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
         for variant_name in ["app", "system"]:
-            exception_component = variants[variant_name].component.values[0]
+            exception_component = variants[variant_name].root_component.values[0]
             assert isinstance(exception_component, ExceptionGroupingComponent)
             stacktrace_component = find_given_child_component(
                 exception_component, StacktraceGroupingComponent
@@ -137,7 +137,7 @@ class ComponentTest(TestCase):
         # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
         variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
-        system_exception_component = variants["system"].component.values[0]
+        system_exception_component = variants["system"].root_component.values[0]
         assert isinstance(system_exception_component, ExceptionGroupingComponent)
         system_stacktrace_component = find_given_child_component(
             system_exception_component, StacktraceGroupingComponent
@@ -153,7 +153,7 @@ class ComponentTest(TestCase):
 
         # In the app variant, there's no such thing as a contributing system frame, so all the
         # system frames count as non-contributing
-        app_exception_component = variants["app"].component.values[0]
+        app_exception_component = variants["app"].root_component.values[0]
         assert isinstance(app_exception_component, ExceptionGroupingComponent)
         app_stacktrace_component = find_given_child_component(
             app_exception_component, StacktraceGroupingComponent
@@ -177,7 +177,7 @@ class ComponentTest(TestCase):
         # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
         variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
-        system_exception_component = variants["system"].component.values[0]
+        system_exception_component = variants["system"].root_component.values[0]
         assert isinstance(system_exception_component, ExceptionGroupingComponent)
         system_stacktrace_component = find_given_child_component(
             system_exception_component, StacktraceGroupingComponent
@@ -193,7 +193,7 @@ class ComponentTest(TestCase):
 
         # In the app variant, there's no such thing as a contributing system frame, so all the
         # system frames count as non-contributing
-        app_exception_component = variants["app"].component.values[0]
+        app_exception_component = variants["app"].root_component.values[0]
         assert isinstance(app_exception_component, ExceptionGroupingComponent)
         app_stacktrace_component = find_given_child_component(
             app_exception_component, StacktraceGroupingComponent
@@ -220,7 +220,7 @@ class ComponentTest(TestCase):
         # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
         variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
-        system_exception_component = variants["system"].component.values[0]
+        system_exception_component = variants["system"].root_component.values[0]
         assert isinstance(system_exception_component, ExceptionGroupingComponent)
         system_stacktrace_component = find_given_child_component(
             system_exception_component, StacktraceGroupingComponent
@@ -237,7 +237,7 @@ class ComponentTest(TestCase):
 
         # In the app variant, there's no such thing as a contributing system frame, so all the
         # system frames count as non-contributing
-        app_exception_component = variants["app"].component.values[0]
+        app_exception_component = variants["app"].root_component.values[0]
         assert isinstance(app_exception_component, ExceptionGroupingComponent)
         app_stacktrace_component = find_given_child_component(
             app_exception_component, StacktraceGroupingComponent
@@ -266,7 +266,7 @@ class ComponentTest(TestCase):
         # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
         variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
-        system_threads_component = variants["system"].component.values[0]
+        system_threads_component = variants["system"].root_component.values[0]
         assert isinstance(system_threads_component, ThreadsGroupingComponent)
         system_stacktrace_component = find_given_child_component(
             system_threads_component, StacktraceGroupingComponent
@@ -283,7 +283,7 @@ class ComponentTest(TestCase):
 
         # In the app variant, there's no such thing as a contributing system frame, so all the
         # system frames count as non-contributing
-        app_threads_component = variants["app"].component.values[0]
+        app_threads_component = variants["app"].root_component.values[0]
         assert isinstance(app_threads_component, ThreadsGroupingComponent)
         app_stacktrace_component = find_given_child_component(
             app_threads_component, StacktraceGroupingComponent
@@ -323,7 +323,7 @@ class ComponentTest(TestCase):
         # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
         variants = self.event.get_grouping_variants(normalize_stacktraces=True)
 
-        system_chained_exception_component = variants["system"].component.values[0]
+        system_chained_exception_component = variants["system"].root_component.values[0]
         assert isinstance(system_chained_exception_component, ChainedExceptionGroupingComponent)
         system_exception_components = system_chained_exception_component.values
         assert [
@@ -352,7 +352,7 @@ class ComponentTest(TestCase):
 
         # In the app variant, there's no such thing as a contributing system frame, so all the
         # system frames count as non-contributing
-        app_chained_exception_component = variants["app"].component.values[0]
+        app_chained_exception_component = variants["app"].root_component.values[0]
         assert isinstance(app_chained_exception_component, ChainedExceptionGroupingComponent)
         app_exception_components = app_chained_exception_component.values
         assert [

--- a/tests/sentry/services/eventstore/test_models.py
+++ b/tests/sentry/services/eventstore/test_models.py
@@ -435,10 +435,10 @@ class EventTest(TestCase, PerformanceIssueTestCase):
 
         assert isinstance(default_variant, ComponentVariant)
         assert default_variant.config.id == DEFAULT_GROUPING_CONFIG
-        assert default_variant.component.id == "default"
-        assert len(default_variant.component.values) == 1
-        assert default_variant.component.values[0].id == "message"
-        assert default_variant.component.values[0].values == ["Dogs are great!"]
+        assert default_variant.root_component.id == "default"
+        assert len(default_variant.root_component.values) == 1
+        assert default_variant.root_component.values[0].id == "message"
+        assert default_variant.root_component.values[0].values == ["Dogs are great!"]
 
 
 class EventGroupsTest(TestCase):


### PR DESCRIPTION
This renames the `component` attribute of the `ComponentVariant` and `SaltedComponentVariant` classes to `root_component` for clarity. It's pulled into its own PR because it causes a lot of noisy snapshot updates. 

(Note that the key in the classes' serialized form (set in `_get_metadata_as_dict`) hasn't changed, and so no downstream code which relies on it (grouping info, Seer stacktrace string) needs adjusting.)