### PR TITLE
fix(replay): Fix playing mobile replays on mobile

### DIFF
--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -203,7 +203,7 @@ export class VideoReplayer {
     sourceEl.setAttribute('type', 'video/mp4');
     sourceEl.setAttribute('src', `${this._videoApiPrefix}${segmentData.id}/`);
     el.setAttribute('muted', '');
-    el.setAttribute('playinline', '');
+    el.setAttribute('playsinline', '');
     el.setAttribute('preload', 'auto');
     el.setAttribute('playbackRate', `${this.config.speed}`);
     el.appendChild(sourceEl);

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -201,7 +201,8 @@ export class VideoReplayer {
     el.style.zIndex = index.toString();
     el.style.position = 'absolute';
     sourceEl.setAttribute('type', 'video/mp4');
-    sourceEl.setAttribute('src', `${this._videoApiPrefix}${segmentData.id}/`);
+    // the #t=0.001 is a hack for mobile safari to show the first frame of the video as a placeholder
+    sourceEl.setAttribute('src', `${this._videoApiPrefix}${segmentData.id}/#t=0.001`);
     el.setAttribute('muted', '');
     el.setAttribute('playsinline', '');
     el.setAttribute('preload', 'auto');


### PR DESCRIPTION
Currently, watching mobile replays on a mobile browser will result in playing them in fullscreen. This also means that you only ever see the first replay segment. The cause is a typo in the attribute `playsinline`. Mobile replays should now play inline on mobile browsers (similar to playing on desktop).

I've also added a hack that should fix the mobile replay video not showing a placeholder/preview frame.
