### PR TITLE
fix(aci): Expose targetTypes as strings in the API.

### DIFF
--- a/src/sentry/integrations/discord/handlers/discord_handler.py
+++ b/src/sentry/integrations/discord/handlers/discord_handler.py
@@ -7,7 +7,8 @@ from sentry.notifications.notification_action.action_handler_registry.common imp
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
-from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
+from sentry.workflow_engine.transformers import TargetTypeConfigTransformer
+from sentry.workflow_engine.types import ActionHandler, ConfigTransformer, WorkflowEventData
 
 
 @action_handler_registry.register(Action.Type.DISCORD)
@@ -43,6 +44,10 @@ class DiscordActionHandler(IntegrationActionHandler):
         },
         "additionalProperties": False,
     }
+
+    @staticmethod
+    def get_config_transformer() -> ConfigTransformer | None:
+        return TargetTypeConfigTransformer.from_config_schema(DiscordActionHandler.config_schema)
 
     @staticmethod
     def execute(

--- a/src/sentry/integrations/msteams/handlers/msteams_handler.py
+++ b/src/sentry/integrations/msteams/handlers/msteams_handler.py
@@ -8,7 +8,8 @@ from sentry.notifications.notification_action.action_handler_registry.common imp
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
-from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
+from sentry.workflow_engine.transformers import TargetTypeConfigTransformer
+from sentry.workflow_engine.types import ActionHandler, ConfigTransformer, WorkflowEventData
 
 
 @action_handler_registry.register(Action.Type.MSTEAMS)
@@ -25,6 +26,10 @@ class MSTeamsActionHandler(IntegrationActionHandler):
         "properties": {},
         "additionalProperties": False,
     }
+
+    @staticmethod
+    def get_config_transformer() -> ConfigTransformer | None:
+        return TargetTypeConfigTransformer.from_config_schema(MSTeamsActionHandler.config_schema)
 
     @staticmethod
     def execute(

--- a/src/sentry/integrations/opsgenie/handlers/opsgenie_handler.py
+++ b/src/sentry/integrations/opsgenie/handlers/opsgenie_handler.py
@@ -4,12 +4,18 @@ from sentry.notifications.notification_action.action_handler_registry.base impor
     IntegrationActionHandler,
 )
 from sentry.notifications.notification_action.action_handler_registry.common import (
+    ONCALL_ACTION_CONFIG_API_SCHEMA,
     ONCALL_ACTION_CONFIG_SCHEMA,
 )
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
-from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
+from sentry.workflow_engine.types import (
+    ActionHandler,
+    ConfigTransformer,
+    TargetTypeConfigTransformer,
+    WorkflowEventData,
+)
 
 
 @action_handler_registry.register(Action.Type.OPSGENIE)
@@ -18,6 +24,7 @@ class OpsgenieActionHandler(IntegrationActionHandler):
     provider_slug = IntegrationProviderSlug.OPSGENIE
 
     config_schema = ONCALL_ACTION_CONFIG_SCHEMA
+    api_schema = ONCALL_ACTION_CONFIG_API_SCHEMA
     data_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
@@ -30,6 +37,10 @@ class OpsgenieActionHandler(IntegrationActionHandler):
             "additionalProperties": False,
         },
     }
+
+    @staticmethod
+    def get_config_transformer() -> ConfigTransformer | None:
+        return TargetTypeConfigTransformer(OpsgenieActionHandler.api_schema)
 
     @staticmethod
     def execute(

--- a/src/sentry/integrations/opsgenie/handlers/opsgenie_handler.py
+++ b/src/sentry/integrations/opsgenie/handlers/opsgenie_handler.py
@@ -4,18 +4,13 @@ from sentry.notifications.notification_action.action_handler_registry.base impor
     IntegrationActionHandler,
 )
 from sentry.notifications.notification_action.action_handler_registry.common import (
-    ONCALL_ACTION_CONFIG_API_SCHEMA,
     ONCALL_ACTION_CONFIG_SCHEMA,
 )
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
-from sentry.workflow_engine.types import (
-    ActionHandler,
-    ConfigTransformer,
-    TargetTypeConfigTransformer,
-    WorkflowEventData,
-)
+from sentry.workflow_engine.transformers import TargetTypeConfigTransformer
+from sentry.workflow_engine.types import ActionHandler, ConfigTransformer, WorkflowEventData
 
 
 @action_handler_registry.register(Action.Type.OPSGENIE)
@@ -24,7 +19,6 @@ class OpsgenieActionHandler(IntegrationActionHandler):
     provider_slug = IntegrationProviderSlug.OPSGENIE
 
     config_schema = ONCALL_ACTION_CONFIG_SCHEMA
-    api_schema = ONCALL_ACTION_CONFIG_API_SCHEMA
     data_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
@@ -40,7 +34,7 @@ class OpsgenieActionHandler(IntegrationActionHandler):
 
     @staticmethod
     def get_config_transformer() -> ConfigTransformer | None:
-        return TargetTypeConfigTransformer(OpsgenieActionHandler.api_schema)
+        return TargetTypeConfigTransformer.from_config_schema(OpsgenieActionHandler.config_schema)
 
     @staticmethod
     def execute(

--- a/src/sentry/integrations/pagerduty/handlers/pagerduty_handler.py
+++ b/src/sentry/integrations/pagerduty/handlers/pagerduty_handler.py
@@ -9,7 +9,8 @@ from sentry.notifications.notification_action.action_handler_registry.common imp
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
-from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
+from sentry.workflow_engine.transformers import TargetTypeConfigTransformer
+from sentry.workflow_engine.types import ActionHandler, ConfigTransformer, WorkflowEventData
 
 
 @action_handler_registry.register(Action.Type.PAGERDUTY)
@@ -30,6 +31,10 @@ class PagerdutyActionHandler(IntegrationActionHandler):
             "additionalProperties": False,
         },
     }
+
+    @staticmethod
+    def get_config_transformer() -> ConfigTransformer | None:
+        return TargetTypeConfigTransformer.from_config_schema(PagerdutyActionHandler.config_schema)
 
     @staticmethod
     def execute(

--- a/src/sentry/integrations/slack/handlers/slack_action_handler.py
+++ b/src/sentry/integrations/slack/handlers/slack_action_handler.py
@@ -3,13 +3,19 @@ from sentry.notifications.notification_action.action_handler_registry.base impor
     IntegrationActionHandler,
 )
 from sentry.notifications.notification_action.action_handler_registry.common import (
+    MESSAGING_ACTION_CONFIG_API_SCHEMA,
     MESSAGING_ACTION_CONFIG_SCHEMA,
     NOTES_SCHEMA,
     TAGS_SCHEMA,
 )
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
-from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
+from sentry.workflow_engine.types import (
+    ActionHandler,
+    ConfigTransformer,
+    TargetTypeConfigTransformer,
+    WorkflowEventData,
+)
 
 
 @action_handler_registry.register(Action.Type.SLACK)
@@ -29,6 +35,11 @@ class SlackActionHandler(IntegrationActionHandler):
         },
         "additionalProperties": False,
     }
+    api_schema = MESSAGING_ACTION_CONFIG_API_SCHEMA
+
+    @staticmethod
+    def get_config_transformer() -> ConfigTransformer | None:
+        return TargetTypeConfigTransformer(SlackActionHandler.api_schema)
 
     @staticmethod
     def execute(

--- a/src/sentry/integrations/slack/handlers/slack_action_handler.py
+++ b/src/sentry/integrations/slack/handlers/slack_action_handler.py
@@ -3,19 +3,14 @@ from sentry.notifications.notification_action.action_handler_registry.base impor
     IntegrationActionHandler,
 )
 from sentry.notifications.notification_action.action_handler_registry.common import (
-    MESSAGING_ACTION_CONFIG_API_SCHEMA,
     MESSAGING_ACTION_CONFIG_SCHEMA,
     NOTES_SCHEMA,
     TAGS_SCHEMA,
 )
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
-from sentry.workflow_engine.types import (
-    ActionHandler,
-    ConfigTransformer,
-    TargetTypeConfigTransformer,
-    WorkflowEventData,
-)
+from sentry.workflow_engine.transformers import TargetTypeConfigTransformer
+from sentry.workflow_engine.types import ActionHandler, ConfigTransformer, WorkflowEventData
 
 
 @action_handler_registry.register(Action.Type.SLACK)
