### PR TITLE
chore(checkout v3): More copy tweaks + analytics

### DIFF
--- a/static/gsApp/hooks/rootRoutes.tsx
+++ b/static/gsApp/hooks/rootRoutes.tsx
@@ -7,8 +7,7 @@ import OrganizationSubscriptionContext from 'getsentry/components/organizationSu
 const rootRoutes = (): SentryRouteObject => ({
   children: [
     {
-      // TODO(checkout v3): change this to the correct path (/settings/billing/checkout/)
-      // when GA'd
+      // TODO(checkout v3): rename this to /checkout/ when the legacy checkout route is removed
       path: '/checkout-v3/',
       component: errorHandler(OrganizationSubscriptionContext),
       deprecatedRouteProps: true,

--- a/static/gsApp/utils/trackGetsentryAnalytics.tsx
+++ b/static/gsApp/utils/trackGetsentryAnalytics.tsx
@@ -84,6 +84,7 @@ type GetsentryEventParameters = {
   'checkout.data_slider_changed': {data_type: string; quantity: number} & CheckoutUI;
   // no sub here;
   'checkout.data_sliders_viewed': Record<PropertyKey, unknown> & CheckoutUI;
+  // only used for checkout v3
   'checkout.exit': HasSub;
   'checkout.ondemand_budget.turned_off': Record<PropertyKey, unknown> & CheckoutUI;
   'checkout.ondemand_budget.update': OnDemandBudgetUpdate & CheckoutUI;
@@ -109,7 +110,7 @@ type GetsentryEventParameters = {
   'checkout.upgrade': Partial<
     Record<DataCategory | `previous_${DataCategory}`, number | undefined>
   > & {previous_plan: string} & Checkout &
-    CheckoutUI; // only used for checkout v3
+    CheckoutUI;
   'data_consent_modal.learn_more': Record<PropertyKey, unknown>;
   'data_consent_priority.viewed': Record<PropertyKey, unknown>;
   'data_consent_settings.updated': {setting: string; value: FieldValue};

--- a/static/gsApp/utils/trackGetsentryAnalytics.tsx
+++ b/static/gsApp/utils/trackGetsentryAnalytics.tsx
@@ -84,6 +84,7 @@ type GetsentryEventParameters = {
   'checkout.data_slider_changed': {data_type: string; quantity: number} & CheckoutUI;
   // no sub here;
   'checkout.data_sliders_viewed': Record<PropertyKey, unknown> & CheckoutUI;
+  'checkout.exit': HasSub;
   'checkout.ondemand_budget.turned_off': Record<PropertyKey, unknown> & CheckoutUI;
   'checkout.ondemand_budget.update': OnDemandBudgetUpdate & CheckoutUI;
   'checkout.ondemand_changed': {cents: number} & Checkout;
@@ -108,7 +109,7 @@ type GetsentryEventParameters = {
   'checkout.upgrade': Partial<
     Record<DataCategory | `previous_${DataCategory}`, number | undefined>
   > & {previous_plan: string} & Checkout &
-    CheckoutUI;
+    CheckoutUI; // only used for checkout v3
   'data_consent_modal.learn_more': Record<PropertyKey, unknown>;
   'data_consent_priority.viewed': Record<PropertyKey, unknown>;
   'data_consent_settings.updated': {setting: string; value: FieldValue};
@@ -290,6 +291,7 @@ const getsentryEventMap: Record<GetsentryEventKey, string> = {
   'checkout.click_continue': 'Checkout: Click Continue',
   'checkout.data_slider_changed': 'Checkout: Data Slider Changed',
   'checkout.data_sliders_viewed': 'Checkout: Data Slider Viewed',
+  'checkout.exit': 'Checkout: Back to Subscription Overview',
   'checkout.upgrade': 'Application: Upgrade',
   'checkout.updated_cc': 'Checkout: Updated CC',
   'checkout.updated_billing_details': 'Checkout: Updated billing details',

--- a/static/gsApp/views/amCheckout/cart.spec.tsx
+++ b/static/gsApp/views/amCheckout/cart.spec.tsx
@@ -146,7 +146,7 @@ describe('Cart', () => {
 
     // PAYG-only categories are also shown for paid plans
     expect(planItem).toHaveTextContent('Continuous profile hours');
-    expect(planItem).toHaveTextContent('Available with PAYG');
+    expect(planItem).toHaveTextContent('Available');
 
     const seerItem = screen.getByTestId('summary-item-product-seer');
     expect(seerItem).toHaveTextContent('Seer');

--- a/static/gsApp/views/amCheckout/cart.tsx
+++ b/static/gsApp/views/amCheckout/cart.tsx
@@ -204,20 +204,18 @@ function ItemsSummary({activePlan, formData}: ItemsSummaryProps) {
                   ) : (
                     isPaygOnly &&
                     (hasPaygForCategory ? (
-                      <Tag>
-                        {tct('Available with [budgetTerm]', {
-                          budgetTerm:
-                            activePlan.budgetTerm === 'pay-as-you-go'
-                              ? t('PAYG')
-                              : activePlan.budgetTerm,
-                        })}
-                      </Tag>
+                      <Tag>{t('Available')}</Tag>
                     ) : (
                       <Tooltip
                         title={t('This product is only available with a PAYG budget.')}
                       >
                         <Tag icon={<IconLock locked size="xs" />}>
-                          {t('Product not available')}
+                          {tct('Unlock with [budgetTerm]', {
+                            budgetTerm:
+                              activePlan.budgetTerm === 'pay-as-you-go'
+                                ? t('PAYG')
+                                : activePlan.budgetTerm,
+                          })}
                         </Tag>
                       </Tooltip>
                     ))

--- a/static/gsApp/views/amCheckout/cartDiff.tsx
+++ b/static/gsApp/views/amCheckout/cartDiff.tsx
@@ -105,7 +105,8 @@ function PlanDiff({
           }
           let formattingFunction = (value: any) => value;
           if (key === 'plan' || key === 'contractInterval') {
-            formattingFunction = (value: any) => (value ? capitalize(value) : null);
+            formattingFunction = (value: any) =>
+              value === 'annual' ? t('Yearly') : value ? capitalize(value) : null;
           } else {
             formattingFunction = (value: any) =>
               value

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -140,11 +140,13 @@ class AMCheckout extends Component<Props, State> {
     ) {
       props.onToggleLegacy(props.subscription.planTier);
     }
-    // TODO(checkout v3): remove these checks once checkout v3 is GA'd
+    // TODO(checkout v3): remove these checks once checkout v3 is GA'd and we remove the legacy checkout route
     if (props.location?.pathname.includes('checkout-v3') && !props.isNewCheckout) {
-      props.navigate(`/settings/${props.organization.slug}/billing/checkout/`);
+      props.navigate(`/settings/${props.organization.slug}/billing/checkout/`, {
+        replace: true,
+      });
     } else if (!props.location?.pathname.includes('checkout-v3') && props.isNewCheckout) {
-      props.navigate(`/checkout-v3/`);
+      props.navigate(`/checkout-v3/`, {replace: true});
     }
     let step = 1;
     if (props.location?.hash) {

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -904,6 +904,12 @@ class AMCheckout extends Component<Props, State> {
             <BackButton
               aria-label={t('Back to Subscription Overview')}
               to={`/settings/${organization.slug}/billing/`}
+              onClick={() => {
+                trackGetsentryAnalytics('checkout.exit', {
+                  subscription,
+                  organization,
+                });
+              }}
             >
               <Flex gap="sm" align="center">
                 <IconArrow direction="left" />

--- a/static/gsApp/views/amCheckout/planFeatures.tsx
+++ b/static/gsApp/views/amCheckout/planFeatures.tsx
@@ -63,6 +63,48 @@ const FEATURES: Array<{features: string[]; plan: string}> = [
   },
 ];
 
+// TODO(isabella): Remove this once we've actually surfaced the free plan
+const MODIFIED_FEATURES: Array<{features: string[]; plan: string}> = [
+  {
+    plan: 'developer',
+    features: [
+      t('Unlimited users'),
+      t('50K errors'),
+      t('5GB of logs'),
+      t('5M spans'),
+      t('50 replays'),
+      t('1 cron monitor'),
+      t('1 uptime monitor'),
+      t('1GB of attachments'),
+      t('20 metric alerts'),
+    ],
+  },
+  {
+    plan: 'team',
+    features: [
+      t('Access to UI and Continuous Profiling'),
+      t('Can add event volume to subscription'),
+      t('Third-party integrations'),
+      t('20 custom dashboards'),
+      t('Seer: AI debugging agent (subscription required)'),
+      t('Single Sign-On'),
+      t('Up to 90 day retention'),
+    ],
+  },
+  {
+    plan: 'business',
+    features: [
+      t('Insights (90-day lookback)'),
+      t('Unlimited custom dashboards'),
+      t('Unlimited metric alerts'),
+      t('Advanced quota management'),
+      t('Code Owners support'),
+      t('SAML + SCIM support'),
+      t('BAA'),
+    ],
+  },
+];
+
 function FeatureItem({feature, isIncluded}: {feature: string; isIncluded: boolean}) {
   return (
     <FeatureItemContainer isIncluded={isIncluded} align="start" gap="md">
@@ -104,9 +146,9 @@ function PlanFeatures({
   planOptionsWithFree.forEach((planOption, index) => {
     const planName = planOption.name.toLowerCase();
     const priorPlan = index > 0 ? planOptionsWithFree[index - 1] : null;
-    const featureList = FEATURES.filter(({plan}) => planName.includes(plan)).flatMap(
-      ({features}) => features
-    );
+    const featureList = (planOptions.length >= 3 ? FEATURES : MODIFIED_FEATURES)
+      .filter(({plan}) => planName.includes(plan))
+      .flatMap(({features}) => features);
     const perUnitPriceDiffs =
       !priorPlan || priorPlan?.basePrice === 0
         ? {}
@@ -167,7 +209,7 @@ function PlanFeatures({
                 <EventPriceWarning isIncluded={isIncluded} align="center" gap="sm">
                   <IconWarning size="sm" color="yellow300" />
                   <Tooltip
-                    title={tct('Starting at [priceDiffs] on [planName].', {
+                    title={tct('Starting at [priceDiffs] more on [planName].', {
                       priceDiffs: oxfordizeArray(
                         Object.entries(perUnitPriceDiffs).map(([category, diff]) => {
                           const formattedDiff = displayUnitPrice({cents: diff});


### PR DESCRIPTION
Changes:
- Added analytics for exiting checkout via `Back` button
- Copy tweak for PAYG-only category warnings in cart
- `Annual` --> `Yearly`
- Modified how features are presented when `Developer` is not surfaced in checkout
- Copy tweak for excess usage pricing warning
- Changed navigation behavior when flag is on to replace URL