### PR TITLE
fix(prevent): adjust the integrated org to be a github org

### DIFF
--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx
@@ -14,7 +14,7 @@ import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useGetActiveIntegratedOrgs} from 'sentry/views/prevent/tests/queries/useGetActiveIntegratedOrgs';
 
-const DEFAULT_ORG_LABEL = 'Select Integrated Org';
+const DEFAULT_ORG_LABEL = 'Select GitHub Org';
 
 function AddIntegratedOrgButton() {
   return (
@@ -25,7 +25,7 @@ function AddIntegratedOrgButton() {
       priority="default"
       external
     >
-      {t('Integrated Organization')}
+      {t('GitHub Organization')}
     </LinkButton>
   );
 }
@@ -39,13 +39,13 @@ function OrgFooterMessage() {
         <IconInfo size="sm" style={{margin: '2px 0'}} />
         <div>
           <FooterInfoHeading>
-            To access{' '}
+            Access{' '}
             <ExternalLink href="https://github.com/apps/sentry-io">
-              Integrated Organization
+              GitHub Organization
             </ExternalLink>
           </FooterInfoHeading>
           <FooterInfoSubheading>
-            Ensure admins approve the installation.
+            Ensure admins approve the installation
           </FooterInfoSubheading>
         </div>
       </Flex>


### PR DESCRIPTION
This PR adjusts the naming for the integrated org selector. 

This changes the "integrated organization" to "github integration" and its ancillary text. 

Closes https://linear.app/getsentry/issue/CCMRG-1692/update-integrated-organization-to-be-more-meaningful

Before:

<img width="302" height="217" alt="Screenshot 2025-09-25 at 11 44 38 AM" src="https://github.com/user-attachments/assets/4bf39ac7-0772-4ecd-8869-8dc55b997799" />

After:

<img width="355" height="276" alt="Screenshot 2025-09-25 at 11 44 19 AM" src="https://github.com/user-attachments/assets/afb1e99a-6dd7-4a18-bad0-7758c6c47207" />
