### PR TITLE
feat(preprod): allow size to be marked as failed

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_size.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_size.py
@@ -1,0 +1,88 @@
+import logging
+from typing import Any, TypeVar, cast
+
+import orjson
+import pydantic
+from pydantic.tools import parse_obj_as
+from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactEndpoint
+from sentry.preprod.api.models.launchpad import PutSize
+from sentry.preprod.authentication import LaunchpadRpcSignatureAuthentication
+from sentry.preprod.models import PreprodArtifactSizeMetrics
+
+logger = logging.getLogger(__name__)
+
+
+T = TypeVar("T")
+
+
+def parse_request_with_pydantic(request: Request, model: type[T]) -> T:
+    """Parse request with the given Pydantic model"""
+    try:
+        j = orjson.loads(request.body)
+    except orjson.JSONDecodeError:
+        raise serializers.ValidationError("Invalid json")
+    try:
+        # When we have Pydantic 2 availble TypeAdapter on the model
+        # can be used instead of parse_obj_as
+        return parse_obj_as(model, j)
+    except pydantic.ValidationError:
+        raise serializers.ValidationError("Could not parse PutSize")
+
+
+@region_silo_endpoint
+class ProjectPreprodSizeWithIdentifierEndpoint(PreprodArtifactEndpoint):
+    owner = ApiOwner.EMERGE_TOOLS
+    publish_status = {
+        "PUT": ApiPublishStatus.PRIVATE,
+    }
+    authentication_classes = (LaunchpadRpcSignatureAuthentication,)
+    permission_classes = ()
+
+    def put(
+        self, request: Request, project, head_artifact_id, identifier, head_artifact
+    ) -> Response:
+        return do_put(request, project, identifier, head_artifact)
+
+
+@region_silo_endpoint
+class ProjectPreprodSizeEndpoint(PreprodArtifactEndpoint):
+    owner = ApiOwner.EMERGE_TOOLS
+    publish_status = {
+        "PUT": ApiPublishStatus.PRIVATE,
+    }
+    authentication_classes = (LaunchpadRpcSignatureAuthentication,)
+    permission_classes = ()
+
+    def put(self, request: Request, project, head_artifact_id, head_artifact) -> Response:
+        identifier = None
+        return do_put(request, project, identifier, head_artifact)
+
+
+def do_put(request: Request, project, identifier, head_artifact) -> Response:
+    put: PutSize = parse_request_with_pydantic(request, cast(Any, PutSize))
+
+    metrics, _ = PreprodArtifactSizeMetrics.objects.get_or_create(
+        preprod_artifact=head_artifact, identifier=identifier, identifier__isnull=identifier is None
+    )
+
+    match put.state:
+        case PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED:
+            metrics.state = put.state
+            metrics.error_code = put.error_code
+            metrics.error_message = put.error_message
+        case PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING:
+            metrics.state = put.state
+        case PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING:
+            metrics.state = put.state
+        case _:
+            assert False, "unreachable"
+    metrics.save()
+
+    return Response({"artifactId": head_artifact.id})

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -26,6 +26,10 @@ from .project_preprod_artifact_update import ProjectPreprodArtifactUpdateEndpoin
 from .project_preprod_build_details import ProjectPreprodBuildDetailsEndpoint
 from .project_preprod_check_for_updates import ProjectPreprodArtifactCheckForUpdatesEndpoint
 from .project_preprod_list_builds import ProjectPreprodListBuildsEndpoint
+from .project_preprod_size import (
+    ProjectPreprodSizeEndpoint,
+    ProjectPreprodSizeWithIdentifierEndpoint,
+)
 
 preprod_urlpatterns = [
     re_path(
@@ -116,5 +120,15 @@ preprod_internal_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/(?P<head_artifact_id>[^/]+)/assemble-generic/$",
         ProjectPreprodArtifactAssembleGenericEndpoint.as_view(),
         name="sentry-api-0-project-preprod-artifact-assemble-generic",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/(?P<head_artifact_id>[^/]+)/size/$",
+        ProjectPreprodSizeEndpoint.as_view(),
+        name="sentry-api-0-project-preprod-artifact-size",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/(?P<head_artifact_id>[^/]+)/size/(?P<identifier>[^/]+)/$",
+        ProjectPreprodSizeWithIdentifierEndpoint.as_view(),
+        name="sentry-api-0-project-preprod-artifact-size-identifier",
     ),
 ]

