### PR TITLE
fix(global-selection): Apply all projects when member has no projects

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -30,6 +30,7 @@ import type {Environment, MinimalProject, Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {DAY} from 'sentry/utils/formatters';
+import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {valueIsEqual} from 'sentry/utils/object/valueIsEqual';
 
 type EnvironmentId = Environment['id'];
@@ -291,6 +292,19 @@ export function initializeUrlState({
       pageFilters.datetime = getDatetimeFromState(storedState);
       shouldUsePinnedDatetime = true;
     }
+  }
+
+  const hasNoMemberProjects = memberProjects.length === 0;
+  const hasAccessibleProjects = nonMemberProjects.length > 0;
+  if (
+    hasNoMemberProjects &&
+    hasAccessibleProjects &&
+    pageFilters.projects.length === 0 &&
+    !isActiveSuperuser()
+  ) {
+    // The user has no projects they are a member of, but they could look at "all projects".
+    // We can attempt to be helpful and redirect them to the all projects view.
+    pageFilters.projects = [ALL_ACCESS_PROJECTS];
   }
 
   const {projects, environments: environment, datetime} = pageFilters;

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -12,12 +12,12 @@ import {
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
+import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
-import {useUser} from 'sentry/utils/useUser';
 import {SIDEBAR_NAVIGATION_SOURCE} from 'sentry/views/nav/constants';
 
 import {getDatetimeFromState, getStateFromQuery} from './parse';
@@ -79,11 +79,11 @@ function PageFiltersContainer({
     ? projects.filter(project => specificProjectSlugs.includes(project.slug))
     : projects;
 
-  const user = useUser();
-  const memberProjects = user.isSuperuser
+  const isSuperuser = isActiveSuperuser();
+  const memberProjects = isSuperuser
     ? specifiedProjects
     : specifiedProjects.filter(project => project.isMember);
-  const nonMemberProjects = user.isSuperuser
+  const nonMemberProjects = isSuperuser
     ? []
     : specifiedProjects.filter(project => !project.isMember);
 


### PR DESCRIPTION
When a member is on teams that have no projects:

In the project selector we were already displaying "All Projects", but only requesting "my projects" via the query parameter being empty. Instead, when the user is not an active super user, push them into the All Projects query parameter -1.
