### PR TITLE
fix(onboarding): Change TTL to 7d for onboarding task resolving cache

### DIFF
--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -92,7 +92,7 @@ class OrganizationOnboardingTaskManager(BaseManager["OrganizationOnboardingTask"
             )
 
             # Store marker to prevent running all the time
-            cache.set(cache_key, 1, 3600)
+            cache.set(cache_key, 1, 60 * 60 * 24 * 7)  # 1 week
             return created
         return False
 


### PR DESCRIPTION
Change TTL to 7d instead of 1h. We only ever mark tasks as completed here, so it is fine if we cache it for longer period of time, as this should reduce the load on our database, and once resolved, this task doesn't need to be updated again.
