### PR TITLE
chore(billing): canProductTrial

### DIFF
--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -209,12 +209,8 @@ export const BILLED_DATA_CATEGORY_INFO = {
   [DataCategoryExact.PREVENT_USER]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.PREVENT_USER],
     feature: 'prevent-billing',
+    canProductTrial: true,
     maxAdminGift: 10_000, // TODO(prevent): Update this to the actual max admin gift
     tallyType: 'seat',
-  },
-  [DataCategoryExact.PREVENT_REVIEW]: {
-    ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.PREVENT_REVIEW],
-    feature: 'prevent-billing',
-    maxAdminGift: 10_000, // TODO(prevent): Update this to the actual max admin gift
   },
 } as const satisfies Record<DataCategoryExact, BilledDataCategoryInfo>;


### PR DESCRIPTION
missed canProductTrial in https://github.com/getsentry/sentry/pull/98206 and removes prevent reviews from billed data categories

closes https://linear.app/getsentry/issue/BIL-1387/set-billed-data-categorydatacategoryexactnew-categorycanproducttrial
