### PR TITLE
fix(search): Allow mixing wildcards w/ non-wildcards

### DIFF
--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -544,7 +544,11 @@ def convert_search_filter_to_snuba_query(
         return None
     elif name in key_conversion_map:
         return key_conversion_map[name](search_filter, name, params)
-    elif name in ARRAY_FIELDS and search_filter.value.is_wildcard():
+    elif (
+        name in ARRAY_FIELDS
+        and search_filter.value.is_wildcard()
+        and not search_filter.value.is_str_sequence()
+    ):
         # Escape and convert meta characters for LIKE expressions.
         raw_value = search_filter.value.raw_value
         assert isinstance(raw_value, str), raw_value


### PR DESCRIPTION
Reported in https://github.com/getsentry/sentry/issues/100635. Issue is that we're not correctly recurring when have an array of values. Let's do that instead.

Before:
<img width="1462" height="269" alt="Screenshot 2025-09-30 at 3 18 38 PM" src="https://github.com/user-attachments/assets/9b5e6a5b-4eef-404c-9ec1-d81f72d51c35" />

After:
<img width="1462" height="478" alt="Screenshot 2025-09-30 at 3 19 28 PM" src="https://github.com/user-attachments/assets/15fc6325-bdfb-4bbd-8e49-4ad9511c75f6" />
