### PR TITLE
:sparkles: feat(ticketing): sync group assignee using external user mapping

### DIFF
--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import logging
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from django.db.models.query import QuerySet
 
 from sentry.integrations.mixins.issues import where_should_sync
+from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.project_management.metrics import (
     ProjectManagementActionType,
@@ -14,17 +16,24 @@ from sentry.integrations.project_management.metrics import (
 )
 from sentry.integrations.services.assignment_source import AssignmentSource
 from sentry.integrations.tasks.sync_assignee_outbound import sync_assignee_outbound
+from sentry.integrations.types import EXTERNAL_PROVIDERS_REVERSE, ExternalProviderEnum
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.project import Project
 from sentry.silo.base import region_silo_function
+from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
 
 if TYPE_CHECKING:
     from sentry.integrations.services.integration import RpcIntegration
 
 
-def get_user_id(projects_by_user: dict[int, set[int]], group: Group) -> int | None:
+class AssigneeInboundSyncMethod(StrEnum):
+    EMAIL = "email"
+    EXTERNAL_ACTOR = "external_actor"
+
+
+def _get_user_id(projects_by_user: dict[int, set[int]], group: Group) -> int | None:
     user_ids = [
         user_id
         for user_id, project_ids in projects_by_user.items()
@@ -34,6 +43,103 @@ def get_user_id(projects_by_user: dict[int, set[int]], group: Group) -> int | No
     if not user_ids:
         return None
     return user_ids[0]
+
+
+def _get_affected_groups(
+    integration: RpcIntegration | Integration, external_issue_key: str | None
+) -> QuerySet[Group]:
+    orgs_with_sync_enabled = where_should_sync(integration, "inbound_assignee")
+    return Group.objects.get_groups_by_external_issue(
+        integration,
+        orgs_with_sync_enabled,
+        external_issue_key,
+    )
+
+
+def _handle_deassign(
+    groups: QuerySet[Group], integration: RpcIntegration | Integration
+) -> QuerySet[Group]:
+    for group in groups:
+        GroupAssignee.objects.deassign(
+            group,
+            assignment_source=AssignmentSource.from_integration(integration),
+        )
+    return groups
+
+
+def _handle_assign(
+    affected_groups: QuerySet[Group],
+    integration: RpcIntegration | Integration,
+    users: list[RpcUser],
+) -> list[Group]:
+
+    groups_assigned: list[Group] = []
+
+    users_by_id = {user.id: user for user in users}
+    projects_by_user = Project.objects.get_by_users(users)
+
+    for group in affected_groups:
+        user_id = _get_user_id(projects_by_user, group)
+        user = users_by_id.get(user_id) if user_id is not None else None
+        if user:
+            GroupAssignee.objects.assign(
+                group,
+                user,
+                assignment_source=AssignmentSource.from_integration(integration),
+            )
+            groups_assigned.append(group)
+
+    return groups_assigned
+
+
+@region_silo_function
+def sync_group_assignee_inbound_by_external_actor(
+    integration: RpcIntegration | Integration,
+    external_user_name: str,
+    external_issue_key: str | None,
+    assign: bool = True,
+) -> QuerySet[Group] | list[Group]:
+
+    logger = logging.getLogger(f"sentry.integrations.{integration.provider}")
+
+    with ProjectManagementEvent(
+        action_type=ProjectManagementActionType.INBOUND_ASSIGNMENT_SYNC, integration=integration
+    ).capture() as lifecycle:
+        affected_groups = _get_affected_groups(integration, external_issue_key)
+        log_context = {
+            "integration_id": integration.id,
+            "external_user_name": external_user_name,
+            "issue_key": external_issue_key,
+            "method": AssigneeInboundSyncMethod.EXTERNAL_ACTOR.value,
+        }
+
+        if not affected_groups:
+            logger.info("no-affected-groups", extra=log_context)
+            return []
+
+        if not assign:
+            return _handle_deassign(affected_groups, integration)
+
+        external_actors = ExternalActor.objects.filter(
+            provider=EXTERNAL_PROVIDERS_REVERSE[ExternalProviderEnum(integration.provider)].value,
+            external_name=external_user_name,
+            integration_id=integration.id,
+            user_id__isnull=False,
+        ).values_list("user_id", flat=True)
+
+        user_ids = [
+            external_actor for external_actor in external_actors if external_actor is not None
+        ]
+        users = user_service.get_many_by_id(ids=user_ids)
+
+        groups_assigned = _handle_assign(affected_groups, integration, users)
+
+        if len(groups_assigned) != len(affected_groups):
+            lifecycle.record_halt(
+                ProjectManagementHaltReason.SYNC_INBOUND_ASSIGNEE_NOT_FOUND, extra=log_context
+            )
+
+        return groups_assigned
 
 
 @region_silo_function
@@ -54,53 +160,25 @@ def sync_group_assignee_inbound(
     with ProjectManagementEvent(
         action_type=ProjectManagementActionType.INBOUND_ASSIGNMENT_SYNC, integration=integration
     ).capture() as lifecycle:
-        orgs_with_sync_enabled = where_should_sync(integration, "inbound_assignee")
-        affected_groups = Group.objects.get_groups_by_external_issue(
-            integration,
-            orgs_with_sync_enabled,
-            external_issue_key,
-        )
+        affected_groups = _get_affected_groups(integration, external_issue_key)
         log_context = {
             "integration_id": integration.id,
             "email": email,
             "issue_key": external_issue_key,
+            "method": AssigneeInboundSyncMethod.EMAIL.value,
         }
         if not affected_groups:
             logger.info("no-affected-groups", extra=log_context)
             return []
 
         if not assign:
-            for group in affected_groups:
-                # XXX: Pass an acting user and make the acting_user mandatory
-                GroupAssignee.objects.deassign(
-                    group,
-                    assignment_source=AssignmentSource.from_integration(integration),
-                )
-
-            return affected_groups
+            return _handle_deassign(affected_groups, integration)
 
         users = user_service.get_many_by_email(emails=[email], is_verified=True)
-        users_by_id = {user.id: user for user in users}
-        projects_by_user = Project.objects.get_by_users(users)
 
-        groups_assigned = []
+        groups_assigned = _handle_assign(affected_groups, integration, users)
 
-        assignee_not_found = False
-
-        for group in affected_groups:
-            user_id = get_user_id(projects_by_user, group)
-            user = users_by_id.get(user_id) if user_id is not None else None
-            if user:
-                GroupAssignee.objects.assign(
-                    group,
-                    user,
-                    assignment_source=AssignmentSource.from_integration(integration),
-                )
-                groups_assigned.append(group)
-            else:
-                assignee_not_found = True
-
-        if assignee_not_found:
+        if len(groups_assigned) != len(affected_groups):
             lifecycle.record_halt(
                 ProjectManagementHaltReason.SYNC_INBOUND_ASSIGNEE_NOT_FOUND, extra=log_context
             )

--- a/tests/sentry/integrations/utils/test_sync.py
+++ b/tests/sentry/integrations/utils/test_sync.py
@@ -2,8 +2,12 @@ from unittest import mock
 
 import pytest
 
-from sentry.integrations.types import EventLifecycleOutcome
-from sentry.integrations.utils.sync import sync_group_assignee_inbound
+from sentry.integrations.types import EventLifecycleOutcome, ExternalProviders
+from sentry.integrations.utils.sync import (
+    AssigneeInboundSyncMethod,
+    sync_group_assignee_inbound,
+    sync_group_assignee_inbound_by_external_actor,
+)
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.testutils.cases import TestCase
@@ -105,7 +109,7 @@ class TestSyncAssigneeInbound(TestCase):
     def test_assign_with_multiple_groups(self, mock_record_event: mock.MagicMock) -> None:
         # Create a couple new test unassigned test groups
         groups_to_assign: list[Group] = []
-        for i in range(2):
+        for _ in range(2):
             org = self.create_organization(owner=self.create_user())
             team = self.create_team(organization=org)
             project = self.create_project(organization=org, teams=[team])
@@ -176,6 +180,7 @@ class TestSyncAssigneeInbound(TestCase):
                 "integration_id": self.example_integration.id,
                 "email": "oopsnotfound@example.com",
                 "issue_key": external_issue.key,
+                "method": AssigneeInboundSyncMethod.EMAIL.value,
             },
         )
 
@@ -216,3 +221,440 @@ class TestSyncAssigneeInbound(TestCase):
 
         assert isinstance(exception_param, Exception)
         assert exception_param.args[0] == "oops, something went wrong"
+
+
+@region_silo_test
+class TestSyncAssigneeInboundByExternalActor(TestCase):
+    def setUp(self) -> None:
+        self.example_integration = self.create_integration(
+            organization=self.group.organization,
+            external_id="123456",
+            provider="github",
+            oi_params={"config": {"sync_reverse_assignment": True}},
+        )
+        self.test_user = self.create_user("test@example.com")
+        self.create_member(organization=self.organization, user=self.test_user, teams=[self.team])
+
+        with assume_test_silo_mode_of(UserEmail):
+            UserEmail.objects.filter(user=self.test_user).update(is_verified=True)
+            assert UserEmail.objects.filter(
+                user=self.test_user, email="test@example.com", is_verified=True
+            ).exists()
+
+    def assign_default_group_to_user(self, user: User, group: Group | None = None):
+        group_to_update: Group = group or self.group
+        GroupAssignee.objects.assign(group_to_update, serialize_rpc_user(user))
+        group_to_update.refresh_from_db()
+        group_assignee = group_to_update.get_assignee()
+        assert group_assignee is not None and group_assignee.id == user.id
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_no_affected_groups(self, mock_record_event: mock.MagicMock) -> None:
+        """Test when no groups are affected by the external issue."""
+        self.assign_default_group_to_user(self.test_user)
+
+        sync_group_assignee_inbound_by_external_actor(
+            integration=self.example_integration,
+            external_user_name="johndoe",
+            external_issue_key="this-does-not-exist",
+            assign=True,
+        )
+
+        mock_record_event.record_event(EventLifecycleOutcome.SUCCESS)
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_unassign(self, mock_record_event: mock.MagicMock) -> None:
+        """Test unassigning a group via external actor."""
+        self.assign_default_group_to_user(self.test_user)
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="JIRA-123",
+            integration=self.example_integration,
+        )
+
+        # Create external user mapping
+        self.create_external_user(
+            user=self.test_user,
+            external_name="johndoe",
+            provider=ExternalProviders.GITHUB.value,
+            integration=self.example_integration,
+        )
+
+        sync_group_assignee_inbound_by_external_actor(
+            integration=self.example_integration,
+            external_user_name="johndoe",
+            external_issue_key=external_issue.key,
+            assign=False,
+        )
+
+        assert self.group.get_assignee() is None
+        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_assignment_with_external_actor(self, mock_record_event: mock.MagicMock) -> None:
+        """Test assigning a group to a user via external actor."""
+        assert self.group.get_assignee() is None
+
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="JIRA-123",
+            integration=self.example_integration,
+        )
+
+        # Create external user mapping
+        self.create_external_user(
+            user=self.test_user,
+            external_name="johndoe",
+            provider=ExternalProviders.GITHUB.value,
+            integration=self.example_integration,
+        )
+
+        sync_group_assignee_inbound_by_external_actor(
+            integration=self.example_integration,
+            external_user_name="johndoe",
+            external_issue_key=external_issue.key,
+            assign=True,
+        )
+
+        updated_assignee = self.group.get_assignee()
+        assert updated_assignee is not None
+        assert updated_assignee.id == self.test_user.id
+        assert updated_assignee.email == "test@example.com"
+        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_assign_with_multiple_groups(self, mock_record_event: mock.MagicMock) -> None:
+        """Test assigning multiple groups via external actor."""
+        # Create a couple new test unassigned test groups
+        groups_to_assign: list[Group] = []
+        for _ in range(2):
+            org = self.create_organization(owner=self.create_user())
+            team = self.create_team(organization=org)
+            project = self.create_project(organization=org, teams=[team])
+            self.create_member(organization=org, user=self.test_user, teams=[team])
+            self.create_organization_integration(
+                organization_id=org.id,
+                integration=self.example_integration,
+                config={"sync_reverse_assignment": True},
+            )
+
+            groups_to_assign.append(
+                self.create_group(project=project),
+            )
+
+        external_issue_key = "JIRA-456"
+        for group in groups_to_assign:
+            assert group.get_assignee() is None
+            self.create_integration_external_issue(
+                group=group,
+                key=external_issue_key,
+                integration=self.example_integration,
+            )
+
+        # Create external user mapping
+        self.create_external_user(
+            user=self.test_user,
+            external_name="johndoe",
+            provider=ExternalProviders.GITHUB.value,
+            integration=self.example_integration,
+        )
+
+        sync_group_assignee_inbound_by_external_actor(
+            integration=self.example_integration,
+            external_user_name="johndoe",
+            external_issue_key=external_issue_key,
+            assign=True,
+        )
+
+        for group in groups_to_assign:
+            assignee = group.get_assignee()
+            assert assignee is not None
+            assert isinstance(assignee, RpcUser)
+            assert assignee.id == self.test_user.id
+            assert assignee.email == "test@example.com"
+
+        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_halt")
+    def test_assign_with_no_external_actor_found(self, mock_record_halt: mock.MagicMock) -> None:
+        """Test assignment when no external actor mapping exists."""
+        assert self.group.get_assignee() is None
+
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="JIRA-789",
+            integration=self.example_integration,
+        )
+
+        # Don't create any external user mapping - this should cause a halt
+
+        sync_group_assignee_inbound_by_external_actor(
+            integration=self.example_integration,
+            external_user_name="unknownuser",
+            external_issue_key=external_issue.key,
+            assign=True,
+        )
+
+        updated_assignee = self.group.get_assignee()
+        assert updated_assignee is None
+        mock_record_halt.assert_called_with(
+            "inbound-assignee-not-found",
+            extra={
+                "integration_id": self.example_integration.id,
+                "external_user_name": "unknownuser",
+                "issue_key": external_issue.key,
+                "method": AssigneeInboundSyncMethod.EXTERNAL_ACTOR.value,
+            },
+        )
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_halt")
+    def test_assign_with_user_not_in_project(self, mock_record_halt: mock.MagicMock) -> None:
+        """Test assignment when user exists but is not a member of the project."""
+        assert self.group.get_assignee() is None
+
+        # Create a user that is not a member of the project
+        other_user = self.create_user("other@example.com")
+
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="JIRA-999",
+            integration=self.example_integration,
+        )
+
+        # Create external user mapping for the user who is not in the project
+        self.create_external_user(
+            user=other_user,
+            external_name="outsider",
+            provider=ExternalProviders.GITHUB.value,
+            integration=self.example_integration,
+        )
+
+        sync_group_assignee_inbound_by_external_actor(
+            integration=self.example_integration,
+            external_user_name="outsider",
+            external_issue_key=external_issue.key,
+            assign=True,
+        )
+
+        updated_assignee = self.group.get_assignee()
+        assert updated_assignee is None
+        mock_record_halt.assert_called_with(
+            "inbound-assignee-not-found",
+            extra={
+                "integration_id": self.example_integration.id,
+                "external_user_name": "outsider",
+                "issue_key": external_issue.key,
+                "method": AssigneeInboundSyncMethod.EXTERNAL_ACTOR.value,
+            },
+        )
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_failure")
+    @mock.patch("sentry.models.groupassignee.GroupAssigneeManager.assign")
+    def test_assignment_fails(
+        self, mock_group_assign: mock.MagicMock, mock_record_failure: mock.MagicMock
+    ) -> None:
+        """Test handling when assignment operation fails."""
+
+        def raise_exception(*_args, **_kwargs):
+            raise Exception("oops, something went wrong during assignment")
+
+        assert self.group.get_assignee() is None
+
+        mock_group_assign.side_effect = raise_exception
+
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="JIRA-ERROR",
+            integration=self.example_integration,
+        )
+
+        # Create external user mapping
+        self.create_external_user(
+            user=self.test_user,
+            external_name="johndoe",
+            provider=ExternalProviders.GITHUB.value,
+            integration=self.example_integration,
+        )
+
+        with pytest.raises(Exception) as exc:
+            sync_group_assignee_inbound_by_external_actor(
+                integration=self.example_integration,
+                external_user_name="johndoe",
+                external_issue_key=external_issue.key,
+                assign=True,
+            )
+
+        assert exc.match("oops, something went wrong during assignment")
+
+        updated_assignee = self.group.get_assignee()
+        assert updated_assignee is None
+
+        mock_record_failure.assert_called_once_with(mock.ANY, create_issue=True)
+
+        exception_param = mock_record_failure.call_args_list[0].args[0]
+
+        assert isinstance(exception_param, Exception)
+        assert exception_param.args[0] == "oops, something went wrong during assignment"
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_multiple_external_actors_same_name(self, mock_record_event: mock.MagicMock) -> None:
+        """Test assignment when multiple users have the same external name (should use the first one found)."""
+        assert self.group.get_assignee() is None
+
+        # Create another user
+        another_user = self.create_user("another@example.com")
+        self.create_member(organization=self.organization, user=another_user, teams=[self.team])
+
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="JIRA-DUP",
+            integration=self.example_integration,
+        )
+
+        # Create external user mappings with the same external name
+        self.create_external_user(
+            user=self.test_user,
+            external_name="duplicate_name",
+            provider=ExternalProviders.GITHUB.value,
+            integration=self.example_integration,
+        )
+        self.create_external_user(
+            user=another_user,
+            external_name="duplicate_name",
+            provider=ExternalProviders.GITHUB.value,
+            integration=self.example_integration,
+        )
+
+        sync_group_assignee_inbound_by_external_actor(
+            integration=self.example_integration,
+            external_user_name="duplicate_name",
+            external_issue_key=external_issue.key,
+            assign=True,
+        )
+
+        updated_assignee = self.group.get_assignee()
+        assert updated_assignee is not None
+        # The assignment should succeed with one of the users
+        assert updated_assignee.id in [self.test_user.id, another_user.id]
+        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_same_external_name_different_users_across_orgs(
+        self, mock_record_event: mock.MagicMock
+    ) -> None:
+        """Test when the same external_user_name maps to different users in different orgs.
+
+        Scenario 1: Both users should be assigned to their respective groups.
+        Scenario 2: When only one user has a group with the external issue, only that user is affected.
+        """
+        # Create two different organizations
+        # org1 is self.organization (already exists)
+        org2 = self.create_organization(owner=self.create_user())
+
+        # Create two different users
+        user1 = self.test_user  # Already exists in org1
+        user2 = self.create_user("user2@example.com")
+
+        # Create teams and memberships
+        team2 = self.create_team(organization=org2)
+        self.create_member(organization=org2, user=user2, teams=[team2])
+
+        # Create projects and groups for each org
+        project2 = self.create_project(organization=org2, teams=[team2])
+        group1 = self.group  # Already exists in org1
+        group2 = self.create_group(project=project2)
+
+        # Setup organization integrations for both orgs
+        self.create_organization_integration(
+            organization_id=org2.id,
+            integration=self.example_integration,
+            config={"sync_reverse_assignment": True},
+        )
+
+        # Create external user mappings - same external name, different users in different orgs
+        self.create_external_user(
+            user=user1,
+            external_name="shared_github_username",
+            provider=ExternalProviders.GITHUB.value,
+            integration=self.example_integration,
+        )
+        self.create_external_user(
+            user=user2,
+            external_name="shared_github_username",
+            provider=ExternalProviders.GITHUB.value,
+            integration=self.example_integration,
+        )
+
+        # Scenario 1: Both groups have the same external issue key
+        external_issue_key = "SHARED-123"
+
+        # Create external issues for both groups
+        self.create_integration_external_issue(
+            group=group1,
+            key=external_issue_key,
+            integration=self.example_integration,
+        )
+        self.create_integration_external_issue(
+            group=group2,
+            key=external_issue_key,
+            integration=self.example_integration,
+        )
+
+        # Verify both groups are unassigned initially
+        assert group1.get_assignee() is None
+        assert group2.get_assignee() is None
+
+        # Perform the sync
+        sync_group_assignee_inbound_by_external_actor(
+            integration=self.example_integration,
+            external_user_name="shared_github_username",
+            external_issue_key=external_issue_key,
+            assign=True,
+        )
+
+        # Both groups should be assigned to their respective users
+        assignee1 = group1.get_assignee()
+        assert assignee1 is not None
+        assert assignee1.id == user1.id
+        assert assignee1.email == "test@example.com"
+
+        assignee2 = group2.get_assignee()
+        assert assignee2 is not None
+        assert assignee2.id == user2.id
+        assert assignee2.email == "user2@example.com"
+
+        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
+
+        # Scenario 2: Only one group has a different external issue
+        group3 = self.create_group(project=self.project)
+        group4 = self.create_group(project=project2)
+
+        unique_issue_key = "UNIQUE-456"
+
+        # Only create external issue for group3 (user1's group)
+        self.create_integration_external_issue(
+            group=group3,
+            key=unique_issue_key,
+            integration=self.example_integration,
+        )
+        # group4 does NOT have this external issue
+
+        # Verify both are unassigned initially
+        assert group3.get_assignee() is None
+        assert group4.get_assignee() is None
+
+        # Perform the sync with the unique issue key
+        sync_group_assignee_inbound_by_external_actor(
+            integration=self.example_integration,
+            external_user_name="shared_github_username",
+            external_issue_key=unique_issue_key,
+            assign=True,
+        )
+
+        # Only group3 should be assigned (to user1)
+        assignee3 = group3.get_assignee()
+        assert assignee3 is not None
+        assert assignee3.id == user1.id
+
+        # group4 should remain unassigned
+        assert group4.get_assignee() is None


### PR DESCRIPTION
## Summary
Add support for syncing group assignees using external user mappings when email isn't available in the webhook payload.

Note: We don't use this method anywhere right now, will be used in subsequent PRs

## Context
GitHub's issue assignment webhooks don't include the assignee's email address (unless its a public email which almost noone does).  This made it impossible to sync assignee changes from GitHub to Sentry issues since we relied on email-based user lookup.

## Solution
Introduced a new sync method that leverages the ExternalActor mapping table to resolve external usernames (e.g., GitHub usernames) to Sentry users. This allows assignee sync to work even when only the external username is available.
The implementation:

* Added `sync_group_assignee_inbound_by_external_actor` as an alternative to the email-based sync
* Uses existing external user mappings configured through integration settings


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
