### PR TITLE
ref(grouping): Add hint to variant class

### DIFF
--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -133,6 +133,10 @@ class ComponentVariant(BaseVariant):
     def contributes(self) -> bool:
         return self.root_component.contributes
 
+    @property
+    def hint(self) -> str | None:
+        return self.root_component.hint
+
     def get_hash(self) -> str | None:
         return self.root_component.get_hash()
 

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -42,13 +42,22 @@ class BaseVariant(ABC):
     def description(self) -> str:
         return self.type
 
+    @property
+    def hint(self) -> str | None:
+        return None
+
     # This has to return `Mapping` rather than `dict` so that subtypes can override the return value
     # with a TypedDict if they choose. See https://github.com/python/mypy/issues/4976.
     def _get_metadata_as_dict(self) -> Mapping[str, Any]:
         return {}
 
     def as_dict(self) -> dict[str, Any]:
-        rv = {"type": self.type, "description": self.description, "hash": self.get_hash()}
+        rv = {
+            "type": self.type,
+            "description": self.description,
+            "hash": self.get_hash(),
+            "hint": self.hint,
+        }
         rv.update(self._get_metadata_as_dict())
         return rv
 

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.623079+00:00'
+created: '2025-09-24T22:53:01.986683+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -2606,6 +2606,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "738e7d2503464bc264b4f791286f5122",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -5211,6 +5212,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "19a96e0438d28e48355653def82f887a",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.392514+00:00'
+created: '2025-09-24T22:53:02.050490+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -3935,6 +3935,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -7869,6 +7870,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "2552498cfe69a6ddf1dcdde5440ce9c3",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.413154+00:00'
+created: '2025-09-24T22:53:02.075150+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1094,6 +1094,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "228c649a3aa0901622c0a0e66ab0522c",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -1137,6 +1138,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "default",
     "hash": null,
+    "hint": "ignored because app/system exception takes precedence",
     "key": "default",
     "type": "component"
   },
@@ -2230,6 +2232,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "4ccd0f1953483581ba360c7518f90332",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.431494+00:00'
+created: '2025-09-24T22:53:02.095327+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -144,6 +144,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app thread stack-trace",
     "hash": "ff6c4ee7c54f118a9647ee86f0c2b0b0",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -187,6 +188,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "default",
     "hash": null,
+    "hint": "ignored because app threads take precedence",
     "key": "default",
     "type": "component"
   },
@@ -330,6 +332,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": "ignored because app threads take precedence",
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.450228+00:00'
+created: '2025-09-24T22:53:02.113693+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -307,6 +307,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -613,6 +614,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "d9c9b0f9ba46e32fddd7cd1512fad235",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.483900+00:00'
+created: '2025-09-24T22:53:02.166722+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -104,12 +104,14 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because built-in fingerprint takes precedence",
     "key": "app",
     "type": "component"
   },
   "built_in_fingerprint": {
     "description": "Sentry defined fingerprint",
     "hash": "5d731dcf8ecc4f042eeacf528d8d8da9",
+    "hint": null,
     "key": "built_in_fingerprint",
     "matched_rule": "family:\"javascript\" type:\"ChunkLoadError\" -> \"chunkloaderror\"",
     "type": "built_in_fingerprint",
@@ -217,6 +219,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": null,
+    "hint": "ignored because built-in fingerprint takes precedence",
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.467530+00:00'
+created: '2025-09-24T22:53:02.139683+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -104,6 +104,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because built-in fingerprint takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -114,6 +115,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     ],
     "description": "Sentry defined fingerprint",
     "hash": "5d731dcf8ecc4f042eeacf528d8d8da9",
+    "hint": null,
     "key": "built_in_fingerprint",
     "matched_rule": "family:\"javascript\" type:\"ChunkLoadError\" -> \"chunkloaderror\"",
     "type": "built_in_fingerprint",
@@ -221,6 +223,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": null,
+    "hint": "ignored because built-in fingerprint takes precedence",
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.074658+00:00'
+created: '2025-09-24T22:53:02.189532+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1072,6 +1072,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "4ef1fb44d656c3be2a146971f2a222dc",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -2143,6 +2144,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "47481871aa8d5ab5729cf2db78ce3032",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.819288+00:00'
+created: '2025-09-24T22:53:02.206227+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -8,6 +8,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "checksum": "de46d023e69b171b90ccf3ebca7aede4",
     "description": "hashed legacy checksum",
     "hash": "de46d023e69b171b90ccf3ebca7aede4",
+    "hint": null,
     "key": "hashed_checksum",
     "raw_checksum": "not a legit checksum",
     "type": "hashed_checksum"

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/checksum_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/checksum_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:19.836961+00:00'
+created: '2025-09-24T22:53:02.223315+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -8,6 +8,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "checksum": "11212012123120120415201309082013",
     "description": "legacy checksum",
     "hash": "11212012123120120415201309082013",
+    "hint": null,
     "key": "checksum",
     "type": "checksum"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.550733+00:00'
+created: '2025-09-24T22:53:02.244478+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -516,6 +516,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app thread stack-trace",
     "hash": "7c8a196d16b94be382add324be2605ee",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -559,6 +560,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "default",
     "hash": null,
+    "hint": "ignored because app/system threads take precedence",
     "key": "default",
     "type": "component"
   },
@@ -1074,6 +1076,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "thread stack-trace",
     "hash": "cd7f51d716fd57adc1a5ce1c112e538f",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.570796+00:00'
+created: '2025-09-24T22:53:02.270423+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -553,6 +553,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "6b059b9febc815ac18ac4d2082e38a9b",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -596,6 +597,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "default",
     "hash": null,
+    "hint": "ignored because app/system exception takes precedence",
     "key": "default",
     "type": "component"
   },
@@ -1148,6 +1150,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "013d3477a774fe20c468dc8accd516f1",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.169747+00:00'
+created: '2025-09-24T22:53:02.293300+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -237,6 +237,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "161ce02ecc5d6685a72e8e520ab726b3",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -473,6 +474,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "c5e4b4a9ad1803c4d4ca7feee5e430ae",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.601794+00:00'
+created: '2025-09-24T22:53:02.324571+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -195,6 +195,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -389,6 +390,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "fe92cff6711f8a0a30cabb8b9245b1d6",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.718855+00:00'
+created: '2025-09-24T22:53:02.525237+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -77,6 +77,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "URL",
     "hash": "666766514295bb52812324097cdaf53e",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_img_src.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_img_src.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.617046+00:00'
+created: '2025-09-24T22:53:02.341413+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -68,6 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "URL",
     "hash": "1742101e08eb1608f569751dfedd0062",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.631545+00:00'
