### PR TITLE
chore(settings): Update security views to not accept router props

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -402,14 +402,12 @@ function buildRoutes(): RouteObject[] {
                 'sentry/views/settings/account/accountSecurity/accountSecurityWrapper'
               )
           ),
-          deprecatedRouteProps: true,
           children: [
             {
               index: true,
               component: make(
                 () => import('sentry/views/settings/account/accountSecurity')
               ),
-              deprecatedRouteProps: true,
             },
             {
               path: 'session-history/',
@@ -418,7 +416,6 @@ function buildRoutes(): RouteObject[] {
                 () =>
                   import('sentry/views/settings/account/accountSecurity/sessionHistory')
               ),
-              deprecatedRouteProps: true,
             },
             {
               path: 'mfa/:authId/',
@@ -429,7 +426,6 @@ function buildRoutes(): RouteObject[] {
                     'sentry/views/settings/account/accountSecurity/accountSecurityDetails'
                   )
               ),
-              deprecatedRouteProps: true,
             },
           ],
         },

--- a/static/app/views/settings/account/accountSecurity/accountSecurityDetails.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityDetails.spec.tsx
@@ -5,7 +5,6 @@ import {
 } from 'sentry-fixture/authenticators';
 import {OrganizationsFixture} from 'sentry-fixture/organizations';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
   renderGlobalModal,
