### PR TITLE
fix(aci): Fix detector table column responsiveness

### DIFF
--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -213,7 +213,7 @@ const DetectorListSimpleTable = styled(SimpleTable)`
   }
 
   @container (min-width: ${p => p.theme.breakpoints.sm}) {
-    grid-template-columns: 3fr 0.8fr 1.5fr 0.8fr;
+    grid-template-columns: 3fr 0.8fr 1.5fr;
 
     [data-column-name='last-issue'] {
       display: flex;
@@ -229,7 +229,7 @@ const DetectorListSimpleTable = styled(SimpleTable)`
   }
 
   @container (min-width: ${p => p.theme.breakpoints.lg}) {
-    grid-template-columns: 4.5fr 0.8fr 1.5fr 0.8fr 2fr;
+    grid-template-columns: 4.5fr 0.8fr 1.5fr 0.8fr 1.1fr;
 
     [data-column-name='connected-automations'] {
       display: flex;


### PR DESCRIPTION
Before:

<img width="1962" height="288" alt="CleanShot 2025-09-29 at 15 42 37@2x" src="https://github.com/user-attachments/assets/63568330-857a-4e0a-b858-735e3231fb6f" />

After:

<img width="1932" height="294" alt="CleanShot 2025-09-29 at 15 42 30@2x" src="https://github.com/user-attachments/assets/53b15628-df6a-4f18-a341-2e811e9bc16b" />