@@ -35,11 +30,10 @@ class SlackActionHandler(IntegrationActionHandler):
         },
         "additionalProperties": False,
     }
-    api_schema = MESSAGING_ACTION_CONFIG_API_SCHEMA
 
     @staticmethod
     def get_config_transformer() -> ConfigTransformer | None:
-        return TargetTypeConfigTransformer(SlackActionHandler.api_schema)
+        return TargetTypeConfigTransformer.from_config_schema(SlackActionHandler.config_schema)
 
     @staticmethod
     def execute(

--- a/src/sentry/notifications/notification_action/action_handler_registry/base.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/base.py
@@ -5,6 +5,7 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.utils import execute_via_issue_alert_handler
 from sentry.workflow_engine.models import Action, Detector
+from sentry.workflow_engine.transformers import TargetTypeConfigTransformer
 from sentry.workflow_engine.types import ActionHandler, ConfigTransformer, WorkflowEventData
 
 logger = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ class TicketingActionHandler(IntegrationActionHandler, ABC):
 
     @staticmethod
     def get_config_transformer() -> ConfigTransformer | None:
-        return None
+        return TargetTypeConfigTransformer.from_config_schema(TicketingActionHandler.config_schema)
 
     @staticmethod
     def execute(

--- a/src/sentry/notifications/notification_action/action_handler_registry/base.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/base.py
@@ -5,7 +5,7 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.utils import execute_via_issue_alert_handler
 from sentry.workflow_engine.models import Action, Detector
-from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
+from sentry.workflow_engine.types import ActionHandler, ConfigTransformer, WorkflowEventData
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +53,10 @@ class TicketingActionHandler(IntegrationActionHandler, ABC):
         },
         "additionalProperties": False,
     }
+
+    @staticmethod
+    def get_config_transformer() -> ConfigTransformer | None:
+        return None
 
     @staticmethod
     def execute(

--- a/src/sentry/notifications/notification_action/action_handler_registry/common.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/common.py
@@ -1,4 +1,5 @@
 from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.workflow_engine.types import action_target_strings
 
 MESSAGING_ACTION_CONFIG_SCHEMA = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -10,6 +11,22 @@ MESSAGING_ACTION_CONFIG_SCHEMA = {
         "target_type": {
             "type": ["integer"],
             "enum": [ActionTarget.SPECIFIC.value],
+        },
+    },
+    "required": ["target_display", "target_type"],
+    "additionalProperties": False,
+}
+
+MESSAGING_ACTION_CONFIG_API_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "The configuration schema for a Messaging Action",
+    "type": "object",
+    "properties": {
+        "target_identifier": {"type": ["string"]},
+        "target_display": {"type": ["string"]},
+        "target_type": {
+            "type": ["string"],
+            "enum": action_target_strings([ActionTarget.SPECIFIC]),
         },
     },
     "required": ["target_display", "target_type"],
@@ -41,4 +58,18 @@ ONCALL_ACTION_CONFIG_SCHEMA = {
     },
     "required": ["target_identifier", "target_type"],
     "additionalProperties": False,
+}
+
+ONCALL_ACTION_CONFIG_API_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "The configuration schema for a on-call Action",
+    "type": "object",
+    "properties": {
+        "target_identifier": {"type": ["string"]},
+        "target_display": {"type": ["string", "null"]},
+        "target_type": {
+            "type": ["string"],
+            "enum": action_target_strings([ActionTarget.SPECIFIC]),
+        },
+    },
 }

--- a/src/sentry/notifications/notification_action/action_handler_registry/common.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/common.py
@@ -1,5 +1,4 @@
 from sentry.notifications.models.notificationaction import ActionTarget
-from sentry.workflow_engine.types import action_target_strings
 
 MESSAGING_ACTION_CONFIG_SCHEMA = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -17,21 +16,6 @@ MESSAGING_ACTION_CONFIG_SCHEMA = {
     "additionalProperties": False,
 }
 
-MESSAGING_ACTION_CONFIG_API_SCHEMA = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "The configuration schema for a Messaging Action",
-    "type": "object",
-    "properties": {
-        "target_identifier": {"type": ["string"]},
-        "target_display": {"type": ["string"]},
-        "target_type": {
-            "type": ["string"],
-            "enum": action_target_strings([ActionTarget.SPECIFIC]),
-        },
-    },
-    "required": ["target_display", "target_type"],
-    "additionalProperties": False,
-}
 
 TAGS_SCHEMA = {
     "type": "string",
@@ -58,18 +42,4 @@ ONCALL_ACTION_CONFIG_SCHEMA = {
     },
     "required": ["target_identifier", "target_type"],
     "additionalProperties": False,
-}
-
-ONCALL_ACTION_CONFIG_API_SCHEMA = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "The configuration schema for a on-call Action",
-    "type": "object",
-    "properties": {
-        "target_identifier": {"type": ["string"]},
-        "target_display": {"type": ["string", "null"]},
-        "target_type": {
-            "type": ["string"],
-            "enum": action_target_strings([ActionTarget.SPECIFIC]),
-        },
-    },
 }

--- a/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/email_handler.py
@@ -9,6 +9,7 @@ from sentry.workflow_engine.types import ActionHandler, ConfigTransformer, Workf
 
 @action_handler_registry.register(Action.Type.EMAIL)
 class EmailActionHandler(ActionHandler):
+    _config_transformer: ConfigTransformer | None = None
 
     config_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -52,9 +53,13 @@ class EmailActionHandler(ActionHandler):
 
     group = ActionHandler.Group.NOTIFICATION
 
-    @staticmethod
-    def get_config_transformer() -> ConfigTransformer | None:
-        return TargetTypeConfigTransformer.from_config_schema(EmailActionHandler.config_schema)
+    @classmethod
+    def get_config_transformer(cls) -> ConfigTransformer | None:
+        if cls._config_transformer is None:
+            cls._config_transformer = TargetTypeConfigTransformer.from_config_schema(
+                cls.config_schema
+            )
+        return cls._config_transformer
 
     @staticmethod
     def execute(

--- a/src/sentry/notifications/notification_action/action_handler_registry/plugin_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/plugin_handler.py
@@ -1,7 +1,7 @@
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
-from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
+from sentry.workflow_engine.types import ActionHandler, ConfigTransformer, WorkflowEventData
 
 
 @action_handler_registry.register(Action.Type.PLUGIN)
@@ -26,6 +26,10 @@ class PluginActionHandler(ActionHandler):
         },
     }
     data_schema = {}
+
+    @staticmethod
+    def get_config_transformer() -> ConfigTransformer | None:
+        return None
 
     @staticmethod
     def execute(

--- a/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
@@ -2,7 +2,13 @@ from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
-from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
+from sentry.workflow_engine.types import (
+    ActionHandler,
+    ConfigTransformer,
+    TargetTypeConfigTransformer,
+    WorkflowEventData,
+    action_target_strings,
+)
 from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
@@ -29,6 +35,27 @@ class SentryAppActionHandler(ActionHandler):
         "required": ["target_type", "target_identifier", "sentry_app_identifier"],
         "additionalProperties": False,
     }
+
+    api_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "The configuration schema for a Sentry App Action",
+        "type": "object",
+        "properties": {
+            "target_identifier": {"type": ["string"]},
+            "target_display": {"type": ["string", "null"]},
+            "target_type": {
+                "type": ["string"],
+                "enum": action_target_strings([ActionTarget.SENTRY_APP]),
+            },
+            "sentry_app_identifier": {
+                "type": ["string"],
+                "enum": [*SentryAppIdentifier],
+            },
+        },
+        "required": ["target_type", "target_identifier", "sentry_app_identifier"],
+        "additionalProperties": False,
+    }
+
     data_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
@@ -37,6 +64,10 @@ class SentryAppActionHandler(ActionHandler):
         },
         "additionalProperties": False,
     }
