### PR TITLE
chore: Remove feature.organizations:team-workflow-notifications

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -428,8 +428,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:grouptombstones-hit-counter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable static ClickHouse sampling for `OrganizationTagsEndpoint`
     manager.add("organizations:tag-key-sample-n", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable team workflow notifications
-    manager.add("organizations:team-workflow-notifications", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable feature to load more than 100 rows in performance trace view.
     manager.add("organizations:trace-view-load-more", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature to load new trace view.

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -22,7 +22,6 @@ from sentry.api.helpers.group_index import (
 from sentry.api.serializers import GroupSerializer, GroupSerializerSnuba, serialize
 from sentry.api.serializers.models.group_stream import get_actions, get_available_issue_plugins
 from sentry.api.serializers.models.plugin import PluginSerializer
-from sentry.api.serializers.models.team import TeamSerializer
 from sentry.integrations.api.serializers.models.external_issue import ExternalIssueSerializer
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.issues.constants import get_issue_tsdb_group_model
@@ -36,7 +35,6 @@ from sentry.models.grouplink import GroupLink
 from sentry.models.groupowner import get_owner_details
 from sentry.models.groupseen import GroupSeen
 from sentry.models.groupsubscription import GroupSubscriptionManager
-from sentry.models.team import Team
 from sentry.models.userreport import UserReport
 from sentry.plugins.base import plugins
 from sentry.ratelimits.config import RateLimitConfig
@@ -288,20 +286,6 @@ class GroupDetailsEndpoint(GroupEndpoint):
 
             for participant in participants:
                 participant["type"] = "user"
-
-            if features.has("organizations:team-workflow-notifications", group.organization):
-                team_ids = GroupSubscriptionManager.get_participating_team_ids(group)
-
-                teams = Team.objects.filter(id__in=team_ids)
-                team_serializer = TeamSerializer()
-
-                serialized_teams = []
-                for team in teams:
-                    serialized_team = serialize(team, request.user, team_serializer)
-                    serialized_team["type"] = "team"
-                    serialized_teams.append(serialized_team)
-
-                participants.extend(serialized_teams)
 
             data.update({"participants": participants})
 

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -84,21 +84,7 @@ class GroupAssigneeManager(BaseManager["GroupAssignee"]):
         if not previous_assignee:
             return
 
-        if (
-            features.has("organizations:team-workflow-notifications", group.organization)
-            and previous_assignee.team
-        ):
-            GroupSubscription.objects.filter(
-                group=group,
-                project=group.project,
-                team=previous_assignee.team,
-                reason=GroupSubscriptionReason.assigned,
-            ).delete()
-            logger.info(
-                "groupassignee.remove",
-                extra={"group_id": group.id, "team_id": previous_assignee.team.id},
-            )
-        elif previous_assignee.team:
+        if previous_assignee.team:
             team_members = list(previous_assignee.team.member_set.values_list("user_id", flat=True))
             if (
                 new_assignee is not None

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -36,7 +36,6 @@ from sentry.models.groupsubscription import GroupSubscription
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 from sentry.types.actor import Actor
@@ -823,60 +822,6 @@ class TestHandleAssignedTo(TestCase):
         )
 
     @patch("sentry.analytics.record")
-    @with_feature("organizations:team-workflow-notifications")
-    def test_unassign_team_with_team_workflow_notifications_flag(self, mock_record: Mock) -> None:
-        user1 = self.create_user("foo@example.com")
-        user2 = self.create_user("bar@example.com")
-        team1 = self.create_team()
-        member1 = self.create_member(user=user1, organization=self.organization, role="member")
-        member2 = self.create_member(user=user2, organization=self.organization, role="member")
-        self.create_team_membership(team1, member1, role="admin")
-        self.create_team_membership(team1, member2, role="admin")
-
-        # first assign the issue to team1
-        assigned_to = handle_assigned_to(
-            Actor.from_identifier(f"team:{team1.id}"),
-            None,
-            None,
-            self.group_list,
-            self.project_lookup,
-            self.user,
-        )
-
-        assert GroupAssignee.objects.filter(group=self.group, team_id=team1.id).exists()
-        assert GroupSubscription.objects.filter(
-            group=self.group,
-            project=self.group.project,
-            team_id=team1.id,
-            reason=GroupSubscriptionReason.assigned,
-        ).exists()
-
-        # then unassign it
-        assigned_to = handle_assigned_to(
-            None, None, None, self.group_list, self.project_lookup, self.user
-        )
-
-        assert not GroupAssignee.objects.filter(group=self.group, team_id=team1.id).exists()
-        assert not GroupSubscription.objects.filter(
-            group=self.group,
-            project=self.group.project,
-            user_id=team1.id,
-            reason=GroupSubscriptionReason.assigned,
-        ).exists()
-
-        assert assigned_to is None
-        assert_last_analytics_event(
-            mock_record,
-            ManualIssueAssignment(
-                group_id=self.group.id,
-                organization_id=self.group.project.organization_id,
-                project_id=self.group.project_id,
-                assigned_by=None,
-                had_to_deassign=True,
-            ),
-        )
-
-    @patch("sentry.analytics.record")
     def test_reassign_user(self, mock_record: Mock) -> None:
         user2 = self.create_user(email="meow@meow.meow")
 
@@ -1058,85 +1003,6 @@ class TestHandleAssignedTo(TestCase):
             group=self.group,
             project=self.group.project,
             user_id=user4.id,
-            reason=GroupSubscriptionReason.assigned,
-        ).exists()
-
-        assert assigned_to == {
-            "id": str(team2.id),
-            "name": team2.slug,
-            "type": "team",
-        }
-        assert_last_analytics_event(
-            mock_record,
-            ManualIssueAssignment(
-                group_id=self.group.id,
-                organization_id=self.group.project.organization_id,
-                project_id=self.group.project_id,
-                assigned_by=None,
-                had_to_deassign=True,
-            ),
-        )
-
-    @patch("sentry.analytics.record")
-    @with_feature("organizations:team-workflow-notifications")
-    def test_reassign_team_with_team_workflow_notifications_flag(self, mock_record: Mock) -> None:
-        user1 = self.create_user("foo@example.com")
-        user2 = self.create_user("bar@example.com")
-        team1 = self.create_team()
-        member1 = self.create_member(user=user1, organization=self.organization, role="member")
-        member2 = self.create_member(user=user2, organization=self.organization, role="member")
-        self.create_team_membership(team1, member1, role="admin")
-        self.create_team_membership(team1, member2, role="admin")
-
-        user3 = self.create_user("baz@example.com")
-        user4 = self.create_user("boo@example.com")
-        team2 = self.create_team()
-        member3 = self.create_member(user=user3, organization=self.organization, role="member")
-        member4 = self.create_member(user=user4, organization=self.organization, role="member")
-        self.create_team_membership(team2, member3, role="admin")
-        self.create_team_membership(team2, member4, role="admin")
-
-        # first assign the issue to team1
-        assigned_to = handle_assigned_to(
-            Actor.from_identifier(f"team:{team1.id}"),
-            None,
-            None,
-            self.group_list,
-            self.project_lookup,
-            self.user,
-        )
-
-        assert GroupAssignee.objects.filter(group=self.group, team=team1.id).exists()
-        assert GroupSubscription.objects.filter(
-            group=self.group,
-            project=self.group.project,
-            team=team1,
-            reason=GroupSubscriptionReason.assigned,
-        ).exists()
-
-        # then assign it to team2
-        assigned_to = handle_assigned_to(
-            Actor.from_identifier(f"team:{team2.id}"),
-            None,
-            None,
-            self.group_list,
-            self.project_lookup,
-            self.user,
-        )
-
-        assert not GroupAssignee.objects.filter(group=self.group, team=team1.id).exists()
-        assert not GroupSubscription.objects.filter(
-            group=self.group,
-            project=self.group.project,
-            team=team1,
-            reason=GroupSubscriptionReason.assigned,
-        ).exists()
-
-        assert GroupAssignee.objects.filter(group=self.group, team=team2.id).exists()
-        assert GroupSubscription.objects.filter(
-            group=self.group,
-            project=self.group.project,
-            team=team2,
             reason=GroupSubscriptionReason.assigned,
         ).exists()
 

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -14,8 +14,6 @@ from sentry.notifications.types import (
 )
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.slack import link_team
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.actor import Actor
 from sentry.users.services.user import RpcUser
@@ -74,75 +72,6 @@ class SubscribeTest(TestCase):
 
         assert len(GroupSubscription.objects.filter(group=group)) == 1
 
-    @with_feature("organizations:team-workflow-notifications")
-    def test_bulk_teams(self) -> None:
-        group = self.create_group()
-
-        team_ids = []
-        for _ in range(20):
-            team = self.create_team()
-            team_ids.append(team.id)
-
-        GroupSubscription.objects.bulk_subscribe(group=group, team_ids=team_ids)
-
-        assert len(GroupSubscription.objects.filter(group=group)) == 20
-
-        one_more = self.create_team()
-        team_ids.append(one_more.id)
-
-        # should not error
-        GroupSubscription.objects.bulk_subscribe(group=group, team_ids=team_ids)
-
-        assert len(GroupSubscription.objects.filter(group=group)) == 21
-
-    @with_feature("organizations:team-workflow-notifications")
-    def test_bulk_teams_dupes(self) -> None:
-        group = self.create_group()
-
-        team_ids = []
-
-        team = self.create_team()
-        team_ids.append(team.id)
-        team_ids.append(team.id)
-
-        GroupSubscription.objects.bulk_subscribe(group=group, team_ids=team_ids)
-
-        assert len(GroupSubscription.objects.filter(group=group)) == 1
-
-    @with_feature("organizations:team-workflow-notifications")
-    def test_bulk_users_and_teams(self) -> None:
-        group = self.create_group()
-
-        user_ids = []
-        team_ids = []
-
-        for _ in range(10):
-            user = self.create_user()
-            user_ids.append(user.id)
-            team = self.create_team()
-            team_ids.append(team.id)
-
-        GroupSubscription.objects.bulk_subscribe(group=group, user_ids=user_ids, team_ids=team_ids)
-
-        assert len(GroupSubscription.objects.filter(group=group)) == 20
-
-    @with_feature("organizations:team-workflow-notifications")
-    def test_bulk_user_on_team(self) -> None:
-        """
-        Test that ensures bulk_subscribe subscribes users and teams individually, even if one of those users is part of one of those teams.
-        """
-        group = self.create_group()
-        team = self.create_team()
-        user = self.create_user()
-        self.create_member(user=user, organization=self.organization, role="member", teams=[team])
-
-        team_ids = [team.id]
-        user_ids = [user.id]
-
-        GroupSubscription.objects.bulk_subscribe(group=group, user_ids=user_ids, team_ids=team_ids)
-
-        assert len(GroupSubscription.objects.filter(group=group)) == 2
-
     def test_actor_user(self) -> None:
         group = self.create_group()
         user = self.create_user()
@@ -165,23 +94,6 @@ class SubscribeTest(TestCase):
         GroupSubscription.objects.subscribe_actor(group=group, actor=team)
 
         assert GroupSubscription.objects.filter(group=group, user_id=user.id).exists()
-
-        # should not error
-        GroupSubscription.objects.subscribe_actor(group=group, actor=team)
-
-    @with_feature("organizations:team-workflow-notifications")
-    def test_subscribe_team(self) -> None:
-        org = self.create_organization()
-        group = self.create_group()
-        user = self.create_user(email="foo@example.com")
-        team = self.create_team(organization=org)
-        self.create_member(user=user, organization=org, role="owner", teams=[team])
-
-        GroupSubscription.objects.subscribe_actor(group=group, actor=team)
-
-        assert not GroupSubscription.objects.filter(group=group, user_id=user.id).exists()
-
-        assert GroupSubscription.objects.filter(group=group, team=team).exists()
 
         # should not error
         GroupSubscription.objects.subscribe_actor(group=group, actor=team)
@@ -343,83 +255,6 @@ class GetParticipantsTest(TestCase):
         group = self.create_group(project=project)
         user2 = self.create_user("bar@example.com")
         self.create_member(user=user2, organization=self.org)
-
-        # implicit membership
-        self._assert_subscribers_are(
-            group,
-            email={self.rpc_user: GroupSubscriptionReason.implicit},
-            slack={self.rpc_user: GroupSubscriptionReason.implicit},
-        )
-
-        # unsubscribed
-        GroupSubscription.objects.create(
-            user_id=self.user.id, group=group, project=project, is_active=False
-        )
-
-        self._assert_subscribers_are(group)
-
-        # not participating by default
-        GroupSubscription.objects.filter(user_id=self.user.id, group=group).delete()
-
-        self.update_user_setting_subscribe_only()
-
-        self._assert_subscribers_are(group)
-
-        # explicitly participating
-        GroupSubscription.objects.create(
-            user_id=self.user.id,
-            group=group,
-            project=project,
-            is_active=True,
-            reason=GroupSubscriptionReason.comment,
-        )
-
-        self._assert_subscribers_are(
-            group,
-            email={self.rpc_user: GroupSubscriptionReason.comment},
-            slack={self.rpc_user: GroupSubscriptionReason.comment},
-        )
-
-    @with_feature("organizations:team-workflow-notifications")
-    def test_simple_teams(self) -> None:
-        team = self.create_team(organization=self.org)
-        project = self.create_project(teams=[self.team, team], organization=self.org)
-        group = self.create_group(project=project)
-        user2 = self.create_user("bar@example.com")
-        self.create_member(user=user2, organization=self.org)
-
-        link_team(team, self.integration, "#team-channel", "team_channel_id")
-
-        # explicit participation
-        GroupSubscription.objects.create(
-            team_id=team.id,
-            group=group,
-            project=project,
-            is_active=True,
-            reason=GroupSubscriptionReason.comment,
-        )
-
-        self._assert_subscribers_are(
-            group,
-            email={
-                self.rpc_user: GroupSubscriptionReason.implicit,
-                team: GroupSubscriptionReason.comment,
-            },
-            slack={
-                self.rpc_user: GroupSubscriptionReason.implicit,
-                team: GroupSubscriptionReason.comment,
-            },
-        )
-
-    @with_feature("organizations:team-workflow-notifications")
-    def test_simple_with_workflow(self) -> None:
-        # Include an extra team here to prove the subquery works
-        team_2 = self.create_team(organization=self.org)
-        project = self.create_project(teams=[self.team, team_2], organization=self.org)
-        group = self.create_group(project=project)
-        user2 = self.create_user("bar@example.com")
-        self.create_member(user=user2, organization=self.org)
-        self.update_team_setting_subscribe_only(team_2.id)
 
         # implicit membership
         self._assert_subscribers_are(

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -19,11 +19,7 @@ from sentry.models.repository import Repository
 from sentry.models.team import Team
 from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
 from sentry.notifications.models.notificationsettingprovider import NotificationSettingProvider
-from sentry.notifications.types import (
-    ActionTargetType,
-    FallthroughChoiceType,
-    NotificationSettingEnum,
-)
+from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
 from sentry.notifications.utils.participants import (
     FALLTHROUGH_NOTIFICATION_LIMIT,
     get_fallthrough_recipients,
@@ -35,8 +31,6 @@ from sentry.services.eventstore.models import Event
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now
-from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.slack import link_team
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.types.actor import Actor
@@ -209,28 +203,6 @@ class GetSendToTeamTest(_ParticipantsTest):
                 value="never",
             )
         self.assert_recipients_are(self.get_send_to_team(), email=[self.user.id])
-
-    @with_feature("organizations:team-workflow-notifications")
-    def test_send_workflow_to_team_direct(self) -> None:
-        link_team(self.team, self.integration, "#team-channel", "team_channel_id")
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            NotificationSettingProvider.objects.create(
-                team_id=self.team.id,
-                scope_type="team",
-                scope_identifier=self.team.id,
-                provider="slack",
-                type="workflow",
-                value="always",
-            )
-
-        assert get_send_to(
-            project=self.project,
-            target_type=ActionTargetType.TEAM,
-            target_identifier=self.team.id,
-            notification_type_enum=NotificationSettingEnum.WORKFLOW,
-        ) == {
-            ExternalProviders.SLACK: {Actor.from_orm_team(self.team)},
-        }
 
     def test_other_project_team(self) -> None:
         user_2 = self.create_user()


### PR DESCRIPTION
This feature wasn't rolled out to anyone, time to clean it up.

Relates to https://github.com/getsentry/sentry-options-automator/pull/5317


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `organizations:team-workflow-notifications` and reverts team notifications to member-based behavior, updates Slack team linking message/behavior, and cleans up participants/subscription logic and tests.
> 
> - **Notifications/Subscriptions**:
>   - Remove handling for `organizations:team-workflow-notifications` throughout.
>   - `GroupSubscriptionManager` no longer creates team subscriptions; teams are expanded to member subscriptions; team recipients default to `NEVER` in provider defaults.
>   - `GroupAssigneeManager.remove_old_assignees` always removes member subscriptions (no team-subscription branch).
>   - `NotificationController` simplifies recipients (no org/feature gate) and always treats team defaults as disabled.
> - **Issue Details API**:
>   - `participants` now include only users; team participants removed.
> - **Slack Integration (link team)**:
>   - Always enable `ISSUE_ALERTS` settings on link; drop feature check and "workflow" addon in success message.
> - **Feature flags**:
>   - Delete registration of `organizations:team-workflow-notifications` in `temporary.py`.
> - **Tests**:
>   - Remove/adjust tests tied to team workflow notifications; update Slack link team expectations and participants/subscription assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd4cf5660c6d4a58cb8a1898ca1f08ffd67f7458. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->