### PR TITLE
fix(preprod): fix typo SERECT -> SECRET

### DIFF
--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_size.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_size.py
@@ -5,7 +5,7 @@ from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
 from sentry.testutils.auth import generate_service_request_signature
 from sentry.testutils.cases import TestCase
 
-SHARED_SERECT_FOR_TESTS = "test-secret-key"
+SHARED_SECRET_FOR_TESTS = "test-secret-key"
 
 
 class ProjectPreprodSizeEndpointTest(TestCase):
@@ -18,7 +18,7 @@ class ProjectPreprodSizeEndpointTest(TestCase):
             state=PreprodArtifact.ArtifactState.UPLOADING,
         )
 
-    def _put(self, data, identifier=None, secret=SHARED_SERECT_FOR_TESTS):
+    def _put(self, data, identifier=None, secret=SHARED_SECRET_FOR_TESTS):
         if identifier:
             url = f"/api/0/internal/{self.organization.slug}/{self.project.slug}/files/preprodartifacts/{self.artifact.id}/size/{identifier}/"
         else:
@@ -31,47 +31,47 @@ class ProjectPreprodSizeEndpointTest(TestCase):
             HTTP_AUTHORIZATION=f"rpcsignature {signature}",
         )
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_bad_auth(self) -> None:
         response = self._put(b"{}", secret="wrong secret")
         assert response.status_code == 401
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_missing_fields(self) -> None:
         response = self._put(b"{}")
         assert response.status_code == 400
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_bad_json(self) -> None:
         response = self._put(b"{")
         assert response.status_code == 400
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_invalid_state(self) -> None:
         response = self._put(orjson.dumps({"state": 999}))
         assert response.status_code == 400
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_bad_auth_with_identifier(self) -> None:
         response = self._put(b"{}", identifier="some_feature", secret="wrong secret")
         assert response.status_code == 401
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_bad_json_with_identifier(self) -> None:
         response = self._put(b"{", identifier="some_feature")
         assert response.status_code == 400
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_missing_fields_with_identifier(self) -> None:
         response = self._put(b"{}", identifier="some_feature")
         assert response.status_code == 400
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_invalid_state_with_identifier(self) -> None:
         response = self._put(orjson.dumps({"state": 999}), identifier="some_feature")
         assert response.status_code == 400
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_mark_as_failed(self) -> None:
         PreprodArtifactSizeMetrics.objects.create(preprod_artifact=self.artifact)
 
@@ -86,7 +86,7 @@ class ProjectPreprodSizeEndpointTest(TestCase):
         assert metrics.error_code == 2
         assert metrics.error_message == "detailed reason"
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_mark_as_failed_with_identifier(self) -> None:
         PreprodArtifactSizeMetrics.objects.create(
             preprod_artifact=self.artifact, identifier="some_feature"
@@ -105,7 +105,7 @@ class ProjectPreprodSizeEndpointTest(TestCase):
         assert metrics.error_code == 3
         assert metrics.error_message == "another detailed reason"
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_mark_as_failed_multiple(self) -> None:
         PreprodArtifactSizeMetrics.objects.create(
             preprod_artifact=self.artifact, identifier="some_feature"
@@ -119,7 +119,7 @@ class ProjectPreprodSizeEndpointTest(TestCase):
         )
         assert metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_will_create_with_identifier(self) -> None:
         self._put(
             orjson.dumps({"state": 3, "error_code": 2, "error_message": "detailed reason"}),
@@ -131,7 +131,7 @@ class ProjectPreprodSizeEndpointTest(TestCase):
         )
         assert metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_will_create(self) -> None:
         PreprodArtifactSizeMetrics.objects.create(
             preprod_artifact=self.artifact, identifier="wrong_one"
@@ -144,7 +144,7 @@ class ProjectPreprodSizeEndpointTest(TestCase):
         )
         assert metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_pending(self) -> None:
         PreprodArtifactSizeMetrics.objects.create(preprod_artifact=self.artifact)
 
@@ -153,7 +153,7 @@ class ProjectPreprodSizeEndpointTest(TestCase):
         metrics = PreprodArtifactSizeMetrics.objects.get(preprod_artifact=self.artifact)
         assert metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_processing(self) -> None:
         PreprodArtifactSizeMetrics.objects.create(preprod_artifact=self.artifact)
 
@@ -162,7 +162,7 @@ class ProjectPreprodSizeEndpointTest(TestCase):
         metrics = PreprodArtifactSizeMetrics.objects.get(preprod_artifact=self.artifact)
         assert metrics.state == PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_requires_launchpad_rpc_authentication(self) -> None:
         self.login_as(self.user)
 
@@ -175,7 +175,7 @@ class ProjectPreprodSizeEndpointTest(TestCase):
 
         assert response.status_code == 401
 
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SERECT_FOR_TESTS])
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_requires_launchpad_rpc_authentication_with_identifier(self) -> None:
         self.login_as(self.user)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames `SHARED_SERECT_FOR_TESTS` to `SHARED_SECRET_FOR_TESTS` and updates all references in `tests/sentry/preprod/api/endpoints/test_project_preprod_size.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1053ed570f46e6454d33d5ed75efba64d3ef6d69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->