### PR TITLE
test(ui): Make additionalWrapper available in rtl render

### DIFF
--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -67,7 +67,7 @@ interface ProviderOptions {
 }
 
 interface BaseRenderOptions<T extends boolean = boolean>
-  extends Pick<ProviderOptions, 'organization'>,
+  extends Pick<ProviderOptions, 'organization' | 'additionalWrapper'>,
     rtl.RenderOptions {
   /**
    * @deprecated do not use this option for new tests
@@ -398,6 +398,7 @@ function render<T extends boolean = false>(
 
   const AllTheProviders = makeAllTheProviders({
     organization: options.organization,
+    additionalWrapper: options.additionalWrapper,
     router: legacyRouterConfig,
     deprecatedRouterMocks: options.deprecatedRouterMocks,
     history,


### PR DESCRIPTION
Forgot to make the option available for render. Is available for renderHookWithProviders already.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable `render()` to accept `additionalWrapper` and pass it to providers, aligning with `renderHookWithProviders`.
> 
> - **Testing utilities**:
>   - `tests/js/sentry-test/reactTestingLibrary.tsx`:
>     - Extend `BaseRenderOptions` to include `additionalWrapper`.
>     - Pass `options.additionalWrapper` to `makeAllTheProviders` in `render()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2953b0a2115d09557b928e272a3a6a0a1c4dfbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->