### PR TITLE
fix(aci): disable Next button when no monitor type is selected

### DIFF
--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -6,6 +6,8 @@ import RadioField from 'sentry/components/forms/fields/radioField';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {DetectorType} from 'sentry/types/workflowEngine/detectors';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {getDetectorTypeLabel} from 'sentry/views/detectors/utils/detectorTypeConfig';
 
 export function DetectorTypeForm() {
@@ -24,11 +26,27 @@ export function DetectorTypeForm() {
 }
 
 function MonitorTypeField() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const selectedDetectorType = location.query.detectorType as DetectorType;
+
+  const handleChange = (value: DetectorType) => {
+    navigate({
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        detectorType: value,
+      },
+    });
+  };
+
   return (
     <StyledRadioField
       inline={false}
       flexibleControlStateSize
       name="detectorType"
+      value={selectedDetectorType}
+      onChange={handleChange}
       choices={
         [
           [

--- a/static/app/views/detectors/new.spec.tsx
+++ b/static/app/views/detectors/new.spec.tsx
@@ -23,9 +23,13 @@ describe('DetectorNew', () => {
   it('sets query parameters for project, environment, and detectorType', async () => {
     const {router} = render(<DetectorNew />);
 
+    // Next button should be disabled if no detectorType is selected
+    expect(screen.getByRole('button', {name: 'Next'})).toBeDisabled();
+
     // Set detectorType
     await userEvent.click(screen.getByRole('radio', {name: 'Uptime'}));
 
+    expect(screen.getByRole('button', {name: 'Next'})).toBeEnabled();
     await userEvent.click(screen.getByRole('button', {name: 'Next'}));
 
     expect(router.location).toEqual(

--- a/static/app/views/detectors/new.tsx
+++ b/static/app/views/detectors/new.tsx
@@ -1,6 +1,7 @@
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import EditLayout from 'sentry/components/workflowEngine/layout/edit';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
@@ -83,9 +84,15 @@ export default function DetectorNew() {
         <LinkButton priority="default" to={makeMonitorBasePathname(organization.slug)}>
           {t('Cancel')}
         </LinkButton>
-        <Button priority="primary" type="submit">
-          {t('Next')}
-        </Button>
+        <Tooltip
+          title={t('Select a monitor type to continue')}
+          disabled={!!detectorType}
+          skipWrapper
+        >
+          <Button priority="primary" type="submit" disabled={!detectorType}>
+            {t('Next')}
+          </Button>
+        </Tooltip>
       </EditLayout.Footer>
     </EditLayout>
   );


### PR DESCRIPTION
users should not be able to continue without selecting a monitor type

<img width="1401" height="768" alt="Screenshot 2025-09-25 at 10 30 47 AM" src="https://github.com/user-attachments/assets/a808ed1a-cc6f-426c-917b-2e7d3cf87675" />
