### PR TITLE
feat(aci): disable metric detector creation when quota is reached

### DIFF
--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -221,7 +221,11 @@ function AlertWizard({organization, params, location, projectId}: AlertWizardPro
                   </PanelBody>
                 </div>
                 <WizardFooter>{renderCreateAlertButton()}</WizardFooter>
-                {isMetricAlert && <Hook name="component:metric-alert-quota-message" />}
+                {isMetricAlert && (
+                  <DisabledAlertMessageContainer>
+                    <Hook name="component:metric-alert-quota-message" />
+                  </DisabledAlertMessageContainer>
+                )}
               </WizardPanelBody>
             </WizardPanel>
           </WizardBody>
@@ -324,6 +328,14 @@ const WizardGroupedOptions = styled(RadioPanelGroup)`
   label {
     grid-template-columns: repeat(3, max-content);
   }
+`;
+
+const DisabledAlertMessageContainer = styled('div')`
+  border-top: 1px solid ${p => p.theme.border};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
+  background-color: ${p => p.theme.backgroundSecondary};
+  color: ${p => p.theme.subText};
+  border-radius: 0 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius};
 `;
 
 export default AlertWizard;

--- a/static/gsApp/components/metricAlertQuotaMessage.tsx
+++ b/static/gsApp/components/metricAlertQuotaMessage.tsx
@@ -1,5 +1,3 @@
-import styled from '@emotion/styled';
-
 import {Button} from 'sentry/components/core/button';
 import {Link} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
@@ -58,17 +56,13 @@ export function MetricAlertQuotaMessage() {
   const metricAlertQuota = useMetricDetectorLimit();
 
   if (metricAlertQuota?.hasReachedLimit) {
-    return (
-      <DisabledAlertMessageContainer>
-        {tct(
-          "You have reached your plan's limit on metric monitors ([limit]). [removeLink:Remove existing monitors] or [upgradeLink:upgrade your plan].",
-          {
-            limit: metricAlertQuota.detectorLimit.toLocaleString(),
-            removeLink: <Link to={makeAlertsPathname({organization, path: '/rules/'})} />,
-            upgradeLink: <UpgradeLink />,
-          }
-        )}
-      </DisabledAlertMessageContainer>
+    return tct(
+      "You have reached your plan's limit on metric monitors ([limit]). [removeLink:Remove existing monitors] or [upgradeLink:upgrade your plan].",
+      {
+        limit: metricAlertQuota.detectorLimit.toLocaleString(),
+        removeLink: <Link to={makeAlertsPathname({organization, path: '/rules/'})} />,
+        upgradeLink: <UpgradeLink />,
+      }
     );
   }
 
@@ -76,27 +70,15 @@ export function MetricAlertQuotaMessage() {
     metricAlertQuota &&
     metricAlertQuota.detectorLimit === metricAlertQuota.detectorCount + 1
   ) {
-    return (
-      <DisabledAlertMessageContainer>
-        {tct(
-          'You have used [count] of [limit] metric monitors for your plan. To increase the limit, [upgradeLink:upgrade your plan].',
-          {
-            count: metricAlertQuota.detectorCount.toLocaleString(),
-            limit: metricAlertQuota.detectorLimit.toLocaleString(),
-            upgradeLink: <UpgradeLink />,
-          }
-        )}
-      </DisabledAlertMessageContainer>
+    return tct(
+      'You have used [count] of [limit] metric monitors for your plan. To increase the limit, [upgradeLink:upgrade your plan].',
+      {
+        count: metricAlertQuota.detectorCount.toLocaleString(),
+        limit: metricAlertQuota.detectorLimit.toLocaleString(),
+        upgradeLink: <UpgradeLink />,
+      }
     );
   }
 
   return null;
 }
-
-const DisabledAlertMessageContainer = styled('div')`
-  border-top: 1px solid ${p => p.theme.border};
-  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
-  background-color: ${p => p.theme.backgroundSecondary};
-  color: ${p => p.theme.subText};
-  border-radius: 0 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius};
-`;


### PR DESCRIPTION
uses hook from https://github.com/getsentry/sentry/pull/97953 to disable the creation of more metric detectors (monitors) when quota is reached

<img width="1394" height="613" alt="Screenshot 2025-09-29 at 2 39 36 PM" src="https://github.com/user-attachments/assets/81bc9174-4082-4153-aca0-a8713eb3c164" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables creating metric monitors when quota is reached, displays an info banner, and centralizes styling by wrapping quota messages in a shared container.
> 
> - **Detectors UI**:
>   - Disable `metric_issue` option when `use-metric-detector-limit` indicates quota reached; disable radio and apply muted styling.
>   - Show `component:metric-alert-quota-message` in `infoBanner` when disabled/selected.
>   - Misc UI tweaks: spacing via theme, larger text, adjusted `OptionInfo` font size.
> - **Alerts Wizard**:
>   - Wrap `component:metric-alert-quota-message` in new `DisabledAlertMessageContainer` for consistent styling.
>   - Add `DisabledAlertMessageContainer` styles.
> - **Getsentry**:
>   - `metricAlertQuotaMessage.tsx`: return plain message nodes (remove local container styling) to rely on host container styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce9e467773c900c3e6dc91611b245eaf420dd865. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->