### PR TITLE
chore(deletions): Default to using `RangeQuerySetWrapper` when performing bulk deletions, and remove server side cursor code

### DIFF
--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -79,7 +79,7 @@ class BulkDeleteQuery:
             cursor.execute(query)
             results = cursor.rowcount > 0
 
-    def iterator(self, chunk_size=100, batch_size=100000) -> Generator[tuple[int, ...]]:
+    def iterator(self, chunk_size=100, batch_size=10000) -> Generator[tuple[int, ...]]:
         assert self.days is not None
         assert self.dtfield is not None
         assert self.order_by in [self.dtfield, f"-{self.dtfield}"]

--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import itertools
 from collections.abc import Generator
 from datetime import timedelta
-from typing import Any
-from uuid import uuid4
 
 from django.db import connections, router
 from django.utils import timezone
@@ -81,113 +79,35 @@ class BulkDeleteQuery:
             cursor.execute(query)
             results = cursor.rowcount > 0
 
-    def iterator(
-        self, chunk_size=100, batch_size=100000, use_range_wrapper=False
-    ) -> Generator[tuple[int, ...]]:
+    def iterator(self, chunk_size=100, batch_size=100000) -> Generator[tuple[int, ...]]:
         assert self.days is not None
         assert self.dtfield is not None
         assert self.order_by in [self.dtfield, f"-{self.dtfield}"]
 
-        if use_range_wrapper:
-            cutoff = timezone.now() - timedelta(days=self.days)
-            queryset = self.model.objects.filter(**{f"{self.dtfield}__lt": cutoff})
+        cutoff = timezone.now() - timedelta(days=self.days)
+        queryset = self.model.objects.filter(**{f"{self.dtfield}__lt": cutoff})
 
-            if self.project_id:
-                queryset = queryset.filter(project_id=self.project_id)
-            if self.organization_id:
-                queryset = queryset.filter(organization_id=self.organization_id)
+        if self.project_id:
+            queryset = queryset.filter(project_id=self.project_id)
+        if self.organization_id:
+            queryset = queryset.filter(organization_id=self.organization_id)
 
-            queryset = queryset.values_list("id", self.dtfield)
+        queryset = queryset.values_list("id", self.dtfield)
 
-            if self.order_by[0] == "-":
-                step = -batch_size
-                order_field = self.order_by[1:]
-            else:
-                step = batch_size
-                order_field = self.order_by
-
-            wrapper = RangeQuerySetWrapper(
-                queryset,
-                step=step,
-                order_by=order_field,
-                override_unique_safety_check=True,
-                result_value_getter=lambda item: item[1],
-            )
-
-            for batch in itertools.batched(wrapper, chunk_size):
-                yield tuple(item[0] for item in batch)
+        if self.order_by[0] == "-":
+            step = -batch_size
+            order_field = self.order_by[1:]
         else:
-            dbc = connections[self.using]
-            quote_name = dbc.ops.quote_name
+            step = batch_size
+            order_field = self.order_by
 
-            position: object | None = None
-            cutoff = timezone.now() - timedelta(days=self.days)
+        wrapper = RangeQuerySetWrapper(
+            queryset,
+            step=step,
+            order_by=order_field,
+            override_unique_safety_check=True,
+            result_value_getter=lambda item: item[1],
+        )
 
-            with dbc.get_new_connection(dbc.get_connection_params()) as conn:
-                conn.autocommit = False
-
-                chunk = []
-
-                completed = False
-                while not completed:
-                    # We explicitly use a named cursor here so that we can read a
-                    # large quantity of rows from postgres incrementally, without
-                    # having to pull all rows into memory at once.
-                    with conn.cursor(uuid4().hex) as cursor:
-                        where: list[tuple[str, list[Any]]] = [
-                            (f"{quote_name(self.dtfield)} < %s", [cutoff])
-                        ]
-
-                        if self.project_id:
-                            where.append(("project_id = %s", [self.project_id]))
-                        if self.organization_id:
-                            where.append(("organization_id = %s", [self.organization_id]))
-
-                        if self.order_by[0] == "-":
-                            direction = "desc"
-                            order_field = self.order_by[1:]
-                            if position is not None:
-                                where.append((f"{quote_name(order_field)} <= %s", [position]))
-                        else:
-                            direction = "asc"
-                            order_field = self.order_by
-                            if position is not None:
-                                where.append((f"{quote_name(order_field)} >= %s", [position]))
-
-                        conditions, parameters = zip(*where)
-                        parameters = list(itertools.chain.from_iterable(parameters))
-
-                        query = """
-                            select id, {order_field}
-                            from {table}
-                            where {conditions}
-                            order by {order_field} {direction}
-                            limit {batch_size}
-                        """.format(
-                            table=self.model._meta.db_table,
-                            conditions=" and ".join(conditions),
-                            order_field=quote_name(order_field),
-                            direction=direction,
-                            batch_size=batch_size,
-                        )
-
-                        cursor.execute(query, parameters)
-
-                        i = 0
-                        for i, row in enumerate(cursor, 1):
-                            key, position = row
-                            chunk.append(key)
-                            if len(chunk) == chunk_size:
-                                yield tuple(chunk)
-                                chunk = []
-
-                        # If we retrieved less rows than the batch size, there are
-                        # no more rows remaining to delete and we can exit the
-                        # loop.
-                        if i < batch_size:
-                            completed = True
-
-                    conn.commit()
-
-                if chunk:
-                    yield tuple(chunk)
+        for batch in itertools.batched(wrapper, chunk_size):
+            yield tuple(item[0] for item in batch)

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -253,7 +253,7 @@ def cleanup(
         )
 
         debug_output("Running bulk deletes in DELETES")
