### PR TITLE
chore: Remove feature.organizations:mobile-vitals

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -190,8 +190,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:minute-resolution-sessions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Display CPU and memory metrics in transactions with profiles
     manager.add("organizations:mobile-cpu-memory-in-transactions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Adds the ttid & ttfd vitals to the frontend
-    manager.add("organizations:mobile-vitals", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables higher limit for alert rules
     manager.add("organizations:more-fast-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("organizations:more-slow-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)

--- a/static/app/views/insights/pages/mobile/am1OverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/am1OverviewPage.tsx
@@ -104,7 +104,7 @@ export function Am1MobileOverviewPage() {
   );
   const searchBarEventView = eventView.clone();
 
-  let columnTitles = checkIsReactNative(eventView)
+  const columnTitles = checkIsReactNative(eventView)
     ? REACT_NATIVE_COLUMN_TITLES
     : MOBILE_COLUMN_TITLES;
 
@@ -149,19 +149,6 @@ export function Am1MobileOverviewPage() {
     mepSetting
   );
 
-  if (organization.features.includes('mobile-vitals')) {
-    columnTitles = [
-      ...columnTitles.slice(0, 5),
-      {title: 'ttid'},
-      ...columnTitles.slice(5),
-    ];
-    tripleChartRowCharts.push(
-      ...[
-        PerformanceWidgetSetting.TIME_TO_INITIAL_DISPLAY,
-        PerformanceWidgetSetting.TIME_TO_FULL_DISPLAY,
-      ]
-    );
-  }
   if (organization.features.includes('insight-modules')) {
     doubleChartRowCharts[0] = PerformanceWidgetSetting.SLOW_SCREENS_BY_TTID;
   }

--- a/static/app/views/insights/pages/mobile/am1OverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/am1OverviewPage.tsx
@@ -99,8 +99,7 @@ export function Am1MobileOverviewPage() {
     location,
     projects,
     generateGenericPerformanceEventView(location, withStaticFilters, organization),
-    withStaticFilters,
-    organization
+    withStaticFilters
   );
   const searchBarEventView = eventView.clone();
 

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -83,7 +83,6 @@ function EAPMobileOverviewPage() {
     projects,
     generateGenericPerformanceEventView(location, withStaticFilters, organization),
     withStaticFilters,
-    organization,
     true
   );
 

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -126,14 +126,6 @@ function EAPMobileOverviewPage() {
     mepSetting
   );
 
-  if (organization.features.includes('mobile-vitals')) {
-    tripleChartRowCharts.push(
-      ...[
-        PerformanceWidgetSetting.TIME_TO_INITIAL_DISPLAY,
-        PerformanceWidgetSetting.TIME_TO_FULL_DISPLAY,
-      ]
-    );
-  }
   if (organization.features.includes('insight-modules')) {
     doubleChartRowCharts[0] = PerformanceWidgetSetting.SLOW_SCREENS_BY_TTID;
   }

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -320,9 +320,6 @@ export function generateMobilePerformanceEventView(
     'p75(measurements.frames_slow_rate)',
     'p75(measurements.frames_frozen_rate)',
   ];
-  if (organization.features.includes('mobile-vitals')) {
-    fields.push('p75(measurements.time_to_initial_display)');
-  }
 
   // At this point, all projects are mobile projects.
   // If in addition to that, all projects are react-native projects,

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -306,7 +306,6 @@ export function generateMobilePerformanceEventView(
   projects: Project[],
   genericEventView: EventView,
   withStaticFilters: boolean,
-  organization: Organization,
   useEap = false
 ): EventView {
   const {query} = location;
@@ -502,8 +501,7 @@ export function generatePerformanceEventView(
         location,
         projects,
         eventView,
-        withStaticFilters,
-        organization
+        withStaticFilters
       );
     default:
       return eventView;


### PR DESCRIPTION
This intentionally has backend and frontend changes. The flag is off for all users currently (see https://github.com/getsentry/sentry-options-automator/pull/5289) so it evaluates to `false` in all frontend callsites. If we remove the backend first, or second, the result of `false` will be consistent.

Relates to https://github.com/getsentry/sentry-options-automator/pull/5289
