### PR TITLE
fix(checkout v3): Don't render budget mode changes w/o budgets set

### DIFF
--- a/static/gsApp/views/amCheckout/cartDiff.spec.tsx
+++ b/static/gsApp/views/amCheckout/cartDiff.spec.tsx
@@ -1,0 +1,182 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {OnDemandBudgetMode, type Plan, type Subscription} from 'getsentry/types';
+import CartDiff from 'getsentry/views/amCheckout/cartDiff';
+import {SelectableProduct, type CheckoutFormData} from 'getsentry/views/amCheckout/types';
+
+describe('CartDiff', () => {
+  const bizPlan = PlanDetailsLookupFixture('am3_business')!;
+  const teamAnnualPlan = PlanDetailsLookupFixture('am3_team_auf')!;
+  const org = OrganizationFixture();
+  const sub = SubscriptionFixture({
+    organization: org,
+    plan: teamAnnualPlan.id,
+    isFree: false,
+  });
+  const defaultFormData: CheckoutFormData = {
+    plan: teamAnnualPlan.id,
+    reserved: {
+      ...Object.fromEntries(
+        Object.entries(sub.categories)
+          .filter(([_, history]) => history.reserved)
+          .map(([category, history]) => [category, history.reserved])
+      ),
+    },
+  };
+
+  function renderCartDiff({
+    activePlan = teamAnnualPlan,
+    formData,
+    subscription = sub,
+  }: {
+    formData: CheckoutFormData;
+    activePlan?: Plan;
+    subscription?: Subscription;
+  }) {
+    render(
+      <CartDiff
+        activePlan={activePlan}
+        formData={formData}
+        subscription={subscription}
+        isOpen
+        onToggle={() => {}}
+        organization={org}
+      />
+    );
+  }
+
+  it('renders for returning customers with changes', async () => {
+    const formData: CheckoutFormData = {
+      ...defaultFormData,
+      plan: bizPlan.id,
+      reserved: {
+        ...defaultFormData.reserved,
+        errors: 100_000,
+      },
+      onDemandBudget: {
+        budgetMode: OnDemandBudgetMode.SHARED,
+        sharedMaxBudget: 100_00,
+      },
+      selectedProducts: {
+        [SelectableProduct.SEER]: {
+          enabled: true,
+        },
+      },
+    };
+
+    renderCartDiff({formData, activePlan: bizPlan});
+
+    expect(await screen.findByText('Changes (5)')).toBeInTheDocument();
+    const planDiff = await screen.findByTestId('plan-diff');
+    const reservedDiff = await screen.findByTestId('reserved-diff');
+    const paygDiff = await screen.findByTestId('shared-spend-limit-diff');
+    expect(screen.queryByTestId('per-category-spend-limit-diff')).not.toBeInTheDocument();
+
+    expect(planDiff).toHaveTextContent('Plan');
+    expect(planDiff).toHaveTextContent('TeamBusiness');
+    expect(planDiff).toHaveTextContent('YearlyMonthly');
+    expect(planDiff).toHaveTextContent('Seer');
+
+    expect(reservedDiff).toHaveTextContent('Reserved volume');
+    expect(reservedDiff).toHaveTextContent('Errors50K100K');
+    expect(reservedDiff).not.toHaveTextContent('Replays'); // doesn't show any other categories if there are no changes
+
+    expect(paygDiff).toHaveTextContent('PAYG spend limit');
+    expect(paygDiff).toHaveTextContent('$0$100');
+  });
+
+  it('does not render for returning customers with no changes', () => {
+    renderCartDiff({formData: defaultFormData});
+    expect(screen.queryByTestId('cart-diff')).not.toBeInTheDocument();
+  });
+
+  it('does not render for new customers', () => {
+    const newSub = SubscriptionFixture({
+      organization: org,
+      plan: 'am3_f',
+    });
+    renderCartDiff({formData: defaultFormData, subscription: newSub});
+    expect(screen.queryByTestId('cart-diff')).not.toBeInTheDocument();
+  });
+
+  it('renders shared to per-category spend limits', async () => {
+    const formData: CheckoutFormData = {
+      ...defaultFormData,
+      onDemandBudget: {
+        budgetMode: OnDemandBudgetMode.PER_CATEGORY,
+        budgets: {
+          errors: 10_00,
+        },
+      },
+    };
+
+    renderCartDiff({formData});
+
+    expect(await screen.findByText('Changes (2)')).toBeInTheDocument();
+    const paygDiff = await screen.findByTestId('shared-spend-limit-diff');
+    expect(paygDiff).toHaveTextContent('PAYG spend limit');
+    expect(paygDiff).toHaveTextContent('$0');
+
+    const perCategoryDiff = await screen.findByTestId('per-category-spend-limit-diff');
+    expect(perCategoryDiff).toHaveTextContent('Per-category spend limits');
+    expect(perCategoryDiff).toHaveTextContent('Errors$10');
+  });
+
+  it('renders per-category to shared spend limits', async () => {
+    const perCategorySub = SubscriptionFixture({
+      organization: org,
+      plan: teamAnnualPlan.id,
+      onDemandBudgets: {
+        budgetMode: OnDemandBudgetMode.PER_CATEGORY,
+        budgets: {
+          errors: 10_00,
+          replays: 20_00,
+        },
+        enabled: true,
+        usedSpends: {
+          errors: 0,
+        },
+      },
+      isFree: false,
+    });
+
+    const formData: CheckoutFormData = {
+      ...defaultFormData,
+      onDemandBudget: {
+        budgetMode: OnDemandBudgetMode.SHARED,
+        sharedMaxBudget: 10_00,
+      },
+    };
+
+    renderCartDiff({formData, subscription: perCategorySub});
+    expect(await screen.findByText('Changes (3)')).toBeInTheDocument();
+    const paygDiff = await screen.findByTestId('shared-spend-limit-diff');
+    expect(paygDiff).toHaveTextContent('PAYG spend limit');
+    expect(paygDiff).toHaveTextContent('$10');
+
+    const perCategoryDiff = await screen.findByTestId('per-category-spend-limit-diff');
+    expect(perCategoryDiff).toHaveTextContent('Per-category spend limits');
+    expect(perCategoryDiff).toHaveTextContent('Errors$10');
+    expect(perCategoryDiff).toHaveTextContent('Replays$20');
+  });
+
+  it('does not render budget mode change if budgets are $0', () => {
+    const formData: CheckoutFormData = {
+      ...defaultFormData,
+      onDemandBudget: {
+        budgetMode: OnDemandBudgetMode.PER_CATEGORY,
+        budgets: {
+          errors: 0,
+        },
+      },
+    };
+
+    renderCartDiff({formData});
+
+    expect(screen.queryByTestId('cart-diff')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes a bug where we'd show every single category when changing from shared to per-category and vice versa, even if the budget for that category was $0 (see Linear ticket for screenshot).

If switching modes but all budgets are set to $0, no changes are shown.

# shared to per-category
<img width="430" height="242" alt="Screenshot 2025-09-26 at 11 16 28 AM" src="https://github.com/user-attachments/assets/05e7ce1d-8d8c-43fb-86c9-903d82547df3" />

# per-category to shared
<img width="428" height="267" alt="Screenshot 2025-09-26 at 11 16 09 AM" src="https://github.com/user-attachments/assets/08c32727-14e2-49bb-9f1e-221c7a98151a" />
