### PR TITLE
fix(feedback): hide categories if no seer acknowledgement

### DIFF
--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -14,14 +14,17 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 export default function FeedbackSummaryCategories() {
   const organization = useOrganization();
-  const {areAiFeaturesAllowed} = useOrganizationSeerSetup();
+
   const openForm = useFeedbackForm();
 
-  if (
-    !areAiFeaturesAllowed ||
-    (!organization.features.includes('user-feedback-ai-summaries') &&
-      !organization.features.includes('user-feedback-ai-categorization-features'))
-  ) {
+  const {areAiFeaturesAllowed} = useOrganizationSeerSetup();
+
+  const showSummaryCategories =
+    (organization.features.includes('user-feedback-ai-summaries') ||
+      organization.features.includes('user-feedback-ai-categorization-features')) &&
+    areAiFeaturesAllowed;
+
+  if (!showSummaryCategories) {
     return null;
   }
 

--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -14,17 +14,14 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 export default function FeedbackSummaryCategories() {
   const organization = useOrganization();
-
+  const {areAiFeaturesAllowed} = useOrganizationSeerSetup();
   const openForm = useFeedbackForm();
 
-  const {areAiFeaturesAllowed} = useOrganizationSeerSetup();
-
-  const showSummaryCategories =
-    (organization.features.includes('user-feedback-ai-summaries') ||
-      organization.features.includes('user-feedback-ai-categorization-features')) &&
-    areAiFeaturesAllowed;
-
-  if (!showSummaryCategories) {
+  if (
+    !areAiFeaturesAllowed ||
+    (!organization.features.includes('user-feedback-ai-summaries') &&
+      !organization.features.includes('user-feedback-ai-categorization-features'))
+  ) {
     return null;
   }
 


### PR DESCRIPTION
Right now we're still showing categories, but not summary, if seer ack is missing

Mocking the ack on master rn (categories shouldn't be there):
<img width="398" height="140" alt="Screenshot 2025-09-28 at 6 52 02 PM" src="https://github.com/user-attachments/assets/9e0ac438-3abc-4f52-84ff-f762807e82bd" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gate `FeedbackCategories` behind Seer setup acknowledgement and update tests to mock and validate this behavior.
> 
> - **Frontend**:
>   - `feedback/summaryCategories/feedbackCategories.tsx`:
>     - Integrate `useOrganizationSeerSetup`; show loading while `isOrgSeerSetupPending`.
>     - Return `null` when `isError`, `tooFewFeedbacks`, no `categories`, or `!setupAcknowledgement.orgHasAcknowledged`.
> - **Tests**:
>   - `feedback/summaryCategories/feedbackCategories.spec.tsx`:
>     - Mock `useOrganizationSeerSetup` with default acknowledged state.
>     - Add test ensuring empty render when org has not acknowledged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8206840990fa5facd322e8e73762ff69e654439b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->