### PR TITLE
bug(preprod): Make insight title default text color since not clickable

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
@@ -70,7 +70,7 @@ export function AppSizeInsights({processedInsights}: AppSizeInsightsProps) {
             height="22px"
             padding="xs sm"
           >
-            <Text variant="accent" size="sm" bold>
+            <Text size="sm" bold>
               {insight.name}
             </Text>
             <Flex align="center" gap="sm">


### PR DESCRIPTION
Before
<img width="221" height="134" alt="Screenshot 2025-09-25 at 3 17 21 PM" src="https://github.com/user-attachments/assets/f2ad6dcf-e4a1-4182-9bc6-ef4bfae1c593" />


After
<img width="203" height="134" alt="Screenshot 2025-09-25 at 3 17 16 PM" src="https://github.com/user-attachments/assets/aa8bf583-f63c-41a0-8f9c-292e509df5c1" />


Closes EME-355