### PR TITLE
fix(code-mappings): delete code mappings when a project is transferred

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -638,10 +638,8 @@ class Project(Model):
             "linked_id", flat=True
         )
 
-        # Manually move over code mappings to the new project
-        RepositoryProjectPathConfig.objects.filter(project_id=self.id).update(
-            organization_id=organization.id
-        )
+        # Delete code mappings to prevent them from being stuck on the old org
+        RepositoryProjectPathConfig.objects.filter(project_id=self.id).delete()
 
         for external_issues in chunked(
             RangeQuerySetWrapper(

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -500,6 +500,9 @@ class Project(Model):
         from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
         from sentry.incidents.models.alert_rule import AlertRule
         from sentry.integrations.models.external_issue import ExternalIssue
+        from sentry.integrations.models.repository_project_path_config import (
+            RepositoryProjectPathConfig,
+        )
         from sentry.models.environment import Environment, EnvironmentProject
         from sentry.models.projectteam import ProjectTeam
         from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
@@ -633,6 +636,11 @@ class Project(Model):
         # Manually move over external issues to the new org
         linked_groups = GroupLink.objects.filter(project_id=self.id).values_list(
             "linked_id", flat=True
+        )
+
+        # Manually move over code mappings to the new project
+        RepositoryProjectPathConfig.objects.filter(project_id=self.id).update(
+            project_id=self.id, organization_id=organization.id
         )
 
         for external_issues in chunked(

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -640,7 +640,7 @@ class Project(Model):
 
         # Manually move over code mappings to the new project
         RepositoryProjectPathConfig.objects.filter(project_id=self.id).update(
-            project_id=self.id, organization_id=organization.id
+            organization_id=organization.id
         )
 
         for external_issues in chunked(

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -6,6 +6,7 @@ from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.deletions.tasks.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs_control
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.types import ExternalProviders
 from sentry.models.environment import Environment, EnvironmentProject
 from sentry.models.grouplink import GroupLink
@@ -19,6 +20,7 @@ from sentry.models.projectteam import ProjectTeam
 from sentry.models.release import Release
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.releases.release_project import ReleaseProject
+from sentry.models.repository import Repository
 from sentry.models.rule import Rule
 from sentry.monitors.models import Monitor, MonitorEnvironment, ScheduleType
 from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
@@ -228,6 +230,44 @@ class ProjectTest(APITestCase, TestCase):
             project=project, release=release, environment=environment
         ).exists()
         assert not ReleaseProject.objects.filter(project=project, release=release).exists()
+
+    def test_transfer_repository_project_path_configs(self) -> None:
+        from_org = self.create_organization()
+        to_org = self.create_organization()
+        team = self.create_team(organization=from_org)
+        project = self.create_project(teams=[team])
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration, org_integration = self.create_provider_integration_for(
+                from_org, self.user, provider="github"
+            )
+
+        repository = Repository.objects.create(
+            organization_id=from_org.id,
+            name="example-repo",
+            integration_id=integration.id,
+        )
+
+        config1 = RepositoryProjectPathConfig.objects.create(
+            repository=repository,
+            project=project,
+            organization_integration_id=org_integration.id,
+            organization_id=from_org.id,
+            integration_id=integration.id,
+            stack_root="/app",
+            source_root="/src",
+            default_branch="main",
+        )
+
+        project.transfer_to(organization=to_org)
+
+        config1.refresh_from_db()
+
+        assert config1.organization_id == to_org.id
+        assert RepositoryProjectPathConfig.objects.filter(organization_id=from_org.id).count() == 0
+        assert RepositoryProjectPathConfig.objects.filter(organization_id=to_org.id).count() == 1
+
+        assert RepositoryProjectPathConfig.objects.filter(project_id=project.id).count() == 1
 
     def test_transfer_to_organization_alert_rules(self) -> None:
         from_org = self.create_organization()

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -231,7 +231,7 @@ class ProjectTest(APITestCase, TestCase):
         ).exists()
         assert not ReleaseProject.objects.filter(project=project, release=release).exists()
 
-    def test_transfer_repository_project_path_configs(self) -> None:
+    def test_delete_on_transfer_repository_project_path_configs(self) -> None:
         from_org = self.create_organization()
         to_org = self.create_organization()
         team = self.create_team(organization=from_org)
@@ -263,11 +263,10 @@ class ProjectTest(APITestCase, TestCase):
 
         config1.refresh_from_db()
 
-        assert config1.organization_id == to_org.id
         assert RepositoryProjectPathConfig.objects.filter(organization_id=from_org.id).count() == 0
-        assert RepositoryProjectPathConfig.objects.filter(organization_id=to_org.id).count() == 1
+        assert RepositoryProjectPathConfig.objects.filter(organization_id=to_org.id).count() == 0
 
-        assert RepositoryProjectPathConfig.objects.filter(project_id=project.id).count() == 1
+        assert RepositoryProjectPathConfig.objects.filter(project_id=project.id).count() == 0
 
     def test_transfer_to_organization_alert_rules(self) -> None:
         from_org = self.create_organization()

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -248,7 +248,7 @@ class ProjectTest(APITestCase, TestCase):
             integration_id=integration.id,
         )
 
-        config1 = RepositoryProjectPathConfig.objects.create(
+        RepositoryProjectPathConfig.objects.create(
             repository=repository,
             project=project,
             organization_integration_id=org_integration.id,
@@ -260,8 +260,6 @@ class ProjectTest(APITestCase, TestCase):
         )
 
         project.transfer_to(organization=to_org)
-
-        config1.refresh_from_db()
 
         assert RepositoryProjectPathConfig.objects.filter(organization_id=from_org.id).count() == 0
         assert RepositoryProjectPathConfig.objects.filter(organization_id=to_org.id).count() == 0


### PR DESCRIPTION
When projects are transferred, code mappings (`RepositoryProjectPathConfig`s) are not updated, so both their `project_id` and `organization_id` stay the same, though the project they reference now has a different `organization_id`. Since code mappings also have a key to `organization_integration`, which can't be transferred easily, we delete the old code mappings so they can be recreated in the new org if needed.

See https://github.com/getsentry/getsentry/pull/18516

Refs https://github.com/getsentry/sentry/issues/52316
Refs https://linear.app/getsentry/issue/ID-379/transferring-a-project-breaks-code-mappings