+
+    @staticmethod
+    def get_config_transformer() -> ConfigTransformer | None:
+        return TargetTypeConfigTransformer(SentryAppActionHandler.api_schema)
 
     @staticmethod
     def execute(

--- a/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
@@ -2,13 +2,8 @@ from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
-from sentry.workflow_engine.types import (
-    ActionHandler,
-    ConfigTransformer,
-    TargetTypeConfigTransformer,
-    WorkflowEventData,
-    action_target_strings,
-)
+from sentry.workflow_engine.transformers import TargetTypeConfigTransformer
+from sentry.workflow_engine.types import ActionHandler, ConfigTransformer, WorkflowEventData
 from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
@@ -36,26 +31,6 @@ class SentryAppActionHandler(ActionHandler):
         "additionalProperties": False,
     }
 
-    api_schema = {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "description": "The configuration schema for a Sentry App Action",
-        "type": "object",
-        "properties": {
-            "target_identifier": {"type": ["string"]},
-            "target_display": {"type": ["string", "null"]},
-            "target_type": {
-                "type": ["string"],
-                "enum": action_target_strings([ActionTarget.SENTRY_APP]),
-            },
-            "sentry_app_identifier": {
-                "type": ["string"],
-                "enum": [*SentryAppIdentifier],
-            },
-        },
-        "required": ["target_type", "target_identifier", "sentry_app_identifier"],
-        "additionalProperties": False,
-    }
-
     data_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
@@ -67,7 +42,7 @@ class SentryAppActionHandler(ActionHandler):
 
     @staticmethod
     def get_config_transformer() -> ConfigTransformer | None:
-        return TargetTypeConfigTransformer(SentryAppActionHandler.api_schema)
+        return TargetTypeConfigTransformer.from_config_schema(SentryAppActionHandler.config_schema)
 
     @staticmethod
     def execute(

--- a/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
@@ -1,7 +1,7 @@
 from sentry.notifications.notification_action.utils import execute_via_group_type_registry
 from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.registry import action_handler_registry
-from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
+from sentry.workflow_engine.types import ActionHandler, ConfigTransformer, WorkflowEventData
 
 
 @action_handler_registry.register(Action.Type.WEBHOOK)
@@ -26,6 +26,10 @@ class WebhookActionHandler(ActionHandler):
         },
     }
     data_schema = {}
