### PR TITLE
feat(ui): Migrate domain HoC's away from legacy router hooks

### DIFF
--- a/static/app/utils/withDomainRequired.spec.tsx
+++ b/static/app/utils/withDomainRequired.spec.tsx
@@ -1,19 +1,17 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {setWindowLocation} from 'sentry-test/utils';
 
 import ConfigStore from 'sentry/stores/configStore';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Config} from 'sentry/types/system';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
+import {useParams} from 'sentry/utils/useParams';
 import withDomainRequired from 'sentry/utils/withDomainRequired';
 
 describe('withDomainRequired', () => {
-  type Props = RouteComponentProps<{orgId: string}>;
-  function MyComponent(props: Props) {
-    const {params} = props;
+  function MyComponent() {
+    const params = useParams();
     return <div>Org slug: {params.orgId ?? 'no org slug'}</div>;
   }
   let configState: Config;
@@ -58,27 +56,17 @@ describe('withDomainRequired', () => {
       slug: 'albertos-apples',
       features: [],
     });
-
-    const params = {
-      orgId: 'albertos-apples',
-    };
-    const {router} = initializeOrg({
+    const WrappedComponent = withDomainRequired(MyComponent);
+    const {container} = render(<WrappedComponent />, {
       organization,
-      router: {
-        params,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/albertos-apples/issues/',
+          query: {q: '123'},
+        },
+        route: '/organizations/:orgId/issues/',
       },
     });
-    const WrappedComponent = withDomainRequired(MyComponent);
-    const {container} = render(
-      <WrappedComponent
-        router={router}
-        location={router.location}
-        params={params}
-        routes={router.routes}
-        routeParams={router.params}
-        route={{}}
-      />
-    );
 
     expect(container).toBeEmptyDOMElement();
     expect(testableWindowLocation.replace).toHaveBeenCalledTimes(1);
@@ -107,27 +95,17 @@ describe('withDomainRequired', () => {
       slug: 'albertos-apples',
       features: [],
     });
-
-    const params = {
-      orgId: 'albertos-apples',
-    };
-    const {router} = initializeOrg({
+    const WrappedComponent = withDomainRequired(MyComponent);
+    const {container} = render(<WrappedComponent />, {
       organization,
-      router: {
-        params,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/albertos-apples/issues/',
+          query: {q: '123'},
+        },
+        route: '/organizations/:orgId/issues/',
       },
     });
-    const WrappedComponent = withDomainRequired(MyComponent);
-    const {container} = render(
-      <WrappedComponent
-        router={router}
-        location={router.location}
-        params={params}
-        routes={router.routes}
-        routeParams={router.params}
-        route={{}}
-      />
-    );
 
     expect(container).toBeEmptyDOMElement();
     expect(testableWindowLocation.replace).toHaveBeenCalledTimes(1);
@@ -156,27 +134,17 @@ describe('withDomainRequired', () => {
       slug: 'albertos-apples',
       features: [],
     });
-
-    const params = {
-      orgId: 'albertos-apples',
-    };
-    const {router} = initializeOrg({
+    const WrappedComponent = withDomainRequired(MyComponent);
+    render(<WrappedComponent />, {
       organization,
-      router: {
-        params,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/albertos-apples/issues/',
+          query: {q: '123'},
+        },
+        route: '/organizations/:orgId/issues/',
       },
     });
-    const WrappedComponent = withDomainRequired(MyComponent);
-    render(
-      <WrappedComponent
-        router={router}
-        location={router.location}
-        params={params}
-        routes={router.routes}
-        routeParams={router.params}
-        route={{}}
-      />
-    );
 
     expect(screen.getByText('Org slug: albertos-apples')).toBeInTheDocument();
     expect(testableWindowLocation.replace).toHaveBeenCalledTimes(0);

--- a/static/app/utils/withDomainRequired.tsx
+++ b/static/app/utils/withDomainRequired.tsx
@@ -2,8 +2,9 @@ import trimEnd from 'lodash/trimEnd';
 import trimStart from 'lodash/trimStart';
 
 import ConfigStore from 'sentry/stores/configStore';
-import type {RouteComponent, RouteComponentProps} from 'sentry/types/legacyReactRouter';
+import type {RouteComponent} from 'sentry/types/legacyReactRouter';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
+import {useParams} from 'sentry/utils/useParams';
 
 /**
  * withDomainRequired is a higher-order component (HOC) meant to be used with <Route /> components within
@@ -29,11 +30,9 @@ import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
  *
  * Whenever https://orgslug.sentry.io/ is accessed in the browser, then both conditions above will be satisfied.
  */
-export default function withDomainRequired<P extends RouteComponentProps>(
-  WrappedComponent: RouteComponent
-) {
-  return function withDomainRequiredWrapper(props: P) {
-    const {params} = props;
+export default function withDomainRequired<P>(WrappedComponent: RouteComponent) {
+  return function WithDomainRequiredWrapper(props: P) {
+    const params = useParams();
     const {features, customerDomain, links} = ConfigStore.getState();
     const {sentryUrl} = links;
 


### PR DESCRIPTION
Some sneaky places were creeping in where deprecated route props were required but were being omitted. Easier to remove it from these HoC's so it is no longer required. 

Previously, accidentally omitting the router props would lead to an error.

Fixes [JAVASCRIPT-337C](https://sentry.io/organizations/sentry/issues/?project=11276&query=JAVASCRIPT-337C)