### PR TITLE
bug(preprod): Minor compare item table tweaks

### DIFF
--- a/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
@@ -5,6 +5,7 @@ import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IconAdd, IconFix, IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
+import {capitalize} from 'sentry/utils/string/capitalize';
 import type {DiffItem, DiffType} from 'sentry/views/preprod/types/appSizeTypes';
 
 const tableHeaders = [
@@ -144,15 +145,17 @@ export function SizeCompareItemDiffTable({diffItems}: SizeCompareItemDiffTablePr
               </ChangeTag>
             </SimpleTable.RowCell>
             <SimpleTable.RowCell>{diffItem.path}</SimpleTable.RowCell>
-            <SimpleTable.RowCell>{diffItem.item_type}</SimpleTable.RowCell>
+            <SimpleTable.RowCell>
+              {capitalize(diffItem.item_type ?? '')}
+            </SimpleTable.RowCell>
             <SimpleTable.RowCell>
               {diffItem.head_size
                 ? formatBytesBase10(diffItem.head_size)
                 : formatBytesBase10(diffItem.base_size!)}
             </SimpleTable.RowCell>
             <ChangeAmountCell changeType={diffItem.type}>
-              {diffItem.size_diff > 0 ? '+' : ''}
-              {formatBytesBase10(diffItem.size_diff)}
+              {diffItem.size_diff > 0 ? '+' : '-'}
+              {formatBytesBase10(Math.abs(diffItem.size_diff))}
             </ChangeAmountCell>
           </SimpleTable.Row>
         );


### PR DESCRIPTION
Capitalize item type and handle negative size diff base10 formatting

Before
<img width="653" height="347" alt="Screenshot 2025-09-24 at 2 50 29 PM" src="https://github.com/user-attachments/assets/8712b71a-7201-492b-87db-23b8b0ab324d" />

After
<img width="671" height="423" alt="Screenshot 2025-09-24 at 2 50 05 PM" src="https://github.com/user-attachments/assets/cd69bc7f-43a9-4641-85ab-98c41eeabd13" />

Resolves EME-351