### PR TITLE
chore(aci milestone 3): debugging logs for metric issue charts

### DIFF
--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -147,6 +147,16 @@ def fetch_metric_issue_open_periods(
                 **time_period,
             },
         )
+        # TODO (mifu67): temporary log that I'm going to remove after debugging. Get the data for old and new
+        if organization.slug == "sentry" or organization.slug == "demo":
+            logger.info(
+                "fetching metric issue incidents",
+                extra={
+                    "organization_id": organization.id,
+                    "open_period_id": open_period_identifier,
+                    "response_data": resp.data,
+                },
+            )
         return resp.data
     except Exception as exc:
         logger.error(

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py
@@ -52,6 +52,8 @@ class SlackMetricAlertHandler(BaseMetricAlertHandler):
             "notification_action.execute_via_metric_alert_handler.slack",
             extra={
                 "action_id": alert_context.action_identifier_id,
+                "serialized_incident": incident_serialized_response,
+                "serialized_alert_rule": alert_rule_serialized_response,
             },
         )
 


### PR DESCRIPTION
Flag a high-traffic single processing and high-traffic dual processing org into this log so that we can easily compare payloads.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds targeted debug logging for incident fetches and Slack metric alert notifications to capture payloads for specific orgs.
> 
> - **Debug logging**:
>   - `src/sentry/incidents/charts.py` (`fetch_metric_issue_open_periods`): conditionally logs for `organization.slug` in `{"sentry","demo"}` with `organization_id`, `open_period_id`, and `response_data`.
>   - `src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py`: enriches log context with `serialized_incident` and `serialized_alert_rule`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41601ffcdd5dedef41f81aa56c9e14fd3a86037b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->