### PR TITLE
feat(preprod): allow insights sidebar to be resizable

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -6,8 +6,10 @@ import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
 import {Heading} from 'sentry/components/core/text/heading';
 import SlideOverPanel from 'sentry/components/slideOverPanel';
-import {IconClose} from 'sentry/icons';
+import {IconClose, IconGrabbable} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 import {AppSizeInsightsSidebarRow} from 'sentry/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow';
 import type {ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessing';
 
@@ -24,6 +26,19 @@ export function AppSizeInsightsSidebar({
 }: AppSizeInsightsSidebarProps) {
   const [expandedInsights, setExpandedInsights] = useState<Set<string>>(new Set());
 
+  const {
+    isHeld,
+    onDoubleClick,
+    onMouseDown,
+    size: width,
+  } = useResizableDrawer({
+    direction: 'right',
+    initialSize: 502,
+    min: 502,
+    onResize: () => {},
+    sizeStorageKey: 'app-size-insights-sidebar-width',
+  });
+
   const toggleExpanded = (insightName: string) => {
     const newExpanded = new Set(expandedInsights);
     if (newExpanded.has(insightName)) {
@@ -33,6 +48,9 @@ export function AppSizeInsightsSidebar({
     }
     setExpandedInsights(newExpanded);
   };
+
+  // Constrain width to viewport (leave 50px margin from screen edge)
+  const constrainedWidth = Math.min(width, window.innerWidth - 50);
 
   return (
     <Fragment>
@@ -51,7 +69,7 @@ export function AppSizeInsightsSidebar({
       <SlideOverPanel
         collapsed={!isOpen}
         slidePosition="right"
-        panelWidth="502px"
+        panelWidth={`${constrainedWidth}px`}
         ariaLabel={t('App size insights details')}
       >
         <Flex height="100%" direction="column">
@@ -67,16 +85,27 @@ export function AppSizeInsightsSidebar({
             />
           </Header>
 
-          <Flex flex={1} overflowY="auto" padding="xl">
-            <Flex direction="column" gap="xl" width="100%">
-              {processedInsights.map(insight => (
-                <AppSizeInsightsSidebarRow
-                  key={insight.name}
-                  insight={insight}
-                  isExpanded={expandedInsights.has(insight.name)}
-                  onToggleExpanded={() => toggleExpanded(insight.name)}
-                />
-              ))}
+          <Flex flex={1} position="relative" overflow="hidden">
+            <ResizeHandle
+              onMouseDown={onMouseDown}
+              onDoubleClick={onDoubleClick}
+              data-is-held={isHeld}
+              data-slide-direction="leftright"
+            >
+              <IconGrabbable size="sm" />
+            </ResizeHandle>
+
+            <Flex flex={1} overflowY="auto" padding="xl">
+              <Flex direction="column" gap="xl" width="100%">
+                {processedInsights.map(insight => (
+                  <AppSizeInsightsSidebarRow
+                    key={insight.name}
+                    insight={insight}
+                    isExpanded={expandedInsights.has(insight.name)}
+                    onToggleExpanded={() => toggleExpanded(insight.name)}
+                  />
+                ))}
+              </Flex>
             </Flex>
           </Flex>
         </Flex>
@@ -98,4 +127,31 @@ const Backdrop = styled(motion.div)`
 
 const Header = styled(Flex)`
   border-bottom: 1px solid ${p => p.theme.border};
+`;
+
+const ResizeHandle = styled(Flex)`
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: ${space(2)};
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  cursor: ew-resize;
+  background: transparent;
+
+  &:hover,
+  &[data-is-held='true'] {
+    background: ${p => p.theme.hover};
+  }
+
+  &[data-is-held='true'] {
+    user-select: none;
+  }
+
+  svg {
+    color: ${p => p.theme.subText};
+    transform: rotate(90deg);
+  }
 `;

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -8,7 +8,6 @@ import {Heading} from 'sentry/components/core/text/heading';
 import SlideOverPanel from 'sentry/components/slideOverPanel';
 import {IconClose, IconGrabbable} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 import {AppSizeInsightsSidebarRow} from 'sentry/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow';
 import type {ProcessedInsight} from 'sentry/views/preprod/utils/insightProcessing';
@@ -133,7 +132,7 @@ const ResizeHandle = styled(Flex)`
   position: absolute;
   left: 0;
   top: 0;
-  width: ${space(2)};
+  width: ${p => p.theme.space.xl};
   height: 100%;
   align-items: center;
   justify-content: center;

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -89,6 +89,8 @@ export function AppSizeInsightsSidebarRow({
             display="flex"
             css={() => ({
               flexDirection: 'column',
+              width: '100%',
+              overflow: 'hidden',
               '& > :nth-child(odd)': {
                 backgroundColor: theme.backgroundSecondary,
               },
@@ -156,6 +158,8 @@ const FlexAlternatingRow = styled('div')`
   justify-content: space-between;
   border-radius: ${({theme}) => theme.borderRadius};
   min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
   gap: ${({theme}) => theme.space.lg};
   padding: ${({theme}) => theme.space.xs} ${({theme}) => theme.space.sm};
 `;


### PR DESCRIPTION
Resolves EME-353

I considered a few approaches like showing a tooltip with the full path, showing a copy button on hover, etc, until I finally thought of just letting this sidebar be resizable by the user. 🙇 

<img width="1678" height="957" alt="Screenshot 2025-09-26 at 3 44 20 PM" src="https://github.com/user-attachments/assets/ae74dd8f-de5e-41a4-9fa6-67a3dd388f94" />
