### PR TITLE
feat(aci): Custom monitor radio groups with alerts

### DIFF
--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -28,9 +28,9 @@ export function DetectorTypeForm() {
 }
 
 interface DetectorTypeOption {
+  description: string;
   id: DetectorType;
   name: string;
-  description: string;
   visualization: React.ReactNode;
   infoBanner?: React.ReactNode;
 }

--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -86,13 +86,14 @@ function MonitorTypeField() {
       {options.map(({id, name, description, visualization, infoBanner}) => {
         const checked = selectedDetectorType === id;
         return (
-          <OptionLabel key={id} role="radio" aria-checked={checked}>
+          <OptionLabel key={id} aria-checked={checked}>
             <OptionBody>
               <Flex direction="column" gap="sm">
                 <Radio
                   name="detectorType"
                   checked={checked}
                   onChange={() => handleChange(id)}
+                  aria-label={name}
                 />
                 <Text bold>{name}</Text>
                 {description && <Text size="sm">{description}</Text>}

--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -122,7 +122,6 @@ const RadioOptions = styled('div')`
 `;
 
 const OptionLabel = styled('label')`
-  position: relative;
   display: grid;
   grid-template-columns: 1fr;
   border-radius: ${p => p.theme.borderRadius};

--- a/static/app/views/detectors/new.spec.tsx
+++ b/static/app/views/detectors/new.spec.tsx
@@ -29,6 +29,8 @@ describe('DetectorNew', () => {
     // Set detectorType
     await userEvent.click(screen.getByRole('radio', {name: 'Uptime'}));
 
+    expect(router.location.query.detectorType).toBe('uptime_domain_failure');
+
     expect(screen.getByRole('button', {name: 'Next'})).toBeEnabled();
     await userEvent.click(screen.getByRole('button', {name: 'Next'}));
 
@@ -54,6 +56,8 @@ describe('DetectorNew', () => {
     });
 
     await userEvent.click(screen.getByRole('radio', {name: 'Uptime'}));
+
+    expect(router.location.query.detectorType).toBe('uptime_domain_failure');
 
     await userEvent.click(screen.getByRole('button', {name: 'Next'}));
 

--- a/static/app/views/detectors/new.tsx
+++ b/static/app/views/detectors/new.tsx
@@ -54,7 +54,7 @@ export default function DetectorNew() {
       navigate({
         pathname: `${makeMonitorBasePathname(organization.slug)}new/settings/`,
         query: {
-          detectorType: data.detectorType,
+          detectorType: location.query.detectorType as DetectorType,
           project: data.project,
         },
       });


### PR DESCRIPTION
<img width="1390" height="624" alt="Screenshot 2025-09-26 at 1 33 16 PM" src="https://github.com/user-attachments/assets/193be887-b5bc-4398-b682-c13cd45667c0" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces monitor type selection with a custom radio list that updates the URL and is used for navigation, adds visuals/info banner, and updates tests.
> 
> - **UI (detector selection)**:
>   - Replace `RadioField` in `static/app/views/detectors/components/detectorTypeForm.tsx` with custom `Radio` options (`RadioOptions`, `OptionLabel`, `OptionBody`, `OptionInfo`).
>   - Add per-option visualizations and an optional info banner for `uptime_domain_failure` (external docs link).
>   - Improve layout/accessibility; selection styling and responsive `Visualization` sizing.
> - **Routing/behavior**:
>   - Selecting an option updates `location.query.detectorType`; `static/app/views/detectors/new.tsx` reads the query for `detectorType` on submit.
> - **Tests**:
>   - Update `static/app/views/detectors/new.spec.tsx` to assert `detectorType` is set in the query and carried to the next step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 141a1f5ea8121df51091b9e48d10295b5f4f1913. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->