### PR TITLE
ref(ratelimits): deprecate rate limit config dict

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -36,7 +36,6 @@ from sentry.organizations.absolute_url import generate_organization_url
 from sentry.ratelimits.config import DEFAULT_RATE_LIMIT_CONFIG, RateLimitConfig
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.snuba.query_sources import QuerySource
-from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.cursors import Cursor
 from sentry.utils.dates import to_datetime
@@ -223,11 +222,7 @@ class Endpoint(APIView):
 
     owner: ApiOwner = ApiOwner.UNOWNED
     publish_status: dict[HTTP_METHOD_NAME, ApiPublishStatus] = {}
-    rate_limits: (
-        RateLimitConfig
-        | dict[str, dict[RateLimitCategory, RateLimit]]
-        | Callable[..., RateLimitConfig | dict[str, dict[RateLimitCategory, RateLimit]]]
-    ) = DEFAULT_RATE_LIMIT_CONFIG
+    rate_limits: RateLimitConfig = DEFAULT_RATE_LIMIT_CONFIG
     enforce_rate_limit: bool = settings.SENTRY_RATELIMITER_ENABLED
 
     def build_cursor_link(self, request: HttpRequest, name: str, cursor: Cursor) -> str:

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -246,10 +246,12 @@ class TestGetRateLimitValue(TestCase):
         """Override one or more of the default rate limits"""
 
         class TestEndpoint(Endpoint):
-            rate_limits = {
-                "GET": {RateLimitCategory.IP: RateLimit(limit=100, window=5)},
-                "POST": {RateLimitCategory.USER: RateLimit(limit=20, window=4)},
-            }
+            rate_limits = RateLimitConfig(
+                limit_overrides={
+                    "GET": {RateLimitCategory.IP: RateLimit(limit=100, window=5)},
+                    "POST": {RateLimitCategory.USER: RateLimit(limit=20, window=4)},
+                }
+            )
 
         view = TestEndpoint.as_view()
         rate_limit_config = get_rate_limit_config(view.view_class)
@@ -274,7 +276,9 @@ class RateLimitHeaderTestEndpoint(Endpoint):
     permission_classes = (AllowAny,)
 
     enforce_rate_limit = True
-    rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(limit=2, window=100)}}
+    rate_limits = RateLimitConfig(
+        limit_overrides={"GET": {RateLimitCategory.IP: RateLimit(limit=2, window=100)}}
+    )
 
     def inject_call(self):
         return
@@ -288,7 +292,9 @@ class RaceConditionEndpoint(Endpoint):
     permission_classes = (AllowAny,)
 
     enforce_rate_limit = False
-    rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(limit=40, window=100)}}
+    rate_limits = RateLimitConfig(
+        limit_overrides={"GET": {RateLimitCategory.IP: RateLimit(limit=40, window=100)}}
+    )
 
     def get(self, request):
         return Response({"ok": True})

--- a/tests/sentry/middleware/test_stats.py
+++ b/tests/sentry/middleware/test_stats.py
@@ -8,6 +8,7 @@ from rest_framework.permissions import AllowAny
 from sentry.api.base import Endpoint
 from sentry.middleware.ratelimit import RatelimitMiddleware
 from sentry.middleware.stats import RequestTimingMiddleware
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.testutils.cases import TestCase
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -16,7 +17,9 @@ class RateLimitedEndpoint(Endpoint):
     permission_classes = (AllowAny,)
 
     enforce_rate_limit = True
-    rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(limit=0, window=10)}}
+    rate_limits = RateLimitConfig(
+        limit_overrides={"GET": {RateLimitCategory.IP: RateLimit(limit=0, window=10)}}
+    )
 
     def get(self):
         raise NotImplementedError

--- a/tests/sentry/ratelimits/utils/test_enforce_rate_limit.py
+++ b/tests/sentry/ratelimits/utils/test_enforce_rate_limit.py
@@ -5,6 +5,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -13,7 +14,9 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 class RateLimitTestEndpoint(Endpoint):
     permission_classes = (AllowAny,)
 
-    rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(limit=1, window=100)}}
+    rate_limits = RateLimitConfig(
+        limit_overrides={"GET": {RateLimitCategory.IP: RateLimit(limit=1, window=100)}}
+    )
 
     def get(self, request):
         return Response({"ok": True})

--- a/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
+++ b/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
@@ -51,10 +51,12 @@ class TestGetRateLimitValue(TestCase):
         """Override one or more of the default rate limits."""
 
         class TestEndpoint(Endpoint):
-            rate_limits = {
-                "GET": {RateLimitCategory.IP: RateLimit(limit=100, window=5)},
-                "POST": {RateLimitCategory.USER: RateLimit(limit=20, window=4)},
-            }
+            rate_limits = RateLimitConfig(
+                limit_overrides={
+                    "GET": {RateLimitCategory.IP: RateLimit(limit=100, window=5)},
+                    "POST": {RateLimitCategory.USER: RateLimit(limit=20, window=4)},
+                }
+            )
 
         _test_endpoint = TestEndpoint.as_view()
         rate_limit_config = get_rate_limit_config(_test_endpoint.view_class)


### PR DESCRIPTION
Fully deprecate using a dict for rate limits, in favor of `RateLimitConfig`. Also remove the "callable" option for rate limits, since there aren't any cases of it being used.