### PR TITLE
feat(timeseries): Make valueUnit required

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+import logging
 from collections.abc import Callable, Iterable, Sequence
 from datetime import timedelta
 from typing import Any, cast
@@ -51,6 +52,8 @@ from sentry.utils.cursors import Cursor
 from sentry.utils.dates import get_interval_from_range, get_rollup_from_request, parse_stats_period
 from sentry.utils.http import absolute_uri
 from sentry.utils.snuba import MAX_FIELDS, SnubaTSResult
+
+logger = logging.getLogger(__name__)
 
 
 def get_query_columns(columns: list[str], rollup: int) -> list[str]:
@@ -329,10 +332,15 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             elif field in ["epm()", "spm()", "tpm()", "sample_epm()"]:
                 return "1/minute", field_type
             else:
+                logger.warning(
+                    "sentry.api.bases.organization_events.get_unit_and_type encountered an unknown rate type",
+                    extra={"field": field, "field_type": field_type},
+                )
                 return None, field_type
         elif field_type == "duration":
             return "millisecond", field_type
         else:
+            # There's no unit for integers for example
             return None, field_type
 
     def handle_results_with_meta(

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -68,7 +68,7 @@ class Row(TypedDict):
 class SeriesMeta(TypedDict):
     order: NotRequired[int]
     isOther: NotRequired[str]
-    valueUnit: NotRequired[str]
+    valueUnit: str | None
     dataScanned: NotRequired[Literal["partial", "full"]]
     valueType: str
     interval: float
@@ -352,10 +352,9 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
         unit, field_type = self.get_unit_and_type(axis, result.data["meta"]["fields"][axis])
         series_meta = SeriesMeta(
             valueType=field_type,
+            valueUnit=unit,
             interval=rollup * 1000,
         )
-        if unit is not None:
-            series_meta["valueUnit"] = unit
         if "is_other" in result.data:
             series_meta["isOther"] = result.data["is_other"]
         if "order" in result.data:

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -122,6 +122,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         ]
         assert timeseries["meta"] == {
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 3_600_000,
         }
 
@@ -165,6 +166,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         ]
         assert timeseries["meta"] == {
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 3_600_000,
         }
 
@@ -190,6 +192,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         ]
         assert timeseries["meta"] == {
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 3_600_000,
         }
 
@@ -222,6 +225,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "order": 0,
             "isOther": False,
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 3_600_000,
         }
         assert timeseries["values"] == [
@@ -279,6 +283,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "order": 1,
             "isOther": False,
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 3_600_000,
         }
         assert timeseries["values"] == [
@@ -369,5 +374,6 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         ]
         assert timeseries["meta"] == {
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 3_600_000,
         }

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
@@ -83,6 +83,7 @@ class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpoi
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 3_600_000,
         }
 

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -132,6 +132,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 3_600_000,
         }
 
@@ -312,6 +313,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 3_600_000,
         }
 
@@ -407,6 +409,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 3_600_000,
         }
 
@@ -484,6 +487,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": False,
             "order": 0,
@@ -499,6 +503,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": False,
             "order": 1,
@@ -514,6 +519,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": True,
             "order": 2,
@@ -566,6 +572,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": False,
             "order": 0,
@@ -581,6 +588,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": False,
             "order": 1,
@@ -633,6 +641,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": False,
             "order": 0,
@@ -648,6 +657,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": False,
             "order": 1,
@@ -700,6 +710,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": False,
             "order": 0,
@@ -731,6 +742,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": False,
             "order": 1,
@@ -762,6 +774,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": True,
             "order": 2,
@@ -836,6 +849,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": False,
             "order": 0,
@@ -851,6 +865,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": False,
             "order": 1,
@@ -866,6 +881,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": True,
             "order": 2,
@@ -925,6 +941,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": False,
             "order": 0,
@@ -943,6 +960,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": False,
             "order": 1,
@@ -958,6 +976,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": True,
             "order": 2,
@@ -1046,6 +1065,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 3_600_000,
         }
 
@@ -1294,6 +1314,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 3_600_000,
         }
 
@@ -1340,6 +1361,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 3_600_000,
         }
 
@@ -1419,6 +1441,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             assert timeseries["meta"] == {
                 "dataScanned": "full",
                 "valueType": "integer",
+                "valueUnit": None,
                 "interval": 3_600_000,
             }
 
@@ -1484,6 +1507,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             assert timeseries["meta"] == {
                 "dataScanned": "full",
                 "valueType": "integer",
+                "valueUnit": None,
                 "interval": 3_600_000,
             }
 
@@ -1615,6 +1639,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "percentage",
+            "valueUnit": None,
             "interval": 60_000,
         }
 
@@ -1677,6 +1702,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "percentage",
+            "valueUnit": None,
             "interval": 60_000,
         }
 
@@ -1727,6 +1753,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
         }
 
@@ -1776,6 +1803,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
         }
 
@@ -1808,6 +1836,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
         }
 
@@ -1864,6 +1893,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "isOther": False,
             "order": 0,
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
         }
 
@@ -1902,6 +1932,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "isOther": False,
             "order": 0,
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 60_000,
         }
 
@@ -1952,6 +1983,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "number",
+            "valueUnit": None,
             "interval": 60_000,
         }
 
@@ -2003,6 +2035,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "number",
+            "valueUnit": None,
             "interval": 60_000,
         }
 
@@ -2053,6 +2086,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "number",
+            "valueUnit": None,
             "interval": 60_000,
         }
 
@@ -2065,6 +2099,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "number",
+            "valueUnit": None,
             "interval": 60_000,
         }
 
@@ -2145,6 +2180,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "number",
+            "valueUnit": None,
             "interval": 60_000,
             "isOther": False,
             "order": 0,
@@ -2161,6 +2197,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         ]
         assert timeseries["meta"] == {
             "dataScanned": "full",
+            "valueUnit": None,
             "valueType": "number",
             "interval": 60_000,
             "isOther": False,
@@ -2176,6 +2213,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["groupBy"] is None
         assert timeseries["meta"] == {
             "dataScanned": "full",
+            "valueUnit": None,
             "valueType": "number",
             "interval": 60_000,
             "isOther": True,
@@ -2229,6 +2267,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         assert timeseries["meta"] == {
             "dataScanned": "full",
             "valueType": "integer",
+            "valueUnit": None,
             "interval": 3_600_000,
         }
 


### PR DESCRIPTION
- This makes it easier on the frontend to always include the valueUnit key
- when its a type without a relevant unit we'll just return `None`
- Going to log when we have rates without a unit