### PR TITLE
feat(replay): Add Tap to Event_Logger

### DIFF
--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -16,6 +16,7 @@ from sentry.replays.lib.storage import _make_recording_filename, storage_kv
 from sentry.replays.usecases.ingest.event_logger import (
     emit_click_events,
     emit_request_response_metrics,
+    emit_tap_events,
     emit_trace_items_to_eap,
     log_canvas_size,
     log_multiclick_events,
@@ -221,6 +222,14 @@ def emit_replay_events(
 
     emit_click_events(
         event_meta.click_events,
+        project.id,
+        replay_id,
+        retention_days,
+        start_time=time.time(),
+        environment=environment,
+    )
+    emit_tap_events(
+        event_meta.tap_events,
         project.id,
         replay_id,
         retention_days,

--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -51,7 +51,8 @@ class ReplayActionsEventPayloadTap(TypedDict):
 
 class ReplayActionsEventPayload(TypedDict):
     environment: str
-    clicks: list[ReplayActionsEventPayloadClick] | list[ReplayActionsEventPayloadTap]
+    clicks: list[ReplayActionsEventPayloadClick]
+    taps: list[ReplayActionsEventPayloadTap]
     replay_id: str
     type: Literal["replay_actions"]
 
@@ -92,7 +93,8 @@ def emit_tap_events(
         "environment": environment or "",
         "replay_id": replay_id,
         "type": "replay_actions",
-        "clicks": taps,
+        "clicks": [],
+        "taps": taps,
     }
 
     action: ReplayActionsEvent = {
@@ -147,6 +149,7 @@ def emit_click_events(
         "replay_id": replay_id,
         "type": "replay_actions",
         "clicks": clicks,
+        "taps": [],
     }
 
     action: ReplayActionsEvent = {

--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -11,7 +11,7 @@ from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 from sentry.models.project import Project
 from sentry.replays.lib.eap.write import write_trace_items
 from sentry.replays.lib.kafka import publish_replay_event
-from sentry.replays.usecases.ingest.event_parser import ClickEvent, ParsedEventMeta
+from sentry.replays.usecases.ingest.event_parser import ClickEvent, ParsedEventMeta, TapEvent
 from sentry.replays.usecases.ingest.issue_creation import (
     report_hydration_error_issue_with_replay_event,
     report_rage_click_issue_with_replay_event,
@@ -43,9 +43,15 @@ ReplayActionsEventPayloadClick = TypedDict(
 )
 
 
+class ReplayActionsEventPayloadTap(TypedDict):
+    message: str
+    view_id: str
+    view_class: str
+
+
 class ReplayActionsEventPayload(TypedDict):
     environment: str
-    clicks: list[ReplayActionsEventPayloadClick]
+    clicks: list[ReplayActionsEventPayloadClick] | list[ReplayActionsEventPayloadTap]
     replay_id: str
     type: Literal["replay_actions"]
 
@@ -57,6 +63,48 @@ class ReplayActionsEvent(TypedDict):
     retention_days: int
     start_time: float
     type: Literal["replay_event"]
+
+
+@sentry_sdk.trace
+def emit_tap_events(
+    tap_events: list[TapEvent],
+    project_id: int,
+    replay_id: str,
+    retention_days: int,
+    start_time: float,
+    event_cap: int = 20,
+    environment: str | None = None,
+) -> None:
+    # Skip event emission if no taps specified.
+    if len(tap_events) == 0:
+        return None
+
+    taps: list[ReplayActionsEventPayloadTap] = [
+        {
+            "message": tap.message,
+            "view_id": tap.view_id,
+            "view_class": tap.view_class,
+        }
+        for tap in tap_events[:event_cap]
+    ]
+
+    payload: ReplayActionsEventPayload = {
+        "environment": environment or "",
+        "replay_id": replay_id,
+        "type": "replay_actions",
+        "clicks": taps,
+    }
+
+    action: ReplayActionsEvent = {
+        "project_id": project_id,
+        "replay_id": replay_id,
+        "retention_days": retention_days,
+        "start_time": start_time,
+        "type": "replay_event",
+        "payload": payload,
+    }
+
+    publish_replay_event(json.dumps(action))
 
 
 @sentry_sdk.trace


### PR DESCRIPTION
In order to add user taps to mobile replay search, the event parser ([previous PR](https://github.com/getsentry/sentry/pull/100357)) and event logger need to be updated to support ingestion of a tap SDK event. This PR adds a new emit function and calls it from `emit_replay_events()`

Relates To: https://linear.app/getsentry/issue/REPLAY-751/updating-event-logger-to-emit-tap-events

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tap event support by introducing emit_tap_events, wiring it into emit_replay_events, and extending payload/types; includes tests.
> 
> - **Replay ingest**:
>   - Add `emit_tap_events` to publish mobile tap actions (`message`, `view_id`, `view_class`) to Kafka with environment handling and event cap.
>   - Call `emit_tap_events` from `emit_replay_events` alongside `emit_click_events`.
> - **Types/Schema**:
>   - Introduce `ReplayActionsEventPayloadTap` and extend `ReplayActionsEventPayload.clicks` to accept tap payloads.
>   - Import `TapEvent` in logger.
> - **Tests**:
>   - Add `test_emit_tap_events_environment_handling` and update imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff015a39dc699ecaa4b368f69577c99e5f880f18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->