### PR TITLE
fix(aci): Add back alerts sidebar link during alpha

### DIFF
--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -111,6 +111,13 @@ function ConfigureSection({baseUrl}: {baseUrl: string}) {
           >
             {t('Automations')}
           </SecondaryNav.Item>
+          <SecondaryNav.Item
+            to={`${baseUrl}/alerts/rules/`}
+            activeTo={`${baseUrl}/alerts/`}
+            analyticsItemName="issues_alerts"
+          >
+            {t('Alerts')}
+          </SecondaryNav.Item>
         </Fragment>
       ) : (
         <SecondaryNav.Item


### PR DESCRIPTION
It's annoying to get back to the alerts ui for testing. We can remove it again later.

<img width="224" height="180" alt="image" src="https://github.com/user-attachments/assets/593bbcac-ef42-4e47-b00a-68464ad1c812" />
