### PR TITLE
Tweak insight text colors and weights

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -100,11 +100,11 @@ function FileRow({file}: {file: ProcessedInsightFile}) {
 
   return (
     <FlexAlternatingRow>
-      <Text variant="accent" size="sm" bold ellipsis style={{flex: 1}}>
+      <Text size="sm" ellipsis style={{flex: 1}}>
         {file.path}
       </Text>
       <Flex align="center" gap="sm">
-        <Text variant="primary" size="sm" tabular>
+        <Text variant="primary" bold size="sm" tabular>
           -{formatBytesBase10(file.savings)}
         </Text>
         <Text variant="muted" size="sm" tabular align="right" style={{width: '64px'}}>
@@ -124,11 +124,11 @@ function OptimizableImageFileRow({
 }) {
   return (
     <FlexAlternatingRow>
-      <Text variant="accent" size="sm" bold ellipsis style={{flex: 1}}>
+      <Text size="sm" ellipsis style={{flex: 1}}>
         {file.path}
       </Text>
       <Flex align="center" gap="sm">
-        <Text variant="primary" size="sm" tabular>
+        <Text variant="primary" bold size="sm" tabular>
           -{formatBytesBase10(file.savings)}
         </Text>
         <Text variant="muted" size="sm" tabular align="right" style={{width: '64px'}}>


### PR DESCRIPTION
Purple felt clickable, so make the text non-bold and default text color. Makes size bold for some visual heirarchy.

Before
<img width="468" height="462" alt="Screenshot 2025-09-24 at 3 07 18 PM" src="https://github.com/user-attachments/assets/da73c0c3-e410-4f59-bee4-cf997a09f29e" />

After
<img width="360" height="338" alt="image" src="https://github.com/user-attachments/assets/64aa546c-8b24-45f2-846b-89cbb4a7a152" />
