### PR TITLE
feat(otlp): Improve help text for otlp endpoints in project key page

### DIFF
--- a/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
+++ b/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
@@ -88,7 +88,14 @@ function ProjectKeyCredentials({
         <Fragment>
           <FieldGroup
             label={t('OTLP Logs Endpoint')}
-            help={t(`Set this URL as your OTLP exporter's log endpoint.`)}
+            help={tct(
+              `Set this URL as your OTLP exporter's log endpoint. [link:Learn more]`,
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/concepts/otlp/#opentelemetry-logs" />
+                ),
+              }
+            )}
             inline={false}
             flexibleControlStateSize
           >
@@ -114,7 +121,14 @@ function ProjectKeyCredentials({
         <Fragment>
           <FieldGroup
             label={t('OTLP Traces Endpoint')}
-            help={t(`Set this URL as your OTLP exporter's trace endpoint.`)}
+            help={tct(
+              `Set this URL as your OTLP exporter's trace endpoint. [link:Learn more]`,
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/concepts/otlp/#opentelemetry-traces" />
+                ),
+              }
+            )}
             inline={false}
             flexibleControlStateSize
           >


### PR DESCRIPTION
Link to https://docs.sentry.io/concepts/otlp to improve discoverability of these endpoints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add “Learn more” doc links to OTLP logs/traces endpoint help text on the project key page.
> 
> - **UI**: Update help text in `static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx`
>   - `OTLP Logs Endpoint`: switch to `tct` and add `ExternalLink` “Learn more” to `https://docs.sentry.io/concepts/otlp/#opentelemetry-logs`.
>   - `OTLP Traces Endpoint`: switch to `tct` and add `ExternalLink` “Learn more” to `https://docs.sentry.io/concepts/otlp/#opentelemetry-traces`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ef76a8e82e5e5ecf6004dcb2ef062b0b1a2f0ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->