@@ -48,27 +47,20 @@ describe('AccountSecurityDetails', () => {
     });
 
     it('has enrolled circle indicator', async () => {
-      const params = {
-        authId: '15',
-      };
-      const {router} = initializeOrg({
-        router: {
-          params,
+      render(<AccountSecurityWrapper />, {
+        initialRouterConfig: {
+          location: {
+            pathname: '/settings/account/security/mfa/15/',
+          },
+          route: '/settings/account/security/',
+          children: [
+            {
+              path: 'mfa/:authId/',
+              element: <AccountSecurityDetails />,
+            },
+          ],
         },
       });
-
-      render(
-        <AccountSecurityWrapper>
-          <AccountSecurityDetails
-            onRegenerateBackupCodes={jest.fn()}
-            deleteDisabled={false}
-          />
-        </AccountSecurityWrapper>,
-        {
-          router,
-          deprecatedRouterMocks: true,
-        }
-      );
 
       expect(
         await screen.findByRole('status', {name: 'Authentication Method Active'})
@@ -85,27 +77,20 @@ describe('AccountSecurityDetails', () => {
         method: 'DELETE',
       });
 
-      const params = {
-        authId: '15',
-      };
-      const {router} = initializeOrg({
-        router: {
-          params,
+      render(<AccountSecurityWrapper />, {
+        initialRouterConfig: {
+          location: {
+            pathname: '/settings/account/security/mfa/15/',
+          },
+          route: '/settings/account/security/',
+          children: [
+            {
+              path: 'mfa/:authId/',
+              element: <AccountSecurityDetails />,
+            },
+          ],
         },
       });
-
-      render(
-        <AccountSecurityWrapper>
-          <AccountSecurityDetails
-            onRegenerateBackupCodes={jest.fn()}
-            deleteDisabled={false}
-          />
-        </AccountSecurityWrapper>,
-        {
-          router,
-          deprecatedRouterMocks: true,
-        }
-      );
 
       await userEvent.click(await screen.findByRole('button', {name: 'Remove'}));
 
@@ -127,27 +112,20 @@ describe('AccountSecurityDetails', () => {
         method: 'DELETE',
       });
 
-      const params = {
-        authId: '15',
-      };
-      const {router} = initializeOrg({
-        router: {
-          params,
+      render(<AccountSecurityWrapper />, {
+        initialRouterConfig: {
+          location: {
+            pathname: '/settings/account/security/mfa/15/',
+          },
+          route: '/settings/account/security/',
+          children: [
+            {
+              path: 'mfa/:authId/',
+              element: <AccountSecurityDetails />,
+            },
+          ],
         },
       });
-
-      render(
-        <AccountSecurityWrapper>
-          <AccountSecurityDetails
-            onRegenerateBackupCodes={jest.fn()}
-            deleteDisabled={false}
-          />
-        </AccountSecurityWrapper>,
-        {
-          router,
-          deprecatedRouterMocks: true,
-        }
-      );
 
       await userEvent.click(await screen.findByRole('button', {name: 'Remove'}));
 
@@ -169,28 +147,20 @@ describe('AccountSecurityDetails', () => {
         body: [AuthenticatorsFixture().Totp()],
       });
 
-      const params = {
-        authId: '15',
-      };
-
-      const {router} = initializeOrg({
-        router: {
-          params,
+      render(<AccountSecurityWrapper />, {
+        initialRouterConfig: {
+          location: {
+            pathname: '/settings/account/security/mfa/15/',
+          },
+          route: '/settings/account/security/',
+          children: [
+            {
+              path: 'mfa/:authId/',
+              element: <AccountSecurityDetails />,
+            },
+          ],
         },
       });
-
-      render(
-        <AccountSecurityWrapper>
-          <AccountSecurityDetails
-            onRegenerateBackupCodes={jest.fn()}
-            deleteDisabled={false}
-          />
-        </AccountSecurityWrapper>,
-        {
-          router,
-          deprecatedRouterMocks: true,
-        }
-      );
 
       expect(await screen.findByRole('button', {name: 'Remove'})).toBeDisabled();
     });
@@ -220,28 +190,20 @@ describe('AccountSecurityDetails', () => {
     });
 
     it('has enrolled circle indicator', async () => {
-      const params = {
-        authId: '16',
-      };
-
-      const {router} = initializeOrg({
-        router: {
-          params,
+      render(<AccountSecurityWrapper />, {
+        initialRouterConfig: {
+          location: {
+            pathname: '/settings/account/security/mfa/16/',
+          },
+          route: '/settings/account/security/',
+          children: [
+            {
+              path: 'mfa/:authId/',
+              element: <AccountSecurityDetails />,
+            },
+          ],
         },
       });
-
-      render(
-        <AccountSecurityWrapper>
-          <AccountSecurityDetails
-            onRegenerateBackupCodes={jest.fn()}
-            deleteDisabled={false}
-          />
-        </AccountSecurityWrapper>,
-        {
-          router,
-          deprecatedRouterMocks: true,
-        }
-      );
 
       expect(
         await screen.findByRole('status', {name: 'Authentication Method Active'})
@@ -252,33 +214,31 @@ describe('AccountSecurityDetails', () => {
     });
 
     it('regenerates codes', async () => {
+      MockApiClient.addMockResponse({
+        url: `${ENDPOINT}16/`,
+        method: 'GET',
+        body: AuthenticatorsFixture().Recovery(),
+      });
+
       const deleteMock = MockApiClient.addMockResponse({
         url: `${ENDPOINT}16/`,
         method: 'PUT',
       });
 
-      const params = {
-        authId: '16',
-      };
-
-      const {router} = initializeOrg({
-        router: {
-          params,
+      render(<AccountSecurityWrapper />, {
+        initialRouterConfig: {
+          location: {
+            pathname: '/settings/account/security/mfa/16/',
+          },
+          route: '/settings/account/security/',
+          children: [
+            {
+              path: 'mfa/:authId/',
+              element: <AccountSecurityDetails />,
+            },
+          ],
         },
       });
-
-      render(
-        <AccountSecurityWrapper>
-          <AccountSecurityDetails
-            onRegenerateBackupCodes={jest.fn()}
-            deleteDisabled={false}
-          />
-        </AccountSecurityWrapper>,
-        {
-          router,
-          deprecatedRouterMocks: true,
-        }
-      );
 
       await userEvent.click(
         await screen.findByRole('button', {name: 'Regenerate Codes'})
@@ -298,32 +258,30 @@ describe('AccountSecurityDetails', () => {
     });
 
     it('has copy, print and download buttons', async () => {
-      const params = {
-        authId: '16',
-      };
-
-      const {router} = initializeOrg({
-        router: {
-          params,
-        },
-      });
-
       Object.defineProperty(document, 'queryCommandSupported', {
         value: () => true,
       });
 
-      render(
-        <AccountSecurityWrapper>
-          <AccountSecurityDetails
-            onRegenerateBackupCodes={jest.fn()}
-            deleteDisabled={false}
-          />
-        </AccountSecurityWrapper>,
-        {
-          router,
-          deprecatedRouterMocks: true,
-        }
-      );
+      MockApiClient.addMockResponse({
+        url: `${ENDPOINT}16/`,
+        method: 'GET',
+        body: AuthenticatorsFixture().Recovery(),
+      });
+
+      render(<AccountSecurityWrapper />, {
+        initialRouterConfig: {
+          location: {
+            pathname: '/settings/account/security/mfa/16/',
+          },
+          route: '/settings/account/security/',
+          children: [
+            {
+              path: 'mfa/:authId/',
+              element: <AccountSecurityDetails />,
+            },
+          ],
+        },
+      });
 
       expect(await screen.findByRole('button', {name: 'print'})).toBeInTheDocument();
 

--- a/static/app/views/settings/account/accountSecurity/accountSecurityDetails.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityDetails.tsx
@@ -16,12 +16,12 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Authenticator, AuthenticatorDevice} from 'sentry/types/auth';
 import {useApiQuery, useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
+import {useAccountSecurityContext} from 'sentry/views/settings/account/accountSecurity/accountSecurityWrapper';
 import RecoveryCodes from 'sentry/views/settings/account/accountSecurity/components/recoveryCodes';
 import RemoveConfirm from 'sentry/views/settings/account/accountSecurity/components/removeConfirm';
 import U2fEnrolledDetails from 'sentry/views/settings/account/accountSecurity/components/u2fEnrolledDetails';
@@ -51,12 +51,8 @@ function AuthenticatorDate({label, date}: AuthenticatorDateProps) {
   );
 }
 
-interface Props {
-  deleteDisabled: boolean;
-  onRegenerateBackupCodes: () => void;
-}
-
-function AccountSecurityDetails({deleteDisabled, onRegenerateBackupCodes}: Props) {
+export default function AccountSecurityDetails() {
+  const {deleteDisabled, onRegenerateBackupCodes} = useAccountSecurityContext();
   const api = useApi();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -213,11 +209,9 @@ function AccountSecurityDetails({deleteDisabled, onRegenerateBackupCodes}: Props
   );
 }
 
-export default AccountSecurityDetails;
-
 const AuthenticatorDates = styled('div')`
   display: grid;
-  gap: ${space(0.75)} ${space(2)};
+  gap: ${p => p.theme.space.sm} ${p => p.theme.space.xl};
   grid-template-columns: max-content auto;
 `;
 
@@ -226,10 +220,10 @@ const DateLabel = styled('span')`
 `;
 
 const PhoneWrapper = styled('div')`
-  margin-top: ${space(4)};
+  margin-top: ${p => p.theme.space['3xl']};
 `;
 
 const Phone = styled('span')`
   font-weight: ${p => p.theme.fontWeight.bold};
-  margin-left: ${space(1)};
+  margin-left: ${p => p.theme.space.md};
 `;

--- a/static/app/views/settings/account/accountSecurity/components/twoFactorRequired.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/twoFactorRequired.spec.tsx
@@ -4,10 +4,9 @@ import {AccountEmailsFixture} from 'sentry-fixture/accountEmails';
 import {AuthenticatorsFixture} from 'sentry-fixture/authenticators';
 import {OrganizationsFixture} from 'sentry-fixture/organizations';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import TwoFactorRequired from 'sentry/views/settings/account/accountSecurity/';
+import AccountSecurity from 'sentry/views/settings/account/accountSecurity/';
 import AccountSecurityWrapper from 'sentry/views/settings/account/accountSecurity/accountSecurityWrapper';
 
 const ENDPOINT = '/users/me/authenticators/';
@@ -33,41 +32,46 @@ describe('TwoFactorRequired', () => {
     });
   });
 
-  const {routerProps} = initializeOrg();
-
-  const baseProps = {
-    authenticators: null,
-    countEnrolled: 0,
-    deleteDisabled: false,
-    handleRefresh: () => {},
-    hasVerifiedEmail: false,
-    onDisable: () => {},
-    orgsRequire2fa: [],
-    ...routerProps,
-  };
-
   it('renders empty', async () => {
     MockApiClient.addMockResponse({
       url: ORG_ENDPOINT,
       body: [],
     });
 
-    render(
-      <AccountSecurityWrapper>
-        <TwoFactorRequired {...baseProps} />
-      </AccountSecurityWrapper>
-    );
+    render(<AccountSecurityWrapper />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/settings/account/security/',
+        },
+        route: '/settings/account/security/',
+        children: [
+          {
+            index: true,
+            element: <AccountSecurity />,
+          },
+        ],
+      },
+    });
 
     expect(await screen.findByText('Your current password')).toBeInTheDocument();
     expect(screen.queryByTestId('require-2fa')).not.toBeInTheDocument();
   });
 
   it('does not render when 2FA is disabled and no pendingInvite cookie', async () => {
-    render(
-      <AccountSecurityWrapper>
-        <TwoFactorRequired {...baseProps} />
-      </AccountSecurityWrapper>
-    );
+    render(<AccountSecurityWrapper />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/settings/account/security/',
+        },
+        route: '/settings/account/security/',
+        children: [
+          {
+            index: true,
+            element: <AccountSecurity />,
+          },
+        ],
+      },
+    });
 
     expect(await screen.findByText('Your current password')).toBeInTheDocument();
     expect(screen.queryByTestId('require-2fa')).not.toBeInTheDocument();
@@ -79,11 +83,20 @@ describe('TwoFactorRequired', () => {
       body: [AuthenticatorsFixture().Totp({isEnrolled: true})],
     });
 
-    render(
-      <AccountSecurityWrapper>
-        <TwoFactorRequired {...baseProps} />
-      </AccountSecurityWrapper>
-    );
+    render(<AccountSecurityWrapper />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/settings/account/security/',
+        },
+        route: '/settings/account/security/',
+        children: [
+          {
+            index: true,
+            element: <AccountSecurity />,
+          },
+        ],
+      },
+    });
 
     expect(await screen.findByText('Your current password')).toBeInTheDocument();
     expect(screen.queryByTestId('require-2fa')).not.toBeInTheDocument();
@@ -105,11 +118,20 @@ describe('TwoFactorRequired', () => {
       body: OrganizationsFixture({require2FA: true}),
     });
 
-    render(
-      <AccountSecurityWrapper>
-        <TwoFactorRequired {...baseProps} />
-      </AccountSecurityWrapper>
-    );
+    render(<AccountSecurityWrapper />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/settings/account/security/',
+        },
+        route: '/settings/account/security/',
+        children: [
+          {
+            index: true,
+            element: <AccountSecurity />,
+          },
+        ],
+      },
+    });
 
     expect(await screen.findByText('Your current password')).toBeInTheDocument();
     expect(screen.queryByTestId('require-2fa')).not.toBeInTheDocument();
@@ -123,11 +145,20 @@ describe('TwoFactorRequired', () => {
       body: OrganizationsFixture({require2FA: true}),
     });
 
-    render(
-      <AccountSecurityWrapper>
-        <TwoFactorRequired {...baseProps} />
-      </AccountSecurityWrapper>
-    );
+    render(<AccountSecurityWrapper />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/settings/account/security/',
+        },
+        route: '/settings/account/security/',
+        children: [
+          {
+            index: true,
+            element: <AccountSecurity />,
+          },
+        ],
+      },
+    });
 
     expect(await screen.findByTestId('require-2fa')).toBeInTheDocument();
     Cookies.remove(INVITE_COOKIE);

--- a/static/app/views/settings/account/accountSecurity/components/twoFactorRequired.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/twoFactorRequired.tsx
@@ -3,10 +3,9 @@ import styled from '@emotion/styled';
 import {Alert} from 'sentry/components/core/alert';
 import {ExternalLink} from 'sentry/components/core/link';
 import {tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import getPendingInvite from 'sentry/utils/getPendingInvite';
 
-function TwoFactorRequired() {
+export default function TwoFactorRequired() {
   return getPendingInvite() ? (
     <StyledAlert data-test-id="require-2fa" type="error">
       {tct(
@@ -20,7 +19,5 @@ function TwoFactorRequired() {
 }
 
 const StyledAlert = styled(Alert)`
-  margin: ${space(3)} 0;
+  margin: ${p => p.theme.space['2xl']} 0;
 `;
-
-export default TwoFactorRequired;

--- a/static/app/views/settings/account/accountSecurity/index.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.spec.tsx
@@ -1,7 +1,6 @@
 import {AccountEmailsFixture} from 'sentry-fixture/accountEmails';
 import {AuthenticatorsFixture} from 'sentry-fixture/authenticators';
 import {OrganizationsFixture} from 'sentry-fixture/organizations';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {
   render,
@@ -22,9 +21,7 @@ const ACCOUNT_EMAILS_ENDPOINT = '/users/me/emails/';
 const AUTH_ENDPOINT = '/auth/';
 
 describe('AccountSecurity', () => {
-  const router = RouterFixture();
   beforeEach(() => {
-    MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: ORG_ENDPOINT,
       body: OrganizationsFixture(),
@@ -36,25 +33,20 @@ describe('AccountSecurity', () => {
   });
 
   function renderComponent() {
-    return render(
-      <AccountSecurityWrapper>
-        <AccountSecurity
-          deleteDisabled={false}
-          authenticators={[]}
-          hasVerifiedEmail
-          countEnrolled={0}
-          handleRefresh={jest.fn()}
-          onDisable={jest.fn()}
-          orgsRequire2fa={[]}
-          location={router.location}
-          route={router.routes[0]!}
-          routes={router.routes}
-          router={router}
-          routeParams={router.params}
-          params={{...router.params, authId: '15'}}
-        />
-      </AccountSecurityWrapper>
-    );
+    return render(<AccountSecurityWrapper />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/settings/account/security/',
+        },
+        route: '/settings/account/security/',
+        children: [
+          {
+            index: true,
+            element: <AccountSecurity />,
+          },
+        ],
+      },
+    });
   }
 
   it('renders empty', async () => {

--- a/static/app/views/settings/account/accountSecurity/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.tsx
@@ -18,42 +18,30 @@ import PanelItem from 'sentry/components/panels/panelItem';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
-import type {Authenticator} from 'sentry/types/auth';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import type {OrganizationSummary} from 'sentry/types/organization';
 import oxfordizeArray from 'sentry/utils/oxfordizeArray';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import useApi from 'sentry/utils/useApi';
+import {useAccountSecurityContext} from 'sentry/views/settings/account/accountSecurity/accountSecurityWrapper';
 import RemoveConfirm from 'sentry/views/settings/account/accountSecurity/components/removeConfirm';
 import TwoFactorRequired from 'sentry/views/settings/account/accountSecurity/components/twoFactorRequired';
 import PasswordForm from 'sentry/views/settings/account/passwordForm';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
-type Props = {
-  authenticators: Authenticator[] | null;
-  countEnrolled: number;
-  deleteDisabled: boolean;
-  handleRefresh: () => void;
-  hasVerifiedEmail: boolean;
-  onDisable: (auth: Authenticator) => void;
-  orgsRequire2fa: OrganizationSummary[];
-} & RouteComponentProps;
-
 /**
  * Lists 2fa devices + password change form
  */
-function AccountSecurity({
-  authenticators,
-  countEnrolled,
-  deleteDisabled,
-  onDisable,
-  hasVerifiedEmail,
-  orgsRequire2fa,
-  handleRefresh,
-  location,
-}: Props) {
+export default function AccountSecurity() {
+  const {
+    authenticators,
+    countEnrolled,
+    deleteDisabled,
+    onDisable,
+    hasVerifiedEmail,
+    orgsRequire2fa,
+    handleRefresh,
+  } = useAccountSecurityContext();
+
   const api = useApi();
 
   async function handleSessionClose() {
@@ -238,13 +226,13 @@ function AccountSecurity({
 }
 
 const TabsContainer = styled('div')`
-  margin-bottom: ${space(2)};
+  margin-bottom: ${p => p.theme.space.xl};
 `;
 
 const AuthenticatorList = styled(PanelBody)`
   display: grid;
   grid-template-columns: 1fr max-content;
-  gap: 0 ${space(1)};
+  gap: 0 ${p => p.theme.space.md};
 `;
 
 const AuthenticatorPanelItem = styled(PanelItem)`
@@ -260,14 +248,14 @@ const AuthenticatorPanelItem = styled(PanelItem)`
 const AuthenticatorDetails = styled('div')`
   display: grid;
   grid-template-columns: max-content minmax(auto, 600px);
-  gap: ${space(0.75)};
+  gap: ${p => p.theme.space.sm};
   align-items: center;
 `;
 
 const AuthenticatorTitle = styled('div')`
   display: flex;
   align-items: center;
-  gap: ${space(0.75)};
+  gap: ${p => p.theme.space.sm};
   font-weight: ${p => p.theme.fontWeight.bold};
 `;
 
@@ -275,5 +263,3 @@ const AuthenticatorDescription = styled(TextBlock)`
   grid-column: 2;
   margin: 0;
 `;
-
-export default AccountSecurity;

--- a/static/app/views/settings/account/accountSecurity/sessionHistory/index.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/sessionHistory/index.spec.tsx
@@ -1,4 +1,3 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {isDemoModeActive} from 'sentry/utils/demoMode';
@@ -9,8 +8,6 @@ const ENDPOINT = '/users/me/ips/';
 jest.mock('sentry/utils/demoMode');
 
 describe('AccountSecuritySessionHistory', () => {
-  const {routerProps} = initializeOrg();
-
   beforeEach(() => {
     MockApiClient.addMockResponse({
       url: ENDPOINT,
@@ -35,12 +32,8 @@ describe('AccountSecuritySessionHistory', () => {
     });
   });
 
-  afterEach(() => {
-    MockApiClient.clearMockResponses();
-  });
-
   it('renders an ip address', async () => {
-    render(<SessionHistory {...routerProps} />);
+    render(<SessionHistory />);
 
     expect(await screen.findByText('127.0.0.1')).toBeInTheDocument();
     expect(screen.getByText('192.168.0.1')).toBeInTheDocument();
@@ -50,7 +43,7 @@ describe('AccountSecuritySessionHistory', () => {
   it('renders empty in demo mode even if ips exist', () => {
     (isDemoModeActive as jest.Mock).mockReturnValue(true);
 
-    render(<SessionHistory {...routerProps} />);
+    render(<SessionHistory />);
 
     expect(screen.queryByText('127.0.0.1')).not.toBeInTheDocument();
     expect(screen.queryByText('192.168.0.1')).not.toBeInTheDocument();

--- a/static/app/views/settings/account/accountSecurity/sessionHistory/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/sessionHistory/index.tsx
@@ -8,11 +8,10 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {InternetProtocol} from 'sentry/types/user';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 import SessionRow from './sessionRow';
@@ -20,7 +19,8 @@ import {tableLayout} from './utils';
 
 type IpListType = InternetProtocol[] | null;
 
-function SessionHistory({location}: RouteComponentProps) {
+export default function SessionHistory() {
+  const location = useLocation();
   const {
     data: ipList = [],
     isLoading,
@@ -89,10 +89,8 @@ function SessionHistory({location}: RouteComponentProps) {
 }
 
 const TabsContainer = styled('div')`
-  margin-bottom: ${space(2)};
+  margin-bottom: ${p => p.theme.space.xl};
 `;
-
-export default SessionHistory;
 
 const SessionPanelHeader = styled(PanelHeader)`
   ${tableLayout}

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -1,5 +1,11 @@
 import {Fragment} from 'react';
-import {RouterProvider, useRouteError, type RouteObject, type To} from 'react-router-dom';
+import {
+  Outlet,
+  RouterProvider,
+  useRouteError,
+  type RouteObject,
+  type To,
+} from 'react-router-dom';
 import {cache} from '@emotion/css'; // eslint-disable-line @emotion/no-vanilla
 import {CacheProvider, ThemeProvider} from '@emotion/react';
 import {
@@ -77,6 +83,11 @@ type LocationConfig =
 
 type RouterConfig = {
   /**
+   * Child routes
+   */
+  children?: RouteObject[];
+
+  /**
    * Sets the initial location for the router.
    */
   location?: LocationConfig;
@@ -88,6 +99,7 @@ type RouterConfig = {
    * route: '/issues/:issueId/'
    */
   route?: string;
+
   /**
    * Sets the initial routes for the router.
    *
@@ -103,7 +115,10 @@ type RouterConfig = {
 
 type RenderOptions<T extends boolean = false> = T extends true
   ? BaseRenderOptions<T> & {router?: Partial<InjectedRouter>}
-  : BaseRenderOptions<T> & {initialRouterConfig?: RouterConfig};
+  : BaseRenderOptions<T> & {
+      initialRouterConfig?: RouterConfig;
+      outletContext?: Record<string, unknown>;
+    };
 
 type RenderReturn<T extends boolean = false> = T extends true
   ? rtl.RenderResult
@@ -115,6 +130,7 @@ type RenderHookWithProvidersOptions<Props> = Omit<
 > &
   Pick<ProviderOptions, 'additionalWrapper' | 'organization'> & {
     initialRouterConfig?: RouterConfig;
+    outletContext?: Record<string, unknown>;
   };
 
 // Inject legacy react-router 3 style router mocked navigation functions
@@ -222,7 +238,12 @@ function createRoutesFromConfig(
 
   if (config?.route) {
     return [
-      {path: config.route, element: children, errorElement: <ErrorBoundary />},
+      {
+        path: config.route,
+        element: children,
+        errorElement: <ErrorBoundary />,
+        children: config.children,
+      },
       emptyRoute,
     ];
   }
@@ -233,6 +254,7 @@ function createRoutesFromConfig(
         path: route,
         element: children,
         errorElement: <ErrorBoundary />,
+        children: config.children,
       })),
       emptyRoute,
     ];
@@ -245,12 +267,23 @@ function makeRouter({
   children,
   history,
   config,
+  outletContext,
 }: {
   children: React.ReactNode;
   config: RouterConfig | undefined;
   history: MemoryHistory;
+  outletContext: Record<string, unknown> | undefined;
 }) {
-  const routes = createRoutesFromConfig(children, config);
+  const childRoutes = createRoutesFromConfig(children, config);
+  const routes = outletContext
+    ? [
+        {
+          path: '/',
+          element: <Outlet context={outletContext} />,
+          children: childRoutes,
+        },
+      ]
+    : childRoutes;
 
   const router = createRouter({
     future: {
@@ -317,13 +350,15 @@ function getInitialRouterConfig<T extends boolean = true>(
 ): {
   config: RouterConfig | undefined;
   initialEntry: InitialEntry;
-  legacyRouterConfig?: Partial<InjectedRouter>;
+  legacyRouterConfig: Partial<InjectedRouter> | undefined;
+  outletContext: Record<string, unknown> | undefined;
 } {
   if (options.deprecatedRouterMocks) {
     return {
       initialEntry: options.router?.location?.pathname ?? LocationFixture().pathname,
       legacyRouterConfig: options.router,
       config: undefined,
+      outletContext: undefined,
     };
   }
 
@@ -332,6 +367,7 @@ function getInitialRouterConfig<T extends boolean = true>(
     initialEntry: parseLocationConfig(opts.initialRouterConfig?.location),
     legacyRouterConfig: undefined,
     config: opts.initialRouterConfig,
+    outletContext: opts.outletContext,
   };
 }
 
@@ -353,7 +389,8 @@ function render<T extends boolean = false>(
   ui: React.ReactElement,
   options: RenderOptions<T> = {} as RenderOptions<T>
 ): RenderReturn<T> {
-  const {initialEntry, config, legacyRouterConfig} = getInitialRouterConfig(options);
+  const {initialEntry, config, legacyRouterConfig, outletContext} =
+    getInitialRouterConfig(options);
 
   const history = createMemoryHistory({
     initialEntries: [initialEntry],
@@ -370,6 +407,7 @@ function render<T extends boolean = false>(
     children: <AllTheProviders>{ui}</AllTheProviders>,
     history,
     config,
+    outletContext,
   });
 
   DANGEROUS_SET_REACT_ROUTER_6_HISTORY(memoryRouter);
@@ -384,6 +422,7 @@ function render<T extends boolean = false>(
       children: <AllTheProviders>{newUi}</AllTheProviders>,
       history,
       config,
+      outletContext,
     });
 
     renderResult.rerender(
@@ -406,9 +445,8 @@ function renderHookWithProviders<Result = unknown, Props = unknown>(
   callback: (initialProps: Props) => Result,
   options: RenderHookWithProvidersOptions<Props> = {} as RenderHookWithProvidersOptions<Props>
 ): rtl.RenderHookResult<Result, Props> & {router: TestRouter} {
-  const {initialEntry, config, legacyRouterConfig} = getInitialRouterConfig(
-    options as unknown as RenderOptions<false>
-  );
+  const {initialEntry, config, legacyRouterConfig, outletContext} =
+    getInitialRouterConfig(options as unknown as RenderOptions<false>);
 
   const history = createMemoryHistory({
     initialEntries: [initialEntry],
@@ -429,6 +467,7 @@ function renderHookWithProviders<Result = unknown, Props = unknown>(
       children: <AllTheProviders>{children}</AllTheProviders>,
       history,
       config,
+      outletContext,
     });
 
     DANGEROUS_SET_REACT_ROUTER_6_HISTORY(memoryRouter);


### PR DESCRIPTION
Relates to https://github.com/getsentry/frontend-tsc/issues/93

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors Account Security views to use React Router v6 outlet context (dropping legacy router props), updates related routes, styling, and tests with new router utilities.
> 
> - **Settings > Account > Security**:
>   - **Routing/Context**: Convert `AccountSecurityWrapper` to an `Outlet` provider with `useAccountSecurityContext`; `AccountSecurity` and `AccountSecurityDetails` now consume context and no longer accept router props.
>   - **Routes**: Remove `deprecatedRouteProps` from `account/security` nested routes.
>   - **Session History**: Use `useLocation`; drop legacy `RouteComponentProps`.
>   - **TwoFactorRequired**: Minor styling change to theme spacing.
>   - **Styling**: Replace `space()` with theme spacing tokens in multiple components.
> - **Tests**:
>   - Update tests to use `initialRouterConfig` with nested `children` and paths; remove `initializeOrg`/`RouterFixture` usage.
>   - Enhance `reactTestingLibrary` test helpers to support child routes and `Outlet` context injection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 721d983394625df7dfdb22e545c8af4518104932. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->