### PR TITLE
fix(prevent): Fix TA preonboarding gh app link

### DIFF
--- a/static/app/views/prevent/tests/preOnboarding.tsx
+++ b/static/app/views/prevent/tests/preOnboarding.tsx
@@ -19,7 +19,7 @@ const INSTRUCTIONS_TEXT = {
     "You need to install the Sentry App on your GitHub organization as an admin. If you're not an admin, you will need to make sure your GitHub organization admins approve the installation of the Sentry App on GitHub."
   ),
   mainCTA: t('Add installation'),
-  mainCTALink: '/settings/integrations/github',
+  mainCTALink: 'https://github.com/apps/sentry-io',
 } as const;
 
 export default function TestsPreOnboardingPage() {
@@ -72,7 +72,11 @@ export default function TestsPreOnboardingPage() {
             <h2>{INSTRUCTIONS_TEXT.header}</h2>
             <SubtextParagraph>{INSTRUCTIONS_TEXT.subtext}</SubtextParagraph>
             <ButtonBar>
-              <LinkButton priority="primary" href={INSTRUCTIONS_TEXT.mainCTA}>
+              <LinkButton
+                external
+                priority="primary"
+                href={INSTRUCTIONS_TEXT.mainCTALink}
+              >
                 {INSTRUCTIONS_TEXT.mainCTA}
               </LinkButton>
               <LinkButton priority="default" href="/settings/integrations/github">


### PR DESCRIPTION
Current link was using the wrong variable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the primary CTA to point to https://github.com/apps/sentry-io and marks it as an external link on the Tests PreOnboarding page.
> 
> - **Tests PreOnboarding (`static/app/views/prevent/tests/preOnboarding.tsx`)**:
>   - Update CTA link to `https://github.com/apps/sentry-io` via `INSTRUCTIONS_TEXT.mainCTALink`.
>   - Change primary `LinkButton` to `external` and use `href={INSTRUCTIONS_TEXT.mainCTALink}` instead of `mainCTA`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b8d921ccbe998edee53b6cab6c81a39c0d894af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->