### PR TITLE
feat(integrations): auto enroll projects into data forwarding

### DIFF
--- a/src/sentry/receivers/__init__.py
+++ b/src/sentry/receivers/__init__.py
@@ -1,6 +1,7 @@
 from .analytics import *  # noqa: F401,F403
 from .auth import *  # noqa: F401,F403
 from .core import *  # noqa: F401,F403
+from .data_forwarding import *  # noqa: F401,F403
 from .email import *  # noqa: F401,F403
 from .experiments import *  # noqa: F401,F403
 from .features import *  # noqa: F401,F403

--- a/src/sentry/receivers/data_forwarding.py
+++ b/src/sentry/receivers/data_forwarding.py
@@ -14,11 +14,9 @@ def enroll_project_in_data_forwarding(project: Project, **kwargs):
 
     with transaction.atomic(router.db_for_write(DataForwarderProject)):
         for data_forwarder in data_forwarders:
-            DataForwarderProject.objects.get_or_create(
+            DataForwarderProject.objects.create(
                 data_forwarder=data_forwarder,
                 project=project,
-                defaults={
-                    "is_enabled": True,
-                    "overrides": {},
-                },
+                is_enabled=True,
+                overrides={},
             )

--- a/src/sentry/receivers/data_forwarding.py
+++ b/src/sentry/receivers/data_forwarding.py
@@ -1,3 +1,5 @@
+from django.db import IntegrityError
+
 from sentry.integrations.models.data_forwarder import DataForwarder
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.models.project import Project
@@ -15,10 +17,13 @@ def enroll_project_in_data_forwarding(project: Project, **kwargs):
         if not DataForwarderProject.objects.filter(
             data_forwarder=data_forwarder, project=project
         ).exists():
-            DataForwarderProject.objects.create(
-                data_forwarder=data_forwarder,
-                project=project,
-                is_enabled=True,
-                overrides={},
-            )
-            enrolled_count += 1
+            try:
+                DataForwarderProject.objects.create(
+                    data_forwarder=data_forwarder,
+                    project=project,
+                    is_enabled=True,
+                    overrides={},
+                )
+                enrolled_count += 1
+            except IntegrityError:
+                pass

--- a/src/sentry/receivers/data_forwarding.py
+++ b/src/sentry/receivers/data_forwarding.py
@@ -1,0 +1,50 @@
+import logging
+
+from sentry.integrations.models.data_forwarder import DataForwarder
+from sentry.integrations.models.data_forwarder_project import DataForwarderProject
+from sentry.models.project import Project
+from sentry.signals import project_created
+
+logger = logging.getLogger(__name__)
+
+
+@project_created.connect(weak=False, dispatch_uid="enroll_project_in_data_forwarding")
+def enroll_project_in_data_forwarding(project: Project):
+    data_forwarders = DataForwarder.objects.filter(
+        organization_id=project.organization_id, is_enabled=True, enroll_new_projects=True
+    )
+
+    enrolled_count = 0
+    for data_forwarder in data_forwarders:
+        if not DataForwarderProject.objects.filter(
+            data_forwarder=data_forwarder, project=project
+        ).exists():
+            DataForwarderProject.objects.create(
+                data_forwarder=data_forwarder,
+                project=project,
+                is_enabled=True,
+                overrides={},
+            )
+            enrolled_count += 1
+
+            logger.info(
+                "Enrolled new project in data forwarder",
+                extra={
+                    "project_id": project.id,
+                    "project_slug": project.slug,
+                    "organization_id": project.organization_id,
+                    "data_forwarder_id": data_forwarder.id,
+                    "provider": data_forwarder.provider,
+                },
+            )
+
+    if enrolled_count > 0:
+        logger.info(
+            "Auto-enrolled new project in data forwarders",
+            extra={
+                "project_id": project.id,
+                "project_slug": project.slug,
+                "organization_id": project.organization_id,
+                "enrolled_count": enrolled_count,
+            },
+        )

--- a/src/sentry/receivers/data_forwarding.py
+++ b/src/sentry/receivers/data_forwarding.py
@@ -17,6 +17,8 @@ def enroll_project_in_data_forwarding(project: Project, **kwargs):
             DataForwarderProject.objects.get_or_create(
                 data_forwarder=data_forwarder,
                 project=project,
-                is_enabled=True,
-                overrides={},
+                defaults={
+                    "is_enabled": True,
+                    "overrides": {},
+                },
             )

--- a/src/sentry/receivers/data_forwarding.py
+++ b/src/sentry/receivers/data_forwarding.py
@@ -1,15 +1,11 @@
-import logging
-
 from sentry.integrations.models.data_forwarder import DataForwarder
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.models.project import Project
 from sentry.signals import project_created
 
-logger = logging.getLogger(__name__)
-
 
 @project_created.connect(weak=False, dispatch_uid="enroll_project_in_data_forwarding")
-def enroll_project_in_data_forwarding(project: Project):
+def enroll_project_in_data_forwarding(project: Project, **kwargs):
     data_forwarders = DataForwarder.objects.filter(
         organization_id=project.organization_id, is_enabled=True, enroll_new_projects=True
     )
@@ -26,25 +22,3 @@ def enroll_project_in_data_forwarding(project: Project):
                 overrides={},
             )
             enrolled_count += 1