+created: '2025-09-24T22:53:02.362940+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -68,6 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "URL",
     "hash": "efddf1cde918097259aa7d4904fb1942",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_data_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_data_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.646142+00:00'
+created: '2025-09-24T22:53:02.388409+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -68,6 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "URL",
     "hash": "4e6f2bce9d121aa89f4dc5e5da08afb5",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.661439+00:00'
+created: '2025-09-24T22:53:02.414531+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -79,6 +79,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "violation",
     "hash": "56c6520f35bce2f89ed2c4e725ccef65",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.676251+00:00'
+created: '2025-09-24T22:53:02.445174+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -79,6 +79,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "violation",
     "hash": "d346ee37d19a2be6587e609075ca2d57",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.690638+00:00'
+created: '2025-09-24T22:53:02.476834+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -68,6 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "URL",
     "hash": "223cdacfe5b4b830dc700b5c18cc21b4",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_style_src_elem.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_style_src_elem.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.704585+00:00'
+created: '2025-09-24T22:53:02.502108+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -77,6 +77,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "URL",
     "hash": "537a973f594c364842893e9a72af62a5",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.750035+00:00'
+created: '2025-09-24T22:53:02.571090+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -817,6 +817,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": null,
+    "hint": "ignored because custom client fingerprint takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -828,6 +829,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     ],
     "description": "custom fingerprint",
     "hash": "f30afa00b85f5cac5ee0bce01b31f08d",
+    "hint": null,
     "key": "custom_fingerprint",
     "type": "custom_fingerprint",
     "values": [
@@ -1649,6 +1651,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": null,
+    "hint": "ignored because custom client fingerprint takes precedence",
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.734440+00:00'
+created: '2025-09-24T22:53:02.544609+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -817,6 +817,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": null,
+    "hint": "ignored because custom server fingerprint takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -828,6 +829,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     ],
     "description": "custom fingerprint",
     "hash": "554e214208f0372603dc9fa6c1c0965f",
+    "hint": null,
     "key": "custom_fingerprint",
     "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\"",
     "type": "custom_fingerprint",
@@ -1648,6 +1650,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": null,
+    "hint": "ignored because custom server fingerprint takes precedence",
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.765781+00:00'
+created: '2025-09-24T22:53:02.589406+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -817,12 +817,14 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": null,
+    "hint": "ignored because custom server fingerprint takes precedence",
     "key": "app",
     "type": "component"
   },
   "custom_fingerprint": {
     "description": "custom fingerprint",
     "hash": "554e214208f0372603dc9fa6c1c0965f",
+    "hint": null,
     "key": "custom_fingerprint",
     "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\"",
     "type": "custom_fingerprint",
@@ -1643,6 +1645,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": null,
+    "hint": "ignored because custom server fingerprint takes precedence",
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/empty.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/empty.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.559036+00:00'
+created: '2025-09-24T22:53:02.606467+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,6 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "fallback": {
     "description": "fallback",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "hint": null,
     "key": "fallback",
     "type": "fallback"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.797768+00:00'
+created: '2025-09-24T22:53:02.632861+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -823,6 +823,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "029f3b967068b1539f96957b7c0451d7",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -1586,6 +1587,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": "ignored because app exception takes precedence",
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.699956+00:00'
+created: '2025-09-24T22:53:02.692044+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -68,6 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "b23ee1963904c2ca87b145febf94b66c",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.813011+00:00'
+created: '2025-09-24T22:53:02.653190+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -100,6 +100,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "9509e122c6175606d52862fa4f64853c",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -199,6 +200,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": "ignored because app exception takes precedence",
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:38.827909+00:00'
+created: '2025-09-24T22:53:02.674586+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -173,6 +173,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "669cb6664e0f5fed38665da04e464f7e",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -345,6 +346,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": "ignored because app exception takes precedence",
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.538747+00:00'
+created: '2025-09-24T22:53:02.713413+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -142,6 +142,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "e2bf1e0628b7b1824a9b63dec7a079a3",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.578207+00:00'
+created: '2025-09-24T22:53:02.751453+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -109,6 +109,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "93b26686d00504b4e5aa1cb0244d8b37",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.559569+00:00'
+created: '2025-09-24T22:53:02.729706+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -109,6 +109,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "93b26686d00504b4e5aa1cb0244d8b37",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.826050+00:00'
+created: '2025-09-24T22:53:02.772868+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -68,6 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "a4f16891fa438620699cb2d9af5cc827",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.617682+00:00'
+created: '2025-09-24T22:53:02.793775+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -109,6 +109,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "028157fe357e4592e39eacb32eafa2db",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.636080+00:00'
+created: '2025-09-24T22:53:02.813766+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -109,6 +109,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "f0078a82f351095ba595daa7d493aa3c",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.654078+00:00'
+created: '2025-09-24T22:53:02.830895+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -109,6 +109,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "93b26686d00504b4e5aa1cb0244d8b37",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.920031+00:00'
+created: '2025-09-24T22:53:02.849146+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -68,6 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "0809098f9f613b63467605dd1739cc9b",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.941233+00:00'
+created: '2025-09-24T22:53:02.876433+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -68,6 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "0809098f9f613b63467605dd1739cc9b",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_exception.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_exception.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:20.978125+00:00'
+created: '2025-09-24T22:53:02.898564+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -68,6 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "a4f16891fa438620699cb2d9af5cc827",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.002821+00:00'
+created: '2025-09-24T22:53:02.920484+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -68,6 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "a4f16891fa438620699cb2d9af5cc827",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.744859+00:00'
+created: '2025-09-24T22:53:02.943565+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -142,6 +142,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "17022e0561e9b6e6351723a08aa81b18",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.109738+00:00'
+created: '2025-09-24T22:53:02.990851+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -68,6 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "a4f16891fa438620699cb2d9af5cc827",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.772851+00:00'
+created: '2025-09-24T22:53:02.968102+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -109,6 +109,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "f0078a82f351095ba595daa7d493aa3c",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.824399+00:00'
+created: '2025-09-24T22:53:03.009525+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -276,6 +276,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "d505dfb9059ac63c11955233323a9100",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -518,6 +519,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "4f9cc6a81f4eb34f9e917374f281b9dc",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.872231+00:00'
+created: '2025-09-24T22:53:03.072479+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -142,6 +142,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "bca604b98cb4637167eb6190a92e8933",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:17.849793+00:00'
+created: '2025-09-24T22:53:03.033848+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -142,6 +142,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "fca0fd23f09e8da4481304ef2a531100",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.104080+00:00'
+created: '2025-09-24T22:53:03.092703+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -155,6 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -309,6 +310,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "26552f86ca2368e708afa1df6effc1c5",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_type.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_type.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.283940+00:00'
+created: '2025-09-24T22:53:03.112395+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -66,6 +66,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "5eb63bbbe01eeed093cb22bb8f5acdc3",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_value.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.324014+00:00'
+created: '2025-09-24T22:53:03.130531+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -66,6 +66,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "5a2cfd89b7b171fd7b4794b08023d04f",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/expectct.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/expectct.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:18.042146+00:00'
+created: '2025-09-24T22:53:03.221388+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -61,6 +61,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "hostname",
     "hash": "3d2933f4b5ec459ec8d569a398fd328c",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.237302+00:00'
+created: '2025-09-24T22:53:03.251183+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -253,6 +253,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -505,6 +506,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "87497299851e09febfecf4e84e0d45ba",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.255229+00:00'
+created: '2025-09-24T22:53:03.284146+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "526b64456c48836a46ec1a89544fd412",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_empty_list.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.561442+00:00'
+created: '2025-09-24T22:53:03.306447+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -42,12 +42,14 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": null,
     "key": "app",
     "type": "component"
   },
   "fallback": {
     "description": "fallback",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "hint": null,
     "key": "fallback",
     "type": "fallback"
   },
