### PR TITLE
chore: feature.organizations:performance-onboarding-checklist is enabled by default

### DIFF
--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -226,15 +226,6 @@ export function getOnboardingTasks({
       skippable: true,
       actionType: 'action',
       action: router => {
-        // Use `features?.` because getsentry has a different `Organization` type/payload
-        if (!organization.features?.includes('performance-onboarding-checklist')) {
-          window.open(
-            'https://docs.sentry.io/product/performance/getting-started/',
-            '_blank'
-          );
-          return;
-        }
-
         // TODO: add analytics here for this specific action.
 
         if (!projects) {

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -210,19 +210,14 @@ export function LegacyOnboarding({organization, project}: OnboardingProps) {
 
   const {projectsForOnboarding} = filterProjects(projects);
 
-  const showOnboardingChecklist = organization.features.includes(
-    'performance-onboarding-checklist'
-  );
-
   useEffect(() => {
     if (
-      showOnboardingChecklist &&
       location.hash === '#performance-sidequest' &&
       projectsForOnboarding.some(p => p.id === project.id)
     ) {
       OnboardingDrawerStore.open(OnboardingDrawerKey.PERFORMANCE_ONBOARDING);
     }
-  }, [location.hash, projectsForOnboarding, project.id, showOnboardingChecklist]);
+  }, [location.hash, projectsForOnboarding, project.id]);
 
   function handleAdvance(step: number, duration: number) {
     trackAnalytics('performance_views.tour.advance', {
@@ -257,7 +252,7 @@ export function LegacyOnboarding({organization, project}: OnboardingProps) {
     </LinkButton>
   );
 
-  if (hasPerformanceOnboarding && showOnboardingChecklist) {
+  if (hasPerformanceOnboarding) {
     setupButton = (
       <Button
         priority="primary"


### PR DESCRIPTION
The flag is enabled by default for all: https://github.com/getsentry/sentry-options-automator/blob/main/options/default/flagpole.yaml#L1504

So first we'll remove the FE checks, then later we can cleanup the backend machinery