### PR TITLE
feat(crons): Set issue occurrence detection_time to the check-in date

### DIFF
--- a/src/sentry/monitors/logic/incident_occurrence.py
+++ b/src/sentry/monitors/logic/incident_occurrence.py
@@ -177,7 +177,7 @@ def send_incident_occurrence(
         ],
         evidence_data=evidence_data,
         culprit="",
-        detection_time=current_timestamp,
+        detection_time=failed_checkin.date_added,
         level="error",
         assignee=monitor_env.monitor.owner_actor,
     )

--- a/tests/sentry/monitors/logic/test_incident_occurrence.py
+++ b/tests/sentry/monitors/logic/test_incident_occurrence.py
@@ -130,6 +130,7 @@ class IncidentOccurrenceTestCase(TestCase):
                 "type": MonitorIncidentType.type_id,
                 "level": "error",
                 "culprit": "",
+                "detection_time": self.failed_checkin.date_added.timestamp(),
             },
         ) == dict(occurrence)
 
@@ -214,6 +215,7 @@ class IncidentOccurrenceTestCase(TestCase):
                 "type": MonitorIncidentType.type_id,
                 "level": "error",
                 "culprit": "",
+                "detection_time": self.failed_checkin.date_added.timestamp(),
             },
         ) == dict(occurrence)
 


### PR DESCRIPTION
Part of [NEW-538: Update Crons/Uptime issue occurrences timings should match the actual downtime/recovery times](https://linear.app/getsentry/issue/NEW-538/update-cronsuptime-issue-occurrences-timings-should-match-the-actual)