### PR TITLE
feat(uptime): Indicate system spans in span count

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -32,6 +32,11 @@ type Props = {
  */
 const EMPTY_TRACE = '00000000000000000000000000000000';
 
+/**
+ * The number of system uptime spans that are always recorded for each uptime check.
+ */
+const SYSTEM_UPTIME_SPAN_COUNT = 7;
+
 export function UptimeChecksGrid({traceSampling, uptimeChecks}: Props) {
   const traceIds = uptimeChecks?.map(check => check.traceId) ?? [];
 
@@ -156,16 +161,21 @@ function CheckInBodyCell({
         <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/uptime-tracing/" />
       );
 
+      // Check if there are only system spans (no real user spans)
+      const hasOnlySystemSpans = spanCount !== undefined && spanCount === 0;
+      const totalSpanCount =
+        spanCount === undefined ? undefined : spanCount + SYSTEM_UPTIME_SPAN_COUNT;
+
       const badge =
-        spanCount === undefined ? (
+        totalSpanCount === undefined ? (
           <Placeholder height="20px" width="70px" />
-        ) : spanCount === 0 ? (
+        ) : hasOnlySystemSpans ? (
           <Tooltip
             isHoverable
             title={
               traceSampling
                 ? tct(
-                    'No spans found in this trace. Configure your SDKs to see correlated spans across services. [learnMore:Learn more].',
+                    'Only Uptime Spans are present in this trace. Configure your SDKs to see correlated spans across services. [learnMore:Learn more].',
                     {learnMore}
                   )
                 : tct(
@@ -174,10 +184,10 @@ function CheckInBodyCell({
                   )
             }
           >
-            <Tag type="default">{t('0 spans')}</Tag>
+            <Tag type="default">{t('%s spans', totalSpanCount)}</Tag>
           </Tooltip>
         ) : (
-          <Tag type="info">{t('%s spans', spanCount)}</Tag>
+          <Tag type="info">{t('%s spans', totalSpanCount)}</Tag>
         );
 
       return (

--- a/static/app/views/issueDetails/groupUptimeChecks.spec.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.spec.tsx
@@ -111,8 +111,8 @@ describe('GroupUptimeChecks', () => {
     expect(screen.getByText(getShortEventId(uptimeCheck.traceId))).toBeInTheDocument();
     expect(screen.getByText(uptimeCheck.regionName)).toBeInTheDocument();
 
-    // Span counts also need to load
-    expect(await screen.findByText('0 spans')).toBeInTheDocument();
+    // Span counts also need to load (includes 7 system spans)
+    expect(await screen.findByText('7 spans')).toBeInTheDocument();
   });
 
   it('indicates when there are spans in a trace', async () => {
@@ -139,7 +139,8 @@ describe('GroupUptimeChecks', () => {
 
     const traceId = getShortEventId(uptimeCheck.traceId);
 
-    expect(await screen.findByText('10 spans')).toBeInTheDocument();
+    // 10 user spans + 7 system spans = 17 total
+    expect(await screen.findByText('17 spans')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: traceId})).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes [NEW-512: Update Uptime spans count to always include system spans as part of the count](https://linear.app/getsentry/issue/NEW-512/update-uptime-spans-count-to-always-include-system-spans-as-part-of)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Display span counts including 7 system uptime spans and update tooltip/text to reflect “Only Uptime Spans” when no user spans are present.
> 
> - **Uptime Checks Grid (`static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx`)**:
>   - **Span count display**:
>     - Add `SYSTEM_UPTIME_SPAN_COUNT = 7` and show total as `spanCount + SYSTEM_UPTIME_SPAN_COUNT`.
>     - Change zero-user-span state to “Only Uptime Spans” tooltip; badge shows total spans (including system) instead of `0`.
>     - Keep placeholder when counts are loading; link and query unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb3f411d8dcfe84e624a163568779e30325048cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->