### PR TITLE
chore(dashboards): Decouple search bar data providers from context wrappers

### DIFF
--- a/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
+++ b/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
@@ -37,19 +37,34 @@ function fetchCustomMeasurements(
   });
 }
 
+type CustomMeasurementsConfig = {
+  organization: Organization;
+  selection?: PageFilters;
+};
+
 type CustomMeasurementsProviderProps = {
   children:
     | React.ReactNode
     | ((props: CustomMeasurementsContextValue) => React.ReactNode);
-  organization: Organization;
-  selection?: PageFilters;
-};
+} & CustomMeasurementsConfig;
 
 export function CustomMeasurementsProvider({
   children,
   organization,
   selection,
 }: CustomMeasurementsProviderProps) {
+  const state = useCustomMeasurementsConfig({organization, selection});
+  return (
+    <CustomMeasurementsContext value={state}>
+      {typeof children === 'function' ? children(state) : children}
+    </CustomMeasurementsContext>
+  );
+}
+
+export function useCustomMeasurementsConfig({
+  organization,
+  selection,
+}: CustomMeasurementsConfig) {
   const api = useApi();
   const [state, setState] = useState({customMeasurements: {}});
 
@@ -91,9 +106,5 @@ export function CustomMeasurementsProvider({
     };
   }, [selection, api, organization]);
 
-  return (
-    <CustomMeasurementsContext value={state}>
-      {typeof children === 'function' ? children(state) : children}
-    </CustomMeasurementsContext>
-  );
+  return state;
 }

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -96,13 +96,6 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     pageFilters: PageFilters
   ) => TableData;
   /**
-   * Context provider component that wraps the search bar data provider.
-   * Required when the data provider hook needs specific context.
-   */
-  SearchBarDataProviderWrapper?: React.ComponentType<{
-    children: React.ReactNode;
-  }>;
-  /**
    * Configure enabling/disabling sort/direction options with an
    * optional message for why it is disabled.
    */

--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -9,7 +9,7 @@ import type {
   Organization,
 } from 'sentry/types/organization';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
