### PR TITLE
feat(table): Move clickable-row css into SimpleTable

### DIFF
--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -16,6 +16,7 @@ import ReplayPlayPauseButton from 'sentry/components/replays/replayPlayPauseButt
 import NumericDropdownFilter from 'sentry/components/replays/table/filters/numericDropdownFilter';
 import OSBrowserDropdownFilter from 'sentry/components/replays/table/filters/osBrowserDropdownFilter';
 import ScoreBar from 'sentry/components/scoreBar';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IconNot} from 'sentry/icons';
 import {IconCursorArrow} from 'sentry/icons/iconCursorArrow';
 import {IconFire} from 'sentry/icons/iconFire';
@@ -595,38 +596,19 @@ const TabularNumber = styled('div')`
 `;
 
 const CellLink = styled(Link)`
-  margin: -${p => p.theme.space.xl};
-  padding: ${p => p.theme.space.xl};
-  flex-grow: 1;
+  ${SimpleTable.rowLinkStyle}
 
-  &:before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: -1;
-  }
+  flex-grow: 1;
 `;
 
 const PlayPauseButtonContainer = styled(Flex)`
+  ${SimpleTable.rowLinkStyle}
+
   z-index: 1; /* Raise above any ReplaySessionColumn in the row */
-  display: flex;
   flex-direction: column;
   justify-content: center;
 
-  margin: 0 -${space(2)} 0 -${space(1)};
-
-  cursor: pointer;
-  &:before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-  }
+  margin: 0 -${p => p.theme.space.xl} 0 -${p => p.theme.space.md};
 `;
 
 const CheckboxHeaderContainer = styled(Flex)`

--- a/static/app/components/tables/simpleTable/index.stories.tsx
+++ b/static/app/components/tables/simpleTable/index.stories.tsx
@@ -2,8 +2,6 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
-import {Button} from 'sentry/components/core/button';
-import {LinkButton} from 'sentry/components/core/button/linkButton';
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import {Link} from 'sentry/components/core/link';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';

--- a/static/app/components/tables/simpleTable/index.stories.tsx
+++ b/static/app/components/tables/simpleTable/index.stories.tsx
@@ -2,6 +2,8 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
+import {Button} from 'sentry/components/core/button';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import {Link} from 'sentry/components/core/link';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
@@ -138,12 +140,16 @@ export default Storybook.story('SimpleTable', story => {
   });
 
   story('Clickable rows', () => {
+    const RowLink = styled(Link)`
+      ${SimpleTable.rowLinkStyle}
+    `;
+
     return (
       <Fragment>
         <p>
-          If you want to make a row clickable then you can wrap it in a{' '}
-          <Storybook.JSXNode name="Link" /> or a raw <Storybook.JSXNode name="button" />,
-          but be sure to set <code>display: contents; pointer: cursor;</code> in the css
+          If you want to make a row clickable then you can wrap one of your cells in a
+          <Storybook.JSXNode name="Link" />, but be sure to set{' '}
+          <code>SimpleTable.rowLinkStyle</code> into the css.
         </p>
         <SimpleTableWithColumns>
           <SimpleTable.Header>
@@ -154,41 +160,22 @@ export default Storybook.story('SimpleTable', story => {
             ))}
           </SimpleTable.Header>
           <SimpleTable.Row>
-            <Link
-              to="#"
-              onClick={e => {
-                // eslint-disable-next-line no-console
-                console.log('clicked a link');
-                e.preventDefault();
-              }}
-              style={{display: 'contents', cursor: 'pointer'}}
-            >
-              <InteractionStateLayer />
-              <SimpleTable.RowCell>
+            <InteractionStateLayer />
+            <SimpleTable.RowCell>
+              <RowLink
+                to="#"
+                onClick={e => {
+                  // eslint-disable-next-line no-console
+                  console.log('clicked a link');
+                  e.preventDefault();
+                }}
+              >
                 Clickable <Storybook.JSXNode name="Link" />
-              </SimpleTable.RowCell>
-              <SimpleTable.RowCell>123</SimpleTable.RowCell>
-              <SimpleTable.RowCell>123</SimpleTable.RowCell>
-              <SimpleTable.RowCell>123</SimpleTable.RowCell>
-            </Link>
-          </SimpleTable.Row>
-          <SimpleTable.Row>
-            <button
-              onClick={e => {
-                // eslint-disable-next-line no-console
-                console.log('clicked a button');
-                e.preventDefault();
-              }}
-              style={{display: 'contents', cursor: 'pointer'}}
-            >
-              <InteractionStateLayer />
-              <SimpleTable.RowCell>
-                Clickable <Storybook.JSXNode name="button" />
-              </SimpleTable.RowCell>
-              <SimpleTable.RowCell>123</SimpleTable.RowCell>
-              <SimpleTable.RowCell>123</SimpleTable.RowCell>
-              <SimpleTable.RowCell>123</SimpleTable.RowCell>
-            </button>
+              </RowLink>
+            </SimpleTable.RowCell>
+            <SimpleTable.RowCell>123</SimpleTable.RowCell>
+            <SimpleTable.RowCell>123</SimpleTable.RowCell>
+            <SimpleTable.RowCell>123</SimpleTable.RowCell>
           </SimpleTable.Row>
         </SimpleTableWithColumns>
       </Fragment>

--- a/static/app/components/tables/simpleTable/index.tsx
+++ b/static/app/components/tables/simpleTable/index.tsx
@@ -1,5 +1,6 @@
 import type {ComponentProps, CSSProperties, HTMLAttributes, RefObject} from 'react';
 import {css} from '@emotion/react';
+import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
@@ -193,6 +194,21 @@ const ColumnHeaderCell = styled('div')<{isSorted?: boolean}>`
     `}
 `;
 
