### PR TITLE
fix(deletions): Add option to use the `RangeQuerySetWrapper` when  performing bulk deletions.

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -253,7 +253,7 @@ def cleanup(
         )
 
         debug_output("Running bulk deletes in DELETES")
-        for model_tp, dtfield, order_by in deletes:
+        for model_tp, dtfield, order_by, use_range_wrapper in deletes:
             debug_output(f"Removing {model_tp.__name__} for days={days} project={project or '*'}")
 
             if is_filtered(model_tp):
@@ -270,7 +270,7 @@ def cleanup(
                     order_by=order_by,
                 )
 
-                for chunk in q.iterator(chunk_size=100):
+                for chunk in q.iterator(chunk_size=100, use_range_wrapper=use_range_wrapper):
                     task_queue.put((imp, chunk))
 
                 task_queue.join()
@@ -447,7 +447,7 @@ def exported_data(
             item.delete_file()
 
 
-def models_which_use_deletions_code_path() -> list[tuple[type[Model], str, str]]:
+def models_which_use_deletions_code_path() -> list[tuple[type[Model], str, str, bool]]:
     from sentry.models.artifactbundle import ArtifactBundle
     from sentry.models.eventattachment import EventAttachment
     from sentry.models.grouprulestatus import GroupRuleStatus
@@ -458,26 +458,26 @@ def models_which_use_deletions_code_path() -> list[tuple[type[Model], str, str]]
     from sentry.replays.models import ReplayRecordingSegment
 
     # Deletions that use the `deletions` code path (which handles their child relations)
-    # (model, datetime_field, order_by)
+    # (model, datetime_field, order_by, use_range_wrapper)
     return [
-        (EventAttachment, "date_added", "date_added"),
-        (ReplayRecordingSegment, "date_added", "date_added"),
-        (ArtifactBundle, "date_added", "date_added"),
-        (MonitorCheckIn, "date_added", "date_added"),
-        (GroupRuleStatus, "date_added", "date_added"),
-        (PullRequest, "date_added", "date_added"),
-        (RuleFireHistory, "date_added", "date_added"),
-        (Release, "date_added", "date_added"),
+        (EventAttachment, "date_added", "date_added", False),
+        (ReplayRecordingSegment, "date_added", "date_added", False),
+        (ArtifactBundle, "date_added", "date_added", False),
+        (MonitorCheckIn, "date_added", "date_added", False),
+        (GroupRuleStatus, "date_added", "date_added", False),
+        (PullRequest, "date_added", "date_added", False),
+        (RuleFireHistory, "date_added", "date_added", False),
+        (Release, "date_added", "date_added", True),
     ]
 
 
 def remove_cross_project_models(
-    deletes: list[tuple[type[Model], str, str]],
-) -> list[tuple[type[Model], str, str]]:
+    deletes: list[tuple[type[Model], str, str, bool]],
+) -> list[tuple[type[Model], str, str, bool]]:
     from sentry.models.artifactbundle import ArtifactBundle
 
     # These models span across projects, so let's skip them
-    deletes.remove((ArtifactBundle, "date_added", "date_added"))
+    deletes.remove((ArtifactBundle, "date_added", "date_added", False))
     return deletes
 
 

--- a/tests/sentry/db/test_deletion.py
+++ b/tests/sentry/db/test_deletion.py
@@ -86,3 +86,26 @@ class BulkDeleteQueryIteratorTestCase(TransactionTestCase):
             results.update(chunk)
 
         assert results == expected_group_ids
+
+    def test_iteration_with_range_wrapper_descending(self) -> None:
+        target_project = self.project
+        expected_group_ids = {self.create_group().id for i in range(2)}
+
+        other_project = self.create_project()
+        self.create_group(other_project)
+        self.create_group(other_project)
+
+        # Test with descending order
+        iterator = BulkDeleteQuery(
+            model=Group,
+            project_id=target_project.id,
+            dtfield="last_seen",
+            order_by="-last_seen",  # Descending order
+            days=0,
+        ).iterator(chunk_size=1, use_range_wrapper=True)
+
+        results: set[int] = set()
+        for chunk in iterator:
+            results.update(chunk)
+
+        assert results == expected_group_ids

--- a/tests/sentry/db/test_deletion.py
+++ b/tests/sentry/db/test_deletion.py
@@ -64,3 +64,25 @@ class BulkDeleteQueryIteratorTestCase(TransactionTestCase):
             results.update(chunk)
 
         assert results == expected_group_ids
+
+    def test_iteration_with_range_wrapper(self) -> None:
+        target_project = self.project
+        expected_group_ids = {self.create_group().id for i in range(2)}
+
+        other_project = self.create_project()
+        self.create_group(other_project)
+        self.create_group(other_project)
+
+        iterator = BulkDeleteQuery(
+            model=Group,
+            project_id=target_project.id,
+            dtfield="last_seen",
+            order_by="last_seen",
+            days=0,
+        ).iterator(chunk_size=1, use_range_wrapper=True)
+
+        results: set[int] = set()
+        for chunk in iterator:
+            results.update(chunk)
+
+        assert results == expected_group_ids


### PR DESCRIPTION
Currently, `BulkDeleteQuery.iterator` uses a server side cursor to produce batches of results. The problem here is that it's an iterator, and so when it yields results it holds the cursor open.

The main (only?) place that uses this is pushing the chunks from this iterator into a blocking multiprocessing queue. So the end result here is that we end up holding a really long running transaction open during large deletions.

For now, just enabling this for `Release`, but if we see that it works well we can remove the old code.
