### PR TITLE
fix(ui2): Alert.Button which has a fixed size

### DIFF
--- a/static/app/components/core/alert/index.mdx
+++ b/static/app/components/core/alert/index.mdx
@@ -15,7 +15,6 @@ resources:
 import {Alert} from 'sentry/components/core/alert';
 import {AlertLink} from 'sentry/components/core/alert/alertLink';
 import {Badge} from 'sentry/components/core/badge';
-import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
 import {IconAdd, IconDelete, IconEdit, IconMail} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
@@ -169,7 +168,7 @@ You can control the initial expansion state of alerts with the `defaultExpanded`
 
 ### Trailing Items
 
-Add interactive elements like buttons, links or badges to the right side of alerts using the `trailingItems` prop.
+Add interactive elements like buttons, links or badges to the right side of alerts using the `trailingItems` prop. Note that for buttons, the standardized `<Alert.Button>` component should be used because it handles sizing correctly.
 
 <Storybook.Demo>
   <Alert.Container>
@@ -180,12 +179,12 @@ Add interactive elements like buttons, links or badges to the right side of aler
       type="error"
       trailingItems={
         <Flex gap="sm">
-          <Button size="zero" priority="danger" icon={<IconDelete />}>
+          <Alert.Button priority="danger" icon={<IconDelete />}>
             Delete
-          </Button>
-          <Button size="zero" priority="muted" icon={<IconEdit />}>
+          </Alert.Button>
+          <Alert.Button priority="muted" icon={<IconEdit />}>
             Edit
-          </Button>
+          </Alert.Button>
         </Flex>
       }
     >
@@ -197,11 +196,7 @@ Add interactive elements like buttons, links or badges to the right side of aler
 <Alert.Container>
   <Alert
     type="info"
-    trailingItems={
-      <Button size="zero" priority="primary">
-        Take Action
-      </Button>
-    }
+    trailingItems={<Alert.Button priority="primary">Take Action</Alert.Button>}
   >
     This alert has a trailing badge
   </Alert>
@@ -209,12 +204,12 @@ Add interactive elements like buttons, links or badges to the right side of aler
     type="error"
     trailingItems={
       <Flex gap="sm">
-        <Button size="zero" priority="danger" icon={<IconDelete />}>
+        <Alert.Button priority="danger" icon={<IconDelete />}>
           Delete
-        </Button>
-        <Button size="zero" priority="muted" icon={<IconEdit />}>
+        </Alert.Button>
+        <Alert.Button priority="muted" icon={<IconEdit />}>
           Edit
-        </Button>
+        </Alert.Button>
       </Flex>
     }
   >

--- a/static/app/components/core/alert/index.tsx
+++ b/static/app/components/core/alert/index.tsx
@@ -332,7 +332,7 @@ type DistributiveOmit<TObject, TKey extends keyof TObject> = TObject extends any
 
 function AlertButton(props: DistributiveOmit<ButtonProps, 'size'>) {
   const theme = useTheme();
-  return <Button size={theme.isChonk ? 'zero' : 'sm'} {...props} />;
+  return <Button {...props} size={theme.isChonk ? 'zero' : 'sm'} />;
 }
 
 Alert.Button = AlertButton;

--- a/static/app/components/core/alert/index.tsx
+++ b/static/app/components/core/alert/index.tsx
@@ -1,11 +1,10 @@
 import {Fragment, useRef, useState} from 'react';
-import type {Theme} from '@emotion/react';
-import {css} from '@emotion/react';
+import {css, useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useHover} from '@react-aria/interactions';
 import classNames from 'classnames';
 
-import {Button} from 'sentry/components/core/button';
+import {Button, type ButtonProps} from 'sentry/components/core/button';
 import {IconCheckmark, IconChevron, IconInfo, IconNot, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -326,3 +325,14 @@ const Container = styled('div')`
 `;
 
 Alert.Container = Container;
+
+type DistributiveOmit<TObject, TKey extends keyof TObject> = TObject extends any
+  ? Omit<TObject, TKey>
+  : never;
+
+function AlertButton(props: DistributiveOmit<ButtonProps, 'size'>) {
+  const theme = useTheme();
+  return <Button size={theme.isChonk ? 'zero' : 'sm'} {...props} />;
+}
+
+Alert.Button = AlertButton;

--- a/static/app/components/core/alert/index.tsx
+++ b/static/app/components/core/alert/index.tsx
@@ -326,7 +326,7 @@ const Container = styled('div')`
 
 Alert.Container = Container;
 
-type DistributiveOmit<TObject, TKey extends keyof TObject> = TObject extends any
+type DistributiveOmit<TObject, TKey extends keyof TObject> = TObject extends unknown
   ? Omit<TObject, TKey>
   : never;
 

--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -1,8 +1,8 @@
 import type {ErrorInfo} from 'react';
 import {Component, Suspense} from 'react';
-import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
+import {Container, Flex} from 'sentry/components/core/layout';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
@@ -42,9 +42,9 @@ function LazyLoad<C extends React.LazyExoticComponent<any>>({
       <Suspense
         fallback={
           loadingFallback ?? (
-            <LoadingContainer>
+            <Flex flex="1" align="center">
               <LoadingIndicator />
-            </LoadingContainer>
+            </Flex>
           )
         }
       >
@@ -120,28 +120,18 @@ class ErrorBoundary extends Component<{children: React.ReactNode}, ErrorBoundary
   handleRetry = () => this.setState({hasError: false});
 
   render() {
-    if (this.state.hasError) {
+    if (!this.state.hasError) {
       return (
-        <LoadingErrorContainer>
+        <Container flex="1">
           <LoadingError
             onRetry={this.handleRetry}
             message={t('There was an error loading a component.')}
           />
-        </LoadingErrorContainer>
+        </Container>
       );
     }
     return this.props.children;
   }
 }
-
-const LoadingContainer = styled('div')`
-  display: flex;
-  flex: 1;
-  align-items: center;
-`;
-
-const LoadingErrorContainer = styled('div')`
-  flex: 1;
-`;
 
 export default LazyLoad;

--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -120,7 +120,7 @@ class ErrorBoundary extends Component<{children: React.ReactNode}, ErrorBoundary
   handleRetry = () => this.setState({hasError: false});
 
   render() {
-    if (!this.state.hasError) {
+    if (this.state.hasError) {
       return (
         <Container flex="1">
           <LoadingError

--- a/static/app/components/loadingError.tsx
+++ b/static/app/components/loadingError.tsx
@@ -1,5 +1,4 @@
 import {Alert} from 'sentry/components/core/alert';
-import {Button} from 'sentry/components/core/button';
 import {t} from 'sentry/locale';
 
 type Props = {
@@ -25,9 +24,9 @@ function LoadingError({
         className={className}
         trailingItems={
           onRetry && (
-            <Button onClick={onRetry} priority="default" size="sm">
+            <Alert.Button onClick={onRetry} priority="default">
               {t('Retry')}
-            </Button>
+            </Alert.Button>
           )
         }
       >


### PR DESCRIPTION
This PR adds `<Alert.Button>`, which is a button variant with a fixed size that should be used inside the Alert component over regular buttons.

For Alerts to align properly in UI2, buttons need to have size zero, but that sizing doesn’t work well in the old UI.

That’s why the `Alert.Button` component doesn’t expose a size - it sets it internally depending on the theme.

The only replaced usage was done in the reported situation, but we can think about rolling this out to other usages in follow-ups.