### PR TITLE
feat(issue summary): Send trace to seer

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -163,9 +163,11 @@ def _get_serialized_event(
     return serialized_event, event
 
 
-def _get_trace_tree_for_event(event: Event | GroupEvent, project: Project) -> dict[str, Any] | None:
+def _get_trace_tree_for_event(
+    event: Event | GroupEvent, project: Project, timeout: int = 15
+) -> dict[str, Any] | None:
     """
-    Returns the full trace for the given issue event with a 15-second timeout.
+    Returns the full trace for the given issue event with a timeout (default 15 seconds).
     Returns None if the timeout expires or if the trace cannot be fetched.
     """
     trace_id = event.trace_id
@@ -217,8 +219,6 @@ def _get_trace_tree_for_event(event: Event | GroupEvent, project: Project) -> di
             "org_id": project.organization_id,
             "trace": trace,
         }
-
-    timeout = 15  # seconds
 
     try:
         with sentry_sdk.start_span(op="seer.autofix.get_trace_tree_for_event"):

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -13,13 +13,12 @@ from django.contrib.auth.models import AnonymousUser
 from sentry import eventstore, features, quotas
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
-from sentry.constants import DataCategory, ObjectStatus
+from sentry.constants import DataCategory
 from sentry.issues.grouptype import WebVitalsGroup
 from sentry.locks import locks
 from sentry.models.group import Group
-from sentry.models.project import Project
 from sentry.net.http import connection_from_url
