### PR TITLE
ref(feature-flag): Update 'relay-playstation-ingestion' to be internal

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -294,7 +294,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enables PR page
     manager.add("organizations:pr-page", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the playstation ingestion in relay
-    manager.add("organizations:relay-playstation-ingestion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:relay-playstation-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enables OTLP Trace ingestion in Relay for an entire org (see also `projects:relay-otel-endpoint`)
     manager.add("organizations:relay-otlp-traces-endpoint", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables OTLP Log ingestion in Relay for an entire org.


### PR DESCRIPTION
All PlayStation-related functionality is now controlled through org options. Since this has been fully GA and stable since 02.09, we’re updating the flag `organizations:relay-playstation-ingestion` to internal.

**Note**
Should we move this flag to `permant.py` later, even though it isn’t tied to a plan?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `organizations:relay-playstation-ingestion` feature from `FLAGPOLE` to `INTERNAL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70e2f6194e2a27467c47eb0180035f65a154613b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->