@@ -89,6 +91,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.284132+00:00'
+created: '2025-09-24T22:53:03.323443+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "7d2cc7acbf90328200d960bf78a26234",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.298158+00:00'
+created: '2025-09-24T22:53:03.349214+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "465d672b2d322bf6a1b44499f6dabc1f",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.313035+00:00'
+created: '2025-09-24T22:53:03.370037+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "45c0b0a8c777e7a7040d7c39233a08a5",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.657724+00:00'
+created: '2025-09-24T22:53:03.393256+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,12 +76,14 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": null,
     "key": "app",
     "type": "component"
   },
   "fallback": {
     "description": "fallback",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "hint": null,
     "key": "fallback",
     "type": "fallback"
   },
@@ -157,6 +159,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.341558+00:00'
+created: '2025-09-24T22:53:03.409748+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "353e05904b48bd3ae4fa9623934a70d0",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.355376+00:00'
+created: '2025-09-24T22:53:03.430369+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "0094f39fc617031afb6c655419f4a9f2",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.369708+00:00'
+created: '2025-09-24T22:53:03.450701+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "be15ca3d511b96918e087c4f42503ca2",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.383782+00:00'
+created: '2025-09-24T22:53:03.468134+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -167,6 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -333,6 +334,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "e04dce7550635e05dbd7f656102cf304",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.397503+00:00'
+created: '2025-09-24T22:53:03.485330+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "098f6bcd4621d373cade4e832627b4f6",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:21.784262+00:00'
+created: '2025-09-24T22:53:03.506614+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -74,12 +74,14 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": null,
     "key": "app",
     "type": "component"
   },
   "fallback": {
     "description": "fallback",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "hint": null,
     "key": "fallback",
     "type": "fallback"
   },
@@ -153,6 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.429888+00:00'
+created: '2025-09-24T22:53:03.523952+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -85,6 +85,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -169,6 +170,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "64a0e0a34d99dce03a8c5a4c237a4b5a",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.446056+00:00'
+created: '2025-09-24T22:53:03.546739+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -85,6 +85,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -169,6 +170,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "64a0e0a34d99dce03a8c5a4c237a4b5a",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.461313+00:00'
+created: '2025-09-24T22:53:03.564703+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -78,6 +78,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -155,6 +156,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "e0e7c4713e9092dc77635d5a0d5db31d",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.475720+00:00'
+created: '2025-09-24T22:53:03.588849+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "c32a94349d9e9b72d31a46610c6c9589",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.489688+00:00'
+created: '2025-09-24T22:53:03.611265+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "be7f1b8b4014de623c533a8218dba5bd",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.504663+00:00'
+created: '2025-09-24T22:53:03.627975+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "53b9e9679a8ea25880376080b76f98ad",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.549069+00:00'
+created: '2025-09-24T22:53:03.691208+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "538bdfd8d7bb2495d0d6429c3689a420",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.519356+00:00'
+created: '2025-09-24T22:53:03.650067+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "538bdfd8d7bb2495d0d6429c3689a420",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.533642+00:00'
+created: '2025-09-24T22:53:03.673455+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "dc3d511120ce04996b1eef3496516e5c",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.059412+00:00'
+created: '2025-09-24T22:53:03.730459+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,12 +76,14 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": null,
     "key": "app",
     "type": "component"
   },
   "fallback": {
     "description": "fallback",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "hint": null,
     "key": "fallback",
     "type": "fallback"
   },
@@ -157,6 +159,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.563552+00:00'
+created: '2025-09-24T22:53:03.712651+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -78,6 +78,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -155,6 +156,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "0cc175b9c0f1b6a831c399e269772661",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.591943+00:00'
+created: '2025-09-24T22:53:03.748218+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "30eb5001914d29dd8461898b5b8094fe",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.102275+00:00'
+created: '2025-09-24T22:53:03.766838+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -274,12 +274,14 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": null,
     "key": "app",
     "type": "component"
   },
   "fallback": {
     "description": "fallback",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "hint": null,
     "key": "fallback",
     "type": "fallback"
   },
@@ -553,6 +555,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.125429+00:00'
+created: '2025-09-24T22:53:03.783652+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,12 +76,14 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": null,
     "key": "app",
     "type": "component"
   },
   "fallback": {
     "description": "fallback",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "hint": null,
     "key": "fallback",
     "type": "fallback"
   },
@@ -157,6 +159,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.148344+00:00'
+created: '2025-09-24T22:53:03.801682+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,12 +76,14 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": null,
     "key": "app",
     "type": "component"
   },
   "fallback": {
     "description": "fallback",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "hint": null,
     "key": "fallback",
     "type": "fallback"
   },
