### PR TITLE
fix(checkout v3): Don't specify renewal date when no preview data

### DIFF
--- a/static/gsApp/views/amCheckout/cart.spec.tsx
+++ b/static/gsApp/views/amCheckout/cart.spec.tsx
@@ -249,6 +249,7 @@ describe('Cart', () => {
 
     expect(await screen.findByRole('button', {name: 'Confirm and pay'})).toBeDisabled();
     expect(mockResponse).not.toHaveBeenCalled();
+    expect(screen.getByText('Plan renews monthly.')).toBeInTheDocument(); // no renewal date specified
   });
 
   it('renders preview data', async () => {

--- a/static/gsApp/views/amCheckout/cart.tsx
+++ b/static/gsApp/views/amCheckout/cart.tsx
@@ -480,27 +480,33 @@ function TotalSummary({
     }
 
     let subtext = null;
-    if (isDeveloperPlan(activePlan) || !totalOnDemandBudget) {
-      subtext = tct(
-        '[effectiveDateSubtext]Plan renews [longInterval] on [renewalDate].',
-        {
-          effectiveDateSubtext,
-          longInterval,
-          renewalDate: moment(renewalDate).format('MMM D, YYYY'),
-        }
-      );
+    if (renewalDate) {
+      if (isDeveloperPlan(activePlan) || !totalOnDemandBudget) {
+        subtext = tct(
+          '[effectiveDateSubtext]Plan renews [longInterval] on [renewalDate].',
+          {
+            effectiveDateSubtext,
+            longInterval,
+            renewalDate: moment(renewalDate).format('MMM D, YYYY'),
+          }
+        );
+      } else {
+        subtext = tct(
+          '[effectiveDateSubtext]Plan renews [longInterval] on [renewalDate], plus any additional PAYG usage billed monthly (up to [onDemandMaxSpend]/mo).',
+          {
+            effectiveDateSubtext,
+            longInterval,
+            renewalDate: moment(renewalDate).format('MMM D, YYYY'),
+            onDemandMaxSpend: utils.displayPrice({
+              cents: totalOnDemandBudget,
+            }),
+          }
+        );
+      }
     } else {
-      subtext = tct(
-        '[effectiveDateSubtext]Plan renews [longInterval] on [renewalDate], plus any additional PAYG usage billed monthly (up to [onDemandMaxSpend]/mo).',
-        {
-          effectiveDateSubtext,
-          longInterval,
-          renewalDate: moment(renewalDate).format('MMM D, YYYY'),
-          onDemandMaxSpend: utils.displayPrice({
-            cents: totalOnDemandBudget,
-          }),
-        }
-      );
+      subtext = tct('Plan renews [longInterval].', {
+        longInterval,
+      });
     }
     return subtext;
   };


### PR DESCRIPTION
If preview data is empty (ie. no billing info yet, so can't fetch preview data), renewal date will not be set. Therefore we will remove the date specification from the cart subtext if there is no renewal date yet.

<img width="433" height="170" alt="Screenshot 2025-09-29 at 11 43 26 AM" src="https://github.com/user-attachments/assets/6428806d-133a-4617-938a-042a0eeee5b5" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> If no renewal date is available (e.g., no preview data), show a generic renews interval message without a date and update tests accordingly.
> 
> - **Checkout (Cart)**:
>   - **Subtext logic**: In `views/amCheckout/cart.tsx` `getSubtext()`, only include `renewalDate` in messages when present; otherwise show `Plan renews [longInterval].`
>   - Preserves PAYG details when `renewalDate` exists; avoids date formatting when it does not.
> - **Tests**:
>   - In `views/amCheckout/cart.spec.tsx`, assert generic message `Plan renews monthly.` when no renewal date is available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4e4ed204e925915b3682a3c77d86ee51c382c80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->