### PR TITLE
ref(feedback): Call Seer endpoint for user feedback spam detection

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -492,6 +492,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:user-feedback-ai-titles", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable auto spam classification at User Feedback ingest time
     manager.add("organizations:user-feedback-spam-ingest", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable rerouting of auto spam classification at User Feedback ingest time to Seer
+    manager.add("organizations:seer-feedback-spam-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable User Feedback v2 UI
     manager.add("organizations:user-feedback-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable view hierarchies options

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -493,7 +493,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable auto spam classification at User Feedback ingest time
     manager.add("organizations:user-feedback-spam-ingest", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable rerouting of auto spam classification at User Feedback ingest time to Seer
-    manager.add("organizations:seer-feedback-spam-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:user-feedback-seer-spam-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable User Feedback v2 UI
     manager.add("organizations:user-feedback-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable view hierarchies options

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -493,7 +493,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable auto spam classification at User Feedback ingest time
     manager.add("organizations:user-feedback-spam-ingest", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable rerouting of auto spam classification at User Feedback ingest time to Seer
-    manager.add("organizations:user-feedback-seer-spam-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:user-feedback-seer-spam-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable User Feedback v2 UI
     manager.add("organizations:user-feedback-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable view hierarchies options

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -287,7 +287,7 @@ def create_feedback_issue(
                 logger.exception(
                     "Error checking if message is spam", extra={"project_id": project.id}
                 )
-            is_message_spam_metric = is_message_spam
+            is_message_spam_metric = str(is_message_spam)
 
         # In DD we use is_spam = None to indicate spam failed.
         metrics.incr(

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -17,7 +17,7 @@ from sentry.feedback.usecases.label_generation import (
     MAX_AI_LABELS_JSON_LENGTH,
     generate_labels,
 )
-from sentry.feedback.usecases.spam_detection import is_spam, spam_detection_enabled
+from sentry.feedback.usecases.spam_detection import is_spam, is_spam_seer, spam_detection_enabled
 from sentry.feedback.usecases.title_generation import get_feedback_title, truncate_feedback_title
 from sentry.issues.grouptype import FeedbackGroup
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
@@ -274,11 +274,17 @@ def create_feedback_issue(
     is_message_spam = None
     if spam_detection_enabled(project):
         is_spam_enabled = True
-        try:
-            is_message_spam = is_spam(feedback_message)
-        except Exception:
-            # until we have LLM error types ironed out, just catch all exceptions
-            logger.exception("Error checking if message is spam", extra={"project_id": project.id})
+        if features.has("organizations:seer-feedback-spam-detection", project.organization):
+            # Will be None if the request fails.
+            is_message_spam = is_spam_seer(feedback_message, project.organization_id)
+        else:
+            try:
+                is_message_spam = is_spam(feedback_message)
+            except Exception:
+                # until we have LLM error types ironed out, just catch all exceptions
+                logger.exception(
+                    "Error checking if message is spam", extra={"project_id": project.id}
+                )
 
         # In DD we use is_spam = None to indicate spam failed.
         metrics.incr(

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -272,9 +272,9 @@ def create_feedback_issue(
 
     # Spam detection.
     is_message_spam = None
-    if spam_detection_enabled(project):
-        is_spam_enabled = True
-        if features.has("organizations:seer-feedback-spam-detection", project.organization):
+    is_spam_enabled = spam_detection_enabled(project)
+    if is_spam_enabled:
+        if features.has("organizations:user-feedback-seer-spam-detection", project.organization):
             # Will be None if the request fails
             is_message_spam = is_spam_seer(feedback_message, project.organization_id)
             # Add "seer-" to the metric name to differentiate it from the LLM metric
@@ -297,8 +297,6 @@ def create_feedback_issue(
                 "referrer": source.value,
             },
         )
-    else:
-        is_spam_enabled = False
 
     should_query_seer = not is_message_spam and has_seer_access(project.organization)
 

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -278,7 +278,7 @@ def create_feedback_issue(
             # Will be None if the request fails
             is_message_spam = is_spam_seer(feedback_message, project.organization_id)
             # Add "seer-" to the metric name to differentiate it from the LLM metric
-            is_message_spam_metric = "seer-" + str(is_message_spam).lower()
+            is_message_spam_metric = f"seer-{str(is_message_spam).lower()}"
         else:
             try:
                 is_message_spam = is_spam(feedback_message)

--- a/src/sentry/feedback/usecases/spam_detection.py
+++ b/src/sentry/feedback/usecases/spam_detection.py
@@ -11,7 +11,7 @@ from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)
 
-SEER_SPAM_DETECTION_ENDPOINT_PATH = "/v1/automation/summarize/feedback/spam"
+SEER_SPAM_DETECTION_ENDPOINT_PATH = "/v1/automation/summarize/feedback/spam-detection"
 SEER_TIMEOUT_S = 15
 SEER_RETRIES = 0
 

--- a/src/sentry/feedback/usecases/spam_detection.py
+++ b/src/sentry/feedback/usecases/spam_detection.py
@@ -61,17 +61,13 @@ def is_spam_seer(message: str, organization_id: int) -> bool | None:
         )
         return None
 
-    try:
-        result = response_data["is_spam"]
-        if not isinstance(result, bool):
-            logger.error(
-                "Seer returned an invalid spam detection response",
-                extra={"response_data": response.data},
-            )
-            return None
-        return result
-    except Exception:
+    if "is_spam" not in response_data or not isinstance(response_data["is_spam"], bool):
+        logger.error(
+            "Seer returned an invalid spam detection response",
+            extra={"response_data": response.data},
+        )
         return None
+    return response_data["is_spam"]
 
 
 def make_input_prompt(message: str):

--- a/src/sentry/feedback/usecases/spam_detection.py
+++ b/src/sentry/feedback/usecases/spam_detection.py
@@ -1,5 +1,4 @@
 import logging
-from typing import TypedDict
 
 from sentry import features
 from sentry.feedback.lib.seer_api import seer_summarization_connection_pool
@@ -16,19 +15,6 @@ SEER_TIMEOUT_S = 15
 SEER_RETRIES = 0
 
 
-class IsSpamRequest(TypedDict):
-    """Corresponds to IsSpamRequest in Seer."""
-
-    organization_id: int
-    feedback_message: str
-
-
-class IsSpamResponse(TypedDict):
-    """Corresponds to IsSpamResponse in Seer."""
-
-    is_spam: bool
-
-
 def is_spam_seer(message: str, organization_id: int) -> bool | None:
     """
     Check if a message is spam using Seer.
@@ -36,10 +22,10 @@ def is_spam_seer(message: str, organization_id: int) -> bool | None:
     Returns True if the message is spam, False otherwise.
     Returns None if the request fails.
     """
-    seer_request = IsSpamRequest(
-        organization_id=organization_id,
-        feedback_message=message,
-    )
+    seer_request = {
+        "organization_id": organization_id,
+        "feedback_message": message,
+    }
 
     try:
         response = make_signed_seer_api_request(

--- a/src/sentry/feedback/usecases/spam_detection.py
+++ b/src/sentry/feedback/usecases/spam_detection.py
@@ -62,7 +62,14 @@ def is_spam_seer(message: str, organization_id: int) -> bool | None:
         return None
 
     try:
-        return response_data["data"]["is_spam"]
+        result = response_data["is_spam"]
+        if not isinstance(result, bool):
+            logger.error(
+                "Seer returned an invalid spam detection response",
+                extra={"response_data": response.data},
+            )
+            return None
+        return result
     except Exception:
         return None
 

--- a/src/sentry/feedback/usecases/spam_detection.py
+++ b/src/sentry/feedback/usecases/spam_detection.py
@@ -61,7 +61,11 @@ def is_spam_seer(message: str, organization_id: int) -> bool | None:
         )
         return None
 
-    if "is_spam" not in response_data or not isinstance(response_data["is_spam"], bool):
+    if (
+        not isinstance(response_data, dict)
+        or "is_spam" not in response_data
+        or not isinstance(response_data["is_spam"], bool)
+    ):
         logger.error(
             "Seer returned an invalid spam detection response",
             extra={"response_data": response.data},

--- a/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
@@ -642,16 +642,21 @@ def test_create_feedback_spam_detection_with_seer(
 
     # Check DD metrics
     if feature_flag_enabled:
-        expected_metric_value = f"seer-{str(is_spam_result).lower()}"
+        mock_metrics_incr.assert_any_call(
+            "feedback.create_feedback_issue.seer_spam_detection",
+            tags={
+                "is_spam": is_spam_result,
+                "referrer": FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE.value,
+            },
+        )
     else:
-        expected_metric_value = str(is_spam_result)
-    mock_metrics_incr.assert_any_call(
-        "feedback.create_feedback_issue.spam_detection",
-        tags={
-            "is_spam": expected_metric_value,
-            "referrer": FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE.value,
-        },
-    )
+        mock_metrics_incr.assert_any_call(
+            "feedback.create_feedback_issue.spam_detection",
+            tags={
+                "is_spam": is_spam_result,
+                "referrer": FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE.value,
+            },
+        )
 
     # Check group status
     if is_spam_result:

--- a/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
@@ -644,7 +644,7 @@ def test_create_feedback_spam_detection_with_seer(
     if feature_flag_enabled:
         expected_metric_value = f"seer-{str(is_spam_result).lower()}"
     else:
-        expected_metric_value = is_spam_result
+        expected_metric_value = str(is_spam_result)
     mock_metrics_incr.assert_any_call(
         "feedback.create_feedback_issue.spam_detection",
         tags={

--- a/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
@@ -587,6 +587,92 @@ def test_create_feedback_spam_detection_set_status_ignored(default_project) -> N
 
 
 @django_db_all
+@pytest.mark.parametrize(
+    "is_spam_result, expected_evidence_data, expected_evidence_display",
+    [
+        pytest.param(True, True, "True", id="is_spam"),
+        pytest.param(False, False, "False", id="is_not_spam"),
+        pytest.param(None, None, "error", id="error"),
+    ],
+)
+@pytest.mark.parametrize(
+    "feature_flag_enabled, expected_metric_prefix",
+    [
+        pytest.param(True, "seer-", id="seer_enabled_metric_prefix"),
+        pytest.param(False, "", id="seer_disabled_no_metric_prefix"),
+    ],
+)
+@patch("sentry.feedback.usecases.ingest.create_feedback.spam_detection_enabled", return_value=True)
+@patch("sentry.feedback.usecases.ingest.create_feedback.is_spam_seer")
+@patch("sentry.feedback.usecases.ingest.create_feedback.is_spam")
+@patch("sentry.utils.metrics.incr")
+def test_create_feedback_spam_detection_with_seer(
+    mock_metrics_incr,
+    mock_is_spam,
+    mock_is_spam_seer,
+    mock_spam_detection_enabled,
+    default_project,
+    mock_produce_occurrence_to_kafka,
+    feature_flag_enabled,
+    expected_metric_prefix,
+    is_spam_result,
+    expected_evidence_data,
+    expected_evidence_display,
+):
+    """Test spam detection with Seer feature flag enabled/disabled."""
+    mock_is_spam_seer.return_value = is_spam_result
+    mock_is_spam.return_value = is_spam_result
+
+    event = mock_feedback_event(default_project.id, message="Test feedback message")
+
+    with Feature({"organizations:user-feedback-seer-spam-detection": feature_flag_enabled}):
+        create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+
+    # Check that correct spam detection method was called
+    if feature_flag_enabled:
+        mock_is_spam_seer.assert_called_once_with(
+            "Test feedback message", default_project.organization_id
+        )
+        mock_is_spam.assert_not_called()
+    else:
+        mock_is_spam.assert_called_once_with("Test feedback message")
+        mock_is_spam_seer.assert_not_called()
+
+    # Check evidence data
+    occurrence = mock_produce_occurrence_to_kafka.call_args_list[0].kwargs["occurrence"]
+    assert occurrence.evidence_data["is_spam"] == expected_evidence_data
+    assert occurrence.evidence_data["spam_detection_enabled"] is True
+
+    # Check evidence display
+    is_spam_displays = [e.value for e in occurrence.evidence_display if e.name == "is_spam"]
+    is_spam_display = is_spam_displays[0] if is_spam_displays else None
+    assert is_spam_display == expected_evidence_display
+
+    # Check DD metrics
+    if feature_flag_enabled:
+        expected_metric_value = f"{expected_metric_prefix}{str(is_spam_result).lower()}"
+    else:
+        expected_metric_value = is_spam_result
+    mock_metrics_incr.assert_any_call(
+        "feedback.create_feedback_issue.spam_detection",
+        tags={
+            "is_spam": expected_metric_value,
+            "referrer": FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE.value,
+        },
+    )
+
+    # Check group status for spam cases
+    if is_spam_result:
+        # Should have status change kafka message for spam
+        assert mock_produce_occurrence_to_kafka.call_count == 2
+        status_change = mock_produce_occurrence_to_kafka.call_args_list[1].kwargs["status_change"]
+        assert status_change.new_status == GroupStatus.IGNORED
+    else:
+        # Should only have the initial occurrence message
+        assert mock_produce_occurrence_to_kafka.call_count == 1
+
+
+@django_db_all
 def test_create_feedback_evidence_associated_event_id(
     default_project, mock_produce_occurrence_to_kafka
 ):

--- a/tests/sentry/feedback/usecases/test_spam_detection.py
+++ b/tests/sentry/feedback/usecases/test_spam_detection.py
@@ -47,6 +47,7 @@ def test_is_spam_seer_http_error(mock_make_seer_request, status_code):
         pytest.param({"is_spam": "invalid"}, id="string_instead_of_bool"),
         pytest.param({"is_spam": 123}, id="int_instead_of_bool"),
         pytest.param({"is_spam": None}, id="none_instead_of_bool"),
+        pytest.param(None, id="none_instead_of_dict"),
     ],
 )
 @patch("sentry.feedback.usecases.spam_detection.make_signed_seer_api_request")

--- a/tests/sentry/feedback/usecases/test_spam_detection.py
+++ b/tests/sentry/feedback/usecases/test_spam_detection.py
@@ -46,6 +46,7 @@ def test_is_spam_seer_http_error(mock_make_seer_request, status_code):
         pytest.param({"wrong_key": True}, id="missing_is_spam_key"),
         pytest.param({"is_spam": "invalid"}, id="string_instead_of_bool"),
         pytest.param({"is_spam": 123}, id="int_instead_of_bool"),
+        pytest.param({"is_spam": None}, id="none_instead_of_bool"),
     ],
 )
 @patch("sentry.feedback.usecases.spam_detection.make_signed_seer_api_request")

--- a/tests/sentry/feedback/usecases/test_spam_detection.py
+++ b/tests/sentry/feedback/usecases/test_spam_detection.py
@@ -1,4 +1,9 @@
-from sentry.feedback.usecases.spam_detection import make_input_prompt
+from unittest.mock import patch
+
+import pytest
+
+from sentry.feedback.usecases.spam_detection import is_spam_seer, make_input_prompt
+from tests.sentry.feedback import MockSeerResponse
 
 
 def test_make_input_prompt_case_insensitive() -> None:
@@ -7,3 +12,44 @@ def test_make_input_prompt_case_insensitive() -> None:
     prompt2 = make_input_prompt(msg.lower())
 
     assert prompt1 == prompt2
+
+
+@pytest.mark.parametrize("response_is_spam", [True, False])
+@patch("sentry.feedback.usecases.spam_detection.make_signed_seer_api_request")
+def test_is_spam_seer_success(mock_make_seer_request, response_is_spam):
+    mock_make_seer_request.return_value = MockSeerResponse(200, {"is_spam": response_is_spam})
+    if response_is_spam:
+        assert is_spam_seer("Test feedback message", 1) is True
+    else:
+        assert is_spam_seer("Test feedback message", 1) is False
+    mock_make_seer_request.assert_called_once()
+
+
+@patch("sentry.feedback.usecases.spam_detection.make_signed_seer_api_request")
+def test_is_spam_seer_exception(mock_make_seer_request):
+    mock_make_seer_request.side_effect = Exception("Network error")
+    assert is_spam_seer("Test feedback message", 1) is None
+    mock_make_seer_request.assert_called_once()
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 429, 500, 502, 503, 504])
+@patch("sentry.feedback.usecases.spam_detection.make_signed_seer_api_request")
+def test_is_spam_seer_http_error(mock_make_seer_request, status_code):
+    mock_make_seer_request.return_value = MockSeerResponse(status_code, {})
+    assert is_spam_seer("Test feedback message", 1) is None
+    mock_make_seer_request.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "invalid_response",
+    [
+        pytest.param({"wrong_key": True}, id="missing_is_spam_key"),
+        pytest.param({"is_spam": "invalid"}, id="string_instead_of_bool"),
+        pytest.param({"is_spam": 123}, id="int_instead_of_bool"),
+    ],
+)
+@patch("sentry.feedback.usecases.spam_detection.make_signed_seer_api_request")
+def test_is_spam_seer_invalid_response(mock_make_seer_request, invalid_response):
+    mock_make_seer_request.return_value = MockSeerResponse(200, invalid_response)
+    assert is_spam_seer("Test feedback message", 1) is None
+    mock_make_seer_request.assert_called_once()

--- a/tests/sentry/feedback/usecases/test_spam_detection.py
+++ b/tests/sentry/feedback/usecases/test_spam_detection.py
@@ -48,6 +48,7 @@ def test_is_spam_seer_http_error(mock_make_seer_request, status_code):
         pytest.param({"is_spam": 123}, id="int_instead_of_bool"),
         pytest.param({"is_spam": None}, id="none_instead_of_bool"),
         pytest.param(None, id="none_instead_of_dict"),
+        pytest.param({}, id="empty_dict"),
     ],
 )
 @patch("sentry.feedback.usecases.spam_detection.make_signed_seer_api_request")


### PR DESCRIPTION
relates to REPLAY-651

Depends on https://github.com/getsentry/seer/pull/3433 (merged ✅ )

Spam detection currently makes direct API requests to google vertex AI, through the sentry.llm library. For better resilience and observability, we migrate the existing is_spam functionality to the new spam-detection endpoint in Seer. This branch is protected under the `user-feedback-seer-spam-detection` feature flag. We also add a new metric name `feedback.create_feedback_issue.seer_spam_detection` to track success and errors in Datadog.

Contrary to the Cursor summary, we do *not* reroute to the old spam detection if the new Seer call fails.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Seer-backed spam detection for user feedback behind `organizations:user-feedback-seer-spam-detection`, with metrics and tests, falling back to existing LLM path when disabled or on failure.
> 
> - **Backend**
>   - **Spam detection routing**: In `sentry/feedback/usecases/ingest/create_feedback.py`, use Seer via `is_spam_seer(org_id)` when `organizations:user-feedback-seer-spam-detection` is enabled; otherwise fall back to `is_spam`. Records metrics `feedback.create_feedback_issue.seer_spam_detection` (Seer) and existing `feedback.create_feedback_issue.spam_detection` (LLM).
>   - **Seer integration**: Add `is_spam_seer` in `sentry/feedback/usecases/spam_detection.py` calling signed Seer API (`/v1/automation/summarize/feedback/spam-detection`) with timeout/retries, response validation, and error handling.
>   - **Feature flags**: Register `organizations:user-feedback-seer-spam-detection` in `sentry/features/temporary.py`.
> - **Tests**
>   - Add tests for routing between Seer and LLM, evidence/metrics assertions, and group status updates in `tests/sentry/feedback/usecases/ingest/test_create_feedback.py`.
>   - Add unit tests for `is_spam_seer` success, HTTP errors, exceptions, and invalid responses in `tests/sentry/feedback/usecases/test_spam_detection.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76ad4abae5359de68d2927ac7df7855dc219818f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->