@@ -157,6 +159,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.667420+00:00'
+created: '2025-09-24T22:53:03.837021+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "07d1a8e5728b3c4c7aa8b8273fd0e753",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.652562+00:00'
+created: '2025-09-24T22:53:03.819736+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "09e0efcab18f545166318118ed4e0292",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.683584+00:00'
+created: '2025-09-24T22:53:03.853321+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -109,6 +109,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -217,6 +218,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "9bc326575875422d0d4ced3c35d9f916",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.698703+00:00'
+created: '2025-09-24T22:53:03.870586+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "27eed4125fc13d42163ddb0b8f357b48",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.713036+00:00'
+created: '2025-09-24T22:53:03.887186+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "4067a71d7098866f87c746a57a77b2bb",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.741968+00:00'
+created: '2025-09-24T22:53:03.920735+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -74,6 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -147,6 +148,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "2f908c015ad77a50595512fcf65d344c",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.727915+00:00'
+created: '2025-09-24T22:53:03.904450+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -74,6 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -147,6 +148,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "2f908c015ad77a50595512fcf65d344c",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.756484+00:00'
+created: '2025-09-24T22:53:03.938263+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -85,6 +85,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -169,6 +170,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "60e0a667027bef0d0b7c4882891df7e8",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.770300+00:00'
+created: '2025-09-24T22:53:03.955209+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "acbd18db4cc2f85cedef654fccc4a4d8",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.784386+00:00'
+created: '2025-09-24T22:53:03.973057+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -74,6 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -147,6 +148,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "1effb24729ae4c43efa36b460511136a",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.799842+00:00'
+created: '2025-09-24T22:53:03.991052+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -139,6 +139,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "4b8bbc500bd2cabfcadc1f1be867e0bb",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -277,6 +278,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "348fc4026c9fa11ffba8fbfa80a134c9",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.824431+00:00'
+created: '2025-09-24T22:53:04.011550+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1261,6 +1261,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -2521,6 +2522,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "3da34e8c72dbcd4a490ac36eb7130638",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.842691+00:00'
+created: '2025-09-24T22:53:04.034988+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -813,6 +813,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -1625,6 +1626,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "ca733a48a19d237df8577d09449095d9",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.861197+00:00'
+created: '2025-09-24T22:53:04.058641+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -941,6 +941,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -1881,6 +1882,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "2c1bbd635b64d5adccdb64a620044075",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.878189+00:00'
+created: '2025-09-24T22:53:04.080447+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -821,6 +821,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -1641,6 +1642,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "9c336f632f6764c0f082a6a66edbf22d",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.896208+00:00'
+created: '2025-09-24T22:53:04.102548+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1290,6 +1290,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -2579,6 +2580,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "49b6f72b6635cb43190c57ee56b026b0",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.914201+00:00'
+created: '2025-09-24T22:53:04.128077+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1333,6 +1333,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -2665,6 +2666,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "49b6f72b6635cb43190c57ee56b026b0",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.929828+00:00'
+created: '2025-09-24T22:53:04.148363+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -565,6 +565,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -1129,6 +1130,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "aeed765d29d1a60cb094f66d2cd8efb2",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.945687+00:00'
+created: '2025-09-24T22:53:04.166641+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -588,6 +588,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -1175,6 +1176,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "aeed765d29d1a60cb094f66d2cd8efb2",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.965846+00:00'
+created: '2025-09-24T22:53:04.188893+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1898,6 +1898,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -3795,6 +3796,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "8be5979a334287a1b47457228f1d4612",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:39.985232+00:00'
+created: '2025-09-24T22:53:04.211303+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1819,6 +1819,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -3637,6 +3638,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "8be5979a334287a1b47457228f1d4612",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.004951+00:00'
+created: '2025-09-24T22:53:04.232197+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1929,6 +1929,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -3857,6 +3858,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "7e64037e487c78ce0439f750a2ef503f",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.021578+00:00'
+created: '2025-09-24T22:53:04.250324+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -379,6 +379,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -757,6 +758,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "aeed765d29d1a60cb094f66d2cd8efb2",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.040038+00:00'
+created: '2025-09-24T22:53:04.270193+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1135,6 +1135,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -2269,6 +2270,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "6148c73af04344a8597354711f5951ea",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.058753+00:00'
+created: '2025-09-24T22:53:04.290146+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1135,6 +1135,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -2269,6 +2270,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "1056f62d72ff8b4d0c3842d696dbb10a",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.077939+00:00'
+created: '2025-09-24T22:53:04.311979+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1240,6 +1240,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -2479,6 +2480,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "15526a7b64e9b5dc6d89e7ebec864260",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hpkp.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hpkp.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.872529+00:00'
+created: '2025-09-24T22:53:04.331173+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -61,6 +61,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "hostname",
     "hash": "1e37a374cb33572622d02ff7a6237c44",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.895467+00:00'
+created: '2025-09-24T22:53:04.348973+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -72,6 +72,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "modified in-app exception",
     "hash": "e3d593b4335190212ca7c18b8e967fb1",
+    "hint": null,
     "key": "app",
     "type": "salted_component",
     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.127693+00:00'
+created: '2025-09-24T22:53:04.367237+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -822,6 +822,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "modified in-app exception stack-trace",
     "hash": "19163f3ca34f5995c69d85351ce3d697",
+    "hint": null,
     "key": "app",
     "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\"",
     "type": "salted_component",
@@ -1648,6 +1649,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "modified exception stack-trace",
     "hash": "847950eb44d280e6758d136c763d6ddc",
+    "hint": null,
     "key": "system",
     "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\"",
     "type": "salted_component",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.144547+00:00'
+created: '2025-09-24T22:53:04.385618+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -817,6 +817,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": null,
+    "hint": "ignored because custom server fingerprint takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -828,6 +829,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     ],
     "description": "custom fingerprint",
     "hash": "554e214208f0372603dc9fa6c1c0965f",
+    "hint": null,
     "key": "custom_fingerprint",
     "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\"",
     "type": "custom_fingerprint",
@@ -1648,6 +1650,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": null,
+    "hint": "ignored because custom server fingerprint takes precedence",
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.966498+00:00'
+created: '2025-09-24T22:53:04.402426+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -72,6 +72,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "modified in-app exception",
     "hash": "5b5ad5a0fbb4deb5e3fc631ce42681ae",
+    "hint": null,
     "key": "app",
     "type": "salted_component",
     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:22.987371+00:00'
+created: '2025-09-24T22:53:04.420289+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -72,6 +72,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "modified in-app exception",
     "hash": "c5578778212497f1ff3435405e2a4a98",
+    "hint": null,
     "key": "app",
     "type": "salted_component",
     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.053377+00:00'
+created: '2025-09-24T22:53:04.441638+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1155,6 +1155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "5b032559156688c9eabe4e4bd5ae6bd4",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -2309,6 +2310,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "1921b991270e24c19ea1ed6863892d71",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.215420+00:00'
+created: '2025-09-24T22:53:04.464051+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1965,6 +1965,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -2008,6 +2009,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "default",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "default",
     "type": "component"
   },
@@ -3972,6 +3974,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "1959b227a7cf6acf7f3fd401b5d9f09b",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.236287+00:00'
+created: '2025-09-24T22:53:04.485905+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1994,6 +1994,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -2037,6 +2038,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "default",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "default",
     "type": "component"
   },
