### PR TITLE
fix(ui2): use theme.chart.neutral over hard-coded gray values

### DIFF
--- a/static/app/views/projectsDashboard/projectChart.tsx
+++ b/static/app/views/projectsDashboard/projectChart.tsx
@@ -58,12 +58,12 @@ export function ProjectChart({
       xAxisIndex: 1,
       yAxisIndex: 1,
       itemStyle: {
-        color: theme.gray200,
+        color: theme.chart.neutral,
         opacity: 0.8,
       },
       emphasis: {
         itemStyle: {
-          color: theme.gray200,
+          color: theme.chart.neutral,
           opacity: 1.0,
         },
       },


### PR DESCRIPTION
the only visible difference is UI2 in light mode.

before:

| UI1 | UI2 |
|--------|--------|
| <img width="689" height="328" alt="Screenshot 2025-09-25 at 15 52 17" src="https://github.com/user-attachments/assets/6b397104-38c6-43b8-bfe9-d032c215823a" /> | <img width="689" height="328" alt="Screenshot 2025-09-25 at 15 52 06" src="https://github.com/user-attachments/assets/299745e0-dba0-4ddd-bdfb-6686165e0ae5" /> |
| <img width="689" height="328" alt="Screenshot 2025-09-25 at 15 52 14" src="https://github.com/user-attachments/assets/e9131886-1851-4ed7-99ce-24fd7c6c52f3" /> | <img width="689" height="328" alt="Screenshot 2025-09-25 at 15 52 10" src="https://github.com/user-attachments/assets/8ac408d7-d665-40e5-b631-25bf9891e9f0" /> | 

after:

| UI1 | UI2 |
|--------|--------|
| <img width="668" height="328" alt="Screenshot 2025-09-25 at 15 52 41" src="https://github.com/user-attachments/assets/69e00cc9-802e-4697-ae69-ba72c69f8c09" /> | <img width="668" height="328" alt="Screenshot 2025-09-25 at 15 52 28" src="https://github.com/user-attachments/assets/6eaa3c50-b965-4b7a-8b63-e434eb3f9f65" /> |
| <img width="668" height="328" alt="Screenshot 2025-09-25 at 15 52 38" src="https://github.com/user-attachments/assets/c94ac842-5a6c-4a1a-a944-805a85b9f3e1" /> | <img width="668" height="328" alt="Screenshot 2025-09-25 at 15 52 33" src="https://github.com/user-attachments/assets/8b33cffd-f14d-43dd-aa1b-2f1f66ab52f9" /> | 