### PR TITLE
fix(prevent): use maxMenuWidth instead of menuWidth

### DIFF
--- a/static/app/components/prevent/testSuiteDropdown/testSuiteDropdown.tsx
+++ b/static/app/components/prevent/testSuiteDropdown/testSuiteDropdown.tsx
@@ -99,7 +99,7 @@ export function TestSuiteDropdown() {
       onSearch={handleOnSearch}
       emptyMessage={getEmptyMessage()}
       menuTitle={t('Filter Test Suites')}
-      menuWidth={`${MAX_SUITE_UI_LENGTH}em`}
+      maxMenuWidth={`${MAX_SUITE_UI_LENGTH}em`}
       trigger={triggerProps => {
         const areAllSuitesSelected =
           value.length === 0 || testSuites?.every(suite => value.includes(suite));


### PR DESCRIPTION
Allows the menu to collapse in width to the largest item in the menu.

Typically will look like this now

<img alt="clipboard.png" width="322" src="https://i.imgur.com/6jTrpZh.png" />

Previously looked like

<img alt="clipboard.png" width="767" src="https://i.imgur.com/TxUk7UJ.png" />