@@ -4030,6 +4032,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "ef2555bf7958ada8eefafbfdaed1c409",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.181013+00:00'
+created: '2025-09-24T22:53:04.519929+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -68,6 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "10dfd81e2df31e96fae451b9e205ad81",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.157765+00:00'
+created: '2025-09-24T22:53:04.503292+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -68,6 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "b8e2a347e75266ca7bb565e2b3c0722e",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.281712+00:00'
+created: '2025-09-24T22:53:04.537724+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -465,6 +465,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -929,6 +930,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "c0f3f7d6deb17aec9d07259ac684fad0",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.244353+00:00'
+created: '2025-09-24T22:53:04.571873+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -44,6 +44,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "message",
     "hash": "4119639092e62c55ea8be348e4d9260d",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_message_parameterization.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.223992+00:00'
+created: '2025-09-24T22:53:04.554912+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -44,6 +44,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "message",
     "hash": "f9e47f16e3b9770b440157179c47bf7a",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.322962+00:00'
+created: '2025-09-24T22:53:04.588879+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -168,6 +168,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "be36642f41f047346396f018f62375d3",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -335,6 +336,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": "ignored because app exception takes precedence",
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.337301+00:00'
+created: '2025-09-24T22:53:04.611408+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -203,6 +203,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -405,6 +406,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "6ab78545e13144405fb21dadb9045b91",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.351986+00:00'
+created: '2025-09-24T22:53:04.634356+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -395,6 +395,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -789,6 +790,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "c63e8727af1a8fe75872b6a762797113",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.366761+00:00'
+created: '2025-09-24T22:53:04.659667+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -399,6 +399,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -797,6 +798,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "c63e8727af1a8fe75872b6a762797113",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.381518+00:00'
+created: '2025-09-24T22:53:04.681653+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -364,6 +364,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -727,6 +728,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "c63e8727af1a8fe75872b6a762797113",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.395876+00:00'
+created: '2025-09-24T22:53:04.700016+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -413,6 +413,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -825,6 +826,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "b2602ad455472dede8e4c340d8a7eaba",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.410519+00:00'
+created: '2025-09-24T22:53:04.721393+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -417,6 +417,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -833,6 +834,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "b2602ad455472dede8e4c340d8a7eaba",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.424944+00:00'
+created: '2025-09-24T22:53:04.739329+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -382,6 +382,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -763,6 +764,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "b2602ad455472dede8e4c340d8a7eaba",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.442475+00:00'
+created: '2025-09-24T22:53:04.760110+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -444,6 +444,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -887,6 +888,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "b2602ad455472dede8e4c340d8a7eaba",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.459261+00:00'
+created: '2025-09-24T22:53:04.781951+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -428,6 +428,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -855,6 +856,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "c63e8727af1a8fe75872b6a762797113",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.478305+00:00'
+created: '2025-09-24T22:53:04.806697+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -861,6 +861,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "4a3cf3893b6485428dd02da116c8370e",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -1721,6 +1722,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "d5456487ea8dccfe96c1968b19870978",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.495800+00:00'
+created: '2025-09-24T22:53:04.830919+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -718,6 +718,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "4a3cf3893b6485428dd02da116c8370e",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -1435,6 +1436,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "0b81da6ea3d7cc82b1d4825b7aac0b8d",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:19.860032+00:00'
+created: '2025-09-24T22:53:04.875063+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -2167,6 +2167,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "4665d486184740231357ab63f4543a8d",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -4333,6 +4334,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "107ed03036d901157372f260bc3df446",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:19.836386+00:00'
+created: '2025-09-24T22:53:04.849716+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -193,6 +193,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "a728cdf5d62c8e017c35c3fe04051b6e",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -385,6 +386,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "63c67781779781d9b0a442a5b2bdb976",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/logentry_prefers_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/logentry_prefers_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.579619+00:00'
+created: '2025-09-24T22:53:04.896070+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -44,6 +44,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "message",
     "hash": "8ec8bbc71eb6e2af7fbe5076a8534f96",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/logentry_uses_formatted.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/logentry_uses_formatted.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.600117+00:00'
+created: '2025-09-24T22:53:04.912790+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -44,6 +44,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "message",
     "hash": "329b29efcf1f77067a063e34f56e7791",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.574385+00:00'
+created: '2025-09-24T22:53:04.937658+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1584,6 +1584,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -3167,6 +3168,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "b8baf791d22ac902d5f59a7eedd844fd",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.592657+00:00'
+created: '2025-09-24T22:53:04.959577+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1948,6 +1948,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -3895,6 +3896,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "36be6e0b6123ef6ecfbef62f5cb88406",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.609372+00:00'
+created: '2025-09-24T22:53:04.979432+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -825,6 +825,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -1649,6 +1650,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "70b7b816193e06eb5d6649989fbaf605",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_prefers_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_prefers_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.696907+00:00'
+created: '2025-09-24T22:53:05.001047+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -44,6 +44,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "message",
     "hash": "8ec8bbc71eb6e2af7fbe5076a8534f96",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_uses_formatted.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_uses_formatted.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.715952+00:00'
+created: '2025-09-24T22:53:05.021078+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -44,6 +44,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "message",
     "hash": "d3f5e52d24e9c1eae5abe6c866cced63",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_with_key_pair_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.736536+00:00'
+created: '2025-09-24T22:53:05.039736+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -44,6 +44,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "message",
     "hash": "d2ab1028e9cb44352a824e878951f412",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.673115+00:00'
