### PR TITLE
feat(open periods): Add activities to open period serializer

### DIFF
--- a/src/sentry/models/groupopenperiodactivity.py
+++ b/src/sentry/models/groupopenperiodactivity.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from enum import IntEnum
 from uuid import UUID, uuid4
 
@@ -12,6 +13,13 @@ class OpenPeriodActivityType(IntEnum):
     OPENED = 1
     STATUS_CHANGE = 2
     CLOSED = 3
+
+
+OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING: Mapping[int, str] = {
+    OpenPeriodActivityType.OPENED: "opened",
+    OpenPeriodActivityType.STATUS_CHANGE: "status_change",
+    OpenPeriodActivityType.CLOSED: "closed",
+}
 
 
 def generate_random_uuid() -> UUID:

--- a/src/sentry/models/groupopenperiodactivity.py
+++ b/src/sentry/models/groupopenperiodactivity.py
@@ -1,4 +1,3 @@
-from collections.abc import Mapping
 from enum import IntEnum
 from uuid import UUID, uuid4
 
@@ -14,12 +13,11 @@ class OpenPeriodActivityType(IntEnum):
     STATUS_CHANGE = 2
     CLOSED = 3
 
-
-OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING: Mapping[int, str] = {
-    OpenPeriodActivityType.OPENED: "opened",
-    OpenPeriodActivityType.STATUS_CHANGE: "status_change",
-    OpenPeriodActivityType.CLOSED: "closed",
-}
+    def to_str(self) -> str:
+        """
+        Return the string representation of the activity type.
+        """
+        return self.name.lower()
 
 
 def generate_random_uuid() -> UUID:

--- a/src/sentry/types/group.py
+++ b/src/sentry/types/group.py
@@ -78,10 +78,3 @@ class PriorityLevel(IntEnum):
         """
         name = name.upper()
         return self[name] if name in self.__members__ else None
-
-
-PRIORITY_LEVEL_TO_STRING: Mapping[int, str] = {
-    PriorityLevel.LOW: "low",
-    PriorityLevel.MEDIUM: "medium",
-    PriorityLevel.HIGH: "high",
-}

--- a/src/sentry/types/group.py
+++ b/src/sentry/types/group.py
@@ -78,3 +78,10 @@ class PriorityLevel(IntEnum):
         """
         name = name.upper()
         return self[name] if name in self.__members__ else None
+
+
+PRIORITY_LEVEL_TO_STRING: Mapping[int, str] = {
+    PriorityLevel.LOW: "low",
+    PriorityLevel.MEDIUM: "medium",
+    PriorityLevel.HIGH: "high",
+}

--- a/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
@@ -5,13 +5,17 @@ from typing import Any, TypedDict
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models.groupopenperiod import GroupOpenPeriod, get_last_checked_for_open_period
-from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity
+from sentry.models.groupopenperiodactivity import (
+    OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING,
+    GroupOpenPeriodActivity,
+)
+from sentry.types.group import PRIORITY_LEVEL_TO_STRING
 
 
 class GroupOpenPeriodActivityResponse(TypedDict):
     id: str
     type: str
-    value: int | None
+    value: str | None
 
 
 class GroupOpenPeriodResponse(TypedDict):
@@ -31,8 +35,8 @@ class GroupOpenPeriodActivitySerializer(Serializer):
     ) -> GroupOpenPeriodActivityResponse:
         return {
             "id": str(obj.id),
-            "type": str(obj.type),
-            "value": obj.value,
+            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[obj.type],
+            "value": PRIORITY_LEVEL_TO_STRING.get(obj.value),
         }
 
 

--- a/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
@@ -5,11 +5,8 @@ from typing import Any, TypedDict
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models.groupopenperiod import GroupOpenPeriod, get_last_checked_for_open_period
-from sentry.models.groupopenperiodactivity import (
-    OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING,
-    GroupOpenPeriodActivity,
-)
-from sentry.types.group import PRIORITY_LEVEL_TO_STRING
+from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity, OpenPeriodActivityType
+from sentry.types.group import PriorityLevel
 
 
 class GroupOpenPeriodActivityResponse(TypedDict):
