### PR TITLE
fix(devinfra): Stop artifacts action if the run is cancelled

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -167,7 +167,7 @@ jobs:
       # Upload coverage data even if running the tests step fails since
       # it reduces large coverage fluctuations
       - name: Handle artifacts
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/artifacts
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
If the push happenes before this action is finished, we will see the codecov message that is not actionable. Until codecov has `--quiet` option or something similar this is a workaround to not run this action on cancelled workflows.

<img width="1864" height="482" alt="image" src="https://github.com/user-attachments/assets/1ebfe8ed-dbba-4f52-9d93-eba94d284f44" />
