### PR TITLE
fix(ui): Make BetaBadge smaller for Prevent in nav

### DIFF
--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -207,5 +207,8 @@ const BetaBadge = styled(FeatureBadge)`
   position: absolute;
   pointer-events: none;
   top: -2px;
-  right: 4px;
+  right: 2px;
+  font-size: ${p => p.theme.fontSize.xs};
+  padding: 0 ${p => p.theme.space.xs};
+  height: 16px;
 `;


### PR DESCRIPTION
Before

<img alt="clipboard.png" width="119" src="https://i.imgur.com/Xfkjibu.png" />

After

<img alt="clipboard.png" width="97" src="https://i.imgur.com/CsyYiyy.png" />