### PR TITLE
chore: Remove some disabled features

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2019,7 +2019,6 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 SENTRY_EARLY_FEATURES = {
     "organizations:anr-analyze-frames": "Enable anr frame analysis",
     "organizations:device-classification": "Enable device.class as a selectable column",
-    "organizations:gitlab-disable-on-broken": "Enable disabling gitlab integrations when broken is detected",
     "organizations:mobile-cpu-memory-in-transactions": "Display CPU and memory metrics in transactions with profiles",
     "organizations:performance-metrics-backed-transaction-summary": "Enable metrics-backed transaction summary view",
     "organizations:performance-new-trends": "Enable new trends",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -48,8 +48,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
 
     # Enables alert creation on indexed events in UI (use for PoC/testing only)
     manager.add("organizations:alert-allow-indexed", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Use metrics as the dataset for crash free metric alerts
-    manager.add("organizations:alert-crash-free-metrics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable anomaly detection feature for EAP spans
     manager.add("organizations:anomaly-detection-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable anr frame analysis
@@ -152,8 +150,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:gen-ai-explore-traces-consent-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GenAI consent
     manager.add("organizations:gen-ai-consent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable disabling gitlab integrations when broken is detected
-    manager.add("organizations:gitlab-disable-on-broken", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable increased issue_owners rate limit for auto-assignment
     manager.add("organizations:increased-issue-owners-rate-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Starfish: extract metrics from the spans

--- a/static/app/views/alerts/wizard/index.spec.tsx
+++ b/static/app/views/alerts/wizard/index.spec.tsx
@@ -11,12 +11,7 @@ describe('AlertWizard', () => {
   it('sets crash free dataset to metrics', async () => {
     const {organization, project, routerProps, router} = initializeOrg({
       organization: {
-        features: [
-          'alert-crash-free-metrics',
-          'incidents',
-          'performance-view',
-          'crash-rate-alerts',
-        ],
+        features: ['incidents', 'performance-view', 'crash-rate-alerts'],
         access: ['org:write', 'alerts:write'],
       },
     });
@@ -51,7 +46,6 @@ describe('AlertWizard', () => {
     const {organization, project, routerProps, router} = initializeOrg({
       organization: {
         features: [
-          'alert-crash-free-metrics',
           'incidents',
           'performance-view',
           'crash-rate-alerts',
@@ -89,12 +83,7 @@ describe('AlertWizard', () => {
     ConfigStore.set('isSelfHostedErrorsOnly', true);
     const {organization, project, routerProps, router} = initializeOrg({
       organization: {
-        features: [
-          'alert-crash-free-metrics',
-          'incidents',
-          'performance-view',
-          'crash-rate-alerts',
-        ],
+        features: ['incidents', 'performance-view', 'crash-rate-alerts'],
         access: ['org:write', 'alerts:write'],
       },
     });
@@ -120,13 +109,7 @@ describe('AlertWizard', () => {
   it('shows uptime alert according to feature flag', () => {
     const {organization, project, routerProps, router} = initializeOrg({
       organization: {
-        features: [
-          'alert-crash-free-metrics',
-          'incidents',
-          'performance-view',
-          'crash-rate-alerts',
-          'uptime',
-        ],
+        features: ['incidents', 'performance-view', 'crash-rate-alerts', 'uptime'],
         access: ['org:write', 'alerts:write'],
       },
     });
@@ -151,7 +134,6 @@ describe('AlertWizard', () => {
     const {organization, project, routerProps, router} = initializeOrg({
       organization: {
         features: [
-          'alert-crash-free-metrics',
           'incidents',
           'performance-view',
           'crash-rate-alerts',
@@ -185,7 +167,6 @@ describe('AlertWizard', () => {
     const {organization, project, routerProps, router} = initializeOrg({
       organization: {
         features: [
-          'alert-crash-free-metrics',
           'incidents',
           'performance-view',
           'crash-rate-alerts',
@@ -216,7 +197,6 @@ describe('AlertWizard', () => {
     const {organization, project, routerProps, router} = initializeOrg({
       organization: {
         features: [
-          'alert-crash-free-metrics',
           'incidents',
           'performance-view',
           'visibility-explore-view',
@@ -246,7 +226,6 @@ describe('AlertWizard', () => {
     const {organization, project, routerProps, router} = initializeOrg({
       organization: {
         features: [
-          'alert-crash-free-metrics',
           'incidents',
           'performance-view',
           'crash-rate-alerts',


### PR DESCRIPTION
Removes 4 features that had `enabled: false` in their definitions and not much code in sentry/getsentry.
- promotion-mobperf-discount20
- gitlab-disable-on-broken
- alert-crash-free-metrics
- promotion-mobperf-gift50kerr

Related to https://github.com/getsentry/sentry-options-automator/pull/5277
Related to https://github.com/getsentry/getsentry/pull/18485