### PR TITLE
fix(aci): Adjust uptime monitor form layout

### DIFF
--- a/static/app/views/detectors/components/forms/uptime/detect/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/detect/index.tsx
@@ -36,131 +36,150 @@ export function UptimeDetectorFormDetectSection() {
   return (
     <Container>
       <Section title={t('Detect')}>
-        <DetectFieldsContainer>
-          <div>
-            <SelectField
-              options={VALID_INTERVALS_SEC.map(value => ({
-                value,
-                label: t('Every %s', getDuration(value)),
-              }))}
-              name="intervalSeconds"
-              label={t('Interval')}
-              defaultValue={60}
-              flexibleControlStateSize
-              showHelpInTooltip={{isHoverable: true}}
-              help={({model}) =>
-                tct(
-                  'The amount of time between each uptime check request. Selecting a period of [interval] means it will take at least [expectedFailureInterval] until you are notified of a failure. [link:Learn more].',
-                  {
-                    link: (
-                      <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
-                    ),
-                    interval: (
-                      <strong>{getDuration(model.getValue('intervalSeconds'))}</strong>
-                    ),
-                    expectedFailureInterval: (
-                      <strong>
-                        {getDuration(Number(model.getValue('intervalSeconds')) * 3)}
-                      </strong>
-                    ),
-                  }
-                )
-              }
-              required
-            />
-            <RangeField
-              name="timeoutMs"
-              label={t('Timeout')}
-              min={1000}
-              max={60_000}
-              step={250}
-              tickValues={[1_000, 10_000, 20_000, 30_000, 40_000, 50_000, 60_000]}
-              defaultValue={5_000}
-              showTickLabels
-              formatLabel={value => getDuration((value || 0) / 1000, 2, true)}
-              flexibleControlStateSize
-              required
-            />
-            <TextField
-              name="url"
-              label={t('URL')}
-              placeholder={t('The URL to monitor')}
-              flexibleControlStateSize
-              monospace
-              required
-            />
-            <SelectField
-              name="method"
-              label={t('Method')}
-              defaultValue="GET"
-              options={HTTP_METHOD_OPTIONS.map(option => ({
-                value: option,
-                label: option,
-              }))}
-              flexibleControlStateSize
-              required
-            />
-            <UptimeHeadersField
-              name="headers"
-              label={t('Headers')}
-              flexibleControlStateSize
-            />
-            <TextareaField
-              name="body"
-              label={t('Body')}
-              visible={({model}: any) => methodHasBody(model)}
-              rows={4}
-              maxRows={15}
-              autosize
-              monospace
-              placeholder='{"key": "value"}'
-              flexibleControlStateSize
-            />
-            <BooleanField
-              name="traceSampling"
-              label={t('Allow Sampling')}
-              showHelpInTooltip={{isHoverable: true}}
-              help={tct(
-                'Defer the sampling decision to a Sentry SDK configured in your application. Disable to prevent all span sampling. [link:Learn more].',
+        <ConfigurationFieldsContainer>
+          <SelectField
+            options={VALID_INTERVALS_SEC.map(value => ({
+              value,
+              label: t('Every %s', getDuration(value)),
+            }))}
+            name="intervalSeconds"
+            label={t('Interval')}
+            defaultValue={60}
+            flexibleControlStateSize
+            showHelpInTooltip={{isHoverable: true}}
+            help={({model}) =>
+              tct(
+                'The amount of time between each uptime check request. Selecting a period of [interval] means it will take at least [expectedFailureInterval] until you are notified of a failure. [link:Learn more].',
                 {
                   link: (
-                    <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/uptime-tracing/" />
+                    <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/#uptime-check-failures" />
+                  ),
+                  interval: (
+                    <strong>{getDuration(model.getValue('intervalSeconds'))}</strong>
+                  ),
+                  expectedFailureInterval: (
+                    <strong>
+                      {getDuration(Number(model.getValue('intervalSeconds')) * 3)}
+                    </strong>
                   ),
                 }
-              )}
-              flexibleControlStateSize
-            />
-            <NumberField
-              name="downtimeThreshold"
-              min={1}
-              placeholder={t('Defaults to %s', UPTIME_DEFAULT_DOWNTIME_THRESHOLD)}
-              help={({model}) => {
-                const intervalSeconds = Number(model.getValue('intervalSeconds'));
-                const threshold =
-                  Number(model.getValue('downtimeThreshold')) ||
-                  UPTIME_DEFAULT_DOWNTIME_THRESHOLD;
-                const downDuration = intervalSeconds * threshold;
+              )
+            }
+            required
+          />
+          <RangeField
+            name="timeoutMs"
+            label={t('Timeout')}
+            min={1000}
+            max={60_000}
+            step={250}
+            tickValues={[1_000, 10_000, 20_000, 30_000, 40_000, 50_000, 60_000]}
+            defaultValue={5_000}
+            showTickLabels
+            formatLabel={value => getDuration((value || 0) / 1000, 2, true)}
+            flexibleControlStateSize
+            required
+          />
+          <TextField
+            name="url"
+            label={t('URL')}
+            placeholder={t('The URL to monitor')}
+            flexibleControlStateSize
+            monospace
+            required
+          />
+          <SelectField
+            name="method"
+            label={t('Method')}
+            defaultValue="GET"
+            options={HTTP_METHOD_OPTIONS.map(option => ({
+              value: option,
+              label: option,
+            }))}
+            flexibleControlStateSize
+            required
+          />
+          <UptimeHeadersField
+            name="headers"
+            label={t('Headers')}
+            flexibleControlStateSize
+          />
+          <TextareaField
+            name="body"
+            label={t('Body')}
+            visible={({model}: any) => methodHasBody(model)}
+            rows={4}
+            maxRows={15}
+            autosize
+            monospace
+            placeholder='{"key": "value"}'
+            flexibleControlStateSize
+          />
+          <BooleanField
+            name="traceSampling"
+            label={t('Allow Sampling')}
+            showHelpInTooltip={{isHoverable: true}}
+            help={tct(
+              'Defer the sampling decision to a Sentry SDK configured in your application. Disable to prevent all span sampling. [link:Learn more].',
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/uptime-tracing/" />
+                ),
+              }
+            )}
+            flexibleControlStateSize
+          />
+          <NumberField
+            name="downtimeThreshold"
+            min={1}
+            placeholder={t('Defaults to %s', UPTIME_DEFAULT_DOWNTIME_THRESHOLD)}
+            help={({model}) => {
+              const intervalSeconds = Number(model.getValue('intervalSeconds'));
+              const threshold =
+                Number(model.getValue('downtimeThreshold')) ||
+                UPTIME_DEFAULT_DOWNTIME_THRESHOLD;
+              const downDuration = intervalSeconds * threshold;
 
-                return tct(
-                  'Issue created after [threshold] consecutive failures (after [downtime] of downtime).',
-                  {
-                    threshold: <strong>{threshold}</strong>,
-                    downtime: <strong>{getDuration(downDuration)}</strong>,
-                  }
-                );
-              }}
-              label={t('Failure Threshold')}
-              flexibleControlStateSize
-            />
-          </div>
-        </DetectFieldsContainer>
+              return tct(
+                'Issue created after [threshold] consecutive failures (after [downtime] of downtime).',
+                {
+                  threshold: <strong>{threshold}</strong>,
+                  downtime: <strong>{getDuration(downDuration)}</strong>,
+                }
+              );
+            }}
+            label={t('Failure Threshold')}
+            flexibleControlStateSize
+          />
+        </ConfigurationFieldsContainer>
       </Section>
     </Container>
   );
 }
 
