### PR TITLE
fix(ai-insights): chart grouping

### DIFF
--- a/static/app/views/insights/agents/components/llmCallsWidget.tsx
+++ b/static/app/views/insights/agents/components/llmCallsWidget.tsx
@@ -6,7 +6,6 @@ import {openInsightChartModal} from 'sentry/actionCreators/modal';
 import {ExternalLink} from 'sentry/components/core/link';
 import Count from 'sentry/components/count';
 import {t, tct} from 'sentry/locale';
-import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
@@ -18,6 +17,8 @@ import {getAIGenerationsFilter} from 'sentry/views/insights/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/agents/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
 import {
@@ -49,20 +50,20 @@ export default function LLMCallsWidget() {
     Referrer.LLM_CALLS_WIDGET
   );
 
-  const timeSeriesRequest = useFetchSpanTimeSeries(
+  const timeSeriesRequest = useTopNSpanSeries(
     {
       ...pageFilterChartParams,
-      query: fullQuery,
-      groupBy: [SpanFields.GEN_AI_REQUEST_MODEL],
+      search: fullQuery,
+      fields: [SpanFields.GEN_AI_REQUEST_MODEL, 'count(span.duration)'],
       yAxis: ['count(span.duration)'],
       sort: {field: 'count(span.duration)', kind: 'desc'},
-      topEvents: 3,
+      topN: 3,
       enabled: !!generationsRequest.data,
     },
     Referrer.LLM_CALLS_WIDGET
   );
 
-  const timeSeries = timeSeriesRequest?.data?.timeSeries ?? [];
+  const timeSeries = timeSeriesRequest?.data;
 
   const isLoading = timeSeriesRequest.isLoading || generationsRequest.isLoading;
   const error = timeSeriesRequest.error || generationsRequest.error;
@@ -94,8 +95,10 @@ export default function LLMCallsWidget() {
         showLegend: 'never',
         plottables: timeSeries.map(
           (ts, index) =>
-            new Bars(ts, {
-              color: ts.meta.isOther ? theme.chart.neutral : colorPalette[index],
+            new Bars(convertSeriesToTimeseries(ts), {
+              color:
+                ts.seriesName === 'Other' ? theme.chart.neutral : colorPalette[index],
+              alias: ts.seriesName, // Ensures that the tooltip shows the full series name
               stack: 'stack',
             })
         ),

--- a/static/app/views/insights/agents/components/modelCostWidget.tsx
+++ b/static/app/views/insights/agents/components/modelCostWidget.tsx
@@ -18,6 +18,8 @@ import {getAIGenerationsFilter} from 'sentry/views/insights/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/agents/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
 import {
@@ -49,20 +51,20 @@ export default function ModelCostWidget() {
     Referrer.MODEL_COST_WIDGET
   );
 
-  const timeSeriesRequest = useFetchSpanTimeSeries(
+  const timeSeriesRequest = useTopNSpanSeries(
     {
       ...pageFilterChartParams,
-      query: fullQuery,
-      groupBy: [SpanFields.GEN_AI_REQUEST_MODEL],
+      search: fullQuery,
+      fields: [SpanFields.GEN_AI_REQUEST_MODEL, 'sum(gen_ai.usage.total_cost)'],
       yAxis: ['sum(gen_ai.usage.total_cost)'],
       sort: {field: 'sum(gen_ai.usage.total_cost)', kind: 'desc'},
-      topEvents: 3,
+      topN: 3,
       enabled: !!tokensRequest.data,
     },
     Referrer.MODEL_COST_WIDGET
   );
 
-  const timeSeries = timeSeriesRequest.data?.timeSeries || [];
+  const timeSeries = timeSeriesRequest.data;
 
   const isLoading = timeSeriesRequest.isLoading || tokensRequest.isLoading;
   const error = timeSeriesRequest.error || tokensRequest.error;
@@ -97,8 +99,10 @@ export default function ModelCostWidget() {
         showLegend: 'never',
         plottables: timeSeries.map(
           (ts, index) =>
-            new Bars(ts, {
-              color: ts.meta.isOther ? theme.chart.neutral : colorPalette[index],
+            new Bars(convertSeriesToTimeseries(ts), {
+              color:
+                ts.seriesName === 'Other' ? theme.chart.neutral : colorPalette[index],
+              alias: ts.seriesName, // Ensures that the tooltip shows the full series name
               stack: 'stack',
             })
         ),

--- a/static/app/views/insights/agents/components/modelCostWidget.tsx
+++ b/static/app/views/insights/agents/components/modelCostWidget.tsx
@@ -5,7 +5,6 @@ import styled from '@emotion/styled';
 import {openInsightChartModal} from 'sentry/actionCreators/modal';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
-import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';

--- a/static/app/views/insights/agents/components/tokenUsageWidget.tsx
+++ b/static/app/views/insights/agents/components/tokenUsageWidget.tsx
@@ -6,7 +6,6 @@ import {openInsightChartModal} from 'sentry/actionCreators/modal';
 import {ExternalLink} from 'sentry/components/core/link';
 import Count from 'sentry/components/count';
 import {t, tct} from 'sentry/locale';
-import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
@@ -18,6 +17,8 @@ import {getAIGenerationsFilter} from 'sentry/views/insights/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/agents/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useTopNSpanSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
 import {
@@ -49,20 +50,20 @@ export default function TokenUsageWidget() {
     Referrer.TOKEN_USAGE_WIDGET
   );
 
-  const timeSeriesRequest = useFetchSpanTimeSeries(
+  const timeSeriesRequest = useTopNSpanSeries(
     {
       ...pageFilterChartParams,
-      query: fullQuery,
-      groupBy: [SpanFields.GEN_AI_REQUEST_MODEL],
+      search: fullQuery,
+      fields: [SpanFields.GEN_AI_REQUEST_MODEL, 'count(span.duration)'],
       yAxis: ['sum(gen_ai.usage.total_tokens)'],
       sort: {field: 'sum(gen_ai.usage.total_tokens)', kind: 'desc'},
-      topEvents: 3,
+      topN: 3,
       enabled: !!tokensRequest.data,
     },
     Referrer.TOKEN_USAGE_WIDGET
   );
 
-  const timeSeries = timeSeriesRequest.data?.timeSeries || [];
+  const timeSeries = timeSeriesRequest.data || [];
 
   const isLoading = timeSeriesRequest.isLoading || tokensRequest.isLoading;
   const error = timeSeriesRequest.error || tokensRequest.error;
@@ -97,8 +98,10 @@ export default function TokenUsageWidget() {
         showLegend: 'never',
         plottables: timeSeries.map(
           (ts, index) =>
-            new Bars(ts, {
-              color: ts.meta.isOther ? theme.chart.neutral : colorPalette[index],
+            new Bars(convertSeriesToTimeseries(ts), {
+              color:
+                ts.seriesName === 'Other' ? theme.chart.neutral : colorPalette[index],
+              alias: ts.seriesName, // Ensures that the tooltip shows the full series name
               stack: 'stack',
             })
         ),


### PR DESCRIPTION
closes [TET-1204: Other group without data in tokens chart](https://linear.app/getsentry/issue/TET-1204/other-group-without-data-in-tokens-chart)

switches back to `useTopNSpanSeries` since `useFetchSpanTimeSeries` return inconsistent chart grouping when there are less resulting groups than requested