### PR TITLE
fix(seer): Show usage card for sponsored orgs

### DIFF
--- a/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
@@ -1458,15 +1458,14 @@ describe('Subscription > CombinedUsageTotals', () => {
     expect(within(card).queryByText(/trial/)).not.toBeInTheDocument();
   });
 
-  it('does not render card for sponsored orgs', () => {
+  it('does renders card for sponsored orgs', async () => {
     const sponsoredSub = SubscriptionFixture({
       organization,
       plan: 'am2_sponsored_team_auf',
-      // in practice these plans shouldn't even have the zero'd out budgets, but this is for testing purposes
       reservedBudgets: [
         SeerReservedBudgetFixture({
-          id: '0',
-          reservedBudget: 0,
+          id: '1',
+          reservedBudget: 20_00,
         }),
       ],
       isSponsored: true,
@@ -1484,7 +1483,7 @@ describe('Subscription > CombinedUsageTotals', () => {
       />
     );
 
-    expect(screen.queryByTestId('usage-card-seer')).not.toBeInTheDocument();
+    expect(await screen.findByTestId('usage-card-seer')).toBeInTheDocument();
   });
 
   it('renders PAYG legend with per-category', () => {

--- a/static/gsApp/views/subscriptionPage/usageTotals.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.tsx
@@ -803,10 +803,6 @@ export function CombinedUsageTotals({
   const [state, setState] = useState<State>({expanded: false, trialButtonBusy: false});
   const theme = useTheme();
 
-  if (subscription.isSponsored) {
-    return null; // this is just a safety check but sponsored plans shouldn't have access to selectable products for now anyway
-  }
-
   const colors = theme.chart.getColorPalette(5);
   const categoryToColors: Partial<
     Record<DataCategory, {ondemand: string; reserved: string}>


### PR DESCRIPTION
We were hiding the card for sponsored orgs at launch but we've added Seer credits to sponsored orgs since launch, so we should show the card.