### PR TITLE
fix(onboarding): When the doc is not found, the page gets stuck in a loading state

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted.ts
@@ -66,7 +66,7 @@ export function useLoadGettingStarted({
         );
         setModule(mod);
       } catch (err) {
-        setModule(undefined);
+        setModule('none');
         Sentry.captureException(err);
       }
     }


### PR DESCRIPTION
if the path of a documentation is broken or for whatever reason it fails to load (maybe it got deleted? 🤷‍♀️) , the UI doesn't show the error `The getting started documentation for this platform is currently unavailable.` but a forever loading component.

Example:

<img width="1001" height="552" alt="image" src="https://github.com/user-attachments/assets/5fafc4e1-d2c9-48c5-900b-ada2f938deea" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> On import failure, mark docs as `none` instead of `undefined` so the UI shows unavailable state rather than loading forever.
> 
> - **Onboarding Docs Loading (`useLoadGettingStarted`)**:
>   - On import failure, set `module` to `"none"` (was `undefined`) to stop the loading state and render the unavailable message.
>   - Maintains `isLoading` logic (`module === undefined`) and maps `"none"` to `docs: null`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a9c7e8baf081faf22f3619290b72c913a605800. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->