### PR TITLE
fix(aci): reduce automation creation form header size

### DIFF
--- a/static/app/views/automations/components/automationForm.tsx
+++ b/static/app/views/automations/components/automationForm.tsx
@@ -2,7 +2,7 @@ import {useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
-import {Text} from 'sentry/components/core/text';
+import {Heading, Text} from 'sentry/components/core/text';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import type FormModel from 'sentry/components/forms/model';
 import {DebugForm} from 'sentry/components/workflowEngine/form/debug';
@@ -49,9 +49,9 @@ export default function AutomationForm({model}: {model: FormModel}) {
       />
       <Card>
         <Flex direction="column" gap="sm">
-          <Text size="lg" bold>
+          <Heading as="h2" size="lg">
             {t('Choose Environment')}
-          </Text>
+          </Heading>
           <Text size="sm" variant="muted">
             {t(
               'If you select environments different than your monitors then the automation will not fire.'
@@ -61,15 +61,15 @@ export default function AutomationForm({model}: {model: FormModel}) {
         <EnvironmentSelector value={environment} onChange={updateEnvironment} />
       </Card>
       <Card>
-        <Text size="lg" bold>
+        <Heading as="h2" size="lg">
           {t('Automation Builder')}
-        </Text>
+        </Heading>
         <AutomationBuilder />
       </Card>
       <Card>
-        <Text size="lg" bold>
+        <Heading as="h2" size="lg">
           {t('Action Interval')}
-        </Text>
+        </Heading>
         <EmbeddedSelectField
           required
           name="frequency"

--- a/static/app/views/automations/components/automationForm.tsx
+++ b/static/app/views/automations/components/automationForm.tsx
@@ -2,6 +2,7 @@ import {useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import type FormModel from 'sentry/components/forms/model';
 import {DebugForm} from 'sentry/components/workflowEngine/form/debug';
@@ -47,22 +48,28 @@ export default function AutomationForm({model}: {model: FormModel}) {
         setConnectedIds={setConnectedIds}
       />
       <Card>
-        <Flex direction="column" gap="xs">
-          <Heading>{t('Choose Environment')}</Heading>
-          <Description>
+        <Flex direction="column" gap="sm">
+          <Text size="lg" bold>
+            {t('Choose Environment')}
+          </Text>
+          <Text size="sm" variant="muted">
             {t(
               'If you select environments different than your monitors then the automation will not fire.'
             )}
-          </Description>
+          </Text>
         </Flex>
         <EnvironmentSelector value={environment} onChange={updateEnvironment} />
       </Card>
       <Card>
-        <Heading>{t('Automation Builder')}</Heading>
+        <Text size="lg" bold>
+          {t('Automation Builder')}
+        </Text>
         <AutomationBuilder />
       </Card>
       <Card>
-        <Heading>{t('Action Interval')}</Heading>
+        <Text size="lg" bold>
+          {t('Action Interval')}
+        </Text>
         <EmbeddedSelectField
           required
           name="frequency"
@@ -75,18 +82,6 @@ export default function AutomationForm({model}: {model: FormModel}) {
     </Flex>
   );
 }
-
-const Heading = styled('h2')`
-  font-size: ${p => p.theme.fontSize.xl};
-  margin: 0;
-`;
-
-const Description = styled('span')`
-  font-size: ${p => p.theme.fontSize.md};
-  color: ${p => p.theme.subText};
-  margin: 0;
-  padding: 0;
-`;
 
 const EmbeddedSelectField = styled(SelectField)`
   padding: 0;


### PR DESCRIPTION
the text was really big 🧍‍♀️

new:
<img width="1379" height="747" alt="Screenshot 2025-09-26 at 2 36 00 PM" src="https://github.com/user-attachments/assets/d62b5846-d521-49ab-b5fa-1e2bf0c6b379" />