-from sentry.seer.autofix.autofix import trigger_autofix
+from sentry.seer.autofix.autofix import _get_trace_tree_for_event, trigger_autofix
 from sentry.seer.autofix.constants import (
     AutofixAutomationTuningSettings,
     FixabilityScoreThresholds,
@@ -128,13 +127,8 @@ def _get_event(
 def _call_seer(
     group: Group,
     serialized_event: dict[str, Any],
-    connected_groups: list[Group],
-    connected_serialized_events: list[dict[str, Any]],
+    trace_tree: dict[str, Any] | None,
 ):
-    # limit amount of connected data we send to first few connected issues
-    connected_groups = connected_groups[:4]
-    connected_serialized_events = connected_serialized_events[:4]
-
     path = "/v1/automation/summarize/issue"
     body = orjson.dumps(
         {
@@ -145,15 +139,7 @@ def _call_seer(
                 "short_id": group.qualified_short_id,
                 "events": [serialized_event],
             },
-            "connected_issues": [
-                {
-                    "id": connected_groups[i].id,
-                    "title": connected_groups[i].title,
-                    "short_id": connected_groups[i].qualified_short_id,
-                    "events": [connected_serialized_events[i]],
-                }
-                for i in range(len(connected_groups))
-            ],
+            "trace_tree": trace_tree,
             "organization_slug": group.organization.slug,
             "organization_id": group.organization.id,
             "project_id": group.project.id,
@@ -198,54 +184,6 @@ def _generate_fixability_score(group: Group) -> SummarizeIssueResponse:
         raise Exception(f"Seer API error: {response.status}")
     response_data = orjson.loads(response.data)
     return SummarizeIssueResponse.validate(response_data)
-
-
-def _get_trace_connected_issues(event: GroupEvent) -> list[Group]:
-    try:
-        trace_id = event.trace_id
-        if not trace_id:
-            return []
-    except (
-        AttributeError
-    ):  # sometimes the trace doesn't exist and this errors, so we just ignore it
-        return []
-    organization = event.group.organization
-    conditions = [["trace", "=", trace_id]]
-    start = event.datetime - timedelta(days=1)
-    end = event.datetime + timedelta(days=1)
-    project_ids = list(
-        dict(
-            Project.objects.filter(
-                organization=organization, status=ObjectStatus.ACTIVE
-            ).values_list("id", "slug")
-        ).keys()
-    )
-    event_filter = eventstore.Filter(
-        conditions=conditions, start=start, end=end, project_ids=project_ids
-    )
-    connected_events = eventstore.backend.get_events(
-        filter=event_filter,
-        referrer="api.group_ai_summary",
-        tenant_ids={"organization_id": organization.id},
-        limit=5,
-    )
-    connected_events = sorted(
-        connected_events, key=lambda event: event.datetime
-    )  # sort chronologically
-
-    issue_ids = set()
-    connected_issues = []
-    for e in connected_events:
-        if event.event_id == e.event_id:
-            continue
-        if e.group_id not in issue_ids:
-            issue_ids.add(e.group_id)
-            try:
-                if e.group:
-                    connected_issues.append(e.group)
-            except Group.DoesNotExist:
-                continue
-    return connected_issues
 
 
 def _is_issue_fixable(group: Group, fixability_score: float) -> bool:
@@ -341,23 +279,19 @@ def _generate_summary(
     if not serialized_event or not event:
         return {"detail": "Could not find an event for the issue"}, 400
 
-    # get trace connected issues
-    connected_issues = _get_trace_connected_issues(event)
-
-    # get recommended event for each connected issue
-    serialized_events_for_connected_issues = []
-    filtered_connected_issues = []
-    for issue in connected_issues:
-        serialized_connected_event, _ = _get_event(issue, user)
-        if serialized_connected_event:
-            serialized_events_for_connected_issues.append(serialized_connected_event)
-            filtered_connected_issues.append(issue)
+    trace_tree = None
+    if event:
+        try:
+            trace_tree = _get_trace_tree_for_event(event, group.project, timeout=3)
+        except Exception:
+            logger.warning(
+                "Failed to get trace for event in issue summary", extra={"group_id": group.id}
+            )
 
     issue_summary = _call_seer(
         group,
         serialized_event,
-        filtered_connected_issues,
-        serialized_events_for_connected_issues,
+        trace_tree,
     )
 
     try:

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -285,7 +285,9 @@ def _generate_summary(
             trace_tree = _get_trace_tree_for_event(event, group.project, timeout=3)
         except Exception:
             logger.warning(
-                "Failed to get trace for event in issue summary", extra={"group_id": group.id}, exc_info=True
+                "Failed to get trace for event in issue summary",
+                extra={"group_id": group.id},
+                exc_info=True,
             )
 
     issue_summary = _call_seer(

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -285,7 +285,7 @@ def _generate_summary(
             trace_tree = _get_trace_tree_for_event(event, group.project, timeout=3)
         except Exception:
             logger.warning(
-                "Failed to get trace for event in issue summary", extra={"group_id": group.id}
+                "Failed to get trace for event in issue summary", extra={"group_id": group.id}, exc_info=True
             )
 
     issue_summary = _call_seer(

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -1,7 +1,7 @@
 import datetime
 import threading
 import time
-from unittest.mock import ANY, MagicMock, Mock, call, patch
+from unittest.mock import MagicMock, Mock, call, patch
 
 import orjson
 import pytest
@@ -12,14 +12,7 @@ from sentry.issues.grouptype import WebVitalsGroup
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.locks import locks
 from sentry.seer.autofix.constants import SeerAutomationSource
-from sentry.seer.autofix.issue_summary import (
-    _call_seer,
-    _generate_fixability_score,
-    _get_event,
-    _get_trace_connected_issues,
-    _run_automation,
-    get_issue_summary,
-)
+from sentry.seer.autofix.issue_summary import _call_seer, _get_event, get_issue_summary
 from sentry.seer.models import SummarizeIssueResponse, SummarizeIssueScores
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -91,11 +84,11 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_get_acknowledgement.assert_called_once_with(self.group.organization.id)
 
     @patch("sentry.seer.autofix.issue_summary.get_seer_org_acknowledgement")
-    @patch("sentry.seer.autofix.issue_summary._get_trace_connected_issues")
+    @patch("sentry.seer.autofix.issue_summary._get_trace_tree_for_event")
     @patch("sentry.seer.autofix.issue_summary._call_seer")
     @patch("sentry.seer.autofix.issue_summary._get_event")
     def test_get_issue_summary_without_existing_summary(
-        self, mock_get_event, mock_call_seer, mock_get_connected_issues, mock_get_acknowledgement
+        self, mock_get_event, mock_call_seer, mock_get_trace_tree, mock_get_acknowledgement
     ):
         mock_get_acknowledgement.return_value = True
         event = Mock(
@@ -118,7 +111,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             ),
         )
         mock_call_seer.return_value = mock_summary
-        mock_get_connected_issues.return_value = [self.group, self.group]
+        mock_get_trace_tree.return_value = {"trace": "tree"}
 
         expected_response_summary = mock_summary.dict()
         expected_response_summary["event_id"] = event.event_id
@@ -127,14 +120,9 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
 
         assert status_code == 200
         assert summary_data == convert_dict_key_case(expected_response_summary, snake_to_camel_case)
-        mock_get_event.assert_called_with(self.group, ANY)
-        assert mock_get_event.call_count == 3
-        mock_call_seer.assert_called_once_with(
-            self.group,
-            serialized_event,
-            [self.group, self.group],
-            [serialized_event, serialized_event],
-        )
+        mock_get_event.assert_called_once_with(self.group, self.user, provided_event_id=None)
+        mock_get_trace_tree.assert_called_once()
+        mock_call_seer.assert_called_once_with(self.group, serialized_event, {"trace": "tree"})
         mock_get_acknowledgement.assert_called_once_with(self.group.organization.id)
 
         # Check if the cache was set correctly
@@ -195,6 +183,8 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert status_code == 200
         assert summary_data == convert_dict_key_case(expected_response_summary, snake_to_camel_case)
         mock_post.assert_called_once()
+        payload = orjson.loads(mock_post.call_args_list[0].kwargs["data"])
+        assert payload["trace_tree"] is None
         mock_get_acknowledgement.assert_called_once_with(self.group.organization.id)
 
         assert cache.get(f"ai-group-summary-v2:{self.group.id}") == expected_response_summary
@@ -365,7 +355,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         resp.raise_for_status = Mock()
         post.return_value = resp
 
-        result = _call_seer(self.group, {"event_id": "e1"}, [], [])
+        result = _call_seer(self.group, {"event_id": "e1"}, {"trace": "tree"})
 
         assert result.group_id == str(self.group.id)
         assert post.call_count == 1
@@ -374,6 +364,8 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             .args[0]
             .startswith(f"{settings.SEER_SUMMARIZATION_URL}/v1/automation/summarize/issue")
         )
+        payload = orjson.loads(post.call_args_list[0].kwargs["data"])
+        assert payload["trace_tree"] == {"trace": "tree"}
         resp.raise_for_status.assert_called_once()
 
     @patch("sentry.seer.autofix.issue_summary.sign_with_seer_secret", return_value={})
@@ -384,7 +376,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         self, post: MagicMock, sign: MagicMock
     ) -> None:
         with pytest.raises(Exception):
-            _call_seer(self.group, {"event_id": "e1"}, [], [])
+            _call_seer(self.group, {"event_id": "e1"}, None)
 
     @patch("sentry.seer.autofix.issue_summary.cache.get")
     @patch("sentry.seer.autofix.issue_summary._generate_summary")
@@ -415,57 +407,6 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         # Ensure cache was checked three times (once initially, once after lock failure, and once for hideAiFeatures check)
         assert mock_cache_get.call_count == 3
         mock_get_acknowledgement.assert_called_once_with(self.group.organization.id)
-
-    @patch("sentry.seer.autofix.issue_summary.Project.objects.filter")
-    @patch("sentry.seer.autofix.issue_summary.eventstore.backend.get_events")
-    def test_get_trace_connected_issues(
-        self, mock_get_events: MagicMock, mock_project_filter: MagicMock
-    ) -> None:
-        event = Mock()
-        event.trace_id = "test_trace_id"
-        event.datetime = datetime.datetime.now()
-        event.group.organization.id = 1
-
-        mock_project_filter.return_value.values_list.return_value = [
-            (1, "project1"),
-            (2, "project2"),
-        ]
-
-        # connected events
-        mock_event1 = Mock(
-            event_id="1",
-            group_id=1,
-            group=Mock(),
-            datetime=event.datetime - datetime.timedelta(minutes=5),
-        )
-        mock_event2 = Mock(
-            event_id="2",
-            group_id=2,
-            group=Mock(),
-            datetime=event.datetime + datetime.timedelta(minutes=5),
-        )
-        mock_get_events.return_value = [mock_event1, mock_event2]
-
-        result = _get_trace_connected_issues(event)
-
-        assert len(result) == 2
-        assert mock_event1.group in result
-        assert mock_event2.group in result
-
-        mock_project_filter.assert_called_once()
-        mock_get_events.assert_called_once()
-
-        _, kwargs = mock_get_events.call_args
-        assert kwargs["filter"].conditions == [["trace", "=", "test_trace_id"]]
-        assert kwargs["filter"].project_ids == [1, 2]
-        assert kwargs["referrer"] == "api.group_ai_summary"
-        assert kwargs["tenant_ids"] == {"organization_id": 1}
-
-    def test_get_trace_connected_issues_no_trace_id(self) -> None:
-        event = Mock()
-        event.trace_id = None
-        result = _get_trace_connected_issues(event)
-        assert result == []
 
     @patch("sentry.seer.autofix.issue_summary.eventstore.backend.get_event_by_id")
     @patch("sentry.seer.autofix.issue_summary.serialize")
@@ -577,208 +518,16 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
-    def test_run_automation_saves_fixability_score(
-        self,
-        mock_generate_fixability_score,
-        mock_get_autofix_state,
-        mock_trigger_autofix_task,
-    ):
-        """Test that _run_automation saves the fixability score."""
-        self.group.project.update_option("sentry:autofix_automation_tuning", "high")
-        mock_event = Mock(event_id="test_event_id")
-        mock_user = self.user
-
-        mock_fixability_response = SummarizeIssueResponse(
-            group_id=str(self.group.id),
-            headline="some headline",
-            whats_wrong="some whats wrong",
-            trace="some trace",
-            possible_cause="some possible cause",
-            scores=SummarizeIssueScores(
-                fixability_score=0.5,
-                is_fixable=True,
-            ),
-        )
-        mock_generate_fixability_score.return_value = mock_fixability_response
-        mock_get_autofix_state.return_value = None
-
-        self.group.refresh_from_db()
-        assert self.group.seer_fixability_score is None
-
-        _run_automation(self.group, mock_user, mock_event, source=SeerAutomationSource.POST_PROCESS)
-
-        mock_generate_fixability_score.assert_called_once_with(self.group)
-
-        mock_trigger_autofix_task.assert_called_once_with(
-            group_id=self.group.id,
-            event_id="test_event_id",
-            user_id=mock_user.id,
-            auto_run_source="issue_summary_on_post_process_fixability",
-        )
-
-        self.group.refresh_from_db()
-        assert self.group.seer_fixability_score == 0.5
-
-    @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
-    @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
-    @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
-    def test_is_issue_fixable_triggers_autofix(
-        self,
-        mock_generate_fixability_score,
-        mock_get_autofix_state,
-        mock_trigger_autofix_task,
-    ):
-        mock_event = Mock(event_id="test_event_id")
-        mock_user = self.user
-        mock_get_autofix_state.return_value = None
-
-        test_cases = [
-            # option, fixability_score, should_trigger_autofix
-            ("off", 0.9, False),
-            ("low", 0.6, False),
-            ("low", 0.7, True),
-            ("low", 0.8, True),
-            ("medium", 0.39, False),
-            ("medium", 0.5, True),
-            ("medium", 0.6, True),
-            ("high", 0.2, False),
-            ("high", 0.3, True),
-            ("high", 0.4, True),
-            ("always", 0.1, True),
-            ("always", 0.0, True),
-        ]
-
-        for option_value, score, should_trigger in test_cases:
-            mock_trigger_autofix_task.reset_mock()
-            mock_generate_fixability_score.reset_mock()
-            self.group.seer_fixability_score = None
-            self.group.save()
-
-            mock_fixability_response = SummarizeIssueResponse(
-                group_id=str(self.group.id),
-                headline="some headline",
-                whats_wrong="some whats wrong",
-                trace="some trace",
-                possible_cause="some possible cause",
-                scores=SummarizeIssueScores(
-                    fixability_score=score,
-                    is_fixable=True,  # is_fixable from seer doesn't gate our logic
-                ),
-            )
-            mock_generate_fixability_score.return_value = mock_fixability_response
-
-            with self.subTest(option=option_value, score=score, should_trigger=should_trigger):
-                self.group.project.update_option("sentry:autofix_automation_tuning", option_value)
-                _run_automation(
-                    self.group, mock_user, mock_event, source=SeerAutomationSource.POST_PROCESS
-                )
-
-                mock_generate_fixability_score.assert_called_once_with(self.group)
-                self.group.refresh_from_db()
-                assert self.group.seer_fixability_score == score
-
-                if should_trigger:
-                    mock_trigger_autofix_task.assert_called_once_with(
-                        group_id=self.group.id,
-                        event_id="test_event_id",
-                        user_id=mock_user.id,
-                        auto_run_source="issue_summary_on_post_process_fixability",
-                    )
-                else:
-                    mock_trigger_autofix_task.assert_not_called()
-
-    @patch("sentry.seer.autofix.issue_summary.make_signed_seer_api_request")
-    def test_generate_fixability_score_success(self, mock_make_request):
-        """Test that _generate_fixability_score works with GPU endpoint."""
-        issue_summary_response = orjson.dumps(
-            {
-                "group_id": str(self.group.id),
-                "headline": "Test headline",
-                "whats_wrong": "Test whats wrong",
-                "trace": "Test trace",
-                "possible_cause": "Test possible cause",
-                "scores": {
-                    "fixability_score": 0.7,
-                    "is_fixable": True,
-                },
-            }
-        )
-
-        response = Mock()
-        response.status = 200
-        response.data = issue_summary_response
-        mock_make_request.return_value = response
-
-        result = _generate_fixability_score(self.group)
-
-        assert result.group_id == str(self.group.id)
-        assert result.headline == "Test headline"
-        assert result.scores is not None
-        assert result.scores.fixability_score == 0.7
-
-        mock_make_request.assert_called_once()
-        call_args = mock_make_request.call_args
-        assert call_args[0][1] == "/v1/automation/summarize/fixability"
-
-    @patch("sentry.seer.autofix.issue_summary.get_seer_org_acknowledgement")
-    @patch("sentry.seer.autofix.issue_summary._run_automation")
-    @patch("sentry.seer.autofix.issue_summary._call_seer")
-    @patch("sentry.seer.autofix.issue_summary._get_event")
-    @patch("sentry.seer.autofix.issue_summary._get_trace_connected_issues")
-    def test_get_issue_summary_continues_when_automation_fails(
-        self,
-        mock_get_connected_issues,
-        mock_get_event,
-        mock_call_seer,
-        mock_run_automation,
-        mock_get_acknowledgement,
-    ):
-        """Test that issue summary is still returned when _run_automation throws an exception."""
-        mock_get_acknowledgement.return_value = True
-
-        # Set up event and seer response
-        event = Mock(event_id="test_event_id", datetime=datetime.datetime.now())
-        serialized_event = {"event_id": "test_event_id", "data": "test_event_data"}
-        mock_get_event.return_value = [serialized_event, event]
-        mock_get_connected_issues.return_value = []
-
-        mock_summary = SummarizeIssueResponse(
-            group_id=str(self.group.id),
-            headline="Test headline",
-            whats_wrong="Test whats wrong",
-            trace="Test trace",
-            possible_cause="Test possible cause",
-        )
-        mock_call_seer.return_value = mock_summary
-
-        # Make _run_automation raise an exception
-        mock_run_automation.side_effect = Exception("Automation failed")
-
-        # Call get_issue_summary and verify it still returns successfully
-        summary_data, status_code = get_issue_summary(self.group, self.user)
-
-        assert status_code == 200
-        expected_response = mock_summary.dict()
-        expected_response["event_id"] = event.event_id
-        assert summary_data == convert_dict_key_case(expected_response, snake_to_camel_case)
-
-        # Verify _run_automation was called and failed
-        mock_run_automation.assert_called_once()
-        mock_call_seer.assert_called_once()
-
-    @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
-    @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
-    @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.seer.autofix.issue_summary.get_seer_org_acknowledgement")
-    @patch("sentry.seer.autofix.issue_summary._get_trace_connected_issues")
+    @patch("sentry.seer.autofix.issue_summary._get_trace_tree_for_event")
     @patch("sentry.seer.autofix.issue_summary._call_seer")
     @patch("sentry.seer.autofix.issue_summary._get_event")
     def test_get_issue_summary_with_web_vitals_issue(
         self,
         mock_get_event,
         mock_call_seer,
-        mock_get_connected_issues,
+        mock_get_trace_tree,
         mock_get_acknowledgement,
         mock_record_seer_run,
         mock_generate_fixability_score,
@@ -819,7 +568,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             ),
         )
         mock_call_seer.return_value = mock_summary
-        mock_get_connected_issues.return_value = [self.group, self.group]
+        mock_get_trace_tree.return_value = {"trace": "tree"}
         # Create an event
         data = load_data("javascript", timestamp=before_now(minutes=1))
         event = self.store_event(data=data, project_id=self.project.id)
@@ -851,3 +600,85 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert status_code == 200
         mock_record_seer_run.assert_not_called()
         mock_trigger_autofix_task.assert_called_once()
+
+    @patch("sentry.seer.autofix.issue_summary.get_seer_org_acknowledgement")
+    @patch("sentry.seer.autofix.issue_summary._run_automation")
+    @patch("sentry.seer.autofix.issue_summary._get_trace_tree_for_event")
+    @patch("sentry.seer.autofix.issue_summary._call_seer")
+    @patch("sentry.seer.autofix.issue_summary._get_event")
+    def test_get_issue_summary_continues_when_automation_fails(
+        self,
+        mock_get_event,
+        mock_call_seer,
+        mock_get_trace_tree,
+        mock_run_automation,
+        mock_get_acknowledgement,
+    ):
+        """Test that issue summary is still returned when _run_automation throws an exception."""
+        mock_get_acknowledgement.return_value = True
+
+        # Set up event and seer response
+        event = Mock(event_id="test_event_id", datetime=datetime.datetime.now())
+        serialized_event = {"event_id": "test_event_id", "data": "test_event_data"}
+        mock_get_event.return_value = [serialized_event, event]
+        mock_get_trace_tree.return_value = None
+
+        mock_summary = SummarizeIssueResponse(
+            group_id=str(self.group.id),
+            headline="Test headline",
+            whats_wrong="Test whats wrong",
+            trace="Test trace",
+            possible_cause="Test possible cause",
+        )
+        mock_call_seer.return_value = mock_summary
+
+        # Make _run_automation raise an exception
+        mock_run_automation.side_effect = Exception("Automation failed")
+
+        # Call get_issue_summary and verify it still returns successfully
+        summary_data, status_code = get_issue_summary(self.group, self.user)
+
+        assert status_code == 200
+        expected_response = mock_summary.dict()
+        expected_response["event_id"] = event.event_id
+        assert summary_data == convert_dict_key_case(expected_response, snake_to_camel_case)
+
+        # Verify _run_automation was called and failed
+        mock_run_automation.assert_called_once()
+        mock_call_seer.assert_called_once()
+
+    @patch("sentry.seer.autofix.issue_summary._get_trace_tree_for_event")
+    def test_get_issue_summary_handles_trace_tree_errors(
+        self,
+        mock_get_trace_tree,
+    ):
+        mock_get_trace_tree.side_effect = Exception("boom")
+
+        event = Mock(event_id="test_event_id", datetime=datetime.datetime.now())
+        serialized_event = {"event_id": "test_event_id", "data": "test_event_data"}
+
+        with (
+            patch(
+                "sentry.seer.autofix.issue_summary._get_event",
+                return_value=[serialized_event, event],
+            ),
+            patch(
+                "sentry.seer.autofix.issue_summary._call_seer",
+                return_value=SummarizeIssueResponse(
+                    group_id=str(self.group.id),
+                    headline="headline",
+                    whats_wrong="what",
+                    trace="trace",
+                    possible_cause="cause",
+                ),
+            ) as mock_call_seer,
+            patch("sentry.seer.autofix.issue_summary._run_automation"),
+            patch(
+                "sentry.seer.autofix.issue_summary.get_seer_org_acknowledgement",
+                return_value=True,
+            ),
+        ):
+            summary_data, status_code = get_issue_summary(self.group, self.user)
+
+        assert status_code == 200
+        mock_call_seer.assert_called_once_with(self.group, serialized_event, None)


### PR DESCRIPTION
Instead of connected issue events, send a trace tree.

Seer PR: https://github.com/getsentry/seer/pull/3451

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Issue summaries now send a trace tree (with 3s fetch timeout) instead of connected issues; tests and APIs updated accordingly.
> 
> - **Issue Summary API**:
>   - Replace `connected_issues` payload with `trace_tree` in `_call_seer` and request body.
>   - `_generate_summary` now fetches trace via `_get_trace_tree_for_event(event, group.project, timeout=3)` and passes it to Seer; handles errors gracefully and continues.
> - **Trace Fetching**:
>   - `_get_trace_tree_for_event(event, project, timeout=15)` now accepts a configurable `timeout` (default 15s) instead of hardcoded.
> - **Removals/Refactors**:
>   - Delete `_get_trace_connected_issues` and related logic.
>   - Clean up unused imports.
> - **Tests**:
>   - Update tests to expect `trace_tree` in payload (or `None`), remove connected-issues expectations, add error-handling coverage for trace fetch and automation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4703567abf81be449dfca13ede073623973932e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->