### PR TITLE
feat(workflow_engine): Support detection_time in DetectorOccurrence

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Generic, TypeVar
 
+from django.utils import timezone
+
 from sentry.issues.grouptype import GroupType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.types.actor import Actor
@@ -45,6 +47,7 @@ class DetectorOccurrence:
     resource_id: str | None = None
     assignee: Actor | None = None
     priority: DetectorPriorityLevel | None = None
+    detection_time: datetime | None = None
 
     def to_issue_occurrence(
         self,
@@ -52,7 +55,6 @@ class DetectorOccurrence:
         occurrence_id: str,
         project_id: int,
         status: DetectorPriorityLevel,
-        detection_time: datetime,
         additional_evidence_data: Mapping[str, Any],
         fingerprint: list[str],
     ) -> IssueOccurrence:
@@ -67,7 +69,7 @@ class DetectorOccurrence:
             evidence_data={**self.evidence_data, **additional_evidence_data},
             evidence_display=self.evidence_display,
             type=self.type,
-            detection_time=detection_time,
+            detection_time=self.detection_time or timezone.now(),
             level=self.level,
             culprit=self.culprit,
             priority=self.priority or status,

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -1,7 +1,7 @@
 import abc
 import dataclasses
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from typing import Any, Generic, cast
 from uuid import uuid4
 
@@ -596,7 +596,6 @@ class StatefulDetectorHandler(
             occurrence_id=str(uuid4()),
             project_id=self.detector.project_id,
             status=new_priority,
-            detection_time=datetime.now(UTC),
             additional_evidence_data=evidence_data,
         )
 

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Any
 from unittest import mock
 
@@ -255,7 +254,6 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
         group_key: DetectorGroupKey,
         value: int,
         priority: DetectorPriorityLevel,
-        detection_time: datetime,
         occurrence_id: str,
     ) -> tuple[IssueOccurrence, dict[str, Any]]:
         fingerprint = [f"{detector.id}{':' + group_key if group_key is not None else ''}"]
@@ -268,7 +266,6 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
             occurrence_id=occurrence_id,
             project_id=detector.project_id,
             status=priority,
-            detection_time=detection_time,
             additional_evidence_data=evidence_data,
             fingerprint=fingerprint,
         )
@@ -278,10 +275,10 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
                 detector_occurrence.event_data.copy() if detector_occurrence.event_data else {}
             )
         event_data["environment"] = detector.config.get("environment")
-        event_data["timestamp"] = detection_time
+        event_data["timestamp"] = issue_occurrence.detection_time
         event_data["project_id"] = detector.project_id
         event_data["event_id"] = occurrence_id
         event_data.setdefault("platform", "python")
-        event_data.setdefault("received", detection_time)
+        event_data.setdefault("received", issue_occurrence.detection_time)
         event_data.setdefault("tags", {})
         return issue_occurrence, event_data

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1,6 +1,5 @@
 import unittest
 import uuid
-from datetime import UTC, datetime
 from unittest import mock
 from unittest.mock import MagicMock, call
 
@@ -103,7 +102,6 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             group_key=None,
             value=6,
             priority=DetectorPriorityLevel.HIGH,
-            detection_time=datetime.now(UTC),
             occurrence_id=str(self.mock_uuid4.return_value),
         )
 
@@ -137,14 +135,12 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             detector.detector_handler, "group_1", PriorityLevel.HIGH
         )
 
-        detection_time = datetime.now(UTC)
         issue_occurrence_1, event_data_1 = self.detector_to_issue_occurrence(
             detector_occurrence=detector_occurrence_1,
             detector=detector,
             group_key="group_1",
             value=6,
             priority=DetectorPriorityLevel.HIGH,
-            detection_time=detection_time,
             occurrence_id=str(self.mock_uuid4.return_value),
         )
 
@@ -166,7 +162,6 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             group_key="group_2",
             value=10,
             priority=DetectorPriorityLevel.HIGH,
-            detection_time=detection_time,
             occurrence_id=str(self.mock_uuid4.return_value),
         )
 
@@ -259,7 +254,6 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             group_key=None,
             value=6,
             priority=DetectorPriorityLevel.HIGH,
-            detection_time=datetime.now(UTC),
             occurrence_id=str(self.mock_uuid4.return_value),
         )
 
@@ -544,14 +538,12 @@ class TestEvaluate(BaseDetectorHandlerTest):
             handler, "val1", PriorityLevel.HIGH
         )
 
-        detection_time = datetime.now(UTC)
         issue_occurrence, event_data = self.detector_to_issue_occurrence(
             detector_occurrence=detector_occurrence,
             detector=handler.detector,
             group_key="val1",
             value=6,
             priority=DetectorPriorityLevel.HIGH,
-            detection_time=detection_time,
             occurrence_id=str(self.mock_uuid4.return_value),
         )
 
@@ -585,14 +577,12 @@ class TestEvaluate(BaseDetectorHandlerTest):
             handler, "val1", PriorityLevel.HIGH
         )
 
-        detection_time = datetime.now(UTC)
         issue_occurrence, event_data = self.detector_to_issue_occurrence(
             detector_occurrence=detector_occurrence,
             detector=handler.detector,
             group_key="val1",
             value=6,
             priority=DetectorPriorityLevel.HIGH,
-            detection_time=detection_time,
             occurrence_id=str(self.mock_uuid4.return_value),
         )
 
@@ -641,14 +631,12 @@ class TestEvaluate(BaseDetectorHandlerTest):
             handler, "val1", PriorityLevel.HIGH
         )
 
-        detection_time = datetime.now(UTC)
         issue_occurrence, event_data = self.detector_to_issue_occurrence(
             detector_occurrence=detector_occurrence,
             detector=handler.detector,
             group_key="val1",
             value=100,
             priority=DetectorPriorityLevel.HIGH,
-            detection_time=detection_time,
             occurrence_id=str(self.mock_uuid4.return_value),
         )
 
@@ -684,14 +672,12 @@ class TestEvaluate(BaseDetectorHandlerTest):
             handler, "val1", PriorityLevel.HIGH
         )
 
-        detection_time = datetime.now(UTC)
         issue_occurrence, event_data = self.detector_to_issue_occurrence(
             detector_occurrence=detector_occurrence,
             detector=handler.detector,
             group_key="val1",
             value=8,
             priority=DetectorPriorityLevel.HIGH,
-            detection_time=detection_time,
             occurrence_id=str(self.mock_uuid4.return_value),
         )
 
@@ -748,14 +734,12 @@ class TestEvaluateGroupValue(BaseDetectorHandlerTest):
                 handler, "val1", PriorityLevel.HIGH
             )
 
-            detection_time = datetime.now(UTC)
             issue_occurrence, event_data = self.detector_to_issue_occurrence(
                 detector_occurrence=detector_occurrence,
                 detector=handler.detector,
                 group_key="group_key",
                 value=10,
                 priority=DetectorPriorityLevel.HIGH,
-                detection_time=detection_time,
                 occurrence_id=str(self.mock_uuid4.return_value),
             )
 


### PR DESCRIPTION
Allows the detector occurrence to be provided with the detection_time, which the IssueOccurrence will inherit.

Will allow for things like the UptimeDetector to specify that a downtime issue was detected at the specific time we made the check, instead of the time the issue was actually created.

Part of [NEW-538: Update Crons/Uptime issue occurrences timings should match the actual downtime/recovery times](https://linear.app/getsentry/issue/NEW-538/update-cronsuptime-issue-occurrences-timings-should-match-the-actual)