+const rowLinkStyle = (p: {theme: Theme}) => css`
+  /** Adjust margin/padding to account for StyledRowCell padding */
+  margin: -${p.theme.space.lg} -${p.theme.space.xl};
+  padding: ${p.theme.space.lg} ${p.theme.space.xl};
+
+  /** Ensure cursor is set in case this is applied to a div */
+  cursor: pointer;
+
+  &:before {
+    content: '';
+    position: absolute;
+    inset: 0;
+  }
+`;
+
 const SortIndicator = styled(IconArrow, {
   shouldForwardProp: prop => prop !== 'isSorted',
 })<{isSorted?: boolean}>`
@@ -220,4 +236,5 @@ SimpleTable.Header = Header;
 SimpleTable.HeaderCell = HeaderCell;
 SimpleTable.Row = Row;
 SimpleTable.RowCell = RowCell;
+SimpleTable.rowLinkStyle = rowLinkStyle;
 SimpleTable.Empty = StyledEmptyMessage;


### PR DESCRIPTION
I wanted to move some general css, that's actually a neat trick, into the SimpleTable file so it's a bit easier for people to find.

Basically you want to use the css `:before {...}` snippet which will change a normal Link (or Button) inside a cell, into a Link that spans the whole Row!

<img width="1201" height="805" alt="SCR-20250925-mmba" src="https://github.com/user-attachments/assets/75c51700-1a01-415c-9a77-7b6ab2b85742" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `SimpleTable.rowLinkStyle` for full-row clickable cells, replaces custom CSS in replays table, and updates Storybook examples.
> 
> - **SimpleTable**:
>   - Add `rowLinkStyle` helper (margin/padding, cursor, full-row `:before` overlay) and export as `SimpleTable.rowLinkStyle`.
>   - Minor: import `Theme` type.
> - **Replays Table (`replayTableColumns.tsx`)**:
>   - Use `SimpleTable.rowLinkStyle` in `CellLink` and `PlayPauseButtonContainer` instead of custom CSS; adjust margins to match table cell padding.
> - **Storybook (`simpleTable/index.stories.tsx`)**:
>   - Update "Clickable rows" to wrap a cell `Link` styled with `SimpleTable.rowLinkStyle`; simplify example and guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94a406315ff30bbc147674813ab6741854fee2c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->