### PR TITLE
chore(explore): Migrate traces to use query params for fields

### DIFF
--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -31,7 +31,7 @@ export type TracingEventParameters = {
     natural_language_query: string;
   };
   'trace.explorer.metadata': {
-    columns: string[];
+    columns: readonly string[];
     columns_count: number;
     confidences: string[];
     dataScanned: string;

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -7,7 +7,6 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {
   PageParamsProvider,
   useExplorePageParams,
-  useSetExploreFields,
   useSetExploreMode,
   useSetExplorePageParams,
   useSetExploreQuery,
@@ -21,6 +20,7 @@ import {
   Visualize,
 } from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {
+  useSetQueryParamsFields,
   useSetQueryParamsGroupBys,
   useSetQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
@@ -52,7 +52,7 @@ describe('defaults', () => {
 describe('PageParamsProvider', () => {
   let pageParams: ReturnType<typeof useExplorePageParams>;
   let setPageParams: ReturnType<typeof useSetExplorePageParams>;
-  let setFields: ReturnType<typeof useSetExploreFields>;
+  let setFields: ReturnType<typeof useSetQueryParamsFields>;
   let setGroupBys: ReturnType<typeof useSetQueryParamsGroupBys>;
   let setMode: ReturnType<typeof useSetExploreMode>;
   let setQuery: ReturnType<typeof useSetExploreQuery>;
@@ -62,7 +62,7 @@ describe('PageParamsProvider', () => {
   function Component() {
     pageParams = useExplorePageParams();
     setPageParams = useSetExplorePageParams();
-    setFields = useSetExploreFields();
+    setFields = useSetQueryParamsFields();
     setGroupBys = useSetQueryParamsGroupBys();
     setMode = useSetExploreMode();
     setQuery = useSetExploreQuery();
@@ -692,8 +692,7 @@ describe('PageParamsProvider', () => {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        // span.duration should be added automatically once setPageParams is migrated to use setQueryParams.
-        fields: ['id', 'timestamp', 'span.self_time' /* 'span.duration' */],
+        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
       })
     );
   });

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -249,11 +249,6 @@ export function useExploreDataset(): DiscoverDatasets {
   return DiscoverDatasets.SPANS;
 }
 
-export function useExploreFields(): string[] {
-  const pageParams = useExplorePageParams();
-  return pageParams.fields;
-}
-
 export function useExploreQuery(): string {
   const pageParams = useExplorePageParams();
   return pageParams.query;
@@ -505,16 +500,6 @@ export function useSetExplorePageParams(): (
       navigate(target);
     },
     [location, navigate, readablePageParams, managedFields, setManagedFields]
-  );
-}
-
-export function useSetExploreFields() {
-  const setPageParams = useSetExplorePageParams();
-  return useCallback(
-    (fields: string[]) => {
-      setPageParams({fields});
-    },
-    [setPageParams]
   );
 }
 

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -13,7 +13,6 @@ import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {
   useExploreDataset,
-  useExploreFields,
   useExploreQuery,
   useExploreTitle,
 } from 'sentry/views/explore/contexts/pageParamsContext';
@@ -370,7 +369,7 @@ export function useAnalytics({
   const dataset = useExploreDataset();
   const title = useExploreTitle();
   const query = useExploreQuery();
-  const fields = useExploreFields();
+  const fields = useQueryParamsFields();
   const visualizes = useQueryParamsVisualizes();
   const topEvents = useTopEvents();
   const isTopN = topEvents ? topEvents > 0 : false;

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -44,7 +44,7 @@ const {info, fmt} = Sentry.logger;
 interface UseTrackAnalyticsProps {
   aggregatesTableResult: AggregatesTableResult;
   dataset: DiscoverDatasets;
-  fields: string[];
+  fields: readonly string[];
   interval: string;
   isTopN: boolean;
   page_source: 'explore' | 'compare';

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -6,14 +6,16 @@ import EventView from 'sentry/utils/discover/eventView';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {
   useExploreDataset,
-  useExploreFields,
   useExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {
   useProgressiveQuery,
   type SpansRPCQueryExtras,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
-import {useQueryParamsExtrapolate} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsExtrapolate,
+  useQueryParamsFields,
+} from 'sentry/views/explore/queryParams/context';
 import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
 
 interface UseExploreSpansTableOptions {
@@ -63,7 +65,7 @@ function useExploreSpansTableImp({
   const {selection} = usePageFilters();
 
   const dataset = useExploreDataset();
-  const fields = useExploreFields();
+  const fields = useQueryParamsFields();
   const sortBys = useExploreSortBys();
 
   const visibleFields = useMemo(

--- a/static/app/views/explore/hooks/useSortByFields.tsx
+++ b/static/app/views/explore/hooks/useSortByFields.tsx
@@ -7,7 +7,12 @@ import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
-type Props = {fields: string[]; groupBys: readonly string[]; mode: Mode; yAxes: string[]};
+interface Props {
+  fields: readonly string[];
+  groupBys: readonly string[];
+  mode: Mode;
+  yAxes: string[];
+}
 
 export function useSortByFields({fields, yAxes, groupBys, mode}: Props) {
   const {tags: numberTags} = useTraceItemTags('number');

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -14,13 +14,13 @@ import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import type {TagCollection} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {FieldKind} from 'sentry/utils/fields';
-import {
-  PageParamsProvider,
-  useExploreFields,
-} from 'sentry/views/explore/contexts/pageParamsContext';
+import {PageParamsProvider} from 'sentry/views/explore/contexts/pageParamsContext';
 import * as spanTagsModule from 'sentry/views/explore/contexts/spanTagsContext';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
-import {useQueryParamsGroupBys} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsFields,
+  useQueryParamsGroupBys,
+} from 'sentry/views/explore/queryParams/context';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {SpansTabContent} from 'sentry/views/explore/spans/spansTab';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -169,7 +169,7 @@ describe('SpansTabContent', () => {
     let fields: string[] = [];
     let groupBys: readonly string[] = [];
     function Component() {
-      fields = useExploreFields();
+      fields = useQueryParamsFields();
       groupBys = useQueryParamsGroupBys();
       return <SpansTabContent datePageFilterProps={datePageFilterProps} />;
     }

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -166,7 +166,7 @@ describe('SpansTabContent', () => {
   });
 
   it('inserts group bys from aggregate mode as fields in samples mode', async () => {
-    let fields: string[] = [];
+    let fields: readonly string[] = [];
     let groupBys: readonly string[] = [];
     function Component() {
       fields = useQueryParamsFields();

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -50,7 +50,6 @@ import SchemaHintsList, {
 } from 'sentry/views/explore/components/schemaHints/schemaHintsList';
 import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHints/schemaHintsUtils';
 import {
-  useExploreFields,
   useExploreId,
   useExploreQuery,
   useSetExplorePageParams,
@@ -67,6 +66,7 @@ import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
 import {useVisitQuery} from 'sentry/views/explore/hooks/useVisitQuery';
 import {
   useQueryParamsExtrapolate,
+  useQueryParamsFields,
   useQueryParamsMode,
   useQueryParamsVisualizes,
   useSetQueryParamsVisualizes,
@@ -226,7 +226,7 @@ function SpansSearchBar({
 
 function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) {
   const mode = useQueryParamsMode();
-  const fields = useExploreFields();
+  const fields = useQueryParamsFields();
   const query = useExploreQuery();
   const setExplorePageParams = useSetExplorePageParams();
 

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -31,7 +31,6 @@ import {
   useTableStyles,
 } from 'sentry/views/explore/components/table';
 import {
-  useExploreFields,
   useExploreQuery,
   useExploreSortBys,
   useSetExploreSortBys,
@@ -44,6 +43,7 @@ import {TOP_EVENTS_LIMIT, useTopEvents} from 'sentry/views/explore/hooks/useTopE
 import {
   useQueryParamsAggregateCursor,
   useQueryParamsAggregateFields,
+  useQueryParamsFields,
   useQueryParamsGroupBys,
   useQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
@@ -63,7 +63,7 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
 
   const topEvents = useTopEvents();
   const aggregateFields = useQueryParamsAggregateFields();
-  const fields = useExploreFields();
+  const fields = useQueryParamsFields();
   const groupBys = useQueryParamsGroupBys();
   const visualizes = useQueryParamsVisualizes();
   const sorts = useExploreSortBys();

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -129,7 +129,7 @@ export function ColumnEditorModal({
 
   // We keep a temporary state for the columns so that we can apply the changes
   // only when the user clicks on the apply button.
-  const [tempColumns, setTempColumns] = useState<string[]>(columns);
+  const [tempColumns, setTempColumns] = useState<string[]>(columns.slice());
 
   function handleApply() {
     onColumnsChange(tempColumns.filter(Boolean));

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -25,7 +25,7 @@ import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface ColumnEditorModalProps extends ModalRenderProps {
-  columns: string[];
+  columns: readonly string[];
   numberTags: TagCollection;
   onColumnsChange: (columns: string[]) => void;
   stringTags: TagCollection;

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -10,10 +10,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Confidence} from 'sentry/types/organization';
 import useOrganization from 'sentry/utils/useOrganization';
-import {
-  useExploreFields,
-  useSetExploreFields,
-} from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
@@ -22,7 +18,9 @@ import type {TracesTableResult} from 'sentry/views/explore/hooks/useExploreTrace
 import {Tab} from 'sentry/views/explore/hooks/useTab';
 import {
   useQueryParamsAggregateFields,
+  useQueryParamsFields,
   useSetQueryParamsAggregateFields,
+  useSetQueryParamsFields,
 } from 'sentry/views/explore/queryParams/context';
 import {AggregateColumnEditorModal} from 'sentry/views/explore/tables/aggregateColumnEditorModal';
 import {AggregatesTable} from 'sentry/views/explore/tables/aggregatesTable';
@@ -48,8 +46,8 @@ export function ExploreTables(props: ExploreTablesProps) {
   const aggregateFields = useQueryParamsAggregateFields();
   const setAggregateFields = useSetQueryParamsAggregateFields();
 
-  const fields = useExploreFields();
-  const setFields = useSetExploreFields();
+  const fields = useQueryParamsFields();
+  const setFields = useSetQueryParamsFields();
 
   const {tags: numberTags} = useTraceItemTags('number');
   const {tags: stringTags} = useTraceItemTags('string');

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -23,13 +23,13 @@ import {
   useTableStyles,
 } from 'sentry/views/explore/components/table';
 import {
-  useExploreFields,
   useExploreSortBys,
   useSetExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import {usePaginationAnalytics} from 'sentry/views/explore/hooks/usePaginationAnalytics';
+import {useQueryParamsFields} from 'sentry/views/explore/queryParams/context';
 
 import {FieldRenderer} from './fieldRenderer';
 
@@ -38,12 +38,12 @@ interface SpansTableProps {
 }
 
 export function SpansTable({spansTableResult}: SpansTableProps) {
-  const fields = useExploreFields();
+  const fields = useQueryParamsFields();
   const sortBys = useExploreSortBys();
   const setSortBys = useSetExploreSortBys();
 
   const visibleFields = useMemo(
-    () => (fields.includes('id') ? fields : ['id', ...fields]),
+    () => (fields.includes('id') ? [...fields] : ['id', ...fields]),
     [fields]
   );
 

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -16,7 +16,6 @@ import {openAddToDashboardModal} from 'sentry/actionCreators/modal';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {
   PageParamsProvider,
-  useExploreFields,
   useExploreSortBys,
   useSetExploreMode,
 } from 'sentry/views/explore/contexts/pageParamsContext';
@@ -24,6 +23,7 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {
   useQueryParamsAggregateFields,
+  useQueryParamsFields,
   useQueryParamsGroupBys,
   useQueryParamsMode,
   useQueryParamsVisualizes,
@@ -230,10 +230,10 @@ describe('ExploreToolbar', () => {
   });
 
   it('allows changing visualizes', async () => {
-    let fields!: string[];
+    let fields!: readonly string[];
     let visualizes: any;
     function Component() {
-      fields = useExploreFields();
+      fields = useQueryParamsFields();
       visualizes = useQueryParamsVisualizes();
       return <ExploreToolbar />;
     }

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -28,7 +28,6 @@ import useProjects from 'sentry/utils/useProjects';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {ToolbarSection} from 'sentry/views/explore/components/toolbar/styles';
 import {
-  useExploreFields,
   useExploreId,
   useExploreQuery,
   useExploreSortBys,
@@ -39,6 +38,7 @@ import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {useSpansSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
 import {generateExploreCompareRoute} from 'sentry/views/explore/multiQueryMode/locationUtils';
 import {
+  useQueryParamsFields,
   useQueryParamsGroupBys,
   useQueryParamsMode,
   useQueryParamsVisualizes,
@@ -59,7 +59,7 @@ export function ToolbarSaveAs() {
   const query = useExploreQuery();
   const groupBys = useQueryParamsGroupBys();
   const visualizes = useQueryParamsVisualizes();
-  const fields = useExploreFields();
+  const fields = useQueryParamsFields();
   const sortBys = useExploreSortBys();
   const mode = useQueryParamsMode();
   const id = useExploreId();

--- a/static/app/views/explore/toolbar/toolbarSortBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarSortBy.tsx
@@ -13,7 +13,6 @@ import {
   ToolbarSection,
 } from 'sentry/views/explore/components/toolbar/styles';
 import {
-  useExploreFields,
   useExploreSortBys,
   useSetExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
@@ -21,6 +20,7 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useSortByFields} from 'sentry/views/explore/hooks/useSortByFields';
 import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
 import {
+  useQueryParamsFields,
   useQueryParamsGroupBys,
   useQueryParamsMode,
   useQueryParamsVisualizes,
@@ -28,7 +28,7 @@ import {
 
 export function ToolbarSortBy() {
   const mode = useQueryParamsMode();
-  const fields = useExploreFields();
+  const fields = useQueryParamsFields();
   const groupBys = useQueryParamsGroupBys();
   const visualizes = useQueryParamsVisualizes();
 

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -267,7 +267,7 @@ export function generateTargetQuery({
   sorts,
   yAxes,
 }: {
-  fields: string[];
+  fields: readonly string[];
   groupBys: readonly string[];
   location: Location;
   // needed to generate targets when `project` is in the group by
@@ -365,7 +365,7 @@ export function viewSamplesTarget({
   row,
   projects,
 }: {
-  fields: string[];
+  fields: readonly string[];
   groupBys: readonly string[];
   location: Location;
   // needed to generate targets when `project` is in the group by


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch trace explorer to use query-param-managed `fields`, removing pageParams field setters, updating components/tests/analytics, and adopting readonly types.
> 
> - **Explore (traces)**:
>   - Migrate `fields` to query params: replace `useExploreFields`/`useSetExploreFields` with `useQueryParamsFields`/setter across spans tab, tables, toolbar, hooks, and specs.
>   - Remove `useExploreFields` and `useSetExploreFields` from `pageParamsContext`; adjust consumers accordingly.
>   - Ensure `span.duration` is auto-managed with visualize changes; update expectations in tests.
> - **Types/immutability**:
>   - Make `fields`/`columns` parameters readonly (`readonly string[]`) across analytics, hooks, utilities, and column editor; clone where mutation needed.
>   - Update `useSortByFields`, `useExploreSpansTable`, `generateTargetQuery`/`viewSamplesTarget`, and table components to accept readonly arrays and maintain visible fields immutably.
> - **Analytics**:
>   - Update `trace.explorer.metadata` typing to accept readonly `columns`; use query-param `fields` for samples/compare analytics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28140e5c6c0d3f5f68b76129dfee8cada16c1cb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->