### PR TITLE
fix(ui): Alignment of compactSelect loading indicator

### DIFF
--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -645,6 +645,8 @@ const MenuTitle = styled('span')`
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
+  display: flex;
+  align-items: center;
   && {
     margin: 0;
   }


### PR DESCRIPTION
Before

<img alt="clipboard.png" width="197" src="https://i.imgur.com/FEVpmDX.png" />

After

<img alt="clipboard.png" width="294" src="https://i.imgur.com/4OHjuZ5.png" />