@@ -35,8 +32,8 @@ class GroupOpenPeriodActivitySerializer(Serializer):
     ) -> GroupOpenPeriodActivityResponse:
         return {
             "id": str(obj.id),
-            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[obj.type],
-            "value": PRIORITY_LEVEL_TO_STRING.get(obj.value) if obj.value else None,
+            "type": OpenPeriodActivityType(obj.type).to_str(),
+            "value": PriorityLevel(obj.value).to_str() if obj.value else None,
         }
 
 

--- a/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
@@ -36,7 +36,7 @@ class GroupOpenPeriodActivitySerializer(Serializer):
         return {
             "id": str(obj.id),
             "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[obj.type],
-            "value": PRIORITY_LEVEL_TO_STRING.get(obj.value),
+            "value": PRIORITY_LEVEL_TO_STRING.get(obj.value) if obj.value else None,
         }
 
 

--- a/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, TypedDict
+from typing import Any
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models.groupopenperiod import GroupOpenPeriod, get_last_checked_for_open_period
@@ -9,13 +10,15 @@ from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity, OpenP
 from sentry.types.group import PriorityLevel
 
 
-class GroupOpenPeriodActivityResponse(TypedDict):
+@dataclass(frozen=True)
+class GroupOpenPeriodActivityResponse:
     id: str
     type: str
     value: str | None
 
 
-class GroupOpenPeriodResponse(TypedDict):
+@dataclass(frozen=True)
+class GroupOpenPeriodResponse:
     id: str
     start: datetime
     end: datetime | None

--- a/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
@@ -42,7 +42,9 @@ class GroupOpenPeriodSerializer(Serializer):
         result: defaultdict[GroupOpenPeriod, dict[str, list[GroupOpenPeriodActivityResponse]]] = (
             defaultdict(dict)
         )
-        activities = GroupOpenPeriodActivity.objects.filter(group_open_period__in=item_list)[:1000]
+        activities = GroupOpenPeriodActivity.objects.filter(
+            group_open_period__in=item_list
+        ).order_by("id")
 
         gopas = defaultdict(list)
         for activity, serialized_activity in zip(
@@ -50,7 +52,7 @@ class GroupOpenPeriodSerializer(Serializer):
         ):
             gopas[activity.group_open_period].append(serialized_activity)
         for item in item_list:
-            result[item]["activities"] = gopas[item]
+            result[item]["activities"] = gopas[item][:100]
 
         return result
 

--- a/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
@@ -30,8 +30,8 @@ class GroupOpenPeriodActivitySerializer(Serializer):
     ) -> GroupOpenPeriodResponse:
         return {
             "id": str(obj.id),
-            "type": str(obj.type),  # convert to string?
-            "value": obj.value,  # convert to string?
+            "type": str(obj.type),
+            "value": obj.value,
         }
 
 
@@ -39,7 +39,7 @@ class GroupOpenPeriodActivitySerializer(Serializer):
 class GroupOpenPeriodSerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
         result: defaultdict[GroupOpenPeriod, dict[str, Any]] = defaultdict(dict)
