### PR TITLE
feat(uptime/crons): Add disable / enable toast

### DIFF
--- a/static/app/actionCreators/monitors.tsx
+++ b/static/app/actionCreators/monitors.tsx
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react';
 import {
   addErrorMessage,
   addLoadingMessage,
+  addSuccessMessage,
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
 import type {Client} from 'sentry/api';
@@ -63,6 +64,14 @@ export async function updateMonitor(
       {method: 'PUT', data}
     );
     clearIndicators();
+
+    if (data.status !== undefined) {
+      const isEnabled = data.status === 'active';
+      addSuccessMessage(
+        isEnabled ? t('Cron Monitor enabled') : t('Cron Monitor disabled')
+      );
+    }
+
     return resp;
   } catch (err: any) {
     const respError: RequestError = err;

--- a/static/app/actionCreators/uptime.tsx
+++ b/static/app/actionCreators/uptime.tsx
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react';
 import {
   addErrorMessage,
   addLoadingMessage,
+  addSuccessMessage,
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
 import type {Client} from 'sentry/api';
@@ -31,6 +32,14 @@ export async function updateUptimeRule(
       }
     );
     clearIndicators();
+
+    if (data.status !== undefined) {
+      const isEnabled = data.status === 'active';
+      addSuccessMessage(
+        isEnabled ? t('Uptime monitor enabled') : t('Uptime monitor disabled')
+      );
+    }
+
     return resp;
   } catch (err) {
     const respError = err as RequestError;


### PR DESCRIPTION
Fixes [NEW-57: Successfully enabling a disabled monitor does not show a success toast](https://linear.app/getsentry/issue/NEW-57/successfully-enabling-a-disabled-monitor-does-not-show-a-success-toast)