### PR TITLE
chore(sidebar): Update collapsed state's expand button

### DIFF
--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -70,11 +70,18 @@ SecondaryNav.Header = function SecondaryNavHeader({children}: {children?: ReactN
       <div>{children}</div>
       <div>
         <Button
-          borderless
+          borderless={isCollapsed ? false : true}
           size="xs"
-          icon={<IconChevron direction={isCollapsed ? 'right' : 'left'} isDouble />}
+          icon={
+            <IconChevron
+              direction={isCollapsed ? 'right' : 'left'}
+              isDouble
+              color={isCollapsed ? 'white' : undefined}
+            />
+          }
           aria-label={isCollapsed ? t('Expand') : t('Collapse')}
           onClick={() => setIsCollapsed(!isCollapsed)}
+          priority={isCollapsed ? 'primary' : undefined}
         />
       </div>
     </Header>


### PR DESCRIPTION
makes the sidebar expand button more visible in the collapsed state

before: 
<img width="189" height="103" alt="Screenshot 2025-09-25 at 2 33 59 PM" src="https://github.com/user-attachments/assets/58a3da03-19d0-4ece-993f-3da5a02789b0" />

after: 
<img width="189" height="100" alt="Screenshot 2025-09-25 at 2 33 14 PM" src="https://github.com/user-attachments/assets/1d8299f8-709d-4b1f-8abd-67db3fe96156" />
