### PR TITLE
fix(ui): Do not set `prism-dark`

### DIFF
--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -152,7 +152,7 @@ export function CodeSnippet({
   const snippet = (
     <Wrapper
       isRounded={isRounded}
-      className={`${dark ? 'prism-dark ' : ''}${className ?? ''}`}
+      className={className ?? ''}
       data-render-inline={dataRenderInline}
     >
       <Header isFloating={hasFloatingHeader}>


### PR DESCRIPTION
Instead just let the theme do the work of setting the color scheme for
prism.

Fixes a regression where prism-dark is setting the background to be the
same as the primary background for code snippets.