-
-            logger.info(
-                "Enrolled new project in data forwarder",
-                extra={
-                    "project_id": project.id,
-                    "project_slug": project.slug,
-                    "organization_id": project.organization_id,
-                    "data_forwarder_id": data_forwarder.id,
-                    "provider": data_forwarder.provider,
-                },
-            )
-
-    if enrolled_count > 0:
-        logger.info(
-            "Auto-enrolled new project in data forwarders",
-            extra={
-                "project_id": project.id,
-                "project_slug": project.slug,
-                "organization_id": project.organization_id,
-                "enrolled_count": enrolled_count,
-            },
-        )

--- a/tests/sentry/receivers/test_data_forwarding.py
+++ b/tests/sentry/receivers/test_data_forwarding.py
@@ -89,6 +89,7 @@ class DataForwardingReceiverTest(TestCase):
         )
         assert enrollments.count() == 1
         enrollment = enrollments.first()
+        assert enrollment is not None
         assert enrollment.overrides == {"custom_key": "custom_value"}
 
     def test_multiple_data_forwarders_enroll_same_project(self) -> None:

--- a/tests/sentry/receivers/test_data_forwarding.py
+++ b/tests/sentry/receivers/test_data_forwarding.py
@@ -1,0 +1,165 @@
+from sentry.integrations.models.data_forwarder import DataForwarder
+from sentry.integrations.models.data_forwarder_project import DataForwarderProject
+from sentry.signals import project_created
+from sentry.testutils.cases import TestCase
+
+
+class DataForwardingReceiverTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization()
+        self.project = self.create_project(organization=self.organization)
+
+    def test_auto_enrollment_when_enroll_new_projects_enabled(self) -> None:
+        data_forwarder = DataForwarder.objects.create(
+            organization=self.organization,
+            is_enabled=True,
+            enroll_new_projects=True,
+            provider="segment",
+            config={"write_key": "test_key"},
+        )
+
+        new_project = self.create_project(organization=self.organization, fire_project_created=True)
+
+        enrollment = DataForwarderProject.objects.filter(
+            data_forwarder=data_forwarder, project=new_project
+        ).first()
+        assert enrollment is not None
+        assert enrollment.is_enabled is True
+        assert enrollment.overrides == {}
+
+    def test_no_enrollment_when_enroll_new_projects_disabled(self) -> None:
+        data_forwarder = DataForwarder.objects.create(
+            organization=self.organization,
+            is_enabled=True,
+            enroll_new_projects=False,
+            provider="segment",
+            config={"write_key": "test_key"},
+        )
+
+        new_project = self.create_project(organization=self.organization, fire_project_created=True)
+
+        # Verify the project was not enrolled
+        enrollment = DataForwarderProject.objects.filter(
+            data_forwarder=data_forwarder, project=new_project
+        ).first()
+        assert enrollment is None
+
+    def test_no_enrollment_when_data_forwarder_disabled(self) -> None:
+        data_forwarder = DataForwarder.objects.create(
+            organization=self.organization,
+            is_enabled=False,
+            enroll_new_projects=True,
+            provider="segment",
+            config={"write_key": "test_key"},
+        )
+
+        new_project = self.create_project(organization=self.organization, fire_project_created=True)
+
+        enrollment = DataForwarderProject.objects.filter(
+            data_forwarder=data_forwarder, project=new_project
+        ).first()
+        assert enrollment is None
+
+    def test_no_duplicate_enrollment_when_project_already_enrolled(self) -> None:
+        data_forwarder = DataForwarder.objects.create(
+            organization=self.organization,
+            is_enabled=True,
+            enroll_new_projects=True,
+            provider="segment",
+            config={"write_key": "test_key"},
+        )
+
+        DataForwarderProject.objects.create(
+            data_forwarder=data_forwarder,
+            project=self.project,
+            is_enabled=True,
+            overrides={"custom_key": "custom_value"},
+        )
+
+        project_created.send_robust(
+            project=self.project,
+            user=self.create_user(),
+            default_rules=True,
+            sender=self.__class__,
+        )
+
+        enrollments = DataForwarderProject.objects.filter(
+            data_forwarder=data_forwarder, project=self.project
+        )
+        assert enrollments.count() == 1
+        enrollment = enrollments.first()
+        assert enrollment.overrides == {"custom_key": "custom_value"}
+
+    def test_multiple_data_forwarders_enroll_same_project(self) -> None:
+        segment_forwarder = DataForwarder.objects.create(
+            organization=self.organization,
+            is_enabled=True,
+            enroll_new_projects=True,
+            provider="segment",
+            config={"write_key": "segment_key"},
+        )
+
+        sqs_forwarder = DataForwarder.objects.create(
+            organization=self.organization,
+            is_enabled=True,
+            enroll_new_projects=True,
+            provider="sqs",
+            config={"queue_url": "test_queue"},
+        )
+
+        new_project = self.create_project(organization=self.organization, fire_project_created=True)
+
+        segment_enrollment = DataForwarderProject.objects.filter(
+            data_forwarder=segment_forwarder, project=new_project
+        ).first()
+        assert segment_enrollment is not None
+        assert segment_enrollment.is_enabled is True
+
+        sqs_enrollment = DataForwarderProject.objects.filter(
+            data_forwarder=sqs_forwarder, project=new_project
+        ).first()
+        assert sqs_enrollment is not None
+        assert sqs_enrollment.is_enabled is True
+
+    def test_mixed_data_forwarders_only_enroll_into_some(self) -> None:
+        enabled_forwarder = DataForwarder.objects.create(
+            organization=self.organization,
+            is_enabled=True,
+            enroll_new_projects=True,
+            provider="segment",
+            config={"write_key": "segment_key"},
+        )
+
+        disabled_forwarder = DataForwarder.objects.create(
+            organization=self.organization,
+            is_enabled=False,
+            enroll_new_projects=True,
+            provider="sqs",
+            config={"queue_url": "test_queue"},
+        )
+
+        no_auto_enroll_forwarder = DataForwarder.objects.create(
+            organization=self.organization,
+            is_enabled=True,
+            enroll_new_projects=False,
+            provider="splunk",
+            config={"endpoint": "test_endpoint"},
+        )
+
+        new_project = self.create_project(organization=self.organization, fire_project_created=True)
+
+        enabled_enrollment = DataForwarderProject.objects.filter(
+            data_forwarder=enabled_forwarder, project=new_project
+        ).first()
+        assert enabled_enrollment is not None
+
+        disabled_enrollment = DataForwarderProject.objects.filter(
+            data_forwarder=disabled_forwarder, project=new_project
+        ).first()
+        assert disabled_enrollment is None
+
+        no_auto_enroll_enrollment = DataForwarderProject.objects.filter(
+            data_forwarder=no_auto_enroll_forwarder, project=new_project
+        ).first()
+        assert no_auto_enroll_enrollment is None


### PR DESCRIPTION
Auto enroll projects into enabled data forwarding configs under the project's org if `auto_enroll_new_projects` is true for that config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Auto-enrolls new projects into enabled org data forwarders when `enroll_new_projects` is true, avoiding duplicates.
> 
> - **Backend**:
>   - **Receivers**: Add `sentry/receivers/data_forwarding.py` to listen to `project_created` and `get_or_create` `DataForwarderProject` entries for matching `DataForwarder` (`is_enabled=True`, `enroll_new_projects=True`) with defaults `is_enabled=True`, `overrides={}` (wrapped in a transaction).
>   - **Wiring**: Import `data_forwarding` in `sentry/receivers/__init__.py`.
> - **Tests**:
>   - Add `tests/sentry/receivers/test_data_forwarding.py` covering auto-enrollment, disabled/no-auto-enroll cases, duplicate prevention, and multiple forwarders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57b2b7e13cc6595a85cd85227ad880a264ebed6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->