### PR TITLE
ref(tempest): Remove tempest feature check BE

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1109,7 +1109,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "debugFilesRole": attrs["options"].get("sentry:debug_files_role"),
         }
 
-        if has_tempest_access(obj.organization, user):
+        if has_tempest_access(obj.organization):
             data["tempestFetchScreenshots"] = attrs["options"].get(
                 "sentry:tempest_fetch_screenshots", False
             )

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -440,8 +440,7 @@ E.g. `['release', 'environment']`""",
 
     def validate_tempestFetchScreenshots(self, value):
         organization = self.context["project"].organization
-        actor = self.context["request"].user
-        if not has_tempest_access(organization, actor=actor):
+        if not has_tempest_access(organization):
             raise serializers.ValidationError(
                 "Organization does not have the tempest feature enabled."
             )
@@ -449,8 +448,7 @@ E.g. `['release', 'environment']`""",
 
     def validate_tempestFetchDumps(self, value):
         organization = self.context["project"].organization
-        actor = self.context["request"].user
-        if not has_tempest_access(organization, actor=actor):
+        if not has_tempest_access(organization):
             raise serializers.ValidationError(
                 "Organization does not have the tempest feature enabled."
             )

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -634,14 +634,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
         api_expose=False,
     )
 
-    # Controls access to tempest features
-    manager.add(
-        "organizations:tempest-access",
-        OrganizationFeature,
-        FeatureHandlerStrategy.FLAGPOLE,
-        api_expose=True,
-    )
-
     # Control access to a new debug files role management
     manager.add(
         "organizations:debug-files-role-management",

--- a/src/sentry/tempest/endpoints/tempest_credentials.py
+++ b/src/sentry/tempest/endpoints/tempest_credentials.py
@@ -29,7 +29,7 @@ class TempestCredentialsEndpoint(ProjectEndpoint):
     permission_classes = (TempestCredentialsPermission,)
 
     def get(self, request: Request, project: Project) -> Response:
-        if not has_tempest_access(project.organization, request.user):
+        if not has_tempest_access(project.organization):
             raise NotFound
 
         tempest_credentials_qs = TempestCredentials.objects.filter(project=project)
@@ -41,7 +41,7 @@ class TempestCredentialsEndpoint(ProjectEndpoint):
         )
 
     def post(self, request: Request, project: Project) -> Response:
-        if not has_tempest_access(project.organization, request.user):
+        if not has_tempest_access(project.organization):
             raise NotFound
 
         serializer = DRFTempestCredentialsSerializer(data=request.data)

--- a/src/sentry/tempest/endpoints/tempest_credentials_details.py
+++ b/src/sentry/tempest/endpoints/tempest_credentials_details.py
@@ -23,7 +23,7 @@ class TempestCredentialsDetailsEndpoint(ProjectEndpoint):
     permission_classes = (TempestCredentialsPermission,)
 
     def delete(self, request: Request, project: Project, tempest_credentials_id: int) -> Response:
-        if not has_tempest_access(project.organization, request.user):
+        if not has_tempest_access(project.organization):
             raise NotFound
 
         try:

--- a/src/sentry/tempest/utils.py
+++ b/src/sentry/tempest/utils.py
@@ -1,20 +1,12 @@
-from django.contrib.auth.models import AnonymousUser
-
-from sentry import features
 from sentry.models.organization import Organization
-from sentry.users.models.user import User
-from sentry.users.services.user import RpcUser
 
 
-def has_tempest_access(
-    organization: Organization | None, actor: User | RpcUser | AnonymousUser | None = None
-) -> bool:
-    has_tempest_feature = features.has("organizations:tempest-access", organization, actor=actor)
+def has_tempest_access(organization: Organization | None) -> bool:
 
-    if organization:
-        enabled_platforms = organization.get_option("sentry:enabled_console_platforms", [])
-        has_playstation_access = "playstation" in enabled_platforms
+    if not organization:
+        return False
 
-        return has_tempest_feature or has_playstation_access
+    enabled_platforms = organization.get_option("sentry:enabled_console_platforms", [])
+    has_playstation_access = "playstation" in enabled_platforms
 
-    return has_tempest_feature
+    return has_playstation_access

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -2106,17 +2106,7 @@ class TestTempestProjectDetails(TestProjectDetailsBase):
             token = ApiToken.objects.create(user=self.user, scope_list=["project:write"])
         self.authorization = f"Bearer {token.token}"
 
-    @with_feature("organizations:tempest-access")
     def test_put_tempest_fetch_screenshots(self) -> None:
