### PR TITLE
fix(checkout v3): Success page accounts for immediate non-charges

### DIFF
--- a/static/gsApp/views/amCheckout/checkoutSuccess.spec.tsx
+++ b/static/gsApp/views/amCheckout/checkoutSuccess.spec.tsx
@@ -1,3 +1,5 @@
+import moment from 'moment-timezone';
+
 import {InvoiceFixture} from 'getsentry-test/fixtures/invoice';
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -39,7 +41,9 @@ describe('CheckoutSuccess', () => {
       <CheckoutSuccess
         basePlan={bizPlan}
         nextQueryParams={[]}
-        previewData={PreviewDataFixture({})}
+        previewData={PreviewDataFixture({
+          effectiveAt: moment(mockDate).add(1, 'day').toISOString(),
+        })}
       />
     );
 
@@ -54,7 +58,7 @@ describe('CheckoutSuccess', () => {
         basePlan={bizPlan}
         nextQueryParams={[]}
         previewData={PreviewDataFixture({
-          effectiveAt: mockDate.toISOString(),
+          effectiveAt: moment(mockDate).subtract(1, 'day').toISOString(),
         })}
       />
     );

--- a/static/gsApp/views/amCheckout/checkoutSuccess.tsx
+++ b/static/gsApp/views/amCheckout/checkoutSuccess.tsx
@@ -509,7 +509,7 @@ function CheckoutSuccess({
   // are effective immediately but without an immediate charge
   const effectiveToday =
     isImmediateCharge ||
-    (effectiveDate && effectiveDate === moment().add(1, 'day').format('MMMM D, YYYY'));
+    (effectiveDate && effectiveDate <= moment().add(1, 'day').format('MMMM D, YYYY'));
 
   const total = isImmediateCharge
     ? (invoice.amountBilled ?? invoice.amount)

--- a/static/gsApp/views/amCheckout/checkoutSuccess.tsx
+++ b/static/gsApp/views/amCheckout/checkoutSuccess.tsx
@@ -509,7 +509,7 @@ function CheckoutSuccess({
   // are effective immediately but without an immediate charge
   const effectiveToday =
     isImmediateCharge ||
-    (effectiveDate && effectiveDate <= moment().add(1, 'day').format('MMMM D, YYYY'));
+    (effectiveDate && moment(effectiveDate) <= moment().add(1, 'day'));
 
   const total = isImmediateCharge
     ? (invoice.amountBilled ?? invoice.amount)


### PR DESCRIPTION
These include: making no changes, only making PAYG changes.

<img width="2622" height="1350" alt="Screenshot 2025-09-29 at 11 18 46 AM" src="https://github.com/user-attachments/assets/c0419457-c7e2-4f5c-9d17-c8964f0e10db" />

Discussing with the team how to display PAYG changes in the success page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts effective date logic to treat past/today effectiveAt as immediate (no scheduled changes) and updates tests to use date offsets accordingly.
> 
> - **Checkout Success** (`static/gsApp/views/amCheckout/checkoutSuccess.tsx`):
>   - Refines `effectiveToday` to compare dates with `moment(effectiveDate) <= moment().add(1, 'day')` instead of formatted string equality, treating past/today effective dates as immediate (no scheduled changes).
> - **Tests** (`static/gsApp/views/amCheckout/checkoutSuccess.spec.tsx`):
>   - Use `moment(mockDate)` offsets for `previewData.effectiveAt` to explicitly cover scheduled (future) vs immediate (past) scenarios.
>   - Import `moment-timezone` for date manipulation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77a7ba4b82b3199dff41993f3f890c6e9c723721. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->