### PR TITLE
fix(aci): Display open period ids, fix anomaly tooltips

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -946,6 +946,7 @@ export interface BaseGroup {
 export interface GroupOpenPeriod {
   duration: string;
   end: string;
+  id: string;
   isOpen: boolean;
   lastChecked: string;
   start: string;

--- a/static/app/views/detectors/components/details/common/ongoingIssues.tsx
+++ b/static/app/views/detectors/components/details/common/ongoingIssues.tsx
@@ -84,7 +84,7 @@ function OpenPeriodsSubTable({groupId, onZoom}: OpenPeriodsSubTableProps) {
           <SimpleTable.Row key={`${period.start}-${idx}`}>
             <SimpleTable.RowCell>
               {/* TODO: Status Color */}
-              #ID_MISSING
+              <Text tabular>#{period.id}</Text>
             </SimpleTable.RowCell>
             <SimpleTable.RowCell>
               <Text>

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -44,7 +44,7 @@ function incidentSeriesTooltip(ctx: IncidentTooltipContext) {
   const priorityDot = `<span style="display:inline-block;width:10px;height:8px;border-radius:100%;background:${ctx.theme.red400};margin-right:6px;vertical-align:middle;"></span>`;
   return [
     '<div class="tooltip-series">',
-    `<div><span class="tooltip-label"><strong>#ID_MISSING</strong></span></div>`,
+    `<div><span class="tooltip-label"><strong>#${ctx.period.id}</strong></span></div>`,
     `<div><span class="tooltip-label">${t('Started')}</span> ${startTime}</div>`,
     `<div><span class="tooltip-label">${t('Ended')}</span> ${endTime}</div>`,
     `<div><span class="tooltip-label">${t('Priority')}</span> ${priorityDot} ${t('Critical')}</div>`,
@@ -58,7 +58,7 @@ function incidentMarklineTooltip(ctx: IncidentTooltipContext) {
   const priorityDot = `<span style="display:inline-block;width:10px;height:8px;border-radius:100%;background:${ctx.theme.red400};margin-right:6px;vertical-align:middle;"></span>`;
   return [
     '<div class="tooltip-series">',
-    `<div><span class="tooltip-label"><strong>${t('#%s Triggered', 'ID_MISSING')}</strong></span></div>`,
+    `<div><span class="tooltip-label"><strong>${t('#%s Triggered', ctx.period.id)}</strong></span></div>`,
     `<div><span class="tooltip-label">${t('Started')}</span> ${time}</div>`,
     `<div><span class="tooltip-label">${t('Priority')}</span> ${priorityDot} ${t('Critical')}</div>`,
     '</div>',

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -1,8 +1,10 @@
 import {Fragment, useMemo} from 'react';
+import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {YAXisComponentOption} from 'echarts';
 
 import {AreaChart} from 'sentry/components/charts/areaChart';
+import {defaultFormatAxisLabel} from 'sentry/components/charts/components/tooltip';
 import ErrorPanel from 'sentry/components/charts/errorPanel';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {Flex} from 'sentry/components/core/layout';
@@ -25,6 +27,7 @@ import {
 import {getBackendDataset} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import type {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {useIncidentMarkers} from 'sentry/views/detectors/hooks/useIncidentMarkers';
+import type {IncidentPeriod} from 'sentry/views/detectors/hooks/useIncidentMarkers';
 import {useMetricDetectorAnomalyPeriods} from 'sentry/views/detectors/hooks/useMetricDetectorAnomalyPeriods';
 import {useMetricDetectorSeries} from 'sentry/views/detectors/hooks/useMetricDetectorSeries';
 import {useMetricDetectorThresholdSeries} from 'sentry/views/detectors/hooks/useMetricDetectorThresholdSeries';
@@ -32,6 +35,37 @@ import {useTimePeriodSelection} from 'sentry/views/detectors/hooks/useTimePeriod
 import {getDetectorChartFormatters} from 'sentry/views/detectors/utils/detectorChartFormatting';
 
 const CHART_HEIGHT = 180;
+
+interface AnomalyTooltipContext {
+  period: IncidentPeriod;
+  theme: Theme;
+}
+
+function anomalySeriesTooltip(ctx: AnomalyTooltipContext) {
+  const startTime = defaultFormatAxisLabel(ctx.period.start, true, false, true, false);
+  const endTime = ctx.period.end
+    ? defaultFormatAxisLabel(ctx.period.end, true, false, true, false)
+    : '-';
+  return [
+    '<div class="tooltip-series">',
+    `<div><span class="tooltip-label"><strong>${t('Anomaly')}</strong></span></div>`,
+    `<div><span class="tooltip-label">${t('Started')}</span> ${startTime}</div>`,
+    `<div><span class="tooltip-label">${t('Ended')}</span> ${endTime}</div>`,
+    '</div>',
+    '<div class="tooltip-arrow arrow-top"></div>',
+  ].join('');
+}
+
+function anomalyMarklineTooltip(ctx: AnomalyTooltipContext) {
+  const time = defaultFormatAxisLabel(ctx.period.start, true, false, true, false);
+  return [
+    '<div class="tooltip-series">',
+    `<div><span class="tooltip-label"><strong>${t('Anomaly Detected')}</strong></span></div>`,
+    `<div><span class="tooltip-label">${t('Started')}</span> ${time}</div>`,
+    '</div>',
+    '<div class="tooltip-arrow arrow-top"></div>',
+  ].join('');
+}
 
 function ChartError() {
   return (
@@ -174,6 +208,8 @@ export function MetricDetectorChart({
     seriesName: t('Anomalies'),
     seriesId: '__anomaly_marker__',
     yAxisIndex: 1, // Use index 1 to avoid conflict with main chart axis
+    seriesTooltip: anomalySeriesTooltip,
+    markLineTooltip: anomalyMarklineTooltip,
   });
 
   // Calculate y-axis bounds to ensure all thresholds are visible

--- a/static/app/views/detectors/hooks/useIncidentMarkers.tsx
+++ b/static/app/views/detectors/hooks/useIncidentMarkers.tsx
@@ -45,6 +45,7 @@ export interface IncidentPeriod {
    * End timestamp in milliseconds
    */
   end: number;
+  id: string;
   /**
    * Display name for the incident
    */

--- a/static/app/views/detectors/hooks/useMetricDetectorAnomalyPeriods.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorAnomalyPeriods.tsx
@@ -76,6 +76,8 @@ function groupAnomaliesForBubbles(
       if (currentPeriod === null) {
         // Start a new anomaly period
         currentPeriod = {
+          // Anomaly id is not shown
+          id: anomalies.indexOf(anomaly).toString(),
           type: anomaly.anomaly.anomaly_type,
           name: isHighConfidence
             ? t('High Confidence Anomaly')


### PR DESCRIPTION
Displays open period ids. Anomaly tooltips got weird with the tooltip changes to incidents


<img width="304" height="264" alt="image" src="https://github.com/user-attachments/assets/48054a2a-476d-4490-9e64-782aeb0624d8" />


table with open period ids

<img width="881" height="322" alt="image" src="https://github.com/user-attachments/assets/269f1486-a218-45dc-90e0-c745620ab26d" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show open period IDs in tables and incident tooltips; add proper anomaly tooltips; introduce `id` on `GroupOpenPeriod` and `IncidentPeriod`.
> 
> - **Detectors UI**:
>   - **Ongoing Issues**: Display `#<id>` for each open period in the sub-table (`ongoingIssues.tsx`).
>   - **Metric Details Chart**: Incident tooltips now include `#<period.id>` for series and marklines (`details/metric/chart.tsx`).
>   - **Metric Form Chart**: Add anomaly series/markline tooltips and wire them into `useIncidentMarkers` (`components/forms/metric/metricDetectorChart.tsx`).
> - **Types/Hooks**:
>   - Add `id` to `GroupOpenPeriod` (`types/group.tsx`) and to `IncidentPeriod` (`hooks/useIncidentMarkers.tsx`).
>   - Populate anomaly period `id`s when grouping anomalies (`useMetricDetectorAnomalyPeriods.tsx`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12c43ad87c9290000ac4fd4c052d91b542e8b2e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->