### PR TITLE
feat(issues): Support specifying update_date in status change messages

### DIFF
--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -69,6 +69,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             activity_type=activity_type,
             activity_data=status_change.get("activity_data"),
             detector_id=status_change.get("detector_id"),
+            update_date=status_change.get("update_date"),
         )
         remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED)
         kick_off_status_syncs.apply_async(
@@ -94,6 +95,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             activity_type=activity_type,
             activity_data=status_change.get("activity_data"),
             detector_id=status_change.get("detector_id"),
+            update_date=status_change.get("update_date"),
         )
         remove_group_from_inbox(group, action=GroupInboxRemoveAction.IGNORED)
         kick_off_status_syncs.apply_async(
@@ -133,6 +135,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             from_substatus=group.substatus,
             activity_data=status_change.get("activity_data"),
             detector_id=status_change.get("detector_id"),
+            update_date=status_change.get("update_date"),
         )
         add_group_to_inbox(group, group_inbox_reason)
         kick_off_status_syncs.apply_async(
@@ -243,6 +246,7 @@ def _get_status_change_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
         "new_substatus": payload.get("new_substatus", None),
         "detector_id": payload.get("detector_id", None),
         "activity_data": payload.get("activity_data", None),
+        "update_date": payload.get("update_date", None),
     }
 
     process_occurrence_data(data)

--- a/src/sentry/issues/status_change_message.py
+++ b/src/sentry/issues/status_change_message.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, TypedDict
+from datetime import datetime
+from typing import Any, NotRequired, TypedDict
 from uuid import uuid4
 
 
@@ -14,6 +15,7 @@ class StatusChangeMessageData(TypedDict):
     id: str
     detector_id: int | None
     activity_data: dict[str, Any] | None
+    update_date: NotRequired[datetime | None]
 
 
 @dataclass(frozen=True)
@@ -24,6 +26,7 @@ class StatusChangeMessage:
     new_substatus: int | None
     detector_id: int | None = None
     activity_data: dict[str, Any] | None = None
+    update_date: datetime | None = None
     id: str = field(default_factory=lambda: uuid4().hex)
 
     def to_dict(
@@ -36,5 +39,6 @@ class StatusChangeMessage:
             "new_substatus": self.new_substatus,
             "detector_id": self.detector_id,
             "activity_data": self.activity_data,
+            "update_date": self.update_date,
             "id": self.id,
         }

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
+from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -87,6 +88,7 @@ class ActivityManager(BaseManager["Activity"]):
         user_id: int | None = None,
         data: Mapping[str, Any] | None = None,
         send_notification: bool = True,
+        datetime: datetime | None = None,
     ) -> Activity:
         if user:
             user_id = user.id
@@ -98,6 +100,8 @@ class ActivityManager(BaseManager["Activity"]):
         }
         if user_id is not None:
             activity_args["user_id"] = user_id
+        if datetime is not None:
+            activity_args["datetime"] = datetime
         activity = self.create(**activity_args)
 
         if send_notification:

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -445,6 +445,7 @@ class GroupManager(BaseManager["Group"]):
         send_activity_notification: bool = True,
         from_substatus: int | None = None,
         detector_id: int | None = None,
+        update_date: datetime | None = None,
     ) -> None:
         """For each groups, update status to `status` and create an Activity."""
         from sentry.incidents.grouptype import MetricIssue
@@ -468,7 +469,7 @@ class GroupManager(BaseManager["Group"]):
         should_reopen_open_period = {
             group.id: group.status == GroupStatus.RESOLVED for group in selected_groups
         }
-        resolved_at = timezone.now()
+        resolved_at = update_date if update_date is not None else timezone.now()
         updated_priority = {}
         for group in selected_groups:
             group.status = status
@@ -493,6 +494,7 @@ class GroupManager(BaseManager["Group"]):
                 activity_type,
                 data=activity_data,
                 send_notification=send_activity_notification,
+                datetime=update_date,
             )
             record_group_history_from_activity_type(group, activity_type.value)
 
@@ -505,6 +507,7 @@ class GroupManager(BaseManager["Group"]):
                         "priority": new_priority.to_str(),
                         "reason": PriorityChangeReason.ONGOING,
                     },
+                    datetime=update_date,
                 )
                 record_group_history(group, PRIORITY_TO_GROUP_HISTORY_STATUS[new_priority])
 


### PR DESCRIPTION
This allows us to backdate / forward-date status changes for issues (typically for resolving an issue at a specific time)

This is useful for crons to mark an issue has having been resolved when the cron job recovered, even if the recovering check-in was processed minutes after (and thus resolution happened minutes after) the time the check-in was actually received.

Part of [NEW-538: Update Crons/Uptime issue occurrences timings should match the actual downtime/recovery times](https://linear.app/getsentry/issue/NEW-538/update-cronsuptime-issue-occurrences-timings-should-match-the-actual)