### PR TITLE
chore(launchpad): [admin] add better error handling for artifact download

### DIFF
--- a/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
+++ b/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
@@ -88,7 +88,7 @@ export function useBuildDetailsActions({
           try {
             errorJson = JSON.parse(errorText);
           } catch {
-            errorMessage = errorText || errorMessage;
+            addErrorMessage(t('Download failed: %s', errorText || errorMessage));
             return;
           }
 


### PR DESCRIPTION
The attempt to download artifacts would sometimes fail and so far the main reason is that our session needs to be re-authenticated to verify staff access. Currently there is no UI showing the error from server. This adds it to make the issue more clear