### PR TITLE
ref(symbolication): Disables index on nvidia source

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2347,7 +2347,6 @@ SENTRY_BUILTIN_SOURCES = {
         "filters": {"filetypes": ["pe", "pdb"]},
         "url": "https://driver-symbols.nvidia.com/",
         "is_public": True,
-        "has_index": True,
     },
     "chromium": {
         "type": "http",


### PR DESCRIPTION
Temporarily to address INGEST-496

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `has_index` flag from the `nvidia` builtin symbol source in `src/sentry/conf/server.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b9e246fd402a4fd7ae562972aecdbe843a28686. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->