### PR TITLE
feat(issues): Prevent duplicate issue event request

### DIFF
--- a/static/app/views/issueDetails/streamline/eventSearch.tsx
+++ b/static/app/views/issueDetails/streamline/eventSearch.tsx
@@ -43,7 +43,10 @@ interface EventSearchProps {
   queryBuilderProps?: Partial<SearchQueryBuilderProps>;
 }
 
-function taglessQueryFilter(
+/**
+ * Filters out tokens that are not valid for an event level query without using group tags.
+ */
+function eventLevelQueryFilter(
   token: NonNullable<ReturnType<typeof parseQueryBuilderValue>>[number]
 ): boolean {
   if (token.type !== Token.FILTER) {
@@ -92,7 +95,7 @@ export function useEventQuery({groupId}: {groupId: string}): string {
   const validQuery = isPending
     ? // While tags are loading, use our static list of issue properties to filter the query
       // This allows us to optimistically make the correct query. It might be possible in some cases to not use tags at all.
-      withoutFreeText.filter(taglessQueryFilter)
+      withoutFreeText.filter(eventLevelQueryFilter)
     : withoutFreeText.filter(token => {
         if (token.type === Token.FILTER) {
           let tagKey = token.key.text;


### PR DESCRIPTION
If you have a search query on issue details like `is:unresolved level:error` we attempt to find recommended events with `level:error`. While the group tags are loading, we make a request for an empty string and then `level:error` which takes twice as long. This optimizes for more of a optimistic approach and keeps more of the query while tags are loading.
