### PR TITLE
Adapt symbolication to `symbolicate-any` endpoint

### DIFF
--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -74,10 +74,6 @@ class CachedAttachment:
         return self._data
 
     def delete(self):
-        if self.stored_id:
-            # TODO: delete the stored file
-            raise NotImplementedError()
-
         for key in self.chunk_keys:
             self._cache.inner.delete(key)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3505,6 +3505,9 @@ register("objectstore.enable_for.attachments", default=0.0, flags=FLAG_AUTOMATOR
 # configuration where it writes to the new objectstore alongside the existing filestore.
 # This is mutually exclusive with the above setting.
 register("objectstore.double_write.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+# This forces symbolication to use the "stored attachment" codepath,
+# regardless of whether the attachment has already been stored.
+register("objectstore.force-stored-symbolication", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # option used to enable/disable tracking
 # rate of potential functions metrics to


### PR DESCRIPTION
Changes the symbolication pipeline to use the new `symbolicate-any` endpoint which passes a `storage_url` within a JSON request for stored attachments. Also adds a new feature flag to force running minidump symbolication through that endpoint, and `objectstore`.

---

This is a companion PR to https://github.com/getsentry/symbolicator/pull/1795
Ref FS-103
