### PR TITLE
fix(integration): Handles different comment update failure scenarios

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -531,7 +531,16 @@ class JiraIntegration(IssueSyncIntegration):
         # https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=texteffects
         comment = group_note.data["text"]
         quoted_comment = self.create_comment_attribution(user_id, comment)
-        return self.get_client().create_comment(issue_id, quoted_comment)
+        try:
+            return self.get_client().create_comment(issue_id, quoted_comment)
+        except ApiUnauthorized as e:
+            raise IntegrationInstallationConfigurationError(
+                "Insufficient permissions to create a comment on the Jira issue."
+            ) from e
+        except ApiError as e:
+            raise IntegrationError(
+                "There was an error creating a comment on the Jira issue."
+            ) from e
 
     def create_comment_attribution(self, user_id, comment_text):
         user = user_service.get_user(user_id=user_id)
@@ -542,9 +551,18 @@ class JiraIntegration(IssueSyncIntegration):
 
     def update_comment(self, issue_id, user_id, group_note):
         quoted_comment = self.create_comment_attribution(user_id, group_note.data["text"])
-        return self.get_client().update_comment(
-            issue_id, group_note.data["external_id"], quoted_comment
-        )
+        try:
+            return self.get_client().update_comment(
+                issue_id, group_note.data["external_id"], quoted_comment
+            )
+        except ApiUnauthorized as e:
+            raise IntegrationInstallationConfigurationError(
+                "Insufficient permissions to update a comment on the Jira issue."
+            ) from e
+        except ApiError as e:
+            raise IntegrationError(
+                "There was an error updating a comment on the Jira issue."
+            ) from e
 
     def search_issues(self, query: str | None, **kwargs) -> dict[str, Any]:
         try:

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -534,7 +534,7 @@ class JiraIntegration(IssueSyncIntegration):
         try:
             return self.get_client().create_comment(issue_id, quoted_comment)
         except ApiUnauthorized as e:
-            raise IntegrationInstallationConfigurationError(
+            raise IntegrationConfigurationError(
                 "Insufficient permissions to create a comment on the Jira issue."
             ) from e
         except ApiError as e:
@@ -556,7 +556,7 @@ class JiraIntegration(IssueSyncIntegration):
                 issue_id, group_note.data["external_id"], quoted_comment
             )
         except ApiUnauthorized as e:
-            raise IntegrationInstallationConfigurationError(
+            raise IntegrationConfigurationError(
                 "Insufficient permissions to update a comment on the Jira issue."
             ) from e
         except ApiError as e:

--- a/src/sentry/integrations/project_management/metrics.py
+++ b/src/sentry/integrations/project_management/metrics.py
@@ -17,6 +17,10 @@ class ProjectManagementActionType(StrEnum):
     LINK_EXTERNAL_ISSUE = "link_external_issue"
     CREATE_EXTERNAL_ISSUE_VIA_ISSUE_DETAIL = "create_external_issue_via_issue_detail"
 
+    # External Issue Comment Sync
+    SYNC_EXTERNAL_ISSUE_COMMENT_CREATE = "sync_external_issue_comment_create"
+    SYNC_EXTERNAL_ISSUE_COMMENT_UPDATE = "sync_external_issue_comment_update"
+
 
 class ProjectManagementHaltReason(StrEnum):
     SYNC_INBOUND_ASSIGNEE_NOT_FOUND = "inbound-assignee-not-found"

--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -43,10 +43,6 @@ class SCMIntegrationInteractionType(StrEnum):
     DERIVE_CODEMAPPINGS = "derive_codemappings"
     STUDENT_PACK = "student_pack"
 
-    # External Issue Comment Sync
-    SYNC_EXTERNAL_ISSUE_COMMENT_CREATE = "sync_external_issue_comment_create"
-    SYNC_EXTERNAL_ISSUE_COMMENT_UPDATE = "sync_external_issue_comment_update"
-
     # Releases
     COMPARE_COMMITS = "compare_commits"
 

--- a/src/sentry/integrations/tasks/create_comment.py
+++ b/src/sentry/integrations/tasks/create_comment.py
@@ -8,7 +8,7 @@ from sentry.integrations.project_management.metrics import (
 )
 from sentry.integrations.tasks import should_comment_sync
 from sentry.models.activity import Activity
-from sentry.shared_integrations.exceptions import IntegrationInstallationConfigurationError
+from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.config import TaskworkerConfig
@@ -75,5 +75,5 @@ def create_comment(external_issue_id: int, user_id: int, group_note_id: int) -> 
                     organization_id=external_issue.organization_id,
                 )
             )
-        except IntegrationInstallationConfigurationError as e:
+        except IntegrationConfigurationError as e:
             lifecycle.record_halt(halt_reason=e)

