### PR TITLE
fix(api): Filter `OrganizationMember` queryset using only valid IDs provided

### DIFF
--- a/src/sentry/core/endpoints/organization_member_index.py
+++ b/src/sentry/core/endpoints/organization_member_index.py
@@ -235,10 +235,14 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
                     )
 
                 elif key == "id":
-                    queryset = queryset.filter(id__in=value)
+                    ids = [v for v in value if v.isdigit()]
+                    queryset = queryset.filter(id__in=ids) if ids else queryset.none()
 
                 elif key == "user.id":
-                    queryset = queryset.filter(user_id__in=value)
+                    user_ids = [v for v in value if v.isdigit()]
+                    queryset = (
+                        queryset.filter(user_id__in=user_ids) if user_ids else queryset.none()
+                    )
 
                 elif key == "scope":
                     queryset = queryset.filter(role__in=[r.id for r in roles.with_any_scope(value)])

--- a/tests/sentry/core/endpoints/test_organization_member_index.py
+++ b/tests/sentry/core/endpoints/test_organization_member_index.py
@@ -236,6 +236,12 @@ class OrganizationMemberListTest(OrganizationMemberListTestBase, HybridCloudTest
         assert len(response.data) == 1
         assert response.data[0]["email"] == "billy@localhost"
 
+    def test_id_query_with_invalid_value(self) -> None:
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "id:not-a-number"}
+        )
+        assert len(response.data) == 0
+
     def test_user_id_query(self) -> None:
         user = self.create_user("zoo@localhost", username="zoo")
         OrganizationMember.objects.create(user_id=user.id, organization=self.organization)
@@ -245,6 +251,12 @@ class OrganizationMemberListTest(OrganizationMemberListTestBase, HybridCloudTest
 
         assert len(response.data) == 1
         assert response.data[0]["email"] == "zoo@localhost"
+
+    def test_user_id_query_with_invalid_value(self) -> None:
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "user.id:undefined"}
+        )
+        assert len(response.data) == 0
 
     def test_query_null_user(self) -> None:
         OrganizationMember.objects.create(email="billy@localhost", organization=self.organization)


### PR DESCRIPTION
Fixes [SENTRY-4N01](https://sentry.sentry.io/issues/6871438823/?project=1&referrer=issue-list&statsPeriod=90d).

Filter down the `OrganizationMember` queryset in `OrganizationMemberIndexEndpoint` only using valid IDs, if provided in the request.