### PR TITLE
test(relay): Fix Relay container shutdown

### DIFF
--- a/src/sentry/testutils/pytest/template/config.yml
+++ b/src/sentry/testutils/pytest/template/config.yml
@@ -7,6 +7,8 @@ relay:
 logging:
   level: TRACE
   enable_backtraces: true
+limits:
+  shutdown_timeout: 0
 processing:
   enabled: true
   kafka_config:


### PR DESCRIPTION
Essentially reverts #95729, the fix was not correct for multiple reasons:

- Relay's shutdown limit is > 10 seconds, it would always kill. Running 69 tests results in more than 11 minutes of additional runtime for tests!
- The `relay_server_setup` fixture *already* had a builtin shutdown
- The new code ignored the `RELAY_TEST_KEEP_CONTAINER` setting

This now adds a graceful shutdown path to `_remove_container_if_exists` and configures the shutdown limit for Relay.

It addresses this regression:
<img width="1075" height="232" alt="image" src="https://github.com/user-attachments/assets/03120999-3794-463b-9d50-c3e8643d7dca" />
