### PR TITLE
fix(slack): fix unfurl by reverting to markdown block

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -40,31 +40,6 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         }
 
     @staticmethod
-    def get_rich_text_link(emojis: list[str], text: str, link: str | None = None) -> SlackBlock:
-        elements: list[dict[str, Any]] = []
-        for emoji in emojis:
-            elements.append({"type": "emoji", "name": emoji})
-            elements.append({"type": "text", "text": " "})
-
-        url: dict[str, Any] = {}
-        if link:
-            url = {
-                "type": "link",
-                "url": link,
-                "text": text,
-                "style": {"bold": True},
-            }
-        else:
-            url = {"type": "text", "text": text}
-
-        elements.append(url)
-
-        return {
-            "type": "rich_text",
-            "elements": [{"type": "rich_text_section", "elements": elements}],
-        }
-
-    @staticmethod
     def get_markdown_quote_block(text: str, max_block_text_length: int) -> SlackBlock:
         if len(text) > max_block_text_length:
             text = text[: max_block_text_length - 3] + "..."

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -508,7 +508,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         title = summary_headline or build_attachment_title(event_or_group)
         title_emojis = self.get_title_emoji(has_action)
 
-        title_text = f"{title_emojis}<{title_link}|*{escape_slack_text(title)}*>"
+        title_text = f"{title_emojis} <{title_link}|*{escape_slack_text(title)}*>"
         return self.get_markdown_block(title_text)
 
     def get_title_emoji(self, has_action: bool) -> str:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -508,9 +508,10 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         title = summary_headline or build_attachment_title(event_or_group)
         title_emojis = self.get_title_emoji(has_action)
 
-        return self.get_rich_text_link(title_emojis, title, title_link)
+        title_text = f"{title_emojis}<{title_link}|*{escape_slack_text(title)}*>"
+        return self.get_markdown_block(title_text)
 
-    def get_title_emoji(self, has_action: bool) -> list[str]:
+    def get_title_emoji(self, has_action: bool) -> str:
         is_error_issue = self.group.issue_category == GroupCategory.ERROR
 
         title_emojis: list[str] = []
@@ -527,7 +528,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         else:
             title_emojis = CATEGORY_TO_EMOJI.get(self.group.issue_category, [])
 
-        return title_emojis
+        return " ".join(title_emojis)
 
     def get_issue_summary_headline(self, event_or_group: Event | GroupEvent | Group) -> str | None:
         if self.issue_summary is None:

