### PR TITLE
fix(preprod): fix the comparison build selector page for mobile

### DIFF
--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -1,4 +1,4 @@
-import {useTheme} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
@@ -47,7 +47,7 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
     <Flex direction="column" gap="lg" style={{padding: `0 0 ${theme.space.lg} 0`}}>
       <Breadcrumbs crumbs={breadcrumbs} />
       <Heading as="h1">Build comparison</Heading>
-      <Flex gap="lg">
+      <Flex gap="lg" align="center" wrap="wrap">
         <Flex gap="sm" align="center">
           <AppIcon>
             <AppIconPlaceholder>

--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -1,4 +1,4 @@
-import {css, useTheme} from '@emotion/react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -70,6 +70,25 @@ function BuildButton({buildDetails, icon, label, onRemove}: BuildButtonProps) {
   );
 }
 
+const ComparisonContainer = styled(Flex)`
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: ${p => p.theme.space.lg};
+  width: 100%;
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    flex-direction: column;
+    gap: ${p => p.theme.space.md};
+    padding-bottom: ${p => p.theme.space.lg};
+
+    > * {
+      min-width: 0;
+      max-width: 100%;
+    }
+  }
+`;
+
 interface SizeCompareSelectedBuildsProps {
   headBuildDetails: BuildDetailsApiResponse;
   isComparing: boolean;
@@ -86,7 +105,7 @@ export function SizeCompareSelectedBuilds({
   onTriggerComparison,
 }: SizeCompareSelectedBuildsProps) {
   return (
-    <Flex align="center" gap="lg" width="100%" justify="center">
+    <ComparisonContainer>
       <BuildButton
         buildDetails={headBuildDetails}
         icon={<IconLock size="xs" locked />}
@@ -95,38 +114,34 @@ export function SizeCompareSelectedBuilds({
 
       <Text>{t('vs')}</Text>
 
-      <Flex align="center" gap="sm">
-        {baseBuildDetails ? (
-          <BuildButton
-            buildDetails={baseBuildDetails}
-            icon={<IconFocus size="xs" color="purple400" />}
-            label={t('Base')}
-            onRemove={onClearBaseBuild}
-          />
-        ) : (
-          <SelectBuild>
-            <Text size="sm">{t('Select a build')}</Text>
-          </SelectBuild>
-        )}
-      </Flex>
+      {baseBuildDetails ? (
+        <BuildButton
+          buildDetails={baseBuildDetails}
+          icon={<IconFocus size="xs" color="purple400" />}
+          label={t('Base')}
+          onRemove={onClearBaseBuild}
+        />
+      ) : (
+        <SelectBuild>
+          <Text size="sm">{t('Select a build')}</Text>
+        </SelectBuild>
+      )}
 
       {onTriggerComparison && (
-        <Flex align="center" gap="sm">
-          <Button
-            onClick={() => {
-              if (baseBuildDetails) {
-                onTriggerComparison();
-              }
-            }}
-            disabled={!baseBuildDetails || isComparing}
-            priority="primary"
-            icon={<IconTelescope size="sm" />}
-          >
-            {isComparing ? t('Comparing...') : t('Compare builds')}
-          </Button>
-        </Flex>
+        <Button
+          onClick={() => {
+            if (baseBuildDetails) {
+              onTriggerComparison();
+            }
+          }}
+          disabled={!baseBuildDetails || isComparing}
+          priority="primary"
+          icon={<IconTelescope size="sm" />}
+        >
+          {isComparing ? t('Comparing...') : t('Compare builds')}
+        </Button>
       )}
-    </Flex>
+    </ComparisonContainer>
   );
 }
 


### PR DESCRIPTION
Fixes the flexbox display to use columns for small breakpoints, and fixes some overflow issues as well.

<img width="397" height="688" alt="Screenshot 2025-09-29 at 5 43 23 PM" src="https://github.com/user-attachments/assets/eb38b422-fa7d-46e2-a991-1384c26abcf0" />

<img width="1429" height="696" alt="Screenshot 2025-09-29 at 5 39 11 PM" src="https://github.com/user-attachments/assets/b6ba35e1-46c1-4d77-98cf-531cbfcc4fd3" />

Resolves EME-375

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improve build comparison layout for small screens by adding a responsive container, enabling wrapping/centering, and simplifying nested flex wrappers.
> 
> - **UI/Layout**:
>   - `static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx`:
>     - Introduce `ComparisonContainer` (styled `Flex`) with wrap, centered layout, and mobile column behavior; replace outer `Flex`.
>     - Remove redundant inner `Flex` wrappers around the base build and compare button.
>   - `static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx`:
>     - Update header info row `Flex` to `align="center"` and `wrap="wrap"` to prevent overflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 358e5d5d71013a7df4e9d46ab6def1dba69c802e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->