### PR TITLE
ref(tempest): Remove tempest feature check FE

### DIFF
--- a/static/app/utils/tempest/features.tsx
+++ b/static/app/utils/tempest/features.tsx
@@ -1,8 +1,5 @@
 import type {Organization} from 'sentry/types/organization';
 
 export function hasTempestAccess(organization: Organization) {
-  return (
-    organization.features.includes('tempest-access') ||
-    organization.enabledConsolePlatforms?.includes('playstation')
-  );
+  return organization.enabledConsolePlatforms?.includes('playstation');
 }

--- a/static/app/views/settings/project/tempest/index.spec.tsx
+++ b/static/app/views/settings/project/tempest/index.spec.tsx
@@ -24,7 +24,6 @@ describe('TempestSettings', () => {
   describe('Access Control', () => {
     it('renders warning alert when user does not have tempest access', () => {
       const organizationWithoutAccess = OrganizationFixture({
-        features: [],
         enabledConsolePlatforms: [],
       });
 
@@ -40,25 +39,8 @@ describe('TempestSettings', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('renders settings when user has tempest-access feature', () => {
-      const organizationWithFeature = OrganizationFixture({
-        features: ['tempest-access'],
-        enabledConsolePlatforms: [],
-      });
-
-      render(
-        <TempestSettings organization={organizationWithFeature} project={project} />
-      );
-
-      expect(
-        screen.queryByText("You don't have access to this feature")
-      ).not.toBeInTheDocument();
-      expect(screen.getByRole('heading', {name: 'DevKit Crashes'})).toBeInTheDocument();
-    });
-
     it('renders settings when user has playstation console platform enabled', () => {
       const organizationWithPlatform = OrganizationFixture({
-        features: [],
         enabledConsolePlatforms: ['playstation'],
       });
 
@@ -72,9 +54,8 @@ describe('TempestSettings', () => {
       expect(screen.getByRole('heading', {name: 'DevKit Crashes'})).toBeInTheDocument();
     });
 
-    it('renders settings when user has both tempest-access feature and playstation platform', () => {
+    it('renders settings when user has playstation platform', () => {
       const organizationWithBoth = OrganizationFixture({
-        features: ['tempest-access'],
         enabledConsolePlatforms: ['playstation'],
       });
 
@@ -88,7 +69,6 @@ describe('TempestSettings', () => {
 
     it('does not grant access with other console platforms', () => {
       const organizationWithOtherPlatform = OrganizationFixture({
-        features: [],
         enabledConsolePlatforms: ['xbox', 'nintendo'],
       });
 


### PR DESCRIPTION
All PlayStation-related functionality is now managed through org options. Since this change has been fully GA without issues as of 02.09, we are removing the tempest-access checks

contributes to https://linear.app/getsentry/issue/TET-911/remove-tempest-feature-flag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove `tempest-access` flag checks; Tempest access now depends only on PlayStation platform enablement, with tests updated accordingly.
> 
> - **Tempest access logic**:
>   - Update `hasTempestAccess` to rely solely on `organization.enabledConsolePlatforms` containing `playstation`.
> - **Tests** (`static/app/views/settings/project/tempest/index.spec.tsx`):
>   - Remove feature-flag (`tempest-access`) based access cases; retain and consolidate tests around PlayStation platform access.
>   - Adjust fixtures to drop `features` usage and validate denial for non-PlayStation platforms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 714e610dc7de810219092816f2f226a41bc00372. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->