-        activities = GroupOpenPeriodActivity.objects.filter(group_open_period__in=item_list)
+        activities = GroupOpenPeriodActivity.objects.filter(group_open_period__in=item_list)[:1000]
 
         gopas = defaultdict(list)
         for activity, serialized_activity in zip(

--- a/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
@@ -8,6 +8,12 @@ from sentry.models.groupopenperiod import GroupOpenPeriod, get_last_checked_for_
 from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity
 
 
+class GroupOpenPeriodActivityResponse(TypedDict):
+    id: str
+    type: str
+    value: int | None
+
+
 class GroupOpenPeriodResponse(TypedDict):
     id: str
     start: datetime
@@ -15,19 +21,14 @@ class GroupOpenPeriodResponse(TypedDict):
     duration: timedelta | None
     isOpen: bool
     lastChecked: datetime
-
-
-class GroupOpenPeriodActivityResponse(TypedDict):
-    id: str
-    type: int
-    value: int | None
+    activities: GroupOpenPeriodActivityResponse | None
 
 
 @register(GroupOpenPeriodActivity)
 class GroupOpenPeriodActivitySerializer(Serializer):
     def serialize(
         self, obj: GroupOpenPeriodActivity, attrs: Mapping[str, Any], user, **kwargs
-    ) -> GroupOpenPeriodResponse:
+    ) -> GroupOpenPeriodActivityResponse:
         return {
             "id": str(obj.id),
             "type": str(obj.type),
@@ -38,7 +39,9 @@ class GroupOpenPeriodActivitySerializer(Serializer):
 @register(GroupOpenPeriod)
 class GroupOpenPeriodSerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
-        result: defaultdict[GroupOpenPeriod, dict[str, Any]] = defaultdict(dict)
+        result: defaultdict[GroupOpenPeriod, dict[str, list[GroupOpenPeriodActivityResponse]]] = (
+            defaultdict(dict)
+        )
         activities = GroupOpenPeriodActivity.objects.filter(group_open_period__in=item_list)[:1000]
 
         gopas = defaultdict(list)

--- a/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
@@ -1,9 +1,11 @@
+from collections import defaultdict
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Any, TypedDict
 
-from sentry.api.serializers import Serializer, register
+from sentry.api.serializers import Serializer, register, serialize
 from sentry.models.groupopenperiod import GroupOpenPeriod, get_last_checked_for_open_period
+from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity
 
 
 class GroupOpenPeriodResponse(TypedDict):
@@ -15,8 +17,40 @@ class GroupOpenPeriodResponse(TypedDict):
     lastChecked: datetime
 
 
+class GroupOpenPeriodActivityResponse(TypedDict):
+    id: str
+    type: int
+    value: int | None
+
+
+@register(GroupOpenPeriodActivity)
+class GroupOpenPeriodActivitySerializer(Serializer):
+    def serialize(
+        self, obj: GroupOpenPeriodActivity, attrs: Mapping[str, Any], user, **kwargs
+    ) -> GroupOpenPeriodResponse:
+        return {
+            "id": str(obj.id),
+            "type": str(obj.type),  # convert to string?
+            "value": obj.value,  # convert to string?
+        }
+
+
 @register(GroupOpenPeriod)
 class GroupOpenPeriodSerializer(Serializer):
+    def get_attrs(self, item_list, user, **kwargs):
+        result: defaultdict[GroupOpenPeriod, dict[str, Any]] = defaultdict(dict)
+        activities = GroupOpenPeriodActivity.objects.filter(group_open_period__in=item_list)
+
+        gopas = defaultdict(list)
+        for activity, serialized_activity in zip(
+            activities, serialize(list(activities), user=user, **kwargs)
+        ):
+            gopas[activity.group_open_period].append(serialized_activity)
+        for item in item_list:
+            result[item]["activities"] = gopas[item]
+
+        return result
+
     def serialize(
         self, obj: GroupOpenPeriod, attrs: Mapping[str, Any], user, **kwargs
     ) -> GroupOpenPeriodResponse:
@@ -27,4 +61,5 @@ class GroupOpenPeriodSerializer(Serializer):
             "duration": obj.date_ended - obj.date_started if obj.date_ended else None,
             "isOpen": obj.date_ended is None,
             "lastChecked": get_last_checked_for_open_period(obj.group),
+            "activities": attrs.get("activities"),
         }

--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -12,9 +12,14 @@ from sentry.models.groupopenperiod import (
     get_open_periods_for_group,
     update_group_open_period,
 )
-from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity, OpenPeriodActivityType
+from sentry.models.groupopenperiodactivity import (
+    OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING,
+    GroupOpenPeriodActivity,
+    OpenPeriodActivityType,
+)
 from sentry.testutils.cases import APITestCase
 from sentry.types.activity import ActivityType
+from sentry.types.group import PRIORITY_LEVEL_TO_STRING
 from sentry.workflow_engine.models.detector_group import DetectorGroup
 
 
@@ -71,8 +76,8 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert len(open_period["activities"]) == 1
         assert open_period["activities"][0] == {
             "id": str(self.opened_gopa.id),
-            "type": str(OpenPeriodActivityType.OPENED.value),
-            "value": self.group.priority,
+            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.OPENED.value],
+            "value": PRIORITY_LEVEL_TO_STRING.get(self.group.priority),
         }
 
     def test_open_periods_group_id(self) -> None:
@@ -106,8 +111,8 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp["lastChecked"] >= last_checked
         assert resp["activities"][0] == {
             "id": str(self.opened_gopa.id),
-            "type": str(OpenPeriodActivityType.OPENED.value),
-            "value": self.group.priority,
+            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.OPENED.value],
+            "value": PRIORITY_LEVEL_TO_STRING.get(self.group.priority),
         }
 
     def test_open_periods_resolved_group(self) -> None:
