### PR TITLE
feat(aci): Add support for nested dataSource error messages

### DIFF
--- a/static/app/components/forms/form.tsx
+++ b/static/app/components/forms/form.tsx
@@ -30,6 +30,7 @@ export interface FormProps
     | 'onFieldChange'
     | 'onSubmitError'
     | 'onSubmitSuccess'
+    | 'mapFormErrors'
   > {
   additionalFieldProps?: Record<string, any>;
   cancelLabel?: string;
@@ -122,6 +123,7 @@ function Form({
   footerStyle,
   hideFooter,
   initialData,
+  mapFormErrors,
   model,
   onCancel,
   onFieldChange,
@@ -159,6 +161,7 @@ function Form({
       saveOnBlur,
       apiEndpoint,
       apiMethod,
+      mapFormErrors,
     });
 
     return resolvedModel;

--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -21,6 +21,7 @@ type EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload> = {
   detector: TDetector;
   formDataToEndpointPayload: (formData: TFormData) => TUpdatePayload;
   savedDetectorToFormData: (detector: TDetector) => TFormData;
+  mapFormErrors?: (error: any) => any;
   previewChart?: React.ReactNode;
 };
 
@@ -34,6 +35,7 @@ export function EditDetectorLayout<
   children,
   formDataToEndpointPayload,
   savedDetectorToFormData,
+  mapFormErrors,
 }: EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload>) {
   const handleFormSubmit = useEditDetectorFormSubmit({
     detector,
@@ -47,6 +49,7 @@ export function EditDetectorLayout<
   const formProps = {
     initialData,
     onSubmit: handleFormSubmit,
+    mapFormErrors,
   };
 
   return (

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -69,6 +69,7 @@ export function EditExistingMetricDetectorForm({detector}: {detector: Detector})
       previewChart={<MetricDetectorPreviewChart />}
       formDataToEndpointPayload={metricDetectorFormDataToEndpointPayload}
       savedDetectorToFormData={metricSavedDetectorToFormData}
+      mapFormErrors={mapMetricDetectorFormErrors}
     >
       <MetricDetectorForm />
     </EditDetectorLayout>
@@ -82,11 +83,28 @@ export function NewMetricDetectorForm() {
       previewChart={<MetricDetectorPreviewChart />}
       formDataToEndpointPayload={metricDetectorFormDataToEndpointPayload}
       initialFormData={DEFAULT_THRESHOLD_METRIC_FORM_DATA}
+      mapFormErrors={mapMetricDetectorFormErrors}
     >
       <MetricDetectorForm />
     </NewDetectorLayout>
   );
 }
+
+// Errors come back as nested objects, we need to flatten them
+// to match the form state
+const mapMetricDetectorFormErrors = (error: unknown) => {
+  if (typeof error !== 'object' || error === null) {
+    return error;
+  }
+
+  if ('dataSource' in error && typeof error.dataSource === 'object') {
+    return {
+      ...error,
+      ...error.dataSource,
+    };
+  }
+  return error;
+};
 
 const DETECTION_TYPE_MAP: Record<
   MetricDetectorConfig['detectionType'],

--- a/static/app/views/detectors/components/forms/newDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/newDetectorLayout.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 
+import type {FormProps} from 'sentry/components/forms/form';
 import type {Data} from 'sentry/components/forms/types';
 import EditLayout from 'sentry/components/workflowEngine/layout/edit';
 import type {
@@ -18,6 +19,7 @@ type NewDetectorLayoutProps<TFormData, TUpdatePayload> = {
   detectorType: DetectorType;
   formDataToEndpointPayload: (formData: TFormData) => TUpdatePayload;
   initialFormData: Partial<TFormData>;
+  mapFormErrors?: (error: any) => any;
   previewChart?: React.ReactNode;
 };
 
@@ -28,6 +30,7 @@ export function NewDetectorLayout<
   children,
   formDataToEndpointPayload,
   initialFormData,
+  mapFormErrors,
   previewChart,
   detectorType,
 }: NewDetectorLayoutProps<TFormData, TUpdatePayload>) {
@@ -58,9 +61,10 @@ export function NewDetectorLayout<
     projects,
   ]);
 
-  const formProps = {
+  const formProps: FormProps = {
     initialData,
     onSubmit: formSubmitHandler,
+    mapFormErrors,
   };
 
   return (

--- a/static/app/views/insights/crons/components/monitorCreateForm.tsx
+++ b/static/app/views/insights/crons/components/monitorCreateForm.tsx
@@ -53,7 +53,6 @@ export default function MonitorCreateForm() {
   const form = useRef(
     new FormModel({
       transformData: transformMonitorFormData,
-      mapFormErrors: mapMonitorFormErrors,
     })
   );
 
@@ -99,6 +98,7 @@ export default function MonitorCreateForm() {
       }}
       onSubmitSuccess={onCreateMonitor}
       submitLabel={t('Create')}
+      mapFormErrors={mapMonitorFormErrors}
     >
       <FieldContainer>
         <ProjectOwnerNameInputs>

--- a/static/app/views/insights/crons/components/monitorForm.tsx
+++ b/static/app/views/insights/crons/components/monitorForm.tsx
@@ -181,7 +181,6 @@ function MonitorForm({
   const form = useRef(
     new FormModel({
       transformData: transformMonitorFormData,
-      mapFormErrors: mapMonitorFormErrors,
     })
   );
   const {projects} = useProjects();
@@ -255,6 +254,7 @@ function MonitorForm({
       }
       onSubmitSuccess={onSubmitSuccess}
       submitLabel={submitLabel}
+      mapFormErrors={mapMonitorFormErrors}
     >
       <StyledList symbol="colored-numeric">
         {monitor?.isUpserting && (

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -163,9 +163,7 @@ export default function SentryApplicationDetails(props: Props) {
   const {appSlug} = props.params;
   const {router, location} = props;
   const organization = useOrganization();
-  const [form] = useState<SentryAppFormModel>(
-    () => new SentryAppFormModel({mapFormErrors})
-  );
+  const [form] = useState<SentryAppFormModel>(() => new SentryAppFormModel());
 
   const isEditingApp = !!appSlug;
 
@@ -410,6 +408,7 @@ export default function SentryApplicationDetails(props: Props) {
           onSubmitSuccess={handleSubmitSuccess}
           onSubmitError={handleSubmitError}
           onFieldChange={onFieldChange}
+          mapFormErrors={mapFormErrors}
         >
           <Observer>
             {() => {


### PR DESCRIPTION
For the monitor form, we were getting nested errors like `{ dataSource: { nonFieldErrors: ['Error message'] } }`

We need to flatten it for the form model.

Before:

<img width="602" height="220" alt="image" src="https://github.com/user-attachments/assets/a663ddd4-0687-4cfe-9319-c9e4db1dfa93" />

After:

<img width="1388" height="186" alt="CleanShot 2025-09-30 at 14 55 48@2x" src="https://github.com/user-attachments/assets/30fc0f61-ac93-47b2-a504-34f0c1ed3090" />