### PR TITLE
ref(releases): fix adoption rate chart on release index

### DIFF
--- a/static/app/views/releases/list/releaseCard/releaseCardStatsPeriod.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardStatsPeriod.tsx
@@ -14,12 +14,12 @@ type Props = {
 };
 
 function ReleaseCardStatsPeriod({location, selection}: Props) {
-  const activePeriod =
-    location.query.healthStatsPeriod || HealthStatsPeriodOption.TWENTY_FOUR_HOURS;
+  const activePeriod = location.query.healthStatsPeriod || HealthStatsPeriodOption.AUTO;
   const {pathname, query} = location;
 
   return (
     <Wrapper>
+      {/* don't show duplicate 24h options */}
       {selection.datetime.period !== HealthStatsPeriodOption.TWENTY_FOUR_HOURS && (
         <Period
           to={{

--- a/static/app/views/releases/list/releaseListInner.tsx
+++ b/static/app/views/releases/list/releaseListInner.tsx
@@ -78,7 +78,7 @@ function ReleaseListInner({
       releasesReloading={reloading}
       healthStatsPeriod={
         typeof location.query.healthStatsPeriod === 'string'
-          ? HealthStatsPeriodOption.TWENTY_FOUR_HOURS
+          ? location.query.healthStatsPeriod === HealthStatsPeriodOption.TWENTY_FOUR_HOURS
             ? HealthStatsPeriodOption.TWENTY_FOUR_HOURS
             : HealthStatsPeriodOption.AUTO
           : undefined


### PR DESCRIPTION
fixes https://linear.app/getsentry/issue/REPLAY-749/release-list-adoption-rates-not-updating-over-time

there was a bug where the adoption chart was always showing 24h granularity, no matter what the timeframe chosen was.

before:

https://github.com/user-attachments/assets/c0fea457-c157-4468-9d8b-12a310f1dc72


after: 

https://github.com/user-attachments/assets/72ae013b-761c-4fc9-9f11-f2da2ccb2f66

