### PR TITLE
ref(seer-rpc): instrument tracing for rpc calls and get_replay_summary_logs

### DIFF
--- a/src/sentry/replays/usecases/summarize.py
+++ b/src/sentry/replays/usecases/summarize.py
@@ -458,6 +458,7 @@ def _parse_url(s: str, trunc_length: int) -> str:
     return s
 
 
+@sentry_sdk.trace
 def rpc_get_replay_summary_logs(
     project_id: int, replay_id: str, num_segments: int
 ) -> dict[str, Any]:

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -175,6 +175,7 @@ class SeerRpcServiceEndpoint(Endpoint):
     permission_classes = ()
     enforce_rate_limit = False
 
+    @sentry_sdk.trace
     def _is_authorized(self, request: Request) -> bool:
         if request.auth and isinstance(
             request.successful_authenticator, SeerRpcSignatureAuthentication
@@ -182,6 +183,7 @@ class SeerRpcServiceEndpoint(Endpoint):
             return True
         return False
 
+    @sentry_sdk.trace
     def _dispatch_to_local_method(self, method_name: str, arguments: dict[str, Any]) -> Any:
         if method_name not in seer_method_registry:
             raise RpcResolutionException(f"Unknown method {method_name}")
@@ -189,6 +191,7 @@ class SeerRpcServiceEndpoint(Endpoint):
         method = seer_method_registry[method_name]
         return method(**arguments)
 
+    @sentry_sdk.trace
     def post(self, request: Request, method_name: str) -> Response:
         if not self._is_authorized(request):
             raise PermissionDenied


### PR DESCRIPTION
[Trace](https://sentry.sentry.io/issues/trace/4e6caa99666e481fb59c4ab69741e1fe/?fov=0%2C60199.5830078125&groupId=6903673932&node=span-bb0abf869b96e14b&pageEnd=2025-09-26T08%3A17%3A28.055&pageStart=2025-09-25T08%3A17%3A28.055&project=6178942&referrer=github-pr-bot&source=issue_details&timestamp=1758831448.034) showing no instrumentation after the POST:
<img width="574" height="55" alt="Screenshot 2025-09-25 at 2 14 19 PM" src="https://github.com/user-attachments/assets/303664a5-667a-4021-a8e3-637413779354" />