### PR TITLE
fix: Change caseInsensitive to a bool

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -169,7 +169,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 query_string=query,
                 sampling_mode=sampling_mode,
                 debug=request.user.is_superuser and "debug" in request.GET,
-                case_insensitive="caseInsensitive" in request.GET,
+                case_insensitive=request.GET.get("caseInsensitive", "false").lower() == "true",
             )
             return params
 


### PR DESCRIPTION
- Makes it so caseInsensitive=false will turn of sensitivity instead of needing to exclude the param entirely