-        for model_tp, dtfield, order_by, use_range_wrapper in deletes:
+        for model_tp, dtfield, order_by in deletes:
             debug_output(f"Removing {model_tp.__name__} for days={days} project={project or '*'}")
 
             if is_filtered(model_tp):
@@ -270,9 +270,7 @@ def cleanup(
                     order_by=order_by,
                 )
 
-                for chunk in q.iterator(
-                    chunk_size=100, batch_size=10000, use_range_wrapper=use_range_wrapper
-                ):
+                for chunk in q.iterator(chunk_size=100):
                     task_queue.put((imp, chunk))
 
                 task_queue.join()
@@ -449,7 +447,7 @@ def exported_data(
             item.delete_file()
 
 
-def models_which_use_deletions_code_path() -> list[tuple[type[Model], str, str, bool]]:
+def models_which_use_deletions_code_path() -> list[tuple[type[Model], str, str]]:
     from sentry.models.artifactbundle import ArtifactBundle
     from sentry.models.eventattachment import EventAttachment
     from sentry.models.grouprulestatus import GroupRuleStatus
@@ -460,26 +458,26 @@ def models_which_use_deletions_code_path() -> list[tuple[type[Model], str, str, 
     from sentry.replays.models import ReplayRecordingSegment
 
     # Deletions that use the `deletions` code path (which handles their child relations)
-    # (model, datetime_field, order_by, use_range_wrapper)
+    # (model, datetime_field, order_by)
     return [
-        (EventAttachment, "date_added", "date_added", False),
-        (ReplayRecordingSegment, "date_added", "date_added", False),
-        (ArtifactBundle, "date_added", "date_added", False),
-        (MonitorCheckIn, "date_added", "date_added", False),
-        (GroupRuleStatus, "date_added", "date_added", False),
-        (PullRequest, "date_added", "date_added", False),
-        (RuleFireHistory, "date_added", "date_added", False),
-        (Release, "date_added", "date_added", True),
+        (EventAttachment, "date_added", "date_added"),
+        (ReplayRecordingSegment, "date_added", "date_added"),
+        (ArtifactBundle, "date_added", "date_added"),
+        (MonitorCheckIn, "date_added", "date_added"),
+        (GroupRuleStatus, "date_added", "date_added"),
+        (PullRequest, "date_added", "date_added"),
+        (RuleFireHistory, "date_added", "date_added"),
+        (Release, "date_added", "date_added"),
     ]
 
 
 def remove_cross_project_models(
-    deletes: list[tuple[type[Model], str, str, bool]],
-) -> list[tuple[type[Model], str, str, bool]]:
+    deletes: list[tuple[type[Model], str, str]],
+) -> list[tuple[type[Model], str, str]]:
     from sentry.models.artifactbundle import ArtifactBundle
 
     # These models span across projects, so let's skip them
-    deletes.remove((ArtifactBundle, "date_added", "date_added", False))
+    deletes.remove((ArtifactBundle, "date_added", "date_added"))
     return deletes
 
 

--- a/tests/sentry/db/test_deletion.py
+++ b/tests/sentry/db/test_deletion.py
@@ -65,7 +65,7 @@ class BulkDeleteQueryIteratorTestCase(TransactionTestCase):
 
         assert results == expected_group_ids
 
-    def test_iteration_with_range_wrapper(self) -> None:
+    def test_iteration_descending(self) -> None:
         target_project = self.project
         expected_group_ids = {self.create_group().id for i in range(2)}
 
@@ -77,32 +77,9 @@ class BulkDeleteQueryIteratorTestCase(TransactionTestCase):
             model=Group,
             project_id=target_project.id,
             dtfield="last_seen",
-            order_by="last_seen",
+            order_by="-last_seen",
             days=0,
-        ).iterator(chunk_size=1, use_range_wrapper=True)
-
-        results: set[int] = set()
-        for chunk in iterator:
-            results.update(chunk)
-
-        assert results == expected_group_ids
-
-    def test_iteration_with_range_wrapper_descending(self) -> None:
-        target_project = self.project
-        expected_group_ids = {self.create_group().id for i in range(2)}
-
-        other_project = self.create_project()
-        self.create_group(other_project)
-        self.create_group(other_project)
-
-        # Test with descending order
-        iterator = BulkDeleteQuery(
-            model=Group,
-            project_id=target_project.id,
-            dtfield="last_seen",
-            order_by="-last_seen",  # Descending order
-            days=0,
-        ).iterator(chunk_size=1, use_range_wrapper=True)
+        ).iterator(chunk_size=1)
 
         results: set[int] = set()
         for chunk in iterator:


### PR DESCRIPTION
This worked well for deleting releases, so switching over all bulk deletes to do the same.
