### PR TITLE
chore(logs): Remove logs page params

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -17,7 +17,6 @@ import {
   LogsPageDataProvider,
   useLogsPageDataQueryResult,
 } from 'sentry/views/explore/contexts/logs/logsPageData';
-import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {LogRowContent} from 'sentry/views/explore/logs/tables/logsTableRow';
@@ -42,14 +41,9 @@ export function OurlogsSection({
       source="state"
       freeze={traceId ? {traceId} : undefined}
     >
-      <LogsPageParamsProvider
-        analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
-        isTableFrozen
-      >
-        <LogsPageDataProvider>
-          <OurlogsSectionContent event={event} group={group} project={project} />
-        </LogsPageDataProvider>
-      </LogsPageParamsProvider>
+      <LogsPageDataProvider>
+        <OurlogsSectionContent event={event} group={group} project={project} />
+      </LogsPageDataProvider>
     </LogsQueryParamsProvider>
   );
 }
@@ -86,23 +80,18 @@ function OurlogsSectionContent({
             source="state"
             freeze={traceId ? {traceId} : undefined}
           >
-            <LogsPageParamsProvider
-              analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
-              isTableFrozen
-            >
-              <LogsPageDataProvider>
-                <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
-                  <OurlogsDrawer
-                    group={group}
-                    event={event}
-                    project={project}
-                    embeddedOptions={
-                      expandedLogId ? {openWithExpandedIds: [expandedLogId]} : undefined
-                    }
-                  />
-                </TraceItemAttributeProvider>
-              </LogsPageDataProvider>
-            </LogsPageParamsProvider>
+            <LogsPageDataProvider>
+              <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
+                <OurlogsDrawer
+                  group={group}
+                  event={event}
+                  project={project}
+                  embeddedOptions={
+                    expandedLogId ? {openWithExpandedIds: [expandedLogId]} : undefined
+                  }
+                />
+              </TraceItemAttributeProvider>
+            </LogsPageDataProvider>
           </LogsQueryParamsProvider>
         ),
         {

--- a/static/app/views/explore/contexts/logs/fields.tsx
+++ b/static/app/views/explore/contexts/logs/fields.tsx
@@ -10,11 +10,3 @@ import {OurLogKnownFieldKey, type OurLogFieldKey} from 'sentry/views/explore/log
 export function defaultLogFields(): OurLogKnownFieldKey[] {
   return [OurLogKnownFieldKey.TIMESTAMP, OurLogKnownFieldKey.MESSAGE];
 }
-
-export function getLogFieldsFromLocation(location: Location): OurLogFieldKey[] {
-  const fields = decodeList(location.query[LOGS_FIELDS_KEY]);
-  if (fields.length) {
-    return fields;
-  }
-  return defaultLogFields();
-}

--- a/static/app/views/explore/contexts/logs/fields.tsx
+++ b/static/app/views/explore/contexts/logs/fields.tsx
@@ -1,4 +1,4 @@
-import {OurLogKnownFieldKey, type OurLogFieldKey} from 'sentry/views/explore/logs/types';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 
 /**
  * These are the default fields that are shown in the logs table (aside from static columns like severity). The query will always add other hidden fields required to render details view etc.

--- a/static/app/views/explore/contexts/logs/fields.tsx
+++ b/static/app/views/explore/contexts/logs/fields.tsx
@@ -1,7 +1,3 @@
-import type {Location} from 'history';
-
-import {decodeList} from 'sentry/utils/queryString';
-import {LOGS_FIELDS_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {OurLogKnownFieldKey, type OurLogFieldKey} from 'sentry/views/explore/logs/types';
 
 /**

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -1,28 +1,11 @@
-import {useLayoutEffect, useState} from 'react';
+import {useLayoutEffect} from 'react';
 import type {Location} from 'history';
 
-import type {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import type {Sort} from 'sentry/utils/discover/fields';
 import localStorage from 'sentry/utils/localStorage';
-import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
-import {decodeScalar} from 'sentry/utils/queryString';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
-import {useLocation} from 'sentry/utils/useLocation';
-import {
-  defaultLogFields,
-  getLogFieldsFromLocation,
-} from 'sentry/views/explore/contexts/logs/fields';
-import {
-  getLogAggregateSortBysFromLocation,
-  getLogSortBysFromLocation,
-  logsTimestampDescendingSortBy,
-} from 'sentry/views/explore/contexts/logs/sortBys';
-import {
-  getModeFromLocation,
-  type Mode,
-} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+import {defaultLogFields} from 'sentry/views/explore/contexts/logs/fields';
+import {logsTimestampDescendingSortBy} from 'sentry/views/explore/contexts/logs/sortBys';
 
 const LOGS_PARAMS_VERSION = 2;
 export const LOGS_QUERY_KEY = 'logsQuery'; // Logs may exist on other pages.
@@ -32,150 +15,6 @@ export const LOGS_FIELDS_KEY = 'logsFields';
 export const LOGS_AGGREGATE_FN_KEY = 'logsAggregate'; // e.g., p99
 export const LOGS_AGGREGATE_PARAM_KEY = 'logsAggregateParam'; // e.g., message.parameters.0
 export const LOGS_GROUP_BY_KEY = 'logsGroupBy'; // e.g., message.template
-
-interface LogsPageParams {
-  /** In the 'aggregates' table, if you GROUP BY, there can be many rows. This is the cursor for pagination there. */
-  readonly aggregateCursor: string;
-  /** In the 'aggregates' table, if you GROUP BY, there can be many rows. This is the 'sort by' for that table. */
-  readonly aggregateSortBys: Sort[];
-  readonly analyticsPageSource: LogsAnalyticsPageSource;
-  readonly cursor: string;
-  readonly fields: string[];
-  readonly isTableFrozen: boolean | undefined;
-  readonly mode: Mode;
-  readonly search: MutableSearch;
-  /**
-   * See setSearchForFrozenPages
-   */
-  readonly setCursorForFrozenPages: (cursor: string) => void;
-  /**
-   * On frozen pages (like the issues page), we don't want to store the search in the URL
-   * Instead, use a useState in the context, so that it's dropped if you navigate away or refresh.
-   */
-  readonly setSearchForFrozenPages: (val: MutableSearch) => void;
-
-  /**
-   * E.g., -timestamp
-   */
-  readonly sortBys: Sort[];
-
-  /**
-   * E.g., p99
-   */
-  readonly aggregateFn?: string;
-  /**
-   * E.g., message.parameters.0
-   */
-  readonly aggregateParam?: string;
-
-  /**
-   * E.g., message.template
-   */
-  readonly groupBy?: string;
-
-  /**
-   * The id of the query, if a saved query.
-   */
-  readonly id?: string;
-
-  /**
-   * The title of the query, if a saved query.
-   */
-  readonly title?: string;
-}
-
-const [_LogsPageParamsProvider, _useLogsPageParams, LogsPageParamsContext] =
-  createDefinedContext<LogsPageParams>({
-    name: 'LogsPageParamsContext',
-  });
-
-interface LogsPageParamsProviderProps {
-  analyticsPageSource: LogsAnalyticsPageSource;
-  children: React.ReactNode;
-  isTableFrozen?: boolean;
-}
-
-export function LogsPageParamsProvider({
-  children,
-  isTableFrozen,
-  analyticsPageSource,
-}: LogsPageParamsProviderProps) {
-  const location = useLocation();
-  const logsQuery = decodeLogsQuery(location);
-
-  // on embedded pages with search bars, use a useState instead of a URL parameter
-  const [searchForFrozenPages, setSearchForFrozenPages] = useState(new MutableSearch(''));
-  const [cursorForFrozenPages, setCursorForFrozenPages] = useState('');
-
-  const search = isTableFrozen ? searchForFrozenPages : new MutableSearch(logsQuery);
-
-  const title = getLogTitleFromLocation(location);
-  const id = getLogIdFromLocation(location);
-  const fields = isTableFrozen ? defaultLogFields() : getLogFieldsFromLocation(location);
-  const sortBys = isTableFrozen
-    ? [logsTimestampDescendingSortBy]
-    : getLogSortBysFromLocation(location, fields);
-  const groupBy = isTableFrozen
-    ? undefined
-    : decodeScalar(location.query[LOGS_GROUP_BY_KEY]);
-  const aggregateFn = isTableFrozen
-    ? undefined
-    : (decodeScalar(location.query[LOGS_AGGREGATE_FN_KEY]) ?? 'count');
-  const _aggregateParam = isTableFrozen
-    ? undefined
-    : decodeScalar(location.query[LOGS_AGGREGATE_PARAM_KEY]);
-  const aggregateParam =
-    aggregateFn === 'count' && !_aggregateParam
-      ? OurLogKnownFieldKey.MESSAGE
-      : _aggregateParam;
-  const aggregate = `${aggregateFn}(${aggregateParam})`;
-  const aggregateSortBys = getLogAggregateSortBysFromLocation(location, [
-    ...(groupBy ? [groupBy] : []),
-    aggregate,
-  ]);
-  const mode = getModeFromLocation(location);
-  // TODO we should handle environments in a similar way to projects - otherwise page filters might break embedded views
-
-  const cursor = isTableFrozen
-    ? cursorForFrozenPages
-    : getLogCursorFromLocation(location);
-  const aggregateCursor = getLogAggregateCursorFromLocation(location);
-
-  return (
-    <LogsPageParamsContext
-      value={{
-        aggregateCursor,
-        aggregateSortBys,
-        fields,
-        search,
-        setSearchForFrozenPages,
-        sortBys,
-        title,
-        id,
-        cursor,
-        setCursorForFrozenPages,
-        isTableFrozen,
-        analyticsPageSource,
-        groupBy,
-        aggregateFn,
-        aggregateParam,
-        mode,
-      }}
-    >
-      {children}
-    </LogsPageParamsContext>
-  );
-}
-
-const decodeLogsQuery = (location: Location): string => {
-  if (!location.query?.[LOGS_QUERY_KEY]) {
-    return '';
-  }
-
-  const queryParameter = location.query[LOGS_QUERY_KEY];
-
-  return decodeScalar(queryParameter, '').trim();
-};
 
 export interface PersistedLogsPageParams {
   fields: string[];
@@ -199,30 +38,6 @@ export function usePersistedLogsPageParams() {
       sortBys: [logsTimestampDescendingSortBy],
     }
   );
-}
-
-function getLogTitleFromLocation(location: Location): string {
-  return decodeScalar(location.query.title, '');
-}
-
-function getLogIdFromLocation(location: Location): string {
-  return decodeScalar(location.query.id, '');
-}
-
-function getLogCursorFromLocation(location: Location): string {
-  if (!location.query?.[LOGS_CURSOR_KEY]) {
-    return '';
-  }
-
-  return decodeScalar(location.query[LOGS_CURSOR_KEY], '');
-}
-
-function getLogAggregateCursorFromLocation(location: Location): string {
-  if (!location.query?.[LOGS_AGGREGATE_CURSOR_KEY]) {
-    return '';
-  }
-
-  return decodeScalar(location.query[LOGS_AGGREGATE_CURSOR_KEY], '');
 }
 
 export function stripLogParamsFromLocation(location: Location): Location {

--- a/static/app/views/explore/contexts/logs/sortBys.tsx
+++ b/static/app/views/explore/contexts/logs/sortBys.tsx
@@ -19,59 +19,6 @@ export const logsTimestampAscendingSortBy: Sort = {
   kind: 'asc' as const,
 };
 
-export function getLogSortBysFromLocation(location: Location, fields: string[]): Sort[] {
-  const sortBys = decodeSorts(location.query[LOGS_SORT_BYS_KEY]);
-
-  if (sortBys.length > 0) {
-    if (sortBys.every(sortBy => fields.includes(sortBy.field))) {
-      return sortBys;
-    }
-  }
-
-  if (fields.includes(OurLogKnownFieldKey.TIMESTAMP)) {
-    return [logsTimestampDescendingSortBy];
-  }
-
-  if (!fields[0]) {
-    throw new Error(
-      'fields should not be empty - did you somehow delete all of the fields?'
-    );
-  }
-
-  return [
-    {
-      field: fields[0],
-      kind: 'desc' as const,
-    },
-  ];
-}
-
-export function getLogAggregateSortBysFromLocation(
-  location: Location,
-  fields: string[]
-): Sort[] {
-  const sortBys = decodeSorts(location.query[LOGS_AGGREGATE_SORT_BYS_KEY]);
-
-  if (sortBys.length > 0) {
-    if (sortBys.every(sortBy => fields.includes(sortBy.field))) {
-      return sortBys;
-    }
-  }
-
-  if (!fields.length) {
-    throw new Error(
-      'fields should not be empty - did you somehow delete all of the fields?'
-    );
-  }
-
-  return [
-    {
-      field: fields[fields.length - 1]!,
-      kind: 'desc' as const,
-    },
-  ];
-}
-
 export function updateLocationWithLogSortBys(
   location: Location,
   sortBys: Sort[] | null | undefined

--- a/static/app/views/explore/contexts/logs/sortBys.tsx
+++ b/static/app/views/explore/contexts/logs/sortBys.tsx
@@ -2,7 +2,6 @@ import type {Location} from 'history';
 
 import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
-import {decodeSorts} from 'sentry/utils/queryString';
 import {LOGS_CURSOR_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -18,7 +18,6 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import ExploreBreadcrumb from 'sentry/views/explore/components/breadcrumb';
 import {LogsPageDataProvider} from 'sentry/views/explore/contexts/logs/logsPageData';
-import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {LogsTabOnboarding} from 'sentry/views/explore/logs/logsOnboarding';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
@@ -80,32 +79,28 @@ export default function LogsContent() {
           analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
           source="location"
         >
-          <LogsPageParamsProvider
-            analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-          >
-            <Layout.Page>
-              <LogsHeader />
-              <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
-                <LogsPageDataProvider>
-                  {defined(onboardingProject) ? (
-                    <LogsTabOnboarding
-                      organization={organization}
-                      project={onboardingProject}
-                      defaultPeriod={defaultPeriod}
-                      maxPickableDays={maxPickableDays}
-                      relativeOptions={relativeOptions}
-                    />
-                  ) : (
-                    <LogsTabContent
-                      defaultPeriod={defaultPeriod}
-                      maxPickableDays={maxPickableDays}
-                      relativeOptions={relativeOptions}
-                    />
-                  )}
-                </LogsPageDataProvider>
-              </TraceItemAttributeProvider>
-            </Layout.Page>
-          </LogsPageParamsProvider>
+          <Layout.Page>
+            <LogsHeader />
+            <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
+              <LogsPageDataProvider>
+                {defined(onboardingProject) ? (
+                  <LogsTabOnboarding
+                    organization={organization}
+                    project={onboardingProject}
+                    defaultPeriod={defaultPeriod}
+                    maxPickableDays={maxPickableDays}
+                    relativeOptions={relativeOptions}
+                  />
+                ) : (
+                  <LogsTabContent
+                    defaultPeriod={defaultPeriod}
+                    maxPickableDays={maxPickableDays}
+                    relativeOptions={relativeOptions}
+                  />
+                )}
+              </LogsPageDataProvider>
+            </TraceItemAttributeProvider>
+          </Layout.Page>
         </LogsQueryParamsProvider>
       </PageFiltersContainer>
     </SentryDocumentTitle>

--- a/static/app/views/explore/logs/logsAutoRefresh.spec.tsx
+++ b/static/app/views/explore/logs/logsAutoRefresh.spec.tsx
@@ -7,10 +7,7 @@ import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {LOGS_AUTO_REFRESH_KEY} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {LogsPageDataProvider} from 'sentry/views/explore/contexts/logs/logsPageData';
-import {
-  LOGS_FIELDS_KEY,
-  LogsPageParamsProvider,
-} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {LOGS_FIELDS_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {AutorefreshToggle} from 'sentry/views/explore/logs/logsAutoRefresh';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
@@ -51,11 +48,7 @@ describe('LogsAutoRefresh Integration Tests', () => {
         analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
         source="location"
       >
-        <LogsPageParamsProvider
-          analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-        >
-          <LogsPageDataProvider>{children}</LogsPageDataProvider>
-        </LogsPageParamsProvider>
+        <LogsPageDataProvider>{children}</LogsPageDataProvider>
       </LogsQueryParamsProvider>,
       options
     ) as ReturnType<typeof render> & {router: any}; // Can't select the router type without exporting it.

--- a/static/app/views/explore/logs/logsExport.spec.tsx
+++ b/static/app/views/explore/logs/logsExport.spec.tsx
@@ -3,10 +3,7 @@ import {initializeLogsTest} from 'sentry-fixture/log';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
-import {
-  LOGS_QUERY_KEY,
-  LogsPageParamsProvider,
-} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {LOGS_QUERY_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {QUERY_PAGE_LIMIT} from 'sentry/views/explore/logs/constants';
 import {LogsExportButton} from 'sentry/views/explore/logs/logsExport';
@@ -36,11 +33,7 @@ describe('LogsExportButton', () => {
         analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
         source="location"
       >
-        <LogsPageParamsProvider
-          analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-        >
-          {children}
-        </LogsPageParamsProvider>
+        {children}
       </LogsQueryParamsProvider>
     );
   }

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -7,7 +7,6 @@ import {LogsPageDataProvider} from 'sentry/views/explore/contexts/logs/logsPageD
 import {
   LOGS_FIELDS_KEY,
   LOGS_QUERY_KEY,
-  LogsPageParamsProvider,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
@@ -41,13 +40,9 @@ describe('LogsTabContent', () => {
         analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
         source="location"
       >
-        <LogsPageParamsProvider
-          analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-        >
-          <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
-            <LogsPageDataProvider>{children}</LogsPageDataProvider>
-          </TraceItemAttributeProvider>
-        </LogsPageParamsProvider>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
+          <LogsPageDataProvider>{children}</LogsPageDataProvider>
+        </TraceItemAttributeProvider>
       </LogsQueryParamsProvider>
     );
   }

--- a/static/app/views/explore/logs/logsToolbar.spec.tsx
+++ b/static/app/views/explore/logs/logsToolbar.spec.tsx
@@ -3,7 +3,6 @@ import type {ReactNode} from 'react';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
-import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {LogsToolbar} from 'sentry/views/explore/logs/logsToolbar';
 
@@ -13,9 +12,7 @@ function Wrapper({children}: {children: ReactNode}) {
       analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
       source="location"
     >
-      <LogsPageParamsProvider analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}>
-        {children}
-      </LogsPageParamsProvider>
+      {children}
     </LogsQueryParamsProvider>
   );
 }

--- a/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
@@ -11,7 +11,6 @@ import {
   LOGS_FIELDS_KEY,
   LOGS_GROUP_BY_KEY,
   LOGS_QUERY_KEY,
-  LogsPageParamsProvider,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_AGGREGATE_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
@@ -35,11 +34,7 @@ describe('LogsAggregateTable', () => {
         analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
         source="location"
       >
-        <LogsPageParamsProvider
-          analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-        >
-          <LogsAggregateTable aggregatesTableResult={aggregatesTableResult} />
-        </LogsPageParamsProvider>
+        <LogsAggregateTable aggregatesTableResult={aggregatesTableResult} />
       </LogsQueryParamsProvider>
     );
   }

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -21,7 +21,6 @@ import {LogsPageDataProvider} from 'sentry/views/explore/contexts/logs/logsPageD
 import {
   LOGS_FIELDS_KEY,
   LOGS_QUERY_KEY,
-  LogsPageParamsProvider,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {DEFAULT_TRACE_ITEM_HOVER_TIMEOUT} from 'sentry/views/explore/logs/constants';
@@ -204,11 +203,7 @@ describe('LogsInfiniteTable', () => {
           analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
           source="location"
         >
-          <LogsPageParamsProvider
-            analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-          >
-            <LogsPageDataProvider>{children}</LogsPageDataProvider>
-          </LogsPageParamsProvider>
+          <LogsPageDataProvider>{children}</LogsPageDataProvider>
         </LogsQueryParamsProvider>
       </OrganizationContext.Provider>
     );

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -9,10 +9,7 @@ import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingL
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
-import {
-  LOGS_FIELDS_KEY,
-  LogsPageParamsProvider,
-} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {LOGS_FIELDS_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {type TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {DEFAULT_TRACE_ITEM_HOVER_TIMEOUT} from 'sentry/views/explore/logs/constants';
@@ -26,11 +23,9 @@ function ProviderWrapper({children}: {children?: React.ReactNode}) {
       analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
       source="location"
     >
-      <LogsPageParamsProvider analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}>
-        <table>
-          <tbody>{children}</tbody>
-        </table>
-      </LogsPageParamsProvider>
+      <table>
+        <tbody>{children}</tbody>
+      </table>
     </LogsQueryParamsProvider>
   );
 }

--- a/static/app/views/explore/logs/useLogsQuery.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.spec.tsx
@@ -18,7 +18,6 @@ import {
   LOGS_REFRESH_INTERVAL_KEY,
   type AutoRefreshState,
 } from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
-import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import type {
@@ -60,13 +59,9 @@ describe('useInfiniteLogsQuery', () => {
             analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
             source="location"
           >
-            <LogsPageParamsProvider
-              analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-            >
-              <OrganizationContext.Provider value={organization}>
-                {children}
-              </OrganizationContext.Provider>
-            </LogsPageParamsProvider>
+            <OrganizationContext.Provider value={organization}>
+              {children}
+            </OrganizationContext.Provider>
           </LogsQueryParamsProvider>
         </QueryClientProvider>
       );
@@ -447,13 +442,9 @@ describe('Virtual Streaming Integration (Auto Refresh Behaviour)', () => {
             analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
             source="location"
           >
-            <LogsPageParamsProvider
-              analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-            >
-              <OrganizationContext.Provider value={organization}>
-                {children}
-              </OrganizationContext.Provider>
-            </LogsPageParamsProvider>
+            <OrganizationContext.Provider value={organization}>
+              {children}
+            </OrganizationContext.Provider>
           </LogsQueryParamsProvider>
         </QueryClientProvider>
       );

--- a/static/app/views/explore/logs/useSaveAsItems.spec.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.spec.tsx
@@ -14,7 +14,6 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {useSaveAsItems} from 'sentry/views/explore/logs/useSaveAsItems';
@@ -50,11 +49,7 @@ describe('useSaveAsItems', () => {
               analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
               source="location"
             >
-              <LogsPageParamsProvider
-                analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-              >
-                {children}
-              </LogsPageParamsProvider>
+              {children}
             </LogsQueryParamsProvider>
           </QueryClientProvider>
         </OrganizationContext.Provider>

--- a/static/app/views/explore/logs/useStreamingTimeseriesResult.spec.tsx
+++ b/static/app/views/explore/logs/useStreamingTimeseriesResult.spec.tsx
@@ -11,10 +11,7 @@ import {
   LOGS_AUTO_REFRESH_KEY,
   type AutoRefreshState,
 } from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
-import {
-  LOGS_GROUP_BY_KEY,
-  LogsPageParamsProvider,
-} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {LOGS_GROUP_BY_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
@@ -73,11 +70,7 @@ describe('useStreamingTimeseriesResult', () => {
             analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
             source="location"
           >
-            <LogsPageParamsProvider
-              analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-            >
-              {children}
-            </LogsPageParamsProvider>
+            {children}
           </LogsQueryParamsProvider>
         </OrganizationContext.Provider>
       );

--- a/static/app/views/explore/logs/useVirtualStreaming.spec.tsx
+++ b/static/app/views/explore/logs/useVirtualStreaming.spec.tsx
@@ -13,7 +13,6 @@ import {
   LOGS_AUTO_REFRESH_KEY,
   type AutoRefreshState,
 } from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
-import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import type {
   EventsLogsResult,
@@ -69,11 +68,7 @@ describe('useVirtualStreaming', () => {
                 analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
                 source="location"
               >
-                <LogsPageParamsProvider
-                  analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-                >
-                  {children}
-                </LogsPageParamsProvider>
+                {children}
               </LogsQueryParamsProvider>
             </OrganizationContext.Provider>
           </QueryClientProvider>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -22,7 +22,6 @@ import {
   LogsPageDataProvider,
   useLogsPageDataQueryResult,
 } from 'sentry/views/explore/contexts/logs/logsPageData';
-import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {useExploreDataset} from 'sentry/views/explore/contexts/pageParamsContext';
 import {
   useTraceItemDetails,
@@ -240,12 +239,7 @@ export function SpanNodeDetails(
                 },
               }}
             >
-              <LogsPageParamsProvider
-                isTableFrozen
-                analyticsPageSource={LogsAnalyticsPageSource.TRACE_DETAILS}
-              >
-                <LogsPageDataProvider>{content}</LogsPageDataProvider>
-              </LogsPageParamsProvider>
+              <LogsPageDataProvider>{content}</LogsPageDataProvider>
             </LogsQueryParamsProvider>
           </ProfileGroupProvider>
         )}

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -8,7 +8,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {LogsPageDataProvider} from 'sentry/views/explore/contexts/logs/logsPageData';
-import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {LogsInfiniteTable} from 'sentry/views/explore/logs/tables/logsInfiniteTable';
 import {
@@ -31,12 +30,7 @@ export function TraceViewLogsDataProvider({
       source="state"
       freeze={{traceId: traceSlug}}
     >
-      <LogsPageParamsProvider
-        isTableFrozen
-        analyticsPageSource={LogsAnalyticsPageSource.TRACE_DETAILS}
-      >
-        <LogsPageDataProvider>{children}</LogsPageDataProvider>
-      </LogsPageParamsProvider>
+      <LogsPageDataProvider>{children}</LogsPageDataProvider>
     </LogsQueryParamsProvider>
   );
 }

--- a/static/app/views/replays/detail/ourlogs/index.tsx
+++ b/static/app/views/replays/detail/ourlogs/index.tsx
@@ -14,7 +14,6 @@ import {
   LogsPageDataProvider,
   useLogsPageData,
 } from 'sentry/views/explore/contexts/logs/logsPageData';
-import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {logsTimestampAscendingSortBy} from 'sentry/views/explore/contexts/logs/sortBys';
 import {
   TraceItemAttributeProvider,
@@ -62,16 +61,11 @@ export default function OurLogs() {
         fields: rearrangedLogsReplayFields(defaultLogFields()),
       }}
     >
-      <LogsPageParamsProvider
-        analyticsPageSource={LogsAnalyticsPageSource.REPLAY_DETAILS}
-        isTableFrozen
-      >
-        <LogsPageDataProvider>
-          <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
-            <OurLogsContent startTimestampMs={startTimestampMs} replayId={replayId} />
-          </TraceItemAttributeProvider>
-        </LogsPageDataProvider>
-      </LogsPageParamsProvider>
+      <LogsPageDataProvider>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
+          <OurLogsContent startTimestampMs={startTimestampMs} replayId={replayId} />
+        </TraceItemAttributeProvider>
+      </LogsPageDataProvider>
     </LogsQueryParamsProvider>
   );
 }


### PR DESCRIPTION
Logs have been migrated to use the query params context so it's time to remove the legacy page params.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the legacy logs page params context and location-derived helpers, updating components and tests to rely solely on LogsQueryParamsProvider and LogsPageDataProvider.
> 
> - **Logs Context Simplification**:
>   - Remove `LogsPageParamsProvider` and location-derived helpers (`getLogFieldsFromLocation`, sort-by getters), consolidating on `LogsQueryParamsProvider` + `LogsPageDataProvider`.
>   - Trim `logsPageParams.tsx` to persistence/constants utilities (e.g., `usePersistedLogsPageParams`, keys) and `stripLogParamsFromLocation`.
> - **Components Updated**:
>   - Replace nested `LogsPageParamsProvider` usages in `ourlogsSection`, logs explore `content`, trace details (`traceOurlogs.tsx`, span drawer), and replay logs with direct `LogsQueryParamsProvider` + `LogsPageDataProvider` (preserving frozen params where needed).
> - **Utilities**:
>   - Simplify `fields.tsx` to `defaultLogFields` only.
>   - Remove aggregate/sort-by-from-location parsing in `sortBys.tsx`; keep sort constants and update helpers.
> - **Tests**:
>   - Update all logs-related tests to drop `LogsPageParamsProvider` wrappers and imports; keep behavior assertions intact (auto-refresh, export, toolbar, tables, queries, streaming).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e1845bb15a737e317f44b6cee4746831b9cf736. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->