### PR TITLE
chore(comparative workflows): Extrapolation option in request

### DIFF
--- a/static/app/views/explore/hooks/useSuspectAttributes.tsx
+++ b/static/app/views/explore/hooks/useSuspectAttributes.tsx
@@ -44,6 +44,7 @@ function useSuspectAttributes({
   const organization = useOrganization();
   const dataset = useExploreDataset();
   const {selection: pageFilters} = usePageFilters();
+  const aggregateExtrapolation = location.query.extrapolate ?? '1';
 
   const enableQuery = boxSelectOptions.boxCoordRange !== null;
   const {
@@ -81,8 +82,9 @@ function useSuspectAttributes({
       function: chartInfo.yAxis,
       above: 1,
       sampling: SAMPLING_MODE.NORMAL,
+      aggregateExtrapolation,
     };
-  }, [query1, query2, pageFilters, dataset, chartInfo.yAxis]);
+  }, [query1, query2, pageFilters, dataset, chartInfo.yAxis, aggregateExtrapolation]);
 
   return useApiQuery<SuspectAttributesResult>(
     [


### PR DESCRIPTION
- pass in extrapolation option to ranking request
- BE PR where we consume the option: https://github.com/getsentry/sentry/pull/100496

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `aggregateExtrapolation` (from `location.query.extrapolate`, default `1`) to the ranked attributes request and memo deps in `useSuspectAttributes`.
> 
> - **Explore**:
>   - **`useSuspectAttributes`** (`static/app/views/explore/hooks/useSuspectAttributes.tsx`):
>     - Read `location.query.extrapolate` (default `"1"`) as `aggregateExtrapolation`.
>     - Include `aggregateExtrapolation` in request `queryParams` to `/trace-items/attributes/ranked/`.
>     - Add `aggregateExtrapolation` to `useMemo` dependency array.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43b8fa3f2b0132a046eed6c5e99406f811232db6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->