### PR TITLE
fix(prevent): Format values less than 0.01 with `<`

### DIFF
--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -219,13 +219,13 @@ describe('formatSpanOperation', () => {
 });
 
 describe('formatPercentRate', () => {
-  it('formats positive numbers', () => {
+  it('formats positive rates with + sign', () => {
     expect(formatPercentRate(0.1)).toBe('+0.10%');
     expect(formatPercentRate(1)).toBe('+1.00%');
     expect(formatPercentRate(10)).toBe('+10.00%');
   });
 
-  it('formats negative numbers', () => {
+  it('formats negative rates', () => {
     expect(formatPercentRate(-0.1)).toBe('-0.10%');
     expect(formatPercentRate(-1)).toBe('-1.00%');
     expect(formatPercentRate(-10)).toBe('-10.00%');
@@ -233,6 +233,32 @@ describe('formatPercentRate', () => {
 
   it('formats zero', () => {
     expect(formatPercentRate(0)).toBe('0.00%');
+  });
+
+  it('shows "<+{minimumValue}%" for small positive values when minimumValue is provided', () => {
+    expect(formatPercentRate(0.001, {minimumValue: 0.01})).toBe('<+0.01%');
+    expect(formatPercentRate(0.009, {minimumValue: 0.01})).toBe('<+0.01%');
+  });
+
+  it('shows "<-{minimumValue}%" for small negative values when minimumValue is provided', () => {
+    expect(formatPercentRate(-0.001, {minimumValue: 0.01})).toBe('<-0.01%');
+    expect(formatPercentRate(-0.009, {minimumValue: 0.01})).toBe('<-0.01%');
+  });
+
+  it('does not show "<{minimumValue}%" for values >= minimumValue', () => {
+    expect(formatPercentRate(0.01, {minimumValue: 0.01})).toBe('+0.01%');
+    expect(formatPercentRate(-0.01, {minimumValue: 0.01})).toBe('-0.01%');
+    expect(formatPercentRate(0.1, {minimumValue: 0.01})).toBe('+0.10%');
+  });
+
+  it('handles edge case of exactly zero with minimumValue', () => {
+    expect(formatPercentRate(0, {minimumValue: 0.01})).toBe('0.00%');
+  });
+
+  it('uses custom minimumValue', () => {
+    expect(formatPercentRate(0.001, {minimumValue: 0.05})).toBe('<+0.05%');
+    expect(formatPercentRate(-0.03, {minimumValue: 0.05})).toBe('<-0.05%');
+    expect(formatPercentRate(0.05, {minimumValue: 0.05})).toBe('+0.05%');
   });
 });
 

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -243,20 +243,28 @@ function getShortSpanOperationDescription(operation?: string) {
 /**
  * Formats a change rate with a sign (+/-) and 2 decimal places.
  *
- * e.g. `0.46 -> '+0.46%'`, `-0.46 -> '-0.46%'`, `0 -> '0%'`
+ * e.g. `0.46 -> '+0.46%'`, `-0.46 -> '-0.46%'`, `0 -> '0.00%'`
  *
  * @param change the change rate to format
+ * @param options formatting options
+ * @param options.minimumValue minimum value threshold, below which "<{minimumValue}%" is shown
  */
-export function formatPercentRate(change: number) {
+export function formatPercentRate(change: number, options?: {minimumValue?: number}) {
+  const {minimumValue} = options ?? {};
+
+  if (change === 0) {
+    return '0.00%';
+  }
+
+  if (minimumValue && Math.abs(change) > 0 && Math.abs(change) < minimumValue) {
+    return change > 0 ? `<+${minimumValue.toFixed(2)}%` : `<-${minimumValue.toFixed(2)}%`;
+  }
+
   if (change > 0) {
     return `+${change.toFixed(2)}%`;
   }
 
-  if (change < 0) {
-    return `${change.toFixed(2)}%`;
-  }
-
-  return '0.00%';
+  return `${change.toFixed(2)}%`;
 }
 
 /**

--- a/static/app/views/prevent/tests/summaries/ciEfficiency.tsx
+++ b/static/app/views/prevent/tests/summaries/ciEfficiency.tsx
@@ -87,7 +87,7 @@ function CIEfficiencyBody({
         extra={
           totalTestsRunTimeChange ? (
             <Tag type={totalTestsRunTimeChange > 0 ? 'error' : 'success'}>
-              {formatPercentRate(totalTestsRunTimeChange)}
+              {formatPercentRate(totalTestsRunTimeChange, {minimumValue: 0.01})}
             </Tag>
           ) : undefined
         }

--- a/static/app/views/prevent/tests/summaries/testPerformance.spec.tsx
+++ b/static/app/views/prevent/tests/summaries/testPerformance.spec.tsx
@@ -25,7 +25,7 @@ describe('TestPerformance', () => {
   it('renders average flake rate', () => {
     render(<TestPerformance {...testPerformanceData} isLoading={false} />);
 
-    const averageFlakeRate = screen.getByText(/0.10%/);
+    const averageFlakeRate = screen.getByText(/0.1%/);
     expect(averageFlakeRate).toBeInTheDocument();
   });
 

--- a/static/app/views/prevent/tests/summaries/testPerformance.tsx
+++ b/static/app/views/prevent/tests/summaries/testPerformance.tsx
@@ -6,6 +6,7 @@ import {Heading, Text} from 'sentry/components/core/text';
 import {SummaryCard, SummaryCardGroup} from 'sentry/components/prevent/summary';
 import {t} from 'sentry/locale';
 import {formatPercentRate} from 'sentry/utils/formatters';
+import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 
 function FlakyTestsTooltip() {
   return (
@@ -100,7 +101,7 @@ function TestPerformanceBody({
         extra={
           flakyTestsChange ? (
             <Tag type={flakyTestsChange > 0 ? 'error' : 'success'}>
-              {formatPercentRate(flakyTestsChange)}
+              {formatPercentRate(flakyTestsChange, {minimumValue: 0.01})}
             </Tag>
           ) : undefined
         }
@@ -109,12 +110,14 @@ function TestPerformanceBody({
         label={t('Avg. Flake Rate')}
         tooltip={<AverageFlakeTooltip />}
         value={
-          averageFlakeRate === undefined ? undefined : `${averageFlakeRate?.toFixed(2)}%`
+          averageFlakeRate === undefined
+            ? undefined
+            : formatPercentage(averageFlakeRate / 100, 2, {minimumValue: 0.0001})
         }
         extra={
           averageFlakeRateChange ? (
             <Tag type={averageFlakeRateChange > 0 ? 'error' : 'success'}>
-              {formatPercentRate(averageFlakeRateChange)}
+              {formatPercentRate(averageFlakeRateChange, {minimumValue: 0.01})}
             </Tag>
           ) : undefined
         }
@@ -127,7 +130,7 @@ function TestPerformanceBody({
         extra={
           cumulativeFailuresChange ? (
             <Tag type={cumulativeFailuresChange > 0 ? 'error' : 'success'}>
-              {formatPercentRate(cumulativeFailuresChange)}
+              {formatPercentRate(cumulativeFailuresChange, {minimumValue: 0.01})}
             </Tag>
           ) : undefined
         }
@@ -140,7 +143,7 @@ function TestPerformanceBody({
         extra={
           skippedTestsChange ? (
             <Tag type={skippedTestsChange > 0 ? 'error' : 'success'}>
-              {formatPercentRate(skippedTestsChange)}
+              {formatPercentRate(skippedTestsChange, {minimumValue: 0.01})}
             </Tag>
           ) : undefined
         }

--- a/static/app/views/prevent/tests/testAnalyticsTable/tableBody.tsx
+++ b/static/app/views/prevent/tests/testAnalyticsTable/tableBody.tsx
@@ -5,6 +5,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {DateTime} from 'sentry/components/dateTime';
 import PerformanceDuration from 'sentry/components/performanceDuration';
 import {t, tct} from 'sentry/locale';
+import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {
   RIGHT_ALIGNED_FIELDS,
   type Column,
@@ -64,7 +65,7 @@ export function renderTableBody({column, row, wrapToggleValue}: TableBodyProps) 
           )}
         >
           <Text tabular ellipsis>
-            {Number(value).toFixed(2)}%
+            {formatPercentage(Number(value) / 100, 2, {minimumValue: 0.0001})}
           </Text>
         </Tooltip>
       </Flex>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce minimum-value threshold to `formatPercentRate` and switch Prevent test views to consistent percentage formatting with small-value handling.
> 
> - **Utils**:
>   - **`formatPercentRate`**: Add `minimumValue` option to show `<±{min}%` for small magnitudes; keep `+` for positives; format zero as `0.00%`.
>   - **Tests**: Expand coverage for new threshold behavior and zero/positive/negative cases.
> - **Prevent UI**:
>   - **CI Efficiency**: Use `formatPercentRate(..., {minimumValue: 0.01})` for change tags.
>   - **Test Performance**:
>     - Display average flake rate via `formatPercentage(value/100, 2, {minimumValue: 0.0001})` (updates spec from `0.10%` to `0.1%`).
>     - Apply `formatPercentRate(..., {minimumValue: 0.01})` to change tags.
>   - **Test Analytics Table**: Render `flakeRate` with `formatPercentage(value/100, 2, {minimumValue: 0.0001})`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b24cf871f2bd3fed825913f18b8cefd28fb7a690. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->