-import {CustomMeasurementsProvider} from 'sentry/utils/customMeasurements/customMeasurementsProvider';
+import {useCustomMeasurementsConfig} from 'sentry/utils/customMeasurements/customMeasurementsProvider';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
 import type {MetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
@@ -26,9 +26,7 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {AggregationKey} from 'sentry/utils/fields';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
-import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils/getSeriesRequestData';
 import type {Widget, WidgetQuery} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
@@ -72,23 +70,15 @@ const DEFAULT_FIELD: QueryFieldValue = {
   kind: FieldValueKind.FUNCTION,
 };
 
-function EventsSearchBarDataProviderWrapper({children}: {children: React.ReactNode}) {
-  const organization = useOrganization();
-  const {selection} = usePageFilters();
-
-  return (
-    <CustomMeasurementsProvider organization={organization} selection={selection}>
-      {children}
-    </CustomMeasurementsProvider>
-  );
-}
-
 function useEventsSearchBarDataProvider(
   props: SearchBarDataProviderProps
 ): SearchBarData {
   const {pageFilters, widgetQuery} = props;
   const organization = useOrganization();
-  const {customMeasurements} = useCustomMeasurements();
+  const {customMeasurements} = useCustomMeasurementsConfig({
+    organization,
+    selection: pageFilters,
+  });
   const eventView = eventViewFromWidget(
     '',
     widgetQuery ?? DEFAULT_WIDGET_QUERY,
@@ -116,7 +106,6 @@ export const ErrorsConfig: DatasetConfig<
   getCustomFieldRenderer: getCustomEventsFieldRenderer,
   SearchBar: EventsSearchBar,
   useSearchBarDataProvider: useEventsSearchBarDataProvider,
-  SearchBarDataProviderWrapper: EventsSearchBarDataProviderWrapper,
   filterSeriesSortOptions,
   filterYAxisAggregateParams,
   filterYAxisOptions,

--- a/static/app/views/dashboards/datasetConfig/logs.tsx
+++ b/static/app/views/dashboards/datasetConfig/logs.tsx
@@ -50,8 +50,8 @@ import {
   useSearchQueryBuilderProps,
 } from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {
-  TraceItemAttributeProvider,
   useTraceItemAttributes,
+  useTraceItemAttributesWithConfig,
 } from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {isLogsEnabled} from 'sentry/views/explore/logs/isLogsEnabled';
@@ -115,17 +115,6 @@ const EAP_AGGREGATIONS = LOG_AGGREGATES.map(
   {} as Record<AggregationKey, Aggregation>
 );
 
-function LogsSearchBarDataProviderWrapper({children}: {children: React.ReactNode}) {
-  const organization = useOrganization();
-  const enabled = isLogsEnabled(organization);
-
-  return (
-    <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled={enabled}>
-      {children}
-    </TraceItemAttributeProvider>
-  );
-}
-
 function LogsSearchBar({
   widgetQuery,
   onSearch,
@@ -163,10 +152,17 @@ function LogsSearchBar({
 
 function useLogsSearchBarDataProvider(props: SearchBarDataProviderProps): SearchBarData {
   const {pageFilters, widgetQuery} = props;
+  const organization = useOrganization();
+
+  const traceItemAttributeConfig = {
+    traceItemType: TraceItemDataset.LOGS,
+    enabled: isLogsEnabled(organization),
+  };
+
   const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
-    useTraceItemAttributes('string');
+    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'string');
   const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
-    useTraceItemAttributes('number');
+    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'number');
 
   const {filterKeys, filterKeySections, getTagValues} = useSearchQueryBuilderProps({
     itemType: TraceItemDataset.LOGS,
@@ -194,7 +190,6 @@ export const LogsConfig: DatasetConfig<
   enableEquations: false,
   SearchBar: LogsSearchBar,
   useSearchBarDataProvider: useLogsSearchBarDataProvider,
-  SearchBarDataProviderWrapper: LogsSearchBarDataProviderWrapper,
   filterYAxisAggregateParams: () => filterAggregateParams,
   filterYAxisOptions,
   filterSeriesSortOptions,

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -63,10 +63,7 @@ import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {generateFieldOptions} from 'sentry/views/discover/utils';
 import {useSearchQueryBuilderProps} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
-import {
-  TraceItemAttributeProvider,
-  useTraceItemAttributes,
-} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {useTraceItemAttributesWithConfig} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
@@ -139,23 +136,19 @@ const EAP_AGGREGATIONS = ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.reduce(
   {} as Record<AggregationKey, Aggregation>
 );
 
-function SpansSearchBarDataProviderWrapper({children}: {children: React.ReactNode}) {
-  const organization = useOrganization();
-  const enabled = organization.features.includes('visibility-explore-view');
-
-  return (
-    <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled={enabled}>
-      {children}
-    </TraceItemAttributeProvider>
-  );
-}
-
 function useSpansSearchBarDataProvider(props: SearchBarDataProviderProps): SearchBarData {
   const {pageFilters, widgetQuery} = props;
+  const organization = useOrganization();
+
+  const traceItemAttributeConfig = {
+    traceItemType: TraceItemDataset.SPANS,
+    enabled: organization.features.includes('visibility-explore-view'),
+  };
+
   const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
-    useTraceItemAttributes('string');
+    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'string');
   const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
-    useTraceItemAttributes('number');
+    useTraceItemAttributesWithConfig(traceItemAttributeConfig, 'number');
 
   const {filterKeys, filterKeySections, getTagValues} = useSearchQueryBuilderProps({
     itemType: TraceItemDataset.SPANS,
@@ -184,7 +177,6 @@ export const SpansConfig: DatasetConfig<
   enableEquations: true,
   SearchBar: SpansSearchBar,
   useSearchBarDataProvider: useSpansSearchBarDataProvider,
-  SearchBarDataProviderWrapper: SpansSearchBarDataProviderWrapper,
   filterYAxisAggregateParams: () => filterAggregateParams,
   filterYAxisOptions,
   filterSeriesSortOptions,

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -33,12 +33,15 @@ const TraceItemAttributeContext = createContext<
   TypedTraceItemAttributesResult | undefined
 >(undefined);
 
-interface TraceItemAttributeProviderProps {
-  children: React.ReactNode;
+type TraceItemAttributeConfig = {
   enabled: boolean;
   traceItemType: TraceItemDataset;
   projects?: Project[];
-}
+};
+
+type TraceItemAttributeProviderProps = {
+  children: React.ReactNode;
+} & TraceItemAttributeConfig;
 
 export function TraceItemAttributeProvider({
   children,
@@ -46,6 +49,24 @@ export function TraceItemAttributeProvider({
   enabled,
   projects,
 }: TraceItemAttributeProviderProps) {
+  const typedAttributesResult = useTraceItemAttributeConfig({
+    traceItemType,
+    enabled,
+    projects,
+  });
+
+  return (
+    <TraceItemAttributeContext value={typedAttributesResult}>
+      {children}
+    </TraceItemAttributeContext>
+  );
+}
+
+export function useTraceItemAttributeConfig({
+  traceItemType,
+  enabled,
+  projects,
+}: TraceItemAttributeConfig) {
   const {attributes: numberAttributes, isLoading: numberAttributesLoading} =
     useTraceItemAttributeKeys({
       enabled,
@@ -98,34 +119,21 @@ export function TraceItemAttributeProvider({
     };
   }, [traceItemType, stringAttributes]);
 
-  return (
-    <TraceItemAttributeContext
-      value={{
-        number: allNumberAttributes.attributes,
-        string: allStringAttributes.attributes,
-        numberSecondaryAliases: allNumberAttributes.secondaryAliases,
-        stringSecondaryAliases: allStringAttributes.secondaryAliases,
-        numberAttributesLoading,
-        stringAttributesLoading,
-      }}
-    >
-      {children}
-    </TraceItemAttributeContext>
-  );
+  return {
+    number: allNumberAttributes.attributes,
+    string: allStringAttributes.attributes,
+    numberSecondaryAliases: allNumberAttributes.secondaryAliases,
+    stringSecondaryAliases: allStringAttributes.secondaryAliases,
+    numberAttributesLoading,
+    stringAttributesLoading,
+  };
 }
 
-export function useTraceItemAttributes(
+function processTraceItemAttributes(
+  typedAttributesResult: TypedTraceItemAttributesResult,
   type?: 'number' | 'string',
   hiddenKeys?: string[]
 ) {
-  const typedAttributesResult = useContext(TraceItemAttributeContext);
-
-  if (typedAttributesResult === undefined) {
-    throw new Error(
-      'useTraceItemAttributes must be used within a TraceItemAttributeProvider'
-    );
-  }
-
   if (type === 'number') {
     return {
       attributes: hiddenKeys
@@ -146,6 +154,30 @@ export function useTraceItemAttributes(
       : typedAttributesResult.stringSecondaryAliases,
     isLoading: typedAttributesResult.stringAttributesLoading,
   };
+}
+
+export function useTraceItemAttributes(
+  type?: 'number' | 'string',
+  hiddenKeys?: string[]
+) {
+  const typedAttributesResult = useContext(TraceItemAttributeContext);
+
+  if (typedAttributesResult === undefined) {
+    throw new Error(
+      'useTraceItemAttributes must be used within a TraceItemAttributeProvider'
+    );
+  }
+
+  return processTraceItemAttributes(typedAttributesResult, type, hiddenKeys);
+}
+
+export function useTraceItemAttributesWithConfig(
+  config: TraceItemAttributeConfig,
+  type?: 'number' | 'string',
+  hiddenKeys?: string[]
+) {
+  const typedAttributesResult = useTraceItemAttributeConfig(config);
+  return processTraceItemAttributes(typedAttributesResult, type, hiddenKeys);
 }
 
 function getDefaultStringAttributes(itemType: TraceItemDataset) {

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -62,7 +62,7 @@ export function TraceItemAttributeProvider({
   );
 }
 
-export function useTraceItemAttributeConfig({
+function useTraceItemAttributeConfig({
   traceItemType,
   enabled,
   projects,


### PR DESCRIPTION
Separates context values from search bar data providers, removing the need to use context wrappers when retrieving search bar data.

Fixes [DAIN-969](https://linear.app/getsentry/issue/DAIN-969/decouple-search-bar-data-providers-from-context-providers)