### PR TITLE
fix(prevent): adjust the date options order for consistency

### DIFF
--- a/static/app/components/prevent/dateSelector/dateSelector.tsx
+++ b/static/app/components/prevent/dateSelector/dateSelector.tsx
@@ -26,12 +26,7 @@ export function DateSelector() {
   );
 
   const options = useMemo((): Array<SelectOption<string>> => {
-    const currentAndDefaultPreventPeriods = {
-      ...getArbitraryRelativePeriod(preventPeriod),
-      ...PREVENT_DEFAULT_RELATIVE_PERIODS,
-    };
-
-    return Object.entries(currentAndDefaultPreventPeriods).map(
+    return Object.entries(PREVENT_DEFAULT_RELATIVE_PERIODS).map(
       ([key, value]): SelectOption<string> => {
         return {
           value: key,
@@ -40,7 +35,7 @@ export function DateSelector() {
         };
       }
     );
-  }, [preventPeriod]);
+  }, []);
 
   return (
     <CompactSelect

--- a/static/app/components/prevent/dateSelector/dateSelector.tsx
+++ b/static/app/components/prevent/dateSelector/dateSelector.tsx
@@ -5,7 +5,6 @@ import type {SelectOption} from 'sentry/components/core/compactSelect';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import DropdownButton from 'sentry/components/dropdownButton';
 import {usePreventContext} from 'sentry/components/prevent/context/preventContext';
-import {getArbitraryRelativePeriod} from 'sentry/components/timeRangeSelector/utils';
 import {IconCalendar} from 'sentry/icons/iconCalendar';
 import {t} from 'sentry/locale';
 


### PR DESCRIPTION
This PR adjusts the dates of the TA date selector to match the order they are presented for other Sentry date selectors.

Before:

<img width="304" height="202" alt="Screenshot 2025-09-25 at 5 32 19 PM" src="https://github.com/user-attachments/assets/ceb8379f-55c8-4053-8bcf-6c186ed4d3ca" />

After:

<img width="313" height="235" alt="Screenshot 2025-09-25 at 5 32 02 PM" src="https://github.com/user-attachments/assets/6d580a30-aa8f-4dd3-ae0b-b89d926f08d7" />
