### PR TITLE
style(preprod): add config to builds table

### DIFF
--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -109,7 +109,7 @@ export function PreprodBuildsTable({
               <Flex align="center" gap="xs">
                 <IconCommit size="xs" />
                 <Text size="sm" variant="muted" monospace>
-                  #{(build.vcs_info?.head_sha?.slice(0, 7) || '--').toUpperCase()}
+                  {(build.vcs_info?.head_sha?.slice(0, 7) || '--').toUpperCase()}
                 </Text>
                 {build.vcs_info?.head_ref !== null && (
                   <React.Fragment>

--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -2,10 +2,12 @@ import React, {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
+import {CodeSnippet} from 'sentry/components/codeSnippet';
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import {Flex} from 'sentry/components/core/layout';
 import {Link} from 'sentry/components/core/link';
 import {Text} from 'sentry/components/core/text';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
@@ -68,9 +70,23 @@ export function PreprodBuildsTable({
                     {build.app_info?.name || '--'}
                   </Text>
                 </Flex>
-                <Text size="sm" variant="muted">
-                  {build.app_info?.app_id || '--'}
-                </Text>
+                <Flex align="center" gap="xs">
+                  <Text size="sm" variant="muted">
+                    {build.app_info?.app_id || '--'}
+                  </Text>
+                  {build.app_info?.build_configuration && (
+                    <React.Fragment>
+                      <Text size="sm" variant="muted">
+                        {' • '}
+                      </Text>
+                      <Tooltip title={t('Build configuration')}>
+                        <Text size="sm" variant="muted" monospace>
+                          {build.app_info.build_configuration}
+                        </Text>
+                      </Tooltip>
+                    </React.Fragment>
+                  )}
+                </Flex>
               </Flex>
             ) : null}
           </SimpleTable.RowCell>
@@ -179,4 +195,9 @@ const FullRowLink = styled(Link)`
   &:hover {
     color: inherit;
   }
+`;
+
+const InlineCodeSnippet = styled(CodeSnippet)`
+  font-size: ${p => p.theme.fontSize.xs};
+  padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.xs};
 `;

--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -2,7 +2,6 @@ import React, {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
-import {CodeSnippet} from 'sentry/components/codeSnippet';
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import {Flex} from 'sentry/components/core/layout';
 import {Link} from 'sentry/components/core/link';

--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -196,8 +196,3 @@ const FullRowLink = styled(Link)`
     color: inherit;
   }
 `;
-
-const InlineCodeSnippet = styled(CodeSnippet)`
-  font-size: ${p => p.theme.fontSize.xs};
-  padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.xs};
-`;


### PR DESCRIPTION
add build config to builds table
<img width="1382" height="818" alt="image" src="https://github.com/user-attachments/assets/ea481278-caad-48ac-b423-ff92d43bcc9f" />

<img width="1425" height="221" alt="image" src="https://github.com/user-attachments/assets/cc00796c-2aa9-4362-9e04-28d10e1f1743" />


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shows build configuration next to app ID with a tooltip and removes the leading # from the short commit SHA.
> 
> - **Preprod UI**:
>   - **Builds Table (`static/app/components/preprod/preprodBuildsTable.tsx`)**:
>     - Display `app_info.build_configuration` next to `app_id`, with a tooltip labeled “Build configuration”.
>     - Remove leading `#` from displayed short `vcs_info.head_sha`.
>     - Add `Tooltip` import to support the new UI element.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1763efee80fe7588151ea266e770fd015654032. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->