### PR TITLE
fix(checkout v3): Fix on-demand pill being cut off in UI1

### DIFF
--- a/static/gsApp/views/amCheckout/cart.tsx
+++ b/static/gsApp/views/amCheckout/cart.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 import moment from 'moment-timezone';
@@ -154,6 +155,9 @@ function ItemWithPrice({
 }
 
 function ItemsSummary({activePlan, formData}: ItemsSummaryProps) {
+  const theme = useTheme();
+  const isChonk = theme.isChonk;
+
   // TODO(checkout v3): This will need to be updated for non-budget products
   const additionalProductCategories = useMemo(
     () =>
@@ -229,12 +233,21 @@ function ItemsSummary({activePlan, formData}: ItemsSummaryProps) {
                         title={t('This product is only available with a PAYG budget.')}
                       >
                         <Tag icon={<IconLock locked size="xs" />}>
-                          {tct('Unlock with [budgetTerm]', {
-                            budgetTerm:
-                              activePlan.budgetTerm === 'pay-as-you-go'
-                                ? 'PAYG'
-                                : activePlan.budgetTerm,
-                          })}
+                          {isChonk || activePlan.budgetTerm === 'pay-as-you-go' ? (
+                            tct('Unlock with [budgetTerm]', {
+                              budgetTerm:
+                                activePlan.budgetTerm === 'pay-as-you-go'
+                                  ? 'PAYG'
+                                  : activePlan.budgetTerm,
+                            })
+                          ) : (
+                            // "Unlock with on-demand" gets cut off in non-chonk theme
+                            <Text size="xs">
+                              {tct('Unlock with [budgetTerm]', {
+                                budgetTerm: activePlan.budgetTerm,
+                              })}
+                            </Text>
+                          )}
                         </Tag>
                       </Tooltip>
                     ))


### PR DESCRIPTION
# before
<img width="435" height="343" alt="Screenshot 2025-09-29 at 11 51 18 AM" src="https://github.com/user-attachments/assets/1c6663df-a9d9-42a2-985b-0927eeee3aa3" />

# after 
<img width="441" height="328" alt="Screenshot 2025-09-29 at 11 50 58 AM" src="https://github.com/user-attachments/assets/1d8a550c-9b23-49f0-9b38-904ca314de20" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `theme.isChonk` to conditionally shorten the PAYG "Unlock with" tag in `ItemsSummary` to avoid text cutoff; adds `useTheme` import/use.
> 
> - **Checkout UI** (`static/gsApp/views/amCheckout/cart.tsx`):
>   - **Theme-aware tag rendering**: In `ItemsSummary`, use `useTheme()` and `theme.isChonk` to conditionally render the PAYG "Unlock with [budgetTerm]" tag for PAYG-only categories to prevent text cutoff in UI1.
>     - Renders full text (with `PAYG` mapping) in chonk or PAYG budget term.
>     - Renders compact text (`Text size="xs"`) with unmodified `budgetTerm` in non-chonk theme.
>   - Adds `useTheme` import and local `isChonk` usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a13e46ea0967a9d4a769b284d2058dc48364d19a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->