### PR TITLE
fix(autofix): set trace timestamp on source citations

### DIFF
--- a/static/app/components/events/autofix/insights/autofixInsightSources.tsx
+++ b/static/app/components/events/autofix/insights/autofixInsightSources.tsx
@@ -336,7 +336,7 @@ export function generateSourceCards(
       onClick: () => {
         if (sources?.event_trace_id) {
           window.open(
-            `/explore/traces/trace/${sources.event_trace_id}/?node=span-${id}&timestamp=${sources.event_trace_timestamp}`,
+            `/explore/traces/trace/${sources.event_trace_id}/?node=span-${id}&timestamp=${sources.event_trace_timestamp?.toString() ?? ''}`,
             '_blank'
           );
         }

--- a/static/app/components/events/autofix/utils/insightUtils.tsx
+++ b/static/app/components/events/autofix/utils/insightUtils.tsx
@@ -19,6 +19,7 @@ export function deduplicateSources(insights: AutofixInsight[]): InsightSources {
     thoughts: '',
     trace_event_ids_used: [],
     event_trace_id: undefined,
+    event_trace_timestamp: undefined,
   };
 
   const seenUrls = new Set<string>();
@@ -38,6 +39,11 @@ export function deduplicateSources(insights: AutofixInsight[]): InsightSources {
     // Use the first available event_trace_id
     if (!allSources.event_trace_id && sources.event_trace_id) {
       allSources.event_trace_id = sources.event_trace_id;
+    }
+
+    // Use the first available event_trace_timestamp
+    if (!allSources.event_trace_timestamp && sources.event_trace_timestamp) {
+      allSources.event_trace_timestamp = sources.event_trace_timestamp;
     }
 
     // Deduplicate URLs


### PR DESCRIPTION
Accidentally was dropping the trace timestamp when de-duplicating sources. 