+
+    @staticmethod
+    def get_config_transformer() -> ConfigTransformer | None:
+        return None
 
     @staticmethod
     def execute(

--- a/src/sentry/workflow_engine/endpoints/serializers/action_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/action_serializer.py
@@ -3,6 +3,7 @@ from typing import TypedDict
 from sentry.api.serializers import Serializer, register
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.registry import action_handler_registry
 
 
 class ActionSerializerResponse(TypedDict):
@@ -17,11 +18,21 @@ class ActionSerializerResponse(TypedDict):
 @register(Action)
 class ActionSerializer(Serializer):
     def serialize(self, obj: Action, *args, **kwargs) -> ActionSerializerResponse:
+        # Get the action handler and config transformer if available
+        action_handler = action_handler_registry.get(obj.type)
+        config_transformer = action_handler.get_config_transformer()
+
+        # Transform config if transformer is available
+        if config_transformer is not None:
+            config = config_transformer.to_api(obj.config)
+        else:
+            config = obj.config
+
         return {
             "id": str(obj.id),
             "type": obj.type,
             "integrationId": str(obj.integration_id) if obj.integration_id else None,
             "data": obj.data,
-            "config": convert_dict_key_case(obj.config, snake_to_camel_case),
+            "config": convert_dict_key_case(config, snake_to_camel_case),
             "status": obj.get_status_display(),
         }

--- a/src/sentry/workflow_engine/endpoints/validators/base/action.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/action.py
@@ -43,14 +43,11 @@ class BaseActionValidator(CamelSnakeSerializer):
         config_transformer = action_handler.get_config_transformer()
 
         if config_transformer is not None:
-            # Transform from API format to config format, then validate
-            transformed_value = config_transformer.from_api(value)
-            config_schema = action_handler.config_schema
-            return validate_json_schema(transformed_value, config_schema)
+            # Transform from API format (transformer handles API schema validation)
+            return config_transformer.from_api(value)
         else:
             # No transformer, validate directly against config schema
-            config_schema = action_handler.config_schema
-            return validate_json_schema(value, config_schema)
+            return validate_json_schema(value, action_handler.config_schema)
 
     def validate_type(self, value) -> Any:
         try:

--- a/src/sentry/workflow_engine/transformers.py
+++ b/src/sentry/workflow_engine/transformers.py
@@ -28,7 +28,7 @@ def transform_config_schema_target_type_to_api(config_schema: dict[str, Any]) ->
     Raises:
         ValueError: If target_type field is malformed or contains invalid enum values
     """
-    target_type_spec = dictpath.walk(config_schema, "properties", "target_type").expect(dict).get()
+    target_type_spec = dictpath.walk(config_schema, "properties", "target_type").is_type(dict).get()
 
     # Extract type specification
     type_spec = dictpath.walk(target_type_spec, "type").get()
@@ -41,15 +41,13 @@ def transform_config_schema_target_type_to_api(config_schema: dict[str, Any]) ->
         raise ValueError("target_type field must be of type 'integer'")
 
     # Extract enum values
-    enum_values = dictpath.walk(target_type_spec, "enum").expect(list).get()
+    enum_values = dictpath.walk(target_type_spec, "enum").list_of(int).get()
     if len(enum_values) == 0:
         raise ValueError("target_type enum must be a non-empty list")
 
     # Convert integer enum values to ActionTarget instances for validation
     action_targets = []
     for val in enum_values:
-        if not isinstance(val, int):
-            raise ValueError(f"All enum values must be integers, got: {val}")
         # Find the ActionTarget that matches this integer value
         matching_target = None
         for target in ActionTarget:

--- a/src/sentry/workflow_engine/transformers.py
+++ b/src/sentry/workflow_engine/transformers.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.workflow_engine.endpoints.validators.utils import validate_json_schema
+from sentry.workflow_engine.types import ConfigTransformer
+
+
+def action_target_strings(lst: list[ActionTarget]) -> list[str]:
+    """Convert a list of ActionTarget enums to their string representations."""
+    action_target_to_string = dict(ActionTarget.as_choices())
+    return [action_target_to_string[a] for a in lst]
+
+
+def transform_config_schema_target_type_to_api(config_schema: dict[str, Any]) -> dict[str, Any]:
+    """
+    Transform a config schema's target_type field from integer enum to string enum.
+
+    Args:
+        config_schema: Schema with integer target_type field
+
+    Returns:
+        New schema with string target_type field
+
+    Raises:
+        ValueError: If target_type field is malformed or contains invalid enum values
+    """
+    properties = config_schema.get("properties")
+    if properties is None:
+        raise ValueError("config_schema must have 'properties' dict")
+
+    if not isinstance(properties, dict):
+        raise ValueError("config_schema must have 'properties' dict")
+
+    # Look for target_type field
+    target_type_spec = properties.get("target_type")
+    if target_type_spec is None:
+        raise ValueError("target_type field not found in config_schema")
+
+    # Ensure target_type is an integer type
+    if not isinstance(target_type_spec, dict):
+        raise ValueError("target_type field specification must be a dict")
+
+    type_spec = target_type_spec.get("type")
+    if type_spec is None:
+        raise ValueError("target_type field must have a 'type' specification")
+
+    # Handle both single type and list of types
+    if isinstance(type_spec, list):
+        if "integer" not in type_spec:
+            raise ValueError("target_type field must include 'integer' type")
+    elif type_spec != "integer":
+        raise ValueError("target_type field must be of type 'integer'")
+
+    # Extract enum values
+    enum_values = target_type_spec.get("enum")
+    if enum_values is None:
+        raise ValueError("target_type field must have 'enum' values specified")
+
+    if not isinstance(enum_values, list) or len(enum_values) == 0:
+        raise ValueError("target_type enum must be a non-empty list")
+
+    # Convert integer enum values to ActionTarget instances for validation
+    try:
+        action_targets = []
+        for val in enum_values:
+            if not isinstance(val, int):
+                raise ValueError(f"All enum values must be integers, got: {val}")
+            # Find the ActionTarget that matches this integer value
+            matching_target = None
+            for target in ActionTarget:
+                if target.value == val:
+                    matching_target = target
+                    break
+            if matching_target is None:
+                raise ValueError(f"Unknown ActionTarget value: {val}")
+            action_targets.append(matching_target)
+    except Exception as e:
+        raise ValueError(f"Failed to process target_type enum values: {e}")
+
+    # Generate API schema by copying config schema and transforming target_type field
+    api_schema = copy.deepcopy(config_schema)
+
+    # Replace target_type specification with string version
+    api_target_type_spec = copy.deepcopy(target_type_spec)
+
+    # Convert type from integer to string
+    if isinstance(type_spec, list):
+        # Replace "integer" with "string" in the type list
+        api_type_spec: list[str] | str = [t if t != "integer" else "string" for t in type_spec]
+    else:
+        api_type_spec = "string"
+
+    api_target_type_spec["type"] = api_type_spec
+    api_target_type_spec["enum"] = action_target_strings(action_targets)
+
+    api_schema["properties"]["target_type"] = api_target_type_spec
+
+    return api_schema
+
+
+class TargetTypeConfigTransformer(ConfigTransformer):
+    """Transforms target_type field between integer and string representations."""
+
+    def __init__(self, api_schema: dict[str, Any]):
+        self.api_schema = api_schema
+        self.action_target_to_string = dict(ActionTarget.as_choices())
+        self.action_target_from_string = {v: k for k, v in self.action_target_to_string.items()}
+
+    @staticmethod
+    def from_config_schema(config_schema: dict[str, Any]) -> TargetTypeConfigTransformer | None:
+        """
+        Analyze a config schema and generate a TargetTypeConfigTransformer if target_type field is found.
+        """
+        properties = config_schema.get("properties", {})
+        if not isinstance(properties, dict):
+            return None
+
+        # Look for target_type field
+        target_type_spec = properties.get("target_type")
+        if target_type_spec is None:
+            return None
+
+        # Use the extracted transformation function
+        api_schema = transform_config_schema_target_type_to_api(config_schema)
+        return TargetTypeConfigTransformer(api_schema)
+
+    def from_api(self, config: dict[str, Any]) -> dict[str, Any]:
+        """
+        Convert from api format to config_schema format.
+        Main transformation: target_type string -> target_type integer enum
+        """
+        # First validate the input against api_schema
+        validate_json_schema(config, self.api_schema)
+
+        # Create a copy to avoid mutating the input
+        transformed_config = config.copy()
+
+        # Convert target_type from string to ActionTarget enum value
+        if "target_type" in transformed_config:
+            target_type_str = transformed_config["target_type"]
+            transformed_config["target_type"] = self.action_target_from_string[target_type_str]
+
+        return transformed_config
+
+    def to_api(self, config: dict[str, Any]) -> dict[str, Any]:
+        """
+        Convert from config_schema format to api format.
+        Main transformation: target_type integer enum -> target_type string
+        """
+        # Create a copy to avoid mutating the input
+        transformed_config = config.copy()
+
+        # Convert target_type from ActionTarget enum value to string
+        if "target_type" in transformed_config:
+            target_type_enum = transformed_config["target_type"]
+            transformed_config["target_type"] = self.action_target_to_string[target_type_enum]
+
+        return transformed_config

--- a/src/sentry/workflow_engine/transformers.py
+++ b/src/sentry/workflow_engine/transformers.py
@@ -88,15 +88,10 @@ class TargetTypeConfigTransformer(ConfigTransformer):
         self.action_target_from_string = {v: k for k, v in self.action_target_to_string.items()}
 
     @staticmethod
-    def from_config_schema(config_schema: dict[str, Any]) -> TargetTypeConfigTransformer | None:
+    def from_config_schema(config_schema: dict[str, Any]) -> TargetTypeConfigTransformer:
         """
         Analyze a config schema and generate a TargetTypeConfigTransformer if target_type field is found.
         """
-        target_type_result = dictpath.walk(config_schema, "properties", "target_type")
-        if target_type_result.failed():
-            return None
-
-        # Use the extracted transformation function
         api_schema = transform_config_schema_target_type_to_api(config_schema)
         return TargetTypeConfigTransformer(api_schema)
 
@@ -104,8 +99,13 @@ class TargetTypeConfigTransformer(ConfigTransformer):
         """
         Convert from api format to config_schema format.
         Main transformation: target_type string -> target_type integer enum
+
+        IMPORTANT: This method validates against the API schema (not config schema)
+        to provide meaningful error messages about the actual API input that users
+        sent, rather than our internal transformed representation. We assume the
+        transformer logic is correct and focus on user-facing validation errors.
         """
-        # First validate the input against api_schema
+        # Validate the API input against the API schema to catch user errors
         validate_json_schema(config, self.api_schema)
 
         # Create a copy to avoid mutating the input

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -96,9 +96,9 @@ class ActionHandler:
 
     group: ClassVar[Group]
 
-    @staticmethod
-    def get_config_transformer() -> ConfigTransformer | None:
-        raise NotImplementedError
+    @classmethod
+    def get_config_transformer(cls) -> ConfigTransformer | None:
+        return None
 
     @staticmethod
     def execute(event_data: WorkflowEventData, action: Action, detector: Detector) -> None:

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
     from sentry.models.environment import Environment
     from sentry.models.group import Group
     from sentry.models.organization import Organization
-    from sentry.notifications.models.notificationaction import ActionTarget
     from sentry.services.eventstore.models import GroupEvent
     from sentry.snuba.models import SnubaQueryEventType
     from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
@@ -73,6 +72,10 @@ class WorkflowEventData:
 
 
 class ConfigTransformer(ABC):
+    """
+    A ConfigTransformer is used to transform the config between API and internal representations.
+    """
+
     @abstractmethod
     def from_api(self, config: dict[str, Any]) -> dict[str, Any]:
         raise NotImplementedError
@@ -80,57 +83,6 @@ class ConfigTransformer(ABC):
     @abstractmethod
     def to_api(self, config: dict[str, Any]) -> dict[str, Any]:
         raise NotImplementedError
-
-
-def action_target_strings(lst: list[ActionTarget]) -> list[str]:
-    from sentry.notifications.models.notificationaction import ActionTarget
-
-    action_target_to_string = dict(ActionTarget.as_choices())
-    return [action_target_to_string[a] for a in lst]
-
-
-class TargetTypeConfigTransformer(ConfigTransformer):
-    def __init__(self, api_schema: dict[str, Any]):
-        from sentry.notifications.models.notificationaction import ActionTarget
-
-        self.api_schema = api_schema
-        self.action_target_to_string = dict(ActionTarget.as_choices())
-        self.action_target_from_string = {v: k for k, v in self.action_target_to_string.items()}
-
-    def from_api(self, config: dict[str, Any]) -> dict[str, Any]:
-        """
-        Convert from api_schema format to config_schema format.
-        Main transformation: target_type string -> target_type integer enum
-        """
-        # First validate the input against api_schema
-        from sentry.workflow_engine.endpoints.validators.utils import validate_json_schema
-
-        validate_json_schema(config, self.api_schema)
-
-        # Create a copy to avoid mutating the input
-        transformed_config = config.copy()
-
-        # Convert target_type from string to ActionTarget enum value
-        if "target_type" in transformed_config:
-            target_type_str = transformed_config["target_type"]
-            transformed_config["target_type"] = self.action_target_from_string[target_type_str]
-
-        return transformed_config
-
-    def to_api(self, config: dict[str, Any]) -> dict[str, Any]:
-        """
-        Convert from config_schema format to api_schema format.
-        Main transformation: target_type integer enum -> target_type string
-        """
-        # Create a copy to avoid mutating the input
-        transformed_config = config.copy()
-
-        # Convert target_type from ActionTarget enum value to string
-        if "target_type" in transformed_config:
-            target_type_enum = transformed_config["target_type"]
-            transformed_config["target_type"] = self.action_target_to_string[target_type_enum]
-
-        return transformed_config
 
 
 class ActionHandler:
@@ -146,7 +98,7 @@ class ActionHandler:
 
     @staticmethod
     def get_config_transformer() -> ConfigTransformer | None:
-        return None
+        raise NotImplementedError
 
     @staticmethod
     def execute(event_data: WorkflowEventData, action: Action, detector: Detector) -> None:

--- a/src/sentry/workflow_engine/utils/dictpath.py
+++ b/src/sentry/workflow_engine/utils/dictpath.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+def _tname(t: type | tuple[type, ...]) -> str:
+    if isinstance(t, type):
+        return t.__name__
+    return " | ".join(t.__name__ for t in t)
+
+
+class Result[T](Protocol):
+    """
+    A result type for safe dictionary traversal operations.
+
+    Provides a monadic interface for chaining operations that may fail,
+    with automatic error propagation and type-safe value extraction.
+    """
+
+    def expect[V](self, t: type[V]) -> Result[V]:
+        """Validate that the contained value is of the expected type."""
+        raise NotImplementedError
+
+    def failed(self) -> bool:
+        """Check if this result represents a failure."""
+        raise NotImplementedError
+
+    def get(self, fallback: T | None = None) -> T:
+        """Extract the value, raising an exception on failure unless fallback is provided."""
+        raise NotImplementedError
+
+
+class _FailedResultImpl[T]:
+    def __init__(self, exc: ValueError) -> None:
+        self._exc = exc
+
+    def failed(self) -> bool:
+        return True
+
+    def get(self, fallback: T | None = None) -> T:
+        if fallback is not None:
+            return fallback
+        raise self._exc
+
+    def expect[V](self, t: type[V]) -> Result[V]:
+        return _FailedResultImpl[V](self._exc)
+
+
+def _dictpath_error(path: list[str], msg: str) -> ValueError:
+    return ValueError(f"{'.'.join(path)}: {msg}")
+
+
+def _failure[T](path: list[str], msg: str) -> Result[T]:
+    return _FailedResultImpl[T](_dictpath_error(path, msg))
+
+
+class _SuccessResultImpl[T]:
+    def __init__(self, path: list[str], v: T) -> None:
+        self._path = path
+        self._v = v
+
+    def failed(self) -> bool:
+        return False
+
+    def get(self, fallback: T | None = None) -> T:
+        return self._v
+
+    def expect[V](self, t: type[V]) -> Result[V]:
+        v = self._v
+        if not isinstance(v, t):
+            return _failure(self._path, f"Expected {_tname(t)}, got {_tname(type(v))}")
+        # TODO: can we reuse self?
+        return _SuccessResultImpl[V](self._path, v)
+
+
+def _success[T](path: list[str], v: T) -> Result[T]:
+    return _SuccessResultImpl[T](path, v)
+
+
+def walk(data: object, *path: str) -> Result[object]:
+    """
+    Traverse an object based on a path and return a result.
+    """
+    current = data
+    history = []
+    for pathelt in path:
+        history.append(pathelt)
+        if not isinstance(current, dict):
+            return _failure(history, "was not a dict!")
+        if pathelt not in current:
+            return _failure(history, "not found!")
+        current = current[pathelt]
+    return _success(history, current)

--- a/src/sentry/workflow_engine/utils/dictpath.py
+++ b/src/sentry/workflow_engine/utils/dictpath.py
@@ -29,6 +29,10 @@ class Result[T](Protocol):
         """Extract the value, raising an exception on failure unless fallback is provided."""
         ...
 
+    def get_or_none(self) -> T | None:
+        """Extract the value, returning None on failure."""
+        ...
+
     def list_of[V](self, t: type[V]) -> Result[list[V]]:
         """Validate that the contained value is a list of the expected type."""
         ...
@@ -45,6 +49,9 @@ class _FailedResultImpl[T]:
         if fallback is not None:
             return fallback
         raise self._exc
+
+    def get_or_none(self) -> T | None:
+        return None
 
     def is_type[V](self, t: type[V]) -> Result[V]:
         return cast(Result[V], self)
@@ -71,6 +78,9 @@ class _SuccessResultImpl[T]:
         return False
 
     def get(self, fallback: T | None = None) -> T:
+        return self._v
+
+    def get_or_none(self) -> T | None:
         return self._v
 
     def is_type[V](self, t: type[V]) -> Result[V]:

--- a/src/sentry/workflow_engine/utils/dictpath.py
+++ b/src/sentry/workflow_engine/utils/dictpath.py
@@ -96,6 +96,14 @@ def _success[T](path: list[str], v: T) -> Result[T]:
 def walk(data: object, *path: str) -> Result[object]:
     """
     Traverse an object based on a path and return a result.
+
+    Example:
+        >>> walk({"a": {"b": "c"}}, "a", "b").get()
+        "c"
+        >>> walk({"a": {"b": "c"}}, "e", "f", "g").get()
+        ValueError: e.f.g: not found!
+        >>> walk({"a": {"b": "c"}}, "a", "b", "c").is_type(int).get()
+        ValueError: a.b.c: Expected int, got str
     """
     current = data
     history = []

--- a/static/app/types/workflowEngine/actions.tsx
+++ b/static/app/types/workflowEngine/actions.tsx
@@ -27,11 +27,11 @@ export interface ActionConfig {
 }
 
 export enum ActionTarget {
-  SPECIFIC = 0,
-  USER = 1,
-  TEAM = 2,
-  SENTRY_APP = 3,
-  ISSUE_OWNERS = 4,
+  SPECIFIC = 'specific',
+  USER = 'user',
+  TEAM = 'team',
+  SENTRY_APP = 'sentry_app',
+  ISSUE_OWNERS = 'issue_owners',
 }
 
 export enum ActionType {

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_action_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_action_serializer.py
@@ -62,7 +62,7 @@ class TestActionSerializer(TestCase):
             integration_id=self.integration.id,
             config={
                 "target_identifier": "123",
-                "target_type": ActionTarget.SPECIFIC.value,
+                "target_type": ActionTarget.SPECIFIC,
             },
         )
 

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_action_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_action_serializer.py
@@ -73,7 +73,7 @@ class TestActionSerializer(TestCase):
             "type": "opsgenie",
             "data": {"priority": "P1"},
             "integrationId": str(self.integration.id),
-            "config": {"targetType": 0, "targetIdentifier": "123"},
+            "config": {"targetType": "specific", "targetIdentifier": "123"},
             "status": "active",
         }
 
@@ -97,7 +97,7 @@ class TestActionSerializer(TestCase):
             "data": {"tags": "bar"},
             "integrationId": str(self.integration.id),
             "config": {
-                "targetType": 0,
+                "targetType": "specific",
                 "targetDisplay": "freddy frog",
                 "targetIdentifier": "123-id",
             },

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_data_condition_group_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_data_condition_group_serializer.py
@@ -69,7 +69,7 @@ class TestDataConditionGroupSerializer(TestCase):
                     "type": "email",
                     "data": {},
                     "integrationId": None,
-                    "config": {"targetType": 1, "targetIdentifier": "123"},
+                    "config": {"targetType": "user", "targetIdentifier": "123"},
                     "status": "active",
                 }
             ],

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_detector_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_detector_serializer.py
@@ -159,7 +159,7 @@ class TestDetectorSerializer(TestCase):
                         "type": "email",
                         "data": {},
                         "integrationId": None,
-                        "config": {"targetType": 1, "targetIdentifier": "123"},
+                        "config": {"targetType": "user", "targetIdentifier": "123"},
                         "status": "active",
                     }
                 ],

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_workflow_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_workflow_serializer.py
@@ -156,7 +156,7 @@ class TestWorkflowSerializer(TestCase):
                             "type": "email",
                             "data": {},
                             "integrationId": None,
-                            "config": {"targetType": 1, "targetIdentifier": "123"},
+                            "config": {"targetType": "user", "targetIdentifier": "123"},
                             "status": "active",
                         }
                     ],

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -6,7 +6,6 @@ from sentry.integrations.jira.integration import JiraIntegration
 from sentry.integrations.pagerduty.client import PagerDutyClient
 from sentry.integrations.pagerduty.utils import PagerDutyServiceDict, add_service
 from sentry.models.project import Project
-from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.group_type_notification_registry import (
     IssueAlertRegistryHandler,
 )
@@ -81,7 +80,7 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
                 },
                 "config": {
                     "target_identifier": str(service_info["id"]),
-                    "target_type": ActionTarget.SPECIFIC.value,
+                    "target_type": "specific",
                 },
             }
         ]
@@ -144,15 +143,15 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
                         }
                     ],
                 },
-                "config": {"target_type": ActionTarget.SPECIFIC.value},
+                "config": {"target_type": "specific"},
             }
         ]
 
         response = self.get_error_response(self.organization.slug, actions=action_data)
 
         assert response.status_code == 400
-        assert mock_create_issue.call_count == 1
         assert response.data == {"actions": [str(form_errors)]}
+        assert mock_create_issue.call_count == 1
 
     @mock.patch.object(JiraIntegration, "create_issue")
     @mock.patch.object(sentry_sdk, "capture_exception")
@@ -181,7 +180,7 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
                     ],
                 },
                 "config": {
-                    "target_type": ActionTarget.SPECIFIC.value,
+                    "target_type": "specific",
                 },
             }
         ]

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -514,7 +514,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
                         "config": {
                             "targetIdentifier": "test",
                             "targetDisplay": "Test",
-                            "targetType": 0,
+                            "targetType": "specific",
                         },
                         "data": {},
                         "integrationId": self.integration.id,

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_discord.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_discord.py
@@ -3,7 +3,6 @@ from unittest import mock
 from django.core.exceptions import ValidationError
 from rest_framework.exceptions import ErrorDetail
 
-from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
 from sentry.workflow_engine.models import Action
@@ -24,7 +23,7 @@ class TestDiscordActionValidator(TestCase):
             "type": Action.Type.DISCORD,
             "config": {
                 "targetIdentifier": "1234567890",
-                "targetType": ActionTarget.SPECIFIC.value,
+                "targetType": "specific",
             },
             "data": {"tags": "asdf"},
             "integrationId": self.integration.id,
@@ -48,7 +47,7 @@ class TestDiscordActionValidator(TestCase):
             data={
                 **self.valid_data,
                 "config": {
-                    "targetType": ActionTarget.SPECIFIC.value,
+                    "targetType": "specific",
                     "targetIdentifier": "",
                 },
             },

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_email_validator.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_email_validator.py
@@ -1,4 +1,3 @@
-from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
 from sentry.workflow_engine.models import Action
@@ -10,7 +9,7 @@ class TestEmailActionValidator(TestCase):
         self.team = self.create_team(organization=self.organization)
         self.valid_data = {
             "type": Action.Type.EMAIL,
-            "config": {"targetType": ActionTarget.USER, "targetIdentifier": str(self.user.id)},
+            "config": {"targetType": "user", "targetIdentifier": str(self.user.id)},
             "data": {},
         }
 
@@ -26,7 +25,7 @@ class TestEmailActionValidator(TestCase):
         validator = BaseActionValidator(
             data={
                 **self.valid_data,
-                "config": {"target_type": ActionTarget.USER},
+                "config": {"target_type": "user"},
             },
             context={"organization": self.organization},
         )
@@ -38,31 +37,31 @@ class TestEmailActionValidator(TestCase):
             data={
                 **self.valid_data,
                 "config": {
-                    "target_type": ActionTarget.TEAM,
+                    "target_type": "team",
                     "target_identifier": str(self.team.id),
                 },
             },
             context={"organization": self.organization},
         )
-        result = validator.is_valid()
+        result = validator.is_valid(raise_exception=True)
         assert result is True
 
     def test_validate__issue_owners(self):
         validator = BaseActionValidator(
             data={
                 **self.valid_data,
-                "config": {"target_type": ActionTarget.ISSUE_OWNERS},
+                "config": {"target_type": "issue_owners"},
             },
             context={"organization": self.organization},
         )
-        result = validator.is_valid()
+        result = validator.is_valid(raise_exception=True)
         assert result is True
 
     def test_validate__invalid_target_type(self):
         validator = BaseActionValidator(
             data={
                 **self.valid_data,
-                "config": {"targetType": ActionTarget.SPECIFIC},
+                "config": {"targetType": "specific"},
             },
             context={"organization": self.organization},
         )

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_msteams.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_msteams.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 from rest_framework.exceptions import ErrorDetail
 
-from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
 from sentry.workflow_engine.models import Action
@@ -17,7 +16,7 @@ class TestMSTeamsActionValidator(TestCase):
 
         self.valid_data = {
             "type": Action.Type.MSTEAMS,
-            "config": {"targetDisplay": "cathy-sentry", "targetType": ActionTarget.SPECIFIC.value},
+            "config": {"targetDisplay": "cathy-sentry", "targetType": "specific"},
             "data": {},
             "integrationId": self.integration.id,
         }
@@ -43,7 +42,7 @@ class TestMSTeamsActionValidator(TestCase):
             data={
                 **self.valid_data,
                 "config": {
-                    "targetType": ActionTarget.SPECIFIC.value,
+                    "targetType": "specific",
                     "targetIdentifier": "C1234567890",
                     "targetDisplay": "asdf",
                 },

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_opsgenie.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_opsgenie.py
@@ -1,6 +1,5 @@
 from rest_framework.exceptions import ErrorDetail
 
-from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
@@ -35,7 +34,7 @@ class TestOpsgenieActionValidator(TestCase):
 
         self.valid_data = {
             "type": Action.Type.OPSGENIE,
-            "config": {"targetIdentifier": "123-id", "targetType": ActionTarget.SPECIFIC.value},
+            "config": {"targetIdentifier": "123-id", "targetType": "specific"},
             "data": {},
             "integrationId": self.integration.id,
         }
@@ -55,7 +54,7 @@ class TestOpsgenieActionValidator(TestCase):
             data={
                 **self.valid_data,
                 "config": {
-                    "targetType": ActionTarget.SPECIFIC.value,
+                    "targetType": "specific",
                     "targetIdentifier": "54321",
                 },
             },

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_pagerduty.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_pagerduty.py
@@ -1,6 +1,5 @@
 from rest_framework.exceptions import ErrorDetail
 
-from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
@@ -35,7 +34,7 @@ class TestPagerDutyActionValidator(TestCase):
 
         self.valid_data = {
             "type": Action.Type.PAGERDUTY,
-            "config": {"targetIdentifier": "123", "targetType": ActionTarget.SPECIFIC.value},
+            "config": {"targetIdentifier": "123", "targetType": "specific"},
             "data": {},
             "integrationId": self.integration.id,
         }
@@ -55,7 +54,7 @@ class TestPagerDutyActionValidator(TestCase):
             data={
                 **self.valid_data,
                 "config": {
-                    "targetType": ActionTarget.SPECIFIC.value,
+                    "targetType": "specific",
                     "targetIdentifier": "54321",
                 },
             },

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_sentry_app.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_sentry_app.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 from rest_framework.serializers import ErrorDetail
 
-from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.sentry_apps.services.app.model import RpcAlertRuleActionResult
 from sentry.sentry_apps.utils.errors import SentryAppErrorType
 from sentry.testutils.cases import TestCase
@@ -18,7 +17,7 @@ class TestSentryAppActionValidator(TestCase):
             "type": Action.Type.SENTRY_APP,
             "config": {
                 "sentry_app_identifier": "sentry_app_installation_uuid",
-                "targetType": ActionTarget.SENTRY_APP.value,
+                "targetType": "sentry_app",
                 "target_identifier": "123",
             },
             "data": {"settings": []},

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_slack.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_slack.py
@@ -4,7 +4,6 @@ from django.core.exceptions import ValidationError
 from rest_framework.serializers import ErrorDetail
 
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
-from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.shared_integrations.exceptions import DuplicateDisplayNameError
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
@@ -24,7 +23,7 @@ class TestSlackActionValidator(TestCase):
 
         self.valid_data = {
             "type": Action.Type.SLACK,
-            "config": {"targetDisplay": "cathy-sentry", "targetType": ActionTarget.SPECIFIC.value},
+            "config": {"targetDisplay": "cathy-sentry", "targetType": "specific"},
             "data": {"tags": "asdf"},
             "integrationId": self.integration.id,
         }
@@ -52,7 +51,7 @@ class TestSlackActionValidator(TestCase):
             data={
                 **self.valid_data,
                 "config": {
-                    "targetType": ActionTarget.SPECIFIC.value,
+                    "targetType": "specific",
                     "targetIdentifier": "C1234567890",
                     "targetDisplay": "asdf",
                 },
@@ -73,7 +72,7 @@ class TestSlackActionValidator(TestCase):
         validator = BaseActionValidator(
             data={
                 **self.valid_data,
-                "config": {"targetType": ActionTarget.SPECIFIC.value, "targetDisplay": "asdf"},
+                "config": {"targetType": "specific", "targetDisplay": "asdf"},
             },
             context={"organization": self.organization},
         )

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -369,7 +369,7 @@ class TestWorkflowValidatorUpdate(TestCase):
                         "config": {
                             "target_identifier": "foo",
                             "target_display": "bar",
-                            "target_type": 0,
+                            "target_type": "specific",
                         },
                         "data": {},
                         "integrationId": self.integration.id,
@@ -486,7 +486,7 @@ class TestWorkflowValidatorUpdate(TestCase):
                         "config": {
                             "targetIdentifier": "bar",
                             "targetDisplay": "baz",
-                            "targetType": 0,
+                            "targetType": "specific",
                         },
                         "data": {},
                         "integrationId": self.integration.id,
@@ -610,7 +610,7 @@ class TestWorkflowValidatorUpdate(TestCase):
                 "config": {
                     "targetIdentifier": "foo",
                     "targetDisplay": "bar",
-                    "targetType": 0,
+                    "targetType": "specific",
                 },
                 "data": {},
                 "integrationId": self.integration.id,
@@ -639,7 +639,7 @@ class TestWorkflowValidatorUpdate(TestCase):
                 "type": Action.Type.EMAIL,
                 "config": {
                     "targetIdentifier": str(self.user.id),
-                    "targetType": ActionTarget.USER,
+                    "targetType": "user",
                 },
                 "data": {},
             }

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -36,6 +36,7 @@ from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import data_source_type_registry
 from sentry.workflow_engine.types import (
     ActionHandler,
+    ConfigTransformer,
     DataConditionHandler,
     DataConditionResult,
     DetectorPriorityLevel,
@@ -83,6 +84,10 @@ class MockActionHandler(ActionHandler):
         "required": ["baz"],
         "additionalProperties": False,
     }
+
+    @staticmethod
+    def get_config_transformer() -> ConfigTransformer | None:
+        return None
 
 
 class MockActionValidatorTranslator(BaseActionValidatorHandler):

--- a/tests/sentry/workflow_engine/test_transformers.py
+++ b/tests/sentry/workflow_engine/test_transformers.py
@@ -256,18 +256,18 @@ class TestTargetTypeConfigTransformerFromConfigSchema(TestCase):
             },
         }
 
-        transformer = TargetTypeConfigTransformer.from_config_schema(config_schema)
-        assert transformer is None
+        with pytest.raises(ValueError):
+            TargetTypeConfigTransformer.from_config_schema(config_schema)
 
     def test_from_config_schema_invalid_structure(self) -> None:
         """Test returns None for invalid structure."""
         # No properties
-        transformer = TargetTypeConfigTransformer.from_config_schema({"type": "object"})
-        assert transformer is None
+        with pytest.raises(ValueError):
+            TargetTypeConfigTransformer.from_config_schema({"type": "object"})
 
         # Properties not dict
-        transformer = TargetTypeConfigTransformer.from_config_schema({"properties": "not_dict"})
-        assert transformer is None
+        with pytest.raises(ValueError):
+            TargetTypeConfigTransformer.from_config_schema({"properties": "not_dict"})
 
     def test_from_config_schema_invalid_target_type_raises(self) -> None:
         """Test raises ValueError for invalid target_type field."""

--- a/tests/sentry/workflow_engine/test_transformers.py
+++ b/tests/sentry/workflow_engine/test_transformers.py
@@ -1,0 +1,284 @@
+import pytest
+
+from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.transformers import (
+    TargetTypeConfigTransformer,
+    action_target_strings,
+    transform_config_schema_target_type_to_api,
+)
+
+
+class TestActionTargetStrings(TestCase):
+    def test_action_target_strings(self) -> None:
+        targets = [ActionTarget.USER, ActionTarget.TEAM, ActionTarget.ISSUE_OWNERS]
+        result = action_target_strings(targets)
+
+        expected = ["user", "team", "issue_owners"]
+        assert result == expected
+
+    def test_action_target_strings_single(self) -> None:
+        targets = [ActionTarget.SPECIFIC]
+        result = action_target_strings(targets)
+
+        expected = ["specific"]
+        assert result == expected
+
+    def test_action_target_strings_empty(self) -> None:
+        result = action_target_strings([])
+        assert result == []
+
+
+class TestTransformConfigSchemaTargetTypeToApi(TestCase):
+    def test_transform_simple_schema(self) -> None:
+        """Test transforming a simple config schema."""
+        config_schema = {
+            "type": "object",
+            "properties": {
+                "target_identifier": {"type": "string"},
+                "target_type": {
+                    "type": "integer",
+                    "enum": [ActionTarget.SPECIFIC.value],
+                },
+            },
+            "required": ["target_type"],
+        }
+
+        result = transform_config_schema_target_type_to_api(config_schema)
+
+        # Should convert integer target_type to string
+        assert result["properties"]["target_type"]["type"] == "string"
+        assert result["properties"]["target_type"]["enum"] == ["specific"]
+
+        # Should preserve other fields
+        assert result["properties"]["target_identifier"] == {"type": "string"}
+        assert result["required"] == ["target_type"]
+
+    def test_transform_multiple_target_types(self) -> None:
+        """Test transforming schema with multiple target types."""
+        config_schema = {
+            "type": "object",
+            "properties": {
+                "target_type": {
+                    "type": "integer",
+                    "enum": [
+                        ActionTarget.USER.value,
+                        ActionTarget.TEAM.value,
+                        ActionTarget.ISSUE_OWNERS.value,
+                    ],
+                },
+            },
+        }
+
+        result = transform_config_schema_target_type_to_api(config_schema)
+
+        assert result["properties"]["target_type"]["type"] == "string"
+        assert set(result["properties"]["target_type"]["enum"]) == {"user", "team", "issue_owners"}
+
+    def test_transform_list_type(self) -> None:
+        """Test transforming schema where target_type has list of types."""
+        config_schema = {
+            "type": "object",
+            "properties": {
+                "target_type": {
+                    "type": ["integer", "null"],
+                    "enum": [ActionTarget.SPECIFIC.value],
+                },
+            },
+        }
+
+        result = transform_config_schema_target_type_to_api(config_schema)
+
+        assert result["properties"]["target_type"]["type"] == ["string", "null"]
+        assert result["properties"]["target_type"]["enum"] == ["specific"]
+
+    def test_no_properties(self) -> None:
+        """Test schema without properties should raise ValueError."""
+        config_schema = {"type": "object"}
+
+        with pytest.raises(ValueError, match="config_schema must have 'properties' dict"):
+            transform_config_schema_target_type_to_api(config_schema)
+
+    def test_no_target_type(self) -> None:
+        """Test schema without target_type should raise ValueError."""
+        config_schema = {
+            "type": "object",
+            "properties": {"other_field": {"type": "string"}},
+        }
+
+        with pytest.raises(ValueError, match="target_type field not found"):
+            transform_config_schema_target_type_to_api(config_schema)
+
+    def test_invalid_target_type_spec(self) -> None:
+        """Test invalid target_type specification."""
+        config_schema = {
+            "type": "object",
+            "properties": {
+                "target_type": "invalid",  # Should be a dict
+            },
+        }
+
+        with pytest.raises(ValueError, match="target_type field specification must be a dict"):
+            transform_config_schema_target_type_to_api(config_schema)
+
+    def test_missing_type(self) -> None:
+        """Test target_type without type specification."""
+        config_schema = {
+            "type": "object",
+            "properties": {
+                "target_type": {
+                    "enum": [ActionTarget.SPECIFIC.value],
+                    # Missing "type"
+                },
+            },
+        }
+
+        with pytest.raises(ValueError, match="target_type field must have a 'type' specification"):
+            transform_config_schema_target_type_to_api(config_schema)
+
+    def test_wrong_type(self) -> None:
+        """Test target_type with non-integer type."""
+        config_schema = {
+            "type": "object",
+            "properties": {
+                "target_type": {
+                    "type": "string",
+                    "enum": ["test"],
+                },
+            },
+        }
+
+        with pytest.raises(ValueError, match="target_type field must be of type 'integer'"):
+            transform_config_schema_target_type_to_api(config_schema)
+
+    def test_list_type_without_integer(self) -> None:
+        """Test target_type with list type that doesn't include integer."""
+        config_schema = {
+            "type": "object",
+            "properties": {
+                "target_type": {
+                    "type": ["string", "null"],
+                    "enum": ["test"],
+                },
+            },
+        }
+
+        with pytest.raises(ValueError, match="target_type field must include 'integer' type"):
+            transform_config_schema_target_type_to_api(config_schema)
+
+    def test_missing_enum(self) -> None:
+        """Test target_type without enum values."""
+        config_schema = {
+            "type": "object",
+            "properties": {
+                "target_type": {
+                    "type": "integer",
+                    # Missing "enum"
+                },
+            },
+        }
+
+        with pytest.raises(ValueError, match="target_type field must have 'enum' values specified"):
+            transform_config_schema_target_type_to_api(config_schema)
+
+    def test_empty_enum(self) -> None:
+        """Test target_type with empty enum."""
+        config_schema = {
+            "type": "object",
+            "properties": {
+                "target_type": {
+                    "type": "integer",
+                    "enum": [],
+                },
+            },
+        }
+
+        with pytest.raises(ValueError, match="target_type enum must be a non-empty list"):
+            transform_config_schema_target_type_to_api(config_schema)
+
+    def test_non_integer_enum_value(self) -> None:
+        """Test target_type with non-integer enum value."""
+        config_schema = {
+            "type": "object",
+            "properties": {
+                "target_type": {
+                    "type": "integer",
+                    "enum": ["not_integer"],
+                },
+            },
+        }
+
+        with pytest.raises(ValueError, match="All enum values must be integers"):
+            transform_config_schema_target_type_to_api(config_schema)
+
+    def test_unknown_target_value(self) -> None:
+        """Test target_type with unknown ActionTarget value."""
+        config_schema = {
+            "type": "object",
+            "properties": {
+                "target_type": {
+                    "type": "integer",
+                    "enum": [999],  # Unknown ActionTarget value
+                },
+            },
+        }
+
+        with pytest.raises(ValueError, match="Unknown ActionTarget value: 999"):
+            transform_config_schema_target_type_to_api(config_schema)
+
+
+class TestTargetTypeConfigTransformerFromConfigSchema(TestCase):
+    def test_from_config_schema_success(self) -> None:
+        """Test successful creation from config schema."""
+        config_schema = {
+            "type": "object",
+            "properties": {
+                "target_type": {
+                    "type": "integer",
+                    "enum": [ActionTarget.SPECIFIC.value],
+                },
+            },
+        }
+
+        transformer = TargetTypeConfigTransformer.from_config_schema(config_schema)
+
+        assert transformer is not None
+        assert transformer.api_schema["properties"]["target_type"]["type"] == "string"
+        assert transformer.api_schema["properties"]["target_type"]["enum"] == ["specific"]
+
+    def test_from_config_schema_no_target_type(self) -> None:
+        """Test returns None when no target_type field."""
+        config_schema = {
+            "type": "object",
+            "properties": {
+                "other_field": {"type": "string"},
+            },
+        }
+
+        transformer = TargetTypeConfigTransformer.from_config_schema(config_schema)
+        assert transformer is None
+
+    def test_from_config_schema_invalid_structure(self) -> None:
+        """Test returns None for invalid structure."""
+        # No properties
+        transformer = TargetTypeConfigTransformer.from_config_schema({"type": "object"})
+        assert transformer is None
+
+        # Properties not dict
+        transformer = TargetTypeConfigTransformer.from_config_schema({"properties": "not_dict"})
+        assert transformer is None
+
+    def test_from_config_schema_invalid_target_type_raises(self) -> None:
+        """Test raises ValueError for invalid target_type field."""
+        config_schema = {
+            "type": "object",
+            "properties": {
+                "target_type": {
+                    "type": "string",  # Wrong type
+                    "enum": ["test"],
+                },
+            },
+        }
+
+        with pytest.raises(ValueError):
+            TargetTypeConfigTransformer.from_config_schema(config_schema)

--- a/tests/sentry/workflow_engine/test_transformers.py
+++ b/tests/sentry/workflow_engine/test_transformers.py
@@ -96,7 +96,7 @@ class TestTransformConfigSchemaTargetTypeToApi(TestCase):
         """Test schema without properties should raise ValueError."""
         config_schema = {"type": "object"}
 
-        with pytest.raises(ValueError, match="config_schema must have 'properties' dict"):
+        with pytest.raises(ValueError):
             transform_config_schema_target_type_to_api(config_schema)
 
     def test_no_target_type(self) -> None:
@@ -106,7 +106,7 @@ class TestTransformConfigSchemaTargetTypeToApi(TestCase):
             "properties": {"other_field": {"type": "string"}},
         }
 
