### PR TITLE
feat(tasks) Add parameters to instrumented_task()

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -83,19 +83,6 @@ from sentry.utils.sentry_apps.service_hook_manager import (
 
 logger = logging.getLogger("sentry.sentry_apps.tasks.sentry_apps")
 
-TASK_OPTIONS = {
-    "queue": "app_platform",
-    "default_retry_delay": (60 * 5),  # Five minutes.
-    "max_retries": 3,
-    "record_timing": True,
-    "silo_mode": SiloMode.REGION,
-}
-CONTROL_TASK_OPTIONS = {
-    "queue": "app_platform.control",
-    "default_retry_delay": (60 * 5),  # Five minutes.
-    "max_retries": 3,
-    "silo_mode": SiloMode.CONTROL,
-}
 
 retry_decorator = retry(
     on=(RequestException),
@@ -192,7 +179,7 @@ def _webhook_issue_data(
         ),
         processing_deadline_duration=30,
     ),
-    **TASK_OPTIONS,
+    silo_mode=SiloMode.REGION,
 )
 @retry_decorator
 def send_alert_webhook_v2(
@@ -303,7 +290,7 @@ def send_alert_webhook_v2(
             delay=60 * 5,
         ),
     ),
-    **TASK_OPTIONS,
+    silo_mode=SiloMode.REGION,
 )
 @retry_decorator
 def send_alert_webhook(
@@ -481,7 +468,7 @@ def _does_project_filter_allow_project(service_hook_id: int, project_id: int) ->
         ),
         processing_deadline_duration=150,
     ),
-    **TASK_OPTIONS,
+    silo_mode=SiloMode.REGION,
 )
 @retry_decorator
 def process_resource_change_bound(
@@ -499,7 +486,7 @@ def process_resource_change_bound(
             delay=60 * 5,
         ),
     ),
-    **CONTROL_TASK_OPTIONS,
+    silo_mode=SiloMode.CONTROL,
 )
 @retry_decorator
 def installation_webhook(installation_id: int, user_id: int, *args: Any, **kwargs: Any) -> None:
@@ -536,7 +523,7 @@ def installation_webhook(installation_id: int, user_id: int, *args: Any, **kwarg
         ),
         processing_deadline_duration=30,
     ),
-    **CONTROL_TASK_OPTIONS,
+    silo_mode=SiloMode.CONTROL,
 )
 def clear_region_cache(sentry_app_id: int, region_name: str) -> None:
     try:
@@ -586,7 +573,7 @@ def clear_region_cache(sentry_app_id: int, region_name: str) -> None:
             delay=60 * 5,
         ),
     ),
-    **TASK_OPTIONS,
+    silo_mode=SiloMode.REGION,
 )
 @retry_decorator
 def workflow_notification(
@@ -650,7 +637,7 @@ def workflow_notification(
             delay=60 * 5,
         ),
     ),
-    **TASK_OPTIONS,
+    silo_mode=SiloMode.REGION,
 )
 @retry_decorator
 def build_comment_webhook(
@@ -751,7 +738,7 @@ def get_webhook_data(
         compression_type=CompressionType.ZSTD,
         processing_deadline_duration=30,
     ),
-    **TASK_OPTIONS,
+    silo_mode=SiloMode.REGION,
 )
 @retry_decorator
 def send_resource_change_webhook(
@@ -889,7 +876,7 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
     taskworker_config=TaskworkerConfig(
         namespace=sentryapp_control_tasks, retry=Retry(times=3), processing_deadline_duration=60
     ),
-    **CONTROL_TASK_OPTIONS,
+    silo_mode=SiloMode.CONTROL,
 )
 def create_or_update_service_hooks_for_sentry_app(
     sentry_app_id: int, webhook_url: str, events: list[str], **kwargs: dict
@@ -914,7 +901,7 @@ def create_or_update_service_hooks_for_sentry_app(
     taskworker_config=TaskworkerConfig(
         namespace=sentryapp_control_tasks, retry=Retry(times=3), processing_deadline_duration=60
     ),
-    **CONTROL_TASK_OPTIONS,
+    silo_mode=SiloMode.CONTROL,
 )
 def regenerate_service_hooks_for_installation(
     *,
@@ -976,7 +963,7 @@ def regenerate_service_hooks_for_installation(
         ),
         processing_deadline_duration=30,
     ),
-    **TASK_OPTIONS,
+    silo_mode=SiloMode.REGION,
 )
 def broadcast_webhooks_for_organization(
     *,

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -6,8 +6,10 @@ from django.test import override_settings
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.constants import CompressionType
 from sentry.taskworker.namespaces import test_tasks
-from sentry.taskworker.retry import RetryError
+from sentry.taskworker.registry import TaskRegistry
+from sentry.taskworker.retry import Retry, RetryError
 from sentry.taskworker.workerchild import ProcessingDeadlineExceeded
 
 
@@ -191,3 +193,25 @@ def test_retry_timeout_disabled(capture_exception, current_task) -> None:
 
     assert capture_exception.call_count == 0
     assert current_task.retry.call_count == 0
+
+
+def test_instrumented_task_parameters() -> None:
+    registry = TaskRegistry()
+    namespace = registry.create_namespace("registertest")
+
+    @instrumented_task(
+        name="hello_task",
+        namespace=namespace,
+        retry=Retry(times=3, on=(RuntimeError,)),
+        processing_deadline_duration=60,
+        compression_type=CompressionType.ZSTD,
+    )
+    def hello_task():
+        pass
+
+    decorated = namespace.get("hello_task")
+    assert decorated
+    assert decorated.compression_type == CompressionType.ZSTD
+    assert decorated.retry
+    assert decorated.retry._times == 3
+    assert decorated.retry._allowed_exception_types == (RuntimeError,)


### PR DESCRIPTION
I'd like to deprecated and remove `TaskworkerConfig`. Before that can be done, we need to have parameters on `instrumented_task`.

Refs STREAM-435

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extend instrumented_task to accept task parameters directly and refactor Sentry App tasks to specify silo_mode without TASK_OPTIONS; add tests covering new parameters.
> 
> - **Tasks Framework**:
>   - **instrumented_task**: Add direct parameters (`namespace`, `retry`, `expires`, `processing_deadline_duration`, `at_most_once`, `wait_for_delivery`, `compression_type`) and allow using either `namespace` or `taskworker_config`.
>   - Update imports to include `CompressionType`, `TaskNamespace`, and `Retry`.
> - **Sentry App Tasks (`src/sentry/sentry_apps/tasks/sentry_apps.py`)**:
>   - Remove `TASK_OPTIONS`/`CONTROL_TASK_OPTIONS` usage; pass `silo_mode=SiloMode.REGION|CONTROL` directly on `@instrumented_task` across task definitions.
> - **Tests**:
>   - Add test ensuring `instrumented_task` parameters are applied (verifies `compression_type` and `retry` settings).
>   - Update test imports to use new `Retry` and registry APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d8a7bb807d1e11a30fa9fe0952cc48f22ca9c80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->