### PR TITLE
feat(search): Add support for wildcard ops in MutableSearch

### DIFF
--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -203,6 +203,33 @@ describe('utils/tokenizeSearch', () => {
           ],
         },
       },
+      {
+        name: 'should handle contains filter',
+        string: 'message:\uf00dContains\uf00d"test value"',
+        object: {
+          tokens: [
+            {type: TokenType.CONTAINS_FILTER, key: 'message', value: 'test value'},
+          ],
+        },
+      },
+      {
+        name: 'should handle starts with filter',
+        string: 'message:\uf00dStartsWith\uf00d"test value"',
+        object: {
+          tokens: [
+            {type: TokenType.STARTS_WITH_FILTER, key: 'message', value: 'test value'},
+          ],
+        },
+      },
+      {
+        name: 'should handle ends with filter',
+        string: 'message:\uf00dEndsWith\uf00d"test value"',
+        object: {
+          tokens: [
+            {type: TokenType.ENDS_WITH_FILTER, key: 'message', value: 'test value'},
+          ],
+        },
+      },
     ];
 
     for (const {name, string, object} of cases) {
@@ -380,6 +407,18 @@ describe('utils/tokenizeSearch', () => {
       results = new MutableSearch(['a:a', '(b:b1', 'OR', 'b:b2', 'OR', 'b:b3)', 'c:c']);
       results.removeFilter('b');
       expect(results.formatString()).toBe('a:a c:c');
+
+      results = new MutableSearch(['a:a', 'message:\uf00dContains\uf00d"test value"']);
+      results.removeFilter('message');
+      expect(results.formatString()).toBe('a:a');
+
+      results = new MutableSearch(['a:a', 'message:\uf00dStartsWith\uf00d"test value"']);
+      results.removeFilter('message');
+      expect(results.formatString()).toBe('a:a');
+
+      results = new MutableSearch(['a:a', 'message:\uf00dEndsWith\uf00d"test value"']);
+      results.removeFilter('message');
+      expect(results.formatString()).toBe('a:a');
     });
 
     it('can return the tag keys', () => {
@@ -398,6 +437,23 @@ describe('utils/tokenizeSearch', () => {
       expect(results.getFilterValues('tag')).toEqual(['value', 'value2']);
 
       expect(results.getFilterValues('nonexistent')).toEqual([]);
+    });
+
+    it('handles adding wildcard filters', () => {
+      const results = new MutableSearch(['a:a']);
+
+      results.addContainsFilterValue('b', 'b');
+      expect(results.formatString()).toBe('a:a b:\uf00dContains\uf00db');
+
+      results.addStartsWithFilterValue('c', 'c');
+      expect(results.formatString()).toBe(
+        'a:a b:\uf00dContains\uf00db c:\uf00dStartsWith\uf00dc'
+      );
+
+      results.addEndsWithFilterValue('d', 'd');
+      expect(results.formatString()).toBe(
+        'a:a b:\uf00dContains\uf00db c:\uf00dStartsWith\uf00dc d:\uf00dEndsWith\uf00dd'
+      );
     });
   });
 
@@ -579,6 +635,21 @@ describe('utils/tokenizeSearch', () => {
         name: 'should leave escaped brackets as is',
         object: new MutableSearch(['message:"[test, "[Filtered]"]"']),
         string: 'message:"[test, "[Filtered]"]"',
+      },
+      {
+        name: 'handles contains filter',
+        object: new MutableSearch(['message:\uf00dContains\uf00d"test value"']),
+        string: 'message:\uf00dContains\uf00d"test value"',
+      },
+      {
+        name: 'handles starts with filter',
+        object: new MutableSearch(['message:\uf00dStartsWith\uf00d"test value"']),
+        string: 'message:\uf00dStartsWith\uf00d"test value"',
+      },
+      {
+        name: 'handles ends with filter',
+        object: new MutableSearch(['message:\uf00dEndsWith\uf00d"test value"']),
+        string: 'message:\uf00dEndsWith\uf00d"test value"',
       },
     ];
 

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -1,3 +1,4 @@
+import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
 import {escapeDoubleQuotes} from 'sentry/utils';
 
 const ALLOWED_WILDCARD_FIELDS = [
@@ -14,7 +15,17 @@ export enum TokenType {
   OPERATOR = 0,
   FILTER = 1,
   FREE_TEXT = 2,
+  CONTAINS_FILTER = 3,
+  STARTS_WITH_FILTER = 4,
+  ENDS_WITH_FILTER = 5,
 }
+
+const FILTER_TOKENS = [
+  TokenType.FILTER,
+  TokenType.CONTAINS_FILTER,
+  TokenType.STARTS_WITH_FILTER,
+  TokenType.ENDS_WITH_FILTER,
+];
 
 type Token = {
   type: TokenType;
@@ -37,6 +48,38 @@ function isParen(token: Token, character: '(' | ')') {
     ['(', ')'].includes(token.value) &&
     token.value === character
   );
+}
+
+function isProperlyBracketed(value: string): boolean {
+  return /^\[.*\]$/.test(value);
+}
+
+function isProperlyQuoted(value: string): boolean {
+  return /^".*"$/.test(value);
+}
+
+function requiresQuotes(value: string): boolean {
+  return /[\s\(\)\\"]/g.test(value);
+}
+
+function generateFilterValue(token: Token, operator: string): string {
+  if (token.value === '' || token.value === null) {
+    return `${token.key}${operator}""`;
+  }
+
+  if (
+    // Don't quote if it's already a properly formatted bracket expression
+    isProperlyBracketed(token.value) ||
+    // Don't quote if it's already properly quoted
+    isProperlyQuoted(token.value)
+  ) {
+    return `${token.key}${operator}${token.value}`;
+  }
+
+  if (requiresQuotes(token.value)) {
+    return `${token.key}${operator}"${escapeDoubleQuotes(token.value)}"`;
+  }
+  return `${token.key}${operator}${token.value}`;
 }
 
 // TODO(epurkhiser): This is legacy from before the existence of
@@ -120,9 +163,28 @@ export class MutableSearch {
 
         // We may have entered a filter condition
         if (char === ':') {
-          const nextChar = token[i + 1] || '';
-          if ([':', ' '].includes(nextChar)) {
+          const indexOffset = i + 1;
+          const nextChar = token[indexOffset] || '';
+
+          if (nextChar === ':' || nextChar === ' ') {
             tokenState = TokenType.FREE_TEXT;
+          } else if (
+            token.slice(indexOffset, indexOffset + WildcardOperators.CONTAINS.length) ===
+            WildcardOperators.CONTAINS
+          ) {
+            tokenState = TokenType.CONTAINS_FILTER;
+          } else if (
+            token.slice(
+              indexOffset,
+              indexOffset + WildcardOperators.STARTS_WITH.length
+            ) === WildcardOperators.STARTS_WITH
+          ) {
+            tokenState = TokenType.STARTS_WITH_FILTER;
+          } else if (
+            token.slice(indexOffset, indexOffset + WildcardOperators.ENDS_WITH.length) ===
+            WildcardOperators.ENDS_WITH
+          ) {
+            tokenState = TokenType.ENDS_WITH_FILTER;
           } else {
             tokenState = TokenType.FILTER;
           }
@@ -143,6 +205,15 @@ export class MutableSearch {
         this.addFreeText(token);
       } else if (tokenState === TokenType.FILTER) {
         this.addStringFilter(token, false);
+      } else if (tokenState === TokenType.CONTAINS_FILTER) {
+        token = token.replace(WildcardOperators.CONTAINS, '');
+        this.addStringContainsFilter(token, false);
+      } else if (tokenState === TokenType.STARTS_WITH_FILTER) {
+        token = token.replace(WildcardOperators.STARTS_WITH, '');
+        this.addStringStartsWithFilter(token, false);
+      } else if (tokenState === TokenType.ENDS_WITH_FILTER) {
+        token = token.replace(WildcardOperators.ENDS_WITH, '');
+        this.addStringEndsWithFilter(token, false);
       }
 
       if (trailingParen !== '') {
@@ -156,26 +227,25 @@ export class MutableSearch {
     for (const token of this.tokens) {
       switch (token.type) {
         case TokenType.FILTER:
-          if (token.value === '' || token.value === null) {
-            formattedTokens.push(`${token.key}:""`);
-          } else if (
-            // Don't quote if it's already a properly formatted bracket expression
-            /^\[.*\]$/.test(token.value) ||
-            // Don't quote if it's already properly quoted
-            /^".*"$/.test(token.value)
-          ) {
-            formattedTokens.push(`${token.key}:${token.value}`);
-          } else if (
-            // Quote if contains spaces, parens, or quotes
-            /[\s\(\)\\"]/g.test(token.value)
-          ) {
-            formattedTokens.push(`${token.key}:"${escapeDoubleQuotes(token.value)}"`);
-          } else {
-            formattedTokens.push(`${token.key}:${token.value}`);
-          }
+          formattedTokens.push(generateFilterValue(token, ':'));
+          break;
+        case TokenType.CONTAINS_FILTER:
+          formattedTokens.push(
+            generateFilterValue(token, `:${WildcardOperators.CONTAINS}`)
+          );
+          break;
+        case TokenType.STARTS_WITH_FILTER:
+          formattedTokens.push(
+            generateFilterValue(token, `:${WildcardOperators.STARTS_WITH}`)
+          );
+          break;
+        case TokenType.ENDS_WITH_FILTER:
+          formattedTokens.push(
+            generateFilterValue(token, `:${WildcardOperators.ENDS_WITH}`)
+          );
           break;
         case TokenType.FREE_TEXT:
-          if (/[\s\(\)\\"]/g.test(token.value)) {
+          if (requiresQuotes(token.value)) {
             formattedTokens.push(`"${escapeDoubleQuotes(token.value)}"`);
           } else {
             formattedTokens.push(token.value);
@@ -209,9 +279,48 @@ export class MutableSearch {
     return this;
   }
 
+  addStringContainsFilter(filter: string, shouldEscape = true) {
+    const [key, value] = parseFilter(filter);
+    this.addContainsFilterValues(key!, [value!], shouldEscape);
+    return this;
+  }
+
+  addStringStartsWithFilter(filter: string, shouldEscape = true) {
+    const [key, value] = parseFilter(filter);
+    this.addStartsWithFilterValues(key!, [value!], shouldEscape);
+    return this;
+  }
+
+  addStringEndsWithFilter(filter: string, shouldEscape = true) {
+    const [key, value] = parseFilter(filter);
+    this.addEndsWithFilterValues(key!, [value!], shouldEscape);
+    return this;
+  }
+
   addFilterValues(key: string, values: string[], shouldEscape = true) {
     for (const value of values) {
       this.addFilterValue(key, value, shouldEscape);
+    }
+    return this;
+  }
+
+  addContainsFilterValues(key: string, values: string[], shouldEscape = true) {
+    for (const value of values) {
+      this.addContainsFilterValue(key, value, shouldEscape);
+    }
+    return this;
+  }
+
+  addStartsWithFilterValues(key: string, values: string[], shouldEscape = true) {
+    for (const value of values) {
+      this.addStartsWithFilterValue(key, value, shouldEscape);
+    }
+    return this;
+  }
+
+  addEndsWithFilterValues(key: string, values: string[], shouldEscape = true) {
+    for (const value of values) {
+      this.addEndsWithFilterValue(key, value, shouldEscape);
     }
     return this;
   }
@@ -250,6 +359,24 @@ export class MutableSearch {
     return this;
   }
 
+  addContainsFilterValue(key: string, value: string, shouldEscape = true) {
+    const escaped = shouldEscape ? escapeFilterValue(value) : value;
+    const token: Token = {type: TokenType.CONTAINS_FILTER, key, value: escaped};
+    this.tokens.push(token);
+  }
+
+  addStartsWithFilterValue(key: string, value: string, shouldEscape = true) {
+    const escaped = shouldEscape ? escapeFilterValue(value) : value;
+    const token: Token = {type: TokenType.STARTS_WITH_FILTER, key, value: escaped};
+    this.tokens.push(token);
+  }
+
+  addEndsWithFilterValue(key: string, value: string, shouldEscape = true) {
+    const escaped = shouldEscape ? escapeFilterValue(value) : value;
+    const token: Token = {type: TokenType.ENDS_WITH_FILTER, key, value: escaped};
+    this.tokens.push(token);
+  }
+
   get filters() {
     type Filters = Record<string, string[]>;
 
@@ -259,7 +386,7 @@ export class MutableSearch {
     });
 
     return this.tokens
-      .filter(t => t.type === TokenType.FILTER)
+      .filter(t => FILTER_TOKENS.includes(t.type))
       .reduce<Filters>(reducer, {});
   }
 


### PR DESCRIPTION
This PR updates `MutableSearch` to add in support specifically for wildcard operators. This should resolve some issues with using wildcard operators and mutable search, and also make it easier to add/remove wildcard operators with `MutableSearch`.