### PR TITLE
feat(workflow_engine): Add get_detection_timestamp to StatefulDetectorHandler

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -57,6 +57,7 @@ class DetectorOccurrence:
         status: DetectorPriorityLevel,
         additional_evidence_data: Mapping[str, Any],
         fingerprint: list[str],
+        detection_time: datetime | None = None,
     ) -> IssueOccurrence:
         return IssueOccurrence(
             id=occurrence_id,
@@ -69,7 +70,7 @@ class DetectorOccurrence:
             evidence_data={**self.evidence_data, **additional_evidence_data},
             evidence_display=self.evidence_display,
             type=self.type,
-            detection_time=self.detection_time or timezone.now(),
+            detection_time=self.detection_time or detection_time or timezone.now(),
             level=self.level,
             culprit=self.culprit,
             priority=self.priority or status,


### PR DESCRIPTION
This allows implementations of the handler to provide an implementation
that returns the 'detection time' for the processed packet. This will be
used in issue occurrence creation and issue resolution.

By default this just uses timestamp.now() -- which is consistent with
what was used previously.