### PR TITLE
fix(releases): Display package next to version in resolution modal

### DIFF
--- a/static/app/components/customResolutionModal.tsx
+++ b/static/app/components/customResolutionModal.tsx
@@ -40,7 +40,7 @@ function CustomResolutionModal(props: CustomResolutionModalProps) {
         value: release.version,
         label: (
           <Fragment>
-            {release.versionInfo.package && (
+            {release.versionInfo?.package && (
               <Fragment>{release.versionInfo.package}@</Fragment>
             )}
             <Version version={release.version} anchor={false} />{' '}

--- a/static/app/components/customResolutionModal.tsx
+++ b/static/app/components/customResolutionModal.tsx
@@ -40,6 +40,9 @@ function CustomResolutionModal(props: CustomResolutionModalProps) {
         value: release.version,
         label: (
           <Fragment>
+            {release.versionInfo.package && (
+              <Fragment>{release.versionInfo.package}@</Fragment>
+            )}
             <Version version={release.version} anchor={false} />{' '}
             {isVersionInfoSemver(release.versionInfo.version)
               ? t('(semver)')


### PR DESCRIPTION
Fixes REPLAY-645

Previously we sometimes display duplicate versions in the resolution modal dropdown because they belong to different packages:

<img width="889" height="475" alt="Screenshot 2025-09-25 at 2 14 28 PM" src="https://github.com/user-attachments/assets/99ffc712-4243-4333-8a8b-b1d962ef6aff" />

Here we add the package next to the version name so users can tell which version they're resolving the issue by:

<img width="889" height="475" alt="Screenshot 2025-09-25 at 2 17 16 PM" src="https://github.com/user-attachments/assets/123f3f88-0c94-4093-9601-20fc66503e86" />
