### PR TITLE
chore(comparative workflows): Disable extrapolation option

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -48,8 +48,12 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsV2Endpoin
         except NoProjects:
             return Response({"rankedAttributes": []})
 
+        resolver_config = SearchResolverConfig(
+            disable_aggregate_extrapolation="disableAggregateExtrapolation" in request.GET
+        )
+
         resolver = SearchResolver(
-            params=snuba_params, config=SearchResolverConfig(), definitions=SPAN_DEFINITIONS
+            params=snuba_params, config=resolver_config, definitions=SPAN_DEFINITIONS
         )
 
         meta = resolver.resolve_meta(
@@ -91,7 +95,7 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsV2Endpoin
                 query_string=query_1,
                 selected_columns=[f"{function_name}({function_parameter})"],
                 orderby=None,
-                config=SearchResolverConfig(),
+                config=resolver_config,
                 offset=0,
                 limit=1,
                 sampling_mode=snuba_params.sampling_mode,
@@ -152,7 +156,7 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsV2Endpoin
                 query_string=query_1,
                 selected_columns=["count(span.duration)"],
                 orderby=None,
-                config=SearchResolverConfig(),
+                config=resolver_config,
                 offset=0,
                 limit=1,
                 sampling_mode=snuba_params.sampling_mode,
@@ -170,7 +174,7 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsV2Endpoin
                 query_string=query_2,
                 selected_columns=["count(span.duration)"],
                 orderby=None,
-                config=SearchResolverConfig(),
+                config=resolver_config,
                 offset=0,
                 limit=1,
                 sampling_mode=snuba_params.sampling_mode,

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -48,8 +48,9 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsV2Endpoin
         except NoProjects:
             return Response({"rankedAttributes": []})
 
+        disable_aggregate_extrapolation = request.GET.get("disableAggregateExtrapolation") == "1"
         resolver_config = SearchResolverConfig(
-            disable_aggregate_extrapolation="disableAggregateExtrapolation" in request.GET
+            disable_aggregate_extrapolation=disable_aggregate_extrapolation
         )
 
         resolver = SearchResolver(

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -48,9 +48,9 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsV2Endpoin
         except NoProjects:
             return Response({"rankedAttributes": []})
 
-        disable_aggregate_extrapolation = request.GET.get("disableAggregateExtrapolation") == "1"
+        aggregate_extrapolation = request.GET.get("aggregateExtrapolation") == "1"
         resolver_config = SearchResolverConfig(
-            disable_aggregate_extrapolation=disable_aggregate_extrapolation
+            disable_aggregate_extrapolation=not aggregate_extrapolation
         )
 
         resolver = SearchResolver(


### PR DESCRIPTION
- Add option to disable extrapolation to keep consistent with other charts on page
- FE PR where we pass in the option: https://github.com/getsentry/sentry/pull/100498


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds GET param `aggregateExtrapolation` to control aggregate extrapolation, wiring config into `SearchResolver` and related span table queries.
> 
> - **API**: `src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py`
>   - Introduces GET param `aggregateExtrapolation` ("1" to enable) to toggle aggregate extrapolation via `SearchResolverConfig(disable_aggregate_extrapolation=...)`.
>   - Applies the resolver config to `SearchResolver` and all `Spans.run_table_query` calls used for percentile segmentation and totals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32ee8b24ec1a7de20a0cf1220f11deafaebdb8b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->