### PR TITLE
fix(routes): Fix `/disabled-member/`

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -243,6 +243,7 @@ function buildRoutes(): RouteObject[] {
           path: '/disabled-member/',
           component: make(() => import('sentry/views/disabledMember')),
           withOrgPath: true,
+          deprecatedRouteProps: true,
         },
       ],
     },


### PR DESCRIPTION
Adds back `deprecatedRouteProps` to `/disabled-member/` route (https://github.com/getsentry/sentry/pull/100265).

Fixes JAVASCRIPT-33M2
