### PR TITLE
feat(mobile): AASA for Apple platform deeplinks

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -110,6 +110,9 @@ def mcp_json(request):
 
 @cache_control(max_age=3600, public=True)
 def apple_app_site_association(request):
+    if settings.SENTRY_MODE == SentryMode.SELF_HOSTED:
+        return HttpResponse(status=404)
+
     return HttpResponse(json.dumps(AASA_CONFIG), content_type="application/json")
 
 

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -66,6 +66,18 @@ MCP_CONFIG = {
     "endpoint": "https://mcp.sentry.dev/mcp",
 }
 
+AASA_CONFIG = {
+    "applinks": {
+        "apps": [],
+        "details": [
+            {
+                "appID": "97JCY7859U.io.sentry.SentryMobileAgent",
+                "components": [{"/": "/auth/login/*", "?": {"code": "*", "state": "*"}}],
+            }
+        ],
+    }
+}
+
 
 class ClientConfigView(BaseView):
     def get(self, request: Request) -> HttpResponse:
@@ -94,6 +106,11 @@ def mcp_json(request):
         return HttpResponse(status=404)
 
     return HttpResponse(json.dumps(MCP_CONFIG), content_type="application/json")
+
+
+@cache_control(max_age=3600, public=True)
+def apple_app_site_association(request):
+    return HttpResponse(json.dumps(AASA_CONFIG), content_type="application/json")
 
 
 @cache_control(max_age=60)

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -72,7 +72,7 @@ AASA_CONFIG = {
         "details": [
             {
                 "appID": "97JCY7859U.io.sentry.SentryMobileAgent",
-                "components": [{"/": "/auth/login/*", "?": {"code": "*", "state": "*"}}],
+                "components": [{"/": "/mobile/auth", "?": {"code": "*", "state": "*"}}],
             }
         ],
     }

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1243,6 +1243,11 @@ urlpatterns += [
         api.mcp_json,
         name="sentry-mcp-json",
     ),
+    re_path(
+        r"^\.well-known/apple-app-site-association$",
+        api.apple_app_site_association,
+        name="sentry-apple-app-site-association",
+    ),
     # Force a 404 of favicon.ico.
     # This url is commonly requested by browsers, and without
     # blocking this, it was treated as a 200 OK for a react page view.

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -759,14 +759,22 @@ class AppleAppSiteAssociationTest(TestCase):
     def path(self) -> str:
         return reverse("sentry-apple-app-site-association")
 
-    def test_aasa_endpoint_accessible(self) -> None:
-        response = self.client.get("/.well-known/apple-app-site-association")
+    def test_aasa_saas_mode(self) -> None:
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get("/.well-known/apple-app-site-association")
 
         assert response.status_code == 200
         assert response["Content-Type"] == "application/json"
 
+    def test_aasa_self_hosted_mode(self) -> None:
+        with override_settings(SENTRY_MODE="self_hosted"):
+            response = self.client.get("/.well-known/apple-app-site-association")
+
+        assert response.status_code == 404
+
     def test_aasa_content_structure(self) -> None:
-        response = self.client.get("/.well-known/apple-app-site-association")
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get("/.well-known/apple-app-site-association")
 
         assert response.status_code == 200
         data = json.loads(response.content)
@@ -788,7 +796,8 @@ class AppleAppSiteAssociationTest(TestCase):
         assert "components" in app_config
 
     def test_aasa_app_configuration(self) -> None:
-        response = self.client.get("/.well-known/apple-app-site-association")
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get("/.well-known/apple-app-site-association")
 
         assert response.status_code == 200
         data = json.loads(response.content)
@@ -817,7 +826,8 @@ class AppleAppSiteAssociationTest(TestCase):
         assert query_params["state"] == "*"
 
     def test_aasa_cache_control(self) -> None:
-        response = self.client.get("/.well-known/apple-app-site-association")
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get("/.well-known/apple-app-site-association")
 
         assert response.status_code == 200
         assert "max-age=3600" in response["Cache-Control"]
@@ -825,17 +835,20 @@ class AppleAppSiteAssociationTest(TestCase):
 
     def test_aasa_reverse_url(self) -> None:
         # Test that the named URL works correctly
-        response = self.client.get(self.path)
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get(self.path)
 
         assert response.status_code == 200
         assert response["Content-Type"] == "application/json"
 
         # Should return the same content as direct path
-        direct_response = self.client.get("/.well-known/apple-app-site-association")
+        with override_settings(SENTRY_MODE="saas"):
+            direct_response = self.client.get("/.well-known/apple-app-site-association")
         assert response.content == direct_response.content
 
     def test_aasa_json_validity(self) -> None:
-        response = self.client.get("/.well-known/apple-app-site-association")
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get("/.well-known/apple-app-site-association")
 
         assert response.status_code == 200
 
@@ -861,7 +874,8 @@ class AppleAppSiteAssociationTest(TestCase):
 
     def test_aasa_oauth_compatibility(self) -> None:
         """Test that AASA configuration matches expected OAuth redirect patterns"""
-        response = self.client.get("/.well-known/apple-app-site-association")
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get("/.well-known/apple-app-site-association")
 
         assert response.status_code == 200
         data = json.loads(response.content)


### PR DESCRIPTION
We need to serve this file in order for redirects from auth to be allowed to deep link back to the mobile app after a user logs in using ASWebAuthenticationSession.

For more info on this body of work, please see https://www.notion.so/sentry/Seer-Mobile-Auth-2628b10e4b5d80e589dcdbb2e03782d5?source=copy_link 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a cached SaaS-only AASA endpoint at `/.well-known/apple-app-site-association` returning applinks config for the mobile app.
> 
> - **Backend/Web**:
>   - **AASA endpoint**: Adds `apple_app_site_association` in `src/sentry/web/api.py` to return AASA JSON (SaaS only, `Cache-Control: max-age=3600, public`).
>   - **Routing**: Registers `/.well-known/apple-app-site-association` in `src/sentry/web/urls.py`.
> - **Tests**:
>   - Introduces `AppleAppSiteAssociationTest` verifying SaaS vs self-hosted behavior, JSON validity/structure, `appID` (`97JCY7859U.io.sentry.SentryMobileAgent`), components matching OAuth redirect (`/auth/login/*` with `code` and `state`), cache headers, and reverse URL parity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9019e7bb2b958caae94682523b5a89816ba676d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->