### PR TITLE
feat(issues): Remove jump to navigation links, correct ordering

### DIFF
--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -166,12 +166,18 @@ type UpdateDetectorDetailsAction = {
   type: 'UPDATE_DETECTOR_DETAILS';
 };
 
+type RemoveEventSectionAction = {
+  key: SectionKey;
+  type: 'REMOVE_EVENT_SECTION';
+};
+
 type IssueDetailsActions =
   | UpdateEventSectionAction
   | UpdateNavScrollMarginAction
   | UpdateEventCountAction
   | UpdateSidebarAction
-  | UpdateDetectorDetailsAction;
+  | UpdateDetectorDetailsAction
+  | RemoveEventSectionAction;
 
 function updateEventSection(
   state: IssueDetailsState,
@@ -207,6 +213,10 @@ export function IssueDetailsContextProvider({children}: {children: React.ReactNo
           return {...state, eventCount: action.count};
         case 'UPDATE_DETECTOR_DETAILS':
           return {...state, detectorDetails: action.detectorDetails};
+        case 'REMOVE_EVENT_SECTION': {
+          const {[action.key]: _removed, ...remainingSections} = state.sectionData;
+          return {...state, sectionData: remainingSections};
+        }
         default:
           return state;
       }

--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -1,15 +1,13 @@
 import {Fragment, useMemo, type CSSProperties} from 'react';
-import {css, useTheme, type SerializedStyles} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import Color from 'color';
 
 import {Button} from 'sentry/components/core/button';
-import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {ExternalLink} from 'sentry/components/core/link';
 import {useAutofixData} from 'sentry/components/events/autofix/useAutofix';
 import {useActionableItemsWithProguardErrors} from 'sentry/components/events/interfaces/crashContent/exception/useActionableItems';
 import {useGroupSummaryData} from 'sentry/components/group/groupSummary';
-import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCopy, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -26,13 +24,10 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 import {Divider} from 'sentry/views/issueDetails/divider';
 import EventCreatedTooltip from 'sentry/views/issueDetails/eventCreatedTooltip';
-import {
-  SectionKey,
-  useIssueDetails,
-  type SectionConfig,
-} from 'sentry/views/issueDetails/streamline/context';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {getFoldSectionKey} from 'sentry/views/issueDetails/streamline/foldSection';
 import {issueAndEventToMarkdown} from 'sentry/views/issueDetails/streamline/hooks/useCopyIssueDetails';
+import {IssueDetailsJumpTo} from 'sentry/views/issueDetails/streamline/issueDetailsJumpTo';
 
 type EventNavigationProps = {
   event: Event;
@@ -44,21 +39,6 @@ type EventNavigationProps = {
   'data-stuck'?: boolean;
   ref?: React.Ref<HTMLDivElement>;
   style?: CSSProperties;
-};
-
-const sectionLabels: Partial<Record<SectionKey, string>> = {
-  [SectionKey.HIGHLIGHTS]: t('Highlights'),
-  [SectionKey.STACKTRACE]: t('Stack Trace'),
-  [SectionKey.EXCEPTION]: t('Stack Trace'),
-  [SectionKey.THREADS]: t('Stack Trace'),
-  [SectionKey.REPLAY]: t('Replay'),
-  [SectionKey.BREADCRUMBS]: t('Breadcrumbs'),
-  [SectionKey.TRACE]: t('Trace'),
-  [SectionKey.LOGS]: t('Logs'),
-  [SectionKey.TAGS]: t('Tags'),
-  [SectionKey.CONTEXTS]: t('Context'),
-  [SectionKey.USER_FEEDBACK]: t('User Feedback'),
-  [SectionKey.FEATURE_FLAGS]: t('Flags'),
 };
 
 export const MIN_NAV_HEIGHT = 44;
@@ -95,20 +75,6 @@ function GroupMarkdownButton({group, event}: {event: Event; group: Group}) {
 export function EventTitle({event, group, ref, ...props}: EventNavigationProps) {
   const organization = useOrganization();
   const theme = useTheme();
-  const showTraceLink = organization.features.includes('performance-view');
-  const showLogsLink = organization.features.includes('ourlogs-enabled');
-  const excludedSectionKeys: SectionKey[] = [];
-  if (!showTraceLink) {
-    excludedSectionKeys.push(SectionKey.TRACE);
-  }
-  if (!showLogsLink) {
-    excludedSectionKeys.push(SectionKey.LOGS);
-  }
-
-  const {sectionData} = useIssueDetails();
-  const eventSectionConfigs = Object.values(sectionData ?? {}).filter(
-    config => sectionLabels[config.key] && !excludedSectionKeys.includes(config.key)
-  );
 
   const [_isEventErrorCollapsed, setEventErrorCollapsed] = useSyncedLocalStorageState(
     getFoldSectionKey(SectionKey.PROCESSING_ERROR),
@@ -202,65 +168,9 @@ export function EventTitle({event, group, ref, ...props}: EventNavigationProps) 
             </Fragment>
           )}
         </EventInfo>
-        {eventSectionConfigs.length > 0 && (
-          <JumpTo>
-            <JumpToLabel aria-hidden>{t('Jump to:')}</JumpToLabel>
-            <ScrollCarousel gap={0.25} aria-label={t('Jump to section links')}>
-              {eventSectionConfigs.map(config => (
-                <EventNavigationLink
-                  key={config.key}
-                  config={config}
-                  propCss={grayText}
-                />
-              ))}
-            </ScrollCarousel>
-          </JumpTo>
-        )}
+        <IssueDetailsJumpTo />
       </EventInfoJumpToWrapper>
     </div>
-  );
-}
-
-function EventNavigationLink({
-  config,
-  propCss,
-}: {
-  config: SectionConfig;
-  propCss: SerializedStyles;
-}) {
-  const [_isCollapsed, setIsCollapsed] = useSyncedLocalStorageState(
-    getFoldSectionKey(config.key),
-    config?.initialCollapse ?? false
-  );
-  return (
-    <LinkButton
-      to={{
-        ...location,
-        hash: `#${config.key}`,
-      }}
-      onClick={event => {
-        // If command click do nothing, assume user wants to open in new tab
-        if (event.metaKey || event.ctrlKey) {
-          return;
-        }
-
-        setIsCollapsed(false);
-        // Animation frame avoids conflicting with react-router ScrollRestoration
-        requestAnimationFrame(() => {
-          document
-            .getElementById(config.key)
-            ?.scrollIntoView({block: 'start', behavior: 'smooth'});
-        });
-      }}
-      borderless
-      size="xs"
-      css={propCss}
-      analyticsEventName="Issue Details: Jump To Clicked"
-      analyticsEventKey="issue_details.jump_to_clicked"
-      analyticsParams={{section: config.key}}
-    >
-      {sectionLabels[config.key]}
-    </LinkButton>
   );
 }
 
@@ -297,21 +207,6 @@ const EventInfo = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints.sm}) {
     padding-top: ${p => p.theme.space.md};
   }
