### PR TITLE
feat(preprod): add basic onboarding (EME-332)

### DIFF
--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -25,6 +25,7 @@ interface PreprodBuildsTableProps {
   organizationSlug: string;
   projectSlug: string;
   error?: boolean;
+  hasSearchQuery?: boolean;
   pageLinks?: string | null;
 }
 
@@ -35,6 +36,7 @@ export function PreprodBuildsTable({
   pageLinks,
   organizationSlug,
   projectSlug,
+  hasSearchQuery,
 }: PreprodBuildsTableProps) {
   const header = (
     <SimpleTable.Header>
@@ -140,7 +142,9 @@ export function PreprodBuildsTable({
     tableContent = (
       <SimpleTable.Empty>
         <Text as="p">
-          {t('There are no preprod builds associated with this project.')}
+          {hasSearchQuery
+            ? t('No builds found for your search')
+            : t('There are no preprod builds associated with this project.')}
         </Text>
       </SimpleTable.Empty>
     );

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -133,9 +133,6 @@ export default function PreprodBuilds() {
             pageLinks={pageLinks}
             organizationSlug={organization.slug}
             projectSlug={projectSlug}
-            emptyStateMessage={
-              hasSearchQuery ? t('No builds found for your search') : undefined
-            }
           />
         )}
       </Layout.Main>

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -95,6 +95,11 @@ export default function PreprodBuilds() {
   const builds = buildsData?.builds || [];
   const pageLinks = getResponseHeader?.('Link') || null;
 
+  const shouldShowSearchBar = builds.length > 0 || !!urlSearchQuery?.trim();
+  const emptyStateMessage = shouldShowSearchBar
+    ? t('No builds found for your search')
+    : t('No preprod builds found for this release');
+
   return (
     <Layout.Body>
       <Layout.Main fullWidth>
@@ -104,13 +109,15 @@ export default function PreprodBuilds() {
           projectSlug={projectSlug}
         />
         {buildsError && <LoadingError onRetry={refetch} />}
-        <Container paddingBottom="md">
-          <SearchBar
-            placeholder={t('Search by build, SHA, branch name, or pull request')}
-            onChange={handleSearch}
-            query={localSearchQuery}
-          />
-        </Container>
+        {shouldShowSearchBar && (
+          <Container paddingBottom="md">
+            <SearchBar
+              placeholder={t('Search by build, SHA, branch name, or pull request')}
+              onChange={handleSearch}
+              query={localSearchQuery}
+            />
+          </Container>
+        )}
         <PreprodBuildsTable
           builds={builds}
           isLoading={isLoadingBuilds}
@@ -118,6 +125,7 @@ export default function PreprodBuilds() {
           pageLinks={pageLinks}
           organizationSlug={organization.slug}
           projectSlug={projectSlug}
+          emptyStateMessage={emptyStateMessage}
         />
       </Layout.Main>
     </Layout.Body>

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -20,11 +20,13 @@ import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import type {ListBuildsApiResponse} from 'sentry/views/preprod/types/listBuildsTypes';
 import {ReleaseContext} from 'sentry/views/releases/detail';
 
+import {PreprodOnboarding} from './preprodOnboarding';
+
 export default function PreprodBuilds() {
   const organization = useOrganization();
   const releaseContext = useContext(ReleaseContext);
   const projectSlug = releaseContext.project.slug;
-
+  const projectPlatform = releaseContext.project.platform;
   const params = useParams<{release: string}>();
   const location = useLocation();
 
@@ -96,9 +98,8 @@ export default function PreprodBuilds() {
   const pageLinks = getResponseHeader?.('Link') || null;
 
   const shouldShowSearchBar = builds.length > 0 || !!urlSearchQuery?.trim();
-  const emptyStateMessage = shouldShowSearchBar
-    ? t('No builds found for your search')
-    : t('No preprod builds found for this release');
+  const hasSearchQuery = !!urlSearchQuery?.trim();
+  const showOnboarding = builds.length === 0 && !hasSearchQuery && !isLoadingBuilds;
 
   return (
     <Layout.Body>
@@ -118,15 +119,23 @@ export default function PreprodBuilds() {
             />
           </Container>
         )}
-        <PreprodBuildsTable
-          builds={builds}
-          isLoading={isLoadingBuilds}
-          error={!!buildsError}
-          pageLinks={pageLinks}
-          organizationSlug={organization.slug}
-          projectSlug={projectSlug}
-          emptyStateMessage={emptyStateMessage}
-        />
+        {showOnboarding ? (
+          <PreprodOnboarding
+            organizationSlug={organization.slug}
+            projectPlatform={projectPlatform || null}
+            projectSlug={projectSlug}
+          />
+        ) : (
+          <PreprodBuildsTable
+            builds={builds}
+            isLoading={isLoadingBuilds}
+            error={!!buildsError}
+            pageLinks={pageLinks}
+            organizationSlug={organization.slug}
+            projectSlug={projectSlug}
+            emptyStateMessage={hasSearchQuery ? t('No builds found for your search') : undefined}
+          />
+        )}
       </Layout.Main>
     </Layout.Body>
   );

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -133,7 +133,9 @@ export default function PreprodBuilds() {
             pageLinks={pageLinks}
             organizationSlug={organization.slug}
             projectSlug={projectSlug}
-            emptyStateMessage={hasSearchQuery ? t('No builds found for your search') : undefined}
+            emptyStateMessage={
+              hasSearchQuery ? t('No builds found for your search') : undefined
+            }
           />
         )}
       </Layout.Main>

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -133,6 +133,7 @@ export default function PreprodBuilds() {
             pageLinks={pageLinks}
             organizationSlug={organization.slug}
             projectSlug={projectSlug}
+            hasSearchQuery
           />
         )}
       </Layout.Main>

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -97,8 +97,8 @@ export default function PreprodBuilds() {
   const builds = buildsData?.builds || [];
   const pageLinks = getResponseHeader?.('Link') || null;
 
-  const shouldShowSearchBar = builds.length > 0 || !!urlSearchQuery?.trim();
   const hasSearchQuery = !!urlSearchQuery?.trim();
+  const shouldShowSearchBar = builds.length > 0 || hasSearchQuery;
   const showOnboarding = builds.length === 0 && !hasSearchQuery && !isLoadingBuilds;
 
   return (

--- a/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
@@ -1,0 +1,454 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+import {PlatformIcon} from 'platformicons';
+
+import emptyBuildImg from 'sentry-images/spot/releases-tour-commits.svg';
+
+import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {OnboardingCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {PlatformKey} from 'sentry/types/project';
+
+interface PreprodOnboardingProps {
+  organizationSlug: string;
+  projectPlatform: PlatformKey | null;
+  projectSlug: string;
+}
+
+type UploadMethod = 'fastlane' | 'gradle' | 'cli';
+
+function FastlaneMethod({
+  organizationSlug,
+  projectSlug,
+}: {
+  organizationSlug: string;
+  projectSlug: string;
+}) {
+  return (
+    <div>
+      <StepContainer>
+        <StepDescription>Add to your fastlane/Pluginfile:</StepDescription>
+        <OnboardingCodeSnippet language="ruby">
+          {`gem 'fastlane-plugin-sentry', git: 'https://github.com/getsentry/sentry-fastlane-plugin.git', ref: 'b0c36a1472a6bfde0a4766c612c1154706dbd014'`}
+        </OnboardingCodeSnippet>
+      </StepContainer>
+
+      <StepContainer>
+        <StepDescription>Add a lane to your Fastfile:</StepDescription>
+        <OnboardingCodeSnippet language="ruby">
+          {`sentry_upload_build(
+  org_slug: '${organizationSlug}',
+  project_slug: '${projectSlug}',
+  base_ref: ENV['GITHUB_BASE_REF'],
+  base_sha: ENV['GITHUB_BASE_SHA'],
+  head_ref: ENV['GITHUB_HEAD_REF'] || ENV['GITHUB_REF']&.sub('refs/heads/', ''),
+  head_sha: ENV['SENTRY_SHA'],
+)`}
+        </OnboardingCodeSnippet>
+      </StepContainer>
+
+      <StepContainer>
+        <StepDescription>
+          Set environment variables in your GitHub Action:
+        </StepDescription>
+        <OnboardingCodeSnippet language="yaml">
+          {`env:
+  SENTRY_AUTH_TOKEN: \${{ secrets.SENTRY_AUTH_TOKEN }}
+  SENTRY_CONFIGURATION: Release
+  GITHUB_BASE_SHA: \${{ github.event.pull_request.base.sha }}
+  SENTRY_SHA: \${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}`}
+        </OnboardingCodeSnippet>
+      </StepContainer>
+    </div>
+  );
+}
+
+function GradleMethod() {
+  return (
+    <div>
+      <StepContainer>
+        <StepDescription>Apply the plugin (use version 6.0.0-alpha.3):</StepDescription>
+        <OnboardingCodeSnippet language="kotlin">
+          {`plugins {
+  id "io.sentry.android.gradle" version "6.0.0-alpha.3"
+}`}
+        </OnboardingCodeSnippet>
+      </StepContainer>
+
+      <StepContainer>
+        <StepDescription>Configure the plugin:</StepDescription>
+        <OnboardingCodeSnippet language="kotlin">
+          {`sentry {
+  sizeAnalysis {
+    enabled = true
+  }
+
+  vcsInfo {
+    fun env(key: String): String? = System.getenv(key)?.takeIf { it.isNotEmpty() }
+
+    (env("GITHUB_HEAD_REF") ?: env("GITHUB_REF")?.removePrefix("refs/heads/"))?.let { headRef.set(it) }
+    env("GITHUB_BASE_REF")?.let { baseRef.set(it) }
+    env("GITHUB_BASE_SHA")?.let { baseSha.set(it) }
+    env("SENTRY_SHA")?.let { headSha.set(it) }
+  }
+}`}
+        </OnboardingCodeSnippet>
+      </StepContainer>
+
+      <StepContainer>
+        <StepDescription>Set environment variables in GitHub Actions:</StepDescription>
+        <OnboardingCodeSnippet language="yaml">
+          {`env:
+  SENTRY_AUTH_TOKEN: \${{ secrets.SENTRY_AUTH_TOKEN }}
+  GITHUB_BASE_SHA: \${{ github.event.pull_request.base.sha }}
+  SENTRY_SHA: \${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}`}
+        </OnboardingCodeSnippet>
+      </StepContainer>
+    </div>
+  );
+}
+
+function CliMethod({
+  organizationSlug,
+  projectSlug,
+}: {
+  organizationSlug: string;
+  projectSlug: string;
+}) {
+  return (
+    <div>
+      <StepContainer>
+        <StepDescription>Install the Sentry CLI tool:</StepDescription>
+        <OnboardingCodeSnippet language="bash">
+          {`# Using npm
+npm install -g @sentry/cli
+
+# Using curl
+curl -sL https://sentry.io/get-cli/ | bash`}
+        </OnboardingCodeSnippet>
+      </StepContainer>
+
+      <StepContainer>
+        <StepDescription>Upload your build using the CLI:</StepDescription>
+        <OnboardingCodeSnippet language="bash">
+          {`sentry-cli build upload <path-to-apk|aab|xcarchive> \\
+  --org ${organizationSlug} \\
+  --project ${projectSlug} \\
+  --head-sha <sha> \\
+  --base-sha <sha> \\
+  --head-repo-name <org/repo> \\
+  --pr-number <pr-number> \\
+  --vcs-provider github \\
+  --build-configuration <build-config>`}
+        </OnboardingCodeSnippet>
+      </StepContainer>
+
+      <StepContainer>
+        <StepDescription>Set these environment variables in your CI:</StepDescription>
+        <OnboardingCodeSnippet language="bash">
+          {`export SENTRY_AUTH_TOKEN=<your-auth-token>
+# These are set automatically in GitHub Actions:
+# --repo-name, --vcs-provider, --pr-number`}
+        </OnboardingCodeSnippet>
+      </StepContainer>
+    </div>
+  );
+}
+
+export function PreprodOnboarding({
+  organizationSlug,
+  projectPlatform,
+  projectSlug,
+}: PreprodOnboardingProps) {
+  const isIOS = projectPlatform?.includes('apple') || projectPlatform?.includes('ios');
+  const isAndroid = projectPlatform?.includes('android');
+
+  let availableMethods: Array<{label: string; value: UploadMethod}>;
+  let defaultMethod: UploadMethod;
+
+  if (isIOS) {
+    availableMethods = [
+      {label: 'Fastlane', value: 'fastlane'},
+      {label: 'Sentry CLI', value: 'cli'},
+    ];
+    defaultMethod = 'fastlane';
+  } else if (isAndroid) {
+    availableMethods = [
+      {label: 'Gradle Plugin', value: 'gradle'},
+      {label: 'Sentry CLI', value: 'cli'},
+    ];
+    defaultMethod = 'gradle';
+  } else {
+    availableMethods = [
+      {label: 'Sentry CLI', value: 'cli'},
+      {label: 'Gradle Plugin', value: 'gradle'},
+      {label: 'Fastlane', value: 'fastlane'},
+    ];
+    defaultMethod = 'cli';
+  }
+
+  const [selectedMethod, setSelectedMethod] = useState<UploadMethod>(defaultMethod);
+
+  const renderMethodContent = () => {
+    switch (selectedMethod) {
+      case 'fastlane':
+        return (
+          <FastlaneMethod organizationSlug={organizationSlug} projectSlug={projectSlug} />
+        );
+      case 'gradle':
+        return <GradleMethod />;
+      case 'cli':
+      default:
+        return (
+          <CliMethod organizationSlug={organizationSlug} projectSlug={projectSlug} />
+        );
+    }
+  };
+
+  return (
+    <Panel>
+      <PanelBody>
+        <div>
+          <HeaderWrapper>
+            <HeaderText>
+              <Title>{t('Upload Builds to Sentry')}</Title>
+              <SubTitle>
+                {t('Monitor & reduce your app size and distribute pre-release builds')}
+              </SubTitle>
+              <BulletList>
+                <li>{t('Get automated checks and PR comments for size regressions')}</li>
+                <li>
+                  {t('See actionable insights on what can be removed or optimized')}
+                </li>
+                <li>{t('Track app size trends over time across releases')}</li>
+              </BulletList>
+            </HeaderText>
+            <Image src={emptyBuildImg} />
+          </HeaderWrapper>
+          <Divider />
+          <Body>
+            <Setup>
+              <Section>
+                <SectionTitle>Prerequisites</SectionTitle>
+                <Description>
+                  {tct(
+                    'You need a Sentry Auth Token to upload builds. [link:Generate one here] and set it as [code:SENTRY_AUTH_TOKEN] in your environment.',
+                    {
+                      link: (
+                        <a
+                          href={`/settings/${organizationSlug}/auth-tokens/`}
+                          target="_blank"
+                          rel="noreferrer"
+                        />
+                      ),
+                      code: <code />,
+                    }
+                  )}
+                </Description>
+              </Section>
+
+              <Section>
+                <SectionTitle>
+                  {projectPlatform && <PlatformIcon platform={projectPlatform} />}
+                  Uploading Builds
+                </SectionTitle>
+                <TabsContainer>
+                  {availableMethods.map(method => (
+                    <Tab
+                      key={method.value}
+                      active={selectedMethod === method.value}
+                      onClick={() => setSelectedMethod(method.value)}
+                    >
+                      {method.label}
+                    </Tab>
+                  ))}
+                </TabsContainer>
+
+                {renderMethodContent()}
+              </Section>
+
+              {/* Next Steps */}
+              <Section>
+                <SectionTitle>Integrating into CI</SectionTitle>
+                <Description>
+                  {tct(
+                    'Integrating the GitHub App is required for PR annotations and workflow automation. [link:Install the GitHub App →]',
+                    {
+                      link: (
+                        <a
+                          href="https://docs.sentry.io/organization/integrations/source-code-mgmt/github/"
+                          target="_blank"
+                          rel="noreferrer"
+                        />
+                      ),
+                    }
+                  )}
+                </Description>
+
+                <ActionsContainer>
+                  <LinkButton
+                    priority="primary"
+                    href="https://docs.sentry.io/organization/integrations/source-code-mgmt/github/"
+                    size="md"
+                  >
+                    Install GitHub App
+                  </LinkButton>
+                  <LinkButton
+                    href="https://docs.sentry.io/product/builds/"
+                    external
+                    disabled
+                    size="md"
+                  >
+                    View Documentation
+                  </LinkButton>
+                </ActionsContainer>
+              </Section>
+            </Setup>
+          </Body>
+        </div>
+      </PanelBody>
+    </Panel>
+  );
+}
+
+const SubTitle = styled('div')`
+  margin-bottom: ${space(1)};
+`;
+
+const Title = styled('div')`
+  font-size: 26px;
+  font-weight: ${p => p.theme.fontWeight.bold};
+`;
+
+const BulletList = styled('ul')`
+  list-style-type: disc;
+  padding-left: 20px;
+  margin-bottom: ${space(2)};
+
+  li {
+    margin-bottom: ${space(1)};
+  }
+`;
+
+const HeaderWrapper = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  gap: ${space(3)};
+  border-radius: ${p => p.theme.borderRadius};
+  padding: ${space(4)};
+`;
+
+const HeaderText = styled('div')`
+  flex: 0.65;
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    flex: 1;
+  }
+`;
+
+const BodyTitle = styled('div')`
+  font-size: ${p => p.theme.fontSize.xl};
+  font-weight: ${p => p.theme.fontWeight.bold};
+  margin-bottom: ${space(1)};
+`;
+
+const Setup = styled('div')`
+  padding: ${space(4)};
+`;
+
+const Body = styled('div')`
+  display: grid;
+  position: relative;
+  grid-auto-columns: minmax(0, 1fr);
+  grid-auto-flow: column;
+
+  h4 {
+    margin-bottom: 0;
+  }
+`;
+
+const Image = styled('img')`
+  display: block;
+  pointer-events: none;
+  height: 120px;
+  overflow: hidden;
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    display: none;
+  }
+`;
+
+const Divider = styled('hr')`
+  height: 1px;
+  width: 95%;
+  background: ${p => p.theme.border};
+  border: none;
+  margin-top: 0;
+  margin-bottom: 0;
+`;
+
+const Section = styled('section')`
+  margin-bottom: ${space(3)};
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+const SectionTitle = styled('h3')`
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: ${space(2)};
+  color: ${p => p.theme.textColor};
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.sm};
+`;
+
+const Description = styled('p')`
+  margin-bottom: ${space(2)};
+  color: ${p => p.theme.subText};
+  line-height: 1.5;
+`;
+
+const TabsContainer = styled('div')`
+  display: flex;
+  border-bottom: 1px solid ${p => p.theme.border};
+  margin-bottom: ${space(2)};
+  gap: ${space(2)};
+`;
+
+const Tab = styled('button')<{active: boolean}>`
+  padding: ${space(1)} ${space(2)};
+  background: none;
+  border: none;
+  border-bottom: 2px solid ${p => (p.active ? p.theme.active : 'transparent')};
+  color: ${p => (p.active ? p.theme.textColor : p.theme.subText)};
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: ${p => (p.active ? 600 : 400)};
+  transition: all 0.2s ease;
+
+  &:hover {
+    color: ${p => p.theme.textColor};
+    background-color: ${p => p.theme.backgroundSecondary};
+  }
+`;
+
+const StepContainer = styled('div')`
+  margin-bottom: ${space(3)};
+`;
+
+const StepDescription = styled('p')`
+  margin-bottom: ${space(1)};
+  color: ${p => p.theme.subText};
+  font-size: 14px;
+`;
+
+const ActionsContainer = styled('div')`
+  display: flex;
+  gap: ${space(2)};
+  flex-wrap: wrap;
+`;

--- a/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
@@ -1,7 +1,6 @@
 import {useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import {PlatformIcon} from 'platformicons';
 
 import emptyBuildImg from 'sentry-images/spot/releases-tour-commits.svg';
 

--- a/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
@@ -325,11 +325,12 @@ export function PreprodOnboarding({
 
             <Flex direction="column" gap="md">
               <Heading as="h3" size="lg">
-                Integrating into CI
+                {t('Integrating into CI')}
               </Heading>
               <Text as="p" size="md">
-                Integrating the GitHub App is required for PR annotations and workflow
-                automation
+                {t(
+                  'Integrating the GitHub App is required for PR annotations and workflow automation'
+                )}
               </Text>
 
               <Flex gap="xl" wrap="wrap">
@@ -338,7 +339,7 @@ export function PreprodOnboarding({
                   href="/settings/integrations/github"
                   size="md"
                 >
-                  Install GitHub App
+                  {t('Install GitHub App')}
                 </LinkButton>
                 <LinkButton
                   href="https://docs.sentry.io/product/builds/"
@@ -346,7 +347,7 @@ export function PreprodOnboarding({
                   disabled
                   size="md"
                 >
-                  View Documentation
+                  {t('View Documentation')}
                 </LinkButton>
               </Flex>
             </Flex>

--- a/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
@@ -83,7 +83,7 @@ function GradleMethod({projectPlatform}: {projectPlatform: PlatformKey | null}) 
     <MethodContent>
       {!isAndroid && (
         <Alert type="info" showIcon>
-          {t('Gradle Plugin is for Android only.')}
+          {t('Gradle Plugin is for Android applications only')}
         </Alert>
       )}
       <div>

--- a/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
@@ -328,7 +328,6 @@ export function PreprodOnboarding({
             </Flex>
             {renderMethodContent()}
 
-            {/* Next Steps */}
             <Container>
               <Heading as="h3" size="lg" style={{marginBottom: space(2)}}>
                 Integrating into CI

--- a/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
@@ -8,6 +8,7 @@ import emptyBuildImg from 'sentry-images/spot/releases-tour-commits.svg';
 import {Alert} from 'sentry/components/core/alert';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Container, Flex} from 'sentry/components/core/layout';
+import {ExternalLink, Link} from 'sentry/components/core/link';
 import {TabList, Tabs} from 'sentry/components/core/tabs';
 import {Heading, Text} from 'sentry/components/core/text';
 import List from 'sentry/components/list';
@@ -16,7 +17,6 @@ import {OnboardingCodeSnippet} from 'sentry/components/onboarding/gettingStarted
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {PlatformKey} from 'sentry/types/project';
 
 interface PreprodOnboardingProps {
@@ -45,16 +45,16 @@ function FastlaneMethod({
           {t('Fastlane is for iOS applications only')}
         </Alert>
       )}
-      <div>
+      <Container>
         <Text as="p" size="md">
           Add to your fastlane/Pluginfile:
         </Text>
         <OnboardingCodeSnippet language="ruby">
           {`gem 'fastlane-plugin-sentry', git: 'https://github.com/getsentry/sentry-fastlane-plugin.git', ref: 'b0c36a1472a6bfde0a4766c612c1154706dbd014'`}
         </OnboardingCodeSnippet>
-      </div>
+      </Container>
 
-      <div>
+      <Container>
         <Text as="p" size="md">
           Add a lane to your Fastfile:
         </Text>
@@ -68,9 +68,9 @@ function FastlaneMethod({
   head_sha: ENV['SENTRY_SHA'],
 )`}
         </OnboardingCodeSnippet>
-      </div>
+      </Container>
 
-      <div>
+      <Container>
         <Text as="p" size="md">
           Set environment variables in your GitHub Action:
         </Text>
@@ -81,7 +81,7 @@ function FastlaneMethod({
   GITHUB_BASE_SHA: \${{ github.event.pull_request.base.sha }}
   SENTRY_SHA: \${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}`}
         </OnboardingCodeSnippet>
-      </div>
+      </Container>
     </Flex>
   );
 }
@@ -96,7 +96,7 @@ function GradleMethod({projectPlatform}: {projectPlatform: PlatformKey | null}) 
           {t('Gradle Plugin is for Android applications only')}
         </Alert>
       )}
-      <div>
+      <Container>
         <Text as="p" size="md">
           Apply the plugin (use version 6.0.0-alpha.3):
         </Text>
@@ -105,9 +105,9 @@ function GradleMethod({projectPlatform}: {projectPlatform: PlatformKey | null}) 
   id "io.sentry.android.gradle" version "6.0.0-alpha.3"
 }`}
         </OnboardingCodeSnippet>
-      </div>
+      </Container>
 
-      <div>
+      <Container>
         <Text as="p" size="md">
           Configure the plugin:
         </Text>
@@ -127,9 +127,9 @@ function GradleMethod({projectPlatform}: {projectPlatform: PlatformKey | null}) 
   }
 }`}
         </OnboardingCodeSnippet>
-      </div>
+      </Container>
 
-      <div>
+      <Container>
         <Text as="p" size="md">
           Set environment variables in GitHub Actions:
         </Text>
@@ -139,7 +139,7 @@ function GradleMethod({projectPlatform}: {projectPlatform: PlatformKey | null}) 
   GITHUB_BASE_SHA: \${{ github.event.pull_request.base.sha }}
   SENTRY_SHA: \${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}`}
         </OnboardingCodeSnippet>
-      </div>
+      </Container>
     </Flex>
   );
 }
@@ -153,11 +153,11 @@ function CliMethod({
 }) {
   return (
     <Flex direction="column" gap="2xl">
-      <div>
+      <Container>
         <Text as="p" size="md">
           {tct('Install the [link:Sentry CLI]', {
             link: (
-              <a
+              <ExternalLink
                 href="https://docs.sentry.io/cli/installation/"
                 target="_blank"
                 rel="noreferrer"
@@ -172,9 +172,9 @@ npm install -g @sentry/cli
 # Using curl
 curl -sL https://sentry.io/get-cli/ | bash`}
         </OnboardingCodeSnippet>
-      </div>
+      </Container>
 
-      <div>
+      <Container>
         <Text as="p" size="md">
           Upload your build using the CLI:
         </Text>
@@ -189,9 +189,9 @@ curl -sL https://sentry.io/get-cli/ | bash`}
   --vcs-provider github \\
   --build-configuration <build-config>`}
         </OnboardingCodeSnippet>
-      </div>
+      </Container>
 
-      <div>
+      <Container>
         <Text as="p" size="md">
           Set these environment variables in your CI:
         </Text>
@@ -200,7 +200,7 @@ curl -sL https://sentry.io/get-cli/ | bash`}
 # These are set automatically in GitHub Actions:
 # --repo-name, --vcs-provider, --pr-number`}
         </OnboardingCodeSnippet>
-      </div>
+      </Container>
     </Flex>
   );
 }
@@ -216,6 +216,7 @@ export function PreprodOnboarding({
 
   let availableMethods: Array<{label: string; value: UploadMethod}>;
   let defaultMethod: UploadMethod;
+  let platformLabel: string | null = null;
 
   if (isIOS) {
     availableMethods = [
@@ -223,12 +224,14 @@ export function PreprodOnboarding({
       {label: 'Sentry CLI', value: 'cli'},
     ];
     defaultMethod = 'fastlane';
+    platformLabel = 'iOS';
   } else if (isAndroid) {
     availableMethods = [
       {label: 'Gradle Plugin', value: 'gradle'},
       {label: 'Sentry CLI', value: 'cli'},
     ];
     defaultMethod = 'gradle';
+    platformLabel = 'Android';
   } else {
     availableMethods = [
       {label: 'Sentry CLI', value: 'cli'},
@@ -288,19 +291,13 @@ export function PreprodOnboarding({
           <Flex direction="column" gap="2xl">
             <Container>
               <Heading as="h3" size="lg" style={{marginBottom: theme.space.xl}}>
-                Prerequisites
+                {t('Prerequisites')}
               </Heading>
               <Text as="p" size="md">
                 {tct(
                   'You need a Sentry Auth Token to upload builds. [link:Generate one here] and set it as [code:SENTRY_AUTH_TOKEN] in your environment.',
                   {
-                    link: (
-                      <a
-                        href={`/settings/${organizationSlug}/auth-tokens/`}
-                        target="_blank"
-                        rel="noreferrer"
-                      />
-                    ),
+                    link: <Link to={`/settings/${organizationSlug}/auth-tokens/`} />,
                     code: <code />,
                   }
                 )}
@@ -309,9 +306,8 @@ export function PreprodOnboarding({
 
             <Flex direction="column" gap="md">
               <Flex align="center" gap="sm">
-                {projectPlatform && <PlatformIcon platform={projectPlatform} />}
                 <Heading as="h3" size="lg">
-                  Uploading Builds
+                  {t('Uploading %s Builds', platformLabel || 'Mobile')}
                 </Heading>
               </Flex>
               <Container borderBottom="primary">
@@ -328,29 +324,19 @@ export function PreprodOnboarding({
             </Flex>
             {renderMethodContent()}
 
-            <Container>
-              <Heading as="h3" size="lg" style={{marginBottom: space(2)}}>
+            <Flex direction="column" gap="md">
+              <Heading as="h3" size="lg">
                 Integrating into CI
               </Heading>
-              <Text as="p" size="md" style={{marginBottom: space(2), lineHeight: 1.5}}>
-                {tct(
-                  'Integrating the GitHub App is required for PR annotations and workflow automation. [link:Install the GitHub App →]',
-                  {
-                    link: (
-                      <a
-                        href="https://docs.sentry.io/organization/integrations/source-code-mgmt/github/"
-                        target="_blank"
-                        rel="noreferrer"
-                      />
-                    ),
-                  }
-                )}
+              <Text as="p" size="md">
+                Integrating the GitHub App is required for PR annotations and workflow
+                automation
               </Text>
 
               <Flex gap="xl" wrap="wrap">
                 <LinkButton
                   priority="primary"
-                  href="https://docs.sentry.io/organization/integrations/source-code-mgmt/github/"
+                  href="/settings/integrations/github"
                   size="md"
                 >
                   Install GitHub App
@@ -364,7 +350,7 @@ export function PreprodOnboarding({
                   View Documentation
                 </LinkButton>
               </Flex>
-            </Container>
+            </Flex>
           </Flex>
         </Flex>
       </PanelBody>

--- a/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
@@ -6,11 +7,16 @@ import emptyBuildImg from 'sentry-images/spot/releases-tour-commits.svg';
 
 import {Alert} from 'sentry/components/core/alert';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {Container, Flex} from 'sentry/components/core/layout';
 import {TabList, Tabs} from 'sentry/components/core/tabs';
+import {Heading, Text} from 'sentry/components/core/text';
+import List from 'sentry/components/list';
+import ListItem from 'sentry/components/list/listItem';
 import {OnboardingCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {PlatformKey} from 'sentry/types/project';
 
 interface PreprodOnboardingProps {
@@ -33,21 +39,25 @@ function FastlaneMethod({
   const isIOS = projectPlatform?.includes('apple') || projectPlatform?.includes('ios');
 
   return (
-    <MethodContent>
+    <Flex direction="column" gap="2xl">
       {!isIOS && (
         <Alert type="info" showIcon>
           {t('Fastlane is for iOS applications only')}
         </Alert>
       )}
       <div>
-        <StepDescription>Add to your fastlane/Pluginfile:</StepDescription>
+        <Text as="p" size="md">
+          Add to your fastlane/Pluginfile:
+        </Text>
         <OnboardingCodeSnippet language="ruby">
           {`gem 'fastlane-plugin-sentry', git: 'https://github.com/getsentry/sentry-fastlane-plugin.git', ref: 'b0c36a1472a6bfde0a4766c612c1154706dbd014'`}
         </OnboardingCodeSnippet>
       </div>
 
       <div>
-        <StepDescription>Add a lane to your Fastfile:</StepDescription>
+        <Text as="p" size="md">
+          Add a lane to your Fastfile:
+        </Text>
         <OnboardingCodeSnippet language="ruby">
           {`sentry_upload_build(
   org_slug: '${organizationSlug}',
@@ -61,9 +71,9 @@ function FastlaneMethod({
       </div>
 
       <div>
-        <StepDescription>
+        <Text as="p" size="md">
           Set environment variables in your GitHub Action:
-        </StepDescription>
+        </Text>
         <OnboardingCodeSnippet language="yaml">
           {`env:
   SENTRY_AUTH_TOKEN: \${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -72,7 +82,7 @@ function FastlaneMethod({
   SENTRY_SHA: \${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}`}
         </OnboardingCodeSnippet>
       </div>
-    </MethodContent>
+    </Flex>
   );
 }
 
@@ -80,14 +90,16 @@ function GradleMethod({projectPlatform}: {projectPlatform: PlatformKey | null}) 
   const isAndroid = projectPlatform?.includes('android');
 
   return (
-    <MethodContent>
+    <Flex direction="column" gap="2xl">
       {!isAndroid && (
         <Alert type="info" showIcon>
           {t('Gradle Plugin is for Android applications only')}
         </Alert>
       )}
       <div>
-        <StepDescription>Apply the plugin (use version 6.0.0-alpha.3):</StepDescription>
+        <Text as="p" size="md">
+          Apply the plugin (use version 6.0.0-alpha.3):
+        </Text>
         <OnboardingCodeSnippet language="kotlin">
           {`plugins {
   id "io.sentry.android.gradle" version "6.0.0-alpha.3"
@@ -96,7 +108,9 @@ function GradleMethod({projectPlatform}: {projectPlatform: PlatformKey | null}) 
       </div>
 
       <div>
-        <StepDescription>Configure the plugin:</StepDescription>
+        <Text as="p" size="md">
+          Configure the plugin:
+        </Text>
         <OnboardingCodeSnippet language="kotlin">
           {`sentry {
   sizeAnalysis {
@@ -116,7 +130,9 @@ function GradleMethod({projectPlatform}: {projectPlatform: PlatformKey | null}) 
       </div>
 
       <div>
-        <StepDescription>Set environment variables in GitHub Actions:</StepDescription>
+        <Text as="p" size="md">
+          Set environment variables in GitHub Actions:
+        </Text>
         <OnboardingCodeSnippet language="yaml">
           {`env:
   SENTRY_AUTH_TOKEN: \${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -124,7 +140,7 @@ function GradleMethod({projectPlatform}: {projectPlatform: PlatformKey | null}) 
   SENTRY_SHA: \${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}`}
         </OnboardingCodeSnippet>
       </div>
-    </MethodContent>
+    </Flex>
   );
 }
 
@@ -136,9 +152,9 @@ function CliMethod({
   projectSlug: string;
 }) {
   return (
-    <MethodContent>
+    <Flex direction="column" gap="2xl">
       <div>
-        <StepDescription>
+        <Text as="p" size="md">
           {tct('Install the [link:Sentry CLI]', {
             link: (
               <a
@@ -148,7 +164,7 @@ function CliMethod({
               />
             ),
           })}
-        </StepDescription>
+        </Text>
         <OnboardingCodeSnippet language="bash">
           {`# Using npm
 npm install -g @sentry/cli
@@ -159,7 +175,9 @@ curl -sL https://sentry.io/get-cli/ | bash`}
       </div>
 
       <div>
-        <StepDescription>Upload your build using the CLI:</StepDescription>
+        <Text as="p" size="md">
+          Upload your build using the CLI:
+        </Text>
         <OnboardingCodeSnippet language="bash">
           {`sentry-cli build upload <path-to-apk|aab|xcarchive> \\
   --org ${organizationSlug} \\
@@ -174,14 +192,16 @@ curl -sL https://sentry.io/get-cli/ | bash`}
       </div>
 
       <div>
-        <StepDescription>Set these environment variables in your CI:</StepDescription>
+        <Text as="p" size="md">
+          Set these environment variables in your CI:
+        </Text>
         <OnboardingCodeSnippet language="bash">
           {`export SENTRY_AUTH_TOKEN=<your-auth-token>
 # These are set automatically in GitHub Actions:
 # --repo-name, --vcs-provider, --pr-number`}
         </OnboardingCodeSnippet>
       </div>
-    </MethodContent>
+    </Flex>
   );
 }
 
@@ -190,6 +210,7 @@ export function PreprodOnboarding({
   projectPlatform,
   projectSlug,
 }: PreprodOnboardingProps) {
+  const theme = useTheme();
   const isIOS = projectPlatform?.includes('apple') || projectPlatform?.includes('ios');
   const isAndroid = projectPlatform?.includes('android');
 
@@ -242,157 +263,115 @@ export function PreprodOnboarding({
   return (
     <Panel>
       <PanelBody>
-        <div>
-          <HeaderWrapper>
-            <HeaderText>
-              <Title>{t('Upload Builds to Sentry')}</Title>
-              <SubTitle>
+        <Flex padding="3xl" gap="2xl" direction="column">
+          <Flex justify="between" align="center" gap="xl">
+            <Container>
+              <Heading as="h1" size="2xl">
+                {t('Upload Builds to Sentry')}
+              </Heading>
+              <Text as="p" size="md" style={{marginBottom: theme.space.md}}>
                 {t('Monitor & reduce your app size and distribute pre-release builds')}
-              </SubTitle>
-              <BulletList>
-                <li>{t('Get automated checks and PR comments for size regressions')}</li>
-                <li>
-                  {t('See actionable insights on what can be removed or optimized')}
-                </li>
-                <li>{t('Track app size trends over time across releases')}</li>
-              </BulletList>
-            </HeaderText>
+              </Text>
+              <List symbol="bullet">
+                <ListItem>
+                  {t('Get automated checks size regressions and distributable builds')}
+                </ListItem>
+                <ListItem>
+                  {t('See actionable insights on how to reduce your app size')}
+                </ListItem>
+                <ListItem>{t('Distribute pre-release builds to your team')}</ListItem>
+              </List>
+            </Container>
             <Image src={emptyBuildImg} />
-          </HeaderWrapper>
+          </Flex>
           <Divider />
-          <Body>
-            <Setup>
-              <Section>
-                <SectionTitle>Prerequisites</SectionTitle>
-                <Description>
-                  {tct(
-                    'You need a Sentry Auth Token to upload builds. [link:Generate one here] and set it as [code:SENTRY_AUTH_TOKEN] in your environment.',
-                    {
-                      link: (
-                        <a
-                          href={`/settings/${organizationSlug}/auth-tokens/`}
-                          target="_blank"
-                          rel="noreferrer"
-                        />
-                      ),
-                      code: <code />,
-                    }
-                  )}
-                </Description>
-              </Section>
+          <Flex direction="column" gap="2xl">
+            <Container>
+              <Heading as="h3" size="lg" style={{marginBottom: theme.space.xl}}>
+                Prerequisites
+              </Heading>
+              <Text as="p" size="md">
+                {tct(
+                  'You need a Sentry Auth Token to upload builds. [link:Generate one here] and set it as [code:SENTRY_AUTH_TOKEN] in your environment.',
+                  {
+                    link: (
+                      <a
+                        href={`/settings/${organizationSlug}/auth-tokens/`}
+                        target="_blank"
+                        rel="noreferrer"
+                      />
+                    ),
+                    code: <code />,
+                  }
+                )}
+              </Text>
+            </Container>
 
-              <Section>
-                <SectionTitle>
-                  {projectPlatform && <PlatformIcon platform={projectPlatform} />}
+            <Flex direction="column" gap="md">
+              <Flex align="center" gap="sm">
+                {projectPlatform && <PlatformIcon platform={projectPlatform} />}
+                <Heading as="h3" size="lg">
                   Uploading Builds
-                </SectionTitle>
-                <TabsWrapper>
-                  <Tabs value={selectedMethod} onChange={setSelectedMethod}>
-                    <TabList>
-                      {availableMethods.map(method => (
-                        <TabList.Item key={method.value} textValue={method.label}>
-                          {method.label}
-                        </TabList.Item>
-                      ))}
-                    </TabList>
-                  </Tabs>
-                </TabsWrapper>
-                {renderMethodContent()}
-              </Section>
+                </Heading>
+              </Flex>
+              <Container borderBottom="primary">
+                <Tabs value={selectedMethod} onChange={setSelectedMethod}>
+                  <TabList>
+                    {availableMethods.map(method => (
+                      <TabList.Item key={method.value} textValue={method.label}>
+                        {method.label}
+                      </TabList.Item>
+                    ))}
+                  </TabList>
+                </Tabs>
+              </Container>
+            </Flex>
+            {renderMethodContent()}
 
-              {/* Next Steps */}
-              <Section>
-                <SectionTitle>Integrating into CI</SectionTitle>
-                <Description>
-                  {tct(
-                    'Integrating the GitHub App is required for PR annotations and workflow automation. [link:Install the GitHub App →]',
-                    {
-                      link: (
-                        <a
-                          href="https://docs.sentry.io/organization/integrations/source-code-mgmt/github/"
-                          target="_blank"
-                          rel="noreferrer"
-                        />
-                      ),
-                    }
-                  )}
-                </Description>
+            {/* Next Steps */}
+            <Container>
+              <Heading as="h3" size="lg" style={{marginBottom: space(2)}}>
+                Integrating into CI
+              </Heading>
+              <Text as="p" size="md" style={{marginBottom: space(2), lineHeight: 1.5}}>
+                {tct(
+                  'Integrating the GitHub App is required for PR annotations and workflow automation. [link:Install the GitHub App →]',
+                  {
+                    link: (
+                      <a
+                        href="https://docs.sentry.io/organization/integrations/source-code-mgmt/github/"
+                        target="_blank"
+                        rel="noreferrer"
+                      />
+                    ),
+                  }
+                )}
+              </Text>
 
-                <ActionsContainer>
-                  <LinkButton
-                    priority="primary"
-                    href="https://docs.sentry.io/organization/integrations/source-code-mgmt/github/"
-                    size="md"
-                  >
-                    Install GitHub App
-                  </LinkButton>
-                  <LinkButton
-                    href="https://docs.sentry.io/product/builds/"
-                    external
-                    disabled
-                    size="md"
-                  >
-                    View Documentation
-                  </LinkButton>
-                </ActionsContainer>
-              </Section>
-            </Setup>
-          </Body>
-        </div>
+              <Flex gap="xl" wrap="wrap">
+                <LinkButton
+                  priority="primary"
+                  href="https://docs.sentry.io/organization/integrations/source-code-mgmt/github/"
+                  size="md"
+                >
+                  Install GitHub App
+                </LinkButton>
+                <LinkButton
+                  href="https://docs.sentry.io/product/builds/"
+                  external
+                  disabled
+                  size="md"
+                >
+                  View Documentation
+                </LinkButton>
+              </Flex>
+            </Container>
+          </Flex>
+        </Flex>
       </PanelBody>
     </Panel>
   );
 }
-
-const SubTitle = styled('div')`
-  margin-bottom: ${p => p.theme.space.md};
-`;
-
-const Title = styled('div')`
-  font-size: 26px;
-  font-weight: ${p => p.theme.fontWeight.bold};
-`;
-
-const BulletList = styled('ul')`
-  list-style-type: disc;
-  padding-left: 20px;
-  margin-bottom: ${p => p.theme.space.xl};
-
-  li {
-    margin-bottom: ${p => p.theme.space.md};
-  }
-`;
-
-const HeaderWrapper = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  gap: ${p => p.theme.space['2xl']};
-  border-radius: ${p => p.theme.borderRadius};
-  padding: ${p => p.theme.space['3xl']};
-`;
-
-const HeaderText = styled('div')`
-  flex: 0.65;
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    flex: 1;
-  }
-`;
-
-const Setup = styled('div')`
-  padding: ${p => p.theme.space['3xl']};
-`;
-
-const Body = styled('div')`
-  display: grid;
-  position: relative;
-  grid-auto-columns: minmax(0, 1fr);
-  grid-auto-flow: column;
-
-  h4 {
-    margin-bottom: 0;
-  }
-`;
 
 const Image = styled('img')`
   display: block;
@@ -400,61 +379,15 @@ const Image = styled('img')`
   height: 120px;
   overflow: hidden;
 
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+  @media (max-width: ${p => p.theme.breakpoints.md}) {
     display: none;
   }
 `;
 
 const Divider = styled('hr')`
   height: 1px;
-  width: 95%;
+  width: 100%;
   background: ${p => p.theme.border};
   border: none;
-  margin-top: 0;
-  margin-bottom: 0;
-`;
-
-const Section = styled('section')`
-  margin-bottom: ${p => p.theme.space['2xl']};
-  &:last-child {
-    margin-bottom: 0;
-  }
-`;
-
-const SectionTitle = styled('h3')`
-  font-size: 18px;
-  font-weight: 600;
-  margin-bottom: ${p => p.theme.space.xl};
-  color: ${p => p.theme.textColor};
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.sm};
-`;
-
-const Description = styled('p')`
-  margin-bottom: ${p => p.theme.space.xl};
-  color: ${p => p.theme.subText};
-  line-height: 1.5;
-`;
-
-const MethodContent = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${p => p.theme.space['2xl']};
-`;
-
-const TabsWrapper = styled('div')`
-  margin-bottom: ${p => p.theme.space['2xl']};
-  border-bottom: 1px solid ${p => p.theme.border};
-`;
-
-const StepDescription = styled('p')`
-  color: ${p => p.theme.subText};
-  font-size: ${p => p.theme.fontSize.md};
-`;
-
-const ActionsContainer = styled('div')`
-  display: flex;
-  gap: ${p => p.theme.space.xl};
-  flex-wrap: wrap;
+  margin: 0;
 `;

--- a/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
@@ -286,17 +286,17 @@ export function PreprodOnboarding({
                   {projectPlatform && <PlatformIcon platform={projectPlatform} />}
                   Uploading Builds
                 </SectionTitle>
-                <TabsContainer>
-                  {availableMethods.map(method => (
-                    <Tab
-                      key={method.value}
-                      active={selectedMethod === method.value}
-                      onClick={() => setSelectedMethod(method.value)}
-                    >
-                      {method.label}
-                    </Tab>
-                  ))}
-                </TabsContainer>
+                <TabsWrapper>
+                  <Tabs value={selectedMethod} onChange={setSelectedMethod}>
+                    <TabList>
+                      {availableMethods.map(method => (
+                        <TabList.Item key={method.value} textValue={method.label}>
+                          {method.label}
+                        </TabList.Item>
+                      ))}
+                    </TabList>
+                  </Tabs>
+                </TabsWrapper>
                 {renderMethodContent()}
               </Section>
 
@@ -443,28 +443,9 @@ const MethodContent = styled('div')`
   gap: ${p => p.theme.space['2xl']};
 `;
 
-const TabsContainer = styled('div')`
-  display: flex;
-  gap: ${p => p.theme.space.sm};
-  margin-bottom: ${p => p.theme.space.xl};
+const TabsWrapper = styled('div')`
+  margin-bottom: ${p => p.theme.space['2xl']};
   border-bottom: 1px solid ${p => p.theme.border};
-`;
-
-const Tab = styled('button')<{active: boolean}>`
-  padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
-  background: none;
-  border: none;
-  border-bottom: 2px solid ${p => (p.active ? p.theme.active : 'transparent')};
-  color: ${p => (p.active ? p.theme.textColor : p.theme.subText)};
-  cursor: pointer;
-  font-size: ${p => p.theme.fontSize.md};
-  font-weight: ${p => (p.active ? 600 : 400)};
-  transition: all 0.2s ease;
-
-  &:hover {
-    color: ${p => p.theme.textColor};
-    background-color: ${p => p.theme.backgroundSecondary};
-  }
 `;
 
 const StepDescription = styled('p')`

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -201,7 +201,7 @@ const NavTabsBadge = styled(Badge)`
 `;
 
 const BadgeWrapper = styled('div')`
-  margin-left: ${p => (p.theme.isChonk ? '' : p.theme.space.sm)};
+  margin-left: ${p => (p.theme.isChonk ? 0 : p.theme.space.sm)};
 `;
 
 export default ReleaseHeader;

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -5,6 +5,7 @@ import pick from 'lodash/pick';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Badge} from 'sentry/components/core/badge';
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {ExternalLink} from 'sentry/components/core/link';
 import {TabList} from 'sentry/components/core/tabs';
 import {Tooltip} from 'sentry/components/core/tooltip';
@@ -15,12 +16,20 @@ import {URL_PARAM} from 'sentry/constants/pageFilters';
 import {IconOpen} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
+import type {PlatformKey} from 'sentry/types/project';
 import type {Release, ReleaseMeta, ReleaseProject} from 'sentry/types/release';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
 import ReleaseActions from './releaseActions';
+
+const MOBILE_PLATFORMS: PlatformKey[] = [
+  'android',
+  'apple-ios',
+  'flutter',
+  'react-native',
+];
 
 type Props = {
   location: Location;
@@ -72,14 +81,17 @@ function ReleaseHeader({
   ];
 
   const numberOfMobileBuilds = releaseMeta.preprodBuildCount;
-  if (numberOfMobileBuilds) {
+  if (numberOfMobileBuilds || MOBILE_PLATFORMS.includes(project.platform)) {
     tabs.push({
       title: tct('Builds [count]', {
-        count: (
-          <NavTabsBadge type="default">
-            {formatAbbreviatedNumber(numberOfMobileBuilds)}
-          </NavTabsBadge>
-        ),
+        count:
+          numberOfMobileBuilds === 0 ? (
+            <FeatureBadge type="new" />
+          ) : (
+            <NavTabsBadge type="default">
+              {formatAbbreviatedNumber(numberOfMobileBuilds)}
+            </NavTabsBadge>
+          ),
       }),
       to: `builds/`,
     });

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -86,7 +86,9 @@ function ReleaseHeader({
       title: tct('Builds [count]', {
         count:
           numberOfMobileBuilds === 0 ? (
-            <FeatureBadge type="new" />
+            <BadgeWrapper>
+              <FeatureBadge type="new" />
+            </BadgeWrapper>
           ) : (
             <NavTabsBadge type="default">
               {formatAbbreviatedNumber(numberOfMobileBuilds)}
@@ -196,6 +198,10 @@ const NavTabsBadge = styled(Badge)`
   @media (max-width: ${p => p.theme.breakpoints.sm}) {
     display: none;
   }
+`;
+
+const BadgeWrapper = styled('div')`
+  margin-left: ${p => (p.theme.isChonk ? '' : p.theme.space.sm)};
 `;
 
 export default ReleaseHeader;


### PR DESCRIPTION
Add basic onboarding to releases page for mobile builds. Style and conventions come from `static/app/views/insights/mcp/views/onboarding.tsx`

Test links (local dev):
- iOS: https://emerge-tools.dev.getsentry.net:7999/explore/releases/com.emergetools.hackernews%403.11%2B1/builds/?project=4506027753668608
- Android: https://emerge-tools.dev.getsentry.net:7999/explore/releases/com.emergetools.hackernews.debugMain%401.0.2%2B13/builds/?project=4506028523388928
- RN: https://demo.dev.getsentry.net:7999/explore/releases/org.reactjs.native.example.sentry-react-native%403.1.9%2B20/builds/?project=4508968204632064

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds onboarding for uploading mobile builds, updates search/empty states, and shows the Builds tab (with a “new” badge) for mobile projects even with zero builds.
> 
> - **Releases UI**:
>   - **Builds tab** in `views/releases/detail/header/releaseHeader.tsx` now appears for mobile platforms even with 0 builds; shows a "new" feature badge when count is 0, otherwise the numeric badge.
> - **Preprod Builds Page** (`views/releases/detail/commitsAndFiles/preprodBuilds.tsx`):
>   - Adds `PreprodOnboarding` with platform-specific upload methods (Fastlane, Gradle, CLI), prerequisites, and CI integration links.
>   - Conditionally shows search bar only when there are builds or an active search; shows onboarding when no builds and no search.
>   - Passes `hasSearchQuery` to table to refine empty-state messaging.
> - **Components**:
>   - `components/preprod/preprodBuildsTable.tsx`: supports `hasSearchQuery` to display "No builds found for your search" when applicable.
> - **New**: `views/releases/detail/commitsAndFiles/preprodOnboarding.tsx` component with onboarding content and tabs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3da826c2aafa831946873d940d2638049950d00b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->