### PR TITLE
feat(pr-page): Add PR page header content and skeleton main content

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -604,7 +604,7 @@ if (
       '.docker.internal',
       // SEO: ngrok, hot reload, SENTRY_UI_HOT_RELOAD. Uncomment this to allow hot-reloading when using ngrok. This is disabled by default
       // since ngrok urls are public and can be accessed by anyone.
-      // '.ngrok.io',
+      '.ngrok.io',
     ],
     static: {
       directory: './src/sentry/static/sentry',

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -604,7 +604,7 @@ if (
       '.docker.internal',
       // SEO: ngrok, hot reload, SENTRY_UI_HOT_RELOAD. Uncomment this to allow hot-reloading when using ngrok. This is disabled by default
       // since ngrok urls are public and can be accessed by anyone.
-      '.ngrok.io',
+      // '.ngrok.io',
     ],
     static: {
       directory: './src/sentry/static/sentry',

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -33,9 +33,9 @@ from .project_preprod_size import (
 
 preprod_urlpatterns = [
     re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/pullrequest-files/(?P<repo_name>.+?)/(?P<pr_number>\d+)/$",
+        r"^(?P<organization_id_or_slug>[^/]+)/pullrequest-details/(?P<repo_name>.+?)/(?P<pr_number>\d+)/$",
         OrganizationPullRequestDetailsEndpoint.as_view(),
-        name="sentry-api-0-organization-pullrequest-files",
+        name="sentry-api-0-organization-pullrequest-details",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/assemble/$",

--- a/static/app/views/pullRequest/details/header/pullRequestDetailsHeaderContent.tsx
+++ b/static/app/views/pullRequest/details/header/pullRequestDetailsHeaderContent.tsx
@@ -5,7 +5,7 @@ import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Container, Flex, Stack} from 'sentry/components/core/layout';
 import {Heading, Text} from 'sentry/components/core/text';
 import {IconBranch, IconCommit, IconFile, IconGithub} from 'sentry/icons';
-import {tn} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import type {
   PullRequestDetailsSuccessResponse,
   PullRequestState,
@@ -70,7 +70,7 @@ export function PullRequestDetailsHeaderContent({
         </Stack>
         {pr.url && (
           <LinkButton icon={<IconGithub size="sm" />} href={pr.url} external>
-            View on GitHub
+            {t('View on GitHub')}
           </LinkButton>
         )}
       </Flex>
@@ -84,7 +84,7 @@ export function PullRequestDetailsHeaderContent({
   );
 }
 
-function getPrStateBadge(state: PullRequestState) {
+function getPrStateBadge(state: PullRequestState): React.ReactNode | null {
   switch (state) {
     case 'open':
       return <Tag type="success">Open</Tag>;
@@ -92,8 +92,10 @@ function getPrStateBadge(state: PullRequestState) {
       return <Tag type="error">Closed</Tag>;
     case 'merged':
       return <Tag type="info">Merged</Tag>;
-    default:
+    case 'draft':
       return <Tag type="default">Draft</Tag>;
+    default:
+      return null;
   }
 }
 

--- a/static/app/views/pullRequest/details/header/pullRequestDetailsHeaderContent.tsx
+++ b/static/app/views/pullRequest/details/header/pullRequestDetailsHeaderContent.tsx
@@ -5,7 +5,7 @@ import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Container, Flex, Stack} from 'sentry/components/core/layout';
 import {Heading, Text} from 'sentry/components/core/text';
 import {IconBranch, IconCommit, IconFile, IconGithub} from 'sentry/icons';
-import {t, tn} from 'sentry/locale';
+import {tn} from 'sentry/locale';
 import type {
   PullRequestDetailsSuccessResponse,
   PullRequestState,

--- a/static/app/views/pullRequest/details/header/pullRequestDetailsHeaderContent.tsx
+++ b/static/app/views/pullRequest/details/header/pullRequestDetailsHeaderContent.tsx
@@ -1,0 +1,110 @@
+import styled from '@emotion/styled';
+
+import {Tag} from 'sentry/components/core/badge/tag';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {Container, Flex, Stack} from 'sentry/components/core/layout';
+import {Heading, Text} from 'sentry/components/core/text';
+import {IconBranch, IconCommit, IconFile, IconGithub} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
+import type {
+  PullRequestDetailsSuccessResponse,
+  PullRequestState,
+} from 'sentry/views/pullRequest/types/pullRequestDetailsTypes';
+
+interface PullRequestDetailsHeaderContentProps {
+  pullRequest: PullRequestDetailsSuccessResponse;
+}
+
+export function PullRequestDetailsHeaderContent({
+  pullRequest,
+}: PullRequestDetailsHeaderContentProps) {
+  const {pull_request: pr} = pullRequest;
+
+  return (
+    <Stack gap="md" paddingTop="md" paddingBottom="md">
+      <Flex justify="between" align="start">
+        <Stack gap="sm">
+          <Heading as="h1">
+            #{pr.number}: {pr.title || 'Untitled'}
+          </Heading>
+          <Flex gap="lg" align="center">
+            {getPrStateBadge(pr.state)}
+            <Flex gap="sm" align="center">
+              {pr.author.avatar_url && <GitHubAvatar src={pr.author.avatar_url} />}
+              {pr.author.username && (
+                <Text variant="muted" size="sm">
+                  {pr.author.username}
+                </Text>
+              )}
+            </Flex>
+            <Flex gap="xs" align="center">
+              <IconBranch />
+              <BranchLabel size="sm" monospace variant="muted">
+                {pr.source_branch}
+              </BranchLabel>
+            </Flex>
+            <Flex gap="xs" align="center">
+              <Text size="sm" variant="success" bold>
+                +{pr.additions}
+              </Text>
+              <Text size="sm" variant="muted">
+                /
+              </Text>
+              <Text size="sm" variant="danger" bold>
+                -{pr.deletions}
+              </Text>
+            </Flex>
+            <Flex gap="xs" align="center">
+              <IconCommit size="xs" />
+              <Text size="sm" variant="muted">
+                {tn('%s commit', '%s commits', pr.commits_count)}
+              </Text>
+            </Flex>
+            <Flex gap="xs" align="center">
+              <IconFile size="xs" />
+              <Text size="sm" variant="muted">
+                {tn('%s file', '%s files', pr.changed_files_count)}
+              </Text>
+            </Flex>
+          </Flex>
+        </Stack>
+        {pr.url && (
+          <LinkButton icon={<IconGithub size="sm" />} href={pr.url} external>
+            View on GitHub
+          </LinkButton>
+        )}
+      </Flex>
+
+      {pr.description && (
+        <Container background="secondary" radius="md" padding="md">
+          <Text>{pr.description}</Text>
+        </Container>
+      )}
+    </Stack>
+  );
+}
+
+function getPrStateBadge(state: PullRequestState) {
+  switch (state) {
+    case 'open':
+      return <Tag type="success">Open</Tag>;
+    case 'closed':
+      return <Tag type="error">Closed</Tag>;
+    case 'merged':
+      return <Tag type="info">Merged</Tag>;
+    default:
+      return <Tag type="default">Draft</Tag>;
+  }
+}
+
+const GitHubAvatar = styled('img')`
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+`;
+
+const BranchLabel = styled(Text)`
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
+  background-color: ${p => p.theme.gray100};
+  border-radius: ${p => p.theme.borderRadius};
+`;

--- a/static/app/views/pullRequest/details/main/pullRequestDetailsMainContent.tsx
+++ b/static/app/views/pullRequest/details/main/pullRequestDetailsMainContent.tsx
@@ -1,5 +1,6 @@
 import {Stack} from 'sentry/components/core/layout/stack';
 import {Heading, Text} from 'sentry/components/core/text';
+import {t} from 'sentry/locale';
 import type {PullRequestDetailsSuccessResponse} from 'sentry/views/pullRequest/types/pullRequestDetailsTypes';
 
 interface PullRequestDetailsMainContentProps {
@@ -11,7 +12,9 @@ export function PullRequestDetailsMainContent({
 }: PullRequestDetailsMainContentProps) {
   return (
     <Stack gap="md">
-      <Heading as="h2">Files Changed ({pullRequest.files.length})</Heading>
+      <Heading as="h2">
+        {t('Files Changed')} ({pullRequest.files.length})
+      </Heading>
 
       <Text>Coming soon...</Text>
     </Stack>

--- a/static/app/views/pullRequest/details/main/pullRequestDetailsMainContent.tsx
+++ b/static/app/views/pullRequest/details/main/pullRequestDetailsMainContent.tsx
@@ -1,0 +1,19 @@
+import {Stack} from 'sentry/components/core/layout/stack';
+import {Heading, Text} from 'sentry/components/core/text';
+import type {PullRequestDetailsSuccessResponse} from 'sentry/views/pullRequest/types/pullRequestDetailsTypes';
+
+interface PullRequestDetailsMainContentProps {
+  pullRequest: PullRequestDetailsSuccessResponse;
+}
+
+export function PullRequestDetailsMainContent({
+  pullRequest,
+}: PullRequestDetailsMainContentProps) {
+  return (
+    <Stack gap="md">
+      <Heading as="h2">Files Changed ({pullRequest.files.length})</Heading>
+
+      <Text>Coming soon...</Text>
+    </Stack>
+  );
+}

--- a/static/app/views/pullRequest/details/pullRequestDetails.tsx
+++ b/static/app/views/pullRequest/details/pullRequestDetails.tsx
@@ -1,4 +1,98 @@
-// TODO
+import {Container, Flex, Stack} from 'sentry/components/core/layout';
+import {Heading, Text} from 'sentry/components/core/text';
+import * as Layout from 'sentry/components/layouts/thirds';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import {PullRequestDetailsHeaderContent} from 'sentry/views/pullRequest/details/header/pullRequestDetailsHeaderContent';
+import {PullRequestDetailsMainContent} from 'sentry/views/pullRequest/details/main/pullRequestDetailsMainContent';
+import type {
+  PullRequestDetailsErrorResponse,
+  PullRequestDetailsResponse,
+  PullRequestDetailsSuccessResponse,
+} from 'sentry/views/pullRequest/types/pullRequestDetailsTypes';
+
 export default function PullRequestDetails() {
-  return <div>PullRequestDetails</div>;
+  const organization = useOrganization();
+  const params = useParams() as {prId: string; repoName: string; repoOrg: string};
+
+  const pullRequestQuery: UseApiQueryResult<PullRequestDetailsResponse, RequestError> =
+    useApiQuery<PullRequestDetailsResponse>(
+      [
+        `/projects/${organization.slug}/pullrequest-details/${params.repoOrg}/${params.repoName}/${params.prId}/`,
+      ],
+      {
+        staleTime: 0,
+        enabled: !!params.repoName && !!params.prId,
+      }
+    );
+
+  const {data, isLoading, error} = pullRequestQuery;
+
+  if (isLoading) {
+    return (
+      <Layout.Page>
+        <Layout.Header>
+          <Layout.Title>Pull Request Details</Layout.Title>
+        </Layout.Header>
+        <Layout.Body>
+          <Layout.Main>
+            <Flex justify="center" align="center" style={{minHeight: '200px'}}>
+              <LoadingIndicator />
+            </Flex>
+          </Layout.Main>
+        </Layout.Body>
+      </Layout.Page>
+    );
+  }
+
+  const errorData = error?.responseJSON as PullRequestDetailsErrorResponse | undefined;
+  if (error || !data) {
+    return (
+      <Layout.Page>
+        <Layout.Header>
+          <Layout.Title>Pull Request Details</Layout.Title>
+        </Layout.Header>
+        <Layout.Body>
+          <Layout.Main>
+            <Container background="primary" radius="lg" padding="xl" border="primary">
+              <Stack gap="md">
+                <Heading as="h2">Error Loading Pull Request</Heading>
+                <Text>
+                  {errorData?.message ||
+                    error?.message ||
+                    'Failed to load pull request details'}
+                </Text>
+                {errorData?.details && (
+                  <Text variant="muted" size="sm">
+                    {errorData.details}
+                  </Text>
+                )}
+              </Stack>
+            </Container>
+          </Layout.Main>
+        </Layout.Body>
+      </Layout.Page>
+    );
+  }
+
+  const prSuccessData = data as PullRequestDetailsSuccessResponse;
+
+  return (
+    <Layout.Page
+      title={`#${prSuccessData.pull_request.number}: ${prSuccessData.pull_request.title}`}
+    >
+      <Layout.Header>
+        <PullRequestDetailsHeaderContent pullRequest={prSuccessData} />
+      </Layout.Header>
+
+      <Layout.Body>
+        <Layout.Main>
+          <PullRequestDetailsMainContent pullRequest={prSuccessData} />
+        </Layout.Main>
+      </Layout.Body>
+    </Layout.Page>
+  );
 }

--- a/static/app/views/pullRequest/types/pullRequestDetailsTypes.ts
+++ b/static/app/views/pullRequest/types/pullRequestDetailsTypes.ts
@@ -1,5 +1,5 @@
 export type PullRequestState = 'open' | 'closed' | 'merged' | 'draft';
-export type PullRequestFileStatus = 'added' | 'modified' | 'removed' | 'renamed';
+type PullRequestFileStatus = 'added' | 'modified' | 'removed' | 'renamed';
 
 interface PullRequestAuthor {
   avatar_url: string | null;

--- a/static/app/views/pullRequest/types/pullRequestDetailsTypes.ts
+++ b/static/app/views/pullRequest/types/pullRequestDetailsTypes.ts
@@ -1,0 +1,55 @@
+export type PullRequestState = 'open' | 'closed' | 'merged' | 'draft';
+export type PullRequestFileStatus = 'added' | 'modified' | 'removed' | 'renamed';
+
+interface PullRequestAuthor {
+  avatar_url: string | null;
+  display_name: string | null;
+  id: string | null;
+  username: string | null;
+}
+
+interface PullRequestDetails {
+  additions: number;
+  author: PullRequestAuthor;
+  changed_files_count: number;
+  closed_at: string | null;
+  commits_count: number;
+  created_at: string | null;
+  deletions: number;
+  description: string | null;
+  id: string | null;
+  merged_at: string | null;
+  number: number;
+  source_branch: string | null;
+  state: PullRequestState;
+  target_branch: string | null;
+  title: string | null;
+  updated_at: string | null;
+  url: string | null;
+}
+
+interface PullRequestFileChange {
+  additions: number;
+  changes: number;
+  deletions: number;
+  filename: string;
+  patch: string | null;
+  previous_filename: string | null;
+  sha: string | null;
+  status: PullRequestFileStatus;
+}
+
+export interface PullRequestDetailsSuccessResponse {
+  files: PullRequestFileChange[];
+  pull_request: PullRequestDetails;
+}
+
+export interface PullRequestDetailsErrorResponse {
+  error: string;
+  message: string;
+  details?: string;
+}
+
+export type PullRequestDetailsResponse =
+  | PullRequestDetailsSuccessResponse
+  | PullRequestDetailsErrorResponse;


### PR DESCRIPTION
Adds header content for PR page, as well as minimal main content to be iterated on in future.

Pre-chonk:
<img width="1024" height="257" alt="Screenshot 2025-09-30 at 11 12 49 AM" src="https://github.com/user-attachments/assets/b3d5b998-6386-48cc-8a80-b4797163883e" />

Chonk:
<img width="1022" height="248" alt="Screenshot 2025-09-30 at 11 13 06 AM" src="https://github.com/user-attachments/assets/b59552b3-e8c4-46f6-93b9-345d7c7f1d75" />