-const DetectFieldsContainer = styled('div')`
+const ConfigurationFieldsContainer = styled('div')`
+  display: grid;
+  gap: 0 ${p => p.theme.space.xl};
+  grid-template-columns: fit-content(250px) 1fr;
+  align-items: center;
+
   ${FieldWrapper} {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
     padding-left: 0;
+
+    label {
+      width: auto;
+    }
+  }
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    ${FieldWrapper} {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: ${p => p.theme.space.md};
+    }
   }
 `;

--- a/static/app/views/detectors/components/forms/uptime/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/index.tsx
@@ -53,6 +53,7 @@ export function EditExistingUptimeDetectorForm({detector}: {detector: UptimeDete
 const FormStack = styled('div')`
   display: flex;
   flex-direction: column;
-  gap: ${space(3)};
-  max-width: ${p => p.theme.breakpoints.xl};
+  gap: ${p => p.theme.space['2xl']};
+  max-width: ${p => p.theme.breakpoints.lg};
+  padding-bottom: 160px;
 `;

--- a/static/app/views/detectors/components/forms/uptime/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/index.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import {space} from 'sentry/styles/space';
 import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
 import {AssignSection} from 'sentry/views/detectors/components/forms/common/assignSection';


### PR DESCRIPTION
- Shrinks the overall max width
- Adjusts the left/right side to be closer to the old version
- fixes layout on mobile

before

<img width="1512" height="1084" alt="image" src="https://github.com/user-attachments/assets/8e849f28-246f-4b9e-b66f-962875cf4058" />


after
<img width="1303" height="1142" alt="image" src="https://github.com/user-attachments/assets/54129be6-cf53-42ef-97ec-a80c9bab9010" />

after mobile

<img width="531" height="875" alt="image" src="https://github.com/user-attachments/assets/4aec097a-8e26-4bde-878f-e7a7340c8090" />
