### PR TITLE
feat(prevent): prevent ai organization config

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -48,7 +48,7 @@ from sentry.constants import (
     ISSUE_ALERTS_THREAD_DEFAULT,
     JOIN_REQUESTS_DEFAULT,
     METRIC_ALERTS_THREAD_DEFAULT,
-    PREVENT_AI_CONFIG_DEFAULT,
+    PREVENT_AI_CONFIG_GITHUB_DEFAULT,
     PROJECT_RATE_LIMIT_DEFAULT,
     REQUIRE_SCRUB_DATA_DEFAULT,
     REQUIRE_SCRUB_DEFAULTS_DEFAULT,
@@ -727,7 +727,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             ),
             "preventAiConfigGithub": obj.get_option(
                 "sentry:prevent_ai_config_github",
-                PREVENT_AI_CONFIG_DEFAULT,
+                PREVENT_AI_CONFIG_GITHUB_DEFAULT,
             ),
             "enablePrReviewTestGeneration": bool(
                 obj.get_option(

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -48,7 +48,6 @@ from sentry.constants import (
     ISSUE_ALERTS_THREAD_DEFAULT,
     JOIN_REQUESTS_DEFAULT,
     METRIC_ALERTS_THREAD_DEFAULT,
-    PREVENT_AI_CONFIG_GITHUB_DEFAULT,
     PROJECT_RATE_LIMIT_DEFAULT,
     REQUIRE_SCRUB_DATA_DEFAULT,
     REQUIRE_SCRUB_DEFAULTS_DEFAULT,
@@ -80,6 +79,7 @@ from sentry.models.project import Project
 from sentry.models.team import Team, TeamStatus
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import RpcOrganizationSummary
+from sentry.types.prevent_config import PREVENT_AI_CONFIG_GITHUB_DEFAULT
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -564,7 +564,7 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     streamlineOnly: bool
     defaultAutofixAutomationTuning: str
     defaultSeerScannerAutomation: bool
-    preventAiConfig: dict[str, Any]
+    preventAiConfigGithub: dict[str, Any]
     enablePrReviewTestGeneration: bool
     enableSeerEnhancedAlerts: bool
     enableSeerCoding: bool
@@ -725,8 +725,8 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 "sentry:default_seer_scanner_automation",
                 DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT,
             ),
-            "preventAiConfig": obj.get_option(
-                "sentry:prevent_ai_config",
+            "preventAiConfigGithub": obj.get_option(
+                "sentry:prevent_ai_config_github",
                 PREVENT_AI_CONFIG_DEFAULT,
             ),
             "enablePrReviewTestGeneration": bool(
@@ -809,7 +809,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         "streamlineOnly",
         "ingestThroughTrustedRelaysOnly",
         "enabledConsolePlatforms",
-        "preventAiConfig",
+        "preventAiConfigGithub",
     ]
 )
 class DetailedOrganizationSerializerWithProjectsAndTeamsResponse(

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -48,6 +48,7 @@ from sentry.constants import (
     ISSUE_ALERTS_THREAD_DEFAULT,
     JOIN_REQUESTS_DEFAULT,
     METRIC_ALERTS_THREAD_DEFAULT,
+    PREVENT_AI_CONFIG_DEFAULT,
     PROJECT_RATE_LIMIT_DEFAULT,
     REQUIRE_SCRUB_DATA_DEFAULT,
     REQUIRE_SCRUB_DEFAULTS_DEFAULT,
@@ -563,6 +564,7 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     streamlineOnly: bool
     defaultAutofixAutomationTuning: str
     defaultSeerScannerAutomation: bool
+    preventAiConfig: dict[str, Any]
     enablePrReviewTestGeneration: bool
     enableSeerEnhancedAlerts: bool
     enableSeerCoding: bool
@@ -722,6 +724,10 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             "defaultSeerScannerAutomation": obj.get_option(
                 "sentry:default_seer_scanner_automation",
                 DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT,
+            ),
+            "preventAiConfig": obj.get_option(
+                "sentry:prevent_ai_config",
+                PREVENT_AI_CONFIG_DEFAULT,
             ),
             "enablePrReviewTestGeneration": bool(
                 obj.get_option(

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -809,6 +809,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         "streamlineOnly",
         "ingestThroughTrustedRelaysOnly",
         "enabledConsolePlatforms",
+        "preventAiConfig",
     ]
 )
 class DetailedOrganizationSerializerWithProjectsAndTeamsResponse(

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -264,14 +264,6 @@ DEFAULT_ALERT_GROUP_THRESHOLD = (1000, 25)  # 1000%, 25 events
 # Default sort option for the group stream
 DEFAULT_SORT_OPTION = "date"
 
-# Default value for prevent AI config
-PREVENT_AI_CONFIG_GITHUB_DEFAULT = {
-    "org_defaults": {
-        "on_command_phrase": {"bug_prediction": True, "vanilla": True},
-        "on_ready_for_review": {"bug_prediction": True, "vanilla": False},
-    },
-    "repo_overrides": {},
-}
 
 # Setup languages for only available locales
 _language_map = dict(settings.LANGUAGES)

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -265,7 +265,7 @@ DEFAULT_ALERT_GROUP_THRESHOLD = (1000, 25)  # 1000%, 25 events
 DEFAULT_SORT_OPTION = "date"
 
 # Default value for prevent AI config
-PREVENT_AI_CONFIG_DEFAULT = {
+PREVENT_AI_CONFIG_GITHUB_DEFAULT = {
     "org_defaults": {
         "on_command_phrase": {"bug_prediction": True, "vanilla": True},
         "on_ready_for_review": {"bug_prediction": True, "vanilla": False},

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -267,8 +267,8 @@ DEFAULT_SORT_OPTION = "date"
 # Default value for prevent AI config
 PREVENT_AI_CONFIG_DEFAULT = {
     "org_defaults": {
-        "on_command_phrase": {"bug_prediction": True, "pr_review": True},
-        "on_ready_for_review": {"bug_prediction": True, "pr_review": False},
+        "on_command_phrase": {"bug_prediction": True, "vanilla": True},
+        "on_ready_for_review": {"bug_prediction": True, "vanilla": False},
     },
     "repo_overrides": {},
 }

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -264,6 +264,15 @@ DEFAULT_ALERT_GROUP_THRESHOLD = (1000, 25)  # 1000%, 25 events
 # Default sort option for the group stream
 DEFAULT_SORT_OPTION = "date"
 
+# Default value for prevent AI config
+PREVENT_AI_CONFIG_DEFAULT = {
+    "org_defaults": {
+        "on_command_phrase": {"bug_prediction": True, "pr_review": True},
+        "on_ready_for_review": {"bug_prediction": True, "pr_review": False},
+    },
+    "repo_overrides": {},
+}
+
 # Setup languages for only available locales
 _language_map = dict(settings.LANGUAGES)
 LANGUAGES = [(k, _language_map[k]) for k in get_all_languages() if k in _language_map]

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -987,8 +987,6 @@ Below is an example of a payload for a set of advanced data scrubbing rules for 
     )
     apdexThreshold = serializers.IntegerField(required=False)
 
-    preventAiConfig = serializers.JSONField(required=False)
-
 
 # NOTE: We override the permission class of this endpoint in getsentry with the OrganizationDetailsPermission class
 @extend_schema(tags=["Organizations"])

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -5,6 +5,7 @@ from copy import copy
 from datetime import datetime, timedelta, timezone
 from typing import TypedDict
 
+from django import forms
 from django.db import models, router, transaction
 from django.db.models.query_utils import DeferredAttribute
 from django.urls import reverse
@@ -61,7 +62,6 @@ from sentry.constants import (
     JOIN_REQUESTS_DEFAULT,
     LEGACY_RATE_LIMIT_OPTIONS,
     METRIC_ALERTS_THREAD_DEFAULT,
-    PREVENT_AI_CONFIG_GITHUB_DEFAULT,
     PROJECT_RATE_LIMIT_DEFAULT,
     REQUIRE_SCRUB_DATA_DEFAULT,
     REQUIRE_SCRUB_DEFAULTS_DEFAULT,
@@ -109,8 +109,10 @@ from sentry.services.organization.provisioning import (
     OrganizationSlugCollisionException,
     organization_provisioning_service,
 )
+from sentry.types.prevent_config import PREVENT_AI_CONFIG_GITHUB_DEFAULT, PREVENT_AI_CONFIG_SCHEMA
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.utils.audit import create_audit_entry
+from sentry.workflow_engine.endpoints.validators.utils import validate_json_schema
 
 ERR_DEFAULT_ORG = "You cannot remove the default organization."
 ERR_NO_USER = "This request requires an authenticated user."
@@ -118,6 +120,8 @@ ERR_NO_2FA = "Cannot require two-factor authentication without personal two-fact
 ERR_SSO_ENABLED = "Cannot require two-factor authentication with SSO enabled"
 ERR_3RD_PARTY_PUBLISHED_APP = "Cannot delete an organization that owns a published integration. Contact support if you need assistance."
 ERR_PLAN_REQUIRED = "A paid plan is required to enable this feature."
+
+
 ORG_OPTIONS = (
     # serializer field name, option key name, type, default value
     (
@@ -497,6 +501,14 @@ class OrganizationSerializer(BaseOrganizationSerializer):
 
         # as this is handled by a choice field, we don't need to check the values of the field
 
+        return value
+
+    def validate_preventAiConfigGithub(self, value):
+        """Validate the structure using JSON Schema - generic error for invalid configs."""
+        try:
+            validate_json_schema(value, PREVENT_AI_CONFIG_SCHEMA)
+        except forms.ValidationError:
+            raise serializers.ValidationError("Prevent AI config option is invalid")
         return value
 
     def validate(self, attrs):

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -61,7 +61,7 @@ from sentry.constants import (
     JOIN_REQUESTS_DEFAULT,
     LEGACY_RATE_LIMIT_OPTIONS,
     METRIC_ALERTS_THREAD_DEFAULT,
-    PREVENT_AI_CONFIG_DEFAULT,
+    PREVENT_AI_CONFIG_GITHUB_DEFAULT,
     PROJECT_RATE_LIMIT_DEFAULT,
     REQUIRE_SCRUB_DATA_DEFAULT,
     REQUIRE_SCRUB_DEFAULTS_DEFAULT,
@@ -254,7 +254,7 @@ ORG_OPTIONS = (
         "preventAiConfigGithub",
         "sentry:prevent_ai_config_github",
         dict,
-        PREVENT_AI_CONFIG_DEFAULT,
+        PREVENT_AI_CONFIG_GITHUB_DEFAULT,
     ),
     (
         "enablePrReviewTestGeneration",

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -1166,13 +1166,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                         serializer.validated_data["defaultSeerScannerAutomation"],
                     )
 
-            # Handle prevent AI config option
-            if "preventAiConfig" in changed_data:
-                organization.update_option(
-                    "sentry:prevent_ai_config",
-                    serializer.validated_data["preventAiConfig"],
-                )
-
             if was_pending_deletion:
                 self.create_audit_entry(
                     request=request,

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -251,8 +251,8 @@ ORG_OPTIONS = (
         DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT,
     ),
     (
-        "preventAiConfig",
-        "sentry:prevent_ai_config",
+        "preventAiConfigGithub",
+        "sentry:prevent_ai_config_github",
         dict,
         PREVENT_AI_CONFIG_DEFAULT,
     ),
@@ -367,7 +367,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     )
     enablePrReviewTestGeneration = serializers.BooleanField(required=False)
     enableSeerEnhancedAlerts = serializers.BooleanField(required=False)
-    preventAiConfig = serializers.JSONField(required=False)
+    preventAiConfigGithub = serializers.JSONField(required=False)
     enableSeerCoding = serializers.BooleanField(required=False)
     ingestThroughTrustedRelaysOnly = serializers.ChoiceField(
         choices=[("enabled", "enabled"), ("disabled", "disabled")], required=False
@@ -774,7 +774,7 @@ def create_console_platform_audit_log(
         "genAIConsent",
         "defaultAutofixAutomationTuning",
         "defaultSeerScannerAutomation",
-        "preventAiConfig",
+        "preventAiConfigGithub",
         "ingestThroughTrustedRelaysOnly",
         "enabledConsolePlatforms",
     ]

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -61,6 +61,7 @@ from sentry.constants import (
     JOIN_REQUESTS_DEFAULT,
     LEGACY_RATE_LIMIT_OPTIONS,
     METRIC_ALERTS_THREAD_DEFAULT,
+    PREVENT_AI_CONFIG_DEFAULT,
     PROJECT_RATE_LIMIT_DEFAULT,
     REQUIRE_SCRUB_DATA_DEFAULT,
     REQUIRE_SCRUB_DEFAULTS_DEFAULT,
@@ -250,6 +251,12 @@ ORG_OPTIONS = (
         DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT,
     ),
     (
+        "preventAiConfig",
+        "sentry:prevent_ai_config",
+        dict,
+        PREVENT_AI_CONFIG_DEFAULT,
+    ),
+    (
         "enablePrReviewTestGeneration",
         "sentry:enable_pr_review_test_generation",
         bool,
@@ -360,6 +367,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     )
     enablePrReviewTestGeneration = serializers.BooleanField(required=False)
     enableSeerEnhancedAlerts = serializers.BooleanField(required=False)
+    preventAiConfig = serializers.JSONField(required=False)
     enableSeerCoding = serializers.BooleanField(required=False)
     ingestThroughTrustedRelaysOnly = serializers.ChoiceField(
         choices=[("enabled", "enabled"), ("disabled", "disabled")], required=False
@@ -1154,6 +1162,13 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                         "sentry:default_seer_scanner_automation",
                         serializer.validated_data["defaultSeerScannerAutomation"],
                     )
+
+            # Handle prevent AI config option
+            if "preventAiConfig" in changed_data:
+                organization.update_option(
+                    "sentry:prevent_ai_config",
+                    serializer.validated_data["preventAiConfig"],
+                )
 
             if was_pending_deletion:
                 self.create_audit_entry(

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -774,6 +774,7 @@ def create_console_platform_audit_log(
         "genAIConsent",
         "defaultAutofixAutomationTuning",
         "defaultSeerScannerAutomation",
+        "preventAiConfig",
         "ingestThroughTrustedRelaysOnly",
         "enabledConsolePlatforms",
     ]
@@ -985,6 +986,8 @@ Below is an example of a payload for a set of advanced data scrubbing rules for 
         min_value=PROJECT_RATE_LIMIT_DEFAULT, required=False
     )
     apdexThreshold = serializers.IntegerField(required=False)
+
+    preventAiConfig = serializers.JSONField(required=False)
 
 
 # NOTE: We override the permission class of this endpoint in getsentry with the OrganizationDetailsPermission class

--- a/src/sentry/types/prevent_config.py
+++ b/src/sentry/types/prevent_config.py
@@ -1,0 +1,72 @@
+PREVENT_AI_CONFIG_GITHUB_DEFAULT = {
+    "org_defaults": {
+        "on_command_phrase": {"bug_prediction": True, "vanilla": True},
+        "on_ready_for_review": {"bug_prediction": True, "vanilla": False},
+    },
+    "repo_overrides": {},
+}
+
+
+PREVENT_AI_CONFIG_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "org_defaults": {
+            "type": "object",
+            "properties": {
+                "on_command_phrase": {
+                    "type": "object",
+                    "properties": {
+                        "bug_prediction": {"type": "boolean"},
+                        "vanilla": {"type": "boolean"},
+                    },
+                    "required": ["bug_prediction", "vanilla"],
+                    "additionalProperties": False,
+                },
+                "on_ready_for_review": {
+                    "type": "object",
+                    "properties": {
+                        "bug_prediction": {"type": "boolean"},
+                        "vanilla": {"type": "boolean"},
+                    },
+                    "required": ["bug_prediction", "vanilla"],
+                    "additionalProperties": False,
+                },
+            },
+            "required": ["on_command_phrase", "on_ready_for_review"],
+            "additionalProperties": False,
+        },
+        "repo_overrides": {
+            "type": "object",
+            "patternProperties": {
+                ".*": {
+                    "type": "object",
+                    "properties": {
+                        "on_command_phrase": {
+                            "type": "object",
+                            "properties": {
+                                "bug_prediction": {"type": "boolean"},
+                                "vanilla": {"type": "boolean"},
+                            },
+                            "required": ["bug_prediction", "vanilla"],
+                            "additionalProperties": False,
+                        },
+                        "on_ready_for_review": {
+                            "type": "object",
+                            "properties": {
+                                "bug_prediction": {"type": "boolean"},
+                                "vanilla": {"type": "boolean"},
+                            },
+                            "required": ["bug_prediction", "vanilla"],
+                            "additionalProperties": False,
+                        },
+                    },
+                    "required": ["on_command_phrase", "on_ready_for_review"],
+                    "additionalProperties": False,
+                }
+            },
+            "additionalProperties": False,
+        },
+    },
+    "required": ["org_defaults", "repo_overrides"],
+    "additionalProperties": False,
+}

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1343,61 +1343,67 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         self.get_success_response(self.organization.slug, **data)
         assert self.organization.get_option("sentry:default_seer_scanner_automation") is True
 
-    def test_prevent_ai_config(self) -> None:
+    def test_prevent_ai_config_github(self) -> None:
         data = {
-            "preventAiConfig": {
+            "preventAiConfigGithub": {
                 "org_defaults": {
-                    "on_command_phrase": {"bug_prediction": True, "pr_review": True},
-                    "on_ready_for_review": {"bug_prediction": True, "pr_review": False},
+                    "on_command_phrase": {"bug_prediction": True, "vanilla": True},
+                    "on_ready_for_review": {"bug_prediction": True, "vanilla": False},
                 },
                 "repo_overrides": {
                     "my_repo_name": {
-                        "on_command_phrase": {"bug_prediction": True, "pr_review": False},
-                        "on_ready_for_review": {"bug_prediction": False, "pr_review": True},
+                        "on_command_phrase": {"bug_prediction": True, "vanilla": False},
+                        "on_ready_for_review": {"bug_prediction": False, "vanilla": True},
                     }
                 },
             }
         }
         self.get_success_response(self.organization.slug, **data)
-        assert self.organization.get_option("sentry:prevent_ai_config") == data["preventAiConfig"]
+        assert (
+            self.organization.get_option("sentry:prevent_ai_config_github")
+            == data["preventAiConfigGithub"]
+        )
 
         data = {
-            "preventAiConfig": {
+            "preventAiConfigGithub": {
                 "org_defaults": {
-                    "on_command_phrase": {"bug_prediction": True, "pr_review": True},
-                    "on_ready_for_review": {"bug_prediction": True, "pr_review": False},
+                    "on_command_phrase": {"bug_prediction": True, "vanilla": True},
+                    "on_ready_for_review": {"bug_prediction": True, "vanilla": False},
                 },
                 "repo_overrides": {
                     "my_repo_name": {
-                        "on_command_phrase": {"bug_prediction": False, "pr_review": True},
-                        "on_ready_for_review": {"bug_prediction": True, "pr_review": False},
+                        "on_command_phrase": {"bug_prediction": False, "vanilla": True},
+                        "on_ready_for_review": {"bug_prediction": True, "vanilla": False},
                     },
                     "my_other_repo_name": {
-                        "on_command_phrase": {"bug_prediction": True, "pr_review": True},
-                        "on_ready_for_review": {"bug_prediction": False, "pr_review": False},
+                        "on_command_phrase": {"bug_prediction": True, "vanilla": True},
+                        "on_ready_for_review": {"bug_prediction": False, "vanilla": False},
                     },
                 },
             }
         }
         self.get_success_response(self.organization.slug, **data)
-        assert self.organization.get_option("sentry:prevent_ai_config") == data["preventAiConfig"]
+        assert (
+            self.organization.get_option("sentry:prevent_ai_config_github")
+            == data["preventAiConfigGithub"]
+        )
 
-    def test_prevent_ai_config_null_rejected(self) -> None:
-        """Test that setting preventAiConfig to null is rejected"""
-        data = {"preventAiConfig": None}
+    def test_prevent_ai_config_github_null_rejected(self) -> None:
+        """Test that setting preventAiConfigGithub to null is rejected"""
+        data = {"preventAiConfigGithub": None}
         self.get_error_response(self.organization.slug, status_code=400, **data)
 
-    def test_prevent_ai_config_get_default(self) -> None:
+    def test_prevent_ai_config_github_get_default(self) -> None:
         # Verify that when no config is set, it returns the default config
         expected_default = {
             "org_defaults": {
-                "on_command_phrase": {"bug_prediction": True, "pr_review": True},
-                "on_ready_for_review": {"bug_prediction": True, "pr_review": False},
+                "on_command_phrase": {"bug_prediction": True, "vanilla": True},
+                "on_ready_for_review": {"bug_prediction": True, "vanilla": False},
             },
             "repo_overrides": {},
         }
         response = self.get_success_response(self.organization.slug)
-        assert response.data["preventAiConfig"] == expected_default
+        assert response.data["preventAiConfigGithub"] == expected_default
 
     def test_enabled_console_platforms_present_in_response(self) -> None:
         response = self.get_success_response(self.organization.slug)

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1408,7 +1408,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
     def test_prevent_ai_config_github_validation_missing_fields(self) -> None:
         """Test that missing required fields are rejected"""
         # Missing org_defaults
-        data = {"preventAiConfigGithub": {"repo_overrides": {}}}
+        data: dict[str, dict[str, dict]] = {"preventAiConfigGithub": {"repo_overrides": {}}}
         response = self.get_error_response(self.organization.slug, status_code=400, **data)
         # Verify we get a validation error for missing required field
         assert "preventAiConfigGithub" in response.data
@@ -1418,14 +1418,14 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
     def test_prevent_ai_config_github_validation_invalid_structure(self) -> None:
         """Test that invalid structures are rejected"""
         # Not an object
-        data = {"preventAiConfigGithub": "invalid"}
-        response = self.get_error_response(self.organization.slug, status_code=400, **data)
+        data_1 = {"preventAiConfigGithub": "invalid"}
+        response = self.get_error_response(self.organization.slug, status_code=400, **data_1)
         # Check for validation error
         error_msg = str(response.data["preventAiConfigGithub"])
         assert "Prevent AI config option is invalid" in error_msg
 
         # Missing trigger fields
-        data = {
+        data_2: dict[str, dict] = {
             "preventAiConfigGithub": {
                 "org_defaults": {
                     "on_command_phrase": {"bug_prediction": True},  # Missing vanilla
@@ -1434,7 +1434,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
                 "repo_overrides": {},
             }
         }
-        response = self.get_error_response(self.organization.slug, status_code=400, **data)
+        response = self.get_error_response(self.organization.slug, status_code=400, **data_2)
         # Check for validation error
         assert "preventAiConfigGithub" in response.data
         error_msg = str(response.data["preventAiConfigGithub"])

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1361,24 +1361,31 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         self.get_success_response(self.organization.slug, **data)
         assert self.organization.get_option("sentry:prevent_ai_config") == data["preventAiConfig"]
 
+        data = {
+            "preventAiConfig": {
+                "org_defaults": {
+                    "on_command_phrase": {"bug_prediction": True, "pr_review": True},
+                    "on_ready_for_review": {"bug_prediction": True, "pr_review": False},
+                },
+                "repo_overrides": {
+                    "my_repo_name": {
+                        "on_command_phrase": {"bug_prediction": False, "pr_review": True},
+                        "on_ready_for_review": {"bug_prediction": True, "pr_review": False},
+                    },
+                    "my_other_repo_name": {
+                        "on_command_phrase": {"bug_prediction": True, "pr_review": True},
+                        "on_ready_for_review": {"bug_prediction": False, "pr_review": False},
+                    },
+                },
+            }
+        }
+        self.get_success_response(self.organization.slug, **data)
+        assert self.organization.get_option("sentry:prevent_ai_config") == data["preventAiConfig"]
+
     def test_prevent_ai_config_null_rejected(self) -> None:
         """Test that setting preventAiConfig to null is rejected"""
         data = {"preventAiConfig": None}
         self.get_error_response(self.organization.slug, status_code=400, **data)
-
-    def test_prevent_ai_config_get(self) -> None:
-        # First test PUT functionality - set via API
-        config_value = {
-            "org_defaults": {"on_command_phrase": {"bug_prediction": True, "pr_review": False}}
-        }
-
-        # Verify the option was saved correctly
-        saved_value = self.organization.get_option("sentry:prevent_ai_config")
-        assert saved_value == config_value
-
-        # Then verify it appears in GET response
-        response = self.get_success_response(self.organization.slug)
-        assert response.data["preventAiConfig"] == config_value
 
     def test_prevent_ai_config_get_default(self) -> None:
         # Verify that when no config is set, it returns the default config

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1361,17 +1361,20 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         self.get_success_response(self.organization.slug, **data)
         assert self.organization.get_option("sentry:prevent_ai_config") == data["preventAiConfig"]
 
-    def test_prevent_ai_config_none(self) -> None:
+    def test_prevent_ai_config_null_rejected(self) -> None:
+        """Test that setting preventAiConfig to null is rejected"""
         data = {"preventAiConfig": None}
-        self.get_success_response(self.organization.slug, **data)
-        assert self.organization.get_option("sentry:prevent_ai_config") is None
+        self.get_error_response(self.organization.slug, status_code=400, **data)
 
     def test_prevent_ai_config_get(self) -> None:
-        # First set the config
+        # First test PUT functionality - set via API
         config_value = {
             "org_defaults": {"on_command_phrase": {"bug_prediction": True, "pr_review": False}}
         }
-        self.organization.update_option("sentry:prevent_ai_config", config_value)
+
+        # Verify the option was saved correctly
+        saved_value = self.organization.get_option("sentry:prevent_ai_config")
+        assert saved_value == config_value
 
         # Then verify it appears in GET response
         response = self.get_success_response(self.organization.slug)


### PR DESCRIPTION
Update organization config for prevent ai features. 
to retrieve GET  /api/0/organizations/{organization_id_or_slug}/?detailed=1
to update  PUT /api/0/organizations/{organization_id_or_slug}/
body:
```
{
   "preventAiConfig": {
      "org_defaults": {
        ...
      },
      "repo_overrides": {
        ...
      }
   }
}
```

design doc: https://www.notion.so/sentry/Overwatch-config-planning-doc-23a8b10e4b5d80c29d38f0e27928292a


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `preventAiConfigGithub` org setting (stored as `sentry:prevent_ai_config_github`) with default, exposure in org details, and strict JSON Schema validation on update.
> 
> - **API/Org Settings**:
>   - Add org option `sentry:prevent_ai_config_github`, surfaced as `preventAiConfigGithub` in `DetailedOrganizationSerializer`; persisted via `ORG_OPTIONS` and omitted from the projects+teams response.
>   - Validate `preventAiConfigGithub` on PUT using JSON Schema (`PREVENT_AI_CONFIG_SCHEMA`), returning a generic validation error on bad input.
>   - Include default value via `PREVENT_AI_CONFIG_GITHUB_DEFAULT` when unset.
> - **Types/Config**:
>   - New `sentry/types/prevent_config.py` defining `PREVENT_AI_CONFIG_GITHUB_DEFAULT` and `PREVENT_AI_CONFIG_SCHEMA`.
> - **Tests**:
>   - Comprehensive tests for setting, default retrieval, and schema validation (missing fields, wrong types, repo overrides).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d3a0ad8d6b3a31511cf0d8ffb483059a64a0afb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->