### PR TITLE
ref(releases): Update env var to SENTRY_BUILD_CONFIGURATION

### DIFF
--- a/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodOnboarding.tsx
@@ -72,7 +72,7 @@ function FastlaneMethod({
         <OnboardingCodeSnippet language="yaml">
           {`env:
   SENTRY_AUTH_TOKEN: \${{ secrets.SENTRY_AUTH_TOKEN }}
-  SENTRY_CONFIGURATION: Release  # Adjust to your actual build configuration`}
+  SENTRY_BUILD_CONFIGURATION: Release  # Adjust to your actual build configuration`}
         </OnboardingCodeSnippet>
       </Container>
     </Flex>


### PR DESCRIPTION
## Summary
- Updated environment variable name from `SENTRY_CONFIGURATION` to `SENTRY_BUILD_CONFIGURATION` in the Fastlane onboarding documentation

See source: https://github.com/getsentry/sentry-fastlane-plugin/blob/840ac30316aeda41630db1be6c3d17d2c870d08c/lib/fastlane/plugin/sentry/actions/sentry_upload_build.rb#L95