### PR TITLE
chore(checkout v3): Don't stop replay recording manually

### DIFF
--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -235,10 +235,6 @@ class AMCheckout extends Component<Props, State> {
     }
   }
 
-  componentWillUnmount() {
-    Sentry.getReplay()?.stop();
-  }
-
   readonly initialStep: number;
 
   get referrer(): string | undefined {


### PR DESCRIPTION
We'll let the replay SDK handle stopping instead.

This will help inform us where customers go after checkout (esp in the case they exit quickly).