### PR TITLE
feat(replays): Add copy link functionality to replay ID breadcrumb

### DIFF
--- a/static/app/views/replays/detail/header/replayDetailsPageBreadcrumbs.tsx
+++ b/static/app/views/replays/detail/header/replayDetailsPageBreadcrumbs.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {Button} from 'sentry/components/core/button';
+import {Flex} from 'sentry/components/core/layout';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Placeholder from 'sentry/components/placeholder';
@@ -76,7 +77,9 @@ export default function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
 
   const replayCrumb = {
     label: replayRecord ? (
-      <ReplayIdContainer
+      <Flex
+        align="center"
+        gap="xs"
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
@@ -92,7 +95,7 @@ export default function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
             />
           </Tooltip>
         )}
-      </ReplayIdContainer>
+      </Flex>
     ) : (
       <Placeholder width="100%" height="16px" />
     ),
@@ -109,10 +112,4 @@ export default function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
 
 const StyledBreadcrumbs = styled(Breadcrumbs)`
   padding: 0;
-`;
-
-const ReplayIdContainer = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
 `;

--- a/static/app/views/replays/detail/header/replayDetailsPageBreadcrumbs.tsx
+++ b/static/app/views/replays/detail/header/replayDetailsPageBreadcrumbs.tsx
@@ -1,13 +1,19 @@
-import {Fragment} from 'react';
+import {useState} from 'react';
+import styled from '@emotion/styled';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
+import {Button} from 'sentry/components/core/button';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Placeholder from 'sentry/components/placeholder';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import {getShortEventId} from 'sentry/utils/events';
 import type useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
+import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromId from 'sentry/utils/useProjectFromId';
@@ -23,6 +29,23 @@ export default function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
   const location = useLocation();
   const eventView = EventView.fromLocation(location);
   const project = useProjectFromId({project_id: replayRecord?.project_id ?? undefined});
+  const [isHovered, setIsHovered] = useState(false);
+  const {currentTime} = useReplayContext();
+
+  // Create URL with current timestamp for copying
+  const replayUrlWithTimestamp = replayRecord
+    ? (() => {
+        const url = new URL(window.location.href);
+        const currentTimeInSeconds = Math.floor(currentTime / 1000);
+        url.searchParams.set('t', String(currentTimeInSeconds));
+        return url.toString();
+      })()
+    : '';
+
+  const {onClick: handleCopyReplayLink} = useCopyToClipboard({
+    text: replayUrlWithTimestamp,
+    successMessage: t('Copied replay link to clipboard'),
+  });
 
   const listPageCrumb = {
     to: {
@@ -53,7 +76,23 @@ export default function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
 
   const replayCrumb = {
     label: replayRecord ? (
-      <Fragment>{getShortEventId(replayRecord?.id)}</Fragment>
+      <ReplayIdContainer
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <div onClick={handleCopyReplayLink}>{getShortEventId(replayRecord?.id)}</div>
+        {isHovered && (
+          <Tooltip title={t('Copy link to replay at current timestamp')}>
+            <Button
+              aria-label={t('Copy link to replay at current timestamp')}
+              onClick={handleCopyReplayLink}
+              size="zero"
+              borderless
+              icon={<IconCopy size="xs" color="subText" />}
+            />
+          </Tooltip>
+        )}
+      </ReplayIdContainer>
     ) : (
       <Placeholder width="100%" height="16px" />
     ),
@@ -65,5 +104,15 @@ export default function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
     replayRecord ? replayCrumb : null,
   ].filter(defined);
 
-  return <Breadcrumbs crumbs={crumbs} />;
+  return <StyledBreadcrumbs crumbs={crumbs} />;
 }
+
+const StyledBreadcrumbs = styled(Breadcrumbs)`
+  padding: 0;
+`;
+
+const ReplayIdContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+`;


### PR DESCRIPTION
- Add hover state with copy icon button for replay ID in breadcrumbs
- Enable clicking directly on replay ID to copy URL with current timestamp
- Include timestamp parameter (t) in copied URL for deep linking
- Show tooltip 'Copy link to replay at current timestamp'
- Display success message when URL is copied to clipboard
- Style breadcrumbs with proper spacing and hover interactions

<img width="452" height="114" alt="image" src="https://github.com/user-attachments/assets/d91ebd2f-cbb5-4403-bd49-af0c6f2b1acf" />

