### PR TITLE
chore: Remove feature.organizations:performance-chart-interpolation

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -57,7 +57,6 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
         self, organization: Organization, request: Request
     ) -> Mapping[str, bool | None]:
         feature_names = [
-            "organizations:performance-chart-interpolation",
             "organizations:performance-use-metrics",
             "organizations:dashboards-mep",
             "organizations:mep-rollout-flag",
@@ -164,9 +163,6 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                     sentry_sdk.capture_exception(e)
 
             batch_features = self.get_features(organization, request)
-            has_chart_interpolation = batch_features.get(
-                "organizations:performance-chart-interpolation", False
-            )
             use_metrics = (
                 batch_features.get("organizations:performance-use-metrics", False)
                 or batch_features.get("organizations:dashboards-mep", False)
@@ -497,12 +493,8 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
             return fn
 
         get_event_stats = get_event_stats_factory(dataset)
-        zerofill_results = not (
-            request.GET.get("withoutZerofill") == "1" and has_chart_interpolation
-        )
-        if use_rpc:
-            # The rpc will usually zerofill for us so we don't need to do it ourselves
-            zerofill_results = False
+        # The rpc will usually zerofill for us so we don't need to do it ourselves
+        zerofill_results = not use_rpc
 
         try:
             return Response(

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -228,8 +228,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-calculate-mobile-perf-score-relay", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable performance change explorer panel on trends page
     manager.add("organizations:performance-change-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable interpolation of null data points in charts instead of zerofilling in performance
-    manager.add("organizations:performance-chart-interpolation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Discover Saved Query dataset selector
     manager.add("organizations:performance-discover-dataset-selector", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable deprecate discover widget type

--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -459,10 +459,6 @@ export type EventsChartProps = {
    * Should datetimes be formatted in UTC?
    */
   utc?: boolean | null;
-  /**
-   * Whether or not to zerofill results
-   */
-  withoutZerofill?: boolean;
 } & Pick<
   ChartProps,
   | 'seriesTransformer'
@@ -539,7 +535,6 @@ class EventsChart extends Component<EventsChartProps> {
       chartComponent,
       usePageZoom,
       height,
-      withoutZerofill,
       fromDiscover,
       additionalSeries,
       loadingAdditionalSeries,
@@ -681,8 +676,6 @@ class EventsChart extends Component<EventsChartProps> {
               topEvents={topEvents}
               confirmedQuery={confirmedQuery}
               partial
-              // Cannot do interpolation when stacking series
-              withoutZerofill={withoutZerofill && !this.isStacked()}
               dataset={dataset}
             >
               {eventData => {

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -218,10 +218,6 @@ type EventsRequestPartialProps = {
    */
   useOnDemandMetrics?: boolean;
   /**
-   * Whether or not to zerofill results
-   */
-  withoutZerofill?: boolean;
-  /**
    * The yAxis being plotted. If multiple yAxis are requested,
    * the child render function will be called with `results`
    */

--- a/static/app/views/discover/results/resultsChart.tsx
+++ b/static/app/views/discover/results/resultsChart.tsx
@@ -65,10 +65,6 @@ class ResultsChart extends Component<ResultsChartProps> {
       customMeasurements,
     } = this.props;
 
-    const hasPerformanceChartInterpolation = organization.features.includes(
-      'performance-chart-interpolation'
-    );
-
     const globalSelection = eventView.getPageFilters();
     const start = globalSelection.datetime.start
       ? getUtcToLocalDateObject(globalSelection.datetime.start)
@@ -147,7 +143,6 @@ class ResultsChart extends Component<ResultsChartProps> {
               orderby={isTopEvents ? decodeScalar(apiPayload.sort) : undefined}
               utc={utc === 'true'}
               confirmedQuery={confirmedQuery}
-              withoutZerofill={hasPerformanceChartInterpolation}
               chartComponent={chartComponent}
               referrer={referrer}
               fromDiscover

--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -77,7 +77,6 @@ type Props = {
   location: Location;
   organization: Organization;
   totalValue: number | null;
-  withoutZerofill: boolean;
   project?: Project;
 };
 
@@ -87,7 +86,6 @@ function TransactionSummaryCharts({
   organization,
   location,
   currentFilter,
-  withoutZerofill,
   project,
 }: Props) {
   const navigate = useNavigate();
@@ -215,7 +213,6 @@ function TransactionSummaryCharts({
             end={eventView.end}
             statsPeriod={eventView.statsPeriod}
             currentFilter={currentFilter}
-            withoutZerofill={withoutZerofill}
             queryExtras={queryExtras}
           />
         )}
@@ -246,7 +243,6 @@ function TransactionSummaryCharts({
             start={eventView.start}
             end={eventView.end}
             statsPeriod={eventView.statsPeriod}
-            withoutZerofill={withoutZerofill}
             projects={project ? [project] : []}
             withBreakpoint={organization.features.includes('performance-new-trends')}
           />
@@ -261,7 +257,6 @@ function TransactionSummaryCharts({
             start={eventView.start}
             end={eventView.end}
             statsPeriod={eventView.statsPeriod}
-            withoutZerofill={withoutZerofill}
             queryExtras={queryExtras}
           />
         )}
@@ -275,7 +270,6 @@ function TransactionSummaryCharts({
             start={eventView.start}
             end={eventView.end}
             statsPeriod={eventView.statsPeriod}
-            withoutZerofill={withoutZerofill}
           />
         )}
       </ChartContainer>

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -414,10 +414,6 @@ function SummaryContent({
     return null;
   }, [organization, mepDataContext]);
 
-  const hasPerformanceChartInterpolation = organization.features.includes(
-    'performance-chart-interpolation'
-  );
-
   const query = useMemo(() => {
     return decodeScalar(location.query.query, '');
   }, [location]);
@@ -577,7 +573,6 @@ function SummaryContent({
             eventView={eventView}
             totalValue={totalCount}
             currentFilter={spanOperationBreakdownFilter}
-            withoutZerofill={hasPerformanceChartInterpolation}
             project={project}
           />
           <TransactionsList

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx
@@ -27,7 +27,6 @@ type Props = ViewProps & {
   currentFilter: SpanOperationBreakdownFilter;
   organization: OrganizationSummary;
   queryExtra: Query;
-  withoutZerofill: boolean;
   queryExtras?: Record<string, string>;
 };
 
@@ -45,7 +44,6 @@ function DurationChart({
   statsPeriod,
   queryExtra,
   currentFilter,
-  withoutZerofill,
   start: propsStart,
   end: propsEnd,
   queryExtras,
@@ -140,7 +138,6 @@ function DurationChart({
         includePrevious={false}
         yAxis={yAxis}
         partial
-        withoutZerofill={withoutZerofill}
         referrer="api.insights.transaction-summary.duration-chart"
         queryExtras={queryExtras}
       >

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
@@ -40,7 +40,6 @@ type Props = ViewProps & {
   queryExtra: Query;
   trendFunction: TrendFunctionField;
   trendParameter: string;
-  withoutZerofill: boolean;
   withBreakpoint?: boolean;
 };
 
@@ -53,7 +52,6 @@ function TrendChart({
   trendFunction,
   trendParameter,
   queryExtra,
-  withoutZerofill,
   withBreakpoint,
   eventView,
   start: propsStart,
@@ -228,7 +226,6 @@ function TrendChart({
                 yAxis={trendDisplay}
                 currentSeriesNames={[trendDisplay]}
                 partial
-                withoutZerofill={withoutZerofill}
                 referrer="api.insights.transaction-summary.trends-chart"
               >
                 {({errored, loading, reloading, timeseriesData, timeframe}) => {
@@ -269,7 +266,6 @@ function TrendChart({
           yAxis={trendDisplay}
           currentSeriesNames={[trendDisplay]}
           partial
-          withoutZerofill={withoutZerofill}
           referrer="api.insights.transaction-summary.trends-chart"
         >
           {({errored, loading, reloading, timeseriesData, timeframe: timeFrame}) => {

--- a/static/app/views/performance/transactionSummary/transactionOverview/userMiseryChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userMiseryChart/index.tsx
@@ -21,7 +21,6 @@ import type {ViewProps} from 'sentry/views/performance/types';
 type Props = ViewProps & {
   organization: OrganizationSummary;
   queryExtra: Query;
-  withoutZerofill: boolean;
 };
 
 /**
@@ -33,7 +32,6 @@ function UserMiseryChart({
   organization,
   query,
   statsPeriod,
-  withoutZerofill,
   start: propsStart,
   end: propsEnd,
 }: Props) {
@@ -82,7 +80,6 @@ function UserMiseryChart({
         includePrevious={false}
         yAxis={yAxis}
         partial
-        withoutZerofill={withoutZerofill}
         referrer="api.insights.transaction-summary.user-misery-chart"
         queryExtras={getMEPQueryParams(mepContext)}
       >

--- a/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/index.tsx
@@ -22,7 +22,6 @@ import Content from './content';
 type Props = ViewProps & {
   organization: OrganizationSummary;
   queryExtra: Query;
-  withoutZerofill: boolean;
   queryExtras?: Record<string, string>;
 };
 
@@ -33,7 +32,6 @@ function VitalsChart({
   query,
   statsPeriod,
   queryExtra,
-  withoutZerofill,
   start: propsStart,
   end: propsEnd,
   queryExtras,
@@ -134,7 +132,6 @@ function VitalsChart({
         includePrevious={false}
         yAxis={yAxis}
         partial
-        withoutZerofill={withoutZerofill}
         referrer="api.insights.transaction-summary.vitals-chart"
         queryExtras={queryExtras}
       >

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any, DefaultDict, TypedDict
 from unittest import mock
 from uuid import uuid4
@@ -1011,30 +1011,6 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             [{"count": 2}],
             [{"count": 0}],
         ]
-
-    def test_without_zerofill(self) -> None:
-        start = self.day_ago.isoformat()
-        end = (self.day_ago + timedelta(hours=2)).isoformat()
-        response = self.do_request(
-            data={
-                "start": start,
-                "end": end,
-                "interval": "30m",
-                "withoutZerofill": "1",
-            },
-            features={
-                "organizations:performance-chart-interpolation": True,
-                "organizations:discover-basic": True,
-            },
-        )
-
-        assert response.status_code == 200, response.content
-        assert [attrs for time, attrs in response.data["data"]] == [
-            [{"count": 1}],
-            [{"count": 2}],
-        ]
-        assert response.data["start"] == datetime.fromisoformat(start).timestamp()
-        assert response.data["end"] == datetime.fromisoformat(end).timestamp()
 
     def test_comparison_error_dataset(self) -> None:
         self.store_event(


### PR DESCRIPTION
This flag is not rolled out at all, we should clean it up and all the prop passing too.

This is intentionally a backend and frontend change. The flag value is False in all cases, and will continue to be False if the backend is deployed first, or second, relative to the frontend.

Related to https://github.com/getsentry/sentry-options-automator/pull/5294