### PR TITLE
chore(cleanup): Add ReleaseFile deletion task

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -82,6 +82,7 @@ def load_defaults(manager: DeletionTaskManager) -> None:
     manager.register(models.PullRequest, defaults.PullRequestDeletionTask)
     manager.register(models.Release, defaults.ReleaseDeletionTask)
     manager.register(models.ReleaseCommit, BulkModelDeletionTask)
+    manager.register(models.ReleaseFile, defaults.ReleaseFileDeletionTask)
     manager.register(models.ReleaseEnvironment, BulkModelDeletionTask)
     manager.register(models.ReleaseHeadCommit, BulkModelDeletionTask)
     manager.register(models.ReleaseProject, BulkModelDeletionTask)

--- a/src/sentry/deletions/defaults/__init__.py
+++ b/src/sentry/deletions/defaults/__init__.py
@@ -22,6 +22,7 @@ from .project import *  # noqa: F401,F403
 from .pullrequest import *  # noqa: F401,F403
 from .querysubscription import *  # noqa: F401,F403
 from .release import *  # noqa: F401,F403
+from .releasefile import *  # noqa: F401,F403
 from .repository import *  # noqa: F401,F403
 from .repositoryprojectpathconfig import *  # noqa: F401,F403
 from .rule import *  # noqa: F401,F403

--- a/src/sentry/deletions/defaults/releasefile.py
+++ b/src/sentry/deletions/defaults/releasefile.py
@@ -1,0 +1,43 @@
+from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
+from sentry.models.releasefile import ReleaseFile
+
+
+class ReleaseFileDeletionTask(ModelDeletionTask[ReleaseFile]):
+    def get_child_relations(self, instance: ReleaseFile) -> list[BaseRelation]:
+        from sentry.models.files.file import File
+
+        # Always safe to delete Files for these types as they are 1:1 with ReleaseFile
+        always_safe_types = {
+            "release.file",  # Regular uploaded files
+            "release.artifact-index",  # Artifact index files (release-specific)
+        }
+
+        if instance.file.type in always_safe_types:
+            return [
+                ModelRelation(File, {"id": instance.file_id}),
+            ]
+
+        # For artifact.bundle files, only delete if no other references exist
+        if instance.file.type == "artifact.bundle":
+            if self._is_last_reference_to_file(instance):
+                return [
+                    ModelRelation(File, {"id": instance.file_id}),
+                ]
+
+        # For other unknown types, don't delete the File to be safe
+        return []
+
+    def _is_last_reference_to_file(self, instance: ReleaseFile) -> bool:
+        """Check if this ReleaseFile is the last reference to the File."""
+        from sentry.models.artifactbundle import ArtifactBundle
+
+        # Count other ReleaseFile records pointing to the same file (excluding this one)
+        other_releasefiles = (
+            ReleaseFile.objects.filter(file_id=instance.file_id).exclude(id=instance.id).count()
+        )
+
+        # Count ArtifactBundle records pointing to the same file
+        artifact_bundles = ArtifactBundle.objects.filter(file_id=instance.file_id).count()
+
+        # Only safe to delete if no other references exist
+        return other_releasefiles == 0 and artifact_bundles == 0

--- a/src/sentry/deletions/defaults/releasefile.py
+++ b/src/sentry/deletions/defaults/releasefile.py
@@ -11,38 +11,16 @@ class ReleaseFileDeletionTask(ModelDeletionTask[ReleaseFile]):
         except File.DoesNotExist:
             return []
 
-        # Always safe to delete Files for these types as they are 1:1 with ReleaseFile
-        always_safe_types = {
+        # Only delete Files for these types as they are 1:1 with ReleaseFile
+        safe_to_delete_types = {
             "release.file",  # Regular uploaded files
             "release.artifact-index",  # Artifact index files (release-specific)
         }
 
-        if file_type in always_safe_types:
+        if file_type in safe_to_delete_types:
             return [
                 ModelRelation(File, {"id": instance.file_id}),
             ]
 
-        # For artifact.bundle files, only delete if no other references exist
-        if file_type == "artifact.bundle":
-            if self._is_last_reference_to_file(instance):
-                return [
-                    ModelRelation(File, {"id": instance.file_id}),
-                ]
-
-        # For other unknown types, don't delete the File to be safe
+        # For other types, don't delete the File to be safe
         return []
-
-    def _is_last_reference_to_file(self, instance: ReleaseFile) -> bool:
-        """Check if this ReleaseFile is the last reference to the File."""
-        from sentry.models.artifactbundle import ArtifactBundle
-
-        # Count other ReleaseFile records pointing to the same file (excluding this one)
-        other_releasefiles = (
-            ReleaseFile.objects.filter(file_id=instance.file_id).exclude(id=instance.id).count()
-        )
-
-        # Count ArtifactBundle records pointing to the same file
-        artifact_bundles = ArtifactBundle.objects.filter(file_id=instance.file_id).count()
-
-        # Only safe to delete if no other references exist
-        return other_releasefiles == 0 and artifact_bundles == 0


### PR DESCRIPTION
The task makes sure to cleanup the associated File model, preventing the ReleaseFile deletion from leaving an orphaned row in the File table.
Added checks to assert the type of the File to be related to releases, with "artifact.bundle" getting special treatment and only deleting the File if nothing else is referencing it.