### PR TITLE
ref(prevent): Remove NoProjectMessage

### DIFF
--- a/static/app/views/prevent/index.tsx
+++ b/static/app/views/prevent/index.tsx
@@ -1,6 +1,5 @@
 import Feature from 'sentry/components/acl/feature';
 import {NoAccess} from 'sentry/components/noAccess';
-import NoProjectMessage from 'sentry/components/noProjectMessage';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
@@ -16,7 +15,7 @@ export default function PreventPage({children}: Props) {
       organization={organization}
       renderDisabled={NoAccess}
     >
-      <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
+      {children}
     </Feature>
   );
 }


### PR DESCRIPTION
A project is not required to use the Prevent features

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `PreventPage` no longer wraps content in `NoProjectMessage`, rendering children directly while remaining gated by `prevent-ai`.
> 
> - **Frontend**
>   - **PreventPage (`static/app/views/prevent/index.tsx`)**
>     - Render children directly; remove `NoProjectMessage` wrapper.
>     - Drop `NoProjectMessage` import; feature gate with `prevent-ai` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af48ac70a3eac2cce2e6a997370752eaab8f81b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->