### PR TITLE
fix(replay): pass correct field param to index endpoint

### DIFF
--- a/static/app/utils/replays/hooks/useReplayListQueryKey.tsx
+++ b/static/app/utils/replays/hooks/useReplayListQueryKey.tsx
@@ -61,7 +61,7 @@ export default function useReplayListQueryKey({
         query: {
           per_page: 50,
           ...query,
-          fields,
+          field: fields, // Passed as multiple params, e.g. field=a&field=b
           project,
           queryReferrer,
         },


### PR DESCRIPTION
Redo of https://github.com/getsentry/sentry/pull/99942.

Depends on https://github.com/getsentry/sentry/pull/100210

Closes https://linear.app/getsentry/issue/REPLAY-721/unread-dot-not-clearing-after-viewing-replay-session
Closes https://linear.app/getsentry/issue/REPLAY-718/update-replay-index-page-to-use-field-instead-of-fields

Endpoint that uses this: https://github.com/getsentry/sentry/blob/ca9bb26f8e7e4060a4ebc79e820ea3841d000d1e/src/sentry/replays/endpoints/organization_replay_index.py#L101