### PR TITLE
feat(onboarding): Simplify flutter documentation

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -106,12 +106,6 @@ export const platformProductAvailability = {
   'dotnet-winforms': [ProductSolution.PERFORMANCE_MONITORING],
   'dotnet-wpf': [ProductSolution.PERFORMANCE_MONITORING],
   'dotnet-xamarin': [ProductSolution.PERFORMANCE_MONITORING],
-  flutter: [
-    ProductSolution.PERFORMANCE_MONITORING,
-    ProductSolution.PROFILING,
-    ProductSolution.SESSION_REPLAY,
-    ProductSolution.LOGS,
-  ],
   dart: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.LOGS],
   kotlin: [ProductSolution.PERFORMANCE_MONITORING],
   go: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.LOGS],

--- a/static/app/gettingStartedDocs/flutter/flutter.spec.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.spec.tsx
@@ -2,54 +2,28 @@ import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboa
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
-
-import docs, {InstallationMode} from './flutter';
+import docs from './flutter';
 
 describe('flutter onboarding docs', () => {
-  it('renders manual installation docs correctly', async () => {
+  it('renders docs correctly', async () => {
     renderWithOnboardingLayout(docs, {
       releaseRegistry: {
         'sentry.dart.flutter': {
           version: '1.99.9',
         },
       },
-      selectedOptions: {
-        installationMode: InstallationMode.MANUAL,
-      },
     });
 
-    // Renders main headings
-    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {name: /automatic configuration/i})
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', {name: /manual configuration/i})
+    ).toBeInTheDocument();
+
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
-    // Renders SDK version from registry
-    expect(
-      await screen.findByText(textWithMarkupMatcher(/sentry_flutter: \^1\.99\.9/))
-    ).toBeInTheDocument();
-  });
-
-  it('renders wizard docs correctly', async () => {
-    renderWithOnboardingLayout(docs, {
-      releaseRegistry: {
-        'sentry.dart.flutter': {
-          version: '1.99.9',
-        },
-      },
-      selectedOptions: {
-        installationMode: InstallationMode.AUTO,
-      },
-    });
-
-    // Renders install heading only
-    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
-    expect(
-      screen.queryByRole('heading', {name: 'Configure SDK'})
-    ).not.toBeInTheDocument();
-    expect(screen.queryByRole('heading', {name: 'Verify'})).not.toBeInTheDocument();
-
-    // Renders wizard text
     expect(
       await screen.findByText(
         textWithMarkupMatcher(
@@ -57,135 +31,7 @@ describe('flutter onboarding docs', () => {
         )
       )
     ).toBeInTheDocument();
-  });
 
-  it('renders performance onboarding docs correctly', async () => {
-    renderWithOnboardingLayout(docs, {
-      releaseRegistry: {
-        'sentry.dart.flutter': {
-          version: '1.99.9',
-        },
-      },
-      selectedProducts: [ProductSolution.PERFORMANCE_MONITORING],
-      selectedOptions: {
-        installationMode: InstallationMode.MANUAL,
-      },
-    });
-
-    expect(
-      await screen.findByText(textWithMarkupMatcher(/options.tracesSampleRate/))
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(textWithMarkupMatcher(/options\.tracesSampleRate = 1\.0/))
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(
-        textWithMarkupMatcher(
-          /You'll be able to monitor the performance of your app using the SDK./
-        )
-      )
-    ).toBeInTheDocument();
-  });
-
-  it('renders profiling onboarding docs correctly', async () => {
-    renderWithOnboardingLayout(docs, {
-      releaseRegistry: {
-        'sentry.dart.flutter': {
-          version: '1.99.9',
-        },
-      },
-      selectedProducts: [
-        ProductSolution.PERFORMANCE_MONITORING,
-        ProductSolution.PROFILING,
-      ],
-      selectedOptions: {
-        installationMode: InstallationMode.MANUAL,
-      },
-    });
-
-    expect(
-      await screen.findByText(textWithMarkupMatcher(/options.profilesSampleRate/))
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(textWithMarkupMatcher(/options\.profilesSampleRate = 1\.0/))
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(
-        textWithMarkupMatcher(/Flutter Profiling alpha is available/)
-      )
-    ).toBeInTheDocument();
-  });
-
-  it('renders replay onboarding docs correctly', async () => {
-    renderWithOnboardingLayout(docs, {
-      releaseRegistry: {
-        'sentry.dart.flutter': {
-          version: '1.99.9',
-        },
-      },
-      selectedProducts: [
-        ProductSolution.PERFORMANCE_MONITORING,
-        ProductSolution.PROFILING,
-        ProductSolution.SESSION_REPLAY,
-      ],
-      selectedOptions: {
-        installationMode: InstallationMode.MANUAL,
-      },
-    });
-
-    expect(
-      await screen.findByText(
-        textWithMarkupMatcher(/options\.replay\.sessionSampleRate = 0\.1/)
-      )
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(
-        textWithMarkupMatcher(/options\.replay\.onErrorSampleRate = 1\.0/)
-      )
-    ).toBeInTheDocument();
-  });
-
-  it('renders logs configuration for manual installation when logs are selected', async () => {
-    renderWithOnboardingLayout(docs, {
-      releaseRegistry: {
-        'sentry.dart.flutter': {
-          version: '1.99.9',
-        },
-      },
-      selectedProducts: [ProductSolution.LOGS],
-      selectedOptions: {
-        installationMode: InstallationMode.MANUAL,
-      },
-    });
-
-    // Should include logs configuration
-    expect(
-      await screen.findByText(textWithMarkupMatcher(/options\.enableLogs = true/))
-    ).toBeInTheDocument();
-
-    // Should include a log call in the verify snippet
-    expect(
-      await screen.findByText(textWithMarkupMatcher(/Sentry\.logger\.info/))
-    ).toBeInTheDocument();
-
-    // Should include logging next step
-    expect(await screen.findByText('Structured Logs')).toBeInTheDocument();
-  });
-
-  it('renders logs configuration for auto installation when logs are selected', async () => {
-    renderWithOnboardingLayout(docs, {
-      releaseRegistry: {
-        'sentry.dart.flutter': {
-          version: '1.99.9',
-        },
-      },
-      selectedProducts: [ProductSolution.LOGS],
-      selectedOptions: {
-        installationMode: InstallationMode.AUTO,
-      },
-    });
-
-    // Should include logging next step even in auto mode
-    expect(await screen.findByText('Structured Logs')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Structured Logs'})).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/flutter/flutter.spec.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.spec.tsx
@@ -15,6 +15,14 @@ describe('flutter onboarding docs', () => {
     });
 
     expect(
+      await screen.findByText(
+        textWithMarkupMatcher(
+          /Add Sentry automatically to your app with the Sentry wizard/
+        )
+      )
+    ).toBeInTheDocument();
+
+    expect(
       screen.getByRole('heading', {name: /automatic configuration/i})
     ).toBeInTheDocument();
 
@@ -23,14 +31,6 @@ describe('flutter onboarding docs', () => {
     ).toBeInTheDocument();
 
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
-
-    expect(
-      await screen.findByText(
-        textWithMarkupMatcher(
-          /Add Sentry automatically to your app with the Sentry wizard/
-        )
-      )
-    ).toBeInTheDocument();
 
     expect(screen.getByRole('link', {name: 'Structured Logs'})).toBeInTheDocument();
   });


### PR DESCRIPTION
**Problem**
In the Sentry Flutter documentation, when the "Auto" option is selected, toggling options like Replay, Profiling, or Tracing doesn’t update the UI. This happens because only the manual configuration is being updated.

https://github.com/user-attachments/assets/497e4548-7833-4281-a697-addf8083f4e7



**Solution**
To simplify, we now provide only the recommended automatic configuration. For those who need manual setup, there’s a collapsed section with the project DSN and a link to detailed documentation. This makes the in-app onboarding much simpler.

https://github.com/user-attachments/assets/b093140c-4811-4373-8e72-d799bbe2ad74

closes https://linear.app/getsentry/issue/TET-1215/flutter-onboarding-product-selection-buttons-dont-do-anything-in-auto

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies Flutter onboarding to a single automatic setup with a collapsible manual section, updates types/APIs, and streamlines tests.
> 
> - **Onboarding Docs (Flutter)**:
>   - Replace mode selector with a single, recommended automatic configuration flow using the Sentry wizard.
>   - Add a collapsible “Manual Configuration” section with DSN copy field and link to manual setup docs.
>   - Simplify steps to new content schema (titles/text/code/list), keep a dedicated Verify step, and always include “Structured Logs” in Next Steps.
>   - Remove dynamic/manual per-product configuration snippets (performance, profiling, replay, logs) from the main onboarding; keep dedicated flows (replay, feedback, logs) and update their generics/types accordingly.
> - **Types/API**:
>   - Remove `InstallationMode` and `platformOptions`; update `OnboardingConfig`/`Docs` usages and parameters.
>   - Introduce `CopyDsnField` in manual config.
> - **Tests**:
>   - Simplify `flutter.spec.tsx` to validate the new automatic/manual headings and Verify content; drop tests tied to manual/auto modes and per-product options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dfa3bd0821b176a65246f0d7edd7b7531ab8fa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->