### PR TITLE
fix(prevent): Redirect prevent-ai to ai-code-review

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2385,6 +2385,11 @@ function buildRoutes(): RouteObject[] {
       ],
     },
     {
+      // Backwards compatibility for renamed route (still used in marketing links)
+      path: 'prevent-ai/*',
+      redirectTo: '/prevent/ai-code-review/',
+    },
+    {
       path: 'ai-code-review/',
       children: [
         {


### PR DESCRIPTION
Redirect the prevent-ai routes to ai-code-review. Follows up to this [PR](https://github.com/getsentry/sentry/pull/100511), as it turns out some marketing materials were going to the old route, so do this redirect instead of breaking change
