### PR TITLE
ref(grouping): Allow `GroupingComponent.get_subcomponent` to work recursively

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -115,10 +115,15 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]](
         return self.name or self.id
 
     def get_subcomponent(
-        self, id: str, only_contributing: bool = False
+        self, id: str, recursive: bool = False, only_contributing: bool = False
     ) -> str | int | BaseGroupingComponent[Any] | None:
         """Looks up a subcomponent by the id and returns the first or `None`."""
-        return next(self.iter_subcomponents(id=id, only_contributing=only_contributing), None)
+        return next(
+            self.iter_subcomponents(
+                id=id, recursive=recursive, only_contributing=only_contributing
+            ),
+            None,
+        )
 
     def iter_subcomponents(
         self, id: str, recursive: bool = False, only_contributing: bool = False

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -117,7 +117,16 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]](
     def get_subcomponent(
         self, id: str, recursive: bool = False, only_contributing: bool = False
     ) -> str | int | BaseGroupingComponent[Any] | None:
-        """Looks up a subcomponent by the id and returns the first or `None`."""
+        """
+        Looks up a subcomponent by id and returns the first instance found, or `None` if no
+        instances are found.
+
+        Unless `recursive=True` is passed, only direct children (the components in `self.values`)
+        are checked.
+
+        By default, any matching result will be returned. To filter out non-contributing components,
+        pass `only_contributing=True`.
+        """
         return next(
             self.iter_subcomponents(
                 id=id, recursive=recursive, only_contributing=only_contributing

--- a/tests/sentry/grouping/test_components.py
+++ b/tests/sentry/grouping/test_components.py
@@ -378,3 +378,23 @@ class ComponentTest(TestCase):
             in_app_non_contributing_frames=21,
             in_app_contributing_frames=39,
         )
+
+    def test_get_subcomponent(self) -> None:
+        root_component = self.event.get_grouping_variants()["app"].root_component
+
+        # When `recursive` isn't specified, it should find direct children but not grandchildren
+        exception_component = root_component.get_subcomponent("exception")
+        stacktrace_component = root_component.get_subcomponent("stacktrace")
+        assert exception_component
+        assert not stacktrace_component
+
+        # Grandchildren can be found, however, if the search is recursive
+        stacktrace_component = root_component.get_subcomponent("stacktrace", recursive=True)
+        assert stacktrace_component
+
+        # The `only_contributing` flag can be used to exclude components which don't contribute
+        assert stacktrace_component.contributes is False
+        contributing_stacktrace_component = root_component.get_subcomponent(
+            "stacktrace", recursive=True, only_contributing=True
+        )
+        assert not contributing_stacktrace_component


### PR DESCRIPTION
In the `GroupingComponent` classes, the (currently unused, but soon to be useful) `get_subcomponent` method relies on the `iter_subcomponents` iterator, which takes a `recursive` flag to force it to visit multiple levels of the component tree. This adds a similar flag to `get_subcomponent`, in order to be able to find descendants which aren't direct children.