### PR TITLE
ref(alerts): Let UnsubscribeProject call useLocation instead of deprecatedRouteProps

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -213,12 +213,10 @@ function buildRoutes(): RouteObject[] {
       path: '/unsubscribe/project/:id/',
       component: make(() => import('sentry/views/unsubscribe/project')),
       customerDomainOnlyRoute: true,
-      deprecatedRouteProps: true,
     },
     {
       path: '/unsubscribe/:orgId/project/:id/',
       component: make(() => import('sentry/views/unsubscribe/project')),
-      deprecatedRouteProps: true,
     },
     {
       path: '/unsubscribe/issue/:id/',

--- a/static/app/views/unsubscribe/project.spec.tsx
+++ b/static/app/views/unsubscribe/project.spec.tsx
@@ -1,10 +1,8 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import UnsubscribeProject from 'sentry/views/unsubscribe/project';
 
 describe('UnsubscribeProject', () => {
-  const params = {orgId: 'acme', id: '9876'};
   let mockUpdate: jest.Mock;
   let mockGet: jest.Mock;
   beforeEach(() => {

--- a/static/app/views/unsubscribe/project.spec.tsx
+++ b/static/app/views/unsubscribe/project.spec.tsx
@@ -27,16 +27,17 @@ describe('UnsubscribeProject', () => {
   });
 
   it('loads data from the API based on URL parameters', async () => {
-    const {router, routerProps} = initializeOrg({
-      router: {location: {query: {_: 'signature-value'}}, params},
+    render(<UnsubscribeProject />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/unsubscribe/acme/project/9876/',
+          query: {
+            _: 'signature-value',
+          },
+        },
+        route: '/unsubscribe/:orgId/project/:id/',
+      },
     });
-    render(
-      <UnsubscribeProject {...routerProps} location={router.location} params={params} />,
-      {
-        router,
-        deprecatedRouterMocks: true,
-      }
-    );
 
     expect(await screen.findByText('acme / react')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Unsubscribe'})).toBeInTheDocument();
@@ -44,16 +45,17 @@ describe('UnsubscribeProject', () => {
   });
 
   it('makes an API request when the form is submitted', async () => {
-    const {router, routerProps} = initializeOrg({
-      router: {location: {query: {_: 'signature-value'}}, params},
+    render(<UnsubscribeProject />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/unsubscribe/acme/project/9876/',
+          query: {
+            _: 'signature-value',
+          },
+        },
+        route: '/unsubscribe/:orgId/project/:id/',
+      },
     });
-    render(
-      <UnsubscribeProject {...routerProps} location={router.location} params={params} />,
-      {
-        router,
-        deprecatedRouterMocks: true,
-      }
-    );
 
     expect(await screen.findByText('acme / react')).toBeInTheDocument();
     const button = screen.getByRole('button', {name: 'Unsubscribe'});

--- a/static/app/views/unsubscribe/project.tsx
+++ b/static/app/views/unsubscribe/project.tsx
@@ -7,20 +7,14 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NarrowLayout from 'sentry/components/narrowLayout';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
 
-type RouteParams = {
-  id: string;
-  orgId: string;
-};
-
-type Props = RouteComponentProps<RouteParams>;
-
-function UnsubscribeProject({location}: Props) {
+export default function UnsubscribeProject() {
+  const location = useLocation();
   const signature = decodeScalar(location.query._);
   const params = useParams();
   return (
@@ -106,5 +100,3 @@ function UnsubscribeBody({orgSlug, issueId, signature}: BodyProps) {
     </Fragment>
   );
 }
-
-export default UnsubscribeProject;


### PR DESCRIPTION
Related to https://github.com/getsentry/frontend-tsc/issues/93