### PR TITLE
ref(groupingInfo): add hint in line to grouping variant title

### DIFF
--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -158,18 +158,7 @@ function GroupingVariant({event, variant, showNonContributing}: GroupingVariantP
   const renderTitle = () => {
     const isContributing = variant.hash !== null;
 
-    let title: string;
-    let hint: string | null | undefined;
-    if (isContributing) {
-      title = t('Contributing variant');
-    } else {
-      hint = 'component' in variant ? variant.component?.hint : undefined;
-      if (hint) {
-        title = t('Non-contributing variant: %s', hint);
-      } else {
-        title = t('Non-contributing variant');
-      }
-    }
+    const hint = 'component' in variant ? variant.component?.hint : undefined;
 
     return (
       <VariantTitle>

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -211,7 +211,7 @@ const VariantTitle = styled('h5')`
   align-items: center;
 `;
 
-const VariantHint = styled('text')`
+const VariantHint = styled('span')`
   font-size: ${p => p.theme.fontSize.sm};
   margin-left: ${p => p.theme.space.xs};
   font-weight: ${p => p.theme.fontWeight.normal};

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import {Tooltip} from 'sentry/components/core/tooltip';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
 import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
 import QuestionTooltip from 'sentry/components/questionTooltip';
@@ -173,16 +172,14 @@ function GroupingVariant({event, variant, showNonContributing}: GroupingVariantP
     }
 
     return (
-      <Tooltip title={title}>
-        <VariantTitle>
-          <ContributionIcon isContributing={isContributing} />
-          {variant.description
-            ?.split(' ')
-            .map(i => capitalize(i))
-            .join(' ') ?? t('Nothing')}
-          <VariantHint>{!isContributing && hint && t('(%s)', hint)}</VariantHint>
-        </VariantTitle>
-      </Tooltip>
+      <VariantTitle>
+        <ContributionIcon isContributing={isContributing} />
+        {variant.description
+          ?.split(' ')
+          .map(i => capitalize(i))
+          .join(' ') ?? t('Nothing')}
+        <VariantHint>{!isContributing && hint && t('(%s)', hint)}</VariantHint>
+      </VariantTitle>
     );
   };
 

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -226,10 +226,10 @@ const VariantTitle = styled('h5')`
 `;
 
 const VariantHint = styled('span')`
-  font-size: ${p => p.theme.fontSize.md};
-  color: ${p => p.theme.textColor};
+  font-size: ${p => p.theme.fontSize.sm};
   margin-left: ${p => p.theme.space.xs};
   font-weight: ${p => p.theme.fontWeight.normal};
+  color: ${p => p.theme.subText};
 `;
 
 const ContributionIcon = styled(({isContributing, ...p}: any) =>

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -160,10 +160,11 @@ function GroupingVariant({event, variant, showNonContributing}: GroupingVariantP
     const isContributing = variant.hash !== null;
 
     let title: string;
+    let hint: string | null | undefined;
     if (isContributing) {
       title = t('Contributing variant');
     } else {
-      const hint = 'component' in variant ? variant.component?.hint : undefined;
+      hint = 'component' in variant ? variant.component?.hint : undefined;
       if (hint) {
         title = t('Non-contributing variant: %s', hint);
       } else {
@@ -179,6 +180,7 @@ function GroupingVariant({event, variant, showNonContributing}: GroupingVariantP
             ?.split(' ')
             .map(i => capitalize(i))
             .join(' ') ?? t('Nothing')}
+          <VariantHint>{!isContributing && hint && t('(%s)', hint)}</VariantHint>
         </VariantTitle>
       </Tooltip>
     );
@@ -221,6 +223,13 @@ const VariantTitle = styled('h5')`
   margin: 0;
   display: flex;
   align-items: center;
+`;
+
+const VariantHint = styled('span')`
+  font-size: ${p => p.theme.fontSize.md};
+  color: ${p => p.theme.textColor};
+  margin-left: ${p => p.theme.space.xs};
+  font-weight: ${p => p.theme.fontWeight.normal};
 `;
 
 const ContributionIcon = styled(({isContributing, ...p}: any) =>

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -167,7 +167,7 @@ function GroupingVariant({event, variant, showNonContributing}: GroupingVariantP
           ?.split(' ')
           .map(i => capitalize(i))
           .join(' ') ?? t('Nothing')}
-        <VariantHint>{!isContributing && hint && t('(%s)', hint)}</VariantHint>
+        <VariantHint>{hint && t('(%s)', hint)}</VariantHint>
       </VariantTitle>
     );
   };
@@ -211,7 +211,7 @@ const VariantTitle = styled('h5')`
   align-items: center;
 `;
 
-const VariantHint = styled('span')`
+const VariantHint = styled('text')`
   font-size: ${p => p.theme.fontSize.sm};
   margin-left: ${p => p.theme.space.xs};
   font-weight: ${p => p.theme.fontWeight.normal};


### PR DESCRIPTION
Add hint for grouping variant in line with title instead of tooltip. 

<img width="1037" height="283" alt="image" src="https://github.com/user-attachments/assets/ef249190-e2f6-437b-a46f-7010ae97afb9" />

Eventually the top of the stack trace with `in-app` with the same hint will be removed 