### PR TITLE
fix(replay): Fix missing `textValue` warning

### DIFF
--- a/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
+++ b/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
@@ -78,6 +78,7 @@ export default function ReplayPreferenceDropdown({
                   <DurationDisplay>{durationDisplay}</DurationDisplay>
                 </Flex>
               ),
+              textValue: baseLabel,
               value: option,
             };
           }


### PR DESCRIPTION
Fixes the warning `<Item> with non-plain text contents is unsupported by type to select for accessibility. Please add a textValue prop.` in the replay prefs dropdown
