### PR TITLE
ref(ui): Improve global inline code style

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -163,6 +163,16 @@ const styles = (theme: Theme, isDark: boolean) => css`
     color: ${theme.textColor};
   }
 
+  :not(pre) > code {
+    display: inline-block;
+    color: ${theme.pink400};
+    font-size: 0.85em;
+    border-radius: 2px;
+    line-height: 0.8;
+    padding: 0.05em 0.2em 0.15em 0.15em;
+    background: ${theme.pink100};
+  }
+
   pre {
     background-color: ${theme.backgroundSecondary};
     white-space: pre-wrap;

--- a/static/less/base.less
+++ b/static/less/base.less
@@ -370,15 +370,6 @@ samp {
   font-size: 1em;
 }
 
-// Inline code
-code {
-  padding: 2px 4px;
-  font-size: 90%;
-  color: @code-color;
-  background-color: @code-bg;
-  border-radius: @border-radius-base;
-}
-
 // User input typically entered via keyboard
 kbd {
   padding: 2px 4px;

--- a/static/less/includes/bootstrap/variables.less
+++ b/static/less/includes/bootstrap/variables.less
@@ -676,13 +676,6 @@
 @close-color: #000;
 @close-text-shadow: 0 1px 0 #fff;
 
-//== Code
-//
-//##
-
-@code-color: #c7254e;
-@code-bg: #f9f2f4;
-
 @kbd-color: #fff;
 @kbd-bg: #333;
 


### PR DESCRIPTION
Before

<img alt="clipboard.png" width="992" src="https://i.imgur.com/FESsjuh.png" />

After

<img alt="clipboard.png" width="1005" src="https://i.imgur.com/UFEphlb.png" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves inline code styling from LESS to Emotion and updates its appearance (themed pink background), removing old LESS rules and related variables.
> 
> - **UI Styles**:
>   - **Inline Code**:
>     - Adds Emotion-based styles in `static/app/styles/global.tsx` for `:not(pre) > code` (pink text/background, compact padding, small font).
>     - Removes legacy LESS inline code rules from `static/less/base.less`.
>     - Removes obsolete `@code-color` and `@code-bg` variables from `static/less/includes/bootstrap/variables.less`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7eb2c3a7e6e784c6d6a1418fb3b3cc33dedec0d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->