### PR TITLE
fix(ui2): improve filter highlighting

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -291,8 +291,10 @@ const FilterWrapper = styled('div')<{state: 'invalid' | 'warning' | 'valid'}>`
   /* Ensures that filters do not grow outside of the container */
   min-width: 0;
 
-  :focus {
+  :focus,
+  &[aria-selected='true'] {
     background-color: ${p => p.theme.gray100};
+    border-color: ${p => (p.theme.isChonk ? p.theme.tokens.border.accent : undefined)};
     outline: none;
   }
 
@@ -308,10 +310,6 @@ const FilterWrapper = styled('div')<{state: 'invalid' | 'warning' | 'valid'}>`
             background-color: ${p.theme.gray100};
           `
         : ''}
-
-  &[aria-selected='true'] {
-    background-color: ${p => p.theme.gray100};
-  }
 `;
 
 const GridInvalidTokenTooltip = styled(InvalidTokenTooltip)`


### PR DESCRIPTION
In UI2, the input already has a darker background color, so just applying another background color for focussing isn’t enough signal to the user. As per the suggestion of @natemoo-re, we’re now also applying an accent border color.

This applies to both when pressing `cmd-A` to select all filters, as well as pressing backspace to focus the last filter.

In this comparison, `age` is focused. Especially in light mode, this was almost invisible:

| before | after |
|--------|--------|
| <img width="594" height="141" alt="Screenshot 2025-09-26 at 14 01 20" src="https://github.com/user-attachments/assets/f489f884-341c-4f32-810c-c6cd74ce6eb5" /> | <img width="610" height="127" alt="Screenshot 2025-09-26 at 14 02 03" src="https://github.com/user-attachments/assets/1ff85d83-c2b8-48bf-9e1e-c988ecfe7561" /> |
| <img width="577" height="130" alt="Screenshot 2025-09-26 at 14 01 28" src="https://github.com/user-attachments/assets/f3b107e0-f7eb-435c-adb9-12e0c860cdf4" /> | <img width="611" height="124" alt="Screenshot 2025-09-26 at 14 01 55" src="https://github.com/user-attachments/assets/343e531e-5e74-4fb2-9e42-084a9f1a4816" /> | 