### PR TITLE
test(ui):Replace custom test providers with renderHookWithProviders

### DIFF
--- a/static/app/utils/api/useFetchSequentialPages.spec.tsx
+++ b/static/app/utils/api/useFetchSequentialPages.spec.tsx
@@ -1,18 +1,7 @@
-import type {ReactNode} from 'react';
-
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import useFetchSequentialPages from 'sentry/utils/api/useFetchSequentialPages';
-import type {QueryClient} from 'sentry/utils/queryClient';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {getPaginationPageLink} from 'sentry/views/organizationStats/utils';
-
-function makeWrapper(queryClient: QueryClient) {
-  return function wrapper({children}: {children?: ReactNode}) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
-  };
-}
 
 const MOCK_API_ENDPOINT = '/api/test/';
 function queryKeyFactory() {
@@ -23,8 +12,7 @@ describe('useFetchSequentialPages', () => {
   it('should not call the queryFn when enabled is false', () => {
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchSequentialPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchSequentialPages, {
       initialProps: {
         enabled: false,
         getQueryKey,
@@ -44,8 +32,7 @@ describe('useFetchSequentialPages', () => {
     });
     const getQueryKey = queryKeyFactory();
 
-    const {result, rerender} = renderHook(useFetchSequentialPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result, rerender} = renderHookWithProviders(useFetchSequentialPages, {
       initialProps: {
         enabled: false,
         getQueryKey,
@@ -74,8 +61,7 @@ describe('useFetchSequentialPages', () => {
     });
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchSequentialPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchSequentialPages, {
       initialProps: {
         enabled: true,
         getQueryKey,
@@ -99,8 +85,7 @@ describe('useFetchSequentialPages', () => {
     });
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchSequentialPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchSequentialPages, {
       initialProps: {
         enabled: true,
         getQueryKey,
@@ -131,8 +116,7 @@ describe('useFetchSequentialPages', () => {
     });
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchSequentialPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchSequentialPages, {
       initialProps: {
         enabled: true,
         getQueryKey,
@@ -163,8 +147,7 @@ describe('useFetchSequentialPages', () => {
     });
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchSequentialPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchSequentialPages, {
       initialProps: {
         enabled: true,
         getQueryKey,
@@ -190,8 +173,7 @@ describe('useFetchSequentialPages', () => {
     });
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchSequentialPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchSequentialPages, {
       initialProps: {
         enabled: true,
         getQueryKey,
@@ -226,8 +208,7 @@ describe('useFetchSequentialPages', () => {
     });
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchSequentialPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchSequentialPages, {
       initialProps: {
         enabled: true,
         getQueryKey,

--- a/static/app/utils/profiling/hooks/useProfileEventsStats.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEventsStats.spec.tsx
@@ -1,23 +1,12 @@
-import type {ReactNode} from 'react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {useProfileEventsStats} from 'sentry/utils/profiling/hooks/useProfileEventsStats';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-
-const {organization} = initializeOrg();
-function TestContext({children}: {children?: ReactNode}) {
-  return (
-    <QueryClientProvider client={makeTestQueryClient()}>
-      <OrganizationContext value={organization}>{children}</OrganizationContext>
-    </QueryClientProvider>
-  );
-}
 
 describe('useProfileEvents', () => {
+  const organization = OrganizationFixture();
   afterEach(() => {
     MockApiClient.clearMockResponses();
   });
@@ -29,8 +18,8 @@ describe('useProfileEvents', () => {
       match: [MockApiClient.matchQuery({dataset: 'discover'})],
     });
 
-    const {result} = renderHook(useProfileEventsStats, {
-      wrapper: TestContext,
+    const {result} = renderHookWithProviders(useProfileEventsStats, {
+      organization,
       initialProps: {
         dataset: 'profiles' as const,
         yAxes: [],
@@ -75,8 +64,8 @@ describe('useProfileEvents', () => {
       ],
     });
 
-    const {result} = renderHook(useProfileEventsStats, {
-      wrapper: TestContext,
+    const {result} = renderHookWithProviders(useProfileEventsStats, {
+      organization,
       initialProps: {
         dataset: 'profiles' as const,
         yAxes,
@@ -136,8 +125,8 @@ describe('useProfileEvents', () => {
       ],
     });
 
-    const {result} = renderHook(useProfileEventsStats, {
-      wrapper: TestContext,
+    const {result} = renderHookWithProviders(useProfileEventsStats, {
+      organization,
       initialProps: {
         dataset: 'profiles' as const,
         yAxes,
@@ -164,16 +153,6 @@ describe('useProfileEvents', () => {
   it('handles 1 axis using discover', async () => {
     const {organization: organizationUsingTransactions} = initializeOrg();
 
-    function TestContextUsingTransactions({children}: {children?: ReactNode}) {
-      return (
-        <QueryClientProvider client={makeTestQueryClient()}>
-          <OrganizationContext value={organizationUsingTransactions}>
-            {children}
-          </OrganizationContext>
-        </QueryClientProvider>
-      );
-    }
-
     const yAxes = ['count()'];
 
     MockApiClient.addMockResponse({
@@ -198,8 +177,8 @@ describe('useProfileEvents', () => {
       ],
     });
 
-    const {result} = renderHook(useProfileEventsStats, {
-      wrapper: TestContextUsingTransactions,
+    const {result} = renderHookWithProviders(useProfileEventsStats, {
+      organization: organizationUsingTransactions,
       initialProps: {
         dataset: 'profiles' as const,
         yAxes,

--- a/static/app/utils/theme/theme.spec.tsx
+++ b/static/app/utils/theme/theme.spec.tsx
@@ -1,22 +1,12 @@
 import {useTheme} from '@emotion/react';
-import {QueryClient} from '@tanstack/react-query';
 import {expectTypeOf} from 'expect-type';
 
-import {renderHook} from 'sentry-test/reactTestingLibrary';
-
-import {ThemeAndStyleProvider} from 'sentry/components/themeAndStyleProvider';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
-
-const wrapper = ({children}: {children?: React.ReactNode}) => (
-  <QueryClientProvider client={new QueryClient()}>
-    <ThemeAndStyleProvider>{children}</ThemeAndStyleProvider>
-  </QueryClientProvider>
-);
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 describe('theme', () => {
   describe('getColorPalette', () => {
     it('should return correct amount of colors', () => {
-      const {result} = renderHook(useTheme, {wrapper});
+      const {result} = renderHookWithProviders(useTheme);
 
       const theme = result.current;
 
@@ -24,7 +14,7 @@ describe('theme', () => {
     });
 
     it('should have strict types', () => {
-      const {result} = renderHook(useTheme, {wrapper});
+      const {result} = renderHookWithProviders(useTheme);
 
       const theme = result.current;
 

--- a/static/app/utils/theme/useThemeSwitcher.spec.tsx
+++ b/static/app/utils/theme/useThemeSwitcher.spec.tsx
@@ -27,7 +27,7 @@ describe('useChonkTheme', () => {
 
   describe('disabled states', () => {
     it('returns null if no organization is loaded', () => {
-      const {result} = renderHookWithProviders(() => useThemeSwitcher());
+      const {result} = renderHookWithProviders(useThemeSwitcher);
       expect(result.current).toBe(lightTheme);
     });
 
@@ -38,7 +38,7 @@ describe('useChonkTheme', () => {
         })
       );
 
-      const {result} = renderHookWithProviders(() => useThemeSwitcher());
+      const {result} = renderHookWithProviders(useThemeSwitcher);
       expect(result.current).toBe(lightTheme);
     });
 
@@ -49,7 +49,7 @@ describe('useChonkTheme', () => {
         })
       );
 
-      const {result} = renderHookWithProviders(() => useThemeSwitcher());
+      const {result} = renderHookWithProviders(useThemeSwitcher);
       expect(result.current).toBe(lightTheme);
     });
 
@@ -68,7 +68,7 @@ describe('useChonkTheme', () => {
         })
       );
 
-      const {result} = renderHookWithProviders(() => useThemeSwitcher());
+      const {result} = renderHookWithProviders(useThemeSwitcher);
       expect(result.current).toBe(darkTheme);
     });
   });
@@ -84,7 +84,7 @@ describe('useChonkTheme', () => {
       );
       OrganizationStore.onUpdate(OrganizationFixture({features: ['chonk-ui']}));
 
-      const {result} = renderHookWithProviders(() => useThemeSwitcher());
+      const {result} = renderHookWithProviders(useThemeSwitcher);
       expect(result.current).toBe(DO_NOT_USE_lightChonkTheme);
     });
 
@@ -98,7 +98,7 @@ describe('useChonkTheme', () => {
       );
       OrganizationStore.onUpdate(OrganizationFixture({features: ['chonk-ui']}));
 
-      const {result} = renderHookWithProviders(() => useThemeSwitcher());
+      const {result} = renderHookWithProviders(useThemeSwitcher);
       expect(result.current).toBe(DO_NOT_USE_darkChonkTheme);
     });
   });

--- a/static/app/utils/theme/useThemeSwitcher.spec.tsx
+++ b/static/app/utils/theme/useThemeSwitcher.spec.tsx
@@ -2,15 +2,10 @@ import {ConfigFixture} from 'sentry-fixture/config';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {renderHook} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
-import {
-  DEFAULT_QUERY_CLIENT_CONFIG,
-  QueryClient,
-  QueryClientProvider,
-} from 'sentry/utils/queryClient';
 // eslint-disable-next-line no-restricted-imports -- @TODO(jonasbadalic): Remove theme import
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
@@ -18,11 +13,6 @@ import {DO_NOT_USE_darkChonkTheme, DO_NOT_USE_lightChonkTheme} from './theme.cho
 import {useThemeSwitcher} from './useThemeSwitcher';
 
 jest.mock('sentry/utils/removeBodyTheme');
-
-const queryClient = new QueryClient(DEFAULT_QUERY_CLIENT_CONFIG);
-const wrapper = ({children}: {children?: React.ReactNode}) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-);
 
 describe('useChonkTheme', () => {
   beforeEach(() => {
@@ -37,7 +27,7 @@ describe('useChonkTheme', () => {
 
   describe('disabled states', () => {
     it('returns null if no organization is loaded', () => {
-      const {result} = renderHook(() => useThemeSwitcher(), {wrapper});
+      const {result} = renderHookWithProviders(() => useThemeSwitcher());
       expect(result.current).toBe(lightTheme);
     });
 
@@ -48,7 +38,7 @@ describe('useChonkTheme', () => {
         })
       );
 
-      const {result} = renderHook(() => useThemeSwitcher(), {wrapper});
+      const {result} = renderHookWithProviders(() => useThemeSwitcher());
       expect(result.current).toBe(lightTheme);
     });
 
@@ -59,7 +49,7 @@ describe('useChonkTheme', () => {
         })
       );
 
-      const {result} = renderHook(() => useThemeSwitcher(), {wrapper});
+      const {result} = renderHookWithProviders(() => useThemeSwitcher());
       expect(result.current).toBe(lightTheme);
     });
 
@@ -78,7 +68,7 @@ describe('useChonkTheme', () => {
         })
       );
 
-      const {result} = renderHook(() => useThemeSwitcher(), {wrapper});
+      const {result} = renderHookWithProviders(() => useThemeSwitcher());
       expect(result.current).toBe(darkTheme);
     });
   });
@@ -94,7 +84,7 @@ describe('useChonkTheme', () => {
       );
       OrganizationStore.onUpdate(OrganizationFixture({features: ['chonk-ui']}));
 
-      const {result} = renderHook(() => useThemeSwitcher(), {wrapper});
+      const {result} = renderHookWithProviders(() => useThemeSwitcher());
       expect(result.current).toBe(DO_NOT_USE_lightChonkTheme);
     });
 
@@ -108,7 +98,7 @@ describe('useChonkTheme', () => {
       );
       OrganizationStore.onUpdate(OrganizationFixture({features: ['chonk-ui']}));
 
-      const {result} = renderHook(() => useThemeSwitcher(), {wrapper});
+      const {result} = renderHookWithProviders(() => useThemeSwitcher());
       expect(result.current).toBe(DO_NOT_USE_darkChonkTheme);
     });
   });

--- a/static/app/views/discover/table/quickContext/eventContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/eventContext.spec.tsx
@@ -17,7 +17,6 @@ import type {
 import {EntryType, EventOrGroupType} from 'sentry/types/event';
 import type {EventData} from 'sentry/utils/discover/eventView';
 import type EventView from 'sentry/utils/discover/eventView';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
 
 import EventContext from './eventContext';
 
@@ -38,14 +37,12 @@ const dataRow: EventData = {
 const renderEventContext = (location?: Location, eventView?: EventView) => {
   const organization = OrganizationFixture();
   render(
-    <QueryClientProvider client={makeTestQueryClient()}>
-      <EventContext
-        dataRow={dataRow}
-        organization={organization}
-        location={location}
-        eventView={eventView}
-      />
-    </QueryClientProvider>,
+    <EventContext
+      dataRow={dataRow}
+      organization={organization}
+      location={location}
+      eventView={eventView}
+    />,
     {organization}
   );
 };

--- a/static/app/views/discover/table/quickContext/eventContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/eventContext.spec.tsx
@@ -3,7 +3,6 @@ import {EventFixture} from 'sentry-fixture/event';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
@@ -2,31 +2,17 @@ import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {mockTraceItemAttributeKeysApi} from 'sentry-fixture/traceItemAttributeKeys';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import type {Tag} from 'sentry/types/group';
-import type {Organization} from 'sentry/types/organization';
 import {FieldKind} from 'sentry/utils/fields';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
 import {TraceItemDataset} from 'sentry/views/explore/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/useLocation');
 const mockedUsedLocation = jest.mocked(useLocation);
-
-function createWrapper(organization: Organization) {
-  return function ({children}: {children?: React.ReactNode}) {
-    return (
-      <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext value={organization}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
-  };
-}
 
 describe('useTraceItemAttributeKeys', () => {
   const {organization} = initializeOrg();
@@ -81,15 +67,11 @@ describe('useTraceItemAttributeKeys', () => {
       mockAttributeKeys
     );
 
-    const {result} = renderHook(
-      () =>
-        useTraceItemAttributeKeys({
-          traceItemType: TraceItemDataset.LOGS,
-          type: 'string',
-        }),
-      {
-        wrapper: createWrapper(organization),
-      }
+    const {result} = renderHookWithProviders(() =>
+      useTraceItemAttributeKeys({
+        traceItemType: TraceItemDataset.LOGS,
+        type: 'string',
+      })
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -140,15 +122,11 @@ describe('useTraceItemAttributeKeys', () => {
       'number'
     );
 
-    const {result} = renderHook(
-      () =>
-        useTraceItemAttributeKeys({
-          traceItemType: TraceItemDataset.LOGS,
-          type: 'number',
-        }),
-      {
-        wrapper: createWrapper(organization),
-      }
+    const {result} = renderHookWithProviders(() =>
+      useTraceItemAttributeKeys({
+        traceItemType: TraceItemDataset.LOGS,
+        type: 'number',
+      })
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -198,15 +176,11 @@ describe('useTraceItemAttributeKeys', () => {
 
     mockTraceItemAttributeKeysApi(organization.slug, attributesWithInvalidChars);
 
-    const {result} = renderHook(
-      () =>
-        useTraceItemAttributeKeys({
-          traceItemType: TraceItemDataset.LOGS,
-          type: 'string',
-        }),
-      {
-        wrapper: createWrapper(organization),
-      }
+    const {result} = renderHookWithProviders(() =>
+      useTraceItemAttributeKeys({
+        traceItemType: TraceItemDataset.LOGS,
+        type: 'string',
+      })
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -256,15 +230,11 @@ describe('useTraceItemAttributeKeys', () => {
       testAttributeKeys
     );
 
-    const {result} = renderHook(
-      () =>
-        useTraceItemAttributeKeys({
-          traceItemType: TraceItemDataset.LOGS,
-          type: 'string',
-        }),
-      {
-        wrapper: createWrapper(organization),
-      }
+    const {result} = renderHookWithProviders(() =>
+      useTraceItemAttributeKeys({
+        traceItemType: TraceItemDataset.LOGS,
+        type: 'string',
+      })
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));

--- a/static/app/views/explore/hooks/useTraces.spec.tsx
+++ b/static/app/views/explore/hooks/useTraces.spec.tsx
@@ -2,14 +2,10 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import type {Organization} from 'sentry/types/organization';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import {useTraces, type TraceResult} from './useTraces';
 

--- a/static/app/views/explore/hooks/useTraces.spec.tsx
+++ b/static/app/views/explore/hooks/useTraces.spec.tsx
@@ -3,7 +3,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {act, renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -29,16 +29,6 @@ function createTraceResult(trace?: Partial<TraceResult>): TraceResult {
     start: 123,
     trace: '00000000000000000000000000000000',
     ...trace,
-  };
-}
-
-function createWrapper(organization: Organization) {
-  return function ({children}: {children?: React.ReactNode}) {
-    return (
-      <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext value={organization}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
   };
 }
 
@@ -100,9 +90,8 @@ describe('useTraces', () => {
       ],
     });
 
-    const {result} = renderHook(useTraces, {
+    const {result} = renderHookWithProviders(useTraces, {
       ...context,
-      wrapper: createWrapper(organization),
       initialProps: {
         datetime: {
           end: null,

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.spec.tsx
@@ -1,11 +1,7 @@
-import {QueryClientProvider} from '@tanstack/react-query';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import type {Organization} from 'sentry/types/organization';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
@@ -15,10 +11,8 @@ import {
 } from 'sentry/views/explore/multiQueryMode/hooks/useMultiQueryTable';
 import {useReadQueriesFromLocation} from 'sentry/views/explore/multiQueryMode/locationUtils';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/useNavigate');
 jest.mock('sentry/utils/usePageFilters');
 jest.mock('sentry/views/explore/multiQueryMode/locationUtils', () => {
   const actual = jest.requireActual('sentry/views/explore/multiQueryMode/locationUtils');
@@ -27,17 +21,6 @@ jest.mock('sentry/views/explore/multiQueryMode/locationUtils', () => {
     useReadQueriesFromLocation: jest.fn(),
   };
 });
-
-function createWrapper(org: Organization) {
-  return function TestWrapper({children}: {children: React.ReactNode}) {
-    const queryClient = makeTestQueryClient();
-    return (
-      <QueryClientProvider client={queryClient}>
-        <OrganizationContext value={org}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
-  };
-}
 
 describe('useMultiQueryTable', () => {
   let mockNormalRequestUrl: jest.Mock;
@@ -105,18 +88,14 @@ describe('useMultiQueryTable', () => {
         ],
         method: 'GET',
       });
-      renderHook(
-        () =>
-          hook({
-            enabled: true,
-            groupBys: [],
-            query: 'test value',
-            sortBys: [],
-            yAxes: [],
-          }),
-        {
-          wrapper: createWrapper(OrganizationFixture()),
-        }
+      renderHookWithProviders(() =>
+        hook({
+          enabled: true,
+          groupBys: [],
+          query: 'test value',
+          sortBys: [],
+          yAxes: [],
+        })
       );
 
       expect(mockNormalRequestUrl).toHaveBeenCalledTimes(1);

--- a/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
@@ -1,32 +1,19 @@
-import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {NonDefaultSpanSampleFields} from 'sentry/views/insights/common/queries/useSpanSamples';
 import {useSpanSamples} from 'sentry/views/insights/http/queries/useSpanSamples';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/usePageFilters');
 jest.mock('sentry/utils/useLocation');
 
 describe('useSpanSamples', () => {
   const organization = OrganizationFixture();
-
-  function Wrapper({children}: {children?: ReactNode}) {
-    return (
-      <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext value={organization}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
-  }
-
   jest.mocked(usePageFilters).mockReturnValue(
     PageFilterStateFixture({
       selection: {
@@ -63,10 +50,9 @@ describe('useSpanSamples', () => {
       body: {data: []},
     });
 
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       ({fields, enabled}) => useSpanSamples({fields, enabled}),
       {
-        wrapper: Wrapper,
         initialProps: {
           fields: [] satisfies NonDefaultSpanSampleFields[],
           enabled: false,
@@ -102,7 +88,7 @@ describe('useSpanSamples', () => {
       },
     });
 
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       ({filters, fields, referrer}) =>
         useSpanSamples({
           search: MutableSearch.fromQueryObject(filters),
@@ -112,7 +98,6 @@ describe('useSpanSamples', () => {
           max: 900,
         }),
       {
-        wrapper: Wrapper,
         initialProps: {
           filters: {
             'span.group': '221aa7ebd216',


### PR DESCRIPTION
Continuation of #100241

replace custom QueryClientProvider and OrganizationContext with renderHookWithProviders that contains the same set of providers that our render wrapper does.
