### PR TITLE
chore(ownership): More detailed ownership of integrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -376,10 +376,16 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 /src/sentry/api/endpoints/project_rule*.py                           @getsentry/alerts-notifications
 /src/sentry/api/serializers/models/rule.py                           @getsentry/alerts-notifications
 
-
 /src/sentry/digests/                                                 @getsentry/alerts-notifications
 /src/sentry/identity/                                                @getsentry/enterprise
+
 /src/sentry/integrations/                                            @getsentry/product-owners-settings-integrations @getsentry/ecosystem
+/src/sentry/integrations/api/endpoints/organization_code_mapping*.py                            @getsentry/issue-detection-backend
+/src/sentry/integrations/api/endpoints/organization_coding_agents.py                            @getsentry/machine-learning-ai
+/src/sentry/integrations/coding_agent/                                      @getsentry/machine-learning-ai
+/src/sentry/integrations/utils/codecov.py                            @getsentry/codecov
+/src/sentry/integrations/utils/stacktrace_link.py                            @getsentry/issue-detection-backend
+
 /src/sentry/mail/                                                    @getsentry/alerts-notifications
 /src/sentry/notifications/                                           @getsentry/alerts-notifications @getsentry/ecosystem
 /src/sentry/notifications/models/                                    @getsentry/ecosystem


### PR DESCRIPTION
As part of quality quarter, I'm cleaning up our team's Sentry issues. One thing I realized is that we're re-assigning far too many issues to other teams. This is my first attempt to solve this from codeowners stand point.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands CODEOWNERS under integrations with specific endpoints, coding agent, and utility files mapped to appropriate teams.
> 
> - **CODEOWNERS (Integrations)**:
>   - Add ownership for `src/sentry/integrations/api/endpoints/organization_code_mapping*.py` → `@getsentry/issue-detection-backend`.
>   - Add ownership for `src/sentry/integrations/api/endpoints/organization_coding_agents.py` and `src/sentry/integrations/coding_agent/` → `@getsentry/machine-learning-ai`.
>   - Add ownership for `src/sentry/integrations/utils/codecov.py` → `@getsentry/codecov`.
>   - Add ownership for `src/sentry/integrations/utils/stacktrace_link.py` → `@getsentry/issue-detection-backend`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60567d33896ef81d9dec6848c5b07e586bfcb8da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->