@@ -148,12 +153,12 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert len(resp["activities"]) == 2
         assert resp["activities"][0] == {
             "id": str(self.opened_gopa.id),
-            "type": str(OpenPeriodActivityType.OPENED.value),
-            "value": self.group.priority,
+            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.OPENED.value],
+            "value": PRIORITY_LEVEL_TO_STRING.get(self.group.priority),
         }
         assert resp["activities"][1] == {
             "id": str(closed_gopa.id),
-            "type": str(OpenPeriodActivityType.CLOSED.value),
+            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.CLOSED.value],
             "value": None,
         }
 
@@ -232,12 +237,12 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert len(resp["activities"]) == 2
         assert resp["activities"][0] == {
             "id": str(opened_gopa2.id),
-            "type": str(OpenPeriodActivityType.OPENED.value),
-            "value": self.group.priority,
+            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.OPENED.value],
+            "value": PRIORITY_LEVEL_TO_STRING.get(self.group.priority),
         }
         assert resp["activities"][1] == {
             "id": str(closed_gopa2.id),
-            "type": str(OpenPeriodActivityType.CLOSED.value),
+            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.CLOSED.value],
             "value": None,
         }
 
@@ -252,12 +257,12 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert len(resp2["activities"]) == 2
         assert resp2["activities"][0] == {
             "id": str(self.opened_gopa.id),
-            "type": str(OpenPeriodActivityType.OPENED.value),
-            "value": self.group.priority,
+            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.OPENED.value],
+            "value": PRIORITY_LEVEL_TO_STRING.get(self.group.priority),
         }
         assert resp2["activities"][1] == {
             "id": str(closed_gopa.id),
-            "type": str(OpenPeriodActivityType.CLOSED.value),
+            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.CLOSED.value],
             "value": None,
         }
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -15,6 +15,7 @@ from sentry.models.groupopenperiod import (
 from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity, OpenPeriodActivityType
 from sentry.testutils.cases import APITestCase
 from sentry.types.activity import ActivityType
+from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models.detector_group import DetectorGroup
 
 
@@ -28,7 +29,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
         self.login_as(user=self.user)
 
         self.detector = self.create_detector()
-        self.group = self.create_group()
+        self.group = self.create_group(priority=PriorityLevel.LOW)
         # Metric issue is the only type (currently) that has open periods
         self.group.type = MetricIssue.type_id
         self.group.save()
@@ -72,7 +73,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert open_period["activities"][0] == {
             "id": str(self.opened_gopa.id),
             "type": OpenPeriodActivityType.OPENED.to_str(),
-            "value": self.group.priority,
+            "value": PriorityLevel(self.group.priority).to_str(),
         }
 
     def test_open_periods_group_id(self) -> None:
@@ -107,7 +108,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp["activities"][0] == {
             "id": str(self.opened_gopa.id),
             "type": OpenPeriodActivityType.OPENED.to_str(),
-            "value": self.group.priority,
+            "value": PriorityLevel(self.group.priority).to_str(),
         }
 
     def test_open_periods_resolved_group(self) -> None:
@@ -149,12 +150,12 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp["activities"][0] == {
             "id": str(self.opened_gopa.id),
             "type": OpenPeriodActivityType.OPENED.to_str(),
-            "value": self.group.priority,
+            "value": PriorityLevel(self.group.priority).to_str(),
         }
         assert resp["activities"][1] == {
             "id": str(closed_gopa.id),
             "type": OpenPeriodActivityType.CLOSED.to_str(),
-            "value": self.group.priority,
+            "value": None,
         }
 
     def test_open_periods_unresolved_group(self) -> None:
@@ -233,12 +234,12 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp["activities"][0] == {
             "id": str(opened_gopa2.id),
             "type": OpenPeriodActivityType.OPENED.to_str(),
-            "value": self.group.priority,
+            "value": PriorityLevel(self.group.priority).to_str(),
         }
         assert resp["activities"][1] == {
             "id": str(closed_gopa2.id),
             "type": OpenPeriodActivityType.CLOSED.to_str(),
-            "value": self.group.priority,
+            "value": None,
         }
 
         assert resp2["id"] == str(open_period.id)
@@ -253,12 +254,12 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp2["activities"][0] == {
             "id": str(self.opened_gopa.id),
             "type": OpenPeriodActivityType.OPENED.to_str(),
-            "value": self.group.priority,
+            "value": PriorityLevel(self.group.priority).to_str(),
         }
         assert resp2["activities"][1] == {
             "id": str(closed_gopa.id),
             "type": OpenPeriodActivityType.CLOSED.to_str(),
-            "value": self.group.priority,
+            "value": None,
         }
 
     def test_open_periods_limit(self) -> None:

--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -12,14 +12,9 @@ from sentry.models.groupopenperiod import (
     get_open_periods_for_group,
     update_group_open_period,
 )
-from sentry.models.groupopenperiodactivity import (
-    OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING,
-    GroupOpenPeriodActivity,
-    OpenPeriodActivityType,
-)
+from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity, OpenPeriodActivityType
 from sentry.testutils.cases import APITestCase
 from sentry.types.activity import ActivityType
-from sentry.types.group import PRIORITY_LEVEL_TO_STRING
 from sentry.workflow_engine.models.detector_group import DetectorGroup
 
 
@@ -76,8 +71,8 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert len(open_period["activities"]) == 1
         assert open_period["activities"][0] == {
             "id": str(self.opened_gopa.id),
-            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.OPENED.value],
-            "value": PRIORITY_LEVEL_TO_STRING.get(self.group.priority),
+            "type": OpenPeriodActivityType.OPENED.to_str(),
+            "value": self.group.priority,
         }
 
     def test_open_periods_group_id(self) -> None:
