### PR TITLE
fix(checkout v3): Auto-open billing info panels when no info on file

### DIFF
--- a/static/gsApp/components/billingDetails/panel.tsx
+++ b/static/gsApp/components/billingDetails/panel.tsx
@@ -45,14 +45,16 @@ function BillingDetailsPanel({
   title,
   isNewBillingUI,
   analyticsEvent,
+  shouldExpandInitially,
 }: {
   organization: Organization;
   subscription: Subscription;
   analyticsEvent?: GetsentryEventKey;
   isNewBillingUI?: boolean;
+  shouldExpandInitially?: boolean;
   title?: string;
 }) {
-  const [isEditing, setIsEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState(!!shouldExpandInitially);
   const {
     data: billingDetails,
     isLoading,

--- a/static/gsApp/components/creditCardEdit/panel.tsx
+++ b/static/gsApp/components/creditCardEdit/panel.tsx
@@ -55,7 +55,7 @@ function CreditCardPanel({
 }: CreditCardPanelProps) {
   const [cardLastFourDigits, setCardLastFourDigits] = useState<string | null>(null);
   const [cardZipCode, setCardZipCode] = useState<string | null>(null);
-  const [isEditing, setIsEditing] = useState(shouldExpandInitially);
+  const [isEditing, setIsEditing] = useState(!!shouldExpandInitially);
   const [fromBillingFailure, setFromBillingFailure] = useState(false);
   const [referrer, setReferrer] = useState<string | undefined>(undefined);
 

--- a/static/gsApp/components/creditCardEdit/panel.tsx
+++ b/static/gsApp/components/creditCardEdit/panel.tsx
@@ -29,6 +29,7 @@ interface CreditCardPanelProps {
   subscription: Subscription;
   analyticsEvent?: GetsentryEventKey;
   isNewBillingUI?: boolean;
+  shouldExpandInitially?: boolean;
 }
 
 function TextForField({children}: {children: React.ReactNode}) {
@@ -50,10 +51,11 @@ function CreditCardPanel({
   budgetTerm,
   ftcLocation,
   analyticsEvent,
+  shouldExpandInitially,
 }: CreditCardPanelProps) {
   const [cardLastFourDigits, setCardLastFourDigits] = useState<string | null>(null);
   const [cardZipCode, setCardZipCode] = useState<string | null>(null);
-  const [isEditing, setIsEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState(shouldExpandInitially);
   const [fromBillingFailure, setFromBillingFailure] = useState(false);
   const [referrer, setReferrer] = useState<string | undefined>(undefined);
 

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.spec.tsx
@@ -16,6 +16,7 @@ describe('AddBillingInformation', () => {
   const subscription = SubscriptionFixture({organization, plan: 'am3_f'});
 
   beforeEach(() => {
+    organization.access = ['org:billing'];
     api.clear();
     MockApiClient.clearMockResponses();
     SubscriptionStore.set(organization.slug, subscription);
@@ -56,6 +57,16 @@ describe('AddBillingInformation', () => {
       url: `/customers/${organization.slug}/billing-details/`,
       method: 'GET',
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/payments/setup/`,
+      method: 'POST',
+      body: {
+        id: '123',
+        clientSecret: 'seti_abc123',
+        status: 'require_payment_method',
+        lastError: null,
+      },
+    });
   });
 
   it('renders heading with complete existing billing info', async () => {
@@ -80,9 +91,15 @@ describe('AddBillingInformation', () => {
     expect(screen.getByText('Business address')).toBeInTheDocument();
     expect(screen.getByText('Payment method')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Confirm and pay'})).toBeEnabled();
+    expect(
+      screen.getByRole('button', {name: 'Edit business address'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Edit payment method'})).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Save Changes'})).not.toBeInTheDocument();
   });
 
-  it('renders heading with some existing billing info', async () => {
+  it('renders heading with partial billing info', async () => {
+    // subscription has payment source
     render(
       <AMCheckout
         {...RouteComponentPropsFixture()}
@@ -99,9 +116,14 @@ describe('AddBillingInformation', () => {
     expect(screen.getByText('Business address')).toBeInTheDocument();
     expect(screen.getByText('Payment method')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Confirm and pay'})).toBeDisabled();
+    expect(
+      screen.queryByRole('button', {name: 'Edit business address'})
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Edit payment method'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Save Changes'})).toBeInTheDocument();
   });
 
-  it('renders heading with no existing billing info', async () => {
+  it('renders heading and auto opens with no existing billing info', async () => {
     const newSubscription = SubscriptionFixture({
       organization,
       plan: 'am3_f',
@@ -125,5 +147,12 @@ describe('AddBillingInformation', () => {
     expect(screen.getByText('Business address')).toBeInTheDocument();
     expect(screen.getByText('Payment method')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Confirm and pay'})).toBeDisabled();
+    expect(
+      screen.queryByRole('button', {name: 'Edit business address'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Edit payment method'})
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByRole('button', {name: 'Save Changes'})).toHaveLength(2);
   });
 });

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useState} from 'react';
 
+import {Alert} from 'sentry/components/core/alert';
 import {Flex} from 'sentry/components/core/layout';
 import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -8,6 +9,7 @@ import BillingDetailsPanel from 'getsentry/components/billingDetails/panel';
 import CreditCardPanel from 'getsentry/components/creditCardEdit/panel';
 import {useBillingDetails} from 'getsentry/hooks/useBillingDetails';
 import {FTCConsentLocation} from 'getsentry/types';
+import {hasSomeBillingDetails} from 'getsentry/utils/billing';
 import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
 import type {CheckoutV3StepProps} from 'getsentry/views/amCheckout/types';
 import {hasBillingInfo} from 'getsentry/views/amCheckout/utils';
@@ -21,11 +23,16 @@ function AddBillingInformation({
 }: CheckoutV3StepProps) {
   const [isOpen, setIsOpen] = useState(true);
   const location = useLocation();
-  const {data: billingDetails} = useBillingDetails();
+  const {
+    data: billingDetails,
+    isLoading: billingDetailsLoading,
+    error: billingDetailsError,
+  } = useBillingDetails();
   const showEditBillingInfo = hasBillingInfo(billingDetails, subscription, false);
 
   return (
     <Flex direction="column" gap="xl">
+      {billingDetailsError && <Alert type="error">{billingDetailsError.message}</Alert>}
       <StepHeader
         isActive
         isCompleted={false}
@@ -42,12 +49,15 @@ function AddBillingInformation({
       />
       {isOpen && (
         <Fragment>
-          <BillingDetailsPanel
-            organization={organization}
-            subscription={subscription}
-            isNewBillingUI
-            analyticsEvent="checkout.updated_billing_details"
-          />
+          {!billingDetailsLoading && (
+            <BillingDetailsPanel
+              organization={organization}
+              subscription={subscription}
+              isNewBillingUI
+              analyticsEvent="checkout.updated_billing_details"
+              shouldExpandInitially={!hasSomeBillingDetails(billingDetails)}
+            />
+          )}
           <CreditCardPanel
             organization={organization}
             subscription={subscription}
@@ -56,6 +66,7 @@ function AddBillingInformation({
             ftcLocation={FTCConsentLocation.CHECKOUT}
             budgetTerm={activePlan.budgetTerm}
             analyticsEvent="checkout.updated_cc"
+            shouldExpandInitially={subscription.paymentSource === null}
           />
         </Fragment>
       )}

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.tsx
@@ -2,6 +2,7 @@ import {Fragment, useState} from 'react';
 
 import {Alert} from 'sentry/components/core/alert';
 import {Flex} from 'sentry/components/core/layout';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
 
@@ -47,9 +48,11 @@ function AddBillingInformation({
         }
         isNewCheckout
       />
-      {isOpen && (
-        <Fragment>
-          {!billingDetailsLoading && (
+      {isOpen &&
+        (billingDetailsLoading ? (
+          <LoadingIndicator />
+        ) : (
+          <Fragment>
             <BillingDetailsPanel
               organization={organization}
               subscription={subscription}
@@ -57,19 +60,18 @@ function AddBillingInformation({
               analyticsEvent="checkout.updated_billing_details"
               shouldExpandInitially={!hasSomeBillingDetails(billingDetails)}
             />
-          )}
-          <CreditCardPanel
-            organization={organization}
-            subscription={subscription}
-            isNewBillingUI
-            location={location}
-            ftcLocation={FTCConsentLocation.CHECKOUT}
-            budgetTerm={activePlan.budgetTerm}
-            analyticsEvent="checkout.updated_cc"
-            shouldExpandInitially={subscription.paymentSource === null}
-          />
-        </Fragment>
-      )}
+            <CreditCardPanel
+              organization={organization}
+              subscription={subscription}
+              isNewBillingUI
+              location={location}
+              ftcLocation={FTCConsentLocation.CHECKOUT}
+              budgetTerm={activePlan.budgetTerm}
+              analyticsEvent="checkout.updated_cc"
+              shouldExpandInitially={subscription.paymentSource === null}
+            />
+          </Fragment>
+        ))}
     </Flex>
   );
 }


### PR DESCRIPTION
Auto-opens the billing info panels if there's no information for that respective panel to make it more obvious these need to be filled out. For the billing details ("Business address") panel, this will auto-open if there's no billing details besides company name, tax number, and/or billing email.

<img width="1086" height="1235" alt="Screenshot 2025-09-29 at 4 03 55 PM" src="https://github.com/user-attachments/assets/95c029b5-7d1e-4bde-8256-cbb8d148a6fb" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Auto-opens billing address and payment method editors when missing info, adds loading/error handling, and updates tests accordingly.
> 
> - **Checkout V3 – Billing step**:
>   - Show error via `Alert` and loading via `LoadingIndicator` while fetching `useBillingDetails`.
>   - Defer panel render until loading completes; pass `shouldExpandInitially` to panels based on `hasSomeBillingDetails(billingDetails)` and `subscription.paymentSource`.
> - **Panels**:
>   - `BillingDetailsPanel` and `CreditCardPanel` accept `shouldExpandInitially` and initialize `isEditing` from it.
> - **Tests**:
>   - Update mocks (incl. payments setup) and org access; adjust expectations for auto-open behavior and button presence; refine test names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9909464abbe6da7073d439cddfe9ca50fbec7408. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->