### PR TITLE
WIP: Script to generate API ownership list

### DIFF
--- a/script.py
+++ b/script.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+
+import yaml
+from django.urls import resolve
+
+from sentry.api.api_owners import ApiOwner
+
+
+@dataclass
+class Endpoint:
+    path: str
+    cls: type
+    owner: ApiOwner
+    name: str
+
+    def to_dict_item(self):
+        return (
+            self.path,
+            {
+                "class": f"{self.cls.__module__}.{self.cls.__qualname__}",
+                "owner": self.owner.value,
+                "name": self.name,
+            },
+        )
+
+
+def resolve_api_endpoint(path: str):
+    """Resolve the class of an endpoint from a path."""
+    path = path.lstrip("/")
+    return resolve(f"/api/0/{path}")
+
+
+def process_endpoint(endpoint: str) -> Endpoint:
+    """Process an endpoint string into an Endpoint object."""
+    resolved = resolve_api_endpoint(endpoint)
+    cls = resolved.func.cls
+    owner = cls.owner
+    name = resolved.url_name
+    return Endpoint(endpoint, cls, owner, name)
+
+
+def process_endpoints(endpoints: list[str]) -> dict:
+    """Process a list of endpoint strings into a list of Endpoint objects."""
+    return dict(process_endpoint(endpoint).to_dict_item() for endpoint in endpoints)
+
+
+def read_endpoints_from_yaml(file: str) -> list[str]:
+    """Read a list of endpoints from a YAML file."""
+    with open(file) as f:
+        return yaml.safe_load(f)
+
+
+def process_yaml(input_path: str, output_path: str):
+    """Process a YAML file into a dictionary of endpoints."""
+    endpoints_str = read_endpoints_from_yaml(input_path)
+    endpoints = process_endpoints(endpoints_str)
+    with open(output_path, "w") as f:
+        yaml.dump(endpoints, f)
+
+
+if __name__ == "__main__":
+    process_yaml("api_endpoints_absolute_false_list.yaml", "output.yaml")


### PR DESCRIPTION
This PR contains a script which generates a list of ownership information for all endpoints in Sentry.

This is an excerpt from the output:

```yaml
/organizations/{organization_id_or_slug}/avatar/:
  class: sentry.core.endpoints.organization_avatar.OrganizationAvatarEndpoint
  name: sentry-api-0-organization-avatar
  owner: unowned
/organizations/{organization_id_or_slug}/broadcasts/:
  class: sentry.api.endpoints.broadcast_index.BroadcastIndexEndpoint
  name: sentry-api-0-organization-broadcasts
  owner: unowned
/organizations/{organization_id_or_slug}/builtin-symbol-sources/:
  class: sentry.api.endpoints.builtin_symbol_sources.BuiltinSymbolSourcesEndpoint
  name: sentry-api-0-organization-builtin-symbol-sources
  owner: ingest
/organizations/{organization_id_or_slug}/chunk-upload/:
  class: sentry.api.endpoints.chunk.ChunkUploadEndpoint
  name: sentry-api-0-chunk-upload
  owner: ingest
```

### How to run the script

```sh
export SENTRY_SKIP_BACKEND_VALIDATION=1  # otherwise you might get some errors
sentry exec script.py > output.yaml
```

### Potential future improvements

  - Surface more metadata from the endpoints (e.g. HTTP methods)
  - Allow users to provide an endpoint, which we surface the metadata from
       - e.g. a user could run `sentry exec script.py "/organizations/my-customer/issues"` and the output would tell them the parametrized path for that endpoint, as well as the responsible team
  - Auto-generate some docs with this script

### Issues

Closes #100291
Closes ENG-5614