### PR TITLE
fix(prevent): Match Placeholder height to cards

### DIFF
--- a/static/app/components/prevent/summary.tsx
+++ b/static/app/components/prevent/summary.tsx
@@ -165,7 +165,7 @@ export function SummaryCardGroup({
       >
         {isLoading
           ? Array.from({length: placeholderCount}, (_, index) => (
-              <Placeholder key={index} height="62px" />
+              <Placeholder key={index} height="66px" />
             ))
           : children}
       </SummaryListGrid>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increase `Placeholder` height in `SummaryCardGroup` from `62px` to `66px` to align with card height.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6558f4b12948bb08085fc35a98436a5b846500b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->