### PR TITLE
ref(ui): Update unreachable comment

### DIFF
--- a/static/app/utils/unreachable.tsx
+++ b/static/app/utils/unreachable.tsx
@@ -9,7 +9,7 @@
  *     case 'foo':
  *       break;
  *     default:
- *       return assertUnreachable(x); <-- this will throw a type error as x can still be 'bar'
+ *       return unreachable(x); <-- this will cause a type error as x can still be 'bar'
  *   }
  * }
  * ```


### PR DESCRIPTION
Two small changes to the docs for `unreachable`:
- Rename assertUnreachable to unreachable matching the function
- Change throw to cause to avoid confusion with JS runtime TypeError