-`;
-
-const JumpToLabel = styled('div')`
-  margin-top: ${p => p.theme.space['2xs']};
-`;
-
-const JumpTo = styled('div')`
-  display: flex;
-  gap: ${p => p.theme.space.xs};
-  flex-direction: row;
-  align-items: center;
-  color: ${p => p.theme.subText};
-  font-size: ${p => p.theme.fontSize.sm};
-  white-space: nowrap;
-  overflow: hidden;
 `;
 
 const ProcessingErrorButton = styled(Button)`

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -157,6 +157,16 @@ export function FoldSection({
     }
   }, [sectionData, dispatch, sectionKey, initialCollapse, preventCollapse]);
 
+  // Unregister section when component unmounts
+  useLayoutEffect(() => {
+    return () => {
+      dispatch({
+        type: 'REMOVE_EVENT_SECTION',
+        key: sectionKey,
+      });
+    };
+  }, [dispatch, sectionKey]);
+
   const onExpandedChange = useCallback(() => {
     if (preventCollapse) {
       return;

--- a/static/app/views/issueDetails/streamline/issueDetailsJumpTo.spec.tsx
+++ b/static/app/views/issueDetails/streamline/issueDetailsJumpTo.spec.tsx
@@ -1,0 +1,80 @@
+import {Fragment, useState} from 'react';
+
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
+
+import {IssueDetailsContextProvider, SectionKey} from './context';
+import {FoldSection} from './foldSection';
+import {IssueDetailsJumpTo} from './issueDetailsJumpTo';
+
+describe('IssueDetailsJumpTo', () => {
+  function additionalWrapper({children}: {children: React.ReactNode}) {
+    return <IssueDetailsContextProvider>{children}</IssueDetailsContextProvider>;
+  }
+
+  it('renders jump-to links in the order sections appear', async () => {
+    render(
+      <Fragment>
+        <IssueDetailsJumpTo />
+        {/* Render sections in a specific DOM order */}
+        <FoldSection title="Highlights" sectionKey={SectionKey.HIGHLIGHTS}>
+          <div>Highlights content</div>
+        </FoldSection>
+        <FoldSection title="Replay" sectionKey={SectionKey.REPLAY}>
+          <div>Replay content</div>
+        </FoldSection>
+        <FoldSection title="Tags" sectionKey={SectionKey.TAGS}>
+          <div>Tags content</div>
+        </FoldSection>
+      </Fragment>,
+      {additionalWrapper}
+    );
+
+    expect(await screen.findByText('Jump to:')).toBeInTheDocument();
+    // Wait for all expected links to be present
+    expect(await screen.findByRole('button', {name: 'Highlights'})).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'Replay'})).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'Tags'})).toBeInTheDocument();
+
+    // Verify order by reading links as they appear in the Jump To carousel
+    const nav = screen.getByLabelText('Jump to section links');
+    const links = within(nav).getAllByRole('button');
+    expect(links.map(l => l.textContent)).toEqual(['Highlights', 'Replay', 'Tags']);
+  });
+
+  it('removes a jump-to link when its section unmounts', async () => {
+    function TestHarness() {
+      const [showTags, setShowTags] = useState(true);
+      return (
+        <Fragment>
+          <button onClick={() => setShowTags(s => !s)}>Toggle Tags</button>
+          <IssueDetailsJumpTo />
+          <FoldSection title="Highlights" sectionKey={SectionKey.HIGHLIGHTS}>
+            <div>Highlights content</div>
+          </FoldSection>
+          {showTags ? (
+            <FoldSection title="Tags" sectionKey={SectionKey.TAGS}>
+              <div>Tags content</div>
+            </FoldSection>
+          ) : null}
+        </Fragment>
+      );
+    }
+
+    render(<TestHarness />, {additionalWrapper});
+
+    expect(await screen.findByText('Jump to:')).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'Tags'})).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle Tags'}));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', {name: 'Tags'})).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/issueDetails/streamline/issueDetailsJumpTo.tsx
+++ b/static/app/views/issueDetails/streamline/issueDetailsJumpTo.tsx
@@ -1,0 +1,147 @@
+import {useMemo} from 'react';
+import {css, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {ScrollCarousel} from 'sentry/components/scrollCarousel';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
+import {
+  SectionKey,
+  useIssueDetails,
+  type SectionConfig,
+} from 'sentry/views/issueDetails/streamline/context';
+import {getFoldSectionKey} from 'sentry/views/issueDetails/streamline/foldSection';
+
+const sectionLabels: Partial<Record<SectionKey, string>> = {
+  [SectionKey.HIGHLIGHTS]: t('Highlights'),
+  [SectionKey.STACKTRACE]: t('Stack Trace'),
+  [SectionKey.EXCEPTION]: t('Stack Trace'),
+  [SectionKey.THREADS]: t('Stack Trace'),
+  [SectionKey.REPLAY]: t('Replay'),
+  [SectionKey.BREADCRUMBS]: t('Breadcrumbs'),
+  [SectionKey.TRACE]: t('Trace'),
+  [SectionKey.LOGS]: t('Logs'),
+  [SectionKey.TAGS]: t('Tags'),
+  [SectionKey.CONTEXTS]: t('Context'),
+  [SectionKey.USER_FEEDBACK]: t('User Feedback'),
+  [SectionKey.FEATURE_FLAGS]: t('Flags'),
+};
+
+export function IssueDetailsJumpTo() {
+  const {sectionData} = useIssueDetails();
+  const organization = useOrganization();
+
+  const excludedSectionKeys = useMemo(() => {
+    const features = organization.features ?? [];
+    const excluded: SectionKey[] = [];
+    if (!features.includes('performance-view')) {
+      excluded.push(SectionKey.TRACE);
+    }
+    if (!features.includes('ourlogs-enabled')) {
+      excluded.push(SectionKey.LOGS);
+    }
+    return excluded;
+  }, [organization.features]);
+
+  const eventSectionConfigs = useMemo(() => {
+    const configs = Object.values(sectionData ?? {}).filter(
+      config => sectionLabels[config.key] && !excludedSectionKeys.includes(config.key)
+    );
+
+    // Build a position map by querying the DOM once
+    const positionMap = new Map<SectionKey, number>();
+    configs.forEach(config => {
+      const element = document.getElementById(config.key);
+      if (element) {
+        // Use offsetTop as a proxy for vertical position in the document
+        positionMap.set(config.key, element.offsetTop);
+      }
+    });
+
+    // Sort by the actual DOM order of sections on the page
+    return configs.sort((a, b) => {
+      const posA = positionMap.get(a.key);
+      const posB = positionMap.get(b.key);
+
+      // If either element doesn't exist yet, maintain current order
+      if (posA === undefined || posB === undefined) {
+        return 0;
+      }
+
+      return posA - posB;
+    });
+  }, [sectionData, excludedSectionKeys]);
+
+  if (eventSectionConfigs.length === 0) {
+    return null;
+  }
+
+  return (
+    <JumpTo>
+      <JumpToLabel aria-hidden>{t('Jump to:')}</JumpToLabel>
+      <ScrollCarousel gap={0.25} aria-label={t('Jump to section links')}>
+        {eventSectionConfigs.map(config => (
+          <JumpToLink key={config.key} config={config} />
+        ))}
+      </ScrollCarousel>
+    </JumpTo>
+  );
+}
+
+function JumpToLink({config}: {config: SectionConfig}) {
+  const theme = useTheme();
+  const [_isCollapsed, setIsCollapsed] = useSyncedLocalStorageState(
+    getFoldSectionKey(config.key),
+    config?.initialCollapse ?? false
+  );
+  return (
+    <LinkButton
+      to={{
+        ...location,
+        hash: `#${config.key}`,
+      }}
+      onClick={event => {
+        // If command click do nothing, assume user wants to open in new tab
+        if (event.metaKey || event.ctrlKey) {
+          return;
+        }
+
+        setIsCollapsed(false);
+        // Animation frame avoids conflicting with react-router ScrollRestoration
+        requestAnimationFrame(() => {
+          document
+            .getElementById(config.key)
+            ?.scrollIntoView({block: 'start', behavior: 'smooth'});
+        });
+      }}
+      borderless
+      size="xs"
+      css={css`
+        color: ${theme.subText};
+        font-weight: ${theme.fontWeight.normal};
+      `}
+      analyticsEventName="Issue Details: Jump To Clicked"
+      analyticsEventKey="issue_details.jump_to_clicked"
+      analyticsParams={{section: config.key}}
+    >
+      {sectionLabels[config.key]}
+    </LinkButton>
+  );
+}
+
+const JumpToLabel = styled('div')`
+  margin-top: ${p => p.theme.space['2xs']};
+`;
+
+const JumpTo = styled('div')`
+  display: flex;
+  gap: ${p => p.theme.space.xs};
+  flex-direction: row;
+  align-items: center;
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSize.sm};
+  white-space: nowrap;
+  overflow: hidden;
+`;

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -67,7 +67,7 @@ interface ProviderOptions {
 }
 
 interface BaseRenderOptions<T extends boolean = boolean>
-  extends Pick<ProviderOptions, 'organization'>,
+  extends Pick<ProviderOptions, 'organization' | 'additionalWrapper'>,
     rtl.RenderOptions {
   /**
    * @deprecated do not use this option for new tests
@@ -398,6 +398,7 @@ function render<T extends boolean = false>(
 
   const AllTheProviders = makeAllTheProviders({
     organization: options.organization,
+    additionalWrapper: options.additionalWrapper,
     router: legacyRouterConfig,
     deprecatedRouterMocks: options.deprecatedRouterMocks,
     history,


### PR DESCRIPTION
When navigating an issue's events - Some events might have replays and others might not. Now we'll unmount them when they're not shown. Adding them back means we have to check the ordering again, which was not previously handled correctly.


https://github.com/user-attachments/assets/08c9d5a9-b5b8-4f1e-9e29-29ac96e73680


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extracts Jump To into a dedicated component that orders links by DOM position, unregisters sections on unmount, and adds tests plus minor test utils support.
> 
> - **UI/Issue Details**:
>   - **New `IssueDetailsJumpTo`**: Centralizes "Jump to" links, filters by features, and orders links by actual DOM position.
>   - **`EventTitle`**: Replaces inline jump-to logic/styles with `<IssueDetailsJumpTo />` and cleans up unused code.
> - **State Management**:
>   - **Context**: Adds `REMOVE_EVENT_SECTION` action to remove `sectionData[SectionKey]`.
>   - **FoldSection**: Dispatches `REMOVE_EVENT_SECTION` on unmount; registers initial section config as before.
> - **Tests**:
>   - Adds `issueDetailsJumpTo.spec.tsx` covering ordering and removal when sections unmount.
> - **Test Utilities**:
>   - `reactTestingLibrary`: Passes through `additionalWrapper` to providers and hooks to support context wrapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ee6c6a16e75e353ce6cc5cb560820409fdb1a61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->