### PR TITLE
ref(settings): Migrate DataDownload off legacy router props

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -233,7 +233,6 @@ function buildRoutes(): RouteObject[] {
       path: '/data-export/:dataExportId',
       component: make(() => import('sentry/views/dataExport/dataDownload')),
       withOrgPath: true,
-      deprecatedRouteProps: true,
     },
     {
       component: errorHandler(OrganizationContainer),

--- a/static/app/views/dataExport/dataDownload.spec.tsx
+++ b/static/app/views/dataExport/dataDownload.spec.tsx
@@ -138,4 +138,18 @@ describe('DataDownload', () => {
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
     expect(screen.getByRole('button', {name: 'Open in Explore'})).toBeInTheDocument();
   });
+
+  it('should render with null organization', async () => {
+    const status = DownloadStatus.VALID;
+    getDataExportDetails({
+      dateExpired,
+      status,
+      query: {type: ExportQueryType.EXPLORE, info: {}},
+    });
+
+    render(<DataDownload />, {initialRouterConfig, organization: null});
+    expect(
+      await screen.findByRole('button', {name: 'Open in Explore'})
+    ).toBeInTheDocument();
+  });
 });

--- a/static/app/views/dataExport/dataDownload.spec.tsx
+++ b/static/app/views/dataExport/dataDownload.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -11,14 +10,17 @@ describe('DataDownload', () => {
   beforeEach(MockApiClient.clearMockResponses);
   const dateExpired = new Date();
   const organization = OrganizationFixture();
-  const mockRouteParams = {
-    orgId: organization.slug,
-    dataExportId: '721',
+  const dataExportId = '721';
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/data-export/${dataExportId}/`,
+    },
+    route: '/organizations/:orgId/data-export/:dataExportId/',
   };
 
   const getDataExportDetails = (body: any, statusCode = 200) =>
     MockApiClient.addMockResponse({
-      url: `/organizations/${mockRouteParams.orgId}/data-export/${mockRouteParams.dataExportId}/`,
+      url: `/organizations/${organization.slug}/data-export/${dataExportId}/`,
       body,
       statusCode,
     });
@@ -26,7 +28,7 @@ describe('DataDownload', () => {
   it('should send a request to the data export endpoint', () => {
     const getValid = getDataExportDetails(DownloadStatus.VALID);
 
-    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
+    render(<DataDownload />, {initialRouterConfig});
     expect(getValid).toHaveBeenCalledTimes(1);
   });
 
@@ -42,7 +44,7 @@ describe('DataDownload', () => {
     };
     getDataExportDetails({errors}, 403);
 
-    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
+    render(<DataDownload />, {initialRouterConfig});
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
     expect(screen.getByText('403 -')).toBeInTheDocument(); // Either the code or the mock is mistaken about the data return format
   });
@@ -51,7 +53,7 @@ describe('DataDownload', () => {
     const status = DownloadStatus.EARLY;
     getDataExportDetails({status});
 
-    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
+    render(<DataDownload />, {initialRouterConfig});
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
     expect(
       screen.getByText(textWithMarkupMatcher('What are you doing here?'))
@@ -64,12 +66,12 @@ describe('DataDownload', () => {
     const response = {status, query: {type: ExportQueryType.ISSUES_BY_TAG}};
     getDataExportDetails(response);
 
-    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
+    render(<DataDownload />, {initialRouterConfig});
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
     expect(screen.getByText('This is awkward.')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Start a New Download'})).toHaveAttribute(
       'href',
-      `/organizations/${mockRouteParams.orgId}/issues/`
+      `/organizations/${organization.slug}/issues/`
     );
   });
 
@@ -77,12 +79,12 @@ describe('DataDownload', () => {
     const status = DownloadStatus.VALID;
     getDataExportDetails({dateExpired, status});
 
-    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
+    render(<DataDownload />, {initialRouterConfig});
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
     expect(screen.getByText('All done.')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Download CSV'})).toHaveAttribute(
       'href',
-      `/api/0/organizations/${mockRouteParams.orgId}/data-export/${mockRouteParams.dataExportId}/?download=true`
+      `/api/0/organizations/${organization.slug}/data-export/${dataExportId}/?download=true`
     );
     expect(
       screen.getByText(
@@ -102,7 +104,7 @@ describe('DataDownload', () => {
       },
     });
 
-    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
+    render(<DataDownload />, {initialRouterConfig});
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
     expect(screen.getByRole('button', {name: 'Open in Discover'})).toBeInTheDocument();
   });
@@ -118,7 +120,7 @@ describe('DataDownload', () => {
       },
     });
 
-    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
+    render(<DataDownload />, {initialRouterConfig});
     expect(
       screen.queryByRole('button', {name: 'Open in Discover'})
     ).not.toBeInTheDocument();
@@ -132,7 +134,7 @@ describe('DataDownload', () => {
       query: {type: ExportQueryType.EXPLORE, info: {}},
     });
 
-    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
+    render(<DataDownload />, {initialRouterConfig});
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
     expect(screen.getByRole('button', {name: 'Open in Explore'})).toBeInTheDocument();
   });

--- a/static/app/views/dataExport/dataDownload.tsx
+++ b/static/app/views/dataExport/dataDownload.tsx
@@ -14,7 +14,6 @@ import {isAggregateField} from 'sentry/utils/discover/fields';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import Layout from 'sentry/views/auth/layout';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
@@ -71,10 +70,11 @@ type OtherDownload = BaseDownload & {
 type Download = ExploreDownload | OtherDownload;
 
 function DataDownload() {
-  const organization = useOrganization();
-  const {dataExportId} = useParams<{dataExportId: string}>();
+  const {dataExportId, orgId: orgSlug} = useParams<{
+    dataExportId: string;
+    orgId: string;
+  }>();
 
-  const orgSlug = organization.slug;
   const {
     data: download,
     isPending,

--- a/static/app/views/dataExport/dataDownload.tsx
+++ b/static/app/views/dataExport/dataDownload.tsx
@@ -10,11 +10,12 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconDownload} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {isAggregateField} from 'sentry/utils/discover/fields';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import Layout from 'sentry/views/auth/layout';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getLogsUrl} from 'sentry/views/explore/logs/utils';
@@ -25,11 +26,6 @@ export enum DownloadStatus {
   VALID = 'VALID',
   EXPIRED = 'EXPIRED',
 }
-
-type RouteParams = {
-  dataExportId: string;
-  orgId: string;
-};
 
 interface ExploreQueryInfo {
   dataset: TraceItemDataset;
@@ -74,15 +70,17 @@ type OtherDownload = BaseDownload & {
 
 type Download = ExploreDownload | OtherDownload;
 
-type Props = {} & RouteComponentProps<RouteParams>;
+function DataDownload() {
+  const organization = useOrganization();
+  const {dataExportId} = useParams<{dataExportId: string}>();
 
-function DataDownload({params: {orgId, dataExportId}}: Props) {
+  const orgSlug = organization.slug;
   const {
     data: download,
     isPending,
     isError,
     error,
-  } = useApiQuery<Download>([`/organizations/${orgId}/data-export/${dataExportId}/`], {
+  } = useApiQuery<Download>([`/organizations/${orgSlug}/data-export/${dataExportId}/`], {
     staleTime: 0,
   });
 
@@ -118,14 +116,14 @@ function DataDownload({params: {orgId, dataExportId}}: Props) {
   ): string => {
     switch (queryType) {
       case ExportQueryType.ISSUES_BY_TAG:
-        return `/organizations/${orgId}/issues/`;
+        return `/organizations/${orgSlug}/issues/`;
       case ExportQueryType.DISCOVER:
-        return `/organizations/${orgId}/discover/queries/`;
+        return `/organizations/${orgSlug}/discover/queries/`;
       case ExportQueryType.EXPLORE:
         if (traceItemDataset === TraceItemDataset.LOGS) {
-          return `/organizations/${orgId}/explore/logs/`;
+          return `/organizations/${orgSlug}/explore/logs/`;
         }
-        return `/organizations/${orgId}/explore/traces/`;
+        return `/organizations/${orgSlug}/explore/traces/`;
       default:
         return '/';
     }
@@ -205,7 +203,7 @@ function DataDownload({params: {orgId, dataExportId}}: Props) {
     } = download;
 
     const to = {
-      pathname: `/organizations/${orgId}/discover/results/`,
+      pathname: `/organizations/${orgSlug}/discover/results/`,
       query: info,
     };
 
@@ -224,7 +222,7 @@ function DataDownload({params: {orgId, dataExportId}}: Props) {
 
     if (traceItemDataset === TraceItemDataset.LOGS) {
       const url = getLogsUrl({
-        organization: orgId,
+        organization: orgSlug,
         selection: {
           datetime: {
             end: info.end ?? null,
@@ -274,7 +272,7 @@ function DataDownload({params: {orgId, dataExportId}}: Props) {
     };
 
     const to = {
-      pathname: `/organizations/${orgId}/explore/traces/`,
+      pathname: `/organizations/${orgSlug}/explore/traces/`,
       query: {...info, ...(mode === Mode.AGGREGATE ? aggregateInfo : samplesInfo)},
     };
 
@@ -320,7 +318,7 @@ function DataDownload({params: {orgId, dataExportId}}: Props) {
           <LinkButton
             priority="primary"
             icon={<IconDownload />}
-            href={`/api/0/organizations/${orgId}/data-export/${dataExportId}/?download=true`}
+            href={`/api/0/organizations/${orgSlug}/data-export/${dataExportId}/?download=true`}
           >
             {t('Download CSV')}
           </LinkButton>


### PR DESCRIPTION
re-landing #100539 but with a test for when `useOrganization` is null. Reverted after this issue was opened JAVASCRIPT-33PD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `DataDownload` to use `useParams` and updated URL paths, removes `deprecatedRouteProps` from the data-export route, and rewrites tests (including a null-organization case).
> 
> - **Routing/UI**:
>   - Replace legacy `RouteComponentProps` in `DataDownload` with `useParams`; rename `orgId` usage to `orgSlug` and update all URLs/navigation accordingly.
>   - Remove `deprecatedRouteProps` from `/data-export/:dataExportId` route in `static/app/routes.tsx`.
> - **Tests**:
>   - Update `dataDownload.spec.tsx` to render with `initialRouterConfig` instead of `RouteComponentPropsFixture` and align mocked endpoints/links.
>   - Add test ensuring component renders when `organization` is null.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8afd75f1bf24f945e0d6099a6dbed0af1f7b3d98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->