### PR TITLE
chore: Rollout feature.organizations:new-page-filter for all

### DIFF
--- a/.cursor/rules/typescript_tests.mdc
+++ b/.cursor/rules/typescript_tests.mdc
@@ -96,7 +96,6 @@ jest.mocked(usePageFilters)
 // ✅ Update the corresponding data store with your data
 PageFiltersStore.onInitializeUrlState(
     PageFiltersFixture({ projects: [1]}),
-    new Set()
 )
 ```
 

--- a/static/app/actionCreators/pageFilters.spec.tsx
+++ b/static/app/actionCreators/pageFilters.spec.tsx
@@ -78,7 +78,6 @@ describe('PageFilters ActionCreators', () => {
           environments: [],
           projects: [1],
         }),
-        new Set(['projects', 'environments']),
         true
       );
       expect(router.replace).toHaveBeenCalledWith(
@@ -129,7 +128,6 @@ describe('PageFilters ActionCreators', () => {
           environments: [],
           projects: [],
         }),
-        new Set(['projects']),
         false
       );
 
@@ -169,7 +167,6 @@ describe('PageFilters ActionCreators', () => {
             utc: null,
           },
         }),
-        new Set(),
         true
       );
     });
@@ -201,7 +198,6 @@ describe('PageFilters ActionCreators', () => {
             utc: null,
           },
         }),
-        new Set(),
         true
       );
     });
@@ -292,7 +288,6 @@ describe('PageFilters ActionCreators', () => {
           projects: [1],
           environments: [],
         },
-        new Set(),
         true
       );
       expect(router.replace).toHaveBeenCalledWith(
@@ -326,7 +321,6 @@ describe('PageFilters ActionCreators', () => {
           projects: [-1],
           environments: [],
         },
-        new Set(),
         true
       );
     });
@@ -376,7 +370,6 @@ describe('PageFilters ActionCreators', () => {
         expect.objectContaining({
           projects: [-1],
         }),
-        expect.any(Set),
         true
       );
     });
@@ -398,7 +391,6 @@ describe('PageFilters ActionCreators', () => {
         expect.objectContaining({
           projects: [],
         }),
-        expect.any(Set),
         true
       );
     });
@@ -482,7 +474,6 @@ describe('PageFilters ActionCreators', () => {
             utc: null,
           },
         }),
-        new Set(['datetime', 'projects', 'environments']),
         true
       );
       expect(router.replace).toHaveBeenCalledWith(
@@ -548,7 +539,6 @@ describe('PageFilters ActionCreators', () => {
             utc: null,
           },
         }),
-        new Set(['datetime']),
         true
       );
       expect(router.replace).toHaveBeenCalledWith(
@@ -588,7 +578,6 @@ describe('PageFilters ActionCreators', () => {
           environments: [],
           projects: [1],
         }),
-        new Set(['projects', 'environments']),
         true
       );
       expect(router.replace).toHaveBeenCalledWith(
@@ -828,19 +817,16 @@ describe('PageFilters ActionCreators', () => {
           pinnedFilters: new Set(['projects', 'environments', 'datetime']),
         });
 
-      PageFiltersStore.onInitializeUrlState(
-        {
-          projects: [2],
-          environments: ['prod'],
-          datetime: {
-            start: null,
-            end: null,
-            period: '1d',
-            utc: null,
-          },
+      PageFiltersStore.onInitializeUrlState({
+        projects: [2],
+        environments: ['prod'],
+        datetime: {
+          start: null,
+          end: null,
+          period: '1d',
+          utc: null,
         },
-        new Set()
-      );
+      });
       PageFiltersStore.updateDesyncedFilters(
         new Set(['projects', 'environments', 'datetime'])
       );

--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -349,13 +349,7 @@ export function initializeUrlState({
     }
   }
 
-  const pinnedFilters = new Set<PinnedPageFilter>([
-    'projects',
-    'environments',
-    'datetime',
-  ]);
-
-  PageFiltersStore.onInitializeUrlState(pageFilters, pinnedFilters, shouldPersist);
+  PageFiltersStore.onInitializeUrlState(pageFilters, shouldPersist);
   if (shouldUpdateLocalStorage) {
     setPageFiltersStorage(
       organization.slug,

--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -349,9 +349,11 @@ export function initializeUrlState({
     }
   }
 
-  const pinnedFilters = organization.features.includes('new-page-filter')
-    ? new Set<PinnedPageFilter>(['projects', 'environments', 'datetime'])
-    : (storedPageFilters?.pinnedFilters ?? new Set());
+  const pinnedFilters = new Set<PinnedPageFilter>([
+    'projects',
+    'environments',
+    'datetime',
+  ]);
 
   PageFiltersStore.onInitializeUrlState(pageFilters, pinnedFilters, shouldPersist);
   if (shouldUpdateLocalStorage) {

--- a/static/app/components/events/ourlogs/ourlogsSection.spec.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.spec.tsx
@@ -117,19 +117,16 @@ describe('OurlogsSection', () => {
     ProjectsStore.loadInitialData([project]);
 
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [parseInt(project.id, 10)],
-        environments: [],
-        datetime: {
-          period: '14d',
-          start: null,
-          end: null,
-          utc: null,
-        },
+    PageFiltersStore.onInitializeUrlState({
+      projects: [parseInt(project.id, 10)],
+      environments: [],
+      datetime: {
+        period: '14d',
+        start: null,
+        end: null,
+        utc: null,
       },
-      new Set()
-    );
+    });
 
     MockApiClient.addMockResponse({
       url: `/projects/`,

--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -144,14 +144,11 @@ describe('Modals -> WidgetViewerModal', () => {
     });
 
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [1, 2],
-        environments: ['prod', 'dev'],
-        datetime: {start: null, end: null, period: '24h', utc: null},
-      },
-      new Set()
-    );
+    PageFiltersStore.onInitializeUrlState({
+      projects: [1, 2],
+      environments: ['prod', 'dev'],
+      datetime: {start: null, end: null, period: '24h', utc: null},
+    });
   });
 
   afterEach(() => {

--- a/static/app/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState.spec.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState.spec.tsx
@@ -37,19 +37,16 @@ function createWrapper(projectSlug?: string) {
 
 function mockPageFilterStore(projects: Project[]) {
   PageFiltersStore.init();
-  PageFiltersStore.onInitializeUrlState(
-    {
-      projects: projects.map(p => parseInt(p.id, 10)),
-      environments: [],
-      datetime: {
-        period: '7d',
-        start: null,
-        end: null,
-        utc: null,
-      },
+  PageFiltersStore.onInitializeUrlState({
+    projects: projects.map(p => parseInt(p.id, 10)),
+    environments: [],
+    datetime: {
+      period: '7d',
+      start: null,
+      end: null,
+      utc: null,
     },
-    new Set()
-  );
+  });
 }
 
 describe('useCurrentProjectState', () => {

--- a/static/app/components/organizations/datePageFilter.spec.tsx
+++ b/static/app/components/organizations/datePageFilter.spec.tsx
@@ -22,19 +22,16 @@ describe('DatePageFilter', () => {
     OrganizationStore.init();
 
     OrganizationStore.onUpdate(organization, {replace: true});
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [],
-        environments: [],
-        datetime: {
-          period: '7d',
-          start: null,
-          end: null,
-          utc: false,
-        },
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {
+        period: '7d',
+        start: null,
+        end: null,
+        utc: false,
       },
-      new Set(['datetime'])
-    );
+    });
   });
 
   it('can change period', async () => {

--- a/static/app/components/organizations/datePageFilter.spec.tsx
+++ b/static/app/components/organizations/datePageFilter.spec.tsx
@@ -58,7 +58,7 @@ describe('DatePageFilter', () => {
       isReady: true,
       shouldPersist: true,
       desyncedFilters: new Set(),
-      pinnedFilters: new Set(['datetime']),
+      pinnedFilters: new Set(['projects', 'environments', 'datetime']),
       selection: {
         datetime: {
           period: '30d',
@@ -105,7 +105,7 @@ describe('DatePageFilter', () => {
       isReady: true,
       shouldPersist: true,
       desyncedFilters: new Set(),
-      pinnedFilters: new Set(['datetime']),
+      pinnedFilters: new Set(['projects', 'environments', 'datetime']),
       selection: {
         datetime: {
           period: null,

--- a/static/app/components/organizations/environmentPageFilter/index.spec.tsx
+++ b/static/app/components/organizations/environmentPageFilter/index.spec.tsx
@@ -27,14 +27,11 @@ describe('EnvironmentPageFilter', () => {
     OrganizationStore.init();
 
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [],
-        environments: [],
-        datetime: {start: null, end: null, period: '14d', utc: null},
-      },
-      new Set(['environments'])
-    );
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {start: null, end: null, period: '14d', utc: null},
+    });
 
     OrganizationStore.onUpdate(organization, {replace: true});
     ProjectsStore.loadInitialData(projects);

--- a/static/app/components/organizations/pageFilters/container.spec.tsx
+++ b/static/app/components/organizations/pageFilters/container.spec.tsx
@@ -129,7 +129,7 @@ describe('PageFiltersContainer', () => {
       expect(PageFiltersStore.getState()).toEqual({
         isReady: true,
         desyncedFilters: new Set(),
-        pinnedFilters: new Set(),
+        pinnedFilters: new Set(['projects', 'environments', 'datetime']),
         shouldPersist: true,
         selection: {
           datetime: {
@@ -161,7 +161,7 @@ describe('PageFiltersContainer', () => {
       expect(PageFiltersStore.getState()).toEqual({
         isReady: true,
         desyncedFilters: new Set(),
-        pinnedFilters: new Set(),
+        pinnedFilters: new Set(['projects', 'environments', 'datetime']),
         shouldPersist: true,
         selection: {
           datetime: {
@@ -191,7 +191,7 @@ describe('PageFiltersContainer', () => {
       expect(PageFiltersStore.getState()).toEqual({
         isReady: true,
         desyncedFilters: new Set(),
-        pinnedFilters: new Set(),
+        pinnedFilters: new Set(['projects', 'environments', 'datetime']),
         shouldPersist: true,
         selection: {
           datetime: {
@@ -232,7 +232,7 @@ describe('PageFiltersContainer', () => {
     expect(PageFiltersStore.getState()).toEqual({
       isReady: true,
       desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
+      pinnedFilters: new Set(['projects', 'environments', 'datetime']),
       shouldPersist: true,
       selection: {
         datetime: {

--- a/static/app/components/organizations/projectPageFilter/index.spec.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.spec.tsx
@@ -35,14 +35,11 @@ describe('ProjectPageFilter', () => {
     OrganizationStore.init();
 
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [],
-        environments: [],
-        datetime: {start: null, end: null, period: '14d', utc: null},
-      },
-      new Set(['projects'])
-    );
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {start: null, end: null, period: '14d', utc: null},
+    });
 
     OrganizationStore.onUpdate(organization, {replace: true});
     ProjectsStore.loadInitialData(projects);

--- a/static/app/stores/pageFiltersStore.tsx
+++ b/static/app/stores/pageFiltersStore.tsx
@@ -67,11 +67,7 @@ export interface PageFiltersState {
 }
 
 interface PageFiltersStoreDefinition extends StrictStoreDefinition<PageFiltersState> {
-  onInitializeUrlState(
-    newSelection: PageFilters,
-    pinned: Set<PinnedPageFilter>,
-    persist?: boolean
-  ): void;
+  onInitializeUrlState(newSelection: PageFilters, persist?: boolean): void;
   onReset(): void;
   pin(filter: PinnedPageFilter, pin: boolean): void;
   reset(selection?: PageFilters): void;
@@ -110,12 +106,12 @@ const storeConfig: PageFiltersStoreDefinition = {
   /**
    * Initializes the page filters store data
    */
-  onInitializeUrlState(newSelection, pinned, persist = true) {
+  onInitializeUrlState(newSelection, persist = true) {
     this.state = {
       ...this.state,
       isReady: true,
       selection: newSelection,
-      pinnedFilters: pinned,
+      pinnedFilters: new Set<PinnedPageFilter>(['projects', 'environments', 'datetime']),
       shouldPersist: persist,
     };
     this.trigger(this.getState());

--- a/static/app/views/alerts/list/header.spec.tsx
+++ b/static/app/views/alerts/list/header.spec.tsx
@@ -12,19 +12,16 @@ describe('AlertHeader', () => {
   const {organization} = initializeOrg();
   beforeEach(() => {
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [parseInt(project.id, 10)],
-        environments: [],
-        datetime: {
-          period: '7d',
-          start: null,
-          end: null,
-          utc: null,
-        },
+    PageFiltersStore.onInitializeUrlState({
+      projects: [parseInt(project.id, 10)],
+      environments: [],
+      datetime: {
+        period: '7d',
+        start: null,
+        end: null,
+        utc: null,
       },
-      new Set()
-    );
+    });
     ProjectsStore.init();
     ProjectsStore.loadInitialData([project]);
   });

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -54,7 +54,7 @@ describe('AutomationsList', () => {
       url: '/organizations/org-slug/projects/',
       body: [project],
     });
-    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [1]}), new Set());
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [1]}));
     ProjectsStore.loadInitialData([project]);
   });
 
@@ -216,10 +216,7 @@ describe('AutomationsList', () => {
         url: '/organizations/org-slug/detectors/',
         body: [detector],
       });
-      PageFiltersStore.onInitializeUrlState(
-        PageFiltersFixture({projects: [1]}),
-        new Set()
-      );
+      PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [1]}));
     });
 
     it('can select automations', async () => {

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -293,14 +293,11 @@ describe('Dashboards > Detail', () => {
         },
       });
       PageFiltersStore.init();
-      PageFiltersStore.onInitializeUrlState(
-        {
-          projects: [],
-          environments: [],
-          datetime: {start: null, end: null, period: '14d', utc: null},
-        },
-        new Set()
-      );
+      PageFiltersStore.onInitializeUrlState({
+        projects: [],
+        environments: [],
+        datetime: {start: null, end: null, period: '14d', utc: null},
+      });
       widgets = [
         WidgetFixture({
           queries: [

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -35,14 +35,11 @@ describe('NewWidgetBuilder', () => {
     OrganizationStore.init();
 
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [],
-        environments: [],
-        datetime: {start: null, end: null, period: '14d', utc: null},
-      },
-      new Set(['projects'])
-    );
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {start: null, end: null, period: '14d', utc: null},
+    });
 
     OrganizationStore.onUpdate(organization, {replace: true});
     ProjectsStore.loadInitialData(projects);

--- a/static/app/views/detectors/list.spec.tsx
+++ b/static/app/views/detectors/list.spec.tsx
@@ -39,7 +39,7 @@ describe('DetectorsList', () => {
       url: '/organizations/org-slug/detectors/',
       body: [MetricDetectorFixture({name: 'Detector 1'})],
     });
-    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [1]}), new Set());
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [1]}));
   });
 
   it('displays all detector info correctly', async () => {
@@ -295,10 +295,7 @@ describe('DetectorsList', () => {
           }),
         ],
       });
-      PageFiltersStore.onInitializeUrlState(
-        PageFiltersFixture({projects: [1]}),
-        new Set()
-      );
+      PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [1]}));
     });
 
     it('can select detectors', async () => {

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
@@ -12,19 +12,16 @@ describe('useGetTraceItemAttributeValues', () => {
     MockApiClient.clearMockResponses();
 
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [1],
-        environments: [],
-        datetime: {
-          period: '14d',
-          start: null,
-          end: null,
-          utc: false,
-        },
+    PageFiltersStore.onInitializeUrlState({
+      projects: [1],
+      environments: [],
+      datetime: {
+        period: '14d',
+        start: null,
+        end: null,
+        utc: false,
       },
-      new Set()
-    );
+    });
   });
 
   it('getTraceItemAttributeValues works correctly for string type', async () => {

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
@@ -46,19 +46,16 @@ describe('useTraceItemAttributeKeys', () => {
 
     // Setup the PageFilters store with default values
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [1],
-        environments: [],
-        datetime: {
-          period: '14d',
-          start: null,
-          end: null,
-          utc: false,
-        },
+    PageFiltersStore.onInitializeUrlState({
+      projects: [1],
+      environments: [],
+      datetime: {
+        period: '14d',
+        start: null,
+        end: null,
+        utc: false,
       },
-      new Set()
-    );
+    });
   });
 
   it('fetches attribute keys correctly for string type', async () => {

--- a/static/app/views/explore/hooks/useTraces.spec.tsx
+++ b/static/app/views/explore/hooks/useTraces.spec.tsx
@@ -48,19 +48,16 @@ describe('useTraces', () => {
     act(() => {
       ProjectsStore.loadInitialData([project]);
       PageFiltersStore.init();
-      PageFiltersStore.onInitializeUrlState(
-        {
-          projects: [project].map(p => parseInt(p.id, 10)),
-          environments: [],
-          datetime: {
-            period: '3d',
-            start: null,
-            end: null,
-            utc: null,
-          },
+      PageFiltersStore.onInitializeUrlState({
+        projects: [project].map(p => parseInt(p.id, 10)),
+        environments: [],
+        datetime: {
+          period: '3d',
+          start: null,
+          end: null,
+          utc: null,
         },
-        new Set()
-      );
+      });
     });
   });
 

--- a/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
@@ -47,19 +47,16 @@ describe('LogsAggregateTable', () => {
   ProjectsStore.loadInitialData([project]);
 
   PageFiltersStore.init();
-  PageFiltersStore.onInitializeUrlState(
-    {
-      projects: [parseInt(project.id, 10)],
-      environments: [],
-      datetime: {
-        period: '14d',
-        start: null,
-        end: null,
-        utc: null,
-      },
+  PageFiltersStore.onInitializeUrlState({
+    projects: [parseInt(project.id, 10)],
+    environments: [],
+    datetime: {
+      period: '14d',
+      start: null,
+      end: null,
+      utc: null,
     },
-    new Set()
-  );
+  });
   const initialRouterConfig = {
     location: {
       pathname: `/organizations/${organization.slug}/explore/logs/`,

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -141,19 +141,16 @@ describe('LogsInfiniteTable', () => {
     ProjectsStore.loadInitialData([project]);
 
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [parseInt(project.id, 10)],
-        environments: [],
-        datetime: {
-          period: '14d',
-          start: null,
-          end: null,
-          utc: null,
-        },
+    PageFiltersStore.onInitializeUrlState({
+      projects: [parseInt(project.id, 10)],
+      environments: [],
+      datetime: {
+        period: '14d',
+        start: null,
+        end: null,
+        utc: null,
       },
-      new Set()
-    );
+    });
 
     mockUseLocation.mockReturnValue(
       LocationFixture({

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -141,19 +141,16 @@ describe('logsTableRow', () => {
     ProjectsStore.loadInitialData([project]);
 
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [parseInt(project.id, 10)],
-        environments: [],
-        datetime: {
-          period: '14d',
-          start: null,
-          end: null,
-          utc: null,
-        },
+    PageFiltersStore.onInitializeUrlState({
+      projects: [parseInt(project.id, 10)],
+      environments: [],
+      datetime: {
+        period: '14d',
+        start: null,
+        end: null,
+        utc: null,
       },
-      new Set()
-    );
+    });
 
     stacktraceLinkMock = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${projects[0]!.slug}/stacktrace-link/`,

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -30,19 +30,16 @@ describe('MultiQueryModeContent', () => {
     MockApiClient.clearMockResponses();
 
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [project].map(p => parseInt(p.id, 10)),
-        environments: [],
-        datetime: {
-          period: '7d',
-          start: null,
-          end: null,
-          utc: null,
-        },
+    PageFiltersStore.onInitializeUrlState({
+      projects: [project].map(p => parseInt(p.id, 10)),
+      environments: [],
+      datetime: {
+        period: '7d',
+        start: null,
+        end: null,
+        utc: null,
       },
-      new Set()
-    );
+    });
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/setup-check/`,

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -79,14 +79,11 @@ describe('SpansTabContent', () => {
     jest.spyOn(console, 'error').mockImplementation();
 
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [project].map(p => parseInt(p.id, 10)),
-        environments: [],
-        datetime: {period: '7d', start: null, end: null, utc: null},
-      },
-      new Set()
-    );
+    PageFiltersStore.onInitializeUrlState({
+      projects: [project].map(p => parseInt(p.id, 10)),
+      environments: [],
+      datetime: {period: '7d', start: null, end: null, utc: null},
+    });
     MockApiClient.addMockResponse({
       url: `/subscriptions/${organization.slug}/`,
       method: 'GET',

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
@@ -30,7 +30,7 @@ describe('PageOverviewSidebar', () => {
         utc: null,
       },
     };
-    PageFiltersStore.onInitializeUrlState(pageFilters, new Set());
+    PageFiltersStore.onInitializeUrlState(pageFilters);
     const project = ProjectFixture({id: '1', slug: 'project-slug'});
     ProjectsStore.loadInitialData([project]);
 

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
@@ -33,7 +33,7 @@ describe('PageOverview', () => {
         utc: null,
       },
     };
-    PageFiltersStore.onInitializeUrlState(pageFilters, new Set());
+    PageFiltersStore.onInitializeUrlState(pageFilters);
     const project = ProjectFixture({id: '1', slug: 'project-slug'});
     ProjectsStore.loadInitialData([project]);
 

--- a/static/app/views/issueDetails/groupUptimeChecks.spec.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.spec.tsx
@@ -51,14 +51,11 @@ describe('GroupUptimeChecks', () => {
       url: `/organizations/${organization.slug}/detectors/123/`,
       body: UptimeDetectorFixture({id: '123'}),
     });
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [Number(project.id)],
-        environments: [],
-        datetime: {period: '24h', start: null, end: null, utc: null},
-      },
-      new Set()
-    );
+    PageFiltersStore.onInitializeUrlState({
+      projects: [Number(project.id)],
+      environments: [],
+      datetime: {period: '24h', start: null, end: null, utc: null},
+    });
   });
 
   it('renders the empty uptime check table', async () => {

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
@@ -57,14 +57,11 @@ describe('EventDetailsHeader', () => {
       body: [],
     });
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [],
-        environments: [],
-        datetime: {start: null, end: null, period: '14d', utc: null},
-      },
-      new Set(['environments'])
-    );
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {start: null, end: null, period: '14d', utc: null},
+    });
     ProjectsStore.loadInitialData([project]);
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/',

--- a/static/app/views/issueDetails/streamline/eventGraph.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.spec.tsx
@@ -45,14 +45,11 @@ describe('EventGraph', () => {
       body: [project],
     });
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [],
-        environments: [],
-        datetime: {start: null, end: null, period: '14d', utc: null},
-      },
-      new Set(['environments'])
-    );
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {start: null, end: null, period: '14d', utc: null},
+    });
     ProjectsStore.loadInitialData([project]);
     mockEventStats = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-stats/`,

--- a/static/app/views/issueList/index.spec.tsx
+++ b/static/app/views/issueList/index.spec.tsx
@@ -26,14 +26,11 @@ describe('IssueListContainer', () => {
   describe('issue views', () => {
     beforeEach(() => {
       PageFiltersStore.init();
-      PageFiltersStore.onInitializeUrlState(
-        {
-          projects: [],
-          environments: [],
-          datetime: {start: null, end: null, period: '14d', utc: null},
-        },
-        new Set(['projects'])
-      );
+      PageFiltersStore.onInitializeUrlState({
+        projects: [],
+        environments: [],
+        datetime: {start: null, end: null, period: '14d', utc: null},
+      });
 
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/group-search-views/100/',

--- a/static/app/views/issueList/issueViews/issueViewSaveButton.spec.tsx
+++ b/static/app/views/issueList/issueViews/issueViewSaveButton.spec.tsx
@@ -52,7 +52,7 @@ const initialRouterConfigView = {
 };
 
 describe('IssueViewSaveButton', () => {
-  PageFiltersStore.onInitializeUrlState(defaultPageFilters, new Set());
+  PageFiltersStore.onInitializeUrlState(defaultPageFilters);
 
   beforeEach(() => {
     MockApiClient.addMockResponse({
@@ -68,7 +68,7 @@ describe('IssueViewSaveButton', () => {
       body: mockGroupSearchView,
     });
 
-    PageFiltersStore.onInitializeUrlState(defaultPageFilters, new Set());
+    PageFiltersStore.onInitializeUrlState(defaultPageFilters);
 
     const {router} = render(
       <Fragment>
@@ -120,7 +120,7 @@ describe('IssueViewSaveButton', () => {
       body: mockGroupSearchView,
     });
 
-    PageFiltersStore.onInitializeUrlState(defaultPageFilters, new Set());
+    PageFiltersStore.onInitializeUrlState(defaultPageFilters);
 
     const {router} = render(
       <Fragment>
@@ -228,7 +228,7 @@ describe('IssueViewSaveButton', () => {
       body: mockGroupSearchView,
     });
 
-    PageFiltersStore.onInitializeUrlState(defaultPageFilters, new Set());
+    PageFiltersStore.onInitializeUrlState(defaultPageFilters);
 
     const {router} = render(
       <Fragment>
@@ -279,7 +279,7 @@ describe('IssueViewSaveButton', () => {
   });
 
   it('can discard unsaved changes', async () => {
-    PageFiltersStore.onInitializeUrlState(defaultPageFilters, new Set());
+    PageFiltersStore.onInitializeUrlState(defaultPageFilters);
 
     const {router} = render(<IssueViewSaveButton {...defaultProps} />, {
       initialRouterConfig: {

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -143,14 +143,11 @@ describe('IssueList', () => {
       body: [project],
     });
 
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [parseInt(projects[0]!.id, 10)],
-        environments: [],
-        datetime: {period: '14d', start: null, end: null, utc: null},
-      },
-      new Set()
-    );
+    PageFiltersStore.onInitializeUrlState({
+      projects: [parseInt(projects[0]!.id, 10)],
+      environments: [],
+      datetime: {period: '14d', start: null, end: null, utc: null},
+    });
 
     TagStore.init?.();
   });
@@ -256,14 +253,11 @@ describe('IssueList', () => {
         },
       });
 
-      PageFiltersStore.onInitializeUrlState(
-        {
-          projects: [],
-          environments: [],
-          datetime: {period: '14d', start: null, end: null, utc: null},
-        },
-        new Set()
-      );
+      PageFiltersStore.onInitializeUrlState({
+        projects: [],
+        environments: [],
+        datetime: {period: '14d', start: null, end: null, utc: null},
+      });
 
       const {unmount} = render(<IssueListOverview {...routerProps} />, {
         organization,
@@ -429,14 +423,11 @@ describe('IssueList', () => {
       });
 
       act(() =>
-        PageFiltersStore.onInitializeUrlState(
-          {
-            projects: [99],
-            environments: [],
-            datetime: {period: '24h', start: null, end: null, utc: null},
-          },
-          new Set()
-        )
+        PageFiltersStore.onInitializeUrlState({
+          projects: [99],
+          environments: [],
+          datetime: {period: '24h', start: null, end: null, utc: null},
+        })
       );
 
       rerender(<IssueListOverview {...routerProps} />);
@@ -458,14 +449,11 @@ describe('IssueList', () => {
       });
 
       act(() =>
-        PageFiltersStore.onInitializeUrlState(
-          {
-            projects: [99],
-            environments: [],
-            datetime: {period: '14d', start: null, end: null, utc: null},
-          },
-          new Set()
-        )
+        PageFiltersStore.onInitializeUrlState({
+          projects: [99],
+          environments: [],
+          datetime: {period: '14d', start: null, end: null, utc: null},
+        })
       );
 
       rerender(<IssueListOverview {...routerProps} />);
@@ -492,14 +480,11 @@ describe('IssueList', () => {
       });
 
       act(() =>
-        PageFiltersStore.onInitializeUrlState(
-          {
-            projects: [99],
-            environments: [],
-            datetime: {period: '24h', start: null, end: null, utc: null},
-          },
-          new Set()
-        )
+        PageFiltersStore.onInitializeUrlState({
+          projects: [99],
+          environments: [],
+          datetime: {period: '24h', start: null, end: null, utc: null},
+        })
       );
       rerender(<IssueListOverview {...routerProps} />);
 
@@ -582,14 +567,11 @@ describe('IssueList', () => {
 
   describe('Error Robot', () => {
     beforeEach(() => {
-      PageFiltersStore.onInitializeUrlState(
-        {
-          projects: [],
-          environments: [],
-          datetime: {period: '14d', start: null, end: null, utc: null},
-        },
-        new Set()
-      );
+      PageFiltersStore.onInitializeUrlState({
+        projects: [],
+        environments: [],
+        datetime: {period: '14d', start: null, end: null, utc: null},
+      });
     });
 
     const createWrapper = async (moreProps: any) => {

--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -40,7 +40,7 @@ describe('OrganizationStats', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(defaultSelection, new Set());
+    PageFiltersStore.onInitializeUrlState(defaultSelection);
     OrganizationStore.onUpdate(organization, {replace: true});
     ProjectsStore.loadInitialData(projects);
     mockRequest = MockApiClient.addMockResponse({

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -891,19 +891,16 @@ describe('trace view', () => {
     ProjectsStore.loadInitialData([project]);
 
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [parseInt(project.id, 10)],
-        environments: [],
-        datetime: {
-          period: '14d',
-          start: null,
-          end: null,
-          utc: null,
-        },
+    PageFiltersStore.onInitializeUrlState({
+      projects: [parseInt(project.id, 10)],
+      environments: [],
+      datetime: {
+        period: '14d',
+        start: null,
+        end: null,
+        utc: null,
       },
-      new Set()
-    );
+    });
     mockUseProjects.mockReturnValue({
       projects: [
         {

--- a/static/app/views/performance/onboarding.spec.tsx
+++ b/static/app/views/performance/onboarding.spec.tsx
@@ -122,19 +122,16 @@ describe('Testing new onboarding ui', () => {
       body: projectMock,
     });
 
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [parseInt(projectMock.id, 10)],
-        environments: [],
-        datetime: {
-          period: '14d',
-          start: null,
-          end: null,
-          utc: null,
-        },
+    PageFiltersStore.onInitializeUrlState({
+      projects: [parseInt(projectMock.id, 10)],
+      environments: [],
+      datetime: {
+        period: '14d',
+        start: null,
+        end: null,
+        utc: null,
       },
-      new Set()
-    );
+    });
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/traces/`,
@@ -187,19 +184,16 @@ describe('Testing new onboarding ui', () => {
       body: projectMock,
     });
 
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [parseInt(projectMock.id, 10)],
-        environments: [],
-        datetime: {
-          period: '14d',
-          start: null,
-          end: null,
-          utc: null,
-        },
+    PageFiltersStore.onInitializeUrlState({
+      projects: [parseInt(projectMock.id, 10)],
+      environments: [],
+      datetime: {
+        period: '14d',
+        start: null,
+        end: null,
+        utc: null,
       },
-      new Set()
-    );
+    });
 
     const trace = {
       breakdowns: [],

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -40,14 +40,11 @@ describe('ReleasesList', () => {
 
   beforeEach(() => {
     act(() => ProjectsStore.loadInitialData(projects));
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [],
-        environments: [],
-        datetime: {period: null, utc: null, start: null, end: null},
-      },
-      new Set()
-    );
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {period: null, utc: null, start: null, end: null},
+    });
     endpointMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/releases/`,
       body: [

--- a/static/app/views/replays/list.spec.tsx
+++ b/static/app/views/replays/list.spec.tsx
@@ -54,14 +54,11 @@ describe('ReplayList', () => {
   let mockFetchReplayListRequest: jest.Mock;
   beforeEach(() => {
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [],
-        environments: [],
-        datetime: {start: null, end: null, period: '14d', utc: null},
-      },
-      new Set(['projects'])
-    );
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {start: null, end: null, period: '14d', utc: null},
+    });
 
     mockUseHaveSelectedProjectsSentAnyReplayEvents.mockClear();
     mockUseProjectSdkNeedsUpdate.mockClear();

--- a/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.spec.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.spec.tsx
@@ -51,19 +51,16 @@ describe('AttributeField', () => {
 
     // Setup the PageFilters store with default values
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [1],
-        environments: [],
-        datetime: {
-          period: '14d',
-          start: null,
-          end: null,
-          utc: false,
-        },
+    PageFiltersStore.onInitializeUrlState({
+      projects: [1],
+      environments: [],
+      datetime: {
+        period: '14d',
+        start: null,
+        end: null,
+        utc: false,
       },
-      new Set()
-    );
+    });
   });
 
   it('default render', async () => {

--- a/tests/js/fixtures/log.ts
+++ b/tests/js/fixtures/log.ts
@@ -176,7 +176,7 @@ export function initializeLogsTest({
   const setupPageFilters = () => {
     ProjectsStore.loadInitialData([project]);
     PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(initialPageFilters, new Set());
+    PageFiltersStore.onInitializeUrlState(initialPageFilters);
   };
 
   const setupEventsMock = (logFixtures: OurLogsResponseItem[]) => {


### PR DESCRIPTION
This flag is rolled out for everyone, so we don't need to check for it in code anymore.

Followups:
https://github.com/getsentry/sentry/pull/100556
https://github.com/getsentry/sentry-options-automator/pull/5318