### PR TITLE
ref(prevent): Consistent menu titles

### DIFF
--- a/static/app/components/prevent/branchSelector/branchSelector.tsx
+++ b/static/app/components/prevent/branchSelector/branchSelector.tsx
@@ -136,6 +136,7 @@ export function BranchSelector() {
       onSearch={handleOnSearch}
       disableSearchFilter
       searchPlaceholder={t('search by branch name')}
+      menuTitle={t('Filter to branch')}
       options={options}
       value={branch ?? ALL_BRANCHES}
       onChange={handleChange}

--- a/static/app/components/prevent/dateSelector/dateSelector.tsx
+++ b/static/app/components/prevent/dateSelector/dateSelector.tsx
@@ -50,6 +50,7 @@ export function DateSelector() {
       value={preventPeriod ?? ''}
       onChange={handleChange}
       menuWidth={'16rem'}
+      menuTitle={t('Filter to time period')}
       trigger={(triggerProps, isOpen) => {
         const defaultLabel = options.some(item => item.value === preventPeriod)
           ? preventPeriod?.toUpperCase()


### PR DESCRIPTION
We have mneu titles on Filter Test Suite, and after
https://github.com/getsentry/sentry/pull/100194 we would have it on the
branch selector, but now with those changes the dropdowns are a bit
inconsistent with menu titles