### PR TITLE
chore: feature.organizations:performance-span-histogram-view is enabled by default

### DIFF
--- a/src/sentry/api/endpoints/organization_events_spans_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_spans_histogram.py
@@ -3,7 +3,6 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
@@ -42,15 +41,7 @@ class OrganizationEventsSpansHistogramEndpoint(OrganizationEventsV2EndpointBase)
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def has_feature(self, organization, request):
-        return features.has(
-            "organizations:performance-span-histogram-view", organization, actor=request.user
-        )
-
     def get(self, request: Request, organization: Organization) -> Response:
-        if not self.has_feature(organization, request):
-            return Response(status=404)
-
         try:
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2024,7 +2024,6 @@ SENTRY_EARLY_FEATURES = {
     "organizations:performance-metrics-backed-transaction-summary": "Enable metrics-backed transaction summary view",
     "organizations:performance-new-trends": "Enable new trends",
     "organizations:performance-new-widget-designs": "Enable updated landing page widget designs",
-    "organizations:performance-span-histogram-view": "Enable histogram view in span details",
     "organizations:performance-transaction-name-only-search-indexed": "Enable transaction name only search on indexed",
     "organizations:profiling-global-suspect-functions": "Enable global suspect functions in profiling",
     "organizations:user-feedback-ui": "Enable User Feedback v2 UI",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -264,8 +264,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-queries-mongodb-extraction", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable removing the fallback for metrics compatibility
     manager.add("organizations:performance-remove-metrics-compatibility-fallback", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable histogram view in span details
-    manager.add("organizations:performance-span-histogram-view", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable trace explorer features
     manager.add("organizations:performance-trace-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable sentry convention fields

--- a/tests/snuba/api/endpoints/test_organization_events_spans_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_histogram.py
@@ -9,7 +9,6 @@ from sentry.utils.samples import load_data
 
 
 class OrganizationEventsSpansHistogramEndpointTest(APITestCase, SnubaTestCase):
-    FEATURES = ["organizations:performance-span-histogram-view"]
     URL = "sentry-api-0-organization-events-spans-histogram"
 
     def setUp(self) -> None:
@@ -61,19 +60,8 @@ class OrganizationEventsSpansHistogramEndpointTest(APITestCase, SnubaTestCase):
     def format_span(self, op, group) -> str:
         return f"{op}:{group}"
 
-    def do_request(self, query, with_feature=True):
-        features = self.FEATURES if with_feature else []
-        with self.feature(features):
-            return self.client.get(self.url, query, format="json")
-
-    def test_no_feature(self) -> None:
-        query = {
-            "projects": [-1],
-            "span": self.format_span("django.middleware", "2b9cbb96dbf59baa"),
-            "numBuckets": 50,
-        }
-        response = self.do_request(query, False)
-        assert response.status_code == 404
+    def do_request(self, query):
+        return self.client.get(self.url, query, format="json")
 
     def test_no_projects(self) -> None:
         query = {


### PR DESCRIPTION
This is enabled for all: https://github.com/getsentry/sentry-options-automator/pull/5276