### PR TITLE
fix(timeseries): Improve marking delayed data on frontend

### DIFF
--- a/static/app/utils/timeSeries/markDelayedData.tsx
+++ b/static/app/utils/timeSeries/markDelayedData.tsx
@@ -28,12 +28,16 @@ export function markDelayedData(timeSeries: TimeSeries, delay: number): TimeSeri
       }
 
       if (!delayed) {
-        return datum;
+        return {
+          ...datum,
+          incomplete: false,
+        };
       }
 
       return {
         ...datum,
         incomplete: true,
+        incompleteReason: 'INCOMPLETE_BUCKET',
       };
     }),
   };

--- a/static/app/utils/timeSeries/segmentTimeSeriesByIncompleteData.spec.tsx
+++ b/static/app/utils/timeSeries/segmentTimeSeriesByIncompleteData.spec.tsx
@@ -50,14 +50,17 @@ describe('segmentTimeSeriesByIncompleteData', () => {
       {
         value: 90,
         timestamp: 1729785240000, // '2024-10-24T15:54:00.000Z'
+        incomplete: false,
       },
       {
         value: 100,
         timestamp: 1729785300000, // '2024-10-24T15:55:00.000Z'
+        incomplete: false,
       },
       {
         value: 110,
         timestamp: 1729785360000, // '2024-10-24T15:56:00.000Z'
+        incomplete: false,
       },
     ]);
 
@@ -106,21 +109,25 @@ describe('segmentTimeSeriesByIncompleteData', () => {
         value: 90,
         timestamp: 1729785485000, // '2024-10-24T15:58:05.000Z'
         incomplete: true,
+        incompleteReason: 'INCOMPLETE_BUCKET',
       },
       {
         value: 100,
         timestamp: 1729785490000, // '2024-10-24T15:58:10.000Z'
         incomplete: true,
+        incompleteReason: 'INCOMPLETE_BUCKET',
       },
       {
         value: 110,
         timestamp: 1729785495000, // '2024-10-24T15:58:15.000Z'
         incomplete: true,
+        incompleteReason: 'INCOMPLETE_BUCKET',
       },
       {
         value: 120,
         timestamp: 1729785500000, // '2024-10-24T15:58:20.000Z'
         incomplete: true,
+        incompleteReason: 'INCOMPLETE_BUCKET',
       },
     ]);
   });
@@ -168,10 +175,12 @@ describe('segmentTimeSeriesByIncompleteData', () => {
       {
         value: 100,
         timestamp: 1729785300000, // '2024-10-24T15:55:00.000Z'
+        incomplete: false,
       },
       {
         value: 110,
         timestamp: 1729785360000, // '2024-10-24T15:56:00.000Z'
+        incomplete: false,
       },
     ]);
 
@@ -179,21 +188,25 @@ describe('segmentTimeSeriesByIncompleteData', () => {
       {
         value: 110,
         timestamp: 1729785360000, // '2024-10-24T15:56:00.000Z'
+        incomplete: false,
       },
       {
         value: 120,
         timestamp: 1729785420000, // '2024-10-24T15:57:00.000Z'
         incomplete: true,
+        incompleteReason: 'INCOMPLETE_BUCKET',
       },
       {
         value: 130,
         timestamp: 1729785480000, // '2024-10-24T15:58:00.000Z'
         incomplete: true,
+        incompleteReason: 'INCOMPLETE_BUCKET',
       },
       {
         value: 140,
         timestamp: 1729785540000, // '2024-10-24T15:59:00.000Z'
         incomplete: true,
+        incompleteReason: 'INCOMPLETE_BUCKET',
       },
     ]);
   });
@@ -239,14 +252,17 @@ describe('segmentTimeSeriesByIncompleteData', () => {
       {
         value: 110,
         timestamp: 1729771200000, // '2024-10-24T12:00:00.000Z'
+        incomplete: false,
       },
       {
         value: 120,
         timestamp: 1729774800000, // '2024-10-24T13:00:00.000Z'
+        incomplete: false,
       },
       {
         value: 130,
         timestamp: 1729778400000, // '2024-10-24T14:00:00.000Z'
+        incomplete: false,
       },
     ]);
 
@@ -254,11 +270,13 @@ describe('segmentTimeSeriesByIncompleteData', () => {
       {
         value: 130,
         timestamp: 1729778400000, // '2024-10-24T14:00:00.000Z'
+        incomplete: false,
       },
       {
         value: 140,
         timestamp: 1729782000000, // '2024-10-24T15:00:00.000Z'
         incomplete: true,
+        incompleteReason: 'INCOMPLETE_BUCKET',
       },
     ]);
   });


### PR DESCRIPTION
On the backend, all points have an `"incomplete"` property, not just the incomplete ones! Also, "incomplete" points have a reason string, and right now it's always the same.

Updating the frontend incompleteness marking function to match the backend behaviour.