--- a/src/sentry/integrations/slack/message_builder/types.py
+++ b/src/sentry/integrations/slack/message_builder/types.py
@@ -31,24 +31,24 @@ INCIDENT_COLOR_MAPPING = {
 SLACK_URL_FORMAT = "<{url}|{text}>"
 
 LEVEL_TO_EMOJI = {
-    "_incident_resolved": ["green_circle"],
-    "debug": ["bug"],
-    "error": ["red_circle"],
-    "fatal": ["red_circle"],
-    "info": ["large_blue_circle"],
-    "warning": ["large_yellow_circle"],
+    "_incident_resolved": [":green_circle:"],
+    "debug": [":bug:"],
+    "error": [":red_circle:"],
+    "fatal": [":red_circle:"],
+    "info": [":large_blue_circle:"],
+    "warning": [":large_yellow_circle:"],
 }
 
-ACTION_EMOJI = ["white_circle"]
+ACTION_EMOJI = [":white_circle:"]
 
 CATEGORY_TO_EMOJI = {
-    GroupCategory.PERFORMANCE: ["large_blue_circle", "chart_with_upwards_trend"],
-    GroupCategory.FEEDBACK: ["large_blue_circle", "busts_in_silhouette"],
-    GroupCategory.CRON: ["large_yellow_circle", "spiral_calendar_pad"],
+    GroupCategory.PERFORMANCE: [":large_blue_circle:", ":chart_with_upwards_trend:"],
+    GroupCategory.FEEDBACK: [":large_blue_circle:", ":busts_in_silhouette:"],
+    GroupCategory.CRON: [":large_yellow_circle:", ":spiral_calendar_pad:"],
 }
 
 ACTIONED_CATEGORY_TO_EMOJI: dict[GroupCategory, list[str]] = {
-    GroupCategory.PERFORMANCE: [ACTION_EMOJI[0], "chart_with_upwards_trend"],
-    GroupCategory.FEEDBACK: [ACTION_EMOJI[0], "busts_in_silhouette"],
-    GroupCategory.CRON: [ACTION_EMOJI[0], "spiral_calendar_pad"],
+    GroupCategory.PERFORMANCE: [ACTION_EMOJI[0], ":chart_with_upwards_trend:"],
+    GroupCategory.FEEDBACK: [ACTION_EMOJI[0], ":busts_in_silhouette:"],
+    GroupCategory.CRON: [ACTION_EMOJI[0], ":spiral_calendar_pad:"],
 }

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2845,17 +2845,15 @@ class SlackActivityNotificationTest(ActivityTestCase):
         alert_type: FineTuningAPIKey = FineTuningAPIKey.WORKFLOW,
         issue_link_extra_params=None,
     ):
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-        )
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
+
         issue_link = f"http://testserver/organizations/{org.slug}/issues/{group.id}/?referrer={referrer}&notification_uuid={notification_uuid}"
         if issue_link_extra_params is not None:
             issue_link += issue_link_extra_params
-        emoji = "large_blue_circle"
-        text = "N+1 Query"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == issue_link
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[1]["text"]["text"]
+            == f":large_blue_circle: :chart_with_upwards_trend: <{issue_link}|*N+1 Query*>"
+        )
         assert blocks[2]["elements"][0]["text"] == "/books/"
         assert (
             blocks[3]["text"]["text"]
@@ -2879,17 +2877,14 @@ class SlackActivityNotificationTest(ActivityTestCase):
         issue_link_extra_params=None,
         with_culprit=False,
     ):
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-        )
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         issue_link = f"http://testserver/organizations/{org.slug}/issues/{group.id}/?referrer={referrer}&notification_uuid={notification_uuid}"
         if issue_link_extra_params is not None:
             issue_link += issue_link_extra_params
-        emoji = "red_circle"
-        text = f"{TEST_ISSUE_OCCURRENCE.issue_title}"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == issue_link
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[1]["text"]["text"]
+            == f":red_circle: <{issue_link}|*{TEST_ISSUE_OCCURRENCE.issue_title}*>"
+        )
 
         if with_culprit:
             assert blocks[2]["elements"][0]["text"] == "raven.tasks.run_a_test"

--- a/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
+++ b/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
@@ -101,12 +101,10 @@ class TestInit(RuleTestCase):
         blocks = mock_post.call_args.kwargs["blocks"]
         blocks = orjson.loads(blocks)
 
-        emoji = "large_yellow_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack"
-        text = "Hello world"
-        assert blocks[0]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[0]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[0]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[0]["text"]["text"]
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack|*Hello world*>"
+        )
 
         assert NotificationMessage.objects.all().count() == 0
 
@@ -143,12 +141,10 @@ class TestInit(RuleTestCase):
         blocks = mock_post.call_args.kwargs["blocks"]
         blocks = orjson.loads(blocks)
 
-        emoji = "large_yellow_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack"
-        text = "Hello world"
-        assert blocks[0]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[0]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[0]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[0]["text"]["text"]
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack|*Hello world*>"
+        )
 
         assert NotificationMessage.objects.all().count() == 0
 
@@ -208,12 +204,10 @@ class TestInit(RuleTestCase):
         blocks = mock_post.call_args.kwargs["blocks"]
         blocks = orjson.loads(blocks)
 
