### PR TITLE
[fix] Update overwatch_rpc to directly use base64 encoded secret instead of decoding

### DIFF
--- a/src/sentry/overwatch/endpoints/overwatch_rpc.py
+++ b/src/sentry/overwatch/endpoints/overwatch_rpc.py
@@ -1,4 +1,3 @@
-import base64
 import hashlib
 import hmac
 import logging
@@ -38,27 +37,31 @@ def compare_signature(request: Request, signature: str) -> bool:
 
     - Header format: `Authorization: Rpcsignature rpc0:<hex>`
     - Input: raw body bytes
-    - Secret is base64-encoded in settings.OVERWATCH_RPC_SHARED_SECRET
+    - Secret exists in settings.OVERWATCH_RPC_SHARED_SECRET
     """
     if not settings.OVERWATCH_RPC_SHARED_SECRET:
         raise AuthenticationFailed("Missing OVERWATCH shared secret")
 
     if not signature.startswith("rpc0:"):
-        logger.error("Overwatch signature validation failed: invalid signature prefix")
-        return False
+        raise AuthenticationFailed("Invalid signature prefix: expected 'rpc0:'")
 
     try:
-        _, signature_data = signature.split(":", 2)
-        message = _signature_input_from_request(request)
-        for b64_secret in settings.OVERWATCH_RPC_SHARED_SECRET:
-            secret_bytes = base64.b64decode(b64_secret)
-            computed = hmac.new(secret_bytes, message, hashlib.sha256).hexdigest()
-            if hmac.compare_digest(computed.encode(), signature_data.encode()):
-                return True
-        return False
-    except Exception:
-        logger.exception("Overwatch signature validation failed")
-        return False
+        _, signature_data = signature.split(":", 1)
+    except ValueError:
+        raise AuthenticationFailed("Invalid Authorization format. Expected 'rpc0:<hex>'")
+
+    message = _signature_input_from_request(request)
+    expected_digests: list[str] = []
+    for secret in settings.OVERWATCH_RPC_SHARED_SECRET:
+        secret_bytes = secret.encode()
+        computed = hmac.new(secret_bytes, message, hashlib.sha256).hexdigest()
+        expected_digests.append(computed)
+        if hmac.compare_digest(computed, signature_data):
+            return True
+
+    raise AuthenticationFailed(
+        f"Signature mismatch; expected any of {expected_digests}, got {signature_data}"
+    )
 
 
 @AuthenticationSiloLimit(SiloMode.CONTROL, SiloMode.REGION)
@@ -73,8 +76,7 @@ class OverwatchRpcSignatureAuthentication(StandardAuthentication):
         return auth[0].lower() == self.token_name
 
     def authenticate_token(self, request: Request, token: str) -> tuple[Any, Any]:
-        if not compare_signature(request, token):
-            raise AuthenticationFailed("Invalid signature")
+        compare_signature(request, token)
 
         sentry_sdk.get_isolation_scope().set_tag("overwatch_rpc_auth", True)
 

--- a/src/sentry/overwatch/endpoints/overwatch_rpc.py
+++ b/src/sentry/overwatch/endpoints/overwatch_rpc.py
@@ -53,8 +53,7 @@ def compare_signature(request: Request, signature: str) -> bool:
     message = _signature_input_from_request(request)
     expected_digests: list[str] = []
     for secret in settings.OVERWATCH_RPC_SHARED_SECRET:
-        secret_bytes = secret.encode()
-        computed = hmac.new(secret_bytes, message, hashlib.sha256).hexdigest()
+        computed = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
         expected_digests.append(computed)
         if hmac.compare_digest(computed, signature_data):
             return True

--- a/src/sentry/overwatch/endpoints/overwatch_rpc.py
+++ b/src/sentry/overwatch/endpoints/overwatch_rpc.py
@@ -51,16 +51,15 @@ def compare_signature(request: Request, signature: str) -> bool:
         raise AuthenticationFailed("Invalid Authorization format. Expected 'rpc0:<hex>'")
 
     message = _signature_input_from_request(request)
-    expected_digests: list[str] = []
     for secret in settings.OVERWATCH_RPC_SHARED_SECRET:
         computed = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
-        expected_digests.append(computed)
         if hmac.compare_digest(computed, signature_data):
             return True
 
-    raise AuthenticationFailed(
-        f"Signature mismatch; expected any of {expected_digests}, got {signature_data}"
-    )
+    body_len = len(message)
+    sig_len = len(signature_data)
+
+    raise AuthenticationFailed(f"Signature mismatch. body_len={body_len} sig_len={sig_len}")
 
 
 @AuthenticationSiloLimit(SiloMode.CONTROL, SiloMode.REGION)

--- a/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
+++ b/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
@@ -1,4 +1,3 @@
-import base64
 import hashlib
 import hmac
 from unittest.mock import patch
@@ -10,16 +9,15 @@ from sentry.testutils.cases import APITestCase
 
 
 class TestPreventPrReviewResolvedConfigsEndpoint(APITestCase):
-    def _auth_header_for_get(self, url: str, params: dict[str, str], b64_secret: str) -> str:
-        secret_bytes = base64.b64decode(b64_secret)
+    def _auth_header_for_get(self, url: str, params: dict[str, str], secret: str) -> str:
         # For GET we sign an empty JSON array body per Rpcsignature rpc0
         message = b"[]"
-        signature = hmac.new(secret_bytes, message, hashlib.sha256).hexdigest()
+        signature = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
         return f"Rpcsignature rpc0:{signature}"
 
     @patch(
         "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
-        [base64.b64encode(b"test-secret").decode()],
+        ["test-secret"],
     )
     def test_requires_auth(self):
         url = reverse("sentry-api-0-prevent-pr-review-configs-resolved")
@@ -29,24 +27,22 @@ class TestPreventPrReviewResolvedConfigsEndpoint(APITestCase):
 
     @patch(
         "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
-        [base64.b64encode(b"test-secret").decode()],
+        ["test-secret"],
     )
     def test_missing_required_params_returns_400(self):
         url = reverse("sentry-api-0-prevent-pr-review-configs-resolved")
-        b64_secret = base64.b64encode(b"test-secret").decode()
-        auth = self._auth_header_for_get(url, {}, b64_secret)
+        auth = self._auth_header_for_get(url, {}, "test-secret")
         resp = self.client.get(url, HTTP_AUTHORIZATION=auth)
         assert resp.status_code == 400
 
     @patch(
         "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
-        [base64.b64encode(b"test-secret").decode()],
+        ["test-secret"],
     )
     def test_success_returns_empty_config_dict(self):
         url = reverse("sentry-api-0-prevent-pr-review-configs-resolved")
         params = {"ghOrg": "acme", "repo": "acme/repo"}
-        b64_secret = base64.b64encode(b"test-secret").decode()
-        auth = self._auth_header_for_get(url, params, b64_secret)
+        auth = self._auth_header_for_get(url, params, "test-secret")
         resp = self.client.get(url, params, HTTP_AUTHORIZATION=auth)
         assert resp.status_code == 200
         assert resp.data == {}
@@ -54,15 +50,14 @@ class TestPreventPrReviewResolvedConfigsEndpoint(APITestCase):
 
 
 class TestPreventPrReviewSentryOrgEndpoint(APITestCase):
-    def _auth_header_for_get(self, url: str, params: dict[str, str], b64_secret: str) -> str:
-        secret_bytes = base64.b64decode(b64_secret)
+    def _auth_header_for_get(self, url: str, params: dict[str, str], secret: str) -> str:
         message = b"[]"
-        signature = hmac.new(secret_bytes, message, hashlib.sha256).hexdigest()
+        signature = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
         return f"Rpcsignature rpc0:{signature}"
 
     @patch(
         "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
-        [base64.b64encode(b"test-secret").decode()],
+        ["test-secret"],
     )
     def test_requires_auth(self):
         url = reverse("sentry-api-0-prevent-pr-review-github-sentry-org")
@@ -71,25 +66,23 @@ class TestPreventPrReviewSentryOrgEndpoint(APITestCase):
 
     @patch(
         "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
-        [base64.b64encode(b"test-secret").decode()],
+        ["test-secret"],
     )
     def test_missing_required_params_returns_400(self):
         url = reverse("sentry-api-0-prevent-pr-review-github-sentry-org")
-        b64_secret = base64.b64encode(b"test-secret").decode()
-        auth = self._auth_header_for_get(url, {}, b64_secret)
+        auth = self._auth_header_for_get(url, {}, "test-secret")
 
         resp = self.client.get(url, HTTP_AUTHORIZATION=auth)
         assert resp.status_code == 400
 
     @patch(
         "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
-        [base64.b64encode(b"test-secret").decode()],
+        ["test-secret"],
     )
     def test_returns_empty_list_when_no_repos_found(self):
         url = reverse("sentry-api-0-prevent-pr-review-github-sentry-org")
         params = {"repoId": "456"}
-        b64_secret = base64.b64encode(b"test-secret").decode()
-        auth = self._auth_header_for_get(url, params, b64_secret)
+        auth = self._auth_header_for_get(url, params, "test-secret")
 
         resp = self.client.get(url, params, HTTP_AUTHORIZATION=auth)
         assert resp.status_code == 200
@@ -97,7 +90,7 @@ class TestPreventPrReviewSentryOrgEndpoint(APITestCase):
 
     @patch(
         "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
-        [base64.b64encode(b"test-secret").decode()],
+        ["test-secret"],
     )
     def test_returns_org_ids_with_consent(self):
 
@@ -127,8 +120,7 @@ class TestPreventPrReviewSentryOrgEndpoint(APITestCase):
 
         url = reverse("sentry-api-0-prevent-pr-review-github-sentry-org")
         params = {"repoId": repo_id}
-        b64_secret = base64.b64encode(b"test-secret").decode()
-        auth = self._auth_header_for_get(url, params, b64_secret)
+        auth = self._auth_header_for_get(url, params, "test-secret")
 
         resp = self.client.get(url, params, HTTP_AUTHORIZATION=auth)
         assert resp.status_code == 200
@@ -146,7 +138,7 @@ class TestPreventPrReviewSentryOrgEndpoint(APITestCase):
 
     @patch(
         "sentry.overwatch.endpoints.overwatch_rpc.settings.OVERWATCH_RPC_SHARED_SECRET",
-        [base64.b64encode(b"test-secret").decode()],
+        ["test-secret"],
     )
     def test_filters_inactive_repositories(self):
         org = self.create_organization()
@@ -168,8 +160,7 @@ class TestPreventPrReviewSentryOrgEndpoint(APITestCase):
 
         url = reverse("sentry-api-0-prevent-pr-review-github-sentry-org")
         params = {"repoId": repo_id}
-        b64_secret = base64.b64encode(b"test-secret").decode()
-        auth = self._auth_header_for_get(url, params, b64_secret)
+        auth = self._auth_header_for_get(url, params, "test-secret")
 
         resp = self.client.get(url, params, HTTP_AUTHORIZATION=auth)
         assert resp.status_code == 200


### PR DESCRIPTION
<!-- Describe your PR here. -->

Add logs useful for debugging and use b64 encoding secret on the overwatch side directly to sign requests. 

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
