### PR TITLE
fix(seer-autofix): Remove redundant 'agent' suffix from toasts

### DIFF
--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -341,7 +341,7 @@ export function useLaunchCodingAgent(groupId: string, runId: string) {
       });
     },
     onSuccess: (_, params) => {
-      addSuccessMessage(`${params.agentName} agent launched successfully`);
+      addSuccessMessage(`${params.agentName} launched successfully`);
       queryClient.invalidateQueries({
         queryKey: makeAutofixQueryKey(organization.slug, groupId, false),
       });
@@ -350,7 +350,7 @@ export function useLaunchCodingAgent(groupId: string, runId: string) {
       });
     },
     onError: (_, params) => {
-      addErrorMessage(`Failed to launch ${params.agentName} agent`);
+      addErrorMessage(`Failed to launch ${params.agentName}`);
     },
   });
 }

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -8,6 +8,7 @@ import {
   type AutofixData,
   type GroupWithAutofix,
 } from 'sentry/components/events/autofix/types';
+import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import {
   fetchMutation,
@@ -341,7 +342,7 @@ export function useLaunchCodingAgent(groupId: string, runId: string) {
       });
     },
     onSuccess: (_, params) => {
-      addSuccessMessage(`${params.agentName} launched successfully`);
+      addSuccessMessage(t('%s launched successfully', params.agentName));
       queryClient.invalidateQueries({
         queryKey: makeAutofixQueryKey(organization.slug, groupId, false),
       });
@@ -350,7 +351,7 @@ export function useLaunchCodingAgent(groupId: string, runId: string) {
       });
     },
     onError: (_, params) => {
-      addErrorMessage(`Failed to launch ${params.agentName}`);
+      addErrorMessage(t('Failed to launch %s', params.agentName));
     },
   });
 }


### PR DESCRIPTION
We already state the full agent name such as "Cursor Agent" in the `agentName` param, so we got "... Cursor Agent agent", this should fix that
