### PR TITLE
fix(prevent): Show preonboard even if no selector data chosen

### DIFF
--- a/static/app/views/prevent/tests/onboarding.spec.tsx
+++ b/static/app/views/prevent/tests/onboarding.spec.tsx
@@ -699,14 +699,24 @@ describe('TestsOnboardingPage', () => {
   });
 
   describe('when the organization is not in the US region', () => {
-    it('renders the pre-onboarding page with alert and header text', () => {
+    it('navigates to the TA page with preonboarding alert and header text', async () => {
       mockGetRegionData.mockReturnValue({
         name: 'eu',
         displayName: 'European Union (EU)',
         url: 'https://eu.sentry.io',
       });
 
-      render(
+      // Mock API calls to prevent infinite navigation loop
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/repos/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/integrations/`,
+        body: [],
+      });
+
+      const {router} = render(
         <PreventContext.Provider value={mockPreventContext}>
           <TestsOnboardingPage />
         </PreventContext.Provider>,
@@ -720,14 +730,9 @@ describe('TestsOnboardingPage', () => {
         }
       );
 
-      expect(
-        screen.getByText(
-          'Test Analytics data is stored in the U.S. only and is not available in the EU. EU region support is coming soon.'
-        )
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText('Keep Test Problems From Slowing You Down')
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(router.location.pathname).toBe('/prevent/tests');
+      });
     });
   });
 });

--- a/static/app/views/prevent/tests/onboarding.spec.tsx
+++ b/static/app/views/prevent/tests/onboarding.spec.tsx
@@ -708,12 +708,17 @@ describe('TestsOnboardingPage', () => {
 
       // Mock API calls to prevent infinite navigation loop
       MockApiClient.addMockResponse({
-        url: `/organizations/org-slug/repos/`,
-        body: [],
-      });
-      MockApiClient.addMockResponse({
         url: `/organizations/org-slug/integrations/`,
         body: [],
+        method: 'GET',
+        match: [MockApiClient.matchQuery({provider_key: 'github', includeConfig: 0})],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/prevent/owner/123/repository/test-repo/`,
+        body: {
+          testAnalyticsEnabled: false,
+          uploadToken: null,
+        },
       });
 
       const {router} = render(

--- a/static/app/views/prevent/tests/onboarding.tsx
+++ b/static/app/views/prevent/tests/onboarding.tsx
@@ -75,9 +75,7 @@ export default function TestsOnboardingPage() {
 
   const regionData = getRegionDataFromOrganization(organization);
   const isUSStorage = regionData?.name === 'us';
-  const cameFromTestsRoute =
-    location.state?.from === '/prevent/tests' ||
-    document.referrer.includes('/prevent/tests');
+  const cameFromTestsRoute = location.state?.from === '/prevent/tests';
 
   // We want to navigate to show TA if this repo should have data to show, if we need to show
   // preOnboarding when they have no integrations, or if this org is not in the US region

--- a/static/app/views/prevent/tests/onboarding.tsx
+++ b/static/app/views/prevent/tests/onboarding.tsx
@@ -61,9 +61,11 @@ export default function TestsOnboardingPage() {
   const [selectedUploadPermission, setSelectedUploadPermission] =
     useState<UploadPermission>(UploadPermission.OIDC);
 
-  const {data: integrations = [], isPending: isIntegrationsPending} = useApiQuery<
-    OrganizationIntegration[]
-  >(
+  const {
+    data: integrations = [],
+    isPending: isIntegrationsPending,
+    isSuccess: isIntegrationsSuccess,
+  } = useApiQuery<OrganizationIntegration[]>(
     [
       `/organizations/${organization.slug}/integrations/`,
       {query: {includeConfig: 0, provider_key: 'github'}},
@@ -82,7 +84,7 @@ export default function TestsOnboardingPage() {
   if (
     !cameFromTestsRoute &&
     ((repoData?.testAnalyticsEnabled && isRepoSuccess) ||
-      (!integrations.length && !isIntegrationsPending) ||
+      (!integrations.length && isIntegrationsSuccess) ||
       !isUSStorage)
   ) {
     const queryString = getPreventParamsString(location);

--- a/static/app/views/prevent/tests/onboarding.tsx
+++ b/static/app/views/prevent/tests/onboarding.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useState} from 'react';
+import {Fragment, useCallback, useEffect, useState} from 'react';
 import {useSearchParams} from 'react-router-dom';
 import {useTheme} from '@emotion/react';
 
@@ -79,17 +79,37 @@ export default function TestsOnboardingPage() {
 
   // We want to navigate to show TA if this repo should have data to show, if we need to show
   // preOnboarding when they have no integrations, or if this org is not in the US region
+  useEffect(() => {
+    if (
+      !cameFromTestsRoute &&
+      ((repoData?.testAnalyticsEnabled && isRepoSuccess) ||
+        (!integrations.length && isIntegrationsSuccess) ||
+        !isUSStorage)
+    ) {
+      const queryString = getPreventParamsString(location);
+      navigate(`/prevent/tests${queryString ? `?${queryString}` : ''}`, {
+        state: {from: '/prevent/tests/new'},
+        replace: true,
+      });
+    }
+    // No `location` dependency as it causes infinite loop of redirect
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    cameFromTestsRoute,
+    repoData?.testAnalyticsEnabled,
+    isRepoSuccess,
+    integrations.length,
+    isIntegrationsSuccess,
+    isUSStorage,
+    navigate,
+  ]);
+
   if (
     !cameFromTestsRoute &&
     ((repoData?.testAnalyticsEnabled && isRepoSuccess) ||
       (!integrations.length && isIntegrationsSuccess) ||
       !isUSStorage)
   ) {
-    const queryString = getPreventParamsString(location);
-    navigate(`/prevent/tests${queryString ? `?${queryString}` : ''}`, {
-      state: {from: '/prevent/tests/new'},
-      replace: true,
-    });
     return null;
   }
 

--- a/static/app/views/prevent/tests/preOnboarding.spec.tsx
+++ b/static/app/views/prevent/tests/preOnboarding.spec.tsx
@@ -3,7 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {getRegionDataFromOrganization} from 'sentry/utils/regions';
-import TestPreOnboardingPage from 'sentry/views/prevent/tests/preOnboarding';
+import TestsPreOnboardingPage from 'sentry/views/prevent/tests/preOnboarding';
 
 jest.mock('sentry/utils/regions', () => ({
   getRegionDataFromOrganization: jest.fn(),
@@ -11,7 +11,7 @@ jest.mock('sentry/utils/regions', () => ({
 
 const mockGetRegionData = jest.mocked(getRegionDataFromOrganization);
 
-describe('TestPreOnboardingPage', () => {
+describe('TestsPreOnboardingPage', () => {
   const org = OrganizationFixture({
     features: ['codecov-integration'],
   });
@@ -24,7 +24,7 @@ describe('TestPreOnboardingPage', () => {
       url: 'https://eu.sentry.io',
     });
 
-    render(<TestPreOnboardingPage />, {organization: org});
+    render(<TestsPreOnboardingPage />, {organization: org});
 
     // Check that the alert is displayed
     expect(
@@ -42,7 +42,7 @@ describe('TestPreOnboardingPage', () => {
       url: 'https://sentry.io',
     });
 
-    render(<TestPreOnboardingPage />, {organization: org});
+    render(<TestsPreOnboardingPage />, {organization: org});
 
     expect(
       screen.queryByText(
@@ -55,7 +55,7 @@ describe('TestPreOnboardingPage', () => {
     // Mock undefined region data
     mockGetRegionData.mockReturnValue(undefined);
 
-    render(<TestPreOnboardingPage />, {organization: org});
+    render(<TestsPreOnboardingPage />, {organization: org});
 
     // Check that the alert is displayed
     expect(
@@ -72,7 +72,7 @@ describe('TestPreOnboardingPage', () => {
       url: 'https://eu.sentry.io',
     });
 
-    render(<TestPreOnboardingPage />, {organization: org});
+    render(<TestsPreOnboardingPage />, {organization: org});
 
     expect(
       screen.getByText('Keep Test Problems From Slowing You Down')

--- a/static/app/views/prevent/tests/preOnboarding.tsx
+++ b/static/app/views/prevent/tests/preOnboarding.tsx
@@ -22,7 +22,7 @@ const INSTRUCTIONS_TEXT = {
   mainCTALink: '/settings/integrations/github',
 } as const;
 
-export default function TestPreOnboardingPage() {
+export default function TestsPreOnboardingPage() {
   const organization = useOrganization();
   const regionData = getRegionDataFromOrganization(organization);
   const isUSStorage = regionData?.name === 'us';

--- a/static/app/views/prevent/tests/tests.tsx
+++ b/static/app/views/prevent/tests/tests.tsx
@@ -108,7 +108,7 @@ function Content({response}: TestResultsContentData) {
   const location = useLocation();
   const navigate = useNavigate();
   const {branch: selectedBranch} = usePreventContext();
-  const {data: repoData, isPending: isRepoPending} = useRepo();
+  const {data: repoData, isSuccess: isRepoSuccess} = useRepo();
 
   const sorts: [ValidSort] = [
     decodeSorts(location.query?.sort).find(isAValidSort) ?? DEFAULT_SORT,
@@ -150,7 +150,7 @@ function Content({response}: TestResultsContentData) {
     location.state?.from === '/prevent/tests/new' ||
     document.referrer.includes('/prevent/tests/new');
 
-  if (!cameFromOnboardingRoute && !repoData?.testAnalyticsEnabled && !isRepoPending) {
+  if (!cameFromOnboardingRoute && !repoData?.testAnalyticsEnabled && isRepoSuccess) {
     const queryString = getPreventParamsString(location);
     navigate(`/prevent/tests/new${queryString ? `?${queryString}` : ''}`, {
       state: {from: '/prevent/tests'},

--- a/static/app/views/prevent/tests/tests.tsx
+++ b/static/app/views/prevent/tests/tests.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback} from 'react';
+import {Fragment, useCallback, useEffect} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
@@ -148,12 +148,19 @@ function Content({response}: TestResultsContentData) {
 
   const cameFromOnboardingRoute = location.state?.from === '/prevent/tests/new';
 
+  useEffect(() => {
+    if (!cameFromOnboardingRoute && !repoData?.testAnalyticsEnabled && isRepoSuccess) {
+      const queryString = getPreventParamsString(location);
+      navigate(`/prevent/tests/new${queryString ? `?${queryString}` : ''}`, {
+        state: {from: '/prevent/tests'},
+        replace: true,
+      });
+    }
+    // No `location` dependency as it causes infinite loop of redirect
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cameFromOnboardingRoute, repoData?.testAnalyticsEnabled, isRepoSuccess, navigate]);
+
   if (!cameFromOnboardingRoute && !repoData?.testAnalyticsEnabled && isRepoSuccess) {
-    const queryString = getPreventParamsString(location);
-    navigate(`/prevent/tests/new${queryString ? `?${queryString}` : ''}`, {
-      state: {from: '/prevent/tests'},
-      replace: true,
-    });
     return null;
   }
 

--- a/static/app/views/prevent/tests/tests.tsx
+++ b/static/app/views/prevent/tests/tests.tsx
@@ -12,7 +12,6 @@ import {IntegratedOrgSelector} from 'sentry/components/prevent/integratedOrgSele
 import {RepoSelector} from 'sentry/components/prevent/repoSelector/repoSelector';
 import {TestSuiteDropdown} from 'sentry/components/prevent/testSuiteDropdown/testSuiteDropdown';
 import {getPreventParamsString} from 'sentry/components/prevent/utils';
-import Redirect from 'sentry/components/redirect';
 import {IconChevron, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {decodeSorts} from 'sentry/utils/queryString';
@@ -147,9 +146,17 @@ function Content({response}: TestResultsContentData) {
     [navigate, response, location.query]
   );
 
-  if (!repoData?.testAnalyticsEnabled && !isRepoPending) {
+  const cameFromOnboardingRoute =
+    location.state?.from === '/prevent/tests/new' ||
+    document.referrer.includes('/prevent/tests/new');
+
+  if (!cameFromOnboardingRoute && !repoData?.testAnalyticsEnabled && !isRepoPending) {
     const queryString = getPreventParamsString(location);
-    return <Redirect to={`/prevent/tests/new${queryString ? `?${queryString}` : ''}`} />;
+    navigate(`/prevent/tests/new${queryString ? `?${queryString}` : ''}`, {
+      state: {from: '/prevent/tests'},
+      replace: true,
+    });
+    return null;
   }
 
   return (


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/CCMRG-1693/investigate-missing-sentry-gh-app-ui-without-integration-orgs

On the TA results page, we had a check for whether or not to show Content based on if selector data had been chosen. If no selector data was available, we would render EmptyMessage instead. However, if the user did not have the GH app installed, it wouldn't take them to PreOnboarding. This fixes that.

As a side effect, only the TA results `/prevent/tests` route will show preonboarding. This means if the user's entry point is somehow onboarding's `prevent/tests/new/` route, they need to be redirected to /prevent/tests (this is in place).

Ex:
This is my personal org that does not have GH installed yet:
<img width="1718" height="825" alt="Screenshot 2025-09-26 at 12 20 11 PM" src="https://github.com/user-attachments/assets/7fc8238e-5898-44ba-b059-3bd30823ecfd" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show PreOnboarding on `/prevent/tests` when no GitHub integration or non‑US, and add bidirectional, loop-proof redirects between `/prevent/tests` and `/prevent/tests/new` based on repo TA state.
> 
> - **Prevent Tests routing and UX**:
>   - Add guarded redirects using `useNavigate` and `location.state` between `/prevent/tests` and `/prevent/tests/new` to avoid infinite loops.
>     - From onboarding: redirect to `/prevent/tests` when `testAnalyticsEnabled`, no integrations, or non‑US region.
>     - From results: redirect to `/prevent/tests/new` when `testAnalyticsEnabled` is false.
>     - Return `null` during redirects to prevent flicker.
>   - Show PreOnboarding on results page when:
>     - No active GitHub integrations (via `useGetActiveIntegratedOrgs`).
>     - Organization is not in US region.
>   - Add loading state for integrations; switch layout to `Grid` in tests page.
> - **Refactors/renames**:
>   - Rename `TestPreOnboardingPage` to `TestsPreOnboardingPage`.
>   - Minor hook/result var renames (e.g., `isSuccess` -> `isRepoSuccess`, `isIntegrationsPending`).
> - **Tests**:
>   - Update specs to reflect redirects (assert path changes) and new component name.
>   - Add API mocks for integrations and repo endpoints to prevent navigation loops.
>   - Preserve token generation/regeneration tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23fb0d85cc4690b616397b9645903119799b9d16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->