### PR TITLE
ref(suspect-commits): split github graphql queries by repo

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3493,3 +3493,10 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "github.blame-queries.batch-by-repo-rollout",
+    default=0.0,
+    type=Float,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
We're seeing GraphQL timeouts when trying to retrieve suspect commit blames from github. Since [github has a 10 second timeout](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api#timeouts), we either want to retrieve less from github or split up our query into separate requests. This takes the latter approach, and does a graphql query by repo.

See https://sentry.sentry.io/issues/6879549779/events/176025af83e8467880c4693949413ead