### PR TITLE
ref(feedback): metric for 'too few feedbacks to summarize'

### DIFF
--- a/src/sentry/feedback/endpoints/organization_feedback_summary.py
+++ b/src/sentry/feedback/endpoints/organization_feedback_summary.py
@@ -20,7 +20,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.organization import Organization
 from sentry.seer.seer_setup import has_seer_access
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
-from sentry.utils import json
+from sentry.utils import json, metrics
 from sentry.utils.cache import cache
 
 logger = logging.getLogger(__name__)
@@ -136,8 +136,9 @@ class OrganizationFeedbackSummaryEndpoint(OrganizationEndpoint):
             :MAX_FEEDBACKS_TO_SUMMARIZE
         ]
 
-        if groups.count() < MIN_FEEDBACKS_TO_SUMMARIZE:
-            logger.error("Too few feedbacks to summarize")
+        group_count = groups.count()
+        if group_count < MIN_FEEDBACKS_TO_SUMMARIZE:
+            metrics.distribution("feedback.summary.too_few_feedbacks", group_count)
             return Response(
                 {
                     "summary": None,


### PR DESCRIPTION
Emit a metric instead of an error log for the too few feedbacks case. We don't need to be pinged whenever this happens, it's to be expected for small projects
todo - add to dd

Closes [SENTRY-41SD](https://sentry.sentry.io/issues/6686857096/events/aab35005b83147829c56f5f911768310/)