### PR TITLE
chore(search-bar): Change default op to contains for strings

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -34,6 +34,10 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
   const [inputValue, setInputValue] = useState(getKeyLabel(token.key) ?? '');
 
   const organization = useOrganization();
+  const defaultToContains =
+    organization.features.includes('search-query-builder-wildcard-operators') &&
+    organization.features.includes('search-query-builder-default-to-contains');
+
   const {mutate: seerAcknowledgeMutate} = useSeerAcknowledgeMutation();
   const sortedFilterKeys = useSortedFilterKeyItems({
     filterValue: inputValue,
@@ -108,7 +112,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       dispatch({
         type: 'REPLACE_TOKENS_WITH_TEXT',
         tokens: [token],
-        text: getInitialFilterText(keyName, newFieldDef),
+        text: getInitialFilterText(keyName, newFieldDef, defaultToContains),
         focusOverride: {
           itemKey: item.key.toString(),
           part: 'value',
@@ -120,6 +124,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
     [
       currentFilterValueType,
       currentInputValueRef,
+      defaultToContains,
       dispatch,
       getFieldDefinition,
       item.key,

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -98,12 +98,13 @@ function replaceFocusedWordWithFilter(
   value: string,
   cursorPosition: number,
   key: string,
-  getFieldDefinition: FieldDefinitionGetter
+  getFieldDefinition: FieldDefinitionGetter,
+  hasWildcardOperators: boolean
 ) {
   return replaceFocusedWord(
     value,
     cursorPosition,
-    getInitialFilterText(key, getFieldDefinition(key))
+    getInitialFilterText(key, getFieldDefinition(key), hasWildcardOperators)
   );
 }
 
@@ -248,6 +249,10 @@ function SearchQueryBuilderInputInternal({
   const [isOpen, setIsOpen] = useState(false);
   const [inputValue, setInputValue] = useState(trimmedTokenValue);
   const [selectionIndex, setSelectionIndex] = useState(0);
+
+  const defaultToContains =
+    organization.features.includes('search-query-builder-wildcard-operators') &&
+    organization.features.includes('search-query-builder-default-to-contains');
 
   const updateSelectionIndex = useCallback(() => {
     setSelectionIndex(inputRef.current?.selectionStart ?? 0);
@@ -458,7 +463,8 @@ function SearchQueryBuilderInputInternal({
               inputValue,
               selectionIndex,
               value,
-              getFieldDefinition
+              getFieldDefinition,
+              defaultToContains
             ),
             focusOverride: calculateNextFocusForFilter(state, getFieldDefinition(value)),
             shouldCommitQuery: false,
@@ -556,7 +562,8 @@ function SearchQueryBuilderInputInternal({
                     inputValue,
                     selectionIndex,
                     filterValue,
-                    getFieldDefinition
+                    getFieldDefinition,
+                    defaultToContains
                   ),
                   focusOverride: calculateNextFocusForFilter(
                     state,
@@ -597,7 +604,8 @@ function SearchQueryBuilderInputInternal({
                 inputValue,
                 selectionIndex,
                 filterKey,
-                getFieldDefinition
+                getFieldDefinition,
+                defaultToContains
               ),
               focusOverride: calculateNextFocusForFilter(
                 state,

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -3,6 +3,7 @@ import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
 import type {TagValue} from 'sentry/types/group';
 import SpansSearchBar from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
@@ -21,7 +22,15 @@ function renderWithProvider({
   return render(
     <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
       <SpansSearchBar widgetQuery={widgetQuery} onSearch={onSearch} onClose={onClose} />
-    </TraceItemAttributeProvider>
+    </TraceItemAttributeProvider>,
+    {
+      organization: {
+        features: [
+          'search-query-builder-wildcard-operators',
+          'search-query-builder-default-to-contains',
+        ],
+      },
+    }
   );
 }
 
@@ -133,7 +142,10 @@ describe('SpansSearchBar', () => {
     await userEvent.keyboard('{enter}');
 
     await waitFor(() => {
-      expect(onSearch).toHaveBeenCalledWith('span.op:function', expect.anything());
+      expect(onSearch).toHaveBeenCalledWith(
+        `span.op:${WildcardOperators.CONTAINS}function`,
+        expect.anything()
+      );
     });
   });
 

--- a/static/app/views/detectors/list.spec.tsx
+++ b/static/app/views/detectors/list.spec.tsx
@@ -14,6 +14,7 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {
   DataConditionGroupLogicType,
@@ -25,7 +26,11 @@ import DetectorsList from 'sentry/views/detectors/list';
 
 describe('DetectorsList', () => {
   const organization = OrganizationFixture({
-    features: ['workflow-engine-ui'],
+    features: [
+      'workflow-engine-ui',
+      'search-query-builder-wildcard-operators',
+      'search-query-builder-default-to-contains',
+    ],
     access: ['org:write'],
   });
 
@@ -159,7 +164,9 @@ describe('DetectorsList', () => {
       const mockDetectorsRequestErrorType = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/detectors/',
         body: [ErrorDetectorFixture({name: 'Error Detector'})],
-        match: [MockApiClient.matchQuery({query: 'type:error'})],
+        match: [
+          MockApiClient.matchQuery({query: `type:${WildcardOperators.CONTAINS}error`}),
+        ],
       });
 
       render(<DetectorsList />, {organization});
@@ -190,7 +197,11 @@ describe('DetectorsList', () => {
             owner: ActorFixture({id: testUser.id, name: testUser.email, type: 'user'}),
           }),
         ],
-        match: [MockApiClient.matchQuery({query: 'assignee:test@example.com'})],
+        match: [
+          MockApiClient.matchQuery({
+            query: `assignee:${WildcardOperators.CONTAINS}test@example.com`,
+          }),
+        ],
       });
 
       render(<DetectorsList />, {organization});
@@ -490,7 +501,11 @@ describe('DetectorsList', () => {
         headers: {
           'X-Hits': '50',
         },
-        match: [MockApiClient.matchQuery({query: 'assignee:test@example.com'})],
+        match: [
+          MockApiClient.matchQuery({
+            query: `assignee:${WildcardOperators.CONTAINS}test@example.com`,
+          }),
+        ],
       });
 
       // Click through menus to select assignee
@@ -534,7 +549,11 @@ describe('DetectorsList', () => {
         expect(deleteRequest).toHaveBeenCalledWith(
           '/organizations/org-slug/detectors/',
           expect.objectContaining({
-            query: {id: undefined, query: 'assignee:test@example.com', project: [1]},
+            query: {
+              id: undefined,
+              query: `assignee:${WildcardOperators.CONTAINS}test@example.com`,
+              project: [1],
+            },
           })
         );
       });

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
@@ -8,6 +8,7 @@ import {TagsFixture} from 'sentry-fixture/tags';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {IssueCategory, IssueType} from 'sentry/types/group';
@@ -25,7 +26,12 @@ jest.mock('sentry/views/issueDetails/utils', () => ({
 }));
 
 describe('EventDetailsHeader', () => {
-  const organization = OrganizationFixture();
+  const organization = OrganizationFixture({
+    features: [
+      'search-query-builder-wildcard-operators',
+      'search-query-builder-default-to-contains',
+    ],
+  });
   const project = ProjectFixture({
     environments: ['production', 'staging', 'development'],
   });
@@ -118,18 +124,12 @@ describe('EventDetailsHeader', () => {
     const locationQuery = {
       query: {
         ...router.location.query,
-        query: `${tagKey}:${tagValue}`,
+        query: `${tagKey}:${WildcardOperators.CONTAINS}${tagValue}`,
       },
     };
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/tags/${tagKey}/values/`,
-      body: [
-        {
-          key: tagKey,
-          name: tagValue,
-          value: tagValue,
-        },
-      ],
+      body: [{key: tagKey, name: tagValue, value: tagValue}],
       method: 'GET',
     });
 

--- a/static/app/views/issueDetails/streamline/eventSearch.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventSearch.spec.tsx
@@ -14,6 +14,7 @@ import {
   waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
+import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import {
   EventSearch,
@@ -59,7 +60,14 @@ describe('EventSearch', () => {
   });
 
   it('handles basic inputs for tags', async () => {
-    render(<EventSearch {...defaultProps} />);
+    render(<EventSearch {...defaultProps} />, {
+      organization: {
+        features: [
+          'search-query-builder-wildcard-operators',
+          'search-query-builder-default-to-contains',
+        ],
+      },
+    });
     const search = screen.getByRole('combobox', {name: 'Add a search term'});
     expect(search).toBeInTheDocument();
     await userEvent.type(search, `${tagKey}:`);
@@ -69,7 +77,7 @@ describe('EventSearch', () => {
       expect(mockTagKeyQuery).toHaveBeenCalled();
     });
     expect(mockHandleSearch).toHaveBeenCalledWith(
-      `${tagKey}:${tagValue}`,
+      `${tagKey}:${WildcardOperators.CONTAINS}${tagValue}`,
       expect.anything()
     );
   }, 10_000);


### PR DESCRIPTION
>[!note]
>Requires #100522, also is behind the wildcard operator flag.

This PR updates the `getInitialFilterText` util function to default to the `contains` operator when typing in or selecting a new filter key.

Ticket: EXP-499

https://github.com/user-attachments/assets/06a8e1ac-2a54-425f-869f-38d68ac03ad1