### PR TITLE
fix(eco): Adds RPC service needed to properly retrieve and refresh GHE tokens

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, TypedDict
 
 import orjson
@@ -206,14 +206,25 @@ class GithubProxyClient(IntegrationProxyClient):
         return metadata["access_token"]
 
     @control_silo_function
-    def get_access_token(self) -> AccessTokenData | None:
+    def get_access_token(
+        self, token_minimum_validity_time: timedelta | None = None
+    ) -> AccessTokenData | None:
+        """
+        Retrieves an access token for the given integration with an optional
+        minimum validity time. This will guarantee that the token is valid for
+        at least the timedelta provided.
+        """
+        token_minimum_validity_time = token_minimum_validity_time or timedelta(minutes=0)
         now = datetime.utcnow()
         access_token: str | None = self.integration.metadata.get("access_token")
         expires_at: str | None = self.integration.metadata.get("expires_at")
-        is_expired = (
-            expires_at is not None and datetime.fromisoformat(expires_at).replace(tzinfo=None) < now
+
+        close_to_expiry = (
+            expires_at
+            and datetime.fromisoformat(expires_at).replace(tzinfo=None)
+            < now + token_minimum_validity_time
         )
-        should_refresh = not access_token or not expires_at or is_expired
+        should_refresh = not access_token or not expires_at or close_to_expiry
 
         if should_refresh:
             return self._refresh_access_token()

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -600,7 +600,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
             return None
 
         installation = integration.get_installation(organization_id=organization_id)
-        # Get installation doesn't actually check if the integration is
+        # get_installation doesn't actually check if the integration is
         # associated with the organization, so this validates that it does,
         # and caches the org_integration preemptively.
         try:

--- a/src/sentry/integrations/services/integration/service.py
+++ b/src/sentry/integrations/services/integration/service.py
@@ -298,5 +298,12 @@ class IntegrationService(RpcService):
     ) -> RpcIntegrationIdentityContext:
         pass
 
+    @rpc_method
+    @abstractmethod
+    def refresh_github_access_token(
+        self, *, integration_id: int, organization_id: int
+    ) -> RpcIntegration | None:
+        pass
+
 
 integration_service = IntegrationService.create_delegation()

--- a/tests/integration/test_service.py
+++ b/tests/integration/test_service.py
@@ -66,6 +66,7 @@ class IntegrationServiceTest(TestCase):
             organization_id=self.organization.id,
         )
 
+        assert rpc_integration is not None
         assert rpc_integration.metadata["access_token"] == "token_2"
         assert rpc_integration.metadata["expires_at"] == "2025-01-01T06:22:00"
         assert rpc_integration.metadata["permissions"] == {
@@ -104,6 +105,7 @@ class IntegrationServiceTest(TestCase):
             organization_id=self.organization.id,
         )
 
+        assert rpc_integration is not None
         assert rpc_integration.metadata["access_token"] == "token_refreshed"
         assert rpc_integration.metadata["expires_at"] == "2025-01-01T06:32:00"
         assert rpc_integration.metadata["permissions"] == {
@@ -127,6 +129,7 @@ class IntegrationServiceTest(TestCase):
             organization_id=self.organization.id,
         )
 
+        assert rpc_integration is not None
         assert rpc_integration.metadata["access_token"] == "token_valid"
         assert rpc_integration.metadata["expires_at"] == "2025-01-01T05:32:01Z"
         assert rpc_integration.metadata["permissions"] == {
@@ -165,6 +168,7 @@ class IntegrationServiceTest(TestCase):
             organization_id=self.organization.id,
         )
 
