### PR TITLE
chore(explore): Tidy up Snuba referrers on backend

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -109,6 +109,8 @@ class Referrer(StrEnum):
     API_GROUP_HASHES = "api.group-hashes"
 
     # ** Explore **
+    API_EXPLORE_SPANS_STATS = "api.explore.spans-stats"
+    API_EXPLORE_SPANS_TIMESERIES = "api.explore.spans-timeseries"
     API_EXPLORE_SPANS_AGGREGATES_TABLE = "api.explore.spans-aggregates-table"
     API_EXPLORE_SPANS_SAMPLES_TABLE = "api.explore.spans-samples-table"
     API_EXPLORE_SPANS_EXTRAPOLATION_META = "api.explore.spans-extrapolation-meta"

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -95,12 +95,6 @@ class Referrer(StrEnum):
     API_DISCOVER_TRANSACTIONS_LIST = "api.discover.transactions-list"
     API_EVENTS_MEASUREMENTS = "api.events.measurements"
     API_EVENTS_VITALS = "api.events.vitals"
-    API_EXPLORE_SPANS_AGGREGATES_TABLE = "api.explore.spans-aggregates-table"
-    API_EXPLORE_SPANS_SAMPLES_TABLE = "api.explore.spans-samples-table"
-    API_EXPLORE_SPANS_EXTRAPOLATION_META = "api.explore.spans-extrapolation-meta"
-    API_EXPLORE_LOGS_TABLE = "api.explore.logs-table"
-    API_EXPLORE_LOGS_TABLE_ROW = "api.explore.logs-table-row"
-    DATA_EXPORT_TASKS_EXPLORE = "data_export.tasks.explore"
     API_GROUP_AI_AUTOFIX = "api.group_ai_autofix"
     API_GROUP_AI_SUMMARY = "api.group_ai_summary"
     API_GROUP_EVENTS_ERROR_DIRECT_HIT = "api.group-events.error.direct-hit"
@@ -113,6 +107,14 @@ class Referrer(StrEnum):
     )
     API_GROUP_HASHES_LEVELS_GET_LEVELS_OVERVIEW = "api.group_hashes_levels.get_levels_overview"
     API_GROUP_HASHES = "api.group-hashes"
+
+    # ** Explore **
+    API_EXPLORE_SPANS_AGGREGATES_TABLE = "api.explore.spans-aggregates-table"
+    API_EXPLORE_SPANS_SAMPLES_TABLE = "api.explore.spans-samples-table"
+    API_EXPLORE_SPANS_EXTRAPOLATION_META = "api.explore.spans-extrapolation-meta"
+    API_EXPLORE_LOGS_TABLE = "api.explore.logs-table"
+    API_EXPLORE_LOGS_TABLE_ROW = "api.explore.logs-table-row"
+    DATA_EXPORT_TASKS_EXPLORE = "data_export.tasks.explore"
 
     # ** Insights **
 


### PR DESCRIPTION
1. Moves the Explore referrers to their own section, for cleanliness
2. Adds a new referrer `"api.explore.spans-stats"`. Right now, Explore chart uses the referrer `"api.explorer.stats"` which doesn't follow the same convention as the other Explore referrers, and isn't defined (front-end change will be separate)
3. Adds a new referrer for `"api.explore.span-timeseries"` for the conversion to use the `/events-timeseries/` endpoint in Explore
