### PR TITLE
ref(feedback): add back categories cache and gate w/a FF

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -481,7 +481,10 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable querying uptime data from EAP uptime_results instead of uptime_checks
     manager.add("organizations:uptime-eap-uptime-results-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable endpoint and frontend for AI-powered UF summaries
     manager.add("organizations:user-feedback-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable org-level caching for user feedback summaries and categorization
+    manager.add("organizations:user-feedback-ai-summaries-cache", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Enable label generation at ingest time for user feedbacks
     manager.add("organizations:user-feedback-ai-categorization", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the backend endpoint and frontend for categorizing user feedbacks

--- a/src/sentry/feedback/endpoints/organization_feedback_categories.py
+++ b/src/sentry/feedback/endpoints/organization_feedback_categories.py
@@ -143,21 +143,26 @@ class OrganizationFeedbackCategoriesEndpoint(OrganizationEndpoint):
         hashed_project_ids = hash_from_values(project_ids)
 
         if end - start < timedelta(days=2):
-            # Hour granularity.
+            # Hour granularity date range.
             categorization_cache_key = f"feedback_categorization:{organization.id}:{start.strftime('%Y-%m-%d-%H')}:{end.strftime('%Y-%m-%d-%H')}:{hashed_project_ids}"
         else:
-            # Day granularity. Date range is long enough that the categories won't change much (as long as the same day is selected)
+            # Day granularity date range. Date range is long enough that the categories won't change much (as long as the same day is selected)
             categorization_cache_key = f"feedback_categorization:{organization.id}:{start.strftime('%Y-%m-%d')}:{end.strftime('%Y-%m-%d')}:{hashed_project_ids}"
 
-        categories_cache = cache.get(categorization_cache_key)
-        if categories_cache:
-            return Response(
-                {
-                    "categories": categories_cache["categories"],
-                    "success": True,
-                    "numFeedbacksContext": categories_cache["numFeedbacksContext"],
-                }
-            )
+        has_cache = features.has(
+            "organizations:user-feedback-ai-summaries-cache", organization, actor=request.user
+        )
+
+        if has_cache:
+            cache_entry = cache.get(categorization_cache_key)
+            if cache_entry:
+                return Response(
+                    {
+                        "categories": cache_entry["categories"],
+                        "success": True,
+                        "numFeedbacksContext": cache_entry["numFeedbacksContext"],
+                    }
+                )
 
         recent_feedbacks = query_recent_feedbacks_with_ai_labels(
             organization_id=organization.id,
@@ -323,11 +328,12 @@ class OrganizationFeedbackCategoriesEndpoint(OrganizationEndpoint):
         categories.sort(key=lambda x: x["feedbackCount"], reverse=True)
         categories = categories[:MAX_RETURN_CATEGORIES]
 
-        cache.set(
-            categorization_cache_key,
-            {"categories": categories, "numFeedbacksContext": len(context_feedbacks)},
-            timeout=CATEGORIES_CACHE_TIMEOUT,
-        )
+        if has_cache:
+            cache.set(
+                categorization_cache_key,
+                {"categories": categories, "numFeedbacksContext": len(context_feedbacks)},
+                timeout=CATEGORIES_CACHE_TIMEOUT,
+            )
 
         return Response(
             {

--- a/src/sentry/feedback/endpoints/organization_feedback_categories.py
+++ b/src/sentry/feedback/endpoints/organization_feedback_categories.py
@@ -143,22 +143,21 @@ class OrganizationFeedbackCategoriesEndpoint(OrganizationEndpoint):
         hashed_project_ids = hash_from_values(project_ids)
 
         if end - start < timedelta(days=2):
+            # Hour granularity.
             categorization_cache_key = f"feedback_categorization:{organization.id}:{start.strftime('%Y-%m-%d-%H')}:{end.strftime('%Y-%m-%d-%H')}:{hashed_project_ids}"
         else:
-            # Date range is long enough that the categories won't change much (as long as the same day is selected)
+            # Day granularity. Date range is long enough that the categories won't change much (as long as the same day is selected)
             categorization_cache_key = f"feedback_categorization:{organization.id}:{start.strftime('%Y-%m-%d')}:{end.strftime('%Y-%m-%d')}:{hashed_project_ids}"
 
         categories_cache = cache.get(categorization_cache_key)
         if categories_cache:
-            # TODO(vishnupsatish): the below was commented only to be able to iterate on the prompt fast. Uncomment when releasing to Sentry.
-            # return Response(
-            #     {
-            #         "categories": categories_cache["categories"],
-            #         "success": True,
-            #         "numFeedbacksContext": categories_cache["numFeedbacksContext"],
-            #     }
-            # )
-            pass
+            return Response(
+                {
+                    "categories": categories_cache["categories"],
+                    "success": True,
+                    "numFeedbacksContext": categories_cache["numFeedbacksContext"],
+                }
+            )
 
         recent_feedbacks = query_recent_feedbacks_with_ai_labels(
             organization_id=organization.id,

--- a/tests/sentry/feedback/endpoints/test_organization_feedback_summary.py
+++ b/tests/sentry/feedback/endpoints/test_organization_feedback_summary.py
@@ -59,6 +59,7 @@ class OrganizationFeedbackSummaryTest(APITestCase):
         self.project2 = self.create_project(teams=[self.team])
         self.features = {
             "organizations:user-feedback-ai-summaries": True,
+            "organizations:user-feedback-ai-summaries-cache": True,
         }
         self.url = reverse(
             self.endpoint,


### PR DESCRIPTION
For EA, so same-org users can see consistent categories that update every 2d. Closes [REPLAY-634: Cache summaries and categories, add tests back](https://linear.app/getsentry/issue/REPLAY-634/cache-summaries-and-categories-add-tests-back)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `organizations:user-feedback-ai-summaries-cache` and conditionally read/write caches for feedback summaries and categories behind this flag.
> 
> - **Backend**:
>   - **Feature Flags**: Add `organizations:user-feedback-ai-summaries-cache`.
>   - **User Feedback Endpoints**:
>     - `organization_feedback_categories.py`:
>       - Use hour/day-granularity cache keys; on flag, return cached categories and conditionally write cache.
>     - `organization_feedback_summary.py`:
>       - On flag, return cached summary and conditionally write cache using hour-granularity key.
> - **Tests**:
>   - Enable `organizations:user-feedback-ai-summaries-cache` in summary endpoint tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1864a23c9768ddf14d4cef879a52862f21b387af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->