### PR TITLE
fix(project issues): Add exception handling for invalid sort query param on project issues

### DIFF
--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -176,9 +176,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
 
         try:
             cursor_result, query_kwargs = prep_search(request, project, {"count_hits": True})
-        except ValidationError as exc:
-            return Response({"detail": str(exc)}, status=400)
-        except InvalidSearchQuery as exc:
+        except (ValidationError, InvalidSearchQuery) as exc:
             return Response({"detail": str(exc)}, status=400)
 
         results = list(cursor_result)

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -22,6 +22,7 @@ from sentry.api.helpers.group_index import (
 from sentry.api.helpers.group_index.validators import ValidationError
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group_stream import StreamGroupSerializer
+from sentry.exceptions import InvalidSearchQuery
 from sentry.models.environment import Environment
 from sentry.models.group import QUERY_STATUS_LOOKUP, Group, GroupStatus
 from sentry.models.grouphash import GroupHash
@@ -176,6 +177,8 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
         try:
             cursor_result, query_kwargs = prep_search(request, project, {"count_hits": True})
         except ValidationError as exc:
+            return Response({"detail": str(exc)}, status=400)
+        except InvalidSearchQuery as exc:
             return Response({"detail": str(exc)}, status=400)
 
         results = list(cursor_result)

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -76,6 +76,18 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400
         assert "Error parsing search query" in response.data["detail"]
 
+    def test_invalid_sort_query_parameter(self) -> None:
+        self.create_group(last_seen=before_now(seconds=1))
+        self.login_as(user=self.user)
+
+        response = self.client.get(f"{self.path}?sort=-lastSeen", format="json")
+        assert response.status_code == 400
+        assert "Sort key '-lastSeen' not supported" in response.data["detail"]
+
+        response = self.client.get(f"{self.path}?sort=invalidSort", format="json")
+        assert response.status_code == 400
+        assert "Sort key 'invalidSort' not supported" in response.data["detail"]
+
     def test_simple_pagination(self) -> None:
         event1 = self.store_event(
             data={


### PR DESCRIPTION
Fixes [SENTRY-3Z7D](https://sentry.sentry.io/issues/6657566500/?project=1&referrer=issue-list&statsPeriod=90d).

Adds exception handling for `InvalidSearchQuery` in the GET for project issues - raised when the `sort` query param is passed as an invalid value.