@@ -111,8 +106,8 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp["lastChecked"] >= last_checked
         assert resp["activities"][0] == {
             "id": str(self.opened_gopa.id),
-            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.OPENED.value],
-            "value": PRIORITY_LEVEL_TO_STRING.get(self.group.priority),
+            "type": OpenPeriodActivityType.OPENED.to_str(),
+            "value": self.group.priority,
         }
 
     def test_open_periods_resolved_group(self) -> None:
@@ -153,13 +148,13 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert len(resp["activities"]) == 2
         assert resp["activities"][0] == {
             "id": str(self.opened_gopa.id),
-            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.OPENED.value],
-            "value": PRIORITY_LEVEL_TO_STRING.get(self.group.priority),
+            "type": OpenPeriodActivityType.OPENED.to_str(),
+            "value": self.group.priority,
         }
         assert resp["activities"][1] == {
             "id": str(closed_gopa.id),
-            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.CLOSED.value],
-            "value": None,
+            "type": OpenPeriodActivityType.CLOSED.to_str(),
+            "value": self.group.priority,
         }
 
     def test_open_periods_unresolved_group(self) -> None:
@@ -237,13 +232,13 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert len(resp["activities"]) == 2
         assert resp["activities"][0] == {
             "id": str(opened_gopa2.id),
-            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.OPENED.value],
-            "value": PRIORITY_LEVEL_TO_STRING.get(self.group.priority),
+            "type": OpenPeriodActivityType.OPENED.to_str(),
+            "value": self.group.priority,
         }
         assert resp["activities"][1] == {
             "id": str(closed_gopa2.id),
-            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.CLOSED.value],
-            "value": None,
+            "type": OpenPeriodActivityType.CLOSED.to_str(),
+            "value": self.group.priority,
         }
 
         assert resp2["id"] == str(open_period.id)
@@ -257,13 +252,13 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert len(resp2["activities"]) == 2
         assert resp2["activities"][0] == {
             "id": str(self.opened_gopa.id),
-            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.OPENED.value],
-            "value": PRIORITY_LEVEL_TO_STRING.get(self.group.priority),
+            "type": OpenPeriodActivityType.OPENED.to_str(),
+            "value": self.group.priority,
         }
         assert resp2["activities"][1] == {
             "id": str(closed_gopa.id),
-            "type": OPEN_PERIOD_ACTIVITY_TYPE_TO_STRING[OpenPeriodActivityType.CLOSED.value],
-            "value": None,
+            "type": OpenPeriodActivityType.CLOSED.to_str(),
+            "value": self.group.priority,
         }
 
     def test_open_periods_limit(self) -> None:

--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -98,13 +98,17 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         resp = response.data[0]
-        open_period = GroupOpenPeriod.objects.get(group=self.group)
-        assert resp["id"] == str(open_period.id)
+        assert resp["id"] == str(self.group_open_period.id)
         assert resp["start"] == self.group.first_seen
         assert resp["end"] is None
         assert resp["duration"] is None
         assert resp["isOpen"] is True
         assert resp["lastChecked"] >= last_checked
