### PR TITLE
ref(preprod): Add LaunchpadRpcPermission

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_size.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_size.py
@@ -13,7 +13,10 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactEndpoint
 from sentry.preprod.api.models.launchpad import PutSize
-from sentry.preprod.authentication import LaunchpadRpcSignatureAuthentication
+from sentry.preprod.authentication import (
+    LaunchpadRpcPermission,
+    LaunchpadRpcSignatureAuthentication,
+)
 from sentry.preprod.models import PreprodArtifactSizeMetrics
 
 logger = logging.getLogger(__name__)
@@ -43,7 +46,7 @@ class ProjectPreprodSizeWithIdentifierEndpoint(PreprodArtifactEndpoint):
         "PUT": ApiPublishStatus.PRIVATE,
     }
     authentication_classes = (LaunchpadRpcSignatureAuthentication,)
-    permission_classes = ()
+    permission_classes = (LaunchpadRpcPermission,)
 
     def put(
         self, request: Request, project, head_artifact_id, identifier, head_artifact
@@ -58,7 +61,7 @@ class ProjectPreprodSizeEndpoint(PreprodArtifactEndpoint):
         "PUT": ApiPublishStatus.PRIVATE,
     }
     authentication_classes = (LaunchpadRpcSignatureAuthentication,)
-    permission_classes = ()
+    permission_classes = (LaunchpadRpcPermission,)
 
     def put(self, request: Request, project, head_artifact_id, head_artifact) -> Response:
         identifier = None

--- a/src/sentry/preprod/authentication.py
+++ b/src/sentry/preprod/authentication.py
@@ -1,3 +1,6 @@
+from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
+
 from sentry.api.authentication import AuthenticationSiloLimit, ServiceRpcSignatureAuthentication
 from sentry.silo.base import SiloMode
 
@@ -14,3 +17,10 @@ class LaunchpadRpcSignatureAuthentication(ServiceRpcSignatureAuthentication):
     shared_secret_setting_name = LAUNCHPAD_RPC_SHARED_SECRET_SETTING
     service_name = "Launchpad"
     sdk_tag_name = "launchpad_rpc_auth"
+
+
+class LaunchpadRpcPermission(BasePermission):
+    def has_permission(self, request: Request, view: object) -> bool:
+        return bool(request.auth) and isinstance(
+            request.successful_authenticator, LaunchpadRpcSignatureAuthentication
+        )

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_assemble_generic.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_assemble_generic.py
@@ -226,7 +226,7 @@ class ProjectPreprodArtifactAssembleGenericEndpointTest(TestCase):
             },
             authenticated=False,
         )
-        assert response.status_code == 403
+        assert response.status_code == 401
 
     def test_artifact_id_passed_to_task(self) -> None:
         """Test that arbitrary artifact_id values are accepted and passed to the task."""

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -141,7 +141,7 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
 
     def test_update_preprod_artifact_unauthorized(self) -> None:
         response = self._make_request({"artifact_type": 1}, authenticated=False)
-        assert response.status_code == 403
+        assert response.status_code == 401
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_update_preprod_artifact_empty_update(self) -> None:

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_size.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_size.py
@@ -161,3 +161,29 @@ class ProjectPreprodSizeEndpointTest(TestCase):
 
         metrics = PreprodArtifactSizeMetrics.objects.get(preprod_artifact=self.artifact)
         assert metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_requires_launchpad_rpc_authentication(self) -> None:
+        self.login_as(self.user)
+
+        url = f"/api/0/internal/{self.organization.slug}/{self.project.slug}/files/preprodartifacts/{self.artifact.id}/size/"
+        response = self.client.put(
+            url,
+            data=orjson.dumps({"state": 1}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 401
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    def test_requires_launchpad_rpc_authentication_with_identifier(self) -> None:
+        self.login_as(self.user)
+
+        url = f"/api/0/internal/{self.organization.slug}/{self.project.slug}/files/preprodartifacts/{self.artifact.id}/size/some_feature/"
+        response = self.client.put(
+            url,
+            data=orjson.dumps({"state": 1}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 401


### PR DESCRIPTION
Add `LaunchpadRpcPermission` and update preprod endpoints to use it instead of a custom check in each endpoint.
This also closes a bug where the /size/ endpoint required some authentication - but not specifically the
`LaunchpadRpcSignatureAuthentication` due to missing the manual check. Also add a test to prove this now works.
