### PR TITLE
fix(grouping): Various `GroupingComponent.get_subcomponent` fixes

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -125,7 +125,9 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]](
         are checked.
 
         By default, any matching result will be returned. To filter out non-contributing components,
-        pass `only_contributing=True`.
+        pass `only_contributing=True`. (Note that if a component has `contributes = True` but has a
+        non-contributing ancestor, the component is not considered contributing for purposes of this
+        method.)
         """
         return next(
             self.iter_subcomponents(

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -116,7 +116,7 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]](
 
     def get_subcomponent(
         self, id: str, recursive: bool = False, only_contributing: bool = False
-    ) -> str | int | BaseGroupingComponent[Any] | None:
+    ) -> BaseGroupingComponent[Any] | None:
         """
         Looks up a subcomponent by id and returns the first instance found, or `None` if no
         instances are found.
@@ -138,7 +138,7 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]](
 
     def iter_subcomponents(
         self, id: str, recursive: bool = False, only_contributing: bool = False
-    ) -> Iterator[str | int | BaseGroupingComponent[Any] | None]:
+    ) -> Iterator[BaseGroupingComponent[Any] | None]:
         """Finds all subcomponents matching an id, optionally recursively."""
         for value in self.values:
             if isinstance(value, BaseGroupingComponent):

--- a/tests/sentry/grouping/test_components.py
+++ b/tests/sentry/grouping/test_components.py
@@ -385,12 +385,16 @@ class ComponentTest(TestCase):
         # When `recursive` isn't specified, it should find direct children but not grandchildren
         exception_component = root_component.get_subcomponent("exception")
         stacktrace_component = root_component.get_subcomponent("stacktrace")
+        error_value_component = root_component.get_subcomponent("value")
         assert exception_component
         assert not stacktrace_component
+        assert not error_value_component
 
         # Grandchildren can be found, however, if the search is recursive
         stacktrace_component = root_component.get_subcomponent("stacktrace", recursive=True)
+        error_value_component = root_component.get_subcomponent("value", recursive=True)
         assert stacktrace_component
+        assert error_value_component
 
         # The `only_contributing` flag can be used to exclude components which don't contribute
         assert stacktrace_component.contributes is False
@@ -398,3 +402,12 @@ class ComponentTest(TestCase):
             "stacktrace", recursive=True, only_contributing=True
         )
         assert not contributing_stacktrace_component
+
+        # Even if a component itself is marked as contributing, if `only_contributing` is set, the
+        # component won't be found if it has a non-contributing ancestor
+        exception_component.contributes = False
+        assert error_value_component.contributes is True
+        contributing_error_value_component = root_component.get_subcomponent(
+            "value", recursive=True, only_contributing=True
+        )
+        assert not contributing_error_value_component


### PR DESCRIPTION
This fixes two problems with the `GroupingComponent.get_subcomponent` method.

- The `only_contributing` flag excludes not only components which are non-contributing themselves, but also contributing components which have non-contributing ancestors. This fixes the docstring to reflect that fact and adds a test for that case.

- The method's return type was incorrect. It can only return components, not literal values. This fixes that, along with the return type in the method upon which it's based, `iter_subcomponents`.