### PR TITLE
fix(replay): summaries: immediately error on GET error

### DIFF
--- a/static/app/views/replays/detail/ai/useReplaySummary.spec.tsx
+++ b/static/app/views/replays/detail/ai/useReplaySummary.spec.tsx
@@ -67,7 +67,7 @@ describe('useReplaySummary', () => {
       expect(mockRequest).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle API errors gracefully', async () => {
+    it('should retry GET errors and return isPending=true', async () => {
       MockApiClient.addMockResponse({
         url: `/projects/${mockOrganization.slug}/${mockProject.slug}/replays/replay-123/summarize/`,
         statusCode: 500,
@@ -79,9 +79,9 @@ describe('useReplaySummary', () => {
       });
 
       await waitFor(() => {
-        expect(result.current.isError).toBe(true);
+        expect(result.current.isPending).toBe(true);
       });
-      expect(result.current.isPending).toBe(false);
+      expect(result.current.isError).toBe(false);
     });
   });
 

--- a/static/app/views/replays/detail/ai/useReplaySummary.spec.tsx
+++ b/static/app/views/replays/detail/ai/useReplaySummary.spec.tsx
@@ -67,21 +67,20 @@ describe('useReplaySummary', () => {
       expect(mockRequest).toHaveBeenCalledTimes(1);
     });
 
-    it('should retry GET errors and return isPending=true', async () => {
+    it('should handle GET errors gracefully', async () => {
       MockApiClient.addMockResponse({
         url: `/projects/${mockOrganization.slug}/${mockProject.slug}/replays/replay-123/summarize/`,
         statusCode: 500,
         body: {detail: 'Internal server error'},
       });
-
       const {result} = renderHookWithProviders(() => useReplaySummary(mockReplay), {
         organization: mockOrganization,
       });
 
       await waitFor(() => {
-        expect(result.current.isPending).toBe(true);
+        expect(result.current.isError).toBe(true);
       });
-      expect(result.current.isError).toBe(false);
+      expect(result.current.isPending).toBe(false);
     });
   });
 

--- a/static/app/views/replays/detail/ai/useReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useReplaySummary.tsx
@@ -183,24 +183,24 @@ export function useReplaySummary(
     }
   }, [segmentsIncreased, startSummaryRequest, summaryData?.status]);
 
-  const isPendingRet =
-    lastFetchTime < startSummaryRequestTime.current ||
-    isStartSummaryRequestPending ||
-    !summaryData ||
-    ![ReplaySummaryStatus.COMPLETED, ReplaySummaryStatus.ERROR].includes(
+  const isFinishedState =
+    lastFetchTime >= startSummaryRequestTime.current &&
+    !isStartSummaryRequestPending &&
+    summaryData &&
+    [ReplaySummaryStatus.COMPLETED, ReplaySummaryStatus.ERROR].includes(
       summaryData.status
     );
 
-  // Clears the polling timeout when we get valid summary results.
+  // Clears the polling timeout when we get a finished state.
   useEffect(() => {
-    if (!isPendingRet) {
+    if (isFinishedState) {
       cancelPollingTimeout();
     }
-  }, [isPendingRet, cancelPollingTimeout]);
+  }, [isFinishedState, cancelPollingTimeout]);
 
   return {
     summaryData,
-    isPending: isPendingRet,
+    isPending: !isFinishedState,
     isError:
       isStartSummaryRequestError || summaryData?.status === ReplaySummaryStatus.ERROR,
     isTimedOut: didTimeout,

--- a/static/app/views/replays/detail/ai/useReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useReplaySummary.tsx
@@ -183,13 +183,14 @@ export function useReplaySummary(
     }
   }, [segmentsIncreased, startSummaryRequest, summaryData?.status]);
 
+  const isErrorState =
+    isStartSummaryRequestError || summaryData?.status === ReplaySummaryStatus.ERROR;
+
   const isFinishedState =
-    lastFetchTime >= startSummaryRequestTime.current &&
-    !isStartSummaryRequestPending &&
-    summaryData &&
-    [ReplaySummaryStatus.COMPLETED, ReplaySummaryStatus.ERROR].includes(
-      summaryData.status
-    );
+    isErrorState ||
+    (lastFetchTime >= startSummaryRequestTime.current &&
+      !isStartSummaryRequestPending &&
+      summaryData?.status === ReplaySummaryStatus.COMPLETED);
 
   // Clears the polling timeout when we get a finished state.
   useEffect(() => {
@@ -201,8 +202,7 @@ export function useReplaySummary(
   return {
     summaryData,
     isPending: !isFinishedState,
-    isError:
-      isStartSummaryRequestError || summaryData?.status === ReplaySummaryStatus.ERROR,
+    isError: isErrorState,
     isTimedOut: didTimeout,
     startSummaryRequest,
     isStartSummaryRequestPending,

--- a/static/app/views/replays/detail/ai/useReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useReplaySummary.tsx
@@ -150,11 +150,7 @@ export function useReplaySummary(
     startPollingTimeout();
   }, [options?.enabled, startSummaryRequestMutate, startPollingTimeout]);
 
-  const {
-    data: summaryData,
-    isPending,
-    dataUpdatedAt,
-  } = useApiQuery<SummaryResponse>(
+  const {data: summaryData, dataUpdatedAt: lastFetchTime} = useApiQuery<SummaryResponse>(
     createAISummaryQueryKey(organization.slug, project?.slug, replayRecord?.id ?? ''),
     {
       staleTime: 0,
@@ -188,12 +184,12 @@ export function useReplaySummary(
   }, [segmentsIncreased, startSummaryRequest, summaryData?.status]);
 
   const isPendingRet =
-    dataUpdatedAt < startSummaryRequestTime.current ||
+    lastFetchTime < startSummaryRequestTime.current ||
     isStartSummaryRequestPending ||
-    isPending ||
-    summaryData === undefined ||
-    summaryData?.status === ReplaySummaryStatus.NOT_STARTED ||
-    summaryData?.status === ReplaySummaryStatus.PROCESSING;
+    !summaryData ||
+    ![ReplaySummaryStatus.COMPLETED, ReplaySummaryStatus.ERROR].includes(
+      summaryData.status
+    );
 
   // Clears the polling timeout when we get valid summary results.
   useEffect(() => {


### PR DESCRIPTION
Right now when GET errors we don't make a start request, and poll forever. State flickers between loading and error.

This PR makes the page error and stop polling after GET fails. Users can click "retry" to manually retry. The logic for automatic retries is too complex and not worth it imo