### PR TITLE
feat(search-bar): Add case sensitive search

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -805,6 +805,7 @@ export default typescript.config([
     name: 'files/sentry-test',
     files: ['**/*.spec.{ts,js,tsx,jsx}', 'tests/js/**/*.{ts,js,tsx,jsx}'],
     rules: {
+      '@typescript-eslint/await-thenable': 'off', // For awaiting act(...)
       'no-loss-of-precision': 'off', // Sometimes we have wild numbers hard-coded in tests
       'no-restricted-imports': [
         'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -805,7 +805,6 @@ export default typescript.config([
     name: 'files/sentry-test',
     files: ['**/*.spec.{ts,js,tsx,jsx}', 'tests/js/**/*.{ts,js,tsx,jsx}'],
     rules: {
-      '@typescript-eslint/await-thenable': 'off', // For awaiting act(...)
       'no-loss-of-precision': 'off', // Sometimes we have wild numbers hard-coded in tests
       'no-restricted-imports': [
         'error',

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -59,8 +59,10 @@ interface SearchQueryBuilderContextData {
   setDisplayAskSeerFeedback: (enabled: boolean) => void;
   size: 'small' | 'normal';
   wrapperRef: React.RefObject<HTMLDivElement | null>;
+  caseInsensitive?: boolean;
   filterKeyAliases?: TagCollection;
   matchKeySuggestions?: Array<{key: string; valuePattern: RegExp}>;
+  onCaseInsensitiveClick?: (caseInsensitive: boolean) => void;
   placeholder?: string;
   /**
    * The element to render the combobox popovers into.
@@ -108,6 +110,8 @@ export function SearchQueryBuilderProvider({
   replaceRawSearchKeys,
   matchKeySuggestions,
   filterKeyAliases,
+  caseInsensitive,
+  onCaseInsensitiveClick,
 }: SearchQueryBuilderProps & {children: React.ReactNode}) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const actionBarRef = useRef<HTMLDivElement>(null);
@@ -218,9 +222,12 @@ export function SearchQueryBuilderProvider({
       setDisplayAskSeerFeedback,
       askSeerNLQueryRef,
       askSeerSuggestedQueryRef,
+      caseInsensitive,
+      onCaseInsensitiveClick,
     };
   }, [
     autoSubmitSeer,
+    caseInsensitive,
     disabled,
     disallowFreeText,
     disallowWildcard,
@@ -234,6 +241,7 @@ export function SearchQueryBuilderProvider({
     getTagValues,
     handleSearch,
     matchKeySuggestions,
+    onCaseInsensitiveClick,
     parseQuery,
     parsedQuery,
     placeholder,

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -10,6 +10,10 @@ import {
 
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import type {SearchQueryBuilderProps} from 'sentry/components/searchQueryBuilder';
+import type {
+  CaseInsensitive,
+  SetCaseInsensitive,
+} from 'sentry/components/searchQueryBuilder/hooks';
 import {useHandleSearch} from 'sentry/components/searchQueryBuilder/hooks/useHandleSearch';
 import {
   useQueryBuilderState,
@@ -59,10 +63,10 @@ interface SearchQueryBuilderContextData {
   setDisplayAskSeerFeedback: (enabled: boolean) => void;
   size: 'small' | 'normal';
   wrapperRef: React.RefObject<HTMLDivElement | null>;
-  caseInsensitive?: boolean;
+  caseInsensitive?: CaseInsensitive;
   filterKeyAliases?: TagCollection;
   matchKeySuggestions?: Array<{key: string; valuePattern: RegExp}>;
-  onCaseInsensitiveClick?: (caseInsensitive: boolean) => void;
+  onCaseInsensitiveClick?: SetCaseInsensitive;
   placeholder?: string;
   /**
    * The element to render the combobox popovers into.

--- a/static/app/components/searchQueryBuilder/hooks.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks.spec.tsx
@@ -33,10 +33,10 @@ describe('useCaseSensitivity', () => {
 
     const [, setCaseSensitivity] = result.current;
 
-    act(() => setCaseSensitivity(true));
+    await act(() => setCaseSensitivity(true));
     await waitFor(() => expect(router.location.query.caseInsensitive).toBe('true'));
 
-    act(() => setCaseSensitivity(false));
+    await act(() => setCaseSensitivity(false));
     await waitFor(() => expect(router.location.query.caseInsensitive).toBe('false'));
   });
 });

--- a/static/app/components/searchQueryBuilder/hooks.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks.spec.tsx
@@ -1,0 +1,42 @@
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
+
+describe('useCaseSensitivity', () => {
+  it('should return the correct case sensitivity', () => {
+    const {result: noCaseSensitivity} = renderHookWithProviders(() =>
+      useCaseInsensitivity()
+    );
+    expect(noCaseSensitivity.current[0]).toBeUndefined();
+
+    const {result: caseSensitivityFalse} = renderHookWithProviders(
+      () => useCaseInsensitivity(),
+      {
+        initialRouterConfig: {
+          location: {pathname: '/', query: {caseInsensitive: 'false'}},
+        },
+      }
+    );
+    expect(caseSensitivityFalse.current[0]).toBe(false);
+
+    const {result: caseSensitivityTrue} = renderHookWithProviders(
+      () => useCaseInsensitivity(),
+      {initialRouterConfig: {location: {pathname: '/', query: {caseInsensitive: 'true'}}}}
+    );
+    expect(caseSensitivityTrue.current[0]).toBe(true);
+  });
+
+  it('should set the case sensitivity', async () => {
+    const {router, result} = renderHookWithProviders(() => useCaseInsensitivity());
+
+    expect(router.location.query.caseInsensitive).toBeUndefined();
+
+    const [, setCaseSensitivity] = result.current;
+
+    act(() => setCaseSensitivity(true));
+    await waitFor(() => expect(router.location.query.caseInsensitive).toBe('true'));
+
+    act(() => setCaseSensitivity(false));
+    await waitFor(() => expect(router.location.query.caseInsensitive).toBe('false'));
+  });
+});

--- a/static/app/components/searchQueryBuilder/hooks.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks.spec.tsx
@@ -7,23 +7,23 @@ describe('useCaseSensitivity', () => {
     const {result: noCaseSensitivity} = renderHookWithProviders(() =>
       useCaseInsensitivity()
     );
-    expect(noCaseSensitivity.current[0]).toBeUndefined();
+    expect(noCaseSensitivity.current[0]).toBeNull();
 
     const {result: caseSensitivityFalse} = renderHookWithProviders(
       () => useCaseInsensitivity(),
       {
         initialRouterConfig: {
-          location: {pathname: '/', query: {caseInsensitive: 'false'}},
+          location: {pathname: '/', query: {}},
         },
       }
     );
-    expect(caseSensitivityFalse.current[0]).toBe(false);
+    expect(caseSensitivityFalse.current[0]).toBeNull();
 
     const {result: caseSensitivityTrue} = renderHookWithProviders(
       () => useCaseInsensitivity(),
-      {initialRouterConfig: {location: {pathname: '/', query: {caseInsensitive: 'true'}}}}
+      {initialRouterConfig: {location: {pathname: '/', query: {caseInsensitive: '1'}}}}
     );
-    expect(caseSensitivityTrue.current[0]).toBe(true);
+    expect(caseSensitivityTrue.current[0]).toBe(1);
   });
 
   it('should set the case sensitivity', async () => {
@@ -33,10 +33,10 @@ describe('useCaseSensitivity', () => {
 
     const [, setCaseSensitivity] = result.current;
 
-    await act(() => setCaseSensitivity(true));
-    await waitFor(() => expect(router.location.query.caseInsensitive).toBe('true'));
+    await act(() => setCaseSensitivity(1));
+    await waitFor(() => expect(router.location.query.caseInsensitive).toBe('1'));
 
-    await act(() => setCaseSensitivity(false));
-    await waitFor(() => expect(router.location.query.caseInsensitive).toBe('false'));
+    await act(() => setCaseSensitivity(null));
+    await waitFor(() => expect(router.location.query.caseInsensitive).toBeUndefined());
   });
 });

--- a/static/app/components/searchQueryBuilder/hooks.ts
+++ b/static/app/components/searchQueryBuilder/hooks.ts
@@ -1,10 +1,10 @@
 import {parseAsBoolean, useQueryState} from 'nuqs';
 
-export function useCaseInsensitivity(): [boolean | undefined, (c: boolean) => void] {
+export function useCaseInsensitivity() {
   const [caseInsensitive, setCaseInsensitive] = useQueryState(
     'caseInsensitive',
     parseAsBoolean
   );
 
-  return [caseInsensitive ?? undefined, setCaseInsensitive];
+  return [caseInsensitive ?? undefined, setCaseInsensitive] as const;
 }

--- a/static/app/components/searchQueryBuilder/hooks.ts
+++ b/static/app/components/searchQueryBuilder/hooks.ts
@@ -1,23 +1,10 @@
-import {useCallback, useMemo} from 'react';
-
-import {decodeBoolean} from 'sentry/utils/queryString';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
+import {parseAsBoolean, useQueryState} from 'nuqs';
 
 export function useCaseInsensitivity(): [boolean | undefined, (c: boolean) => void] {
-  const navigate = useNavigate();
-  const location = useLocation();
-
-  const caseInsensitive = useMemo(
-    () => decodeBoolean(location.query.caseInsensitive),
-    [location]
+  const [caseInsensitive, setCaseInsensitive] = useQueryState(
+    'caseInsensitive',
+    parseAsBoolean
   );
 
-  const setCaseInsensitive = useCallback(
-    (c: boolean) =>
-      navigate({...location, query: {...location.query, caseInsensitive: c}}),
-    [location, navigate]
-  );
-
-  return [caseInsensitive, setCaseInsensitive];
+  return [caseInsensitive ?? undefined, setCaseInsensitive];
 }

--- a/static/app/components/searchQueryBuilder/hooks.ts
+++ b/static/app/components/searchQueryBuilder/hooks.ts
@@ -1,0 +1,23 @@
+import {useCallback, useMemo} from 'react';
+
+import {decodeBoolean} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+export function useCaseInsensitivity(): [boolean | undefined, (c: boolean) => void] {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const caseInsensitive = useMemo(
+    () => decodeBoolean(location.query.caseInsensitive),
+    [location]
+  );
+
+  const setCaseInsensitive = useCallback(
+    (c: boolean) =>
+      navigate({...location, query: {...location.query, caseInsensitive: c}}),
+    [location, navigate]
+  );
+
+  return [caseInsensitive, setCaseInsensitive];
+}

--- a/static/app/components/searchQueryBuilder/hooks.ts
+++ b/static/app/components/searchQueryBuilder/hooks.ts
@@ -1,10 +1,14 @@
-import {parseAsBoolean, useQueryState} from 'nuqs';
+import {parseAsNumberLiteral, useQueryState} from 'nuqs';
 
 export function useCaseInsensitivity() {
   const [caseInsensitive, setCaseInsensitive] = useQueryState(
     'caseInsensitive',
-    parseAsBoolean
+    parseAsNumberLiteral([1])
   );
 
-  return [caseInsensitive ?? undefined, setCaseInsensitive] as const;
+  return [caseInsensitive, setCaseInsensitive] as const;
 }
+
+export type CaseInsensitive = ReturnType<typeof useCaseInsensitivity>[0];
+
+export type SetCaseInsensitive = ReturnType<typeof useCaseInsensitivity>[1];

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4136,6 +4136,23 @@ describe('SearchQueryBuilder', () => {
     });
   });
 
+  describe('case sensitivity', () => {
+    it('renders the case sensitivity toggle when the feature is enabled', async () => {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          caseInsensitive
+          onCaseInsensitiveClick={() => {}}
+        />,
+        {organization: {features: ['search-query-builder-case-insensitivity']}}
+      );
+
+      expect(
+        await screen.findByRole('button', {name: 'Toggle case sensitivity'})
+      ).toBeInTheDocument();
+    });
+  });
+
   describe('replaceRawSearchKeys', () => {
     it('should replace raw search keys with defined key:value', async () => {
       render(

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4141,8 +4141,8 @@ describe('SearchQueryBuilder', () => {
       render(
         <SearchQueryBuilder
           {...defaultProps}
-          caseInsensitive
-          onCaseInsensitiveClick={() => {}}
+          caseInsensitive={1}
+          onCaseInsensitiveClick={() => Promise.resolve(new URLSearchParams())}
         />,
         {organization: {features: ['search-query-builder-case-insensitivity']}}
       );

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -715,6 +715,47 @@ export default Storybook.story('SearchQueryBuilder', story => {
     );
   });
 
+  story('Case sensitivity', () => {
+    const [caseInsensitive, setCaseInsensitive] = useState(false);
+
+    return (
+      <Fragment>
+        <p>
+          Case sensitivity does not directly apply case sensitivity to the query being
+          submitted. This implementation provides the API to provide the case sensitivity
+          state, and a callback that is triggered when the user clicks on the case icon.
+        </p>
+        <p>
+          <code>caseInsensitive</code> is used to control the active state of the case
+          icon.
+        </p>
+        <p>
+          <code>onCaseInsensitiveClick</code> is called when the user clicks on the case
+          icon. The visibility of the case icon is controlled when the{' '}
+          <code>onCaseInsensitiveClick</code> prop is defined.
+        </p>
+        <p>
+          <ul>
+            <li>
+              <strong>
+                <code>caseInsensitive</code>
+              </strong>{' '}
+              value : <code>{String(caseInsensitive)}</code>
+            </li>
+          </ul>
+        </p>
+        <SearchQueryBuilder
+          initialQuery="browser.name:FiReFox"
+          filterKeys={FILTER_KEYS}
+          getTagValues={getTagValues}
+          searchSource="storybook"
+          caseInsensitive={caseInsensitive}
+          onCaseInsensitiveClick={() => setCaseInsensitive(!caseInsensitive)}
+        />
+      </Fragment>
+    );
+  });
+
   story('Match key suggestions', () => {
     return (
       <Fragment>

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -716,7 +716,7 @@ export default Storybook.story('SearchQueryBuilder', story => {
   });
 
   story('Case sensitivity', () => {
-    const [caseInsensitive, setCaseInsensitive] = useState(false);
+    const [caseInsensitive, setCaseInsensitive] = useState<1 | null>(null);
 
     return (
       <Fragment>
@@ -750,7 +750,10 @@ export default Storybook.story('SearchQueryBuilder', story => {
           getTagValues={getTagValues}
           searchSource="storybook"
           caseInsensitive={caseInsensitive}
-          onCaseInsensitiveClick={() => setCaseInsensitive(!caseInsensitive)}
+          onCaseInsensitiveClick={value => {
+            setCaseInsensitive(value);
+            return Promise.resolve(new URLSearchParams(value ? 'caseInsensitive=1' : ''));
+          }}
         />
       </Fragment>
     );

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -9,6 +9,10 @@ import {
   SearchQueryBuilderProvider,
   useSearchQueryBuilder,
 } from 'sentry/components/searchQueryBuilder/context';
+import type {
+  CaseInsensitive,
+  SetCaseInsensitive,
+} from 'sentry/components/searchQueryBuilder/hooks';
 import {useOnChange} from 'sentry/components/searchQueryBuilder/hooks/useOnChange';
 import {PlainTextQueryInput} from 'sentry/components/searchQueryBuilder/plainTextQueryInput';
 import {TokenizedQueryGrid} from 'sentry/components/searchQueryBuilder/tokenizedQueryGrid';
@@ -44,10 +48,10 @@ export interface SearchQueryBuilderProps {
   autoFocus?: boolean;
   /**
    * Controls the state of the case sensitivity toggle.
-   * - `true` = case insensitive
-   * - `false` = case sensitive
+   * - `1` = case insensitive
+   * - `null` = case sensitive
    */
-  caseInsensitive?: boolean;
+  caseInsensitive?: CaseInsensitive;
   className?: string;
   disabled?: boolean;
   /**
@@ -129,7 +133,7 @@ export interface SearchQueryBuilderProps {
    * When passed, this will display the case sensitivity toggle, and will be called when
    * the user clicks on the case sensitivity button.
    */
-  onCaseInsensitiveClick?: (caseInsensitive: boolean) => void;
+  onCaseInsensitiveClick?: SetCaseInsensitive;
   /**
    * Called when the query value changes
    */
@@ -200,13 +204,13 @@ function ActionButtons({
       {defined(onCaseInsensitiveClick) && hasCaseSensitiveSearch ? (
         <ActionButton
           aria-label={t('Toggle case sensitivity')}
-          aria-pressed={caseInsensitive === true}
+          aria-pressed={caseInsensitive === 1}
           size="zero"
           icon={<IconCase color={caseInsensitive ? 'active' : 'subText'} />}
           borderless
-          active={caseInsensitive === true}
+          active={caseInsensitive === 1}
           onClick={() => {
-            onCaseInsensitiveClick?.(!caseInsensitive);
+            onCaseInsensitiveClick?.(caseInsensitive === 1 ? null : 1);
           }}
         />
       ) : null}

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -2,6 +2,10 @@ import {useMemo} from 'react';
 
 import type {EAPSpanSearchQueryBuilderProps} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {
+  CaseInsensitive,
+  SetCaseInsensitive,
+} from 'sentry/components/searchQueryBuilder/hooks';
 import {t} from 'sentry/locale';
 import {SavedSearchType, type TagCollection} from 'sentry/types/group';
 import type {AggregationKey} from 'sentry/utils/fields';
@@ -19,9 +23,9 @@ export type TraceItemSearchQueryBuilderProps = {
   numberSecondaryAliases: TagCollection;
   stringAttributes: TagCollection;
   stringSecondaryAliases: TagCollection;
-  caseInsensitive?: boolean;
+  caseInsensitive?: CaseInsensitive;
   matchKeySuggestions?: Array<{key: string; valuePattern: RegExp}>;
-  onCaseInsensitiveClick?: (caseInsensitive: boolean) => void;
+  onCaseInsensitiveClick?: SetCaseInsensitive;
   replaceRawSearchKeys?: string[];
 } & Omit<EAPSpanSearchQueryBuilderProps, 'numberTags' | 'stringTags'>;
 

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -19,7 +19,9 @@ export type TraceItemSearchQueryBuilderProps = {
   numberSecondaryAliases: TagCollection;
   stringAttributes: TagCollection;
   stringSecondaryAliases: TagCollection;
+  caseInsensitive?: boolean;
   matchKeySuggestions?: Array<{key: string; valuePattern: RegExp}>;
+  onCaseInsensitiveClick?: (caseInsensitive: boolean) => void;
   replaceRawSearchKeys?: string[];
 } & Omit<EAPSpanSearchQueryBuilderProps, 'numberTags' | 'stringTags'>;
 
@@ -71,6 +73,8 @@ export function useSearchQueryBuilderProps({
   supportedAggregates = [],
   replaceRawSearchKeys,
   matchKeySuggestions,
+  caseInsensitive,
+  onCaseInsensitiveClick,
 }: TraceItemSearchQueryBuilderProps) {
   const placeholderText = itemTypeToDefaultPlaceholder(itemType);
   const functionTags = useFunctionTags(itemType, supportedAggregates);
@@ -108,6 +112,8 @@ export function useSearchQueryBuilderProps({
     replaceRawSearchKeys,
     matchKeySuggestions,
     filterKeyAliases: {...numberSecondaryAliases, ...stringSecondaryAliases},
+    caseInsensitive,
+    onCaseInsensitiveClick,
   };
 }
 

--- a/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
@@ -33,6 +33,7 @@ export function useExploreAggregatesTable({
   enabled,
   limit,
   query,
+  queryExtras,
 }: UseExploreAggregatesTableOptions) {
   const extrapolate = useQueryParamsExtrapolate();
 
@@ -46,7 +47,7 @@ export function useExploreAggregatesTable({
   );
   return useProgressiveQuery<typeof useExploreAggregatesTableImp>({
     queryHookImplementation: useExploreAggregatesTableImp,
-    queryHookArgs: {enabled, limit, query},
+    queryHookArgs: {enabled, limit, query, queryExtras},
     queryOptions: {
       canTriggerHighAccuracy,
       disableExtrapolation: !extrapolate,

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -32,6 +32,7 @@ export function useExploreSpansTable({
   enabled,
   limit,
   query,
+  queryExtras,
 }: UseExploreSpansTableOptions) {
   const extrapolate = useQueryParamsExtrapolate();
 
@@ -46,7 +47,7 @@ export function useExploreSpansTable({
 
   return useProgressiveQuery<typeof useExploreSpansTableImp>({
     queryHookImplementation: useExploreSpansTableImp,
-    queryHookArgs: {enabled, limit, query},
+    queryHookArgs: {enabled, limit, query, queryExtras},
     queryOptions: {
       canTriggerHighAccuracy,
       disableExtrapolation: !extrapolate,

--- a/static/app/views/explore/hooks/useExploreTimeseries.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.tsx
@@ -36,10 +36,8 @@ interface UseExploreTimeseriesResults {
 export const useExploreTimeseries = ({
   query,
   enabled,
-}: {
-  enabled: boolean;
-  query: string;
-}) => {
+  queryExtras,
+}: UseExploreTimeseriesOptions) => {
   const visualizes = useQueryParamsVisualizes();
   const extrapolate = useQueryParamsExtrapolate();
   const topEvents = useTopEvents();
@@ -54,7 +52,7 @@ export const useExploreTimeseries = ({
 
   return useProgressiveQuery<typeof useExploreTimeseriesImpl>({
     queryHookImplementation: useExploreTimeseriesImpl,
-    queryHookArgs: {query, enabled},
+    queryHookArgs: {query, enabled, queryExtras},
     queryOptions: {
       canTriggerHighAccuracy,
       disableExtrapolation: !extrapolate,
@@ -113,7 +111,7 @@ function useExploreTimeseriesImpl({
       enabled,
       ...queryExtras,
     };
-  }, [query, yAxes, interval, fields, orderby, topEvents, enabled, queryExtras]);
+  }, [enabled, fields, interval, orderby, query, queryExtras, topEvents, yAxes]);
 
   const timeseriesResult = useSortedTimeSeries(
     options,

--- a/static/app/views/explore/hooks/useExploreTracesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreTracesTable.tsx
@@ -8,6 +8,7 @@ interface UseExploreTracesTableOptions {
   enabled: boolean;
   limit: number;
   query: string;
+  queryExtras?: {caseInsensitive?: boolean};
 }
 
 export interface TracesTableResult {
@@ -18,6 +19,7 @@ export function useExploreTracesTable({
   enabled,
   limit,
   query,
+  queryExtras,
 }: UseExploreTracesTableOptions): TracesTableResult {
   const location = useLocation();
   const cursor = decodeScalar(location.query.cursor);
@@ -28,6 +30,7 @@ export function useExploreTracesTable({
     limit,
     sort: '-timestamp',
     cursor,
+    caseInsensitive: queryExtras?.caseInsensitive,
   });
 
   return useMemo(() => {

--- a/static/app/views/explore/hooks/useExploreTracesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreTracesTable.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 
+import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useTraces} from 'sentry/views/explore/hooks/useTraces';
@@ -8,7 +9,7 @@ interface UseExploreTracesTableOptions {
   enabled: boolean;
   limit: number;
   query: string;
-  queryExtras?: {caseInsensitive?: boolean};
+  queryExtras?: {caseInsensitive?: CaseInsensitive};
 }
 
 export interface TracesTableResult {

--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -18,6 +18,7 @@ const NON_EXTRAPOLATED_SAMPLING_MODE_QUERY_EXTRAS = {
 
 export type SamplingMode = (typeof SAMPLING_MODE)[keyof typeof SAMPLING_MODE];
 export type SpansRPCQueryExtras = {
+  caseInsensitive?: boolean;
   disableAggregateExtrapolation?: string;
   samplingMode?: SamplingMode;
 };
@@ -69,14 +70,20 @@ export function useProgressiveQuery<
   const nonExtrapolatedMode = disableExtrapolation && queryHookArgs.enabled;
   const nonExtrapolatedModeRequest = queryHookImplementation({
     ...queryHookArgs,
-    queryExtras: NON_EXTRAPOLATED_SAMPLING_MODE_QUERY_EXTRAS,
+    queryExtras: {
+      ...queryHookArgs.queryExtras,
+      ...NON_EXTRAPOLATED_SAMPLING_MODE_QUERY_EXTRAS,
+    },
     enabled: nonExtrapolatedMode,
   });
 
   const normalMode = !disableExtrapolation && queryHookArgs.enabled;
   const normalSamplingModeRequest = queryHookImplementation({
     ...queryHookArgs,
-    queryExtras: NORMAL_SAMPLING_MODE_QUERY_EXTRAS,
+    queryExtras: {
+      ...queryHookArgs.queryExtras,
+      ...NORMAL_SAMPLING_MODE_QUERY_EXTRAS,
+    },
     enabled: normalMode,
   });
 
@@ -89,7 +96,10 @@ export function useProgressiveQuery<
     !disableExtrapolation && queryHookArgs.enabled && triggerHighAccuracy;
   const highAccuracyRequest = queryHookImplementation({
     ...queryHookArgs,
-    queryExtras: HIGH_ACCURACY_SAMPLING_MODE_QUERY_EXTRAS,
+    queryExtras: {
+      ...queryHookArgs.queryExtras,
+      ...HIGH_ACCURACY_SAMPLING_MODE_QUERY_EXTRAS,
+    },
     enabled: highAccuracyMode,
   });
 

--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -1,3 +1,5 @@
+import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
+
 export const SAMPLING_MODE = {
   NORMAL: 'NORMAL',
   HIGH_ACCURACY: 'HIGHEST_ACCURACY',
@@ -18,7 +20,7 @@ const NON_EXTRAPOLATED_SAMPLING_MODE_QUERY_EXTRAS = {
 
 export type SamplingMode = (typeof SAMPLING_MODE)[keyof typeof SAMPLING_MODE];
 export type SpansRPCQueryExtras = {
-  caseInsensitive?: boolean;
+  caseInsensitive?: CaseInsensitive;
   disableAggregateExtrapolation?: string;
   samplingMode?: SamplingMode;
 };

--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -1,6 +1,7 @@
 import {keepPreviousData as keepPreviousDataFn} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import type {PageFilters} from 'sentry/types/core';
 import type {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
 import {parseError} from 'sentry/utils/discover/genericDiscoverQuery';
@@ -59,7 +60,7 @@ interface TraceResults {
 
 interface UseTracesOptions
   extends Pick<UseApiQueryOptions<TraceResults>, 'refetchInterval'> {
-  caseInsensitive?: boolean;
+  caseInsensitive?: CaseInsensitive;
   cursor?: string;
   datetime?: PageFilters['datetime'];
   enabled?: boolean;

--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -59,6 +59,7 @@ interface TraceResults {
 
 interface UseTracesOptions
   extends Pick<UseApiQueryOptions<TraceResults>, 'refetchInterval'> {
+  caseInsensitive?: boolean;
   cursor?: string;
   datetime?: PageFilters['datetime'];
   enabled?: boolean;
@@ -73,6 +74,7 @@ type UseTracesResult = Omit<UseApiQueryResult<TraceResults, RequestError>, 'erro
 };
 
 export function useTraces({
+  caseInsensitive,
   cursor,
   datetime,
   enabled,
@@ -98,6 +100,7 @@ export function useTraces({
       per_page: limit,
       cursor,
       breakdownSlices: BREAKDOWN_SLICES,
+      caseInsensitive,
     },
   };
 

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -273,7 +273,7 @@ describe('LogsTabContent', () => {
           field: [...AlwaysPresentLogFields, 'message', 'sentry.message.parameters.0'],
           sort: 'sentry.message.parameters.0',
           query: 'severity:error',
-          caseInsensitive: true,
+          caseInsensitive: 1,
         }),
       })
     );
@@ -288,7 +288,7 @@ describe('LogsTabContent', () => {
           yAxis: 'count(message)',
           interval: '1h',
           query: 'severity:error timestamp_precise:<=1508208040000000000',
-          caseInsensitive: true,
+          caseInsensitive: 1,
         }),
       })
     );

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -29,7 +29,9 @@ const datePageFilterProps: PickableDays = {
 };
 
 describe('LogsTabContent', () => {
-  const {organization, project, setupPageFilters} = initializeLogsTest();
+  const {organization, project, setupPageFilters} = initializeLogsTest({
+    orgFeatures: ['search-query-builder-case-insensitivity'],
+  });
 
   let eventTableMock: jest.Mock;
   let eventStatsMock: jest.Mock;
@@ -243,6 +245,52 @@ describe('LogsTabContent', () => {
     expect(screen.getByRole('tab', {name: 'Aggregates'})).toHaveAttribute(
       'aria-selected',
       'false'
+    );
+  });
+
+  it('should pass caseInsensitive to the query', async () => {
+    render(
+      <ProviderWrapper>
+        <LogsTabContent {...datePageFilterProps} />
+      </ProviderWrapper>,
+      {initialRouterConfig, organization}
+    );
+
+    expect(eventTableMock).toHaveBeenCalled();
+
+    const caseInsensitiveBtn = await screen.findByRole('button', {
+      name: 'Toggle case sensitivity',
+    });
+    await userEvent.click(caseInsensitiveBtn);
+
+    expect(eventTableMock).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/events/`,
+      expect.objectContaining({
+        query: expect.objectContaining({
+          environment: [],
+          statsPeriod: '14d',
+          dataset: 'ourlogs',
+          field: [...AlwaysPresentLogFields, 'message', 'sentry.message.parameters.0'],
+          sort: 'sentry.message.parameters.0',
+          query: 'severity:error',
+          caseInsensitive: true,
+        }),
+      })
+    );
+
+    expect(eventStatsMock).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/events-stats/`,
+      expect.objectContaining({
+        query: expect.objectContaining({
+          environment: [],
+          statsPeriod: '14d',
+          dataset: 'ourlogs',
+          yAxis: 'count(message)',
+          interval: '1h',
+          query: 'severity:error timestamp_precise:<=1508208040000000000',
+          caseInsensitive: true,
+        }),
+      })
     );
   });
 });

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -10,6 +10,7 @@ import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
+import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import {IconChevron, IconRefresh, IconTable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
@@ -116,6 +117,7 @@ export function LogsTabContent({
     getMaxIngestDelayTimestamp()
   );
   const [_, setPersistentParams] = usePersistedLogsPageParams();
+  const [caseInsensitive] = useCaseInsensitivity();
   usePersistentLogsPageParameters(); // persist the columns you chose last time
 
   const columnEditorButtonRef = useRef<HTMLButtonElement>(null);
@@ -164,6 +166,7 @@ export function LogsTabContent({
       fields: [...groupBys.filter(Boolean), ...yAxes],
       topEvents: topEventsLimit,
       orderby,
+      caseInsensitive,
     },
     'explore.ourlogs.main-chart',
     DiscoverDatasets.OURLOGS

--- a/static/app/views/explore/logs/useLogsQuery.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.spec.tsx
@@ -3,7 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {ApiResult} from 'sentry/api';
 import type {Organization} from 'sentry/types/organization';
@@ -29,7 +29,6 @@ import {
   useInfiniteLogsQuery,
   type LogPageParam,
 } from 'sentry/views/explore/logs/useLogsQuery';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/useLocation');
 const mockUseLocation = jest.mocked(useLocation);
@@ -59,9 +58,7 @@ describe('useInfiniteLogsQuery', () => {
             analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
             source="location"
           >
-            <OrganizationContext.Provider value={organization}>
-              {children}
-            </OrganizationContext.Provider>
+            {children}
           </LogsQueryParamsProvider>
         </QueryClientProvider>
       );
@@ -89,10 +86,14 @@ describe('useInfiniteLogsQuery', () => {
       headers: linkHeaders,
     });
 
-    const {result} = renderHook(({disabled}) => useInfiniteLogsQuery({disabled}), {
-      wrapper: createWrapper(),
-      initialProps: {disabled: true},
-    });
+    const {result} = renderHookWithProviders(
+      ({disabled}) => useInfiniteLogsQuery({disabled}),
+      {
+        additionalWrapper: createWrapper(),
+        initialProps: {disabled: true},
+        organization,
+      }
+    );
 
     expect(result.current.isPending).toBe(true);
     expect(result.current.data).toHaveLength(0);
@@ -113,8 +114,9 @@ describe('useInfiniteLogsQuery', () => {
       );
     }
 
-    const {result, rerender} = renderHook(() => useInfiniteLogsQuery(), {
-      wrapper: createWrapper(),
+    const {result, rerender} = renderHookWithProviders(() => useInfiniteLogsQuery(), {
+      additionalWrapper: createWrapper(),
+      organization,
     });
 
     await waitFor(() => {
@@ -202,8 +204,9 @@ describe('useInfiniteLogsQuery', () => {
       headers: linkHeaders,
     });
 
-    const {result, rerender} = renderHook(() => useInfiniteLogsQuery(), {
-      wrapper: createWrapper(),
+    const {result, rerender} = renderHookWithProviders(() => useInfiniteLogsQuery(), {
+      additionalWrapper: createWrapper(),
+      organization,
     });
 
     await waitFor(() => {
@@ -442,9 +445,7 @@ describe('Virtual Streaming Integration (Auto Refresh Behaviour)', () => {
             analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
             source="location"
           >
-            <OrganizationContext.Provider value={organization}>
-              {children}
-            </OrganizationContext.Provider>
+            {children}
           </LogsQueryParamsProvider>
         </QueryClientProvider>
       );
@@ -480,8 +481,9 @@ describe('Virtual Streaming Integration (Auto Refresh Behaviour)', () => {
       headers: linkHeaders,
     });
 
-    const {result} = renderHook(() => useInfiniteLogsQuery(), {
-      wrapper: createWrapper({autoRefresh: 'enabled'}),
+    const {result} = renderHookWithProviders(() => useInfiniteLogsQuery(), {
+      additionalWrapper: createWrapper({autoRefresh: 'enabled'}),
+      organization,
     });
 
     await waitFor(() => {
@@ -507,8 +509,9 @@ describe('Virtual Streaming Integration (Auto Refresh Behaviour)', () => {
       headers: linkHeaders,
     });
 
-    const {result} = renderHook(() => useInfiniteLogsQuery(), {
-      wrapper: createWrapper({autoRefresh: 'idle'}),
+    const {result} = renderHookWithProviders(() => useInfiniteLogsQuery(), {
+      additionalWrapper: createWrapper({autoRefresh: 'idle'}),
+      organization,
     });
 
     await waitFor(() => {
@@ -563,8 +566,9 @@ describe('Virtual Streaming Integration (Auto Refresh Behaviour)', () => {
       headers: linkHeaders,
     });
 
-    const {result} = renderHook(() => useInfiniteLogsQuery(), {
-      wrapper: createWrapper({autoRefresh: 'enabled'}),
+    const {result} = renderHookWithProviders(() => useInfiniteLogsQuery(), {
+      additionalWrapper: createWrapper({autoRefresh: 'enabled'}),
+      organization,
     });
 
     await waitFor(() => {
@@ -624,8 +628,9 @@ describe('Virtual Streaming Integration (Auto Refresh Behaviour)', () => {
       headers: linkHeaders,
     });
 
-    const {result} = renderHook(() => useInfiniteLogsQuery(), {
-      wrapper: createWrapper({autoRefresh: 'idle'}), // Disable auto refresh to avoid virtual streaming filtering
+    const {result} = renderHookWithProviders(() => useInfiniteLogsQuery(), {
+      additionalWrapper: createWrapper({autoRefresh: 'idle'}), // Disable auto refresh to avoid virtual streaming filtering
+      organization,
     });
 
     await waitFor(() => {

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -2,6 +2,7 @@ import {useCallback, useEffect, useMemo, useState} from 'react';
 import {logger} from '@sentry/react';
 
 import {type ApiResult} from 'sentry/api';
+import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import {defined} from 'sentry/utils';
 import {encodeSort, type EventsMetaType} from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
@@ -93,6 +94,7 @@ function useLogsAggregatesQueryKey({
   const visualizes = useQueryParamsVisualizes();
   const aggregateSortBys = useQueryParamsAggregateSortBys();
   const aggregateCursor = useQueryParamsAggregateCursor();
+  const [caseInsensitive] = useCaseInsensitivity();
   const fields: string[] = [];
   fields.push(...groupBys.filter(Boolean));
   fields.push(...visualizes.map(visualize => visualize.yAxis));
@@ -118,6 +120,7 @@ function useLogsAggregatesQueryKey({
       per_page: limit ? limit : undefined,
       cursor: aggregateCursor,
       referrer,
+      caseInsensitive,
     },
     pageFiltersReady,
     eventView,
@@ -184,6 +187,7 @@ function useLogsQueryKey({
   const location = useLocation();
   const projectIds = useLogsFrozenProjectIds();
   const groupBys = useQueryParamsGroupBys();
+  const [caseInsensitive] = useCaseInsensitivity();
 
   const search = baseSearch ? _search.copy() : _search;
   if (baseSearch) {
@@ -225,6 +229,7 @@ function useLogsQueryKey({
       per_page: limit ? limit : undefined,
       referrer,
       sampling: highFidelity ? 'HIGHEST_ACCURACY_FLEX_TIME' : undefined,
+      caseInsensitive,
     },
     pageFiltersReady,
     eventView,

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
@@ -1,5 +1,6 @@
 import {useCallback} from 'react';
 
+import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import type {TagCollection} from 'sentry/types/group';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePrevious from 'sentry/utils/usePrevious';
@@ -30,6 +31,7 @@ export function useLogsSearchQueryBuilderProps({
   const oldLogsSearch = usePrevious(logsSearch);
   const fields = useQueryParamsFields();
   const setQueryParams = useSetQueryParams();
+  const [caseInsensitive, setCaseInsensitive] = useCaseInsensitivity();
   const onSearch = useCallback(
     (newQuery: string) => {
       const newSearch = new MutableSearch(newQuery);
@@ -58,6 +60,8 @@ export function useLogsSearchQueryBuilderProps({
     itemType: TraceItemDataset.LOGS as TraceItemDataset.LOGS,
     numberSecondaryAliases,
     stringSecondaryAliases,
+    caseInsensitive,
+    onCaseInsensitiveClick: setCaseInsensitive,
   };
 
   const searchQueryBuilderProviderProps = useSearchQueryBuilderProps(

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -281,7 +281,7 @@ describe('SpansTabContent', () => {
       await userEvent.click(caseSensitivityToggle);
 
       expect(caseSensitivityToggle).toHaveAttribute('aria-pressed', 'true');
-      expect(router.location.query.caseInsensitive).toBe('true');
+      expect(router.location.query.caseInsensitive).toBe('1');
     });
 
     it('appends case sensitive to the query', async () => {
@@ -313,7 +313,7 @@ describe('SpansTabContent', () => {
         expect(eventsMock).toHaveBeenCalledWith(
           `/organizations/${organization.slug}/events/`,
           expect.objectContaining({
-            query: expect.objectContaining({caseInsensitive: 'true'}),
+            query: expect.objectContaining({caseInsensitive: '1'}),
           })
         )
       );
@@ -322,7 +322,7 @@ describe('SpansTabContent', () => {
         expect(eventsStatsMock).toHaveBeenCalledWith(
           `/organizations/${organization.slug}/events-stats/`,
           expect.objectContaining({
-            query: expect.objectContaining({caseInsensitive: true}),
+            query: expect.objectContaining({caseInsensitive: 1}),
           })
         )
       );

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -68,6 +68,7 @@ describe('SpansTabContent', () => {
         'gen-ai-features',
         'gen-ai-explore-traces',
         'gen-ai-explore-traces-consent-ui',
+        'search-query-builder-case-insensitivity',
       ],
     },
   });
@@ -94,7 +95,6 @@ describe('SpansTabContent', () => {
       method: 'GET',
       body: {},
     });
-
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/spans/fields/`,
       method: 'GET',
@@ -249,6 +249,84 @@ describe('SpansTabContent', () => {
     expect(screen.queryByTestId('explore-span-toolbar')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Collapse sidebar')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Expand sidebar')).toBeInTheDocument();
+  });
+
+  describe('case sensitivity', () => {
+    it('renders the case sensitivity toggle', () => {
+      render(
+        <Wrapper>
+          <SpansTabContent datePageFilterProps={datePageFilterProps} />
+        </Wrapper>,
+        {organization}
+      );
+
+      const caseSensitivityToggle = screen.getByRole('button', {
+        name: 'Toggle case sensitivity',
+      });
+      expect(caseSensitivityToggle).toBeInTheDocument();
+    });
+
+    it('toggles case sensitivity', async () => {
+      const {router} = render(
+        <Wrapper>
+          <SpansTabContent datePageFilterProps={datePageFilterProps} />
+        </Wrapper>,
+        {organization}
+      );
+
+      const caseSensitivityToggle = screen.getByRole('button', {
+        name: 'Toggle case sensitivity',
+      });
+      expect(caseSensitivityToggle).toBeInTheDocument();
+      await userEvent.click(caseSensitivityToggle);
+
+      expect(caseSensitivityToggle).toHaveAttribute('aria-pressed', 'true');
+      expect(router.location.query.caseInsensitive).toBe('true');
+    });
+
+    it('appends case sensitive to the query', async () => {
+      const eventsMock = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events/`,
+        method: 'GET',
+        body: {},
+      });
+      const eventsStatsMock = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events-stats/`,
+        method: 'GET',
+        body: {},
+      });
+
+      render(
+        <Wrapper>
+          <SpansTabContent datePageFilterProps={datePageFilterProps} />
+        </Wrapper>,
+        {organization}
+      );
+
+      const caseSensitivityToggle = screen.getByRole('button', {
+        name: 'Toggle case sensitivity',
+      });
+      expect(caseSensitivityToggle).toBeInTheDocument();
+      await userEvent.click(caseSensitivityToggle);
+
+      await waitFor(() =>
+        expect(eventsMock).toHaveBeenCalledWith(
+          `/organizations/${organization.slug}/events/`,
+          expect.objectContaining({
+            query: expect.objectContaining({caseInsensitive: 'true'}),
+          })
+        )
+      );
+
+      await waitFor(() =>
+        expect(eventsStatsMock).toHaveBeenCalledWith(
+          `/organizations/${organization.slug}/events-stats/`,
+          expect.objectContaining({
+            query: expect.objectContaining({caseInsensitive: true}),
+          })
+        )
+      );
+    });
   });
 
   describe('schema hints', () => {

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -24,7 +24,6 @@ import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import {TourElement} from 'sentry/components/tours/components';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -546,10 +545,10 @@ function checkIsAllowedSelection(
 const BodySearch = styled(Layout.Body)`
   flex-grow: 0;
   border-bottom: 1px solid ${p => p.theme.border};
-  padding-bottom: ${space(2)};
+  padding-bottom: ${p => p.theme.space.xl};
 
   @media (min-width: ${p => p.theme.breakpoints.md}) {
-    padding-bottom: ${space(2)};
+    padding-bottom: ${p => p.theme.space.xl};
   }
 `;
 
@@ -570,7 +569,7 @@ const BodyContent = styled('div')`
 `;
 
 const ControlSection = styled('aside')<{expanded: boolean}>`
-  padding: ${space(1)} ${space(2)};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
   border-bottom: 1px solid ${p => p.theme.border};
 
   @media (min-width: ${p => p.theme.breakpoints.md}) {
@@ -579,7 +578,8 @@ const ControlSection = styled('aside')<{expanded: boolean}>`
       p.expanded
         ? css`
             width: 343px; /* 300px for the toolbar + padding */
-            padding: ${space(2)} ${space(1.5)} ${space(1)} ${space(4)};
+            padding: ${p.theme.space.xl} ${p.theme.space.lg} ${p.theme.space.md}
+              ${p.theme.space['3xl']};
             border-right: 1px solid ${p.theme.border};
           `
         : css`
@@ -596,23 +596,28 @@ const ContentSection = styled('section')<{expanded: boolean}>`
   flex: 1 1 auto;
   min-width: 0;
 
-  padding: ${space(1)} ${space(2)} ${space(3)} ${space(2)};
+  padding-top: ${p => p.theme.space.md};
+  padding-right: ${p => p.theme.space.xl};
+  padding-bottom: ${p => p.theme.space['2xl']};
+  padding-left: ${p => p.theme.space.xl};
 
   @media (min-width: ${p => p.theme.breakpoints.md}) {
     ${p =>
       p.expanded
         ? css`
-            padding: ${space(1)} ${space(4)} ${space(3)} ${space(1.5)};
+            padding: ${p.theme.space.md} ${p.theme.space['3xl']} ${p.theme.space['2xl']}
+              ${p.theme.space.lg};
           `
         : css`
-            padding: ${space(1)} ${space(4)} ${space(3)} ${space(4)};
+            padding: ${p.theme.space.md} ${p.theme.space['3xl']} ${p.theme.space['2xl']}
+              ${p.theme.space['3xl']};
           `}
   }
 `;
 
 const FilterSection = styled('div')`
   display: grid;
-  gap: ${space(1)};
+  gap: ${p => p.theme.space.md};
 
   @media (min-width: ${p => p.theme.breakpoints.md}) {
     grid-template-columns: minmax(300px, auto) 1fr;
@@ -671,11 +676,11 @@ const ChevronButton = withChonk(
 );
 
 const StyledSchemaHintsSection = styled(SchemaHintsSection)`
-  margin-top: ${space(1)};
+  margin-top: ${p => p.theme.space.md};
   margin-bottom: 0px;
 
   @media (min-width: ${p => p.theme.breakpoints.md}) {
-    margin-top: ${space(1)};
+    margin-top: ${p => p.theme.space.md};
     margin-bottom: 0px;
   }
 `;

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -20,6 +20,7 @@ import {
   SearchQueryBuilderProvider,
   useSearchQueryBuilder,
 } from 'sentry/components/searchQueryBuilder/context';
+import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import {TourElement} from 'sentry/components/tours/components';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
@@ -188,6 +189,7 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
   const fields = useQueryParamsFields();
   const query = useQueryParamsQuery();
   const setExplorePageParams = useSetExplorePageParams();
+  const [caseInsensitive, setCaseInsensitive] = useCaseInsensitivity();
 
   const organization = useOrganization();
   const areAiFeaturesAllowed =
@@ -252,8 +254,11 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
       ],
       numberSecondaryAliases,
       stringSecondaryAliases,
+      caseInsensitive,
+      onCaseInsensitiveClick: setCaseInsensitive,
     }),
     [
+      caseInsensitive,
       fields,
       hasRawSearchReplacement,
       mode,
@@ -261,6 +266,7 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
       numberTags,
       oldSearch,
       query,
+      setCaseInsensitive,
       setExplorePageParams,
       stringSecondaryAliases,
       stringTags,
@@ -365,6 +371,7 @@ function SpanTabContentSection({
   const setVisualizes = useSetQueryParamsVisualizes();
   const extrapolate = useQueryParamsExtrapolate();
   const [tab, setTab] = useTab();
+  const [caseInsensitive] = useCaseInsensitivity();
 
   const queryType: 'aggregate' | 'samples' | 'traces' =
     tab === Mode.AGGREGATE ? 'aggregate' : tab === Tab.TRACE ? 'traces' : 'samples';
@@ -380,22 +387,26 @@ function SpanTabContentSection({
     query,
     limit,
     enabled: isAllowedSelection && queryType === 'aggregate',
+    queryExtras: {caseInsensitive},
   });
   const spansTableResult = useExploreSpansTable({
     query,
     limit,
     enabled: isAllowedSelection && queryType === 'samples',
+    queryExtras: {caseInsensitive},
   });
   const tracesTableResult = useExploreTracesTable({
     query,
     limit,
     enabled: isAllowedSelection && queryType === 'traces',
+    queryExtras: {caseInsensitive},
   });
 
   const {result: timeseriesResult, samplingMode: timeseriesSamplingMode} =
     useExploreTimeseries({
       query,
       enabled: isAllowedSelection,
+      queryExtras: {caseInsensitive},
     });
 
   const confidences = useMemo(

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/react';
 import isEmpty from 'lodash/isEmpty';
 import isEqualWith from 'lodash/isEqualWith';
 
+import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import {NODE_ENV} from 'sentry/constants';
 import type {
   EventsStats,
@@ -52,7 +53,7 @@ const {warn} = Sentry.logger;
 type SeriesMap = Record<string, TimeSeries[]>;
 
 interface Options<Fields> {
-  caseInsensitive?: boolean;
+  caseInsensitive?: CaseInsensitive;
   disableAggregateExtrapolation?: string;
   enabled?: boolean;
   fields?: string[];

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -52,6 +52,7 @@ const {warn} = Sentry.logger;
 type SeriesMap = Record<string, TimeSeries[]>;
 
 interface Options<Fields> {
+  caseInsensitive?: boolean;
   disableAggregateExtrapolation?: string;
   enabled?: boolean;
   fields?: string[];
@@ -85,6 +86,7 @@ export const useSortedTimeSeries = <
     enabled,
     samplingMode,
     disableAggregateExtrapolation,
+    caseInsensitive,
   } = options;
 
   const pageFilters = usePageFilters();
@@ -159,6 +161,7 @@ export const useSortedTimeSeries = <
       // Timeseries requests do not support cursors, overwrite it to undefined so
       // pagination does not cause extra requests
       cursor: undefined,
+      caseInsensitive,
     }),
     options: {
       enabled: enabled && pageFilters.isReady,

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment-timezone';
 
+import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import {defined} from 'sentry/utils';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
@@ -122,7 +123,7 @@ function useSpansQueryBase<T>({
 
 type WrappedDiscoverTimeseriesQueryProps = {
   eventView: EventView;
-  caseInsensitive?: boolean;
+  caseInsensitive?: CaseInsensitive;
   cursor?: string;
   enabled?: boolean;
   initialData?: any;
@@ -231,7 +232,7 @@ type WrappedDiscoverQueryProps<T> = {
   eventView: EventView;
   additionalQueryKey?: string[];
   allowAggregateConditions?: boolean;
-  caseInsensitive?: boolean;
+  caseInsensitive?: CaseInsensitive;
   cursor?: string;
   disableAggregateExtrapolation?: string;
   enabled?: boolean;
@@ -272,8 +273,8 @@ function useWrappedDiscoverQueryBase<T>({
       queryExtras.sampling = samplingMode;
     }
 
-    if (typeof caseInsensitive === 'boolean') {
-      queryExtras.caseInsensitive = caseInsensitive ? 'true' : 'false';
+    if (typeof caseInsensitive === 'number') {
+      queryExtras.caseInsensitive = caseInsensitive.toString();
     }
 
     if (disableAggregateExtrapolation) {

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -108,6 +108,7 @@ function useSpansQueryBase<T>({
     referrer,
     cursor,
     allowAggregateConditions,
+    caseInsensitive: queryExtras?.caseInsensitive,
     samplingMode: queryExtras?.samplingMode,
     disableAggregateExtrapolation: queryExtras?.disableAggregateExtrapolation,
   });
@@ -121,6 +122,7 @@ function useSpansQueryBase<T>({
 
 type WrappedDiscoverTimeseriesQueryProps = {
   eventView: EventView;
+  caseInsensitive?: boolean;
   cursor?: string;
   enabled?: boolean;
   initialData?: any;
@@ -137,6 +139,7 @@ function useWrappedDiscoverTimeseriesQueryBase<T>({
   cursor,
   overriddenRoute,
   samplingMode,
+  caseInsensitive,
 }: WrappedDiscoverTimeseriesQueryProps) {
   const location = useLocation();
   const organization = useOrganization();
@@ -174,6 +177,7 @@ function useWrappedDiscoverTimeseriesQueryBase<T>({
         eventView.dataset === DiscoverDatasets.SPANS && samplingMode
           ? samplingMode
           : undefined,
+      caseInsensitive,
     }),
     options: {
       enabled,
@@ -227,6 +231,7 @@ type WrappedDiscoverQueryProps<T> = {
   eventView: EventView;
   additionalQueryKey?: string[];
   allowAggregateConditions?: boolean;
+  caseInsensitive?: boolean;
   cursor?: string;
   disableAggregateExtrapolation?: string;
   enabled?: boolean;
@@ -254,6 +259,7 @@ function useWrappedDiscoverQueryBase<T>({
   pageFiltersReady,
   additionalQueryKey,
   refetchInterval,
+  caseInsensitive,
 }: WrappedDiscoverQueryProps<T> & {
   pageFiltersReady: boolean;
 }) {
@@ -264,6 +270,10 @@ function useWrappedDiscoverQueryBase<T>({
   if (eventView.dataset === DiscoverDatasets.SPANS) {
     if (samplingMode) {
       queryExtras.sampling = samplingMode;
+    }
+
+    if (typeof caseInsensitive === 'boolean') {
+      queryExtras.caseInsensitive = caseInsensitive ? 'true' : 'false';
     }
 
     if (disableAggregateExtrapolation) {

--- a/tests/js/fixtures/log.ts
+++ b/tests/js/fixtures/log.ts
@@ -82,6 +82,7 @@ export function LogFixtureMeta(
 interface LogsTestInitOptions {
   isProjectOnboarded?: boolean;
   liveRefresh?: boolean;
+  orgFeatures?: string[];
   organization?: Partial<Organization>;
   ourlogs?: boolean;
   pageFiltersPeriod?: string;
@@ -100,6 +101,7 @@ type LocationConfig = {
  * Standardized initialization for logs tests
  */
 export function initializeLogsTest({
+  orgFeatures = [],
   organization: orgOverrides = {},
   project: projectOverrides,
   ourlogs = true,
@@ -127,7 +129,7 @@ export function initializeLogsTest({
   const forcedProject = projectOverrides ?? {hasLogs: true};
   const {organization, project} = initializeOrg({
     organization: {
-      features: baseFeatures,
+      features: [...baseFeatures, ...orgFeatures],
       ...orgOverrides,
     },
     projects: [forcedProject],


### PR DESCRIPTION
This PR adds in a case sensitive API to the search query builder, a hook to manage the case insensitive state, and updates the spans tab and logs tab to support case insensitive searches.

Ticket: EXP-472

Case insensitive search **not enabled**:
<img width="619" height="52" alt="Screenshot 2025-09-29 at 10 02 34" src="https://github.com/user-attachments/assets/1f6f52f1-dd98-4e22-b911-b400e535a7e4" />

Case insensitive search **enabled**:
<img width="672" height="49" alt="Screenshot 2025-09-29 at 09 56 48" src="https://github.com/user-attachments/assets/20bcc383-13bc-4d30-9e3f-0743a1058a30" />