+created: '2025-09-24T22:53:05.058483+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1035,6 +1035,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -2069,6 +2070,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "dcfcd48a02c100bbe4023cbc783054f0",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.688214+00:00'
+created: '2025-09-24T22:53:05.076197+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -162,6 +162,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -323,6 +324,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "9b78cced1eefcd0c655a0a3d8ce2cdd2",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.703152+00:00'
+created: '2025-09-24T22:53:05.102365+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -284,6 +284,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -567,6 +568,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "2e0d26cae5986fcda5edf66612a78268",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.717691+00:00'
+created: '2025-09-24T22:53:05.128330+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -251,6 +251,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -501,6 +502,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "c85e23e804b52ea4b9f290ba838e77a0",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.732822+00:00'
+created: '2025-09-24T22:53:05.148485+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -313,6 +313,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -625,6 +626,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "784442a33bd16c15013bb8f69f68e7d6",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.747252+00:00'
+created: '2025-09-24T22:53:05.166766+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -162,6 +162,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -323,6 +324,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "8f4c7709e4af98d3c47ce3519690e6d9",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.762578+00:00'
+created: '2025-09-24T22:53:05.186943+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -255,6 +255,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -509,6 +510,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "3ff01ce959249abecc6bc8a8f1432b0b",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:23.900918+00:00'
+created: '2025-09-24T22:53:05.205699+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -503,6 +503,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "418120a66f7031923031f5c52aca0724",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -1005,6 +1006,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "bbcdb2e1d8df09ffe0fffd30fb361d4b",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.791546+00:00'
+created: '2025-09-24T22:53:05.223552+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -162,6 +162,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -323,6 +324,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "9b78cced1eefcd0c655a0a3d8ce2cdd2",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.806026+00:00'
+created: '2025-09-24T22:53:05.241099+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -234,6 +234,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -467,6 +468,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "46b84e4da51648cc9f9741abd2bdad51",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.821594+00:00'
+created: '2025-09-24T22:53:05.259368+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -208,6 +208,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -408,6 +409,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "c29439027eafcf7642f641554ab0f0ef",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.836796+00:00'
+created: '2025-09-24T22:53:05.278941+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -491,6 +491,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "a20509269752c9a1bea6078851e4d39c",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -981,6 +982,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "252dc79eb5653bf822e2684d90734cb8",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.851398+00:00'
+created: '2025-09-24T22:53:05.299328+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -137,6 +137,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "be36642f41f047346396f018f62375d3",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -273,6 +274,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": "ignored because app exception takes precedence",
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:20.294724+00:00'
+created: '2025-09-24T22:53:05.319080+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -173,6 +173,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "c52ebcc2d9d0780a23c7d99831678830",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -345,6 +346,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "669cb6664e0f5fed38665da04e464f7e",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.880201+00:00'
+created: '2025-09-24T22:53:05.338001+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -509,6 +509,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "121caa876de75ec51bf72ed4c852cd75",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -1017,6 +1018,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "a5af2577d4caca8f983657c5d1919e14",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.894966+00:00'
+created: '2025-09-24T22:53:05.356287+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -509,6 +509,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -1017,6 +1018,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "90888e813b09fa25061af2883c0fb9bd",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.909751+00:00'
+created: '2025-09-24T22:53:05.373996+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -201,6 +201,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "d59239f5aad3304d60beb1fde3369b78",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -244,6 +245,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "default",
     "hash": null,
+    "hint": "ignored because app/system exception takes precedence",
     "key": "default",
     "type": "component"
   },
@@ -444,6 +446,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "133db3f366b1327dab4e661f66dfb961",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:20.408625+00:00'
+created: '2025-09-24T22:53:05.424477+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -109,6 +109,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "11e6467c8358a9366c6538f95dcd7bd4",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.121057+00:00'
+created: '2025-09-24T22:53:05.391096+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -68,6 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "70dd09f56349dcce62a74137b00bb571",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:20.390956+00:00'
+created: '2025-09-24T22:53:05.408082+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -109,6 +109,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception",
     "hash": "5f209162115f576bedbaf6f0ad30e5aa",
+    "hint": null,
     "key": "app",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.970501+00:00'
+created: '2025-09-24T22:53:05.444807+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1024,6 +1024,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "73470e545e51eea9cff8a6c006f68f57",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -2047,6 +2048,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "ecd413627f0d90a5a25cb28d1ba9c39f",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_cocoa.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.267341+00:00'
+created: '2025-09-24T22:53:05.461267+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -105,6 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app stack-trace",
     "hash": "eb416f98479efa56a77c524602dc9979",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -209,6 +210,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "1df786c8c266506e1acb6669c8df5154",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:40.999128+00:00'
+created: '2025-09-24T22:53:05.478669+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -288,6 +288,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -575,6 +576,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "9bdadae4fa003cef6cf460ff1325e54b",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.322551+00:00'
+created: '2025-09-24T22:53:05.495158+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -105,6 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app stack-trace",
     "hash": "1effb24729ae4c43efa36b460511136a",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -209,6 +210,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "659ad79e2e70c822d30a53d7d889529e",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_discards_seemingly_useless_stack.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_discards_seemingly_useless_stack.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.348654+00:00'
+created: '2025-09-24T22:53:05.512119+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -74,12 +74,14 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": null,
     "key": "app",
     "type": "component"
   },
   "fallback": {
     "description": "fallback",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "hint": null,
     "key": "fallback",
     "type": "fallback"
   },
@@ -153,6 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:41.040675+00:00'
+created: '2025-09-24T22:53:05.529750+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -74,6 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -147,6 +148,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "acbd18db4cc2f85cedef654fccc4a4d8",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_group_different_js_errors.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_group_different_js_errors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.394684+00:00'
+created: '2025-09-24T22:53:05.547372+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -74,12 +74,14 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": null,
     "key": "app",
     "type": "component"
   },
   "fallback": {
     "description": "fallback",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "hint": null,
     "key": "fallback",
     "type": "fallback"
   },
@@ -153,6 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:41.070184+00:00'
+created: '2025-09-24T22:53:05.564976+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -286,6 +286,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -571,6 +572,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "cb57cfc73cc622c2ac1386c9ea531fb9",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:41.084515+00:00'
+created: '2025-09-24T22:53:05.581875+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,6 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -151,6 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "cd2a9fd0cdaa8cd55ed22b101fc65882",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:41.098796+00:00'
+created: '2025-09-24T22:53:05.599318+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -105,6 +105,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app stack-trace",
     "hash": "659ad79e2e70c822d30a53d7d889529e",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -209,6 +210,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": "ignored because app stacktrace takes precedence",
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:41.113543+00:00'
+created: '2025-09-24T22:53:05.617185+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -140,6 +140,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system stacktrace takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -279,6 +280,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "c5da56c71b31f34c5880d734cbc8f5bb",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:41.129056+00:00'
+created: '2025-09-24T22:53:05.635217+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -286,6 +286,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": "ignored because system exception takes precedence",
     "key": "app",
     "type": "component"
   },
@@ -571,6 +572,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "eb87c1031dba55b67df86fb9fff59dc6",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.547655+00:00'
+created: '2025-09-24T22:53:05.653280+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -286,6 +286,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "eb87c1031dba55b67df86fb9fff59dc6",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -571,6 +572,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "cb57cfc73cc622c2ac1386c9ea531fb9",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.571254+00:00'
+created: '2025-09-24T22:53:05.671376+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -286,6 +286,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "eb87c1031dba55b67df86fb9fff59dc6",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -571,6 +572,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "0817e4e604fbe88c4534eff166df1db9",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.595423+00:00'
+created: '2025-09-24T22:53:05.689368+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -415,6 +415,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app stack-trace",
     "hash": "1effb24729ae4c43efa36b460511136a",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -829,6 +830,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "stack-trace",
     "hash": "659ad79e2e70c822d30a53d7d889529e",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/template_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/template_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:52:20.723435+00:00'
