### PR TITLE
fix(alerts): Return early in subscription processor if downgraded

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -650,7 +650,7 @@ class SubscriptionProcessor:
             return True
 
         elif dataset == "generic_metrics" and not features.has(
-            "on-demand-metrics-extraction", organization
+            "organizations:on-demand-metrics-extraction", organization
         ):
             metrics.incr("incidents.alert_rules.ignore_update_missing_on_demand")
             return True

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -635,7 +635,7 @@ class SubscriptionProcessor:
         self.update_alert_rule_stats()
         return fired_incident_triggers
 
-    def has_downgraded(self, dataset: Dataset, organization: Organization) -> bool:
+    def has_downgraded(self, dataset: str, organization: Organization) -> bool:
         """
         Check if the organization has downgraded since the subscription was created, return early if True
         """
@@ -649,7 +649,9 @@ class SubscriptionProcessor:
             metrics.incr("incidents.alert_rules.ignore_update_missing_incidents_performance")
             return True
 
-        elif dataset == "generic_metrics" and not features.has("on-demand-metrics-extraction"):
+        elif dataset == "generic_metrics" and not features.has(
+            "on-demand-metrics-extraction", organization
+        ):
             metrics.incr("incidents.alert_rules.ignore_update_missing_on_demand")
             return True
 

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -635,6 +635,26 @@ class SubscriptionProcessor:
         self.update_alert_rule_stats()
         return fired_incident_triggers
 
+    def has_downgraded(self, dataset: Dataset, organization: Organization) -> bool:
+        """
+        Check if the organization has downgraded since the subscription was created, return early if True
+        """
+        if dataset == "events" and not features.has("organizations:incidents", organization):
+            metrics.incr("incidents.alert_rules.ignore_update_missing_incidents")
+            return True
+
+        elif dataset == "transactions" and not features.has(
+            "organizations:performance-view", organization
+        ):
+            metrics.incr("incidents.alert_rules.ignore_update_missing_incidents_performance")
+            return True
+
+        elif dataset == "generic_metrics" and not features.has("on-demand-metrics-extraction"):
+            metrics.incr("incidents.alert_rules.ignore_update_missing_on_demand")
+            return True
+
+        return False
+
     def process_update(self, subscription_update: QuerySubscriptionUpdate) -> None:
         """
         This is the core processing method utilized when Query Subscription Consumer fetches updates from kafka
@@ -652,15 +672,7 @@ class SubscriptionProcessor:
 
         organization = self.subscription.project.organization
 
-        if dataset == "events" and not features.has("organizations:incidents", organization):
-            # They have downgraded since these subscriptions have been created. So we just ignore updates for now.
-            metrics.incr("incidents.alert_rules.ignore_update_missing_incidents")
-            return
-        elif dataset == "transactions" and not features.has(
-            "organizations:performance-view", organization
-        ):
-            # They have downgraded since these subscriptions have been created. So we just ignore updates for now.
-            metrics.incr("incidents.alert_rules.ignore_update_missing_incidents_performance")
+        if self.has_downgraded(dataset, organization):
             return
 
         if not hasattr(self, "alert_rule"):

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
@@ -359,6 +359,18 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             "incidents.alert_rules.ignore_update_missing_incidents_performance"
         )
 
+    def test_no_feature_on_demand(self) -> None:
+        self.sub.snuba_query.dataset = "generic_metrics"
+        message = self.build_subscription_update(self.sub)
+        with (
+            self.feature("organizations:incidents"),
+            self.feature("organizations:performance-view"),
+        ):
+            SubscriptionProcessor(self.sub).process_update(message)
+        self.metrics.incr.assert_called_once_with(
+            "incidents.alert_rules.ignore_update_missing_on_demand"
+        )
+
     def test_skip_already_processed_update(self) -> None:
         self.send_update(self.rule, self.trigger.alert_threshold)
         self.metrics.incr.reset_mock()


### PR DESCRIPTION
If an organization has downgraded after creating an on demand metric alert we're currently not exiting early like we do for other datasets and throwing an error when we can't complete the query since we're attempting to query it on the wrong dataset. This PR adds a check for the generic metrics dataset and accompanying feature flag and exits early if it's not enabled.