### PR TITLE
feat(tract-details): Detect JSON objects in attributes

### DIFF
--- a/static/app/utils/string/looksLikeAJSONObject.spec.tsx
+++ b/static/app/utils/string/looksLikeAJSONObject.spec.tsx
@@ -1,0 +1,19 @@
+import {looksLikeAJSONObject} from './looksLikeAJSONObject';
+
+describe('looksLikeAJSONObject', () => {
+  it.each([
+    ['{}', true],
+    ['{"hello": "world"}', true],
+    ['{"key": 1}', true],
+    ['{"key": true}', true],
+    ['  {}  ', true],
+    ['[Filtered]', false],
+    ['[]', false],
+    ['hello world', false],
+    ['{incomplete', false],
+    ['incomplete}', false],
+    ['', false],
+  ])('"%s" should return %s', (input, expected) => {
+    expect(looksLikeAJSONObject(input)).toBe(expected);
+  });
+});

--- a/static/app/utils/string/looksLikeAJSONObject.tsx
+++ b/static/app/utils/string/looksLikeAJSONObject.tsx
@@ -1,0 +1,14 @@
+/**
+ * Check if a string value looks like it could be a JSON-encoded object. This is
+ useful for situations where we used JSON strings to store object values because
+ object storage was not possible.
+ *
+ * This function does _not_ parse the string as JSON because in most cases we
+ have to decode the string anyway to render it, and we don't want to decode
+ twice. Instead, the renderer gracefully fails if the JSON is not valid.
+ */
+export function looksLikeAJSONObject(value: string) {
+  const trimmedValue = value.trim();
+
+  return trimmedValue.startsWith('{') && trimmedValue.endsWith('}');
+}


### PR DESCRIPTION
Some SDKs are sending span attributes that are string encoded JSON objects.
This PR builds on the existing JSON array detection to add detection for JSON objects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detects JSON-encoded objects in span attributes and renders them as structured data, removing the hardcoded JSON attribute list.
> 
> - **Trace Details UI**
>   - Extends JSON detection in `attributes.tsx` to handle both arrays and objects via `looksLikeAJSONArray` and new `looksLikeAJSONObject`.
>   - Removes hardcoded `JSON_ATTRIBUTES` and its renderer registration; now uses heuristic detection for any string that looks like JSON.
> - **Utils**
>   - Adds `utils/string/looksLikeAJSONObject` for object-shaped JSON string detection, with tests in `looksLikeAJSONObject.spec.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee3591bc400a1954db11378d7b03e6835c565d83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->