### PR TITLE
fix(autofix): Fix color on loading indicator on button

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
+import color from 'color';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
@@ -236,7 +237,8 @@ const StyledLoadingIndicator = styled(LoadingIndicator)`
   margin-left: ${space(1)};
 
   .loading-indicator {
-    border-left-color: ${p => p.theme.progressBackground};
+    border-color: ${p => color(p.theme.button.primary.color).alpha(0.35).string()};
+    border-left-color: ${p => p.theme.button.primary.color};
   }
 `;
 


### PR DESCRIPTION
Making color work in both light and dark mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Seer CTA button’s loading spinner to use the primary button color (with alpha for non-leading borders) for proper theming.
> 
> - **Frontend**
>   - **Seer CTA (`static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx`)**
>     - *Styling*: Loading indicator now derives colors from `theme.button.primary.color`:
>       - Sets `border-color` to a semi-transparent version and `border-left-color` to the solid primary color.
>     - Adds `color` utility import for alpha manipulation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc103591b3367fe98c4f83b81ec08da727d4be5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->