### PR TITLE
fix(prevent): Fix disable toggle if not manager+

### DIFF
--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -341,7 +341,7 @@ describe('OrganizationSettingsForm', () => {
       jest.mocked(RegionUtils.getRegionDataFromOrganization).mockReturnValue({
         name: 'us',
         displayName: 'United States of America (US)',
-        url: 'https://sentry.de.example.com',
+        url: 'https://sentry.example.com',
       });
 
       render(
@@ -375,6 +375,65 @@ describe('OrganizationSettingsForm', () => {
       );
 
       const preventAiField = screen.getByRole('checkbox', {
+        name: /Enable AI Code Review/i,
+      });
+      expect(preventAiField).toBeInTheDocument();
+      expect(preventAiField).toBeDisabled();
+    });
+
+    it('is enabled when user is an admin (has org:write access)', () => {
+      jest.mocked(RegionUtils.getRegionDataFromOrganization).mockReturnValue({
+        name: 'us',
+        displayName: 'United States of America (US)',
+        url: 'https://sentry.example.com',
+      });
+
+      render(
+        <OrganizationSettingsForm
+          {...routerProps}
+          initialData={OrganizationFixture({
+            hideAiFeatures: true,
+          })}
+          onSave={onSave}
+        />,
+        {
+          organization: {
+            ...organization,
+            access: ['org:write'],
+          },
+        }
+      );
+
+      const preventAiField = screen.getByRole('checkbox', {
+        name: /Enable AI Code Review/i,
+      });
+      expect(preventAiField).toBeInTheDocument();
+      expect(preventAiField).toBeEnabled();
+    });
+
+    it('is disabled when user is a member (does not have org:write access)', async () => {
+      jest.mocked(RegionUtils.getRegionDataFromOrganization).mockReturnValue({
+        name: 'us',
+        displayName: 'United States of America (US)',
+        url: 'https://sentry.example.com',
+      });
+
+      render(
+        <OrganizationSettingsForm
+          {...routerProps}
+          initialData={OrganizationFixture({
+            hideAiFeatures: true,
+          })}
+          onSave={onSave}
+        />,
+        {
+          organization: {
+            access: ['org:read'],
+          },
+        }
+      );
+
+      const preventAiField = await screen.findByRole('checkbox', {
         name: /Enable AI Code Review/i,
       });
       expect(preventAiField).toBeInTheDocument();

--- a/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
@@ -28,7 +28,7 @@ export const makePreventAiField = (organization: Organization): FieldObject => {
       const hideAiFeatures = model.getValue('hideAiFeatures');
       return hideAiFeatures;
     },
-    disabled: () => !isUSOrg,
+    disabled: ({access}) => !isUSOrg || !access.has('org:write'),
     disabledReason: isUSOrg
       ? null
       : t('AI Code Review is only available in the US region'),


### PR DESCRIPTION
Disable the "Enable AI Code Review" toggle visually in the UI if not a manager+ role, like the rest of the toggles on the page. Otherwise, when you try to toggle it you get an error, so should be disabled instead.
Was a regression when I added a condition for disable in this [PR](https://github.com/getsentry/sentry/pull/100042) but didn't catch where need to add this condition here too. No harm done in the meantime though since you would still get an error.

Screenshot:
<img width="1047" height="830" alt="Screenshot 2025-09-24 at 2 58 11 PM" src="https://github.com/user-attachments/assets/fc5b13c8-fbb7-487b-84eb-c33f861a388d" />