--- a/src/sentry/integrations/tasks/create_comment.py
+++ b/src/sentry/integrations/tasks/create_comment.py
@@ -2,12 +2,13 @@ from sentry import analytics
 from sentry.integrations.analytics import IntegrationIssueCommentsSyncedEvent
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.source_code_management.metrics import (
-    SCMIntegrationInteractionEvent,
-    SCMIntegrationInteractionType,
+from sentry.integrations.project_management.metrics import (
+    ProjectManagementActionType,
+    ProjectManagementEvent,
 )
 from sentry.integrations.tasks import should_comment_sync
 from sentry.models.activity import Activity
+from sentry.shared_integrations.exceptions import IntegrationInstallationConfigurationError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.config import TaskworkerConfig
@@ -50,11 +51,9 @@ def create_comment(external_issue_id: int, user_id: int, group_note_id: int) -> 
     except Activity.DoesNotExist:
         return
 
-    with SCMIntegrationInteractionEvent(
-        interaction_type=SCMIntegrationInteractionType.SYNC_EXTERNAL_ISSUE_COMMENT_CREATE,
-        provider_key=installation.model.get_provider().name,
-        organization_id=external_issue.organization.id,
-        integration_id=installation.org_integration.integration_id,
+    with ProjectManagementEvent(
+        action_type=ProjectManagementActionType.SYNC_EXTERNAL_ISSUE_COMMENT_CREATE,
+        integration=installation.model,
     ).capture() as lifecycle:
         lifecycle.add_extras(
             {
@@ -65,13 +64,16 @@ def create_comment(external_issue_id: int, user_id: int, group_note_id: int) -> 
             }
         )
 
-        comment = installation.create_comment(external_issue.key, user_id, note)
-        note.data["external_id"] = installation.get_comment_id(comment)
-        note.save()
-        analytics.record(
-            IntegrationIssueCommentsSyncedEvent(
-                provider=installation.model.provider,
-                id=installation.model.id,
-                organization_id=external_issue.organization_id,
+        try:
+            comment = installation.create_comment(external_issue.key, user_id, note)
+            note.data["external_id"] = installation.get_comment_id(comment)
+            note.save()
+            analytics.record(
+                IntegrationIssueCommentsSyncedEvent(
+                    provider=installation.model.provider,
+                    id=installation.model.id,
+                    organization_id=external_issue.organization_id,
+                )
             )
-        )
+        except IntegrationInstallationConfigurationError as e:
+            lifecycle.record_halt(halt_reason=e)

--- a/src/sentry/integrations/tasks/update_comment.py
+++ b/src/sentry/integrations/tasks/update_comment.py
@@ -2,12 +2,13 @@ from sentry import analytics
 from sentry.integrations.analytics import IntegrationIssueCommentsSyncedEvent
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.source_code_management.metrics import (
-    SCMIntegrationInteractionEvent,
-    SCMIntegrationInteractionType,
+from sentry.integrations.project_management.metrics import (
+    ProjectManagementActionType,
+    ProjectManagementEvent,
 )
 from sentry.integrations.tasks import should_comment_sync
 from sentry.models.activity import Activity
+from sentry.shared_integrations.exceptions import IntegrationInstallationConfigurationError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.config import TaskworkerConfig
@@ -53,11 +54,9 @@ def update_comment(external_issue_id: int, user_id: int, group_note_id: int) -> 
     except Activity.DoesNotExist:
         return
 
-    with SCMIntegrationInteractionEvent(
-        interaction_type=SCMIntegrationInteractionType.SYNC_EXTERNAL_ISSUE_COMMENT_UPDATE,
-        provider_key=installation.model.get_provider().name,
-        integration_id=installation.org_integration.integration_id,
-        organization_id=external_issue.organization.id,
+    with ProjectManagementEvent(
+        action_type=ProjectManagementActionType.SYNC_EXTERNAL_ISSUE_COMMENT_UPDATE,
+        integration=installation.model,
     ).capture() as lifecycle:
         lifecycle.add_extras(
             {
@@ -67,11 +66,14 @@ def update_comment(external_issue_id: int, user_id: int, group_note_id: int) -> 
                 "user_id": user_id,
             }
         )
-        installation.update_comment(external_issue.key, user_id, note)
-        analytics.record(
-            IntegrationIssueCommentsSyncedEvent(
-                provider=installation.model.provider,
-                id=installation.model.id,
-                organization_id=external_issue.organization_id,
+        try:
+            installation.update_comment(external_issue.key, user_id, note)
+            analytics.record(
+                IntegrationIssueCommentsSyncedEvent(
+                    provider=installation.model.provider,
+                    id=installation.model.id,
+                    organization_id=external_issue.organization_id,
+                )
             )
-        )
+        except IntegrationInstallationConfigurationError as e:
+            lifecycle.record_halt(halt_reason=e)

--- a/src/sentry/integrations/tasks/update_comment.py
+++ b/src/sentry/integrations/tasks/update_comment.py
@@ -8,7 +8,7 @@ from sentry.integrations.project_management.metrics import (
 )
 from sentry.integrations.tasks import should_comment_sync
 from sentry.models.activity import Activity
-from sentry.shared_integrations.exceptions import IntegrationInstallationConfigurationError
+from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.config import TaskworkerConfig
@@ -75,5 +75,5 @@ def update_comment(external_issue_id: int, user_id: int, group_note_id: int) -> 
                     organization_id=external_issue.organization_id,
                 )
             )
-        except IntegrationInstallationConfigurationError as e:
+        except IntegrationConfigurationError as e:
             lifecycle.record_halt(halt_reason=e)


### PR DESCRIPTION
- Comments were pinned to the wrong SLO domain, so I've moved their related features to the Project Management one where they belong
- Adds distinct error handling for configuration-related errors to the comment tasks,
- Updates Jira integration to raise configuration errors when auth issues occur