### PR TITLE
fix(uptime): Do not paginate span count query

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -41,6 +41,9 @@ export function UptimeChecksGrid({traceSampling, uptimeChecks}: Props) {
       enabled: traceIds.length > 0,
       search: new MutableSearch('').addDisjunctionFilterValues('trace', traceIds),
       fields: ['trace', 'count()'],
+      // Ignore the cursor parameter, since we use that on this page to
+      // paginate the checks table.
+      noPagination: true,
     },
     'api.uptime-checks-grid'
   );


### PR DESCRIPTION
Fixes [NEW-498: Fix bug: spans not showing in monitor details on pagination](https://linear.app/getsentry/issue/NEW-498/fix-bug-spans-not-showing-in-monitor-details-on-pagination)