### PR TITLE
fix(feedback): fix summary/category render analytics

### DIFF
--- a/static/app/components/feedback/summaryCategories/feedbackCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackCategories.tsx
@@ -51,14 +51,10 @@ export default function FeedbackCategories() {
   const organization = useOrganization();
 
   useEffect(() => {
-    trackAnalytics('feedback.summary.categories-loaded', {
-      organization,
-      num_categories: categories ? categories.length : 0,
-    });
-  }, [organization, categories]);
-
-  useEffect(() => {
     // Analytics for the rendered state. Should match the conditions below.
+    if (isPending || isOrgSeerSetupPending) {
+      return;
+    }
     if (isError) {
       trackAnalytics('feedback.summary.categories-error', {
         organization,
@@ -67,13 +63,15 @@ export default function FeedbackCategories() {
       trackAnalytics('feedback.summary.categories-too-few-feedbacks', {
         organization,
       });
-    } else if (
-      categories &&
-      categories.length > 0 &&
-      setupAcknowledgement.orgHasAcknowledged
-    ) {
+    } else if (!categories || categories.length === 0) {
+      // Expecting very few of this event.
+      trackAnalytics('feedback.summary.categories-empty', {
+        organization,
+      });
+    } else if (setupAcknowledgement.orgHasAcknowledged) {
       trackAnalytics('feedback.summary.categories-rendered', {
         organization,
+        num_categories: categories.length,
       });
     }
   }, [
@@ -82,6 +80,8 @@ export default function FeedbackCategories() {
     tooFewFeedbacks,
     categories,
     setupAcknowledgement.orgHasAcknowledged,
+    isPending,
+    isOrgSeerSetupPending,
   ]);
 
   const currentQuery = useMemo(

--- a/static/app/components/feedback/summaryCategories/feedbackCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackCategories.tsx
@@ -64,7 +64,6 @@ export default function FeedbackCategories() {
         organization,
       });
     } else if (!categories || categories.length === 0) {
-      // Expecting very few of this event.
       trackAnalytics('feedback.summary.categories-empty', {
         organization,
       });

--- a/static/app/components/feedback/summaryCategories/feedbackSummary.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummary.tsx
@@ -21,6 +21,9 @@ export default function FeedbackSummary() {
 
   useEffect(() => {
     // Analytics for the rendered state. Should match the conditions below.
+    if (isPending || isOrgSeerSetupPending) {
+      return;
+    }
     if (!setupAcknowledgement.orgHasAcknowledged) {
       trackAnalytics('feedback.summary.seer-cta-rendered', {
         organization,
@@ -38,7 +41,14 @@ export default function FeedbackSummary() {
         organization,
       });
     }
-  }, [organization, isError, tooFewFeedbacks, setupAcknowledgement.orgHasAcknowledged]);
+  }, [
+    organization,
+    isError,
+    tooFewFeedbacks,
+    setupAcknowledgement.orgHasAcknowledged,
+    isPending,
+    isOrgSeerSetupPending,
+  ]);
 
   if (isPending || isOrgSeerSetupPending) {
     return <LoadingPlaceholder />;

--- a/static/app/utils/analytics/feedbackAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/feedbackAnalyticsEvents.tsx
@@ -9,9 +9,9 @@ export type FeedbackEventParameters = {
   'feedback.list-view-setup-sidebar': {platform: string};
   'feedback.mark-spam-clicked': {type: 'bulk' | 'details'};
   'feedback.no_associated_event_found': {orgSlug: string};
+  'feedback.summary.categories-empty': Record<string, unknown>;
   'feedback.summary.categories-error': Record<string, unknown>;
-  'feedback.summary.categories-loaded': {num_categories: number};
-  'feedback.summary.categories-rendered': Record<string, unknown>;
+  'feedback.summary.categories-rendered': {num_categories: number};
   'feedback.summary.categories-too-few-feedbacks': Record<string, unknown>;
   'feedback.summary.category-selected': {category: string};
   'feedback.summary.seer-cta-rendered': Record<string, unknown>;
@@ -43,8 +43,8 @@ export const feedbackEventMap: Record<FeedbackEventKey, string | null> = {
   'feedback.trace-section.error': 'Error Fetching Trace Data in Feedback Details',
   'feedback.trace-section.loaded': 'Fetched Same-trace Issue Data in Feedback Details',
   'feedback.no_associated_event_found': 'Associated Event Not Found in Feedback',
+  'feedback.summary.categories-empty': 'No Feedback Categories To Render',
   'feedback.summary.categories-error': 'Error Rendering Feedback Categories',
-  'feedback.summary.categories-loaded': 'Loaded Feedback Categories Data',
   'feedback.summary.categories-rendered': 'Rendered Feedback Categories',
   'feedback.summary.categories-too-few-feedbacks':
     'Too Few Feedbacks to Render Feedback Categories',


### PR DESCRIPTION
Follow up on https://github.com/getsentry/sentry/pull/100523
Tested in browser and we're incorrectly sending some events while the data's pending. While pending the seer ack is false, so the useEffects should handle this condition. 

I also felt the categories-loaded event could be combined with rendered, and we can track a categories.length = 0 event instead (expecting the backend to not return this very often).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure analytics only fire after data and Seer setup are ready, remove categories-loaded, add categories-empty, and include num_categories on rendered.
> 
> - **Analytics behavior**:
>   - Gate effects on `isPending` and `isOrgSeerSetupPending` to prevent premature events in `feedbackSummary` and `feedbackCategories`.
>   - In `feedbackCategories`, emit `feedback.summary.categories-empty` when `!categories || categories.length === 0`.
>   - Include `num_categories` on `feedback.summary.categories-rendered` when acknowledged.
> - **Event schema updates** (`static/app/utils/analytics/feedbackAnalyticsEvents.tsx`):
>   - Add `feedback.summary.categories-empty`.
>   - Remove `feedback.summary.categories-loaded` (type and label).
>   - Change `feedback.summary.categories-rendered` to include `{num_categories: number}`.
> - **Components**:
>   - Update effects/deps and early returns in `feedbackSummary.tsx` and `feedbackCategories.tsx` to align with new analytics flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 676e4801881b57341658fe68c389a2659b5a5e8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->