### PR TITLE
fix(issues): Reset "page" query parameter on query change

### DIFF
--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -17,13 +17,15 @@ interface Props {
   sort: IssueSortOptions;
 }
 
+const RESET_PARAMS_ON_CHANGE = ['page', 'cursor'];
+
 function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
   return (
     <FiltersContainer>
       <StyledPageFilterBar>
-        <ProjectPageFilter />
-        <EnvironmentPageFilter />
-        <DatePageFilter />
+        <ProjectPageFilter resetParamsOnChange={RESET_PARAMS_ON_CHANGE} />
+        <EnvironmentPageFilter resetParamsOnChange={RESET_PARAMS_ON_CHANGE} />
+        <DatePageFilter resetParamsOnChange={RESET_PARAMS_ON_CHANGE} />
       </StyledPageFilterBar>
 
       <Search {...{query, onSearch}} />


### PR DESCRIPTION
Resets the "page" query param helper we have on the issues stream when the query is updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resets `page` and `cursor` when project/environment/date filters change in the issue list.
> 
> - **Issue List Filters (`static/app/views/issueList/filters.tsx`)**:
>   - Add `RESET_PARAMS_ON_CHANGE = ['page', 'cursor']`.
>   - Pass `resetParamsOnChange` to `ProjectPageFilter`, `EnvironmentPageFilter`, and `DatePageFilter` to clear pagination on filter changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5744549a0f86060ab36f685f25b0b4b633c83c2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->