### PR TITLE
ref(alerts): Let UnsubscribeIssue call useLocation instead of deprecatedRouteProps

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -224,12 +224,10 @@ function buildRoutes(): RouteObject[] {
       path: '/unsubscribe/issue/:id/',
       component: make(() => import('sentry/views/unsubscribe/issue')),
       customerDomainOnlyRoute: true,
-      deprecatedRouteProps: true,
     },
     {
       path: '/unsubscribe/:orgId/issue/:id/',
       component: make(() => import('sentry/views/unsubscribe/issue')),
-      deprecatedRouteProps: true,
     },
     {
       path: '/organizations/new/',

--- a/static/app/views/unsubscribe/issue.spec.tsx
+++ b/static/app/views/unsubscribe/issue.spec.tsx
@@ -1,10 +1,8 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import UnsubscribeIssue from 'sentry/views/unsubscribe/issue';
 
 describe('UnsubscribeIssue', () => {
-  const params = {orgId: 'acme', id: '9876'};
   let mockUpdate: jest.Mock;
   let mockGet: jest.Mock;
 
@@ -27,19 +25,15 @@ describe('UnsubscribeIssue', () => {
   });
 
   it('loads data from the API based on URL parameters', async () => {
-    const {router, routerProps} = initializeOrg({
-      router: {
-        location: {query: {_: 'signature-value'}},
-        params,
+    render(<UnsubscribeIssue />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/unsubscribe/acme/issue/9876/',
+          query: {_: 'signature-value'},
+        },
+        route: '/unsubscribe/:orgId/issue/:id/',
       },
     });
-    render(
-      <UnsubscribeIssue {...routerProps} location={router.location} params={params} />,
-      {
-        router,
-        deprecatedRouterMocks: true,
-      }
-    );
 
     expect(await screen.findByText('selected issue')).toBeInTheDocument();
     expect(screen.getByText('workflow notifications')).toBeInTheDocument();
@@ -48,19 +42,15 @@ describe('UnsubscribeIssue', () => {
   });
 
   it('makes an API request when the form is submitted', async () => {
-    const {router, routerProps} = initializeOrg({
-      router: {
-        location: {query: {_: 'signature-value'}},
-        params,
+    render(<UnsubscribeIssue />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/unsubscribe/acme/issue/9876/',
+          query: {_: 'signature-value'},
+        },
+        route: '/unsubscribe/:orgId/issue/:id/',
       },
     });
-    render(
-      <UnsubscribeIssue {...routerProps} location={router.location} params={params} />,
-      {
-        router,
-        deprecatedRouterMocks: true,
-      }
-    );
 
     expect(await screen.findByText('selected issue')).toBeInTheDocument();
     const button = screen.getByRole('button', {name: 'Unsubscribe'});

--- a/static/app/views/unsubscribe/issue.tsx
+++ b/static/app/views/unsubscribe/issue.tsx
@@ -8,20 +8,14 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NarrowLayout from 'sentry/components/narrowLayout';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
 
-type RouteParams = {
-  id: string;
-  orgId: string;
-};
-
-type Props = RouteComponentProps<RouteParams>;
-
-function UnsubscribeIssue({location}: Props) {
+function UnsubscribeIssue() {
+  const location = useLocation();
   const signature = decodeScalar(location.query._);
   const params = useParams();
   return (


### PR DESCRIPTION
Related to https://github.com/getsentry/frontend-tsc/issues/93