+        assert resp["activities"][0] == {
+            "id": str(self.opened_gopa.id),
+            "type": str(OpenPeriodActivityType.OPENED.value),
+            "value": self.group.priority,
+        }
 
     def test_open_periods_resolved_group(self) -> None:
         self.group.status = GroupStatus.RESOLVED
@@ -130,6 +134,9 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert response.status_code == 200, response.content
         resp = response.data[0]
         open_period = GroupOpenPeriod.objects.get(group=self.group, date_ended=resolved_time)
+        closed_gopa = GroupOpenPeriodActivity.objects.get(
+            group_open_period=open_period, type=OpenPeriodActivityType.CLOSED
+        )
         assert resp["id"] == str(open_period.id)
         assert resp["start"] == self.group.first_seen
         assert resp["end"] == resolved_time
@@ -138,6 +145,17 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp["lastChecked"].replace(second=0, microsecond=0) == activity.datetime.replace(
             second=0, microsecond=0
         )
+        assert len(resp["activities"]) == 2
+        assert resp["activities"][0] == {
+            "id": str(self.opened_gopa.id),
+            "type": str(OpenPeriodActivityType.OPENED.value),
+            "value": self.group.priority,
+        }
+        assert resp["activities"][1] == {
+            "id": str(closed_gopa.id),
+            "type": str(OpenPeriodActivityType.CLOSED.value),
+            "value": None,
+        }
 
     def test_open_periods_unresolved_group(self) -> None:
         self.group.status = GroupStatus.RESOLVED
@@ -156,6 +174,9 @@ class OrganizationOpenPeriodsTest(APITestCase):
             resolution_activity=resolve_activity,
         )
         open_period = GroupOpenPeriod.objects.get(group=self.group, date_ended=resolved_time)
+        closed_gopa = GroupOpenPeriodActivity.objects.get(
+            group_open_period=open_period, type=OpenPeriodActivityType.CLOSED
+        )
 
         unresolved_time = timezone.now()
         self.group.status = GroupStatus.UNRESOLVED
@@ -186,6 +207,12 @@ class OrganizationOpenPeriodsTest(APITestCase):
         open_period2 = GroupOpenPeriod.objects.get(
             group=self.group, date_ended=second_resolved_time
         )
+        opened_gopa2 = GroupOpenPeriodActivity.objects.get(
+            group_open_period=open_period2, type=OpenPeriodActivityType.OPENED
+        )
+        closed_gopa2 = GroupOpenPeriodActivity.objects.get(
+            group_open_period=open_period2, type=OpenPeriodActivityType.CLOSED
+        )
 
         response = self.get_success_response(
             *self.get_url_args(), qs_params={"groupId": self.group.id}
@@ -202,6 +229,17 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp["lastChecked"].replace(second=0, microsecond=0) == second_resolved_time.replace(
             second=0, microsecond=0
         )
+        assert len(resp["activities"]) == 2
+        assert resp["activities"][0] == {
+            "id": str(opened_gopa2.id),
+            "type": str(OpenPeriodActivityType.OPENED.value),
+            "value": self.group.priority,
+        }
+        assert resp["activities"][1] == {
+            "id": str(closed_gopa2.id),
+            "type": str(OpenPeriodActivityType.CLOSED.value),
+            "value": None,
+        }
 
         assert resp2["id"] == str(open_period.id)
         assert resp2["start"] == self.group.first_seen
@@ -211,6 +249,17 @@ class OrganizationOpenPeriodsTest(APITestCase):
         assert resp2["lastChecked"].replace(second=0, microsecond=0) == resolved_time.replace(
             second=0, microsecond=0
         )
+        assert len(resp2["activities"]) == 2
+        assert resp2["activities"][0] == {
+            "id": str(self.opened_gopa.id),
+            "type": str(OpenPeriodActivityType.OPENED.value),
+            "value": self.group.priority,
+        }
+        assert resp2["activities"][1] == {
+            "id": str(closed_gopa.id),
+            "type": str(OpenPeriodActivityType.CLOSED.value),
+            "value": None,
+        }
 
     def test_open_periods_limit(self) -> None:
         self.group.status = GroupStatus.RESOLVED


### PR DESCRIPTION
Add `GroupOpenPeriodActivity` results to the group open period serializer response.