### PR TITLE
fix(nav): Remove empty item when user has no other orgs to switch to

### DIFF
--- a/static/app/views/nav/orgDropdown.tsx
+++ b/static/app/views/nav/orgDropdown.tsx
@@ -171,10 +171,16 @@ export function OrgDropdown({
               isSubmenu: true,
               hidden: config.singleOrganization || isDemoModeActive(),
               children: [
-                {
-                  key: 'active-orgs',
-                  children: orderBy(activeOrgs, ['name']).map(makeOrganizationMenuItem),
-                },
+                ...(activeOrgs.length === 0
+                  ? []
+                  : [
+                      {
+                        key: 'active-orgs',
+                        children: orderBy(activeOrgs, ['name']).map(
+                          makeOrganizationMenuItem
+                        ),
+                      },
+                    ]),
                 ...(inactiveOrgs.length === 0
                   ? []
                   : [


### PR DESCRIPTION
A section with no items will show a tiny item which looks strange. This ensures that it won't show up at all.