### PR TITLE
fix(aci): handle createdBy for default automations

### DIFF
--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -15,6 +15,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import Pagination from 'sentry/components/pagination';
+import Placeholder from 'sentry/components/placeholder';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import TimeSince from 'sentry/components/timeSince';
 import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
@@ -48,10 +49,6 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
-
-  const {data: createdByUser} = useUserFromId({
-    id: automation.createdBy ? Number(automation.createdBy) : undefined,
-  });
 
   const {
     data: detectors,
@@ -188,11 +185,7 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
                   />
                   <KeyValueTableRow
                     keyName={t('Created by')}
-                    value={
-                      automation.createdBy
-                        ? createdByUser?.name || createdByUser?.email || t('Unknown')
-                        : t('Sentry')
-                    }
+                    value={<UserDisplayName id={automation.createdBy} />}
                   />
                   <KeyValueTableRow
                     keyName={t('Last modified')}
@@ -267,6 +260,19 @@ function Actions({automation}: {automation: Automation}) {
       </LinkButton>
     </Fragment>
   );
+}
+
+function UserDisplayName({id}: {id: string | undefined}) {
+  const {data: createdByUser, isPending} = useUserFromId({
+    id: id ? Number(id) : undefined,
+  });
+  if (!id) {
+    return t('Sentry');
+  }
+  if (isPending) {
+    return <Placeholder height="20px" />;
+  }
+  return createdByUser?.name || createdByUser?.email || t('Unknown');
 }
 
 const StyledPagination = styled(Pagination)`

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -49,7 +49,9 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const {data: createdByUser} = useUserFromId({id: Number(automation.createdBy)});
+  const {data: createdByUser} = useUserFromId({
+    id: automation.createdBy ? Number(automation.createdBy) : undefined,
+  });
 
   const {
     data: detectors,
@@ -186,7 +188,11 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
                   />
                   <KeyValueTableRow
                     keyName={t('Created by')}
-                    value={createdByUser?.name || createdByUser?.email || t('Unknown')}
+                    value={
+                      automation.createdBy
+                        ? createdByUser?.name || createdByUser?.email || t('Unknown')
+                        : t('Sentry')
+                    }
                   />
                   <KeyValueTableRow
                     keyName={t('Last modified')}

--- a/static/app/views/automations/new-settings.tsx
+++ b/static/app/views/automations/new-settings.tsx
@@ -61,6 +61,7 @@ function AutomationBreadcrumbs() {
 }
 
 const initialData = {
+  name: 'New Automation',
   environment: null,
   frequency: 1440,
   enabled: true,


### PR DESCRIPTION
we assume that automations with no `createdBy` value were created by Sentry

this fixes a bug where we were incorrectly trying to fetch a user even when createdBy was undefined, causing the user request to 404