### PR TITLE
ref(replay): update too long summary msg

### DIFF
--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -225,7 +225,7 @@ export default function Ai() {
           {segmentCount > 100 && (
             <Subtext>
               {t(
-                `Note: this replay is too long, so we're currently only summarizing part of it.`
+                `Note: this replay is very long, so we might not be summarizing all of it.`
               )}
             </Subtext>
           )}


### PR DESCRIPTION
Small nit - even if seg count > 100 we may be summarizing all of it (no useful breadcrumbs in the remaining segs)

ex: https://sentry.sentry.io/explore/replays/c1590f0c1f1a42919f1367ab6ee44fba/?query=&referrer=%2Fexplore%2Freplays%2F&statsPeriod=14d&t_main=ai&yAxis=count%28%29