### PR TITLE
fix(eco): Updates Seer GHE to use a Control RPC method when refreshing auth tokens"

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -893,6 +893,8 @@ def get_github_enterprise_integration_config(
         organization_id=organization_id,
     )
 
+    assert integration is not None, "Integration should have existed given previous checks"
+
     access_token = integration.metadata["access_token"]
     permissions = integration.metadata["permissions"]
 

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -43,7 +43,7 @@ from sentry import features, options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import AuthenticationSiloLimit, StandardAuthentication
-from sentry.api.base import Endpoint
+from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.endpoints.organization_trace_item_attributes import as_attribute_key
 from sentry.api.endpoints.project_trace_item_details import convert_rpc_attribute_to_json
 from sentry.constants import (
@@ -164,6 +164,7 @@ class SeerRpcSignatureAuthentication(StandardAuthentication):
         return (AnonymousUser(), token)
 
 
+@region_silo_endpoint
 class SeerRpcServiceEndpoint(Endpoint):
     """
     RPC endpoint for seer microservice to call. Authenticated with a shared secret.


### PR DESCRIPTION
We're currently getting cross-silo issues when attempting to access auth tokens for Seer. This PR updates the Seer RPC side to request token refreshes via a new RPC method. This will ensure 2 things:
1. We have a 10 minute grace period for the existing token, which should be a reasonable amount of time for Seer to complete its work
2. Token access happens directly from the integration metadata returned via the request, meaning we should have the most up-to-date auth available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches GHE token retrieval to an RPC-based refresh and updates tests/silo handling accordingly.
> 
> - **Seer RPC (backend)**:
>   - Replace `installation.get_client().get_access_token()` with `integration_service.refresh_github_access_token(...)`.
>   - Read `access_token` and `permissions` from `integration.metadata`; add assertion and handle missing token.
> - **Tests**:
>   - Remove CONTROL silo decorators; use `assume_test_silo_mode_of(Integration)` where needed and import `Integration`.
>   - Adjust expectations to use permissions from refreshed metadata; keep encryption and error-path validations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbeb2546bb38a73c5eaa1271bc58cf61f3109f75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->