### PR TITLE
chore(spans-migration): Add flag for showing explore url on transaction widget warning

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -456,6 +456,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:traces-schema-hints", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Extraction metrics for transactions during ingestion.
     manager.add("organizations:transaction-metrics-extraction", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
+    # Enable feature to load explore link for transaction widgets
+    manager.add("organizations:transaction-widget-deprecation-explore-view", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Mark URL transactions scrubbed by regex patterns as "sanitized".
     # NOTE: This flag does not concern transactions rewritten by clusterer rules.
     # Those are always marked as "sanitized".


### PR DESCRIPTION
We want to give users a sense of what their translated widgets will look like so we're linking them out to explore to give them a sense of what that will look like. This is just the feature flag to be able to control rollout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `organizations:transaction-widget-deprecation-explore-view` FLAGPOLE feature (api_expose=true) to enable an explore link for transaction widgets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e28dd9a15b6c4da3f70cfabba8dcc51c153fb88e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->