### PR TITLE
feat(replay): Hide "Buffering" message from non-mobile replays

### DIFF
--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -52,7 +52,6 @@ function BasePlayerRoot({
     dimensions: videoDimensions,
     fastForwardSpeed,
     setRoot,
-    isBuffering,
     isVideoBuffering,
     isFetching,
     isFinished,
@@ -152,7 +151,7 @@ function BasePlayerRoot({
       <StyledNegativeSpaceContainer ref={windowEl} className="sentry-block">
         <div ref={viewEl} className={className} data-inspectable={inspectable} />
         {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
-        {isBuffering || isVideoBuffering ? <PositionedBuffering /> : null}
+        {isVideoBuffering ? <PositionedBuffering /> : null}
         {isPreview || isVideoReplay || isFetching || !hasDefaultMaskSettings ? null : (
           <UnmaskAlert />
         )}


### PR DESCRIPTION
Hides the "Buffering" message from non-mobile replays. It was a bit buggy when hiding after you seek around. I think we have done enough perf improvements where this is not needed anymore anyway.
