### PR TITLE
fix(preprod): Use filter().first() to avoid MultipleObjectsReturned

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_pullrequest_details.py
+++ b/src/sentry/preprod/api/endpoints/organization_pullrequest_details.py
@@ -104,13 +104,12 @@ class OrganizationPullRequestDetailsEndpoint(OrganizationEndpoint):
 
 def get_github_client(organization: Organization, repo_name: str) -> GitHubApiClient | None:
     """Get the GitHub integration for this organization."""
-    try:
-        repository = Repository.objects.get(
-            organization_id=organization.id,
-            name=repo_name,
-            provider="integrations:github",
-        )
-    except Repository.DoesNotExist:
+    repository = Repository.objects.filter(
+        organization_id=organization.id,
+        name=repo_name,
+        provider="integrations:github",
+    ).first()
+    if not repository:
         logger.info(
             "preprod.pullrequest_files.no_repository",
             extra={

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -185,13 +185,12 @@ def _get_status_check_client(
     Returns None for expected failure cases (missing repo, integration, etc).
     Raises exceptions for unexpected errors that should be handled upstream.
     """
-    try:
-        repository = Repository.objects.get(
-            organization_id=project.organization_id,
-            name=commit_comparison.head_repo_name,
-            provider=f"integrations:{commit_comparison.provider}",
-        )
-    except Repository.DoesNotExist:
+    repository = Repository.objects.filter(
+        organization_id=project.organization_id,
+        name=commit_comparison.head_repo_name,
+        provider=f"integrations:{commit_comparison.provider}",
+    ).first()
+    if not repository:
         logger.info(
             "preprod.status_checks.create.no_repository",
             extra={


### PR DESCRIPTION
Replace `Repository.objects.get()` with `Repository.objects.filter().first()` in preprod endpoints to avoid `MultipleObjectsReturned` exceptions when duplicate repositories exist with the same (org_id, name, provider) combination.

## Changes

- **src/sentry/preprod/vcs/status_checks/size/tasks.py**: Updated `_get_status_check_client()` function to use `filter().first()`
- **src/sentry/preprod/api/endpoints/organization_pullrequest_details.py**: Updated `get_github_client()` function to use `filter().first()`

## Background

This addresses feedback from Hector in EME-312 that the (org_id, name, provider) combination is not always unique in the database, which can cause `MultipleObjectsReturned` exceptions when using `Repository.objects.get()`.

Using `filter().first()` returns the first matching repository or `None` if no match is found, avoiding the exception while maintaining the same functionality.

Fixes EME-312