### PR TITLE
chore(aci): Remove unused config options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3097,12 +3097,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "delayed_workflow.use_workflow_engine_pool",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "delayed_workflow.rollout",
     type=Bool,
     default=False,
@@ -3138,23 +3132,6 @@ register(
     "workflow_engine.issue_alert.group.type_id.ga",
     type=Sequence,
     default=[],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "workflow_engine.buffer.use_new_buffer",
-    type=Bool,
-    default=True,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-# Control whether delayed workflow engine evaluation is done
-# via the old process_pending_batch task with rules delayed processing, or
-# via the new schedule_delayed_workflows task.
-# NB: These tasks are allowed to run concurrently, so a naive switch here
-# may result in duplicate processing.
-register(
-    "workflow_engine.use_new_scheduling_task",
-    type=Bool,
-    default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 


### PR DESCRIPTION
These are all no longer necessary.


Will wait for https://github.com/getsentry/sentry-options-automator/pull/5307 before merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes three unused options related to delayed workflows and the workflow engine.
> 
> - **Config Options**:
>   - **Removed unused workflow-related options** in `src/sentry/options/defaults.py`:
>     - `delayed_workflow.use_workflow_engine_pool`
>     - `workflow_engine.buffer.use_new_buffer`
>     - `workflow_engine.use_new_scheduling_task`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 657fb20999c0750252cc07cecaff9492dd3af4a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->