### PR TITLE
fix(plugins): Make deprecation API case insensitive

### DIFF
--- a/src/sentry/api/endpoints/organization_plugin_deprecation_info.py
+++ b/src/sentry/api/endpoints/organization_plugin_deprecation_info.py
@@ -24,19 +24,19 @@ class OrganizationPluginDeprecationInfoEndpoint(OrganizationEndpoint):
         Returns a list of objects that are affected by a plugin deprecation. Objects could be issues or alert rules or both
         pparam: organization, plugin_slug
         """
-
+        plugin = plugin_slug.lower()
         plugin_projects = Project.objects.filter(
             status=ObjectStatus.ACTIVE,
             organization=organization,
-            projectoption__key=f"{plugin_slug}:enabled",
+            projectoption__key=f"{plugin}:enabled",
             projectoption__value=True,
         ).distinct()
 
         url_prefix = generate_organization_url(organization.slug)
         affected_rules_urls = self.get_plugin_rules_urls(
-            plugin_projects, f"{url_prefix}/organizations/{organization.slug}", plugin_slug
+            plugin_projects, f"{url_prefix}/organizations/{organization.slug}", plugin
         )
-        affected_issue_urls = self.get_plugin_groups_urls(plugin_projects, plugin_slug, url_prefix)
+        affected_issue_urls = self.get_plugin_groups_urls(plugin_projects, plugin, url_prefix)
 
         return Response(
             {"affected_rules": affected_rules_urls, "affected_groups": affected_issue_urls}

--- a/src/sentry/api/endpoints/organization_plugin_deprecation_info.py
+++ b/src/sentry/api/endpoints/organization_plugin_deprecation_info.py
@@ -24,6 +24,7 @@ class OrganizationPluginDeprecationInfoEndpoint(OrganizationEndpoint):
         Returns a list of objects that are affected by a plugin deprecation. Objects could be issues or alert rules or both
         pparam: organization, plugin_slug
         """
+        # Plugins in the db are stored in lowercase but there is not guarantee that's how the customer will call the API
         plugin = plugin_slug.lower()
         plugin_projects = Project.objects.filter(
             status=ObjectStatus.ACTIVE,

--- a/tests/sentry/api/endpoints/test_organization_plugin_deprecation_info.py
+++ b/tests/sentry/api/endpoints/test_organization_plugin_deprecation_info.py
@@ -30,7 +30,7 @@ class OrganizationPluginDeprecationInfoEndpointTest(APITestCase):
             self.endpoint,
             kwargs={
                 "organization_id_or_slug": organization_slug or self.organization.slug,
-                "plugin_slug": self.plugin_name,
+                "plugin_slug": "Test-Plugin",
             },
         )
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Lowercases the `plugin_slug` in the deprecation info endpoint to match DB storage and updates tests to send a mixed-case slug.
> 
> - **API**:
>   - Lowercase `plugin_slug` in `OrganizationPluginDeprecationInfoEndpoint.get` and use it for:
>     - Filtering `ProjectOption` keys (`"{plugin}:enabled"`).
>     - Passing to `get_plugin_rules_urls` and `get_plugin_groups_urls`.
> - **Tests**:
>   - Update request to use mixed-case `plugin_slug` to validate case-insensitive behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16a7862e429beb5c0fa543ffeb15abbd8d63f112. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->