### PR TITLE
Add util to generate a fully qualified object url

### DIFF
--- a/tests/sentry/objectstore/test_objectstore.py
+++ b/tests/sentry/objectstore/test_objectstore.py
@@ -12,6 +12,16 @@ class Testserver:
     secret = ""
 
 
+def test_object_url() -> None:
+    server = Testserver()
+    client = ClientBuilder("test", {"base_url": server.url}).for_project(123, 456)
+
+    assert (
+        client.object_url("foo")
+        == "http://localhost:8888/v1/foo?usecase=test&scope=org.123%2Fproj.456"
+    )
+
+
 def test_stores_uncompressed() -> None:
     server = Testserver()
     client = ClientBuilder("test", {"base_url": server.url}).for_organization(12345)


### PR DESCRIPTION
Also adapts the client to use `/v1` urls, now that we have introduced this prefix.