-        with pytest.raises(ValueError, match="target_type field not found"):
+        with pytest.raises(ValueError):
             transform_config_schema_target_type_to_api(config_schema)
 
     def test_invalid_target_type_spec(self) -> None:
@@ -118,7 +118,7 @@ class TestTransformConfigSchemaTargetTypeToApi(TestCase):
             },
         }
 
-        with pytest.raises(ValueError, match="target_type field specification must be a dict"):
+        with pytest.raises(ValueError):
             transform_config_schema_target_type_to_api(config_schema)
 
     def test_missing_type(self) -> None:
@@ -133,7 +133,7 @@ class TestTransformConfigSchemaTargetTypeToApi(TestCase):
             },
         }
 
-        with pytest.raises(ValueError, match="target_type field must have a 'type' specification"):
+        with pytest.raises(ValueError):
             transform_config_schema_target_type_to_api(config_schema)
 
     def test_wrong_type(self) -> None:
@@ -178,7 +178,7 @@ class TestTransformConfigSchemaTargetTypeToApi(TestCase):
             },
         }
 
-        with pytest.raises(ValueError, match="target_type field must have 'enum' values specified"):
+        with pytest.raises(ValueError):
             transform_config_schema_target_type_to_api(config_schema)
 
     def test_empty_enum(self) -> None:

