### PR TITLE
fix(uptime): Improve empty state for uptime summary stats

### DIFF
--- a/static/app/views/alerts/rules/uptime/details.tsx
+++ b/static/app/views/alerts/rules/uptime/details.tsx
@@ -56,7 +56,8 @@ export default function UptimeAlertDetails() {
   } = useDetectorQuery<UptimeDetector>(detectorId);
 
   const {data: uptimeSummaries} = useUptimeMonitorSummaries({detectorIds: [detectorId]});
-  const summary = uptimeSummaries?.[detectorId];
+  const summary =
+    uptimeSummaries === undefined ? undefined : (uptimeSummaries?.[detectorId] ?? null);
 
   // Only display the missed window legend when there are visible missed window
   // check-ins in the timeline

--- a/static/app/views/alerts/rules/uptime/detailsSidebar.tsx
+++ b/static/app/views/alerts/rules/uptime/detailsSidebar.tsx
@@ -19,7 +19,7 @@ import {UptimePercent} from 'sentry/views/insights/uptime/components/percent';
 interface UptimeDetailsSidebarProps {
   showMissedLegend: boolean;
   uptimeDetector: UptimeDetector;
-  summary?: UptimeSummary;
+  summary?: UptimeSummary | null;
 }
 
 export function UptimeDetailsSidebar({
@@ -43,16 +43,18 @@ export function UptimeDetailsSidebar({
           <SectionHeading>{t('Legend')}</SectionHeading>
           <DetailsTimelineLegend showMissedLegend={showMissedLegend} />
         </UptimeContainer>
-        {summary?.avgDurationUs !== null && (
+        {summary && summary.avgDurationUs !== null && (
           <div>
             <SectionHeading>{t('Duration')}</SectionHeading>
             <UptimeContainer>
-              {summary ? (
-                <UptimeDuration size="xl" summary={summary} />
-              ) : (
+              {summary === undefined ? (
                 <Text size="xl">
                   <Placeholder width="60px" height="1lh" />
                 </Text>
+              ) : summary === null ? (
+                '-'
+              ) : (
+                <UptimeDuration size="xl" summary={summary} />
               )}
             </UptimeContainer>
           </div>
@@ -60,7 +62,13 @@ export function UptimeDetailsSidebar({
         <div>
           <SectionHeading>{t('Uptime')}</SectionHeading>
           <UptimeContainer>
-            {summary ? (
+            {summary === undefined ? (
+              <Text size="xl">
+                <Placeholder width="60px" height="1lh" />
+              </Text>
+            ) : summary === null ? (
+              '-'
+            ) : (
               <UptimePercent
                 size="xl"
                 summary={summary}
@@ -68,10 +76,6 @@ export function UptimeDetailsSidebar({
                   'The total calculated uptime of this monitors over the last 90 days.'
                 )}
               />
-            ) : (
-              <Text size="xl">
-                <Placeholder width="60px" height="1lh" />
-              </Text>
             )}
           </UptimeContainer>
         </div>

--- a/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
@@ -72,7 +72,9 @@ export function OverviewTimeline({uptimeDetectors}: Props) {
             key={detector.id}
             timeWindowConfig={timeWindowConfig}
             uptimeDetector={detector}
-            summary={summaries?.[detector.id] ?? null}
+            summary={
+              summaries === undefined ? undefined : (summaries[detector.id] ?? null)
+            }
           />
         ))}
       </UptimeAlertRow>

--- a/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
@@ -86,7 +86,7 @@ export function OverviewRow({summary, uptimeDetector, timeWindowConfig, single}:
             <IconTimer />
             {t('Checked every %s', getDuration(subscription.intervalSeconds))}
           </Flex>
-          {summary === undefined ? null : summary === null ? (
+          {summary === null ? null : summary === undefined ? (
             <Fragment>
               <Placeholder width="60px" height="1lh" />
               <Placeholder width="40px" height="1lh" />


### PR DESCRIPTION
Avg duration and uptime % didn't have a great "empty" state, fro when
the data is loaded, but there was no summary for a provided uptime
detector.

I've fixed this by having `undefined` as loading, and `null` as empty.

Part of [NEW-483: Uptime is shown as 100% even though there were no checks during the selected time frame](https://linear.app/getsentry/issue/NEW-483/uptime-is-shown-as-100percent-even-though-there-were-no-checks-during)

(The work I did here was intended for this issue, but from the code, this issue appears to be invalid)