### PR TITLE
fix(prevent): Use ai-code-review instead of prevent in route

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2339,7 +2339,7 @@ function buildRoutes(): RouteObject[] {
   const codecovChildren: SentryRouteObject[] = [
     {
       index: true,
-      redirectTo: 'prevent-ai/new/',
+      redirectTo: 'ai-code-review/new/',
     },
     {
       path: 'coverage/',
@@ -2392,7 +2392,7 @@ function buildRoutes(): RouteObject[] {
       ],
     },
     {
-      path: 'prevent-ai/',
+      path: 'ai-code-review/',
       children: [
         {
           component: make(() => import('sentry/views/prevent/preventAI/wrapper')),

--- a/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.spec.tsx
+++ b/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.spec.tsx
@@ -103,7 +103,7 @@ describe('PreventSecondaryNav', () => {
         organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
         initialRouterConfig: {
           location: {
-            pathname: '/organizations/org-slug/prevent/prevent-ai/new/',
+            pathname: '/organizations/org-slug/prevent/ai-code-review/new/',
           },
         },
       }
@@ -113,7 +113,7 @@ describe('PreventSecondaryNav', () => {
     expect(preventAILink).toBeInTheDocument();
     expect(preventAILink).toHaveAttribute(
       'href',
-      '/organizations/org-slug/prevent/prevent-ai/new/'
+      '/organizations/org-slug/prevent/ai-code-review/new/'
     );
   });
 });

--- a/static/app/views/prevent/pathnames.spec.ts
+++ b/static/app/views/prevent/pathnames.spec.ts
@@ -29,8 +29,8 @@ const testCases: TestCase[] = [
   },
   {
     organization: testOrg,
-    path: '/prevent-ai/',
-    expected: '/organizations/test-org-slug/prevent/prevent-ai/',
+    path: '/ai-code-review/',
+    expected: '/organizations/test-org-slug/prevent/ai-code-review/',
   },
 ];
 

--- a/static/app/views/prevent/preventAI/onboarding.spec.tsx
+++ b/static/app/views/prevent/preventAI/onboarding.spec.tsx
@@ -109,7 +109,7 @@ describe('PreventAIOnboarding', () => {
     const learnMoreLink = screen.getByRole('link', {name: 'Learn more'});
     expect(learnMoreLink).toHaveAttribute(
       'href',
-      'https://docs.sentry.io/product/ai-in-sentry/sentry-prevent-ai/'
+      'https://docs.sentry.io/product/ai-in-sentry/ai-code-review/'
     );
   });
 

--- a/static/app/views/prevent/preventAI/onboarding.tsx
+++ b/static/app/views/prevent/preventAI/onboarding.tsx
@@ -92,7 +92,7 @@ export function FeatureOverview() {
           'Sentry Error Prediction works better with Sentry Issue Context. [link:Learn more] on how to set this up to get the most accurate error prediction we can offer.',
           {
             link: (
-              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/sentry-prevent-ai/" />
+              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/ai-code-review/" />
             ),
           }
         )}

--- a/static/app/views/prevent/settings.tsx
+++ b/static/app/views/prevent/settings.tsx
@@ -12,4 +12,4 @@ export const TOKENS_PAGE_TITLE = t('Tokens');
 export const TOKENS_BASE_URL = 'tokens';
 
 export const PREVENT_AI_PAGE_TITLE = t('AI Code Review');
-export const PREVENT_AI_BASE_URL = 'prevent-ai';
+export const PREVENT_AI_BASE_URL = 'ai-code-review';

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -271,7 +271,7 @@ describe('OrganizationSettingsForm', () => {
     expect(learnMoreLink).toBeInTheDocument();
     expect(learnMoreLink).toHaveAttribute(
       'href',
-      'https://docs.sentry.io/product/ai-in-sentry/sentry-prevent-ai/'
+      'https://docs.sentry.io/product/ai-in-sentry/ai-code-review/'
     );
   });
 

--- a/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/preventAiSettings.tsx
@@ -47,7 +47,7 @@ export const makePreventAiField = (organization: Organization): FieldObject => {
       'Use AI to review, find bugs, and generate tests in pull requests [link:Learn more]',
       {
         link: (
-          <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/sentry-prevent-ai/" />
+          <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/ai-code-review/" />
         ),
       }
     ),


### PR DESCRIPTION
Use `ai-code-review` instead of `prevent-ai` in the route. Follows up to changes in [here](https://github.com/getsentry/sentry/pull/99924).

Also updates it in the docs url which is already redirected.

Note this is a breaking change, but since this is all in beta thought better to hard-change it now.

Screenshot:

<img width="649" height="468" alt="Screenshot 2025-09-29 at 9 48 59 AM" src="https://github.com/user-attachments/assets/5102e964-0f8d-44c2-a634-37b7a67c11c5" />
