### PR TITLE
fix(issue details): Use default rollup value in project sessions query

### DIFF
--- a/src/sentry/release_health/base.py
+++ b/src/sentry/release_health/base.py
@@ -483,11 +483,9 @@ class ReleaseHealthBackend(Service):
         start: datetime | None,
         end: datetime | None,
         environment_ids: Sequence[int] | None = None,
-        rollup: int | None = None,  # rollup in seconds
     ) -> Sequence[ProjectWithCount]:
         """
         Returns the number of sessions for each project specified.
-        Additionally
         """
         raise NotImplementedError()
 

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -1614,7 +1614,6 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         start: datetime | None,
         end: datetime | None,
         environment_ids: Sequence[int] | None = None,
-        rollup: int | None = None,  # rollup in seconds
     ) -> Sequence[ProjectWithCount]:
 
         projects, org_id = self._get_projects_and_org_id(project_ids)
@@ -1648,7 +1647,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             end=end,
             where=where,
             groupby=groupby,
-            granularity=Granularity(rollup),
+            granularity=Granularity(LEGACY_SESSIONS_DEFAULT_ROLLUP),
             include_series=False,
             include_totals=True,
         )

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -1495,7 +1495,6 @@ class CheckNumberOfSessions(TestCase, BaseMetricsTestCase):
         actual = self.backend.get_num_sessions_per_project(
             project_ids=[self.project.id, self.project_2.id],
             environment_ids=None,
-            rollup=60,
             start=self._30_min_ago_dt,
             end=self.now_dt,
         )
@@ -1566,7 +1565,6 @@ class CheckNumberOfSessions(TestCase, BaseMetricsTestCase):
         actual = self.backend.get_num_sessions_per_project(
             project_ids=[project_1.id, project_2.id],
             environment_ids=[dev_env.id, prod_env.id],
-            rollup=60,
             start=self._2_h_ago_dt,
             end=self.now_dt,
         )
@@ -1578,7 +1576,6 @@ class CheckNumberOfSessions(TestCase, BaseMetricsTestCase):
             actual = self.backend.get_num_sessions_per_project(
                 project_ids=[project_1.id, project_2.id],
                 environment_ids=eids,
-                rollup=60,
                 start=self._2_h_ago_dt,
                 end=self.now_dt,
             )


### PR DESCRIPTION
Fixes [SENTRY-3WWQ](https://sentry.sentry.io/issues/6623153675/?project=1&query=is%3Aunresolved%20assigned%3Amy_teams%20timesSeen%3A%3E10k&referrer=issue-stream).

We're not passing a `rollup` value in any calls to `get_num_sessions_per_project`, causing some queries to fail. This PR changes that logic to use the default rollup value (`HOUR`). No change in behavior since this function returns a total count for each project.