### PR TITLE
fix(aci milestone 3): pass correct action identifier

### DIFF
--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -24,6 +24,7 @@ from sentry.snuba.referrer import Referrer
 from sentry.snuba.utils import build_query_strings
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
+from sentry.workflow_engine.models import AlertRuleDetector
 
 CRASH_FREE_SESSIONS = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
 CRASH_FREE_USERS = "percentage(users_crashed, users) AS _crash_rate_alert_aggregate"
@@ -134,6 +135,16 @@ def fetch_metric_issue_open_periods(
     user: User | RpcUser | None = None,
 ) -> list[Any]:
     try:
+        if features.has(
+            "organizations:workflow-engine-single-process-metric-issues",
+            organization,  # Metric issue single processing
+        ):
+            # temporarily fetch the alert rule ID from the detector ID
+            alert_rule_id = AlertRuleDetector.objects.get(
+                detector_id=open_period_identifier
+            ).alert_rule_id
+            open_period_identifier = alert_rule_id
+
         resp = client.get(
             auth=ApiKey(organization_id=organization.id, scope_list=["org:read"]),
             user=user,

--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -15,7 +15,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.groupopenperiod import get_latest_open_period
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.snuba.models import QuerySubscription, SnubaQuery
-from sentry.workflow_engine.models import Action, AlertRuleDetector, Condition, Detector
+from sentry.workflow_engine.models import Action, Condition, Detector
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
 if TYPE_CHECKING:
@@ -130,17 +130,9 @@ class AlertContext:
         except StopIteration:
             raise ValueError("No threshold type found for metric issues")
 
-        try:
-            alert_rule_detector = AlertRuleDetector.objects.get(detector_id=detector.id)
-            alert_rule_id = alert_rule_detector.alert_rule_id
-            if alert_rule_id is None:
-                raise ValueError("Metric issue missing corresponding alert rule")
-        except AlertRuleDetector.DoesNotExist:
-            raise ValueError("Metric issue missing corresponding alert rule")
-
         return cls(
             name=detector.name,
-            action_identifier_id=alert_rule_id,
+            action_identifier_id=detector.id,
             threshold_type=threshold_type,
             detection_type=AlertRuleDetectionType(detector.config.get("detection_type")),
             comparison_delta=detector.config.get("comparison_delta"),


### PR DESCRIPTION
`fetch_metric_issue_open_periods` is still using the legacy incident endpoint to fetch the incidents for metric issue charts. [(link)](https://github.com/getsentry/sentry/blob/5eff1769a64fa0ab7d8bd4986116b1e8f6cd760b/src/sentry/incidents/charts.py#L130-L148) While we build out the open periods endpoint, get the alert rule ID from the lookup tables and pass it to the chart-building method.