### PR TITLE
feat(ui): Add missing CloseButton to RequestIntegrationModal

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
@@ -30,7 +30,8 @@ export default function RequestIntegrationModal(props: Props) {
   const organization = useOrganization();
   const api = useApi({persistInFlight: true});
 
-  const {Header, Body, Footer, name, slug, type, closeModal, onSuccess} = props;
+  const {Header, Body, Footer, CloseButton, name, slug, type, closeModal, onSuccess} =
+    props;
   const endpoint = `/organizations/${organization.slug}/integration-requests/`;
 
   const sendRequestMutation = useMutation({
@@ -70,6 +71,7 @@ export default function RequestIntegrationModal(props: Props) {
     <Fragment>
       <Header>
         <h4>{t('Request %s Installation', name)}</h4>
+        <CloseButton />
       </Header>
       <Body>
         <TextBlock>


### PR DESCRIPTION
<img width="734" height="533" alt="image" src="https://github.com/user-attachments/assets/c781d583-3d51-4c55-8fdd-9e982d46afbc" />

Kind of annoying to get out of this modal without it