### PR TITLE
feat(preprod): persist the selected chart display in the URL params

### DIFF
--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -100,9 +100,6 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
     selectedContentParam === 'treemap' || selectedContentParam === 'categories'
       ? selectedContentParam
       : 'treemap';
-  const setSelectedContent = (value: 'treemap' | 'categories') => {
-    setSelectedContentParam(value);
-  };
   const [searchQuery, setSearchQuery] = useQueryParamState<string>({
     fieldName: 'search',
   });
@@ -238,12 +235,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
     <Flex direction="column" gap="lg" minHeight="700px">
       <Flex align="center" gap="md">
         {categoriesEnabled && (
-          <SegmentedControl
-            value={selectedContent}
-            onChange={value => {
-              setSelectedContent(value);
-            }}
-          >
+          <SegmentedControl value={selectedContent} onChange={setSelectedContentParam}>
             <SegmentedControl.Item key="treemap" value="treemap" icon={<IconGrid />} />
             <SegmentedControl.Item
               key="categories"

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -100,6 +100,10 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
     selectedContentParam === 'treemap' || selectedContentParam === 'categories'
       ? selectedContentParam
       : 'treemap';
+
+  const handleContentChange = (value: 'treemap' | 'categories') => {
+    setSelectedContentParam(value === 'treemap' ? undefined : value);
+  };
   const [searchQuery, setSearchQuery] = useQueryParamState<string>({
     fieldName: 'search',
   });
@@ -235,13 +239,9 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
     <Flex direction="column" gap="lg" minHeight="700px">
       <Flex align="center" gap="md">
         {categoriesEnabled && (
-          <SegmentedControl value={selectedContent} onChange={setSelectedContentParam}>
-            <SegmentedControl.Item key="treemap" value="treemap" icon={<IconGrid />} />
-            <SegmentedControl.Item
-              key="categories"
-              value="categories"
-              icon={<IconGraphCircle />}
-            />
+          <SegmentedControl value={selectedContent} onChange={handleContentChange}>
+            <SegmentedControl.Item key="treemap" icon={<IconGrid />} />
+            <SegmentedControl.Item key="categories" icon={<IconGraphCircle />} />
           </SegmentedControl>
         )}
         {selectedContent === 'treemap' && (

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -91,9 +91,18 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
   const {isPending: isBuildDetailsPending, data: buildDetailsData} =
     props.buildDetailsQuery;
 
-  const [selectedContent, setSelectedContent] = useState<'treemap' | 'categories'>(
-    'treemap'
-  );
+  const [selectedContentParam, setSelectedContentParam] = useQueryParamState<
+    'treemap' | 'categories'
+  >({
+    fieldName: 'view',
+  });
+  const selectedContent =
+    selectedContentParam === 'treemap' || selectedContentParam === 'categories'
+      ? selectedContentParam
+      : 'treemap';
+  const setSelectedContent = (value: 'treemap' | 'categories') => {
+    setSelectedContentParam(value);
+  };
   const [searchQuery, setSearchQuery] = useQueryParamState<string>({
     fieldName: 'search',
   });
@@ -235,8 +244,12 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
               setSelectedContent(value);
             }}
           >
-            <SegmentedControl.Item key="treemap" icon={<IconGrid />} />
-            <SegmentedControl.Item key="categories" icon={<IconGraphCircle />} />
+            <SegmentedControl.Item key="treemap" value="treemap" icon={<IconGrid />} />
+            <SegmentedControl.Item
+              key="categories"
+              value="categories"
+              icon={<IconGraphCircle />}
+            />
           </SegmentedControl>
         )}
         {selectedContent === 'treemap' && (

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -1,4 +1,4 @@
-import {useState, type ReactNode} from 'react';
+import {type ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from 'sentry/components/core/alert';


### PR DESCRIPTION
Previously if you had the categories chart selected and refreshed the page it would go back to the treemap.

Resolves EME-360