### PR TITLE
chore(timeseries): Register feature flag for spot-checking Explore usage of `/events-timeseries/`

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -268,6 +268,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-span-histogram-view", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable trace explorer features
     manager.add("organizations:performance-trace-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable spot checking of `/events-timeseries/` endpoint in Explore
+    manager.add("organizations:explore-events-time-series-spot-check", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable sentry convention fields
     manager.add("organizations:performance-sentry-conventions-fields", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable querying spans fields stats from comparative workflows project


### PR DESCRIPTION
Turning my attention to Explore, I'm going to spot-check `/events-timeseries/` there by running it in parallel with current requests, just like I did for Insights. Contributes to ENG-5608.