### PR TITLE
fix(hydration error): Allow double-click to reset slider view

### DIFF
--- a/static/app/components/contentSliderDiff/index.tsx
+++ b/static/app/components/contentSliderDiff/index.tsx
@@ -63,7 +63,7 @@ function Sides({onDragHandleMouseDown, viewDimensions, before, after}: SideProps
   const dividerElem = useRef<HTMLDivElement>(null);
   const width = `${viewDimensions.width}px`;
 
-  const {onMouseDown} = useResizableDrawer({
+  const {onMouseDown, onDoubleClick} = useResizableDrawer({
     direction: 'left',
     initialSize: viewDimensions.width / 2,
     min: 0,
@@ -112,6 +112,7 @@ function Sides({onDragHandleMouseDown, viewDimensions, before, after}: SideProps
           onDragHandleMouseDown?.(event);
           onMouseDown(event);
         }}
+        onDoubleClick={onDoubleClick}
       >
         <DragIndicator>
           <IconGrabbable size="sm" />


### PR DESCRIPTION
A little double-click and the slider will jump back to a 50/50 split from this:
<img width="912" height="645" alt="SCR-20250926-kifr" src="https://github.com/user-attachments/assets/7da4a047-9a78-4388-a946-c9633cac2a18" />
