### PR TITLE
style(preprod): add build config to compare pages

### DIFF
--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -6,7 +6,9 @@ import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import {Flex} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import {Heading} from 'sentry/components/core/text/heading';
-import {IconCode, IconDownload, IconJson} from 'sentry/icons';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {IconCode, IconDownload, IconJson, IconMobile} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
   isSizeInfoCompleted,
@@ -76,6 +78,14 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
           </InfoIcon>
           <Text>{buildDetails.app_info.app_id}</Text>
         </Flex>
+        {buildDetails.app_info.build_configuration && (
+          <Flex gap="sm" align="center">
+            <IconMobile size="sm" color="gray300" />
+            <Tooltip title={t('Build configuration')}>
+              <Text monospace>{buildDetails.app_info.build_configuration}</Text>
+            </Tooltip>
+          </Flex>
+        )}
         {isSizeInfoCompleted(buildDetails.size_info) && (
           <Flex gap="sm" align="center">
             <IconDownload size="sm" color="gray300" />

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -229,7 +229,7 @@ function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
           )}
           {build.app_info?.build_configuration && (
             <Flex align="center" gap="sm">
-              <IconMobile size="sm" color="gray300" />
+              <IconMobile size="xs" color="gray300" />
               <Tooltip title={t('Build configuration')}>
                 <Text monospace>{build.app_info.build_configuration}</Text>
               </Tooltip>

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -8,10 +8,18 @@ import {Stack} from 'sentry/components/core/layout';
 import {Flex} from 'sentry/components/core/layout/flex';
 import {Radio} from 'sentry/components/core/radio';
 import {Text} from 'sentry/components/core/text';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import TimeSince from 'sentry/components/timeSince';
-import {IconCalendar, IconCode, IconCommit, IconDownload, IconSearch} from 'sentry/icons';
+import {
+  IconCalendar,
+  IconCode,
+  IconCommit,
+  IconDownload,
+  IconMobile,
+  IconSearch,
+} from 'sentry/icons';
 import {IconBranch} from 'sentry/icons/iconBranch';
 import {t} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
@@ -217,6 +225,14 @@ function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
             <Flex align="center" gap="sm">
               <IconCalendar size="xs" color="gray300" />
               <TimeSince date={dateAdded} />
+            </Flex>
+          )}
+          {build.app_info?.build_configuration && (
+            <Flex align="center" gap="sm">
+              <IconMobile size="sm" color="gray300" />
+              <Tooltip title={t('Build configuration')}>
+                <Text monospace>{build.app_info.build_configuration}</Text>
+              </Tooltip>
             </Flex>
           )}
           {isSizeInfoCompleted(sizeInfo) && (


### PR DESCRIPTION
add build config to compare pages
<img width="1434" height="407" alt="image" src="https://github.com/user-attachments/assets/33ece1a5-ee6e-43f7-8d92-71e6a18981b2" />
(see below comment about fonts)
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
