### PR TITLE
fix(checkout): Default to business if no equivalent for current plan can be found

### DIFF
--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -422,11 +422,11 @@ class AMCheckout extends Component<Props, State> {
     const {subscription, checkoutTier} = this.props;
     const {planList, defaultPlan} = billingConfig;
     const initialPlan = planList.find(({id}) => id === subscription.plan);
+    const businessPlan = this.getBusinessPlan(billingConfig);
 
     if (this.shouldDefaultToBusiness()) {
-      const plan = this.getBusinessPlan(billingConfig);
-      if (plan) {
-        return plan;
+      if (businessPlan) {
+        return businessPlan;
       }
     }
 
@@ -456,7 +456,10 @@ class AMCheckout extends Component<Props, State> {
           contractInterval === subscription?.planDetails?.contractInterval
       );
 
-    return legacyInitialPlan || planList.find(({id}) => id === defaultPlan);
+    // if no legacy initial plan found, we fallback to the business plan, then the default plan (usually team)
+    return (
+      legacyInitialPlan || businessPlan || planList.find(({id}) => id === defaultPlan)
+    );
   }
 
   canComparePrices(initialPlan: Plan) {


### PR DESCRIPTION
The original bug described in the Linear ticket occurred because the org was on a test plan, but the billing config does not contain the test plans, so the initial plan logic could not find the equivalent plan. This is fine because their test plans, however, it makes sense to me to try to default to the business plan if no equivalent can be found before falling back to the default plan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates initial plan selection to fall back to the Business plan before the default plan, reusing a single computed businessPlan.
> 
> - **Checkout**
>   - **Initial plan selection** (`static/gsApp/views/amCheckout/index.tsx`):
>     - Compute `businessPlan` once and reuse.
>     - Update fallback order: `legacyInitialPlan` → `businessPlan` → default plan.
>     - Minor refactor in Business default branch to use `businessPlan`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3daaed39920fa6217578b1a591eb1f1319a97b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->