-        emoji = "large_yellow_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={self.rule.id}&alert_type=issue"
-        text = "Hello world"
-        assert blocks[0]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[0]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[0]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[0]["text"]["text"]
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={self.rule.id}&alert_type=issue|*Hello world*>"
+        )
 
         assert NotificationMessage.objects.all().count() == 1
 
@@ -269,12 +263,10 @@ class TestInit(RuleTestCase):
         blocks = mock_post.call_args.kwargs["blocks"]
         blocks = orjson.loads(blocks)
 
-        emoji = "large_yellow_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={self.rule.id}&alert_type=issue"
-        text = "Hello world"
-        assert blocks[0]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[0]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[0]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[0]["text"]["text"]
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={self.rule.id}&alert_type=issue|*Hello world*>"
+        )
 
         assert NotificationMessage.objects.all().count() == 2
         assert (
@@ -318,13 +310,10 @@ class TestInit(RuleTestCase):
         blocks = mock_post.call_args.kwargs["blocks"]
         blocks = orjson.loads(blocks)
 
-        emoji = "large_yellow_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={action_data['legacy_rule_id']}&alert_type=issue"
-        text = "Hello world"
-
-        assert blocks[0]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[0]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[0]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[0]["text"]["text"]
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={action_data['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+        )
 
         assert NotificationMessage.objects.all().count() == 1
 
@@ -366,13 +355,10 @@ class TestInit(RuleTestCase):
         blocks = mock_post.call_args.kwargs["blocks"]
         blocks = orjson.loads(blocks)
 
-        emoji = "large_yellow_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={action_data['legacy_rule_id']}&alert_type=issue"
-        text = "Hello world"
-
-        assert blocks[0]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[0]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[0]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[0]["text"]["text"]
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={action_data['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+        )
 
         # Test action should not create a notification message
         assert NotificationMessage.objects.all().count() == 0
@@ -412,13 +398,10 @@ class TestInit(RuleTestCase):
         blocks = mock_post.call_args.kwargs["blocks"]
         blocks = orjson.loads(blocks)
 
-        emoji = "large_yellow_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&workflow_id={action_data['workflow_id']}&alert_type=issue"
-        text = "Hello world"
-
-        assert blocks[0]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[0]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[0]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[0]["text"]["text"]
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&workflow_id={action_data['workflow_id']}&alert_type=issue|*Hello world*>"
+        )
 
         assert NotificationMessage.objects.all().count() == 1
 
@@ -460,12 +443,10 @@ class TestInit(RuleTestCase):
         blocks = mock_post.call_args.kwargs["blocks"]
         blocks = orjson.loads(blocks)
 
-        emoji = "large_yellow_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={action_data['legacy_rule_id']}&alert_type=issue"
-        text = "Hello world"
-        assert blocks[0]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[0]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[0]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[0]["text"]["text"]
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={action_data['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+        )
 
         assert NotificationMessage.objects.all().count() == 1
 
@@ -523,12 +504,10 @@ class TestInit(RuleTestCase):
         blocks = mock_post.call_args.kwargs["blocks"]
         blocks = orjson.loads(blocks)
 
-        emoji = "large_yellow_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={action_data['legacy_rule_id']}&alert_type=issue"
-        text = "Hello world"
-        assert blocks[0]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[0]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[0]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[0]["text"]["text"]
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={action_data['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+        )
 
         assert NotificationMessage.objects.all().count() == 2
         assert (

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -99,15 +99,11 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert fallback_text == f"Issue assigned to {self.name} by themselves"
         assert blocks[0]["text"]["text"] == fallback_text
 
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
+        assert (
+            blocks[1]["text"]["text"]
+            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=assigned_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
         )
-        emoji = "red_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=assigned_activity-slack&notification_uuid={notification_uuid}"
-        text = f"{self.group.title}"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
 
         assert (
             blocks[3]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -89,12 +89,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert event.group
-        emoji = "red_circle"
-        url = f"http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={self.rule.id}&alert_type=issue"
-        text = "Hello world"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[1]["text"]["text"]
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={self.rule.id}&alert_type=issue|*Hello world*>"
+        )
         assert (
             blocks[4]["elements"][0]["text"]
             == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
@@ -380,12 +378,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert event.group
-        emoji = "red_circle"
-        url = f"http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue"
-        text = "Hello world"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[1]["text"]["text"]
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+        )
         assert (
             blocks[4]["elements"][0]["text"]
             == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
@@ -442,12 +438,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert event.group
-        emoji = "red_circle"
-        url = f"http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment={environment.name}&alert_rule_id={rule.id}&alert_type=issue"
-        text = "Hello world"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[1]["text"]["text"]
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment=production&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+        )
         assert (
             blocks[4]["elements"][0]["text"]
             == f"{event.project.slug} | {environment.name} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
@@ -543,12 +537,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert event.group
-        emoji = "red_circle"
-        url = f"http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue"
-        text = "Hello world"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[1]["text"]["text"]
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+        )
         assert blocks[6]["elements"][0]["text"] == f"Suggested Assignees: #{self.team.slug}"
         assert (
             blocks[7]["elements"][0]["text"]
@@ -703,16 +695,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert self.mock_post.call_args.kwargs["channel"] == "CXXXXXXX2"
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
 
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-        )
+        assert "Hello world" in blocks[1]["text"]["text"]
+        title_link = blocks[1]["text"]["text"][13:][1:-1]
+        notification_uuid = self.get_notification_uuid(title_link)
         assert event.group
-        emoji = "red_circle"
-        url = f"http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue"
-        text = "Hello world"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
         assert (
             blocks[-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
@@ -789,9 +775,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         fallback_text = self.mock_post.call_args.kwargs["text"]
 
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-        )
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
 
         assert (
             fallback_text
@@ -799,12 +783,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert event.group
-        emoji = "red_circle"
-        url = f"http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue"
-        text = "Hello world"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[1]["text"]["text"]
+            == f":red_circle: <http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+        )
         assert (
             blocks[5]["elements"][0]["text"]
             == f"{event.project.slug} | <http://example.com/settings/{event.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
@@ -878,16 +860,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
         assert self.mock_post.call_args.kwargs["channel"] == "CXXXXXXX2"
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-        )
+        assert "Hello world" in blocks[1]["text"]["text"]
+        title_link = blocks[1]["text"]["text"][13:][1:-1]
+        notification_uuid = self.get_notification_uuid(title_link)
         assert event.group
-        emoji = "red_circle"
-        url = f"http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue"
-        text = "Hello world"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
         assert (
             blocks[-2]["elements"][0]["text"]
             == f"{project2.slug} | <http://example.com/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
@@ -987,16 +963,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
         assert data["channel"] == "UXXXXXXX1"
         blocks = orjson.loads(data["blocks"])
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-        )
+        assert "Hello world" in blocks[1]["text"]["text"]
+        title_link = blocks[1]["text"]["text"]
+        notification_uuid = self.get_notification_uuid(title_link)
         assert event.group
-        emoji = "red_circle"
-        url = f"http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue"
-        text = "Hello world"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
         assert (
             blocks[-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
@@ -1006,16 +976,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert data2["channel"] == "UXXXXXXX2"
         assert "blocks" in data2
         blocks = orjson.loads(data2["blocks"])
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-        )
+        assert "Hello world" in blocks[1]["text"]["text"]
+        title_link = blocks[1]["text"]["text"]
+        notification_uuid = self.get_notification_uuid(title_link)
         assert event.group
-        emoji = "red_circle"
-        url = f"http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue"
-        text = "Hello world"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
         assert (
             blocks[-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
@@ -1047,21 +1011,17 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         fallback_text = self.mock_post.call_args.kwargs["text"]
 
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-        )
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             fallback_text
             == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/alerts/rules/{event.project.slug}/{rule.id}/details/|Test Alert>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert event.group
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == "Hello world"
         assert (
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-            == f"http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue"
+            blocks[1]["text"]["text"]
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
         )
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == "red_circle"
         assert (
             blocks[4]["elements"][0]["text"]
             == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -36,16 +36,10 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         fallback_text = self.mock_post.call_args.kwargs["text"]
         assert fallback_text == "Issue marked as regression"
         assert blocks[0]["text"]["text"] == fallback_text
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
+        assert blocks[1]["text"]["text"] == (
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
         )
-        emoji = "red_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}"
-        text = f"{self.group.title}"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
-
         assert blocks[3]["elements"][0]["text"] == (
             f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
@@ -60,20 +54,15 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         fallback_text = self.mock_post.call_args.kwargs["text"]
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-        )
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             fallback_text
             == f"Issue marked as regression in release <http://testserver/organizations/baz/releases/1.0.0/?referrer=regression_activity&notification_uuid={notification_uuid}|1.0.0>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
-        emoji = "red_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}"
-        text = f"{self.group.title}"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
+        assert blocks[1]["text"]["text"] == (
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+        )
         assert blocks[3]["elements"][0]["text"] == (
             f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -34,9 +34,7 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         fallback_text = self.mock_post.call_args.kwargs["text"]
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-        )
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         issue_link = (
             f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}"
         )
@@ -45,12 +43,10 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             == f"{self.name} marked <{issue_link}/?referrer=activity_notification&notification_uuid={notification_uuid}|{self.short_id}> as resolved"
         )
         assert blocks[0]["text"]["text"] == fallback_text
-        emoji = "red_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_activity-slack&notification_uuid={notification_uuid}"
-        text = f"{self.group.title}"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[1]["text"]["text"]
+            == f":red_circle: <{issue_link}/?referrer=resolved_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+        )
         assert (
             blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_pull_request.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_pull_request.py
@@ -39,21 +39,17 @@ class SlackResolvedInPullRequestNotificationTest(
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         fallback_text = self.mock_post.call_args.kwargs["text"]
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-        )
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             fallback_text
             == f"{self.name} made a <{self.pull_request_url}| pull request> that will resolve <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification&notification_uuid={notification_uuid}|{self.short_id}>"
         )
         assert blocks[0]["text"]["text"] == fallback_text
 
-        emoji = "red_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_pull_request_activity-slack&notification_uuid={notification_uuid}"
-        text = f"{self.group.title}"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
+        assert (
+            blocks[1]["text"]["text"]
+            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_pull_request_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+        )
         assert (
             blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_pull_request_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
@@ -78,9 +74,7 @@ class SlackResolvedInPullRequestNotificationTest(
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         fallback_text = self.mock_post.call_args.kwargs["text"]
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-        )
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
 
         assert (
             fallback_text
@@ -115,9 +109,7 @@ class SlackResolvedInPullRequestNotificationTest(
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         fallback_text = self.mock_post.call_args.kwargs["text"]
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-        )
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
 
         assert (
             fallback_text

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -39,15 +39,11 @@ class SlackResolvedInReleaseNotificationTest(
         release_name = notification.activity.data["version"]
         assert fallback_text == f"Issue marked as resolved in {release_name} by {self.name}"
         assert blocks[0]["text"]["text"] == fallback_text
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
+        assert (
+            blocks[1]["text"]["text"]
+            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_release_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
         )
-        emoji = "red_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_release_activity-slack&notification_uuid={notification_uuid}"
-        text = f"{self.group.title}"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
 
         assert (
             blocks[3]["elements"][0]["text"]
@@ -130,9 +126,7 @@ class SlackResolvedInReleaseNotificationTest(
 
         assert fallback_text == f"Issue marked as resolved in 1.0.0 by {self.name}"
         assert blocks[0]["text"]["text"] == fallback_text
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
-        )
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -38,15 +38,10 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
 
         assert fallback_text == f"Issue unassigned by {self.name}"
         assert blocks[0]["text"]["text"] == fallback_text
-        notification_uuid = self.get_notification_uuid(
-            blocks[1]["elements"][0]["elements"][-1]["url"]
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
+        assert blocks[1]["text"]["text"] == (
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=unassigned_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
         )
-        emoji = "red_circle"
-        url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=unassigned_activity-slack&notification_uuid={notification_uuid}"
-        text = f"{self.group.title}"
-        assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-        assert blocks[1]["elements"][0]["elements"][-1]["url"] == url
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == text
         assert (
             blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -97,7 +97,7 @@ class SlackNotifyActionTest(RuleTestCase):
         blocks = mock_post.call_args.kwargs["blocks"]
         blocks = orjson.loads(blocks)
 
-        assert event.title in blocks[0]["elements"][0]["elements"][-1]["text"]
+        assert event.title in blocks[0]["text"]["text"]
 
     def test_render_label_with_notes(self) -> None:
         rule = self.get_rule(
@@ -369,7 +369,7 @@ class SlackNotifyActionTest(RuleTestCase):
             blocks = mock_post.call_args.kwargs["blocks"]
             blocks = orjson.loads(blocks)
 
-            assert event.title in blocks[0]["elements"][0]["elements"][-1]["text"]
+            assert event.title in blocks[0]["text"]["text"]
             assert blocks[5]["text"]["text"] == self.organization.slug
             assert blocks[6]["text"]["text"] == self.integration.id
             assert_last_analytics_event(

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -264,7 +264,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status)
         assert "via" not in blocks[4]["elements"][0]["text"]
-        assert "white_circle" in blocks[0]["elements"][0]["elements"][0]["name"]
+        assert ":white_circle:" in blocks[0]["text"]["text"]
 
         assert len(mock_record.mock_calls) == 4
         start_1, success_1, start_2, success_2 = mock_record.mock_calls
@@ -489,7 +489,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status), text
-        assert "white_circle" in blocks[0]["elements"][0]["elements"][0]["name"]
+        assert ":white_circle:" in blocks[0]["text"]["text"]
 
         # Assign to team
         self.assign_issue(original_message, self.team)
@@ -501,7 +501,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status), text
-        assert "white_circle" in blocks[0]["elements"][0]["elements"][0]["name"]
+        assert ":white_circle:" in blocks[0]["text"]["text"]
 
         # Assert group assignment activity recorded
         group_activity = list(Activity.objects.filter(group=self.group))
@@ -544,7 +544,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
         assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
-        assert "white_circle" in resp.data["blocks"][0]["elements"][0]["elements"][0]["name"]
+        assert ":white_circle:" in resp.data["blocks"][0]["text"]["text"]
 
         # Assert group assignment activity recorded
         group_activity = list(Activity.objects.filter(group=self.group))
@@ -736,7 +736,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"] == expect_status
-        assert "white_circle" in blocks[0]["elements"][0]["elements"][0]["name"]
+        assert ":white_circle:" in blocks[0]["text"]["text"]
 
     @with_feature("organizations:workflow-engine-single-process-workflows")
     @override_options({"workflow_engine.issue_alert.group.type_id.rollout": [1]})
@@ -758,7 +758,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"] == expect_status
-        assert "white_circle" in blocks[0]["elements"][0]["elements"][0]["name"]
+        assert ":white_circle:" in blocks[0]["text"]["text"]
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
@@ -792,8 +792,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             in blocks[2]["text"]["text"]
         )
         assert blocks[3]["text"]["text"] == expect_status
-        assert "white_circle" in blocks[0]["elements"][0]["elements"][0]["name"]
-        assert "chart_with_upwards_trend" in blocks[0]["elements"][0]["elements"][2]["name"]
+        assert ":white_circle: :chart_with_upwards_trend:" in blocks[0]["text"]["text"]
 
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
     def test_resolve_issue_through_unfurl(self, mock_tags: MagicMock) -> None:

--- a/tests/sentry/notifications/notifications/test_assigned.py
+++ b/tests/sentry/notifications/notifications/test_assigned.py
@@ -46,7 +46,7 @@ class AssignedNotificationAPITest(APITestCase):
         fallback_text = mock_post.call_args_list[index].kwargs["text"]
         assert fallback_text == msg
 
-        assert blocks[1]["elements"][0]["elements"][-1]["text"] == group.title
+        assert group.title in blocks[1]["text"]["text"]
         assert project.slug in blocks[-2]["elements"][0]["text"]
         channel = mock_post.call_args_list[index].kwargs["channel"]
         assert channel == str(user_id)
@@ -104,7 +104,7 @@ class AssignedNotificationAPITest(APITestCase):
         blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
         fallback_text = mock_post.call_args.kwargs["text"]
         assert fallback_text == f"Issue assigned to {user.get_display_name()} by themselves"
-        assert self.group.title in blocks[1]["elements"][0]["elements"][-1]["text"]
+        assert self.group.title in blocks[1]["text"]["text"]
         assert self.project.slug in blocks[-2]["elements"][0]["text"]
 
     @with_feature("organizations:suspect-commits-in-emails")

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -307,33 +307,18 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         assert blocks[0]["text"]["text"] == fallback_text
 
         assert event1.group
-        emoji = "red_circle"
-        event1_alert_title = {
-            "url": f"http://testserver/organizations/{self.organization.slug}/issues/{event1.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue",
-            "text": f"{event1.group.title}",
-        }
+        event1_alert_title = f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{event1.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*{event1.group.title}*>"
 
         assert event2.group
-        event2_alert_title = {
-            "url": f"http://testserver/organizations/{self.organization.slug}/issues/{event2.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue",
-            "text": f"{event2.group.title}",
-        }
+        event2_alert_title = f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{event2.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*{event2.group.title}*>"
 
         # digest order not definitive
         try:
-            assert blocks[1]["elements"][0]["elements"][-1]["text"] == event1_alert_title["text"]
-            assert blocks[1]["elements"][0]["elements"][-1]["url"] == event1_alert_title["url"]
-            assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-            assert blocks[5]["elements"][0]["elements"][-1]["text"] == event2_alert_title["text"]
-            assert blocks[5]["elements"][0]["elements"][-1]["url"] == event2_alert_title["url"]
-            assert blocks[5]["elements"][0]["elements"][0]["name"] == emoji
+            assert blocks[1]["text"]["text"] == event1_alert_title
+            assert blocks[5]["text"]["text"] == event2_alert_title
         except AssertionError:
-            assert blocks[1]["elements"][0]["elements"][-1]["text"] == event2_alert_title["text"]
-            assert blocks[1]["elements"][0]["elements"][-1]["url"] == event2_alert_title["url"]
-            assert blocks[1]["elements"][0]["elements"][0]["name"] == emoji
-            assert blocks[5]["elements"][0]["elements"][-1]["text"] == event1_alert_title["text"]
-            assert blocks[5]["elements"][0]["elements"][-1]["url"] == event1_alert_title["url"]
-            assert blocks[5]["elements"][0]["elements"][0]["name"] == emoji
+            assert blocks[1]["text"]["text"] == event2_alert_title
+            assert blocks[5]["text"]["text"] == event1_alert_title
 
         assert (
             blocks[3]["elements"][0]["text"]

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -190,12 +190,13 @@ class ActivityNotificationTest(APITestCase):
         assert f"{self.user.username}</strong> unassigned" in msg.alternatives[0][0]
 
         blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
+        block = blocks[1]["text"]["text"]
         footer = blocks[3]["elements"][0]["text"]
         text = mock_post.call_args.kwargs["text"]
 
         assert text == f"Issue unassigned by {self.name}"
-        assert self.group.title in blocks[1]["elements"][0]["elements"][-1]["text"]
-        title_link = blocks[1]["elements"][0]["elements"][-1]["url"]
+        assert self.group.title in block
+        title_link = block[13:][1:-1]  # removes emoji and <>
         notification_uuid = get_notification_uuid(title_link)
         assert (
             footer
@@ -252,11 +253,12 @@ class ActivityNotificationTest(APITestCase):
         assert f"{self.short_id}</a> as resolved</p>" in msg.alternatives[0][0]
 
         blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
+        block = blocks[1]["text"]["text"]
         footer = blocks[3]["elements"][0]["text"]
         text = mock_post.call_args.kwargs["text"]
 
-        assert self.group.title in blocks[1]["elements"][0]["elements"][-1]["text"]
-        title_link = blocks[1]["elements"][0]["elements"][-1]["url"]
+        assert self.group.title in block
+        title_link = block[13:][1:-1]  # removes emoji and <>
         notification_uuid = get_notification_uuid(title_link)
         assert (
             text
@@ -409,11 +411,12 @@ class ActivityNotificationTest(APITestCase):
         assert f"{group.qualified_short_id}</a> as a regression</p>" in msg.alternatives[0][0]
 
         blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
+        block = blocks[1]["text"]["text"]
         footer = blocks[3]["elements"][0]["text"]
         text = mock_post.call_args.kwargs["text"]
 
         assert text == "Issue marked as regression"
-        title_link = blocks[1]["elements"][0]["elements"][-1]["url"]
+        title_link = block[13:][1:-1]  # removes emoji and <>
         notification_uuid = get_notification_uuid(title_link)
         assert (
             footer
@@ -479,12 +482,13 @@ class ActivityNotificationTest(APITestCase):
         )
 
         blocks = orjson.loads(mock_post.call_args.kwargs["blocks"])
+        block = blocks[1]["text"]["text"]
         footer = blocks[3]["elements"][0]["text"]
         text = mock_post.call_args.kwargs["text"]
 
         assert text == f"Issue marked as resolved in {parsed_version} by {self.name}"
-        assert self.group.title in blocks[1]["elements"][0]["elements"][-1]["text"]
-        title_link = blocks[1]["elements"][0]["elements"][-1]["url"]
+        assert self.group.title in block
+        title_link = block[13:][1:-1]  # removes emoji and <>
         notification_uuid = get_notification_uuid(title_link)
         assert (
             footer
@@ -574,10 +578,11 @@ class ActivityNotificationTest(APITestCase):
         assert "Hello world</pre>" in msg.alternatives[0][0]
 
         blocks = orjson.loads(mock_post.call_args_list[0].kwargs["blocks"])
+        block = blocks[1]["text"]["text"]
         footer = blocks[4]["elements"][0]["text"]
 
-        assert "Hello world" in blocks[1]["elements"][0]["elements"][-1]["text"]
-        title_link = blocks[1]["elements"][0]["elements"][-1]["url"]
+        assert "Hello world" in block
+        title_link = block[13:][1:-1]  # removes emoji and <>
         notification_uuid = get_notification_uuid(title_link)
         assert (
             footer

--- a/tests/sentry/rules/processing/test_processor.py
+++ b/tests/sentry/rules/processing/test_processor.py
@@ -996,9 +996,7 @@ class RuleProcessorTestFilters(TestCase):
         mock_post.assert_called_once()
         assert (
             "notification_uuid"
-            in json.loads(mock_post.call_args.kwargs["blocks"])[0]["elements"][0]["elements"][-1][
-                "url"
-            ]
+            in json.loads(mock_post.call_args.kwargs["blocks"])[0]["text"]["text"]
         )
 
     @patch("sentry.shared_integrations.client.base.BaseApiClient.post")


### PR DESCRIPTION
It appears that converting Slack messages to use rich text, while fixing issue title links in iOS with & signs, also broke all link unfurls because unfurls do not support rich text. The change was introduced here https://github.com/getsentry/sentry/pull/91637