### PR TITLE
feat(ai): Better fuzzy matching of model names

### DIFF
--- a/src/sentry/tasks/ai_agent_monitoring.py
+++ b/src/sentry/tasks/ai_agent_monitoring.py
@@ -27,9 +27,9 @@ OPENROUTER_MODELS_API_URL = "https://openrouter.ai/api/v1/models"
 MODELS_DEV_API_URL = "https://models.dev/api.json"
 
 
-def _create_glob_model_name(model_id: str) -> str:
+def _create_suffix_glob_model_name(model_id: str) -> str:
     """
-    Create a glob version of a model name by stripping dates and versions.
+    Create a suffix glob version of a model name by stripping dates and versions.
 
     Examples:
     - "claude-4-sonnet-20250522" -> "claude-4-sonnet-*"
@@ -77,12 +77,41 @@ def _create_glob_model_name(model_id: str) -> str:
     return glob_name
 
 
+def _create_prefix_glob_model_name(model_id: str) -> str:
+    """
+    Create a glob version of a model name by adding a wildcard prefix.
+
+    This handles cases where models have random prefixes before the actual model name.
+    Can be used on both regular model IDs and suffix-globbed model names.
+
+    Examples:
+    - "gpt-4" -> "*gpt-4"
+    - "claude-3-5-sonnet" -> "*claude-3-5-sonnet"
+    - "o3-pro" -> "*o3-pro"
+    - "gpt-4o-mini-*" -> "*gpt-4o-mini-*"
+    - "model@*" -> "*model@*"
+
+    Args:
+        model_id: The original model ID or a suffix-globbed model name
+
+    Returns:
+        The glob version with a wildcard prefix
+    """
+    # Simply prepend * to the model name
+    return f"*{model_id}"
+
+
 def _add_glob_model_names(models_dict: dict[ModelId, AIModelCostV2]) -> None:
     """
     Add glob versions of model names to the models dictionary.
 
-    For each model, creates a glob version by stripping dates and versions,
-    and adds it to the dictionary if it doesn't already exist.
+    For each model, creates three types of glob versions:
+    1. Suffix pattern: stripping dates and versions (e.g., "model-20241022" -> "model-*")
+    2. Prefix pattern: adding wildcard prefix (e.g., "gpt-4" -> "*gpt-4")
+    3. Prefix-suffix pattern: both wildcards for suffix-globbed names (e.g., "model-*" -> "*model-*")
+
+    We DO NOT want to have prefix-suffix glob patterns for models that don't have a suffix glob pattern
+    because that would result in too fuzzy matching, e.g. "gpt-4" -> "*gpt-4*" would match "gpt-4o-mini".
 
     Args:
         models_dict: The dictionary of models to add glob versions to
@@ -92,10 +121,20 @@ def _add_glob_model_names(models_dict: dict[ModelId, AIModelCostV2]) -> None:
     model_ids = list(models_dict.keys())
 
     for model_id in model_ids:
-        glob_name = _create_glob_model_name(model_id)
+        # Add suffix glob pattern (strip dates/versions)
+        suffix_glob_name = _create_suffix_glob_model_name(model_id)
+        if suffix_glob_name != model_id and suffix_glob_name not in models_dict:
+            models_dict[suffix_glob_name] = models_dict[model_id]
 
-        if glob_name != model_id and glob_name not in models_dict:
-            models_dict[glob_name] = models_dict[model_id]
+            # Add prefix-suffix glob pattern (both wildcards) only for models that have a suffix glob
+            prefix_suffix_glob_name = _create_prefix_glob_model_name(suffix_glob_name)
+            if prefix_suffix_glob_name not in models_dict:
+                models_dict[prefix_suffix_glob_name] = models_dict[model_id]
+
+        # Add prefix glob pattern (wildcard prefix)
+        prefix_glob_name = _create_prefix_glob_model_name(model_id)
+        if prefix_glob_name not in models_dict:
+            models_dict[prefix_glob_name] = models_dict[model_id]
 
 
 @instrumented_task(


### PR DESCRIPTION
Improve fuzzy matching of models for more obscure model names. 

E.g. `us.anthropic.claude-sonnet-4-20250514-v1:0` wouldn't be matched before because of the uncommon prefix.

Closes [TET-1178: Calculate cost for more obscure model names](https://linear.app/getsentry/issue/TET-1178/calculate-cost-for-more-obscure-model-names) and [TET-1188: Famous models not recognized in costs](https://linear.app/getsentry/issue/TET-1188/famous-models-not-recognized-in-costs)
