### PR TITLE
ui(dashboards): Fix day/month/year boundary detection in widget timestamp formatter

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.spec.tsx
@@ -10,11 +10,17 @@ describe('formatXAxisTimestamp', () => {
     // Year starts
     ['2025-01-01T00:00:00', 'Jan 1st 2025'],
     ['2024-01-01T00:00:00', 'Jan 1st 2024'],
+    ['2025-01-01T05:00:00', '5:00 AM'],
+    ['2024-01-01T05:00:00', '5:00 AM'],
     // // Month starts
     ['2025-02-01T00:00:00', 'Feb 1st'],
     ['2024-03-01T00:00:00', 'Mar 1st'],
+    ['2025-02-01T05:00:00', '5:00 AM'],
+    ['2024-03-01T05:00:00', '5:00 AM'],
     // // Day starts
     ['2025-02-05T00:00:00', 'Feb 5th'],
+    ['2025-02-05T05:00:00', '5:00 AM'],
+    ['2025-07-15T04:00:00', '4:00 AM'],
     // // Hour starts
     ['2025-02-05T12:00:00', '12:00 PM'],
     ['2025-02-05T05:00:00', '5:00 AM'],
@@ -43,43 +49,66 @@ describe('formatXAxisTimestamp', () => {
     ['2025-02-05T12:10:05', '12:10:05'],
     ['2025-02-05T12:10:06', '12:10:06'],
     ['2025-02-05T17:25:10', '17:25:10'],
-  ])('formats %s as %s with 24h format (UTC mode)', (raw, formatted) => {
+  ])('formats %s as %s with 24h format (UTC & local mode)', (raw, formatted) => {
     const user = UserFixture();
     user.options.clock24Hours = true;
     ConfigStore.set('user', user);
 
     const timestamp = moment(raw).unix() * 1000;
     expect(formatXAxisTimestamp(timestamp, {utc: true})).toEqual(formatted);
+    expect(formatXAxisTimestamp(timestamp, {utc: false})).toEqual(formatted);
   });
 
-  it.each([
-    // 5:00 AM UTC = midnight EST
-    // Year starts
-    ['2025-01-01T05:00:00Z', 'Jan 1st 2025'],
-    ['2024-01-01T05:00:00Z', 'Jan 1st 2024'],
-    // Month starts
-    ['2025-02-01T05:00:00Z', 'Feb 1st'],
-    ['2024-03-01T05:00:00Z', 'Mar 1st'],
-    // Day starts
-    ['2025-02-05T05:00:00Z', 'Feb 5th'],
-    ['2025-07-15T04:00:00Z', 'Jul 15th'], // 4:00 AM UTC = midnight EDT (daylight time)
-    // Hour starts
-    ['2025-02-05T12:00:00Z', '12:00 PM'],
-    ['2025-02-05T20:00:00Z', '8:00 PM'],
-    ['2025-02-01T06:00:00Z', '6:00 AM'],
-    // Minute starts
-    ['2025-02-05T12:11:00Z', '12:11 PM'],
-    ['2025-02-05T20:25:00Z', '8:25 PM'],
-    // Seconds
-    ['2025-02-05T12:10:05Z', '12:10:05 PM'],
-    ['2025-02-05T12:10:06Z', '12:10:06 PM'],
-    ['2025-02-05T20:25:10Z', '8:25:10 PM'],
-  ])('formats %s as %s with 12h format (local mode)', (raw, formatted) => {
-    const user = UserFixture();
-    user.options.clock24Hours = false;
-    ConfigStore.set('user', user);
+  describe('local mode', () => {
+    beforeEach(() => {
+      // Mock moment's local() method to consistently return EST timezone
+      const originalMoment = moment;
+      jest.spyOn(moment.fn, 'clone').mockImplementation(function (this: any) {
+        const cloned = originalMoment(this);
+        cloned.local = jest.fn().mockImplementation(() => {
+          return originalMoment.tz(this, 'America/New_York');
+        });
+        return cloned;
+      });
+    });
 
-    const timestamp = moment(raw).unix() * 1000;
-    expect(formatXAxisTimestamp(timestamp)).toEqual(formatted); // No utc option = local mode
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it.each([
+      // 5:00 AM UTC = midnight EST
+      // Year starts
+      ['2025-01-01T00:00:00', '12:00 AM'],
+      ['2024-01-01T00:00:00', '12:00 AM'],
+      ['2025-01-01T05:00:00', 'Jan 1st 2025'],
+      ['2024-01-01T05:00:00', 'Jan 1st 2024'],
+      // Month starts
+      ['2025-02-01T00:00:00', '12:00 AM'],
+      ['2024-03-01T00:00:00', '12:00 AM'],
+      ['2025-02-01T05:00:00', 'Feb 1st'],
+      ['2024-03-01T05:00:00', 'Mar 1st'],
+      // Day starts
+      ['2025-02-05T00:00:00', '12:00 AM'],
+      ['2025-02-05T05:00:00', 'Feb 5th'], // 5:00 AM UTC = midnight EST
+      ['2025-07-15T04:00:00', 'Jul 15th'], // 4:00 AM UTC = midnight EDT
+      // Hour starts
+      ['2025-02-05T12:00:00', '12:00 PM'],
+      ['2025-02-01T01:00:00', '1:00 AM'],
+      // Minute starts
+      ['2025-02-05T12:11:00', '12:11 PM'],
+      ['2025-02-05T05:25:00', '5:25 AM'],
+      // Seconds
+      ['2025-02-05T12:10:05', '12:10:05 PM'],
+      ['2025-02-05T12:10:06', '12:10:06 PM'],
+      ['2025-02-05T05:25:10', '5:25:10 AM'],
+    ])('formats %s as %s with 12h format (local mode)', (raw, formatted) => {
+      const user = UserFixture();
+      user.options.clock24Hours = false;
+      ConfigStore.set('user', user);
+
+      const timestamp = moment(raw).unix() * 1000;
+      expect(formatXAxisTimestamp(timestamp, {utc: false})).toEqual(formatted);
+    });
   });
 });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.spec.tsx
@@ -53,26 +53,27 @@ describe('formatXAxisTimestamp', () => {
   });
 
   it.each([
-    // Year starts (local midnight on New Year's)
-    ['2025-01-01T05:00:00Z', 'Jan 1st 2025'], // 5:00 AM UTC = midnight EST on New Year's
-    ['2024-01-01T05:00:00Z', 'Jan 1st 2024'], // 5:00 AM UTC = midnight EST on New Year's
-    // Month starts (local midnight on 1st of month)
-    ['2025-02-01T05:00:00Z', 'Feb 1st'], // 5:00 AM UTC = midnight EST
-    ['2024-03-01T05:00:00Z', 'Mar 1st'], // 5:00 AM UTC = midnight EST
-    // Day starts (local midnight)
-    ['2025-02-05T05:00:00Z', 'Feb 5th'], // 5:00 AM UTC = midnight EST
+    // 5:00 AM UTC = midnight EST
+    // Year starts
+    ['2025-01-01T05:00:00Z', 'Jan 1st 2025'],
+    ['2024-01-01T05:00:00Z', 'Jan 1st 2024'],
+    // Month starts
+    ['2025-02-01T05:00:00Z', 'Feb 1st'],
+    ['2024-03-01T05:00:00Z', 'Mar 1st'],
+    // Day starts
+    ['2025-02-05T05:00:00Z', 'Feb 5th'],
     ['2025-07-15T04:00:00Z', 'Jul 15th'], // 4:00 AM UTC = midnight EDT (daylight time)
-    // Hour boundaries (non-midnight) - should show time
-    ['2025-02-05T12:00:00Z', '12:00 PM'], // Noon UTC = 7:00 AM EST
-    ['2025-02-05T20:00:00Z', '8:00 PM'], // 8:00 PM UTC = 3:00 PM EST
-    ['2025-02-01T06:00:00Z', '6:00 AM'], // 6:00 AM UTC = 1:00 AM EST
+    // Hour starts
+    ['2025-02-05T12:00:00Z', '12:00 PM'],
+    ['2025-02-05T20:00:00Z', '8:00 PM'],
+    ['2025-02-01T06:00:00Z', '6:00 AM'],
     // Minute starts
-    ['2025-02-05T12:11:00Z', '12:11 PM'], // 12:11 PM UTC
-    ['2025-02-05T20:25:00Z', '8:25 PM'], // 8:25 PM UTC
+    ['2025-02-05T12:11:00Z', '12:11 PM'],
+    ['2025-02-05T20:25:00Z', '8:25 PM'],
     // Seconds
-    ['2025-02-05T12:10:05Z', '12:10:05 PM'], // 12:10:05 PM UTC
-    ['2025-02-05T12:10:06Z', '12:10:06 PM'], // 12:10:06 PM UTC
-    ['2025-02-05T20:25:10Z', '8:25:10 PM'], // 8:25:10 PM UTC
+    ['2025-02-05T12:10:05Z', '12:10:05 PM'],
+    ['2025-02-05T12:10:06Z', '12:10:06 PM'],
+    ['2025-02-05T20:25:10Z', '8:25:10 PM'],
   ])('formats %s as %s with 12h format (local mode)', (raw, formatted) => {
     const user = UserFixture();
     user.options.clock24Hours = false;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.spec.tsx
@@ -26,13 +26,13 @@ describe('formatXAxisTimestamp', () => {
     ['2025-02-05T12:10:05', '12:10:05 PM'],
     ['2025-02-05T12:10:06', '12:10:06 PM'],
     ['2025-02-05T05:25:10', '5:25:10 AM'],
-  ])('formats %s as %s with 12h format', (raw, formatted) => {
+  ])('formats %s as %s with 12h format (UTC mode)', (raw, formatted) => {
     const user = UserFixture();
     user.options.clock24Hours = false;
     ConfigStore.set('user', user);
 
     const timestamp = moment(raw).unix() * 1000;
-    expect(formatXAxisTimestamp(timestamp)).toEqual(formatted);
+    expect(formatXAxisTimestamp(timestamp, {utc: true})).toEqual(formatted);
   });
 
   it.each([
@@ -43,12 +43,42 @@ describe('formatXAxisTimestamp', () => {
     ['2025-02-05T12:10:05', '12:10:05'],
     ['2025-02-05T12:10:06', '12:10:06'],
     ['2025-02-05T17:25:10', '17:25:10'],
-  ])('formats %s as %s with 24h format', (raw, formatted) => {
+  ])('formats %s as %s with 24h format (UTC mode)', (raw, formatted) => {
     const user = UserFixture();
     user.options.clock24Hours = true;
     ConfigStore.set('user', user);
 
     const timestamp = moment(raw).unix() * 1000;
-    expect(formatXAxisTimestamp(timestamp)).toEqual(formatted);
+    expect(formatXAxisTimestamp(timestamp, {utc: true})).toEqual(formatted);
+  });
+
+  it.each([
+    // Year starts (local midnight on New Year's)
+    ['2025-01-01T05:00:00Z', 'Jan 1st 2025'], // 5:00 AM UTC = midnight EST on New Year's
+    ['2024-01-01T05:00:00Z', 'Jan 1st 2024'], // 5:00 AM UTC = midnight EST on New Year's
+    // Month starts (local midnight on 1st of month)
+    ['2025-02-01T05:00:00Z', 'Feb 1st'], // 5:00 AM UTC = midnight EST
+    ['2024-03-01T05:00:00Z', 'Mar 1st'], // 5:00 AM UTC = midnight EST
+    // Day starts (local midnight)
+    ['2025-02-05T05:00:00Z', 'Feb 5th'], // 5:00 AM UTC = midnight EST
+    ['2025-07-15T04:00:00Z', 'Jul 15th'], // 4:00 AM UTC = midnight EDT (daylight time)
+    // Hour boundaries (non-midnight) - should show time
+    ['2025-02-05T12:00:00Z', '12:00 PM'], // Noon UTC = 7:00 AM EST
+    ['2025-02-05T20:00:00Z', '8:00 PM'], // 8:00 PM UTC = 3:00 PM EST
+    ['2025-02-01T06:00:00Z', '6:00 AM'], // 6:00 AM UTC = 1:00 AM EST
+    // Minute starts
+    ['2025-02-05T12:11:00Z', '12:11 PM'], // 12:11 PM UTC
+    ['2025-02-05T20:25:00Z', '8:25 PM'], // 8:25 PM UTC
+    // Seconds
+    ['2025-02-05T12:10:05Z', '12:10:05 PM'], // 12:10:05 PM UTC
+    ['2025-02-05T12:10:06Z', '12:10:06 PM'], // 12:10:06 PM UTC
+    ['2025-02-05T20:25:10Z', '8:25:10 PM'], // 8:25:10 PM UTC
+  ])('formats %s as %s with 12h format (local mode)', (raw, formatted) => {
+    const user = UserFixture();
+    user.options.clock24Hours = false;
+    ConfigStore.set('user', user);
+
+    const timestamp = moment(raw).unix() * 1000;
+    expect(formatXAxisTimestamp(timestamp)).toEqual(formatted); // No utc option = local mode
   });
 });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
@@ -38,7 +38,7 @@ export function formatXAxisTimestamp(
     // Start of a year
     format = 'MMM Do YYYY';
   } else if (
-    boundaryTime.date() === 1 &&
+    boundaryTime.day() === 1 &&
     boundaryTime.hour() === 0 &&
     boundaryTime.minute() === 0 &&
     boundaryTime.second() === 0

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
@@ -38,22 +38,21 @@ export function formatXAxisTimestamp(
     // Start of a year
     format = 'MMM Do YYYY';
   } else if (
-    boundaryTime.day() === 0 &&
+    boundaryTime.date() === 1 &&
     boundaryTime.hour() === 0 &&
     boundaryTime.minute() === 0 &&
     boundaryTime.second() === 0
   ) {
     // Start of a month
     format = 'MMM Do';
-  } else if (boundaryTime.minute() === 0 && boundaryTime.second() === 0) {
-    // Hour boundary - check if this represents a day boundary
-    // but keep the parsed object in UTC for consistent display formatting
-    if (boundaryTime.hour() === 0) {
-      format = 'MMM Do'; // Show date for day boundaries
-    } else {
-      format = getTimeFormat(); // Show time for other hour boundaries
-    }
-  } else if (parsed.second() === 0) {
+  } else if (
+    boundaryTime.hour() === 0 &&
+    boundaryTime.minute() === 0 &&
+    boundaryTime.second() === 0
+  ) {
+    // Start of a day
+    format = 'MMM Do';
+  } else if (boundaryTime.second() === 0) {
     // Hours, minutes
     format = getTimeFormat();
   } else {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
@@ -50,7 +50,7 @@ export function formatXAxisTimestamp(
     boundaryTime.minute() === 0 &&
     boundaryTime.second() === 0
   ) {
-    // Start of a day
+    // Start of day
     format = 'MMM Do';
   } else if (boundaryTime.second() === 0) {
     // Hours, minutes

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
@@ -50,7 +50,7 @@ export function formatXAxisTimestamp(
     boundaryTime.minute() === 0 &&
     boundaryTime.second() === 0
   ) {
-    // Start of day
+    // Start of a day
     format = 'MMM Do';
   } else if (boundaryTime.second() === 0) {
     // Hours, minutes

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
@@ -26,42 +26,29 @@ export function formatXAxisTimestamp(
   // parser is not aware of the other ticks
   let format = 'MMM Do';
 
+  // Choose which time to use for boundary detection--local or UTC
+  const boundaryTime = options.utc ? parsed : parsed.clone().local();
+
   if (
-    parsed.dayOfYear() === 1 &&
-    parsed.hour() === 0 &&
-    parsed.minute() === 0 &&
-    parsed.second() === 0
+    boundaryTime.dayOfYear() === 1 &&
+    boundaryTime.hour() === 0 &&
+    boundaryTime.minute() === 0 &&
+    boundaryTime.second() === 0
   ) {
     // Start of a year
     format = 'MMM Do YYYY';
   } else if (
-    parsed.day() === 0 &&
-    parsed.hour() === 0 &&
-    parsed.minute() === 0 &&
-    parsed.second() === 0
+    boundaryTime.day() === 0 &&
+    boundaryTime.hour() === 0 &&
+    boundaryTime.minute() === 0 &&
+    boundaryTime.second() === 0
   ) {
     // Start of a month
     format = 'MMM Do';
-  } else if (parsed.hour() === 0 && parsed.minute() === 0 && parsed.second() === 0) {
-    // Start of a day (exact midnight)
-    format = 'MMM Do';
-  } else if (parsed.minute() === 0 && parsed.second() === 0) {
-    // Hour boundary - check if this represents a day boundary in local timezone
+  } else if (boundaryTime.minute() === 0 && boundaryTime.second() === 0) {
+    // Hour boundary - check if this represents a day boundary
     // but keep the parsed object in UTC for consistent display formatting
-    let isDayBoundary = false;
-
-    if (options.utc) {
-      // UTC mode: check if it's UTC midnight
-      isDayBoundary = parsed.hour() === 0;
-    } else {
-      // Local mode: check if this UTC time represents local midnight
-      // Create a temporary local version just for boundary detection
-      const localTime = parsed.clone().local();
-      isDayBoundary = localTime.hour() === 0;
-      // Note: we don't modify 'parsed', so formatting stays in UTC
-    }
-
-    if (isDayBoundary) {
+    if (boundaryTime.hour() === 0) {
       format = 'MMM Do'; // Show date for day boundaries
     } else {
       format = getTimeFormat(); // Show time for other hour boundaries

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
@@ -26,7 +26,7 @@ export function formatXAxisTimestamp(
   // parser is not aware of the other ticks
   let format = 'MMM Do';
 
-  // Choose which time to use for boundary detection--local or UTC
+  // Choose whether to use local or UTC time for boundary detection
   const boundaryTime = options.utc ? parsed : parsed.clone().local();
 
   if (

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
@@ -43,8 +43,29 @@ export function formatXAxisTimestamp(
     // Start of a month
     format = 'MMM Do';
   } else if (parsed.hour() === 0 && parsed.minute() === 0 && parsed.second() === 0) {
-    // Start of a day
+    // Start of a day (exact midnight)
     format = 'MMM Do';
+  } else if (parsed.minute() === 0 && parsed.second() === 0) {
+    // Hour boundary - check if this represents a day boundary in local timezone
+    // but keep the parsed object in UTC for consistent display formatting
+    let isDayBoundary = false;
+
+    if (options.utc) {
+      // UTC mode: check if it's UTC midnight
+      isDayBoundary = parsed.hour() === 0;
+    } else {
+      // Local mode: check if this UTC time represents local midnight
+      // Create a temporary local version just for boundary detection
+      const localTime = parsed.clone().local();
+      isDayBoundary = localTime.hour() === 0;
+      // Note: we don't modify 'parsed', so formatting stays in UTC
+    }
+
+    if (isDayBoundary) {
+      format = 'MMM Do'; // Show date for day boundaries
+    } else {
+      format = getTimeFormat(); // Show time for other hour boundaries
+    }
   } else if (parsed.second() === 0) {
     // Hours, minutes
     format = getTimeFormat();


### PR DESCRIPTION
Previously the `formatXAxisTimestamp` attempted to detect date boundaries at midnight of the system timezone. This worked when both my system timezone (PDT) and Sentry timezone (PDT) matched. 

However, if I change my Sentry timezone to anything else--like UTC or EDT--such that the system and Sentry timezones are mismatched, the timestamps returned are in _Sentry_ timezone, but the ticks still happen at the _system_ timezone boundaries. For example, assuming my system timezone is PDT: if my Sentry timezone is set to UTC, all my day boundaries happen at 7am UTC (which is 12am in PDT). Therefore, none of the ticks are correctly detected as date boundaries for multi-day ranges by the formatter, and every tick shows 7am:

<img width="402" height="317" alt="Screenshot 2025-10-01 at 12 56 14 PM" src="https://github.com/user-attachments/assets/241f7d68-497d-45c8-bc05-b144b0e898b6" />

This PR allows `formatXAxisTimestamp` to convert timestamps to system time before checking if it's happening at midnight. We now get more useful x tick labels that emulate the expected behavior described in the `formatXAxisTimestamp` comment.

Sentry timezone set to UTC, but system timezone in PDT (7am UTC == 12am PDT):

<img width="402" height="317" alt="Screenshot 2025-10-01 at 12 58 01 PM" src="https://github.com/user-attachments/assets/445556ba-2113-4f14-85d4-5d014de80fab" />

Sentry timezone set to EDT, but system timezone in PDT (3am EDT == 12am PDT):

<img width="402" height="317" alt="Screenshot 2025-10-01 at 12 52 09 PM" src="https://github.com/user-attachments/assets/3051b8e8-285f-44ab-b839-eef959080856" />

Sentry timezone set to PDT, but system timezone is EDT (9pm PDT == 12am EDT):

<img width="402" height="317" alt="Screenshot 2025-10-01 at 3 54 45 PM" src="https://github.com/user-attachments/assets/23eff837-e6b3-4d22-91e1-9d8eea3ec103" />

Sentry and system timezones both in PDT:

<img width="402" height="317" alt="Screenshot 2025-10-01 at 12 53 12 PM" src="https://github.com/user-attachments/assets/5f50aa3d-ff34-4752-bab5-e61042ea8c80" />