--- a/src/sentry/preprod/api/models/launchpad.py
+++ b/src/sentry/preprod/api/models/launchpad.py
@@ -1,0 +1,38 @@
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from sentry.preprod.models import PreprodArtifactSizeMetrics
+
+# For the API between launchpad and the monolith
+
+
+class PutSizeFailed(BaseModel):
+    model_config = ConfigDict()
+    state: Literal[PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED] = (
+        PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED
+    )
+    error_code: int
+    error_message: str
+
+
+class PutSizeProcessing(BaseModel):
+    model_config = ConfigDict()
+    state: Literal[PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING] = (
+        PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
+    )
+
+
+class PutSizePending(BaseModel):
+    model_config = ConfigDict()
+    state: Literal[PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING] = (
+        PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING
+    )
+
+
+# Missing SizeAnalysisState.COMPLETED is on purpose. The only way to mark
+# a size metrics as successful is via the assemble endpoint.
+PutSize = Annotated[
+    PutSizeFailed | PutSizePending | PutSizeProcessing,
+    Field(discriminator="state"),
+]

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_size.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_size.py
@@ -1,0 +1,163 @@
+import orjson
+from django.test import override_settings
+
+from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
+from sentry.testutils.auth import generate_service_request_signature
+from sentry.testutils.cases import TestCase
+
+SHARED_SERECT_FOR_TESTS = "test-secret-key"
+
+
+class ProjectPreprodSizeEndpointTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.file = self.create_file(name="test_artifact.apk", type="application/octet-stream")
+        self.artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            file_id=self.file.id,
+            state=PreprodArtifact.ArtifactState.UPLOADING,
+        )
+
+    def _put(self, data, identifier=None, secret=SHARED_SERECT_FOR_TESTS):
+        if identifier:
+            url = f"/api/0/internal/{self.organization.slug}/{self.project.slug}/files/preprodartifacts/{self.artifact.id}/size/{identifier}/"
+        else:
+            url = f"/api/0/internal/{self.organization.slug}/{self.project.slug}/files/preprodartifacts/{self.artifact.id}/size/"
+        signature = generate_service_request_signature(url, data, [secret], "Launchpad")
+        return self.client.put(
+            url,
+            data=data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"rpcsignature {signature}",
+        )
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_bad_auth(self) -> None:
+        response = self._put(b"{}", secret="wrong secret")
+        assert response.status_code == 401
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_missing_fields(self) -> None:
+        response = self._put(b"{}")
+        assert response.status_code == 400
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_bad_json(self) -> None:
+        response = self._put(b"{")
+        assert response.status_code == 400
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_invalid_state(self) -> None:
+        response = self._put(orjson.dumps({"state": 999}))
+        assert response.status_code == 400
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_bad_auth_with_identifier(self) -> None:
+        response = self._put(b"{}", identifier="some_feature", secret="wrong secret")
+        assert response.status_code == 401
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_bad_json_with_identifier(self) -> None:
+        response = self._put(b"{", identifier="some_feature")
+        assert response.status_code == 400
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_missing_fields_with_identifier(self) -> None:
+        response = self._put(b"{}", identifier="some_feature")
+        assert response.status_code == 400
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_invalid_state_with_identifier(self) -> None:
+        response = self._put(orjson.dumps({"state": 999}), identifier="some_feature")
+        assert response.status_code == 400
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_mark_as_failed(self) -> None:
+        PreprodArtifactSizeMetrics.objects.create(preprod_artifact=self.artifact)
+
+        response = self._put(
+            orjson.dumps({"state": 3, "error_code": 2, "error_message": "detailed reason"})
+        )
+
+        metrics = PreprodArtifactSizeMetrics.objects.get(preprod_artifact=self.artifact)
+
+        assert response.status_code == 200
+        assert metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED
+        assert metrics.error_code == 2
+        assert metrics.error_message == "detailed reason"
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_mark_as_failed_with_identifier(self) -> None:
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.artifact, identifier="some_feature"
+        )
+
+        response = self._put(
+            orjson.dumps({"state": 3, "error_code": 3, "error_message": "another detailed reason"}),
+            identifier="some_feature",
+        )
+
+        metrics = PreprodArtifactSizeMetrics.objects.get(
+            preprod_artifact=self.artifact, identifier="some_feature"
+        )
+        assert response.status_code == 200
+        assert metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED
+        assert metrics.error_code == 3
+        assert metrics.error_message == "another detailed reason"
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_mark_as_failed_multiple(self) -> None:
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.artifact, identifier="some_feature"
+        )
+        PreprodArtifactSizeMetrics.objects.create(preprod_artifact=self.artifact)
+
+        self._put(orjson.dumps({"state": 3, "error_code": 2, "error_message": "detailed reason"}))
+
+        metrics = PreprodArtifactSizeMetrics.objects.get(
+            preprod_artifact=self.artifact, identifier__isnull=True
+        )
+        assert metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_will_create_with_identifier(self) -> None:
+        self._put(
+            orjson.dumps({"state": 3, "error_code": 2, "error_message": "detailed reason"}),
+            identifier="some_feature",
+        )
+
+        metrics = PreprodArtifactSizeMetrics.objects.get(
+            preprod_artifact=self.artifact, identifier="some_feature"
+        )
+        assert metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_will_create(self) -> None:
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.artifact, identifier="wrong_one"
+        )
+
+        self._put(orjson.dumps({"state": 3, "error_code": 2, "error_message": "detailed reason"}))
+
+        metrics = PreprodArtifactSizeMetrics.objects.get(
+            preprod_artifact=self.artifact, identifier__isnull=True
+        )
+        assert metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_pending(self) -> None:
+        PreprodArtifactSizeMetrics.objects.create(preprod_artifact=self.artifact)
+
+        self._put(orjson.dumps({"state": 0}))
+
+        metrics = PreprodArtifactSizeMetrics.objects.get(preprod_artifact=self.artifact)
+        assert metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_processing(self) -> None:
+        PreprodArtifactSizeMetrics.objects.create(preprod_artifact=self.artifact)
+
+        self._put(orjson.dumps({"state": 1}))
+
+        metrics = PreprodArtifactSizeMetrics.objects.get(preprod_artifact=self.artifact)
+        assert metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING


### PR DESCRIPTION
Add a two new endpoints which allow size metrics (either core or additional - those with identifiers)
to be updated to FAILED, PROCESSING, or PENDING states via launchpad.