+created: '2025-09-24T22:53:05.705552+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -61,6 +61,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "template",
     "hash": "1f5bdebe3c9f414c7dbb4296a8353245",
+    "hint": null,
     "key": "default",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:41.201895+00:00'
+created: '2025-09-24T22:53:05.723099+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -84,6 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app thread stack-trace",
     "hash": "1a11687556cf74559f0ae90b1c87e2fd",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -167,6 +168,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "system",
     "hash": null,
+    "hint": "ignored because app threads take precedence",
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_no_hash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_no_hash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.655707+00:00'
+created: '2025-09-24T22:53:05.739571+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -42,12 +42,14 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app",
     "hash": null,
+    "hint": null,
     "key": "app",
     "type": "component"
   },
   "fallback": {
     "description": "fallback",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "hint": null,
     "key": "fallback",
     "type": "fallback"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unity.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.676192+00:00'
+created: '2025-09-24T22:53:05.757662+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -333,6 +333,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "a12d579fed7636c2a5d2fae110c95ce5",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -665,6 +666,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "c0dbeebf0430b3310ad1f7ceb48553a6",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.699407+00:00'
+created: '2025-09-24T22:53:05.777953+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1061,6 +1061,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "ecb890e5cd60dec2b626d500cc866de4",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -2121,6 +2122,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "57493ac3e558feffb778cf170a7fd986",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.722143+00:00'
+created: '2025-09-24T22:53:05.796685+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -809,6 +809,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "8c134ce2a43a0b2c55654902491307c2",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -1617,6 +1618,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "f203e9bc12df86bb01fbd92a45643f86",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.744750+00:00'
+created: '2025-09-24T22:53:05.817916+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1412,6 +1412,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "c246c95d4a435b3d601044aebae72a38",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -2823,6 +2824,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "d0669f63f03ddaec66ac8b9f4e3e449d",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:41.298127+00:00'
+created: '2025-09-24T22:53:05.847428+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -2851,6 +2851,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "e7a1be23aff9a117598bb893ed4bedb4",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -5701,6 +5702,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "1bba3ace796a07d167af26959c6039c9",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-11T21:20:24.791309+00:00'
+created: '2025-09-24T22:53:05.879181+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1637,6 +1637,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app exception stack-trace",
     "hash": "4717aeb08ff642726ef6ea8f1ce55cdf",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -3273,6 +3274,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "exception stack-trace",
     "hash": "65244b22630821cacd0be603ebcef671",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-19T05:53:41.338300+00:00'
+created: '2025-09-24T22:53:05.906276+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1322,6 +1322,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "in-app thread stack-trace",
     "hash": "54e8028fb2526cf31b12dd66c01ad9e2",
+    "hint": null,
     "key": "app",
     "type": "component"
   },
@@ -1365,6 +1366,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "default",
     "hash": null,
+    "hint": "ignored because app/system threads take precedence",
     "key": "default",
     "type": "component"
   },
@@ -2686,6 +2688,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     },
     "description": "thread stack-trace",
     "hash": "9e04decaf79ecba9dc0314dc0edd3993",
+    "hint": null,
     "key": "system",
     "type": "component"
   }

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.169382+00:00'
+created: '2025-09-25T07:58:54.419340+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -14,8 +14,10 @@ variants:
     component:
       contributes: false
       hint: ignored because built-in fingerprint takes precedence
+    hint: ignored because built-in fingerprint takes precedence
     type: component
   built_in_fingerprint:
+    hint: null
     matched_rule: family:"javascript" type:"ChunkLoadError" -> "chunkloaderror"
     type: built_in_fingerprint
     values:
@@ -24,4 +26,5 @@ variants:
     component:
       contributes: false
       hint: ignored because built-in fingerprint takes precedence
+    hint: ignored because built-in fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_abs_path.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_abs_path.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.204370+00:00'
+created: '2025-09-25T07:58:54.460628+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -21,8 +21,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: type:"DatabaseUnavailable" -> "{{ stack.abs_path }}"
     type: custom_fingerprint
     values:
@@ -31,4 +33,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.325058+00:00'
+created: '2025-09-25T07:58:54.595963+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,6 +20,7 @@ fingerprint:
 title: '{[*?]}'
 variants:
   custom_fingerprint:
+    hint: null
     matched_rule: message:"\{\[\*\?\]\}" -> "escaped{{ message }}"
     type: custom_fingerprint
     values:
@@ -29,4 +30,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.126367+00:00'
+created: '2025-09-25T07:58:54.374424+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -21,11 +21,13 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     client_values:
     - my-route
     - '{{ default }}'
+    hint: null
     matched_rule: type:"DatabaseUnavailable" -> "database-unavailable"
     type: custom_fingerprint
     values:
@@ -34,4 +36,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.418290+00:00'
+created: '2025-09-25T07:58:54.698701+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,11 +23,13 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     client_values:
     - my-route
     - '{{ default }}'
+    hint: null
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable"
     type: custom_fingerprint
     values:
@@ -36,4 +38,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:23.969226+00:00'
+created: '2025-09-25T07:58:54.196971+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,6 +27,7 @@ variants:
     component:
       contributes: true
       hint: null
+    hint: null
     type: salted_component
     values:
     - my-route
@@ -38,6 +39,7 @@ variants:
     component:
       contributes: false
       hint: ignored because app exception takes precedence
+    hint: ignored because app exception takes precedence
     type: salted_component
     values:
     - my-route

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.006948+00:00'
+created: '2025-09-25T07:58:54.245582+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,11 +23,13 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     client_values:
     - my-route
     - '{{ default }}'
+    hint: null
     matched_rule: sdk:"sentry.java" type:"DatabaseUnavailable" -> "database-unavailable"
     type: custom_fingerprint
     values:
@@ -36,4 +38,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.290070+00:00'
+created: '2025-09-25T07:58:54.558415+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,6 +27,7 @@ variants:
     component:
       contributes: true
       hint: null
+    hint: null
     type: salted_component
     values:
     - my-route
@@ -38,6 +39,7 @@ variants:
     component:
       contributes: false
       hint: ignored because app exception takes precedence
+    hint: ignored because app exception takes precedence
     type: salted_component
     values:
     - my-route

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.381487+00:00'
+created: '2025-09-25T07:58:54.657685+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,8 +23,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: value:"*went wrong*" -> "something-went-wrong{{ error.value }}"
     type: custom_fingerprint
     values:
