### PR TITLE
Changes from background agent bc-547ae1a9-5634-4d11-aca1-019165efbc07

### DIFF
--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -312,7 +312,7 @@ def create_dif_from_id(
             type="project.dif",
             headers={"Content-Type": DIF_MIMETYPES[meta.file_format]},
         )
-        file.putfile(fileobj)
+        file.putfile_batch(fileobj)
     else:
         file.type = "project.dif"
         file.headers["Content-Type"] = DIF_MIMETYPES[meta.file_format]

--- a/src/sentry/models/files/abstractfile.py
+++ b/src/sentry/models/files/abstractfile.py
@@ -329,6 +329,60 @@ class AbstractFile(Model, _Parent[BlobIndexType, BlobType]):
         return results
 
     @sentry_sdk.tracing.trace
+    def putfile_batch(self, fileobj, blob_size=DEFAULT_BLOB_SIZE, commit=True, logger=nooplogger):
+        """
+        Batch-optimized version of putfile that avoids N+1 queries when creating blobs.
+        
+        Save a fileobj into a number of chunks using batch blob creation.
+
+        Returns a list of `FileBlobIndex` items.
+
+        >>> indexes = file.putfile_batch(fileobj)
+        """
+        # First pass: collect all chunks and their checksums
+        chunks = []
+        file_checksum = sha1(b"")
+        total_size = 0
+        
+        while True:
+            contents = fileobj.read(blob_size)
+            if not contents:
+                break
+            
+            file_checksum.update(contents)
+            chunk_checksum = sha1(contents).hexdigest()
+            chunks.append((contents, chunk_checksum))
+            total_size += len(contents)
+        
+        # Batch create all blobs at once
+        if hasattr(self, '_create_blobs_from_chunks_batch'):
+            # Use batch method if available
+            blobs = self._create_blobs_from_chunks_batch(chunks, logger=logger)
+        else:
+            # Fallback to individual creation
+            blobs = []
+            for contents, chunk_checksum in chunks:
+                blob_fileobj = ContentFile(contents)
+                blob = self._create_blob_from_file(blob_fileobj, logger=logger)
+                blobs.append(blob)
+        
+        # Create blob indexes
+        results = []
+        offset = 0
+        for blob in blobs:
+            results.append(self._create_blob_index(blob=blob, offset=offset))
+            offset += blob.size
+        
+        self.size = total_size
+        self.checksum = file_checksum.hexdigest()
+        metrics.distribution("filestore.file-size", total_size, unit="byte")
+        
+        if commit:
+            self.save()
+        
+        return results
+
+    @sentry_sdk.tracing.trace
     def assemble_from_file_blob_ids(self, file_blob_ids, checksum):
         """
         This creates a file, from file blobs and returns a temp file with the

--- a/src/sentry/models/files/file.py
+++ b/src/sentry/models/files/file.py
@@ -40,7 +40,9 @@ class File(AbstractFile[FileBlobIndex, FileBlob]):
     def _create_blob_from_file(self, contents: ContentFile, logger: Any) -> FileBlob:
         return FileBlob.from_file(contents, logger)
 
-    def _create_blobs_from_chunks_batch(self, chunks: list[tuple[bytes, str]], logger: Any) -> list[FileBlob]:
+    def _create_blobs_from_chunks_batch(
+        self, chunks: list[tuple[bytes, str]], logger: Any
+    ) -> list[FileBlob]:
         """Batch create FileBlobs from chunks to avoid N+1 queries."""
         return FileBlob.from_file_chunks_batch(chunks, logger)
 

--- a/src/sentry/models/files/file.py
+++ b/src/sentry/models/files/file.py
@@ -40,6 +40,10 @@ class File(AbstractFile[FileBlobIndex, FileBlob]):
     def _create_blob_from_file(self, contents: ContentFile, logger: Any) -> FileBlob:
         return FileBlob.from_file(contents, logger)
 
+    def _create_blobs_from_chunks_batch(self, chunks: list[tuple[bytes, str]], logger: Any) -> list[FileBlob]:
+        """Batch create FileBlobs from chunks to avoid N+1 queries."""
+        return FileBlob.from_file_chunks_batch(chunks, logger)
+
     def _get_blobs_by_id(self, blob_ids: Sequence[int]) -> models.QuerySet[FileBlob]:
         return FileBlob.objects.filter(id__in=blob_ids).all()
 

--- a/src/sentry/models/files/utils.py
+++ b/src/sentry/models/files/utils.py
@@ -76,30 +76,27 @@ def get_and_optionally_update_blobs_batch(
     """
     Batch version of get_and_optionally_update_blob that retrieves multiple FileBlobs
     by their checksums in a single query, avoiding N+1 query issues.
