### PR TITLE
fix(slack): handle deleted user

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -739,7 +739,11 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         # build actions
         actions = []
-        assignee = self.group.get_assignee()
+        try:
+            assignee = self.group.get_assignee()
+        except Actor.InvalidActor:
+            assignee = None
+
         for action in payload_actions:
             if action.label in (
                 "Archive",

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -436,7 +436,11 @@ def build_actions(
         )
 
     def _assign_button() -> MessageAction:
-        assignee = group.get_assignee()
+        try:
+            assignee = group.get_assignee()
+        except Actor.InvalidActor:
+            assignee = None
+
         assign_button = MessageAction(
             name="assign",
             label="Select Assignee...",


### PR DESCRIPTION
It can happen that the existing assignee is not a user anymore. This causes slack message to throw an exception. Handling it gracefully.

fixes SENTRY-4ERK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gracefully handle invalid/deleted assignees by catching Actor.InvalidActor and defaulting to no assignee in Slack issue messages.
> 
> - **Slack issue message builder (`src/sentry/integrations/slack/message_builder/issues.py`)**:
>   - In `_assign_button()`, wrap `group.get_assignee()` in `try/except Actor.InvalidActor`; fallback to `None` and no preselected option.
>   - When building actions/blocks, wrap `self.group.get_assignee()` similarly before constructing assign select and suggested assignees.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0be3cb34497bd01950868126edbf3258833547b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->