### PR TITLE
fix(preprod): show image savings relative to app size

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
@@ -44,11 +44,11 @@ describe('AppSizeInsightsSidebarRow', () => {
 
     // Check file savings are displayed with negative values
     expect(screen.getByText(/-\s*512\s*KB/i)).toBeInTheDocument();
-    // Only Icon.js has 256 KB savings (logo.png shows 128 KB for HEIC)
+    // Multiple files have similar savings
     expect(screen.getByText(/-\s*256\s*KB/i)).toBeInTheDocument();
     expect(screen.getByText('(-7.5%)')).toBeInTheDocument();
-    // Only Icon.js has (-4%) savings
-    expect(screen.getByText('(-4%)')).toBeInTheDocument();
+    // Icon.js and logo.png both have (-4%) savings (Icon.js main, logo.png main and HEIC)
+    expect(screen.getAllByText('(-4%)')).toHaveLength(3);
   });
 
   it('calls onToggleExpanded when clicking the toggle button', async () => {
@@ -70,6 +70,8 @@ describe('AppSizeInsightsSidebarRow', () => {
           percentage: 10,
           data: {
             fileType: 'optimizable_image' as const,
+            minifyPercentage: 6.67, // 200000 / 3000000 * 100
+            conversionPercentage: 10, // 300000 / 3000000 * 100
             originalFile: {
               file_path: 'image.png',
               current_size: 1000000,
@@ -95,12 +97,13 @@ describe('AppSizeInsightsSidebarRow', () => {
 
     // Should show max savings in main row (300 KB appears twice: main row + HEIC row)
     expect(screen.getAllByText(/-300\s*KB/i)).toHaveLength(2);
-    expect(screen.getAllByText('(-30%)')).toHaveLength(2);
+    // (-10%) appears in main row and HEIC row
+    expect(screen.getAllByText('(-10%)')).toHaveLength(2);
 
-    // Should show both optimization options
+    // Should show both optimization options with app-relative percentages
     expect(screen.getByText('Optimize:')).toBeInTheDocument();
     expect(screen.getByText(/-200\s*KB/i)).toBeInTheDocument();
-    expect(screen.getByText('(-20%)')).toBeInTheDocument();
+    expect(screen.getByText('(-6.7%)')).toBeInTheDocument();
 
     expect(screen.getByText('Convert to HEIC:')).toBeInTheDocument();
   });
@@ -114,6 +117,8 @@ describe('AppSizeInsightsSidebarRow', () => {
           percentage: 10,
           data: {
             fileType: 'optimizable_image' as const,
+            minifyPercentage: 0,
+            conversionPercentage: 10,
             originalFile: {
               file_path: 'already-optimized.png',
               current_size: 802388,
@@ -149,6 +154,8 @@ describe('AppSizeInsightsSidebarRow', () => {
           percentage: 5,
           data: {
             fileType: 'optimizable_image' as const,
+            minifyPercentage: 5,
+            conversionPercentage: 0,
             originalFile: {
               file_path: 'no-heic.png',
               current_size: 505980,

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.spec.tsx
@@ -44,11 +44,13 @@ describe('AppSizeInsightsSidebarRow', () => {
 
     // Check file savings are displayed with negative values
     expect(screen.getByText(/-\s*512\s*KB/i)).toBeInTheDocument();
-    // Multiple files have similar savings
     expect(screen.getByText(/-\s*256\s*KB/i)).toBeInTheDocument();
+    // logo.png shows 128 KB in both main row and HEIC row
+    expect(screen.getAllByText(/-\s*128\s*KB/i)).toHaveLength(2);
     expect(screen.getByText('(-7.5%)')).toBeInTheDocument();
-    // Icon.js and logo.png both have (-4%) savings (Icon.js main, logo.png main and HEIC)
-    expect(screen.getAllByText('(-4%)')).toHaveLength(3);
+    expect(screen.getByText('(-4%)')).toBeInTheDocument();
+    // logo.png has (-2%) savings (main and HEIC)
+    expect(screen.getAllByText('(-2%)')).toHaveLength(2);
   });
 
   it('calls onToggleExpanded when clicking the toggle button', async () => {

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -157,7 +157,7 @@ function OptimizableImageFileRow({
             -{formatBytesBase10(maxSavings)}
           </Text>
           <Text variant="muted" size="sm" tabular align="right" style={{width: '64px'}}>
-            ({formatUpside(maxSavings / currentSize)})
+            ({formatUpside(file.percentage / 100)})
           </Text>
         </Flex>
       </FlexAlternatingRow>
@@ -181,7 +181,7 @@ function OptimizableImageFileRow({
               tabular
               style={{minWidth: '64px', textAlign: 'right'}}
             >
-              ({formatUpside(originalFile.minify_savings / currentSize)})
+              ({formatUpside(file.data.minifyPercentage / 100)})
             </Text>
           </Flex>
         )}
@@ -204,7 +204,7 @@ function OptimizableImageFileRow({
               tabular
               style={{minWidth: '64px', textAlign: 'right'}}
             >
-              ({formatUpside(originalFile.conversion_savings / currentSize)})
+              ({formatUpside(file.data.conversionPercentage / 100)})
             </Text>
           </Flex>
         )}

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -135,11 +135,14 @@ function OptimizableImageFileRow({
   file: ProcessedInsightFile;
   originalFile: OptimizableImageFile;
 }) {
+  if (file.data.fileType !== 'optimizable_image') {
+    return null;
+  }
+
   const hasMinifySavings =
     originalFile.minified_size !== null && originalFile.minify_savings > 0;
   const hasHeicSavings =
     originalFile.heic_size !== null && originalFile.conversion_savings > 0;
-  const currentSize = originalFile.current_size;
 
   const maxSavings = Math.max(
     originalFile.minify_savings || 0,

--- a/static/app/views/preprod/utils/insightProcessing.ts
+++ b/static/app/views/preprod/utils/insightProcessing.ts
@@ -9,7 +9,12 @@ import type {
 } from 'sentry/views/preprod/types/appSizeTypes';
 
 type FileTypeData =
-  | {fileType: 'optimizable_image'; originalFile: OptimizableImageFile}
+  | {
+      conversionPercentage: number;
+      fileType: 'optimizable_image';
+      minifyPercentage: number;
+      originalFile: OptimizableImageFile;
+    }
   | {fileType: 'strip_binary'; originalFile: StripBinaryFileInfo}
   | {fileType: 'regular'; originalFile: FileSavingsResult};
 
@@ -148,6 +153,8 @@ export function processInsights(
             percentage: (maxSavings / totalSize) * 100,
             data: {
               fileType: 'optimizable_image' as const,
+              minifyPercentage: ((file.minify_savings || 0) / totalSize) * 100,
+              conversionPercentage: ((file.conversion_savings || 0) / totalSize) * 100,
               originalFile: file,
             },
           };

--- a/tests/js/fixtures/preProdAppSize.ts
+++ b/tests/js/fixtures/preProdAppSize.ts
@@ -39,12 +39,12 @@ export function ProcessedInsightFixture(
       },
       {
         path: 'src/assets/logo.png',
-        savings: 256000,
-        percentage: 4.0,
+        savings: 128000,
+        percentage: 2.0,
         data: {
           fileType: 'optimizable_image' as const,
           minifyPercentage: 0,
-          conversionPercentage: 4.0,
+          conversionPercentage: 2.0,
           originalFile: {
             best_optimization_type: 'convert_to_heic',
             conversion_savings: 128000,

--- a/tests/js/fixtures/preProdAppSize.ts
+++ b/tests/js/fixtures/preProdAppSize.ts
@@ -43,6 +43,8 @@ export function ProcessedInsightFixture(
         percentage: 4.0,
         data: {
           fileType: 'optimizable_image' as const,
+          minifyPercentage: 0,
+          conversionPercentage: 4.0,
           originalFile: {
             best_optimization_type: 'convert_to_heic',
             conversion_savings: 128000,


### PR DESCRIPTION
<img width="490" height="582" alt="Screenshot 2025-09-30 at 12 19 47 PM" src="https://github.com/user-attachments/assets/57cdd2fb-73e3-4e02-9b25-558feee75177" />