--- a/tests/sentry/workflow_engine/test_transformers.py
+++ b/tests/sentry/workflow_engine/test_transformers.py
@@ -1,7 +1,8 @@
+from unittest import TestCase
+
 import pytest
 
 from sentry.notifications.models.notificationaction import ActionTarget
-from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.transformers import (
     TargetTypeConfigTransformer,
     action_target_strings,
@@ -208,7 +209,7 @@ class TestTransformConfigSchemaTargetTypeToApi(TestCase):
             },
         }
 
-        with pytest.raises(ValueError, match="All enum values must be integers"):
+        with pytest.raises(ValueError):
             transform_config_schema_target_type_to_api(config_schema)
 
     def test_unknown_target_value(self) -> None:

--- a/tests/sentry/workflow_engine/utils/test_dictpath.py
+++ b/tests/sentry/workflow_engine/utils/test_dictpath.py
@@ -1,0 +1,17 @@
+from sentry.workflow_engine.utils import dictpath
+
+
+def test_basic() -> None:
+    data = {
+        "a": {
+            "b": {
+                "c": 1,
+            },
+        },
+    }
+    assert dictpath.walk(5).get() == 5
+    assert dictpath.walk({}, "no", "nope").get("") == ""
+    assert dictpath.walk(data, "a", "b", "c").get() == 1
+    assert dictpath.walk(data, "a", "b", "c").is_type(int).get() == 1
+    assert dictpath.walk(data, "a", "b", "c").is_type(str).failed()
+    assert dictpath.walk(data, "nope", "b", "c").get(1) == 1


### PR DESCRIPTION
Most Action configs store a targetType as an int enum value.
For the API, we want more intuitive string labels, so this adds a ConfigTransformer that can be
supplied by the ActionHandler, and provides an implementation that translates targetTypes as necessary.


Fixes https://getsentry.atlassian.net/browse/ACI-436.