### PR TITLE
bug(preprod): Add explicit error state for missing comparison with trigger logic to allow user to start a comparison in that case

### DIFF
--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -232,12 +232,29 @@ export function SizeCompareMainContent() {
     );
   }
 
-  if (
-    [
-      SizeAnalysisComparisonState.PROCESSING,
-      SizeAnalysisComparisonState.PENDING,
-    ].includes(mainArtifactComparison.state)
-  ) {
+  // Should likely never be hit, but allow a user to trigger a comparison if they get here.
+  if (mainArtifactComparison.state === SizeAnalysisComparisonState.PENDING) {
+    return (
+      <BuildError
+        title={t('No comparison data available')}
+        message={t("We don't have any comparison data available yet for these builds.")}
+      >
+        <Button
+          priority="primary"
+          onClick={() => {
+            triggerComparison({
+              baseArtifactId,
+              headArtifactId,
+            });
+          }}
+        >
+          {t('Trigger a comparison')}
+        </Button>
+      </BuildError>
+    );
+  }
+
+  if (mainArtifactComparison.state === SizeAnalysisComparisonState.PROCESSING) {
     return (
       <Flex width="100%" justify="center" align="center">
         <BuildProcessing

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -211,31 +211,6 @@ export function SizeCompareMainContent() {
   if (!mainArtifactComparison) {
     return (
       <BuildError
-        title={t('Comparison data not found')}
-        message={t(
-          'Something went wrong and we weren’t able to find the correct comparison.'
-        )}
-      >
-        <Flex gap="sm">
-          <Button
-            priority="default"
-            onClick={() => {
-              navigate(
-                `/organizations/${organization.slug}/preprod/${projectId}/compare/${headArtifactId}/`
-              );
-            }}
-          >
-            {t('Back')}
-          </Button>
-        </Flex>
-      </BuildError>
-    );
-  }
-
-  // Should likely never be hit, but allow a user to trigger a comparison if they get here.
-  if (mainArtifactComparison.state === SizeAnalysisComparisonState.PENDING) {
-    return (
-      <BuildError
         title={t('No comparison data available')}
         message={t("We don't have any comparison data available yet for these builds.")}
       >
@@ -254,7 +229,12 @@ export function SizeCompareMainContent() {
     );
   }
 
-  if (mainArtifactComparison.state === SizeAnalysisComparisonState.PROCESSING) {
+  if (
+    [
+      SizeAnalysisComparisonState.PROCESSING,
+      SizeAnalysisComparisonState.PENDING,
+    ].includes(mainArtifactComparison.state)
+  ) {
     return (
       <Flex width="100%" justify="center" align="center">
         <BuildProcessing


### PR DESCRIPTION
If a user navigates to a comparison that was never triggered, that comparison currently returns a failed state with prompt to navigate back.

The only real way a user can even get here is manually typing in a compare URL that has no comparison that has been triggered yet. 

In this case, let's show a light not found message and give a primary action to trigger a new comparison.
<img width="1283" height="934" alt="Screenshot 2025-09-25 at 10 38 07 AM" src="https://github.com/user-attachments/assets/fe4c8ff0-2cbd-4252-855f-06067b340ccc" />