### PR TITLE
chore: Remove feature.organizations:performance-change-explorer

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -224,8 +224,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:project-creation-games-tab", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable mobile performance score calculation for transactions in relay
     manager.add("organizations:performance-calculate-mobile-perf-score-relay", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Enable performance change explorer panel on trends page
-    manager.add("organizations:performance-change-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Discover Saved Query dataset selector
     manager.add("organizations:performance-discover-dataset-selector", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable deprecate discover widget type

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -475,7 +475,6 @@ class Referrer(StrEnum):
     API_PROFILING_LANDING_CHART = "api.profiling.landing-chart"
     API_PROFILING_LANDING_TABLE = "api.profiling.landing-table"
     API_PROFILING_LANDING_FUNCTIONS_CARD = "api.profiling.landing-functions-card"
-    API_PROFILING_PERFORMANCE_CHANGE_EXPLORER = "api.profiling.performance-change-explorer"
     API_PROFILING_PROFILE_HAS_CHUNKS = "api.profiling.profile-has-chunks"
     API_PROFILING_PROFILE_SUMMARY_CHART = "api.profiling.profile-summary-chart"
     API_PROFILING_PROFILE_SUMMARY_TOTALS = "api.profiling.profile-summary-totals"


### PR DESCRIPTION
This feature isn't rolled out to anyone, and isn't used in the codebase anywwhere. Time to remove.

Relates to https://github.com/getsentry/sentry-options-automator/pull/5314

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `organizations:performance-change-explorer` feature flag and `API_PROFILING_PERFORMANCE_CHANGE_EXPLORER` referrer.
> 
> - **Features**:
>   - Remove `organizations:performance-change-explorer` flag registration in `src/sentry/features/temporary.py`.
> - **Snuba Referrers**:
>   - Remove `API_PROFILING_PERFORMANCE_CHANGE_EXPLORER` enum entry from `src/sentry/snuba/referrer.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54187760a68d4d0087a0b9f5e49eae188afe39d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->