@@ -34,4 +36,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:23.933938+00:00'
+created: '2025-09-25T07:58:54.140761+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -26,8 +26,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       function }}"
     type: custom_fingerprint
@@ -38,4 +40,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.343846+00:00'
+created: '2025-09-25T07:58:54.615540+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,6 +20,7 @@ fingerprint:
 title: Hello my sweet Love
 variants:
   custom_fingerprint:
+    hint: null
     matched_rule: message:"*love*" -> "what-is-love{{ message }}"
     type: custom_fingerprint
     values:
@@ -29,4 +30,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.024728+00:00'
+created: '2025-09-25T07:58:54.267268+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,8 +23,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: message:"*love*" -> "what-is-love{{ message }}"
     type: custom_fingerprint
     values:
@@ -34,4 +36,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.152189+00:00'
+created: '2025-09-25T07:58:54.399370+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,8 +23,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: type:"SymCacheError" function:"symbolicator::actors::symcaches::*"
       -> "symcache-error"
     type: custom_fingerprint
@@ -34,4 +36,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.084533+00:00'
+created: '2025-09-25T07:58:54.330657+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,8 +23,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: function:"symbolicator::actors::symcaches::*" app:"true" -> "symcache-error"
     type: custom_fingerprint
     values:
@@ -33,4 +35,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_non_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_non_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:29.636422+00:00'
+created: '2025-09-25T07:58:54.356898+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,9 +23,11 @@ variants:
     component:
       contributes: true
       hint: null
+    hint: null
     type: component
   system:
     component:
       contributes: true
       hint: null
+    hint: null
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.436876+00:00'
+created: '2025-09-25T07:58:54.719095+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -26,8 +26,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       function }}"
     type: custom_fingerprint
@@ -38,4 +40,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.399568+00:00'
+created: '2025-09-25T07:58:54.678250+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,6 +27,7 @@ variants:
     component:
       contributes: true
       hint: null
+    hint: null
     type: salted_component
     values:
     - my-route
@@ -38,6 +39,7 @@ variants:
     component:
       contributes: false
       hint: ignored because app exception takes precedence
+    hint: ignored because app exception takes precedence
     type: salted_component
     values:
     - my-route

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:23.988697+00:00'
+created: '2025-09-25T07:58:54.219915+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -21,8 +21,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: type:"DatabaseUnavailable" -> "{{ package }}"
     type: custom_fingerprint
     values:
@@ -31,4 +33,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.059149+00:00'
+created: '2025-09-25T07:58:54.305529+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -26,8 +26,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       transaction }}"
     type: custom_fingerprint
@@ -38,4 +40,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:23.864423+00:00'
+created: '2025-09-25T07:58:54.044224+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,8 +25,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: function:"main" -> "{{ type }}{{ module }}{{ function }}"
     type: custom_fingerprint
     values:
@@ -37,4 +39,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.307087+00:00'
+created: '2025-09-25T07:58:54.576424+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -26,6 +26,7 @@ fingerprint:
 title: Love not found.
 variants:
   custom_fingerprint:
+    hint: null
     matched_rule: logger:"sentry.*" level:"ERROR" -> "log-{{ logger }}-{{ level }}"
     type: custom_fingerprint
     values:
@@ -37,4 +38,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.041473+00:00'
+created: '2025-09-25T07:58:54.287081+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -18,6 +18,7 @@ fingerprint:
 title: Es Dee Kay
 variants:
   custom_fingerprint:
+    hint: null
     matched_rule: sdk:"sentry.javascript.nextjs" -> "sdk-nextjs"
     type: custom_fingerprint
     values:
@@ -26,4 +27,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.272566+00:00'
+created: '2025-09-25T07:58:54.537681+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,6 +20,7 @@ fingerprint:
 title: Hello my sweet Love
 variants:
   custom_fingerprint:
+    hint: null
     matched_rule: tags.foobar:"*stuff*" -> "foobar-matched-stuff-{{ tags.barfoo }}"
     type: custom_fingerprint
     values:
@@ -29,4 +30,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:23.951264+00:00'
+created: '2025-09-25T07:58:54.172399+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,6 +20,7 @@ variants:
   custom_fingerprint:
     client_values:
     - client-sent
+    hint: null
     matched_rule: message:"*love*" -> "what-is-love"
     type: custom_fingerprint
     values:
@@ -28,4 +29,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.221657+00:00'
+created: '2025-09-25T07:58:54.478576+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -21,8 +21,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: type:"DatabaseUnavailable" -> "{{ package }}"
     type: custom_fingerprint
     values:
@@ -31,4 +33,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:23.913583+00:00'
+created: '2025-09-25T07:58:54.111619+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -24,8 +24,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: type:"ReadTimeout" path:"**/requests/adapters.py" -> "timeout-in-requests"
     type: custom_fingerprint
     values:
@@ -34,4 +36,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.238693+00:00'
+created: '2025-09-25T07:58:54.496647+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -21,11 +21,13 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     client_values:
     - my-route
     - '{{ default }}'
+    hint: null
     matched_rule: release:"foo.bar@*" -> "foo.bar-release"
     type: custom_fingerprint
     values:
@@ -34,4 +36,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.362823+00:00'
+created: '2025-09-25T07:58:54.635689+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,8 +27,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       transaction }}" title="DatabaseUnavailable ({{ transaction }})"
     type: custom_fingerprint
@@ -39,4 +41,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_two_threads.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_two_threads.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.186835+00:00'
+created: '2025-09-25T07:58:54.438787+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -21,8 +21,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: function:"main" -> "in-main"
     type: custom_fingerprint
     values:
@@ -31,4 +33,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T19:48:24.256043+00:00'
+created: '2025-09-25T07:58:54.514106+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -26,8 +26,10 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
+    hint: null
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "{{ type
       }}{{ module }}"
     type: custom_fingerprint
@@ -38,4 +40,5 @@ variants:
     component:
       contributes: false
       hint: ignored because custom server fingerprint takes precedence
+    hint: ignored because custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -574,6 +574,7 @@ class BuiltInFingerprintingTest(TestCase):
             "values": ["chunkloaderror"],
             "client_values": ["my-route", "{{ default }}"],
             "matched_rule": 'family:"javascript" type:"ChunkLoadError" -> "chunkloaderror"',
+            "hint": None,
         }
 
     def test_built_in_chunkload_rules_value_only(self) -> None:


### PR DESCRIPTION
This adds a `hint` property to both `BaseVariant` and `ComponentVariant`, and in the latter class, uses the root component's hint as the value. This will let us show why certain variants aren't used more prominently in grouping info.