### PR TITLE
fix(timeseries): Fix `TimeSeries` value type and unit typing

### DIFF
--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -23,16 +23,25 @@ type TimeSeriesValueType = AttributeValueType;
 export type TimeSeriesValueUnit = AttributeValueUnit;
 export type TimeSeriesMeta = {
   /**
-   * Difference between the timestamps of the datapoints, in milliseconds
+   * Difference between the timestamps of the datapoints, in milliseconds.
    */
   interval: number;
+  /**
+   * The type of the values (e.g., "duration")
+   */
   valueType: TimeSeriesValueType;
   dataScanned?: 'partial' | 'full';
+  /**
+   * `isOther` is true if this `TimeSeries` is the result of a `groupBy` query, and this is the "other" group.
+   */
   isOther?: boolean;
   /**
    * For a top N request, the order is the position of this `TimeSeries` within the respective yAxis.
    */
   order?: number;
+  /**
+   * The unit of the values, if available. The value unit is null if the value type is unitless (e.g., "number"). The value unit may be missing altogether if the Y axis of the time series is something unknown.
+   */
   valueUnit?: TimeSeriesValueUnit;
 };
 

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -14,8 +14,7 @@ type AttributeValueType =
   | 'size'
   | 'rate'
   | 'score'
-  | 'currency'
-  | null;
+  | 'currency';
 
 type AttributeValueUnit = DataUnit | null;
 
@@ -30,6 +29,10 @@ export type TimeSeriesMeta = {
    * The type of the values (e.g., "duration")
    */
   valueType: TimeSeriesValueType;
+  /**
+   * The unit of the values, if available. The value unit is null if the value type is unitless (e.g., "number"), or the unit could not be determined (this is usually an error case).
+   */
+  valueUnit: TimeSeriesValueUnit;
   dataScanned?: 'partial' | 'full';
   /**
    * `isOther` is true if this `TimeSeries` is the result of a `groupBy` query, and this is the "other" group.
@@ -39,10 +42,6 @@ export type TimeSeriesMeta = {
    * For a top N request, the order is the position of this `TimeSeries` within the respective yAxis.
    */
   order?: number;
-  /**
-   * The unit of the values, if available. The value unit is null if the value type is unitless (e.g., "number"). The value unit may be missing altogether if the Y axis of the time series is something unknown.
-   */
-  valueUnit?: TimeSeriesValueUnit;
 };
 
 export type TimeSeriesItem = {

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -89,7 +89,7 @@ export type TimeSeries = {
   groupBy?: TimeSeriesGroupBy[];
 };
 
-export type TabularValueType = AttributeValueType;
+export type TabularValueType = AttributeValueType | null;
 export type TabularValueUnit = AttributeValueUnit;
 export type TabularMeta<TFields extends string = string> = {
   fields: Record<TFields, TabularValueType>;
@@ -109,7 +109,7 @@ export type TabularData<TFields extends string = string> = {
 export type TabularColumn<TFields extends string = string> = {
   key: TFields;
   sortable?: boolean;
-  type?: AttributeValueType;
+  type?: TabularValueType;
   width?: number;
 };
 

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -27,13 +27,13 @@ export type TimeSeriesMeta = {
    */
   interval: number;
   valueType: TimeSeriesValueType;
-  valueUnit: TimeSeriesValueUnit;
   dataScanned?: 'partial' | 'full';
   isOther?: boolean;
   /**
    * For a top N request, the order is the position of this `TimeSeries` within the respective yAxis.
    */
   order?: number;
+  valueUnit?: TimeSeriesValueUnit;
 };
 
 export type TimeSeriesItem = {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -1215,7 +1215,7 @@ function hasTimestamp(release: Partial<Release>): release is Release {
 }
 
 const NULL_META: TimeSeriesMeta = {
-  valueType: null,
+  valueType: 'number',
   valueUnit: null,
   interval: 0,
 };

--- a/static/app/views/insights/common/utils/convertSeriesToTimeseries.tsx
+++ b/static/app/views/insights/common/utils/convertSeriesToTimeseries.tsx
@@ -23,7 +23,7 @@ export function convertSeriesToTimeseries(series: DiscoverSeries): TimeSeries {
     values,
     meta: {
       // This behavior is a little awkward. Normally `meta` shouldn't be missing, but we sometime return blank meta from helper hooks
-      valueType: series.meta?.fields?.[series.seriesName] ?? null,
+      valueType: series.meta?.fields?.[series.seriesName] ?? 'number',
       valueUnit: (series.meta?.units?.[series.seriesName] ?? null) as DataUnit,
       interval,
     },


### PR DESCRIPTION
A few updates, to match up with reality (and updated decisions and understanding)

1. For `TimeSeries`, the `valueType` is never `null`! I left the _table_ `valueType` alone for now, just to keep the PR more focused, but for `TimeSeries` we will expect to always have a type
2. `valueUnit` will always be provided, so it's not options, but it _may_ be `null`
3. Added some comments to explain all this in more detail