### PR TITLE
chore(dynamic-sampling): remove logs for extrapolated volume

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/logging.py
+++ b/src/sentry/dynamic_sampling/tasks/logging.py
@@ -3,25 +3,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def log_extrapolated_monthly_volume(
-    org_id: int, project_id: int | None, volume: int, extrapolated_volume: int, window_size: int
-) -> None:
-    extra = {
-        "org_id": org_id,
-        "volume": volume,
-        "extrapolated_monthly_volume": extrapolated_volume,
-        "window_size_in_hours": window_size,
-    }
-
-    if project_id is not None:
-        extra["project_id"] = project_id
-
-    logger.info(
-        "dynamic_sampling.extrapolate_monthly_volume",
-        extra=extra,
-    )
-
-
 def log_sample_rate_source(
     org_id: int, project_id: int | None, used_for: str, source: str, sample_rate: float | None
 ) -> None:


### PR DESCRIPTION
- Remove logs for extrapolated volumes, because there doesn't seem to be a use for them
- Remove some comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes extrapolated monthly volume logging by deleting `log_extrapolated_monthly_volume` and its invocation, plus minor comment cleanup.
> 
> - **Dynamic Sampling**:
>   - **Remove extrapolated volume logging**:
>     - Delete `log_extrapolated_monthly_volume` from `src/sentry/dynamic_sampling/tasks/logging.py`.
>     - Remove imports and the sampled logging call in `compute_sliding_window_sample_rate` within `src/sentry/dynamic_sampling/tasks/common.py`.
>   - **Cleanup**: Strip redundant comments in `compute_sliding_window_sample_rate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d128600e13264a42a459211d64a32b1f6e98fa03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->