-    
+
     Returns a dictionary mapping checksum -> FileBlob for existing blobs.
     """
     if not checksums:
         return {}
-    
+
     # Get all existing blobs in a single query
     existing_blobs = file_blob_model.objects.filter(checksum__in=checksums)
-    
+
     # Create a mapping of checksum to blob
     blob_map = {blob.checksum: blob for blob in existing_blobs}
-    
+
     # Update timestamps for old blobs that need it
     now = timezone.now()
     threshold = now - HALF_DAY
-    blobs_to_update = [
-        blob.id for blob in existing_blobs 
-        if blob.timestamp <= threshold
-    ]
-    
+    blobs_to_update = [blob.id for blob in existing_blobs if blob.timestamp <= threshold]
+
     if blobs_to_update:
         # Batch update timestamps
         file_blob_model.objects.filter(id__in=blobs_to_update).update(timestamp=now)
-    
+
     return blob_map
 
 

--- a/src/sentry/models/files/utils.py
+++ b/src/sentry/models/files/utils.py
@@ -70,6 +70,39 @@ def get_and_optionally_update_blob(
     return existing
 
 
+def get_and_optionally_update_blobs_batch(
+    file_blob_model: type[FileModelT], checksums: list[str]
+) -> dict[str, FileModelT]:
+    """
+    Batch version of get_and_optionally_update_blob that retrieves multiple FileBlobs
+    by their checksums in a single query, avoiding N+1 query issues.
+    
+    Returns a dictionary mapping checksum -> FileBlob for existing blobs.
+    """
+    if not checksums:
+        return {}
+    
+    # Get all existing blobs in a single query
+    existing_blobs = file_blob_model.objects.filter(checksum__in=checksums)
+    
+    # Create a mapping of checksum to blob
+    blob_map = {blob.checksum: blob for blob in existing_blobs}
+    
+    # Update timestamps for old blobs that need it
+    now = timezone.now()
+    threshold = now - HALF_DAY
+    blobs_to_update = [
+        blob.id for blob in existing_blobs 
+        if blob.timestamp <= threshold
+    ]
+    
+    if blobs_to_update:
+        # Batch update timestamps
+        file_blob_model.objects.filter(id__in=blobs_to_update).update(timestamp=now)
+    
+    return blob_map
+
+
 class AssembleChecksumMismatch(Exception):
     pass
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes an N+1 query issue in the `/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/files/dsyms/` endpoint during debug file uploads.

**Problem:**
When uploading debug files, the `File.putfile` method processes file chunks individually. For each chunk, it performs a separate database `SELECT` query to check if a `FileBlob` with the chunk's checksum already exists. This leads to an N+1 query pattern, causing significant performance degradation and increased database load for large files with many chunks.

**Solution:**
This PR introduces batch processing for `FileBlob` creation and lookup:
1.  A new utility function `get_and_optionally_update_blobs_batch` is added to perform a single `SELECT` query for multiple blob checksums.
2.  A new `from_file_chunks_batch` method is added to `AbstractFileBlob` to create and retrieve blobs in a batch, utilizing the new batch lookup.
3.  A new `putfile_batch` method is added to `AbstractFile` which collects all file chunks and then processes them using the batch blob creation logic.
4.  The `create_dif_from_id` function in `debugfile.py` is updated to use this new `putfile_batch` method.

This change drastically reduces the number of database queries from one per chunk to a few batch queries, significantly improving the performance of debug file uploads. The original `putfile` method remains unchanged for backward compatibility.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-547ae1a9-5634-4d11-aca1-019165efbc07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-547ae1a9-5634-4d11-aca1-019165efbc07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

