### PR TITLE
fix(explore): Remove project link from span description

### DIFF
--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -357,7 +357,7 @@ function CellAction({
   });
   const align = fieldAlignment(column.key as string, column.type);
 
-  if (useCellActionsV2 && triggerType === ActionTriggerType.BOLD_HOVER)
+  if (useCellActionsV2 && triggerType === ActionTriggerType.BOLD_HOVER) {
     return (
       <Container
         data-test-id={cellActions === null ? undefined : 'cell-action-container'}
@@ -409,6 +409,7 @@ function CellAction({
         )}
       </Container>
     );
+  }
 
   return (
     <Container data-test-id={cellActions === null ? undefined : 'cell-action-container'}>

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -239,6 +239,7 @@ function spanDescriptionRenderFunc(projects: Record<string, Project>) {
                 avatarSize={16}
                 avatarProps={{hasTooltip: true, tooltip: project.slug}}
                 hideName
+                disableLink
               />
             )}
             <WrappingText>


### PR DESCRIPTION
This removes the project link from the span description column in explore. This is because cell actions v2 takes the first link it finds within the rendered field and inserts an open link option in the dropdown. In this context, it was mistakenly taking users to the project details page.