### PR TITLE
fix(spans): Remove ambiguous sentry.description

### DIFF
--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -37,6 +37,12 @@ def convert_span_to_item(span: CompatibleSpan) -> TraceItem:
     client_sample_rate = 1.0
     server_sample_rate = 1.0
 
+    # This key is ambiguous. sentry-conventions and relay interpret it as "raw description",
+    # sentry interprets it as normalized_description.
+    # See https://github.com/getsentry/sentry/blob/7f2ccd1d03e8845a833fe1ee6784bce0c7f0b935/src/sentry/search/eap/spans/attributes.py#L596.
+    # Delete it and relay on top-level `description` for now.
+    (span.get("data") or {}).pop("sentry.description", None)
+
     for k, v in (span.get("data") or {}).items():
         if v is not None:
             try:

--- a/tests/sentry/spans/consumers/process_segments/test_convert.py
+++ b/tests/sentry/spans/consumers/process_segments/test_convert.py
@@ -37,6 +37,7 @@ SPAN_KAFKA_MESSAGE = {
         "sentry.category": "http",
         "sentry.client_sample_rate": 0.1,
         "sentry.environment": "development",
+        "sentry.description": "/api/0/relays/projectconfigs/",
         "sentry.normalized_description": "normalized_description",
         "sentry.op": "http.server",
         "sentry.platform": "python",


### PR DESCRIPTION
The span attribute key `sentry.description` is ambiguous. `sentry-conventions` and relay interpret it as "raw description",
while sentry interprets it as normalized_description:
https://github.com/getsentry/sentry/blob/7f2ccd1d03e8845a833fe1ee6784bce0c7f0b935/src/sentry/search/eap/spans/attributes.py#L596.
 
Before producing to EAP, delete the key and rely on the top-level `description` field for now.

ref: INGEST-531