### PR TITLE
fix(preprod): show both optimize/convert savings for image insights

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
@@ -44,11 +44,11 @@ describe('AppSizeInsightsSidebarRow', () => {
 
     // Check file savings are displayed with negative values
     expect(screen.getByText(/-\s*512\s*KB/i)).toBeInTheDocument();
-    // Two files have 256 KB savings, so we expect 2 matches
-    expect(screen.getAllByText(/-\s*256\s*KB/i)).toHaveLength(2);
+    // Only Icon.js has 256 KB savings (logo.png shows 128 KB for HEIC)
+    expect(screen.getByText(/-\s*256\s*KB/i)).toBeInTheDocument();
     expect(screen.getByText('(-7.5%)')).toBeInTheDocument();
-    // Two files have (-4%) savings, so we expect 2 matches
-    expect(screen.getAllByText('(-4%)')).toHaveLength(2);
+    // Only Icon.js has (-4%) savings
+    expect(screen.getByText('(-4%)')).toBeInTheDocument();
   });
 
   it('calls onToggleExpanded when clicking the toggle button', async () => {
@@ -61,9 +61,118 @@ describe('AppSizeInsightsSidebarRow', () => {
     expect(props.onToggleExpanded).toHaveBeenCalledTimes(1);
   });
 
-  it('handles optimizable image files', () => {
-    render(<AppSizeInsightsSidebarRow {...getDefaultProps()} isExpanded />);
-    expect(screen.getByText('src/assets/logo.png')).toBeInTheDocument();
+  it('shows both optimize and HEIC options for optimizable images', () => {
+    const insightWithOptimizableImage = ProcessedInsightFixture({
+      files: [
+        {
+          path: 'image.png',
+          savings: 300000, // max of minify and conversion
+          percentage: 10,
+          data: {
+            fileType: 'optimizable_image' as const,
+            originalFile: {
+              file_path: 'image.png',
+              current_size: 1000000,
+              minify_savings: 200000,
+              minified_size: 800000,
+              conversion_savings: 300000,
+              heic_size: 700000,
+            },
+          },
+        },
+      ],
+    });
+
+    render(
+      <AppSizeInsightsSidebarRow
+        {...getDefaultProps()}
+        insight={insightWithOptimizableImage}
+        isExpanded
+      />
+    );
+
+    expect(screen.getByText('image.png')).toBeInTheDocument();
+
+    // Should show max savings in main row (300 KB appears twice: main row + HEIC row)
+    expect(screen.getAllByText(/-300\s*KB/i)).toHaveLength(2);
+    expect(screen.getAllByText('(-30%)')).toHaveLength(2);
+
+    // Should show both optimization options
+    expect(screen.getByText('Optimize:')).toBeInTheDocument();
+    expect(screen.getByText(/-200\s*KB/i)).toBeInTheDocument();
+    expect(screen.getByText('(-20%)')).toBeInTheDocument();
+
+    expect(screen.getByText('Convert to HEIC:')).toBeInTheDocument();
+  });
+
+  it('shows only HEIC option when minify savings is zero', () => {
+    const insightWithHeicOnly = ProcessedInsightFixture({
+      files: [
+        {
+          path: 'already-optimized.png',
+          savings: 472700,
+          percentage: 10,
+          data: {
+            fileType: 'optimizable_image' as const,
+            originalFile: {
+              file_path: 'already-optimized.png',
+              current_size: 802388,
+              minify_savings: 0,
+              minified_size: null,
+              conversion_savings: 472700,
+              heic_size: 329688,
+            },
+          },
+        },
+      ],
+    });
+
+    render(
+      <AppSizeInsightsSidebarRow
+        {...getDefaultProps()}
+        insight={insightWithHeicOnly}
+        isExpanded
+      />
+    );
+
+    expect(screen.getByText('already-optimized.png')).toBeInTheDocument();
+    expect(screen.getByText('Convert to HEIC:')).toBeInTheDocument();
+    expect(screen.queryByText('Optimize:')).not.toBeInTheDocument();
+  });
+
+  it('shows only optimize option when HEIC savings is zero', () => {
+    const insightWithOptimizeOnly = ProcessedInsightFixture({
+      files: [
+        {
+          path: 'no-heic.png',
+          savings: 20020,
+          percentage: 5,
+          data: {
+            fileType: 'optimizable_image' as const,
+            originalFile: {
+              file_path: 'no-heic.png',
+              current_size: 505980,
+              minify_savings: 20020,
+              minified_size: 485960,
+              conversion_savings: 0,
+              heic_size: null,
+            },
+          },
+        },
+      ],
+    });
+
+    render(
+      <AppSizeInsightsSidebarRow
+        {...getDefaultProps()}
+        insight={insightWithOptimizeOnly}
+        isExpanded
+      />
+    );
+
+    expect(screen.getByText('no-heic.png')).toBeInTheDocument();
+    expect(screen.getByText('Optimize:')).toBeInTheDocument();
+    expect(screen.queryByText('Convert to HEIC:')).not.toBeInTheDocument();
   });
 
   it('renders with no files', () => {

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -130,25 +130,86 @@ function FileRow({file}: {file: ProcessedInsightFile}) {
 
 function OptimizableImageFileRow({
   file,
-  originalFile: _originalFile,
+  originalFile,
 }: {
   file: ProcessedInsightFile;
   originalFile: OptimizableImageFile;
 }) {
+  const hasMinifySavings =
+    originalFile.minified_size !== null && originalFile.minify_savings > 0;
+  const hasHeicSavings =
+    originalFile.heic_size !== null && originalFile.conversion_savings > 0;
+  const currentSize = originalFile.current_size;
+
+  const maxSavings = Math.max(
+    originalFile.minify_savings || 0,
+    originalFile.conversion_savings || 0
+  );
+
   return (
-    <FlexAlternatingRow>
-      <Text size="sm" ellipsis style={{flex: 1}}>
-        {file.path}
-      </Text>
-      <Flex align="center" gap="sm">
-        <Text variant="primary" bold size="sm" tabular>
-          -{formatBytesBase10(file.savings)}
+    <Container>
+      <FlexAlternatingRow>
+        <Text size="sm" ellipsis style={{flex: 1}}>
+          {file.path}
         </Text>
-        <Text variant="muted" size="sm" tabular align="right" style={{width: '64px'}}>
-          ({formatUpside(file.percentage / 100)})
-        </Text>
+        <Flex align="center" gap="sm">
+          <Text variant="primary" bold size="sm" tabular>
+            -{formatBytesBase10(maxSavings)}
+          </Text>
+          <Text variant="muted" size="sm" tabular align="right" style={{width: '64px'}}>
+            ({formatUpside(maxSavings / currentSize)})
+          </Text>
+        </Flex>
+      </FlexAlternatingRow>
+      <Flex direction="column" gap="xs" padding="xs sm">
+        {hasMinifySavings && (
+          <Flex align="center" gap="sm">
+            <Text size="xs" variant="muted" style={{minWidth: '100px'}}>
+              {t('Optimize:')}
+            </Text>
+            <Text
+              size="xs"
+              variant="primary"
+              tabular
+              style={{minWidth: '80px', textAlign: 'right'}}
+            >
+              -{formatBytesBase10(originalFile.minify_savings)}
+            </Text>
+            <Text
+              size="xs"
+              variant="muted"
+              tabular
+              style={{minWidth: '64px', textAlign: 'right'}}
+            >
+              ({formatUpside(originalFile.minify_savings / currentSize)})
+            </Text>
+          </Flex>
+        )}
+        {hasHeicSavings && (
+          <Flex align="center" gap="sm">
+            <Text size="xs" variant="muted" style={{minWidth: '100px'}}>
+              {t('Convert to HEIC:')}
+            </Text>
+            <Text
+              size="xs"
+              variant="primary"
+              tabular
+              style={{minWidth: '80px', textAlign: 'right'}}
+            >
+              -{formatBytesBase10(originalFile.conversion_savings)}
+            </Text>
+            <Text
+              size="xs"
+              variant="muted"
+              tabular
+              style={{minWidth: '64px', textAlign: 'right'}}
+            >
+              ({formatUpside(originalFile.conversion_savings / currentSize)})
+            </Text>
+          </Flex>
+        )}
       </Flex>
-    </FlexAlternatingRow>
+    </Container>
   );
 }
 

--- a/static/app/views/preprod/types/appSizeTypes.ts
+++ b/static/app/views/preprod/types/appSizeTypes.ts
@@ -146,14 +146,12 @@ interface LooseImagesInsightResult extends GroupsInsightResult {}
 interface MainBinaryExportMetadataResult extends FilesInsightResult {}
 
 export interface OptimizableImageFile {
-  best_optimization_type: 'convert_to_heic' | 'minify' | 'none';
   conversion_savings: number;
   current_size: number;
   file_path: string;
   heic_size: number | null;
   minified_size: number | null;
   minify_savings: number;
-  potential_savings: number;
 }
 
 interface ImageOptimizationInsightResult extends BaseInsightResult {

--- a/static/app/views/preprod/utils/insightProcessing.ts
+++ b/static/app/views/preprod/utils/insightProcessing.ts
@@ -39,7 +39,7 @@ const INSIGHT_CONFIGS: InsightConfig[] = [
     key: 'image_optimization',
     name: 'Optimize images',
     description:
-      'We determine how much size could be saved if images were optimized. In some cases you can convert to HEIC or WebP for better compression.',
+      'We determine how much size could be saved if images were optimized. In some cases you can convert to HEIC for better compression.',
   },
   {
     key: 'duplicate_files',

--- a/static/app/views/preprod/utils/insightProcessing.ts
+++ b/static/app/views/preprod/utils/insightProcessing.ts
@@ -39,7 +39,7 @@ const INSIGHT_CONFIGS: InsightConfig[] = [
     key: 'image_optimization',
     name: 'Optimize images',
     description:
-      'We determine how much size could be saved if images were compressed. In some cases you can convert to WebP for better compression.',
+      'We determine how much size could be saved if images were optimized. In some cases you can convert to HEIC or WebP for better compression.',
   },
   {
     key: 'duplicate_files',


### PR DESCRIPTION
There's still some iteration to be done here, but at least we now display both saving sizes for optimizing the existing image vs converting to a new image format.

I played around with a few different alignments but this looked the best. Like I mentioned we'll iterate on this more in the future.

<img width="493" height="378" alt="Screenshot 2025-09-29 at 2 28 55 PM" src="https://github.com/user-attachments/assets/940ef00f-8722-42f3-bdb5-8d4b1443716c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show max image savings in main row and add per-option breakdown (Optimize vs Convert to HEIC), with updated tests and types.
> 
> - **UI (App Size Insights)**
>   - **Optimizable images**: `OptimizableImageFileRow` now shows max savings in the main line and a sub-list with separate savings/percentages for `Optimize` and `Convert to HEIC` when available.
>   - Uses `originalFile` fields to compute per-option and max savings; updates layout with `Container` and detailed rows.
> - **Tests**
>   - Update expectations for file savings counts; add cases for both options, HEIC-only, and optimize-only scenarios in `appSizeInsightsSidebarRow.spec.tsx`.
> - **Types**
>   - Remove `best_optimization_type` and `potential_savings` from `OptimizableImageFile`.
> - **Copy**
>   - Update `image_optimization` description to reference "optimized" images and converting to HEIC.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9a57ab778a4c964824b197b124461cd6011badb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->