+        assert rpc_integration is not None
         assert rpc_integration.metadata["access_token"] == "token_new"
         assert rpc_integration.metadata["expires_at"] == "2025-01-01T06:22:00"
         assert rpc_integration.metadata["permissions"] == {

--- a/tests/integration/test_service.py
+++ b/tests/integration/test_service.py
@@ -1,7 +1,9 @@
+from typing import Any
 from unittest import mock
 
 import responses
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import integration_service
 from sentry.testutils.cases import TestCase
@@ -14,27 +16,36 @@ from sentry.testutils.silo import all_silo_test, assume_test_silo_mode_of
 class IntegrationServiceTest(TestCase):
     jwt = "my_cool_jwt"
 
-    def setUp(self):
-        self.integration = self.create_integration(
+    def generate_integration(self, metadata: dict[str, Any] | None = None):
+        integration = self.create_integration(
             organization=self.organization,
             provider="github",
             external_id="github:1",
         )
 
+        with assume_test_silo_mode_of(Integration):
+            if metadata is not None:
+                integration.metadata.update(metadata)
+                integration.save()
+
+        return integration
+
     @responses.activate
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=jwt)
     def test_refresh_expired_token(self, mock_jwt):
-        with assume_test_silo_mode_of(Integration):
-            self.integration.metadata["access_token"] = "token_1"
-            self.integration.metadata["expires_at"] = "2025-01-01T05:21:59Z"
-            self.integration.metadata["permissions"] = {
-                "administration": "read",
-                "contents": "read",
-                "issues": "write",
-                "metadata": "read",
-                "pull_requests": "read",
+        integration = self.generate_integration(
+            metadata={
+                "access_token": "token_1",
+                "expires_at": "2025-01-01T05:21:59Z",
+                "permissions": {
+                    "administration": "read",
+                    "contents": "read",
+                    "issues": "write",
+                    "metadata": "read",
+                    "pull_requests": "read",
+                },
             }
-            self.integration.save()
+        )
 
         responses.add(
             responses.POST,
@@ -51,7 +62,7 @@ class IntegrationServiceTest(TestCase):
         )
 
         rpc_integration = integration_service.refresh_github_access_token(
-            integration_id=self.integration.id,
+            integration_id=integration.id,
             organization_id=self.organization.id,
         )
 
@@ -64,13 +75,15 @@ class IntegrationServiceTest(TestCase):
     @responses.activate
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=jwt)
     def test_refresh_token_within_grace_period(self, mock_jwt):
-        with assume_test_silo_mode_of(Integration):
-            self.integration.metadata["access_token"] = "token_1"
-            self.integration.metadata["expires_at"] = "2025-01-01T05:31:59Z"
-            self.integration.metadata["permissions"] = {
-                "contents": "read",
+        integration = self.generate_integration(
+            metadata={
+                "access_token": "token_1",
+                "expires_at": "2025-01-01T05:31:59Z",
+                "permissions": {
+                    "contents": "read",
+                },
             }
-            self.integration.save()
+        )
 
         responses.add(
             responses.POST,
@@ -87,7 +100,7 @@ class IntegrationServiceTest(TestCase):
         )
 
         rpc_integration = integration_service.refresh_github_access_token(
-            integration_id=self.integration.id,
+            integration_id=integration.id,
             organization_id=self.organization.id,
         )
 
@@ -100,16 +113,17 @@ class IntegrationServiceTest(TestCase):
     @responses.activate
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=jwt)
     def test_no_refresh_token_outside_grace_period(self, mock_jwt):
-        with assume_test_silo_mode_of(Integration):
-            self.integration.metadata["access_token"] = "token_valid"
-            self.integration.metadata["expires_at"] = "2025-01-01T05:32:01Z"
-            self.integration.metadata["permissions"] = {
-                "issues": "write",
+        integration = self.generate_integration(
+            metadata={
+                "access_token": "token_valid",
+                "expires_at": "2025-01-01T05:32:01Z",
+                "permissions": {
+                    "issues": "write",
+                },
             }
-            self.integration.save()
-
+        )
         rpc_integration = integration_service.refresh_github_access_token(
-            integration_id=self.integration.id,
+            integration_id=integration.id,
             organization_id=self.organization.id,
         )
 
@@ -122,12 +136,14 @@ class IntegrationServiceTest(TestCase):
     @responses.activate
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=jwt)
     def test_refresh_token_missing_expiration_time(self, mock_jwt):
-        with assume_test_silo_mode_of(Integration):
-            self.integration.metadata["access_token"] = "token_no_expiry"
-            self.integration.metadata["permissions"] = {
-                "metadata": "read",
+        integration = self.generate_integration(
+            metadata={
+                "access_token": "token_no_expiry",
+                "permissions": {
+                    "metadata": "read",
+                },
             }
-            self.integration.save()
+        )
 
         responses.add(
             responses.POST,
@@ -145,7 +161,7 @@ class IntegrationServiceTest(TestCase):
         )
 
         rpc_integration = integration_service.refresh_github_access_token(
-            integration_id=self.integration.id,
+            integration_id=integration.id,
             organization_id=self.organization.id,
         )
 
@@ -155,3 +171,39 @@ class IntegrationServiceTest(TestCase):
             "metadata": "write",
             "pull_requests": "read",
         }
+
+    def test_missing_integration(self):
+        rpc_integration = integration_service.refresh_github_access_token(
+            integration_id=12345,
+            organization_id=self.organization.id,
+        )
+
+        assert rpc_integration is None
+
+    def test_disabled_integration(self):
+        integration = self.generate_integration()
+        with assume_test_silo_mode_of(Integration):
+            integration.status = ObjectStatus.DISABLED
+            integration.save()
+
+        rpc_integration = integration_service.refresh_github_access_token(
+            integration_id=integration.id,
+            organization_id=self.organization.id,
+        )
+
+        assert rpc_integration is None
+
+    def test_missing_installation(self):
+        # Generate a new integration with an installation on a different org.
+        integration = self.create_integration(
+            organization=self.create_organization(owner=self.create_user()),
+            provider="github",
+            external_id="github:1",
+        )
+
+        rpc_integration = integration_service.refresh_github_access_token(
+            integration_id=integration.id,
+            organization_id=self.organization.id,
+        )
+
+        assert rpc_integration is None

--- a/tests/integration/test_service.py
+++ b/tests/integration/test_service.py
@@ -1,0 +1,157 @@
+from unittest import mock
+
+import responses
+
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.services.integration import integration_service
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode_of
+
+
+@all_silo_test
+@freeze_time("2025-01-01T05:22:00Z")
+class IntegrationServiceTest(TestCase):
+    jwt = "my_cool_jwt"
+
+    def setUp(self):
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="github:1",
+        )
+
+    @responses.activate
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=jwt)
+    def test_refresh_expired_token(self, mock_jwt):
+        with assume_test_silo_mode_of(Integration):
+            self.integration.metadata["access_token"] = "token_1"
+            self.integration.metadata["expires_at"] = "2025-01-01T05:21:59Z"
+            self.integration.metadata["permissions"] = {
+                "administration": "read",
+                "contents": "read",
+                "issues": "write",
+                "metadata": "read",
+                "pull_requests": "read",
+            }
+            self.integration.save()
+
+        responses.add(
+            responses.POST,
+            "https://api.github.com/app/installations/github:1/access_tokens",
+            json={
+                "token": "token_2",
+                "expires_at": "2025-01-01T06:22:00Z",
+                "permissions": {
+                    "administration": "read",
+                },
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        rpc_integration = integration_service.refresh_github_access_token(
+            integration_id=self.integration.id,
+            organization_id=self.organization.id,
+        )
+
+        assert rpc_integration.metadata["access_token"] == "token_2"
+        assert rpc_integration.metadata["expires_at"] == "2025-01-01T06:22:00"
+        assert rpc_integration.metadata["permissions"] == {
+            "administration": "read",
+        }
+
+    @responses.activate
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=jwt)
+    def test_refresh_token_within_grace_period(self, mock_jwt):
+        with assume_test_silo_mode_of(Integration):
+            self.integration.metadata["access_token"] = "token_1"
+            self.integration.metadata["expires_at"] = "2025-01-01T05:31:59Z"
+            self.integration.metadata["permissions"] = {
+                "contents": "read",
+            }
+            self.integration.save()
+
+        responses.add(
+            responses.POST,
+            "https://api.github.com/app/installations/github:1/access_tokens",
+            json={
+                "token": "token_refreshed",
+                "expires_at": "2025-01-01T06:32:00Z",
+                "permissions": {
+                    "contents": "write",
+                },
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        rpc_integration = integration_service.refresh_github_access_token(
+            integration_id=self.integration.id,
+            organization_id=self.organization.id,
+        )
+
+        assert rpc_integration.metadata["access_token"] == "token_refreshed"
+        assert rpc_integration.metadata["expires_at"] == "2025-01-01T06:32:00"
+        assert rpc_integration.metadata["permissions"] == {
+            "contents": "write",
+        }
+
+    @responses.activate
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=jwt)
+    def test_no_refresh_token_outside_grace_period(self, mock_jwt):
+        with assume_test_silo_mode_of(Integration):
+            self.integration.metadata["access_token"] = "token_valid"
+            self.integration.metadata["expires_at"] = "2025-01-01T05:32:01Z"
+            self.integration.metadata["permissions"] = {
+                "issues": "write",
+            }
+            self.integration.save()
+
+        rpc_integration = integration_service.refresh_github_access_token(
+            integration_id=self.integration.id,
+            organization_id=self.organization.id,
+        )
+
+        assert rpc_integration.metadata["access_token"] == "token_valid"
+        assert rpc_integration.metadata["expires_at"] == "2025-01-01T05:32:01Z"
+        assert rpc_integration.metadata["permissions"] == {
+            "issues": "write",
+        }
+
+    @responses.activate
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=jwt)
+    def test_refresh_token_missing_expiration_time(self, mock_jwt):
+        with assume_test_silo_mode_of(Integration):
+            self.integration.metadata["access_token"] = "token_no_expiry"
+            self.integration.metadata["permissions"] = {
+                "metadata": "read",
+            }
+            self.integration.save()
+
+        responses.add(
+            responses.POST,
+            "https://api.github.com/app/installations/github:1/access_tokens",
+            json={
+                "token": "token_new",
+                "expires_at": "2025-01-01T06:22:00Z",
+                "permissions": {
+                    "metadata": "write",
+                    "pull_requests": "read",
+                },
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        rpc_integration = integration_service.refresh_github_access_token(
+            integration_id=self.integration.id,
+            organization_id=self.organization.id,
+        )
+
+        assert rpc_integration.metadata["access_token"] == "token_new"
+        assert rpc_integration.metadata["expires_at"] == "2025-01-01T06:22:00"
+        assert rpc_integration.metadata["permissions"] == {
+            "metadata": "write",
+            "pull_requests": "read",
+        }


### PR DESCRIPTION
Auth tokens forwarded to Seer are currently broken, as they cross silo boundaries. This is the first of 2 PRs to correct this behavior by optionally refreshing the auth token with some grace period/guaranteed minimum time the token will be valid.

This also updates the `get_access_token` method on Github/Github Enterprise to take this `token_minimum_validity_time` timedelta as an optional parameter for other contexts.
