### PR TITLE
fix(issues): add gap between tag option select and header

### DIFF
--- a/static/app/components/issues/suspect/suspectTable.tsx
+++ b/static/app/components/issues/suspect/suspectTable.tsx
@@ -57,7 +57,7 @@ const GradientBox = styled('div')`
   height: max-content;
   display: flex;
   flex-direction: column;
-  gap: ${space(1)};
+  gap: ${p => p.theme.space.md};
 `;
 
 const ScrolledBox = styled('div')`

--- a/static/app/components/issues/suspect/suspectTable.tsx
+++ b/static/app/components/issues/suspect/suspectTable.tsx
@@ -57,6 +57,7 @@ const GradientBox = styled('div')`
   height: max-content;
   display: flex;
   flex-direction: column;
+  gap: ${space(1)};
 `;
 
 const ScrolledBox = styled('div')`


### PR DESCRIPTION
Add a little more gap between tag table's option selection and the "Suspect Flags" header.

Before:
<img width="705" height="146" alt="Screenshot 2025-09-29 at 9 30 55 AM" src="https://github.com/user-attachments/assets/ff6a136f-1fc9-4d88-8840-4ec149c818d7" />

After:
<img width="715" height="150" alt="Screenshot 2025-09-29 at 9 31 06 AM" src="https://github.com/user-attachments/assets/a10d9466-36a9-4eca-a398-e678b43b5586" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `gap` to `GradientBox` in suspect table to increase spacing between the option selector and suspect flags.
> 
> - **UI**:
>   - Increase spacing in `static/app/components/issues/suspect/suspectTable.tsx` by adding `gap` to `GradientBox`, separating the option selector from the suspect flags list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e69921ff80de20c33203992d63940413650395aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->