### PR TITLE
feat(preprod): Make main_binary_identifier optional in check-for-updates endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
@@ -66,8 +66,14 @@ class ProjectPreprodArtifactCheckForUpdatesEndpoint(ProjectEndpoint):
         provided_build_number = request.GET.get("build_number")
         provided_build_configuration_name = request.GET.get("build_configuration")
 
-        if not app_id or not platform or not provided_build_version or not main_binary_identifier:
+        if not app_id or not platform or not provided_build_version:
             return Response({"error": "Missing required parameters"}, status=400)
+
+        if not main_binary_identifier and not provided_build_number:
+            return Response(
+                {"error": "Either main_binary_identifier or build_number must be provided"},
+                status=400,
+            )
 
         provided_build_configuration = None
         if provided_build_configuration_name:
@@ -104,10 +110,13 @@ class ProjectPreprodArtifactCheckForUpdatesEndpoint(ProjectEndpoint):
             current_filter_kwargs = get_base_filters()
             current_filter_kwargs.update(
                 {
-                    "main_binary_identifier": main_binary_identifier,
                     "build_version": provided_build_version,
                 }
             )
+
+            # Add main_binary_identifier filter if provided
+            if main_binary_identifier:
+                current_filter_kwargs["main_binary_identifier"] = main_binary_identifier
 
             # Add build_number filter if provided
             if provided_build_number is not None:


### PR DESCRIPTION
## Summary

- Made `main_binary_identifier` parameter optional in the preprod check-for-updates endpoint
- Updated filter logic to conditionally include `main_binary_identifier` when provided
- Added test to verify the endpoint works without the parameter

This allows clients to query for updates without needing to specify a specific binary identifier, making the endpoint more flexible for use cases where the identifier may not be available.