### PR TITLE
feat(replay): Increase error sample rate from 0.5 to 1.0

### DIFF
--- a/static/gsApp/utils/useReplayInit.tsx
+++ b/static/gsApp/utils/useReplayInit.tsx
@@ -80,7 +80,7 @@ export default function useReplayInit() {
     }
 
     const sessionSampleRate = user.isStaff ? 1.0 : 0.05;
-    const errorSampleRate = 0.5;
+    const errorSampleRate = 1.0;
 
     init(sessionSampleRate, errorSampleRate);
 


### PR DESCRIPTION
### Bump errorSampleRate to 1.0

This PR increases the `errorSampleRate` to 1.0 (100%) in `useReplayInit.tsx`. This change aligns with the discussion to bump error sampling up to 100% as noted in the Slack thread.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/C04RDSY3ML1/p1758828285417019?thread_ts=1758828285.417019&cid=C04RDSY3ML1)

<a href="https://cursor.com/background-agent?bcId=bc-dc678748-14d7-4769-a6a9-56b747cd406a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc678748-14d7-4769-a6a9-56b747cd406a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

