### PR TITLE
typing(unmerge): Stronger typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -618,6 +618,7 @@ module = [
     "sentry.tasks.on_demand_metrics",
     "sentry.tasks.reprocessing2",
     "sentry.tasks.store",
+    "sentry.tasks.unmerge",
     "sentry.taskworker.*",
     "sentry.tempest.endpoints.*",
     "sentry.tempest.migrations.*",

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -88,19 +88,8 @@ def merge_mappings(values: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     return result
 
 
-def _generate_culprit(event: GroupEvent) -> str:
-    # XXX(mitsuhiko): workaround: some old events do not have this data yet.
-    # This should be save delete by end of 2019 even considering slow
-    # self-hosted releases. Platform was added back to data in december 2018.
-    data = event.data
-    if data.get("platform") is None:
-        data_dict = dict(data.items())
-        data_dict["platform"] = event.platform
-    return generate_culprit(data)
-
-
 initial_fields = {
-    "culprit": lambda event, group: _generate_culprit(event),
+    "culprit": lambda event, group: generate_culprit(event.data),
     "data": lambda event, group: {
         "last_received": event.data.get("received") or float(event.datetime.strftime("%s")),
         "type": event.data["type"],

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -25,7 +25,7 @@ from sentry.models.grouprelease import GroupRelease
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.userreport import UserReport
-from sentry.services.eventstore.models import BaseEvent, GroupEvent
+from sentry.services.eventstore.models import GroupEvent
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
@@ -165,7 +165,7 @@ def get_group_backfill_attributes(
     }
 
 
-def get_fingerprint(event: BaseEvent) -> str | None:
+def get_fingerprint(event: GroupEvent) -> str | None:
     # TODO: This *might* need to be protected from an IndexError?
     return event.get_primary_hash()
 

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -467,18 +467,19 @@ def repair_tsdb_data(
             for (key, environment_id), value in keys.items():
                 tsdb.backend.incr(model, key, timestamp, value, environment_id=environment_id)
 
-    for timestamp, data in sets.items():
-        for model, keys in data.items():
-            for (key, environment_id), values in keys.items():
+    for timestamp, sets_data in sets.items():
+        for model, sets_keys in sets_data.items():
+            for (key, environment_id), sets_values in sets_keys.items():
                 # TODO: This should use `record_multi` rather than `record`.
                 tsdb.backend.record(
-                    model, key, list(values), timestamp, environment_id=environment_id
+                    model, key, list(sets_values), timestamp, environment_id=environment_id
                 )
 
-    for timestamp, data in frequencies.items():
+    for timestamp, frequencies_data in frequencies.items():
         # Convert the frequency data to the format expected by record_frequency_multi
         frequency_requests: list[tuple[TSDBModel, Mapping[str, Mapping[str, int | float]]]] = [
-            (model, model_data) for model, model_data in data.items()
+            (freq_model, freq_model_data)
+            for freq_model, freq_model_data in frequencies_data.items()
         ]
         if frequency_requests:
             tsdb.backend.record_frequency_multi(

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -467,18 +467,18 @@ def repair_tsdb_data(
             for (key, environment_id), value in keys.items():
                 tsdb.backend.incr(model, key, timestamp, value, environment_id=environment_id)
 
-    for timestamp, sets_data in sets.items():
-        for model, model_keys in sets_data.items():
-            for (key, environment_id), value_set in model_keys.items():
+    for timestamp, data in sets.items():
+        for model, keys in data.items():
+            for (key, environment_id), values in keys.items():
                 # TODO: This should use `record_multi` rather than `record`.
                 tsdb.backend.record(
-                    model, key, list(value_set), timestamp, environment_id=environment_id
+                    model, key, list(values), timestamp, environment_id=environment_id
                 )
 
-    for timestamp, frequency_data in frequencies.items():
+    for timestamp, data in frequencies.items():
         # Convert the frequency data to the format expected by record_frequency_multi
         frequency_requests: list[tuple[TSDBModel, Mapping[str, Mapping[str, int | float]]]] = [
-            (model, model_data) for model, model_data in frequency_data.items()
+            (model, model_data) for model, model_data in data.items()
         ]
         if frequency_requests:
             tsdb.backend.record_frequency_multi(

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -587,7 +587,7 @@ def unmerge(*posargs: Any, **kwargs: Any) -> None:
         return
 
     source_events = []
-    destination_events: dict[str, Sequence[GroupEvent]] = {}
+    destination_events: dict[str, list[GroupEvent]] = {}
 
     for event in events:
         key = args.replacement.get_unmerge_key(event, locked_primary_hashes)

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -422,7 +422,7 @@ def collect_tsdb_data(
     )
 
     frequencies: dict[datetime, dict[TSDBModel, dict[str, dict[str, int | float]]]] = defaultdict(
-        lambda: defaultdict(lambda: defaultdict(dict))
+        lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
     )
 
     for event in events:
@@ -485,7 +485,6 @@ def repair_tsdb_data(
             tsdb.backend.record_frequency_multi(
                 frequency_requests,
                 timestamp,
-                environment_id=environment_id,
             )
 
 

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime
 from functools import reduce
 from typing import Any
@@ -25,7 +25,7 @@ from sentry.models.grouprelease import GroupRelease
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.userreport import UserReport
-from sentry.services.eventstore.models import BaseEvent
+from sentry.services.eventstore.models import GroupEvent
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
@@ -39,10 +39,10 @@ from sentry.utils.query import task_run_batch_query
 logger = logging.getLogger(__name__)
 
 
-def cache(function):
+def cache(function: Callable[..., Any]) -> Callable[..., Any]:
     results: dict[tuple[int, ...], tuple[bool, type[Model] | Exception | None]] = {}
 
-    def fetch(*key):
+    def fetch(*key: Any) -> Any:
         value = results.get(key)
         if value is None:
             try:
@@ -60,7 +60,7 @@ def cache(function):
     return fetch
 
 
-def get_caches():
+def get_caches() -> Mapping[str, Any]:
     return {
         "Environment": cache(
             lambda organization_id, name: Environment.objects.get(
@@ -81,21 +81,21 @@ def get_caches():
     }
 
 
-def merge_mappings(values):
-    result = {}
+def merge_mappings(values: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
     for value in values:
         result.update(value)
     return result
 
 
-def _generate_culprit(event):
+def _generate_culprit(event: GroupEvent) -> str:
     # XXX(mitsuhiko): workaround: some old events do not have this data yet.
     # This should be save delete by end of 2019 even considering slow
     # self-hosted releases. Platform was added back to data in december 2018.
     data = event.data
     if data.get("platform") is None:
-        data = dict(data.items())
-        data["platform"] = event.platform
+        data_dict = dict(data.items())
+        data_dict["platform"] = event.platform
     return generate_culprit(data)
 
 
@@ -131,7 +131,11 @@ backfill_fields = {
 }
 
 
-def get_group_creation_attributes(caches, group, events):
+def get_group_creation_attributes(
+    caches: Mapping[str, Any],
+    group: Group,
+    events: Sequence[GroupEvent],
+) -> dict[str, Any]:
     latest_event = events[0]
     return reduce(
         lambda data, event: merge_mappings(
@@ -142,7 +146,9 @@ def get_group_creation_attributes(caches, group, events):
     )
 
 
-def get_group_backfill_attributes(caches, group, events):
+def get_group_backfill_attributes(
+    caches: Mapping[str, Any], group: Group, events: Sequence[GroupEvent]
+) -> dict[str, Any]:
     return {
         k: v
         for k, v in reduce(
@@ -159,18 +165,18 @@ def get_group_backfill_attributes(caches, group, events):
     }
 
 
-def get_fingerprint(event: BaseEvent) -> str | None:
+def get_fingerprint(event: GroupEvent) -> str | None:
     # TODO: This *might* need to be protected from an IndexError?
     return event.get_primary_hash()
 
 
 def migrate_events(
-    source,
-    caches,
-    project,
+    source: Group,
+    caches: Mapping[str, Any],
+    project: Project,
     args: UnmergeArgs,
-    events,
-    locked_primary_hashes,
+    events: Sequence[GroupEvent],
+    locked_primary_hashes: Sequence[str],
     opt_destination_id: int | None,
     opt_eventstream_state: Mapping[str, Any] | None,
 ) -> tuple[int, Mapping[str, Any]]:
@@ -280,7 +286,7 @@ def update_open_periods(source: Group, destination: Group) -> None:
     )
 
 
-def truncate_denormalizations(project, group):
+def truncate_denormalizations(project: Project, group: Group) -> None:
     GroupRelease.objects.filter(group_id=group.id).delete()
 
     # XXX: This can cause a race condition with the ``FirstSeenEventCondition``
@@ -302,24 +308,28 @@ def truncate_denormalizations(project, group):
 
     tsdb.backend.delete_frequencies(
         [TSDBModel.frequent_releases_by_group, TSDBModel.frequent_environments_by_group],
-        [group.id],
+        [str(group.id)],
     )
 
     similarity.delete(project, group)
 
 
-def collect_group_environment_data(events):
+def collect_group_environment_data(
+    events: Sequence[GroupEvent],
+) -> dict[tuple[int, str], str | None]:
     """\
     Find the first release for a each group and environment pair from a
     date-descending sorted list of events.
     """
-    results = {}
+    results: dict[tuple[int, str], str | None] = {}
     for event in events:
         results[(event.group_id, get_environment_name(event))] = event.get_tag("sentry:release")
     return results
 
 
-def repair_group_environment_data(caches, project, events):
+def repair_group_environment_data(
+    caches: Mapping[str, Any], project: Project, events: Sequence[GroupEvent]
+) -> None:
     for (group_id, env_name), first_release in collect_group_environment_data(events).items():
         fields = {}
         if first_release:
@@ -332,11 +342,13 @@ def repair_group_environment_data(caches, project, events):
         )
 
 
-def get_environment_name(event) -> str:
+def get_environment_name(event: GroupEvent) -> str:
     return Environment.get_name_or_default(event.get_tag("environment"))
 
 
-def collect_release_data(caches, project, events):
+def collect_release_data(
+    caches: Mapping[str, Any], project: Project, events: Sequence[GroupEvent]
+) -> dict[tuple[int, str, Release], tuple[datetime, datetime]]:
     results: dict[tuple[int, str, Release], tuple[datetime, datetime]] = {}
 
     for event in events:
@@ -360,7 +372,9 @@ def collect_release_data(caches, project, events):
     return results
 
 
-def repair_group_release_data(caches, project, events):
+def repair_group_release_data(
+    caches: Mapping[str, Any], project: Project, events: Sequence[GroupEvent]
+) -> None:
     attributes = collect_release_data(caches, project, events).items()
     for (group_id, environment, release_id), (first_seen, last_seen) in attributes:
         instance, created = GroupRelease.objects.get_or_create(
@@ -375,7 +389,7 @@ def repair_group_release_data(caches, project, events):
             instance.update(first_seen=first_seen)
 
 
-def get_event_user_from_interface(value, project):
+def get_event_user_from_interface(value: dict[str, Any], project: Project) -> EventUser:
     analytics.record(
         EventUserEndpointRequest(
             project_id=project.id,
@@ -392,7 +406,13 @@ def get_event_user_from_interface(value, project):
     )
 
 
-def collect_tsdb_data(caches, project, events):
+def collect_tsdb_data(
+    caches: Mapping[str, Any], project: Project, events: Sequence[GroupEvent]
+) -> tuple[
+    dict[datetime, dict[TSDBModel, dict[tuple[int, int], int]]],
+    dict[datetime, dict[TSDBModel, dict[tuple[int, int], set[str]]]],
+    dict[datetime, dict[TSDBModel, dict[str, dict[str, int | float]]]],
+]:
     counters: dict[datetime, dict[TSDBModel, dict[tuple[int, int], int]]] = defaultdict(
         lambda: defaultdict(lambda: defaultdict(int))
     )
@@ -401,8 +421,8 @@ def collect_tsdb_data(caches, project, events):
         lambda: defaultdict(lambda: defaultdict(set))
     )
 
-    frequencies: dict[datetime, dict[TSDBModel, dict[int, dict[int, int]]]] = defaultdict(
-        lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+    frequencies: dict[datetime, dict[TSDBModel, dict[str, dict[str, int | float]]]] = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(dict))
     )
 
     for event in events:
@@ -416,8 +436,8 @@ def collect_tsdb_data(caches, project, events):
                 (event.group_id, environment.id)
             ].add(get_event_user_from_interface(user, project).tag_value)
 
-        frequencies[event.datetime][TSDBModel.frequent_environments_by_group][event.group_id][
-            environment.id
+        frequencies[event.datetime][TSDBModel.frequent_environments_by_group][str(event.group_id)][
+            str(environment.id)
         ] += 1
 
         release = event.get_tag("sentry:release")
@@ -430,14 +450,16 @@ def collect_tsdb_data(caches, project, events):
                 caches["Release"](project.organization_id, release).id,
             )
 
-            frequencies[event.datetime][TSDBModel.frequent_releases_by_group][event.group_id][
-                grouprelease.id
+            frequencies[event.datetime][TSDBModel.frequent_releases_by_group][str(event.group_id)][
+                str(grouprelease.id)
             ] += 1
 
     return counters, sets, frequencies
 
 
-def repair_tsdb_data(caches, project, events):
+def repair_tsdb_data(
+    caches: Mapping[str, Any], project: Project, events: Sequence[GroupEvent]
+) -> None:
     counters, sets, frequencies = collect_tsdb_data(caches, project, events)
 
     for timestamp, data in counters.items():
@@ -445,17 +467,30 @@ def repair_tsdb_data(caches, project, events):
             for (key, environment_id), value in keys.items():
                 tsdb.backend.incr(model, key, timestamp, value, environment_id=environment_id)
 
-    for timestamp, data in sets.items():
-        for model, keys in data.items():
-            for (key, environment_id), values in keys.items():
+    for timestamp, sets_data in sets.items():
+        for model, model_keys in sets_data.items():
+            for (key, environment_id), value_set in model_keys.items():
                 # TODO: This should use `record_multi` rather than `record`.
-                tsdb.backend.record(model, key, values, timestamp, environment_id=environment_id)
+                tsdb.backend.record(
+                    model, key, list(value_set), timestamp, environment_id=environment_id
+                )
 
-    for timestamp, data in frequencies.items():
-        tsdb.backend.record_frequency_multi(data.items(), timestamp)
+    for timestamp, frequency_data in frequencies.items():
+        # Convert the frequency data to the format expected by record_frequency_multi
+        frequency_requests: list[tuple[TSDBModel, Mapping[str, Mapping[str, int | float]]]] = [
+            (model, model_data) for model, model_data in frequency_data.items()
+        ]
+        if frequency_requests:
+            tsdb.backend.record_frequency_multi(
+                frequency_requests,
+                timestamp,
+                environment_id=environment_id,
+            )
 
 
-def repair_denormalizations(caches, project, events):
+def repair_denormalizations(
+    caches: Mapping[str, Any], project: Project, events: Sequence[GroupEvent]
+) -> None:
     repair_group_environment_data(caches, project, events)
     repair_group_release_data(caches, project, events)
     repair_tsdb_data(caches, project, events)
@@ -464,7 +499,7 @@ def repair_denormalizations(caches, project, events):
         similarity.record(project, [event])
 
 
-def lock_hashes(project_id, source_id, fingerprints):
+def lock_hashes(project_id: int, source_id: int, fingerprints: Sequence[str]) -> list[str]:
     with transaction.atomic(router.db_for_write(GroupHash)):
         eligible_hashes = list(
             GroupHash.objects.filter(
@@ -481,7 +516,7 @@ def lock_hashes(project_id, source_id, fingerprints):
     return [h.hash for h in eligible_hashes]
 
 
-def unlock_hashes(project_id, locked_primary_hashes):
+def unlock_hashes(project_id: int, locked_primary_hashes: Sequence[str]) -> None:
     GroupHash.objects.filter(
         project_id=project_id,
         hash__in=locked_primary_hashes,
@@ -498,12 +533,12 @@ def unlock_hashes(project_id, locked_primary_hashes):
         processing_deadline_duration=60,
     ),
 )
-def unmerge(*posargs, **kwargs):
+def unmerge(*posargs: Any, **kwargs: Any) -> None:
     args = UnmergeArgsBase.parse_arguments(*posargs, **kwargs)
 
     source = Group.objects.get(project_id=args.project_id, id=args.source_id)
 
-    caches = get_caches()
+    caches: Mapping[str, Any] = get_caches()
 
     project = caches["Project"](args.project_id)
 
@@ -512,13 +547,13 @@ def unmerge(*posargs, **kwargs):
     # for the new, repaired data.
     if isinstance(args, InitialUnmergeArgs):
         locked_primary_hashes = lock_hashes(
-            args.project_id, args.source_id, args.replacement.primary_hashes_to_lock
+            args.project_id, args.source_id, list(args.replacement.primary_hashes_to_lock)
         )
         truncate_denormalizations(project, source)
         last_event = None
     else:
         last_event = args.last_event
-        locked_primary_hashes = args.locked_primary_hashes
+        locked_primary_hashes = list(args.locked_primary_hashes)
 
     last_event, events = task_run_batch_query(
         filter=eventstore.Filter(project_ids=[args.project_id], group_ids=[source.id]),
@@ -550,7 +585,7 @@ def unmerge(*posargs, **kwargs):
         return
 
     source_events = []
-    destination_events: dict[str, list[BaseEvent]] = {}
+    destination_events: dict[str, list[GroupEvent]] = {}
 
     for event in events:
         key = args.replacement.get_unmerge_key(event, locked_primary_hashes)

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -25,7 +25,7 @@ from sentry.models.grouprelease import GroupRelease
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.userreport import UserReport
-from sentry.services.eventstore.models import GroupEvent
+from sentry.services.eventstore.models import BaseEvent, GroupEvent
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
@@ -60,7 +60,7 @@ def cache(function: Callable[..., Any]) -> Callable[..., Any]:
     return fetch
 
 
-def get_caches() -> Mapping[str, Any]:
+def get_caches() -> dict[str, Callable[..., Any]]:
     return {
         "Environment": cache(
             lambda organization_id, name: Environment.objects.get(
@@ -165,14 +165,14 @@ def get_group_backfill_attributes(
     }
 
 
-def get_fingerprint(event: GroupEvent) -> str | None:
+def get_fingerprint(event: BaseEvent) -> str | None:
     # TODO: This *might* need to be protected from an IndexError?
     return event.get_primary_hash()
 
 
 def migrate_events(
     source: Group,
-    caches: Mapping[str, Any],
+    caches: Mapping[str, Callable[..., Any]],
     project: Project,
     args: UnmergeArgs,
     events: Sequence[GroupEvent],

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -188,7 +188,7 @@ class BaseTSDB(Service):
         self.__legacy_rollups = legacy_rollups
 
     def validate_arguments(
-        self, models: list[TSDBModel], environment_ids: Iterable[int | None]
+        self, models: Sequence[TSDBModel], environment_ids: Iterable[int | None]
     ) -> None:
         if any(e is not None for e in environment_ids):
             unsupported_models = set(models) - self.models_with_environment_support

--- a/src/sentry/unmerge.py
+++ b/src/sentry/unmerge.py
@@ -7,7 +7,7 @@ from typing import Any, Union
 from sentry import eventstream
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
-from sentry.services.eventstore.models import Event
+from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.utils.datastructures import BidirectionalMapping
 
 _DEFAULT_UNMERGE_KEY = "default"
@@ -43,7 +43,9 @@ class UnmergeReplacement(abc.ABC):
             raise TypeError("Either fingerprints or replacement argument is required.")
 
     @abc.abstractmethod
-    def get_unmerge_key(self, event: Event, locked_primary_hashes: Collection[str]) -> str | None:
+    def get_unmerge_key(
+        self, event: GroupEvent, locked_primary_hashes: Collection[str]
+    ) -> str | None:
         """
         The unmerge task iterates through all events of a group. This function
         should return which of them should land in the new group.
@@ -87,7 +89,9 @@ class PrimaryHashUnmergeReplacement(UnmergeReplacement):
 
     fingerprints: Collection[str]
 
-    def get_unmerge_key(self, event: Event, locked_primary_hashes: Collection[str]) -> str | None:
+    def get_unmerge_key(
+        self, event: GroupEvent, locked_primary_hashes: Collection[str]
+    ) -> str | None:
         primary_hash = event.get_primary_hash()
         if primary_hash in self.fingerprints and primary_hash in locked_primary_hashes:
             return _DEFAULT_UNMERGE_KEY

--- a/src/sentry/unmerge.py
+++ b/src/sentry/unmerge.py
@@ -7,7 +7,7 @@ from typing import Any, Union
 from sentry import eventstream
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
-from sentry.services.eventstore.models import Event, GroupEvent
+from sentry.services.eventstore.models import GroupEvent
 from sentry.utils.datastructures import BidirectionalMapping
 
 _DEFAULT_UNMERGE_KEY = "default"

--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -17,7 +17,7 @@ from sentry.db.models.base import Model
 from sentry.services import eventstore
 
 if TYPE_CHECKING:
-    from sentry.services.eventstore.models import GroupEvent
+    from sentry.services.eventstore.models import Event
 
 _leaf_re = re.compile(r"^(UserReport|Event|Group)(.+)")
 
@@ -38,7 +38,7 @@ def task_run_batch_query(
     state: TaskBulkQueryState | None = None,
     fetch_events: bool = True,
     tenant_ids: dict[str, int | str] | None = None,
-) -> tuple[TaskBulkQueryState | None, list[GroupEvent]]:
+) -> tuple[TaskBulkQueryState | None, list[Event]]:
     """
     A tool for batched queries similar in purpose to RangeQuerySetWrapper that
     is used for tasks in issue merge/unmerge/reprocessing.

--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -17,7 +17,7 @@ from sentry.db.models.base import Model
 from sentry.services import eventstore
 
 if TYPE_CHECKING:
-    from sentry.services.eventstore.models import Event
+    from sentry.services.eventstore.models import GroupEvent
 
 _leaf_re = re.compile(r"^(UserReport|Event|Group)(.+)")
 
@@ -38,7 +38,7 @@ def task_run_batch_query(
     state: TaskBulkQueryState | None = None,
     fetch_events: bool = True,
     tenant_ids: dict[str, int | str] | None = None,
-) -> tuple[TaskBulkQueryState | None, list[Event]]:
+) -> tuple[TaskBulkQueryState | None, list[GroupEvent]]:
     """
     A tool for batched queries similar in purpose to RangeQuerySetWrapper that
     is used for tasks in issue merge/unmerge/reprocessing.

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -20,7 +20,7 @@ from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.grouprelease import GroupRelease
 from sentry.models.release import Release
 from sentry.models.userreport import UserReport
-from sentry.services.eventstore.models import Event
+from sentry.services.eventstore.models import GroupEvent
 from sentry.similarity import _make_index_backend, features
 from sentry.tasks.merge import merge_groups
 from sentry.tasks.unmerge import (
@@ -190,7 +190,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
 
         def create_message_event(
             template, parameters, environment, release, fingerprint="group1"
-        ) -> Event:
+        ) -> GroupEvent:
             i = next(sequence)
 
             event_id = uuid.UUID(fields=(i, 0x0, 0x1000, 0x80, 0x80, 0x808080808080)).hex
@@ -228,7 +228,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
 
             return event
 
-        events: dict[str | None, list[Event]] = {}
+        events: dict[str | None, list[GroupEvent]] = {}
 
         for event in (
             create_message_event(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch unmerge to GroupEvent with stronger typing and corrected TSDB frequency/set operations; update mypy config and tests.
> 
> - **Unmerge Task (typing and behavior)**:
>   - Replace `BaseEvent/Event` with `GroupEvent` across `sentry.tasks.unmerge` and `sentry.unmerge` (function signatures, helpers, return types).
>   - Convert fetched events to `GroupEvent` via `event.for_group(source)`; propagate stricter types (e.g., `cache`, `merge_mappings`, `get_*_attributes`).
>   - Normalize inputs to lists where needed (e.g., `primary_hashes_to_lock`, `locked_primary_hashes`).
> - **TSDB interactions**:
>   - Use string keys for `frequent_*_by_group` frequency tables and in `delete_frequencies` (`[str(group.id)]`).
>   - Convert distinct-count set values to lists when calling `tsdb.backend.record`.
>   - Build and pass frequency data in the format expected by `record_frequency_multi`.
> - **Misc/Config**:
>   - Add `sentry.tasks.unmerge` to mypy "stronger typing" modules; tighten annotations throughout.
>   - `BaseTSDB.validate_arguments` now accepts `Sequence[TSDBModel]`.
> - **Tests**:
>   - Update tests to import/use `GroupEvent` and accommodate new typing/TSDB behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b13fdbd685f620e05bf8df458f22d8247844bdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->