-        # assert default value is False, and that put request updates the value
-        assert self.project.get_option("sentry:tempest_fetch_screenshots") is False
-        response = self.get_success_response(
-            self.organization.slug, self.project.slug, method="put", tempestFetchScreenshots=True
-        )
-        assert response.data["tempestFetchScreenshots"] is True
-        assert self.project.get_option("sentry:tempest_fetch_screenshots") is True
-
-    def test_put_tempest_fetch_screenshots_enabled_console_platforms(self) -> None:
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         assert self.project.get_option("sentry:tempest_fetch_screenshots") is False
         response = self.get_success_response(
@@ -2130,15 +2120,7 @@ class TestTempestProjectDetails(TestProjectDetailsBase):
             self.organization.slug, self.project.slug, method="put", tempestFetchScreenshots=True
         )
 
-    @with_feature("organizations:tempest-access")
     def test_get_tempest_fetch_screenshots_options(self) -> None:
-        response = self.get_success_response(
-            self.organization.slug, self.project.slug, method="get"
-        )
-        assert "tempestFetchScreenshots" in response.data
-        assert response.data["tempestFetchScreenshots"] is False
-
-    def test_get_tempest_fetch_screenshots_options_enabled_console_platforms(self) -> None:
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         response = self.get_success_response(
             self.organization.slug, self.project.slug, method="get"
@@ -2152,17 +2134,7 @@ class TestTempestProjectDetails(TestProjectDetailsBase):
         )
         assert "tempestFetchScreenshots" not in response.data
 
-    @with_feature("organizations:tempest-access")
     def test_put_tempest_fetch_dumps(self) -> None:
-        # assert default value is False, and that put request updates the value
-        assert self.project.get_option("sentry:tempest_fetch_dumps") is False
-        response = self.get_success_response(
-            self.organization.slug, self.project.slug, method="put", tempestFetchDumps=True
-        )
-        assert response.data["tempestFetchDumps"] is True
-        assert self.project.get_option("sentry:tempest_fetch_dumps") is True
-
-    def test_put_tempest_fetch_dumps_enabled_console_platforms(self) -> None:
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         assert self.project.get_option("sentry:tempest_fetch_dumps") is False
         response = self.get_success_response(
@@ -2176,15 +2148,7 @@ class TestTempestProjectDetails(TestProjectDetailsBase):
             self.organization.slug, self.project.slug, method="put", tempestFetchDumps=True
         )
 
-    @with_feature("organizations:tempest-access")
     def test_get_tempest_fetch_dumps_options(self) -> None:
-        response = self.get_success_response(
-            self.organization.slug, self.project.slug, method="get"
-        )
-        assert "tempestFetchDumps" in response.data
-        assert response.data["tempestFetchDumps"] is False
-
-    def test_get_tempest_fetch_dumps_options_enabled_console_platforms(self) -> None:
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         response = self.get_success_response(
             self.organization.slug, self.project.slug, method="get"
@@ -2192,7 +2156,7 @@ class TestTempestProjectDetails(TestProjectDetailsBase):
         assert "tempestFetchDumps" in response.data
         assert response.data["tempestFetchDumps"] is False
 
-    def test_get_tempest_fetch_dumps_options_without_feature_flag(self) -> None:
+    def test_get_tempest_fetch_dumps_options_without_enabled_playstation_in_options(self) -> None:
         response = self.get_success_response(
             self.organization.slug, self.project.slug, method="get"
         )

--- a/tests/sentry/tempest/endpoints/test_tempest_credentials.py
+++ b/tests/sentry/tempest/endpoints/test_tempest_credentials.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock, patch
 
 from sentry.tempest.models import TempestCredentials
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import Feature
 
 
 class TestTempestCredentials(APITestCase):
@@ -11,21 +10,6 @@ class TestTempestCredentials(APITestCase):
     valid_credentials_data = {"clientId": "test", "clientSecret": "test"}
 
     def test_get_tempest_credentials(self) -> None:
-        with Feature({"organizations:tempest-access": True}):
-            credentials = [self.create_tempest_credentials(self.project) for _ in range(5)]
-
-            other_project = self.create_project(organization=self.organization)
-            # credentials connected to other project which should not be included in the response
-            for _ in range(5):
-                self.create_tempest_credentials(other_project)
-
-            self.login_as(self.user)
-            response = self.get_success_response(self.project.organization.slug, self.project.slug)
-
-            assert len(response.data) == 5
-            assert {cred.id for cred in credentials} == {item["id"] for item in response.data}
-
-    def test_get_tempest_credentials_enabled_console_platforms(self) -> None:
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         credentials = [self.create_tempest_credentials(self.project) for _ in range(5)]
 
@@ -46,13 +30,6 @@ class TestTempestCredentials(APITestCase):
         assert response.status_code == 404
 
     def test_client_secret_is_obfuscated(self) -> None:
-        with Feature({"organizations:tempest-access": True}):
-            credentials = self.create_tempest_credentials(self.project)
-            self.login_as(self.user)
-            response = self.get_success_response(self.project.organization.slug, self.project.slug)
-            assert response.data[0]["clientSecret"] == "*" * len(credentials.client_secret)
-
-    def test_client_secret_is_obfuscated_enabled_console_platforms(self) -> None:
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         credentials = self.create_tempest_credentials(self.project)
         self.login_as(self.user)
@@ -66,29 +43,6 @@ class TestTempestCredentials(APITestCase):
         "sentry.tempest.endpoints.tempest_credentials.TempestCredentialsEndpoint.create_audit_entry"
     )
     def test_create_tempest_credentials(self, create_audit_entry: MagicMock) -> None:
-        with Feature({"organizations:tempest-access": True}):
-            self.login_as(self.user)
-            response = self.get_success_response(
-                self.project.organization.slug,
-                self.project.slug,
-                method="POST",
-                **self.valid_credentials_data,
-            )
-            assert response.status_code == 201
-            creds_obj = TempestCredentials.objects.get(project=self.project)
-            assert creds_obj.client_id == self.valid_credentials_data["clientId"]
-            assert creds_obj.client_secret == self.valid_credentials_data["clientSecret"]
-            assert creds_obj.project == self.project
-            assert creds_obj.created_by_id == self.user.id
-
-            create_audit_entry.assert_called()
-
-    @patch(
-        "sentry.tempest.endpoints.tempest_credentials.TempestCredentialsEndpoint.create_audit_entry"
-    )
-    def test_create_tempest_credentials_enabled_console_platforms(
-        self, create_audit_entry: MagicMock
-    ) -> None:
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         self.login_as(self.user)
         response = self.get_success_response(
@@ -106,7 +60,7 @@ class TestTempestCredentials(APITestCase):
 
         create_audit_entry.assert_called()
 
-    def test_create_tempest_credentials_without_feature_flag(self) -> None:
+    def test_create_tempest_credentials_without_enabled_playstation_in_options(self) -> None:
         self.login_as(self.user)
         response = self.get_error_response(
             self.project.organization.slug,
@@ -130,21 +84,6 @@ class TestTempestCredentials(APITestCase):
         self.create_member(
             user=non_admin_user, organization=self.project.organization, role="member"
         )
-        with Feature({"organizations:tempest-access": True}):
-            self.login_as(non_admin_user)
-            response = self.get_error_response(
-                self.project.organization.slug,
-                self.project.slug,
-                method="POST",
-                **self.valid_credentials_data,
-            )
-            assert response.status_code == 403
-
-    def test_non_admin_cant_create_tempest_credentials_enabled_console_platforms(self) -> None:
-        non_admin_user = self.create_user()
-        self.create_member(
-            user=non_admin_user, organization=self.project.organization, role="member"
-        )
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         self.login_as(non_admin_user)
         response = self.get_error_response(
@@ -156,25 +95,6 @@ class TestTempestCredentials(APITestCase):
         assert response.status_code == 403
 
     def test_create_tempest_credentials_with_invalid_data(self) -> None:
-        with Feature({"organizations:tempest-access": True}):
-            self.login_as(self.user)
-            response = self.get_error_response(
-                self.project.organization.slug,
-                self.project.slug,
-                method="POST",
-                **{"clientId": "test"},
-            )
-            assert response.status_code == 400
-
-            response2 = self.get_error_response(
-                self.project.organization.slug,
-                self.project.slug,
-                method="POST",
-                **{"clientSecret": "test"},
-            )
-            assert response2.status_code == 400
-
-    def test_create_tempest_credentials_with_invalid_data_enabled_console_platforms(self) -> None:
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         self.login_as(self.user)
         response = self.get_error_response(
@@ -193,23 +113,7 @@ class TestTempestCredentials(APITestCase):
         )
         assert response2.status_code == 400
 
-    def test_cant_create_tempest_credentials_with_duplicate_client_id(self) -> None:
-        with Feature({"organizations:tempest-access": True}):
-            self.login_as(self.user)
-            self.create_tempest_credentials(
-                self.project, client_id=self.valid_credentials_data["clientId"]
-            )
-            response = self.get_error_response(
-                self.project.organization.slug,
-                self.project.slug,
-                method="POST",
-                **self.valid_credentials_data,
-            )
-            # database constraint violation
-            assert response.status_code == 400
-            assert response.data["detail"] == "A credential with this client ID already exists."
-
-    def test_cant_create_tempest_credentials_with_duplicate_client_id_enabled_console_platforms(
+    def test_cant_create_tempest_credentials_with_duplicate_client_id(
         self,
     ) -> None:
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
@@ -228,13 +132,6 @@ class TestTempestCredentials(APITestCase):
         assert response.data["detail"] == "A credential with this client ID already exists."
 
     def test_user_email_in_response(self) -> None:
-        with Feature({"organizations:tempest-access": True}):
-            self.login_as(self.user)
-            self.create_tempest_credentials(self.project, created_by=self.user)
-            response = self.get_success_response(self.project.organization.slug, self.project.slug)
-            assert response.data[0]["createdByEmail"] == self.user.email
-
-    def test_user_email_in_response_enabled_console_platforms(self) -> None:
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         self.login_as(self.user)
         self.create_tempest_credentials(self.project, created_by=self.user)

--- a/tests/sentry/tempest/endpoints/test_tempest_credentials_details.py
+++ b/tests/sentry/tempest/endpoints/test_tempest_credentials_details.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock, patch
 
 from sentry.tempest.models import TempestCredentials
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import Feature
 
 
 class TestTempestCredentialsDetails(APITestCase):
@@ -35,25 +34,6 @@ class TestTempestCredentialsDetails(APITestCase):
         "sentry.tempest.endpoints.tempest_credentials_details.TempestCredentialsDetailsEndpoint.create_audit_entry"
     )
     def test_delete_tempest_credentials_as_org_admin(self, create_audit_entry: MagicMock) -> None:
-        with Feature({"organizations:tempest-access": True}):
-            self.login_as(self.user)
-            response = self.get_response(
-                self.project.organization.slug,
-                self.project.slug,
-                self.tempest_credentials.id,
-                method="DELETE",
-            )
-
-        assert response.status_code == 204
-        assert not TempestCredentials.objects.filter(id=self.tempest_credentials.id).exists()
-        create_audit_entry.assert_called()
-
-    @patch(
-        "sentry.tempest.endpoints.tempest_credentials_details.TempestCredentialsDetailsEndpoint.create_audit_entry"
-    )
-    def test_delete_tempest_credentials_as_org_admin_enabled_console_platforms(
-        self, create_audit_entry
-    ):
         self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
         self.login_as(self.user)
         response = self.get_response(
@@ -68,23 +48,6 @@ class TestTempestCredentialsDetails(APITestCase):
         create_audit_entry.assert_called()
 
     def test_non_admin_cant_delete_credentials(self) -> None:
-        non_admin_user = self.create_user()
-        self.create_member(
-            user=non_admin_user, organization=self.project.organization, role="member"
-        )
-        with Feature({"organizations:tempest-access": True}):
-            self.login_as(non_admin_user)
-            response = self.get_response(
-                self.project.organization.slug,
-                self.project.slug,
-                self.tempest_credentials.id,
-                method="DELETE",
-            )
-
-        assert response.status_code == 403
-        assert TempestCredentials.objects.filter(id=self.tempest_credentials.id).exists()
-
-    def test_non_admin_cant_delete_credentials_enabled_console_platforms(self) -> None:
         non_admin_user = self.create_user()
         self.create_member(
             user=non_admin_user, organization=self.project.organization, role="member"


### PR DESCRIPTION
All PlayStation-related functionality is now managed through org options. Since this change has been fully GA without issues as of 02.09, we are removing the tempest-access checks

contributes to https://linear.app/getsentry/issue/TET-911/remove-tempest-feature-flag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `organizations:tempest-access` checks with `has_tempest_access` based solely on org option `sentry:enabled_console_platforms` containing `playstation`, removing actor handling and updating endpoints/validators/tests.
> 
> - **Tempest access control**:
>   - Replace feature flag `organizations:tempest-access` with org option-based check in `sentry/tempest/utils.py` (`has_tempest_access(organization)` returns true only if `playstation` is enabled).
>   - Remove actor/user parameter from `has_tempest_access` and update all call sites (`project` serializer, project details validators, Tempest credentials endpoints).
>   - Delete feature registration for `organizations:tempest-access` in `features/temporary.py`.
> - **API behavior**:
>   - Project options `tempestFetchScreenshots`/`tempestFetchDumps` validation now depends on org option, not feature flag.
>   - Tempest credentials list/create/delete endpoints now 404 unless `playstation` is enabled via org option.
> - **Tests**:
>   - Remove `with_feature("organizations:tempest-access")` usage; update tests to rely on org `sentry:enabled_console_platforms=["playstation"]` and adjust expectations/names accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adce8020816d377ad6f44c7e65ed97b4c8bb8d42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->