### PR TITLE
ref(preprod): Remove redundant TypeError exception

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
@@ -113,7 +113,7 @@ class ProjectPreprodArtifactCheckForUpdatesEndpoint(ProjectEndpoint):
             if provided_build_number is not None:
                 try:
                     current_filter_kwargs["build_number"] = int(provided_build_number)
-                except (ValueError, TypeError):
+                except ValueError:
                     return Response({"error": "Invalid build_number format"}, status=400)
 
             if provided_build_configuration:


### PR DESCRIPTION
Remove redundant `TypeError` from exception handling in preprod check-for-updates endpoint.

Since `provided_build_number` is already checked for `None` before the try block, `int()` will only raise `ValueError` for invalid string conversions, making `TypeError` unnecessary.