### PR TITLE
ref(gruoping): update event_id if old

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -208,7 +208,7 @@ def create_or_update_grouphash_metadata_if_needed(
             )
 
         # Check if the event ID is older than 90 days, if so update it
-        event_old = eventstore.backend.get_event_by_id(project.id, event.event_id)
+        event_old = eventstore.backend.get_event_by_id(project.id, grouphash.metadata.event_id)
         if not event_old or event_old.datetime < datetime.now() - timedelta(days=90):
             updated_data["event_id"] = event.event_id
 

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -208,8 +208,8 @@ def create_or_update_grouphash_metadata_if_needed(
             )
 
         # Check if the event ID is older than 90 days, if so update it
-        event = eventstore.backend.get_event_by_id(project.id, event.event_id)
-        if not event or event.datetime < datetime.now() - timedelta(days=90):
+        event_old = eventstore.backend.get_event_by_id(project.id, event.event_id)
+        if not event_old or event_old.datetime < datetime.now() - timedelta(days=90):
             updated_data["event_id"] = event.event_id
 
         # Only hit the DB if there's something to change


### PR DESCRIPTION
As of #100519, added `event_id` to grouphash metadata. If an event is older than 90 days it is deleted. Add check for old event and update event if it is old. 