### PR TITLE
ref(api): use `RateLimitConfig` instead of dict for relay

### DIFF
--- a/src/sentry/api/endpoints/relay/constants.py
+++ b/src/sentry/api/endpoints/relay/constants.py
@@ -3,8 +3,10 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 RELAY_AUTH_RATE_LIMITS = RateLimitConfig(
     limit_overrides={
-        RateLimitCategory.IP: RateLimit(limit=200, window=1),
-        RateLimitCategory.USER: RateLimit(limit=200, window=1),
-        RateLimitCategory.ORGANIZATION: RateLimit(limit=200, window=1),
+        "POST": {
+            RateLimitCategory.IP: RateLimit(limit=200, window=1),
+            RateLimitCategory.USER: RateLimit(limit=200, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=200, window=1),
+        },
     }
 )

--- a/src/sentry/api/endpoints/relay/constants.py
+++ b/src/sentry/api/endpoints/relay/constants.py
@@ -1,9 +1,10 @@
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
-RELAY_AUTH_RATE_LIMITS = {
-    "default": {
+RELAY_AUTH_RATE_LIMITS = RateLimitConfig(
+    limit_overrides={
         RateLimitCategory.IP: RateLimit(limit=200, window=1),
         RateLimitCategory.USER: RateLimit(limit=200, window=1),
         RateLimitCategory.ORGANIZATION: RateLimit(limit=200, window=1),
     }
-}
+)


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/99484, moving to RateLimitConfig instead of the rate limit dict.