### PR TITLE
[WIP] fix(dashboards): Rate limit retry

### DIFF
--- a/static/app/utils/concurrentRequestLimiter.spec.tsx
+++ b/static/app/utils/concurrentRequestLimiter.spec.tsx
@@ -291,7 +291,7 @@ describe('ConcurrentRequestLimiter', () => {
         jest.fn().mockResolvedValue(i)
       );
 
-      const promises = fastRequests.map((fn, i) => limiter.execute(() => fn()));
+      const promises = fastRequests.map(fn => limiter.execute(() => fn()));
       const results = await Promise.all(promises);
 
       expect(results).toEqual(Array.from({length: 100}, (_, i) => i));

--- a/static/app/utils/concurrentRequestLimiter.spec.tsx
+++ b/static/app/utils/concurrentRequestLimiter.spec.tsx
@@ -1,0 +1,336 @@
+import {ConcurrentRequestLimiter} from './concurrentRequestLimiter';
+
+// Mock the uniqueId utility
+jest.mock('sentry/utils/guid', () => ({
+  uniqueId: jest.fn(() => 'mock-id-' + Math.random().toString(36).substring(2, 15)),
+}));
+
+describe('ConcurrentRequestLimiter', () => {
+  let limiter: ConcurrentRequestLimiter;
+
+  beforeEach(() => {
+    limiter = new ConcurrentRequestLimiter(2); // Use small limit for easier testing
+  });
+
+  describe('constructor', () => {
+    it('should create limiter with default max concurrent requests', () => {
+      const defaultLimiter = new ConcurrentRequestLimiter();
+      expect(defaultLimiter.getStats().maxConcurrent).toBe(15);
+    });
+
+    it('should create limiter with custom max concurrent requests', () => {
+      const customLimiter = new ConcurrentRequestLimiter(5);
+      expect(customLimiter.getStats().maxConcurrent).toBe(5);
+    });
+
+    it('should throw error for invalid maxConcurrent values', () => {
+      expect(() => new ConcurrentRequestLimiter(0)).toThrow(
+        'maxConcurrent must be greater than 0'
+      );
+      expect(() => new ConcurrentRequestLimiter(-1)).toThrow(
+        'maxConcurrent must be greater than 0'
+      );
+    });
+  });
+
+  describe('execute', () => {
+    it('should execute request immediately when under limit', async () => {
+      const mockFn = jest.fn().mockResolvedValue('result');
+
+      const result = await limiter.execute(mockFn);
+
+      expect(result).toBe('result');
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(limiter.getActiveCount()).toBe(0); // Should be 0 after completion
+      expect(limiter.getQueueLength()).toBe(0);
+    });
+
+    it('should queue requests when at limit', async () => {
+      const slowRequest = jest.fn(
+        () => new Promise(resolve => setTimeout(() => resolve('slow'), 100))
+      );
+      const fastRequest = jest.fn().mockResolvedValue('fast');
+
+      // Start two requests to reach the limit
+      const promise1 = limiter.execute(slowRequest);
+      const promise2 = limiter.execute(slowRequest);
+
+      // This should be queued
+      const promise3 = limiter.execute(fastRequest);
+
+      expect(limiter.getActiveCount()).toBe(2);
+      expect(limiter.getQueueLength()).toBe(1);
+
+      // Wait for all to complete
+      const results = await Promise.all([promise1, promise2, promise3]);
+
+      expect(results).toEqual(['slow', 'slow', 'fast']);
+      expect(limiter.getActiveCount()).toBe(0);
+      expect(limiter.getQueueLength()).toBe(0);
+    });
+
+    it('should process queue in FIFO order', async () => {
+      const executionOrder: string[] = [];
+
+      const createRequest = (id: string, delay = 50) =>
+        jest.fn(
+          () =>
+            new Promise(resolve => {
+              setTimeout(() => {
+                executionOrder.push(id);
+                resolve(id);
+              }, delay);
+            })
+        );
+
+      const request1 = createRequest('first');
+      const request2 = createRequest('second');
+      const request3 = createRequest('third');
+      const request4 = createRequest('fourth');
+
+      // Start requests - first two should execute, others queued
+      const promises = [
+        limiter.execute(request1),
+        limiter.execute(request2),
+        limiter.execute(request3),
+        limiter.execute(request4),
+      ];
+
+      expect(limiter.getActiveCount()).toBe(2);
+      expect(limiter.getQueueLength()).toBe(2);
+
+      await Promise.all(promises);
+
+      // First two can start in any order, but third and fourth should be in queue order
+      expect(executionOrder).toHaveLength(4);
+      expect(executionOrder.slice(0, 2)).toEqual(
+        expect.arrayContaining(['first', 'second'])
+      );
+      expect(executionOrder.slice(2)).toEqual(['third', 'fourth']);
+    });
+
+    it('should handle request errors correctly', async () => {
+      const errorRequest = jest.fn().mockRejectedValue(new Error('Request failed'));
+      const successRequest = jest.fn().mockResolvedValue('success');
+
+      await expect(limiter.execute(errorRequest)).rejects.toThrow('Request failed');
+
+      // Should still be able to execute more requests after error
+      const result = await limiter.execute(successRequest);
+      expect(result).toBe('success');
+
+      expect(limiter.getActiveCount()).toBe(0);
+      expect(limiter.getQueueLength()).toBe(0);
+    });
+
+    it('should handle mixed success and error requests', async () => {
+      const slowError = jest.fn(
+        () =>
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('Slow error')), 50)
+          )
+      );
+      const fastSuccess = jest.fn().mockResolvedValue('fast success');
+      const queuedSuccess = jest.fn().mockResolvedValue('queued success');
+
+      // Start two requests to reach limit
+      const errorPromise = limiter.execute(slowError);
+      const successPromise = limiter.execute(fastSuccess);
+
+      // This should be queued
+      const queuedPromise = limiter.execute(queuedSuccess);
+
+      expect(limiter.getActiveCount()).toBe(2);
+      expect(limiter.getQueueLength()).toBe(1);
+
+      // Wait for all to settle
+      const results = await Promise.allSettled([
+        errorPromise,
+        successPromise,
+        queuedPromise,
+      ]);
+
+      expect(results[0].status).toBe('rejected');
+      expect(results[1].status).toBe('fulfilled');
+      expect(results[2].status).toBe('fulfilled');
+
+      if (results[1].status === 'fulfilled') {
+        expect(results[1].value).toBe('fast success');
+      }
+      if (results[2].status === 'fulfilled') {
+        expect(results[2].value).toBe('queued success');
+      }
+
+      expect(limiter.getActiveCount()).toBe(0);
+      expect(limiter.getQueueLength()).toBe(0);
+    });
+
+    it('should handle concurrent execution correctly', async () => {
+      const concurrentRequests = Array.from({length: 10}, (_, i) =>
+        jest.fn().mockResolvedValue(`result-${i}`)
+      );
+
+      const promises = concurrentRequests.map((fn, _) =>
+        limiter.execute(() => fn().then((result: string) => `${result}-executed`))
+      );
+
+      // Should have 2 active and 8 queued
+      expect(limiter.getActiveCount()).toBe(2);
+      expect(limiter.getQueueLength()).toBe(8);
+
+      const results = await Promise.all(promises);
+
+      expect(results).toHaveLength(10);
+      results.forEach((result, i) => {
+        expect(result).toBe(`result-${i}-executed`);
+      });
+
+      expect(limiter.getActiveCount()).toBe(0);
+      expect(limiter.getQueueLength()).toBe(0);
+    });
+  });
+
+  describe('getActiveCount', () => {
+    it('should return 0 initially', () => {
+      expect(limiter.getActiveCount()).toBe(0);
+    });
+
+    it('should track active requests correctly', async () => {
+      const slowRequest = jest.fn(
+        () => new Promise(resolve => setTimeout(() => resolve('done'), 100))
+      );
+
+      const promise1 = limiter.execute(slowRequest);
+      expect(limiter.getActiveCount()).toBe(1);
+
+      const promise2 = limiter.execute(slowRequest);
+      expect(limiter.getActiveCount()).toBe(2);
+
+      await Promise.all([promise1, promise2]);
+      expect(limiter.getActiveCount()).toBe(0);
+    });
+  });
+
+  describe('getQueueLength', () => {
+    it('should return 0 initially', () => {
+      expect(limiter.getQueueLength()).toBe(0);
+    });
+
+    it('should track queued requests correctly', async () => {
+      const slowRequest = jest.fn(
+        () => new Promise(resolve => setTimeout(() => resolve('done'), 100))
+      );
+
+      // Fill up active slots
+      const promise1 = limiter.execute(slowRequest);
+      const promise2 = limiter.execute(slowRequest);
+      expect(limiter.getQueueLength()).toBe(0);
+
+      // These should be queued
+      const promise3 = limiter.execute(slowRequest);
+      expect(limiter.getQueueLength()).toBe(1);
+
+      const promise4 = limiter.execute(slowRequest);
+      expect(limiter.getQueueLength()).toBe(2);
+
+      await Promise.all([promise1, promise2, promise3, promise4]);
+      expect(limiter.getQueueLength()).toBe(0);
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return correct initial stats', () => {
+      const stats = limiter.getStats();
+
+      expect(stats).toEqual({
+        active: 0,
+        queued: 0,
+        maxConcurrent: 2,
+      });
+    });
+
+    it('should return correct stats during execution', async () => {
+      const slowRequest = jest.fn(
+        () => new Promise(resolve => setTimeout(() => resolve('done'), 100))
+      );
+
+      // Start requests
+      const promise1 = limiter.execute(slowRequest);
+      const promise2 = limiter.execute(slowRequest);
+      const promise3 = limiter.execute(slowRequest);
+
+      const stats = limiter.getStats();
+      expect(stats).toEqual({
+        active: 2,
+        queued: 1,
+        maxConcurrent: 2,
+      });
+
+      await Promise.all([promise1, promise2, promise3]);
+
+      const finalStats = limiter.getStats();
+      expect(finalStats).toEqual({
+        active: 0,
+        queued: 0,
+        maxConcurrent: 2,
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty queue processing', () => {
+      // This tests the internal processNextInQueue method when queue is empty
+      expect(() => {
+        // Trigger internal queue processing (this is tested indirectly through normal execution)
+        limiter.getStats();
+      }).not.toThrow();
+    });
+
+    it('should handle rapid successive requests', async () => {
+      const fastRequests = Array.from({length: 100}, (_, i) =>
+        jest.fn().mockResolvedValue(i)
+      );
+
+      const promises = fastRequests.map((fn, i) => limiter.execute(() => fn()));
+      const results = await Promise.all(promises);
+
+      expect(results).toEqual(Array.from({length: 100}, (_, i) => i));
+      expect(limiter.getActiveCount()).toBe(0);
+      expect(limiter.getQueueLength()).toBe(0);
+    });
+
+    it('should handle requests that throw synchronously', async () => {
+      const syncErrorRequest = jest.fn(() => {
+        throw new Error('Sync error');
+      });
+
+      await expect(limiter.execute(syncErrorRequest)).rejects.toThrow('Sync error');
+
+      // Should still work after sync error
+      const successRequest = jest.fn().mockResolvedValue('success');
+      const result = await limiter.execute(successRequest);
+      expect(result).toBe('success');
+    });
+  });
+
+  describe('type safety', () => {
+    it('should preserve return types', async () => {
+      const stringRequest = jest.fn().mockResolvedValue('string');
+      const numberRequest = jest.fn().mockResolvedValue(42);
+      const objectRequest = jest.fn().mockResolvedValue({key: 'value'});
+
+      const stringResult = await limiter.execute(stringRequest);
+      const numberResult = await limiter.execute(numberRequest);
+      const objectResult = await limiter.execute(objectRequest);
+
+      // TypeScript should infer correct types
+      expect(typeof stringResult).toBe('string');
+      expect(typeof numberResult).toBe('number');
+      expect(typeof objectResult).toBe('object');
+
+      expect(stringResult).toBe('string');
+      expect(numberResult).toBe(42);
+      expect(objectResult).toEqual({key: 'value'});
+    });
+  });
+});

--- a/static/app/utils/concurrentRequestLimiter.tsx
+++ b/static/app/utils/concurrentRequestLimiter.tsx
@@ -309,6 +309,13 @@ export class ComponentScopedLimiter {
 // Global instance for dashboard queries
 export const dashboardRequestLimiter = new ConcurrentRequestLimiter(15);
 
+/**
+ * Factory function to create a component-scoped limiter.
+ */
+export function createComponentLimiter(): ComponentScopedLimiter {
+  return new ComponentScopedLimiter(dashboardRequestLimiter);
+}
+
 // Cleanup on page unload to prevent memory leaks
 if (typeof window !== 'undefined') {
   window.addEventListener('beforeunload', () => {

--- a/static/app/utils/concurrentRequestLimiter.tsx
+++ b/static/app/utils/concurrentRequestLimiter.tsx
@@ -1,0 +1,93 @@
+/**
+ * Global concurrent request limiter to prevent overwhelming the server
+ * with too many simultaneous requests.
+ */
+
+interface QueuedRequest<T> {
+  execute: () => Promise<T>;
+  id: string;
+  reject: (error: any) => void;
+  resolve: (value: T) => void;
+}
+
+class ConcurrentRequestLimiter {
+  private activeRequests = new Set<string>();
+  private queue: Array<QueuedRequest<any>> = [];
+  private maxConcurrent: number;
+
+  constructor(maxConcurrent = 15) {
+    this.maxConcurrent = maxConcurrent;
+  }
+
+  /**
+   * Execute a request function with concurrent limiting.
+   * If the limit is reached, the request will be queued.
+   */
+  async execute<T>(requestFn: () => Promise<T>): Promise<T> {
+    const requestId = Math.random().toString(36).substring(2, 15);
+
+    return new Promise<T>((resolve, reject) => {
+      const request: QueuedRequest<T> = {
+        id: requestId,
+        execute: requestFn,
+        resolve,
+        reject,
+      };
+
+      if (this.activeRequests.size < this.maxConcurrent) {
+        this.executeRequest(request);
+      } else {
+        this.queue.push(request);
+      }
+    });
+  }
+
+  private async executeRequest<T>(request: QueuedRequest<T>) {
+    this.activeRequests.add(request.id);
+
+    try {
+      const result = await request.execute();
+      request.resolve(result);
+    } catch (error) {
+      request.reject(error);
+    } finally {
+      this.activeRequests.delete(request.id);
+      this.processQueue();
+    }
+  }
+
+  private processQueue() {
+    if (this.queue.length > 0 && this.activeRequests.size < this.maxConcurrent) {
+      const nextRequest = this.queue.shift()!;
+      this.executeRequest(nextRequest);
+    }
+  }
+
+  /**
+   * Get the current number of active requests
+   */
+  getActiveCount(): number {
+    return this.activeRequests.size;
+  }
+
+  /**
+   * Get the current queue length
+   */
+  getQueueLength(): number {
+    return this.queue.length;
+  }
+
+  /**
+   * Get stats for debugging
+   */
+  getStats() {
+    return {
+      active: this.activeRequests.size,
+      queued: this.queue.length,
+      maxConcurrent: this.maxConcurrent,
+    };
+  }
+}
+
+// Global instance for discover queries
+export const discoverRequestLimiter = new ConcurrentRequestLimiter(15);

--- a/static/app/utils/concurrentRequestLimiter.tsx
+++ b/static/app/utils/concurrentRequestLimiter.tsx
@@ -54,6 +54,7 @@ export class ConcurrentRequestLimiter {
         reject,
         createdAt: Date.now(),
       };
+      console.log('request execute', request);
 
       if (this.hasAvailableSlot()) {
         void this.executeRequest(request);

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -349,7 +349,7 @@ export async function doDiscoverQuery<T>(
     }
 
     try {
-      console.log('attempting request');
+      console.log('attempting request', dashboardRequestLimiter.getStats());
       // Use the global concurrent request limiter to ensure max 15 requests
       const response = await dashboardRequestLimiter.execute(async () =>
         api.requestPromise(url, {

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -318,7 +318,7 @@ type RetryOptions = {
   timeoutMultiplier?: number;
 };
 
-const BASE_TIMEOUT = 200;
+const BASE_TIMEOUT = 1000;
 const TIMEOUT_MULTIPLIER = 2;
 const wait = (duration: any) => new Promise(resolve => setTimeout(resolve, duration));
 

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -349,8 +349,8 @@ export async function doDiscoverQuery<T>(
     }
 
     try {
-      const makeRequest = () =>
-        api.requestPromise(url, {
+      const makeRequest = async () =>
+        await api.requestPromise(url, {
           method: 'GET',
           includeAllArgs: true,
           query: {

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -317,7 +317,7 @@ type RetryOptions = {
   timeoutMultiplier?: number;
 };
 
-const BASE_TIMEOUT = 400;
+const BASE_TIMEOUT = 1000;
 const TIMEOUT_MULTIPLIER = 2;
 const wait = (duration: any) => new Promise(resolve => setTimeout(resolve, duration));
 

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -340,11 +340,11 @@ export async function doDiscoverQuery<T>(
   let timeout = 0;
   let error: any;
 
-  if (error) {
-    console.log(statusCodes, error, error?.status, typeof error?.status);
-  }
-
   while (tries < maxTries && (!error || statusCodes.includes(error.status))) {
+    if (error) {
+      console.log(statusCodes, error, error?.status, typeof error?.status);
+    }
+
     if (tries !== 0) {
       console.log('tries', tries);
     }
@@ -353,10 +353,9 @@ export async function doDiscoverQuery<T>(
       await wait(timeout);
     }
     if (tries !== 0) {
-      console.log('trying');
+      console.log('trying', tries, params);
     }
     try {
-      tries++;
       const response = await api.requestPromise(url, {
         method: 'GET',
         includeAllArgs: true,
@@ -373,6 +372,7 @@ export async function doDiscoverQuery<T>(
       console.log('error', err);
       error = err;
       timeout = baseTimeout * timeoutMultiplier ** (tries - 1);
+      tries++;
     }
   }
   throw error;

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -371,8 +371,8 @@ export async function doDiscoverQuery<T>(
     } catch (err) {
       console.log('error', err);
       error = err;
-      timeout = baseTimeout * timeoutMultiplier ** (tries - 1);
       tries++;
+      timeout = baseTimeout * timeoutMultiplier ** (tries - 1);
     }
   }
   throw error;

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -344,10 +344,12 @@ export async function doDiscoverQuery<T>(
     if (tries !== 0) {
       // Apply exponential backoff for retries (fixed calculation)
       const timeout = baseTimeout * timeoutMultiplier ** (tries - 1);
+      console.log('timeout', timeout);
       await wait(timeout);
     }
 
     try {
+      console.log('attempting request');
       // Use the global concurrent request limiter to ensure max 15 requests
       const response = await dashboardRequestLimiter.execute(async () =>
         api.requestPromise(url, {
@@ -360,6 +362,8 @@ export async function doDiscoverQuery<T>(
           skipAbort,
         })
       );
+
+      console.log('response', response);
 
       return response;
     } catch (err) {

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -6,7 +6,7 @@ import type {EventQuery} from 'sentry/actionCreators/events';
 import type {ResponseMeta} from 'sentry/api';
 import {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
-import {discoverRequestLimiter} from 'sentry/utils/concurrentRequestLimiter';
+import {dashboardRequestLimiter} from 'sentry/utils/concurrentRequestLimiter';
 import type EventView from 'sentry/utils/discover/eventView';
 import type {ImmutableEventView, LocationQuery} from 'sentry/utils/discover/eventView';
 import {isAPIPayloadSimilar} from 'sentry/utils/discover/eventView';
@@ -341,45 +341,28 @@ export async function doDiscoverQuery<T>(
   let error: any;
 
   while (tries < maxTries && (!error || statusCodes.includes(error.status))) {
-    if (error) {
-      console.log(statusCodes, error, error?.status, typeof error?.status);
-    }
-
     if (tries !== 0) {
-      console.log('tries', tries);
       // Apply exponential backoff for retries (fixed calculation)
       const timeout = baseTimeout * timeoutMultiplier ** (tries - 1);
-      console.log('waiting for timeout', timeout);
       await wait(timeout);
-    }
-
-    if (tries !== 0) {
-      console.log('trying', tries, params);
     }
 
     try {
       // Use the global concurrent request limiter to ensure max 15 requests
-      const response = await discoverRequestLimiter.execute(async () => {
-        console.log(
-          `Starting request (active: ${discoverRequestLimiter.getActiveCount()}, queued: ${discoverRequestLimiter.getQueueLength()})`
-        );
-
-        return api.requestPromise(url, {
+      const response = await dashboardRequestLimiter.execute(async () =>
+        api.requestPromise(url, {
           method: 'GET',
           includeAllArgs: true,
           query: {
             // marking params as any so as to not cause typescript errors
             ...(params as any),
-            referrer: `test-${tries}`,
           },
           skipAbort,
-        });
-      });
+        })
+      );
 
-      console.log('request', response);
       return response;
     } catch (err) {
-      console.log('error', err);
       error = err;
       tries++;
     }

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -317,7 +317,7 @@ type RetryOptions = {
   timeoutMultiplier?: number;
 };
 
-const BASE_TIMEOUT = 200;
+const BASE_TIMEOUT = 400;
 const TIMEOUT_MULTIPLIER = 2;
 const wait = (duration: any) => new Promise(resolve => setTimeout(resolve, duration));
 
@@ -341,7 +341,7 @@ export async function doDiscoverQuery<T>(
   let error: any;
 
   if (error) {
-    console.log(statusCodes, error, error?.status);
+    console.log(statusCodes, error, error?.status, typeof error?.status);
   }
 
   while (tries < maxTries && (!error || statusCodes.includes(error.status))) {

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -6,8 +6,8 @@ import type {EventQuery} from 'sentry/actionCreators/events';
 import type {ResponseMeta} from 'sentry/api';
 import {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
-import type {ImmutableEventView, LocationQuery} from 'sentry/utils/discover/eventView';
 import type EventView from 'sentry/utils/discover/eventView';
+import type {ImmutableEventView, LocationQuery} from 'sentry/utils/discover/eventView';
 import {isAPIPayloadSimilar} from 'sentry/utils/discover/eventView';
 import {PerformanceEventViewContext} from 'sentry/utils/performance/contexts/performanceEventViewContext';
 import type {UseQueryOptions} from 'sentry/utils/queryClient';
@@ -340,22 +340,37 @@ export async function doDiscoverQuery<T>(
   let timeout = 0;
   let error: any;
 
+  if (error) {
+    console.log(statusCodes, error, error?.status);
+  }
+
   while (tries < maxTries && (!error || statusCodes.includes(error.status))) {
+    if (tries !== 0) {
+      console.log('tries', tries);
+    }
     if (timeout > 0) {
+      console.log('waiting for timeout', timeout);
       await wait(timeout);
+    }
+    if (tries !== 0) {
+      console.log('trying');
     }
     try {
       tries++;
-      return await api.requestPromise(url, {
+      const response = await api.requestPromise(url, {
         method: 'GET',
         includeAllArgs: true,
         query: {
           // marking params as any so as to not cause typescript errors
           ...(params as any),
+          referrer: `test-${tries}`,
         },
         skipAbort,
       });
+      console.log('request', response);
+      return response;
     } catch (err) {
+      console.log('error', err);
       error = err;
       timeout = baseTimeout * timeoutMultiplier ** (tries - 1);
     }

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -6,6 +6,7 @@ import type {PageFilters, SelectValue} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import type {Tag, TagCollection} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
+import type {ComponentScopedLimiter} from 'sentry/utils/concurrentRequestLimiter';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import type {MetaType} from 'sentry/utils/discover/eventView';
@@ -205,7 +206,8 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     cursor?: string,
     referrer?: string,
     mepSetting?: MEPState | null,
-    samplingMode?: SamplingMode
+    samplingMode?: SamplingMode,
+    limiter?: ComponentScopedLimiter
   ) => Promise<[TableResponse, string | undefined, ResponseMeta | undefined]>;
   /**
    * Generate the list of sort options for table

--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -8,6 +8,7 @@ import type {
   MultiSeriesEventsStats,
   Organization,
 } from 'sentry/types/organization';
+import type {ComponentScopedLimiter} from 'sentry/utils/concurrentRequestLimiter';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import {CustomMeasurementsProvider} from 'sentry/utils/customMeasurements/customMeasurementsProvider';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
@@ -201,7 +202,8 @@ function getEventsRequest(
   pageFilters: PageFilters,
   limit?: number,
   cursor?: string,
-  referrer?: string
+  referrer?: string,
+  limiter?: ComponentScopedLimiter
 ) {
   const url = `/organizations/${organization.slug}/events/`;
   const eventView = eventViewFromWidget('', query, pageFilters);
@@ -230,6 +232,7 @@ function getEventsRequest(
         statusCodes: [429],
         tries: 3,
       },
+      limiter,
     }
   );
 }

--- a/static/app/views/dashboards/datasetConfig/logs.tsx
+++ b/static/app/views/dashboards/datasetConfig/logs.tsx
@@ -11,6 +11,7 @@ import type {
   Organization,
 } from 'sentry/types/organization';
 import toArray from 'sentry/utils/array/toArray';
+import type {ComponentScopedLimiter} from 'sentry/utils/concurrentRequestLimiter';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
@@ -332,7 +333,8 @@ function getEventsRequest(
   referrer?: string,
   _mepSetting?: MEPState | null,
   queryExtras?: DiscoverQueryExtras,
-  samplingMode?: SamplingMode
+  samplingMode?: SamplingMode,
+  limiter?: ComponentScopedLimiter
 ) {
   const url = `/organizations/${organization.slug}/events/`;
   const eventView = eventViewFromWidget('', query, pageFilters);
@@ -363,6 +365,7 @@ function getEventsRequest(
         statusCodes: [429],
         tries: 3,
       },
+      limiter,
     }
   );
 }

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -13,6 +13,7 @@ import type {
   Organization,
 } from 'sentry/types/organization';
 import toArray from 'sentry/utils/array/toArray';
+import type {ComponentScopedLimiter} from 'sentry/utils/concurrentRequestLimiter';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
 import type {EventData} from 'sentry/utils/discover/eventView';
@@ -213,7 +214,8 @@ export const SpansConfig: DatasetConfig<
     cursor?: string,
     referrer?: string,
     _mepSetting?: MEPState | null,
-    samplingMode?: SamplingMode
+    samplingMode?: SamplingMode,
+    limiter?: ComponentScopedLimiter
   ) => {
     return getEventsRequest(
       api,
@@ -225,7 +227,8 @@ export const SpansConfig: DatasetConfig<
       referrer,
       undefined,
       undefined,
-      samplingMode
+      samplingMode,
+      limiter
     );
   },
   getSeriesRequest,
@@ -328,7 +331,8 @@ function getEventsRequest(
   referrer?: string,
   _mepSetting?: MEPState | null,
   queryExtras?: DiscoverQueryExtras,
-  samplingMode?: SamplingMode
+  samplingMode?: SamplingMode,
+  limiter?: ComponentScopedLimiter
 ) {
   const url = `/organizations/${organization.slug}/events/`;
   const eventView = eventViewFromWidget('', query, pageFilters);
@@ -370,6 +374,7 @@ function getEventsRequest(
         statusCodes: [429],
         tries: 3,
       },
+      limiter,
     }
   );
 }

--- a/static/app/views/dashboards/datasetConfig/transactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/transactions.tsx
@@ -9,6 +9,7 @@ import type {
   Organization,
 } from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
+import type {ComponentScopedLimiter} from 'sentry/utils/concurrentRequestLimiter';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
 import {
@@ -171,7 +172,8 @@ function getEventsRequest(
   cursor?: string,
   referrer?: string,
   mepSetting?: MEPState | null,
-  queryExtras?: DiscoverQueryExtras
+  queryExtras?: DiscoverQueryExtras,
+  limiter?: ComponentScopedLimiter
 ) {
   const isMEPEnabled = defined(mepSetting) && mepSetting !== MEPState.TRANSACTIONS_ONLY;
   const url = `/organizations/${organization.slug}/events/`;
@@ -219,6 +221,7 @@ function getEventsRequest(
         statusCodes: [429],
         tries: 3,
       },
+      limiter,
     }
   );
 }

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -9,10 +9,7 @@ import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import type {Confidence, Organization} from 'sentry/types/organization';
-import {
-  ComponentScopedLimiter,
-  dashboardRequestLimiter,
-} from 'sentry/utils/concurrentRequestLimiter';
+import {createComponentLimiter} from 'sentry/utils/concurrentRequestLimiter';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -218,7 +215,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
   }
 
   private _isMounted = false;
-  private requestLimiter = new ComponentScopedLimiter(dashboardRequestLimiter);
+  private requestLimiter = createComponentLimiter();
 
   applyDashboardFilters(widget: Widget): Widget {
     const {dashboardFilters, skipDashboardFilterParens} = this.props;

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -265,20 +265,19 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
           );
         }
 
-        return this.requestLimiter.execute(() =>
-          requestCreator(
-            api,
-            widget,
-            query,
-            organization,
-            selection,
-            onDemandControlContext,
-            requestLimit,
-            cursor,
-            getReferrer(widget.displayType),
-            mepSetting,
-            samplingMode
-          )
+        return requestCreator(
+          api,
+          widget,
+          query,
+          organization,
+          selection,
+          onDemandControlContext,
+          requestLimit,
+          cursor,
+          getReferrer(widget.displayType),
+          mepSetting,
+          samplingMode,
+          this.requestLimiter
         );
       })
     );
@@ -334,18 +333,16 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
 
     const responses = await Promise.all(
       widget.queries.map((_query, index) => {
-        return this.requestLimiter.execute(() =>
-          config.getSeriesRequest!(
-            api,
-            widget,
-            index,
-            organization,
-            selection,
-            onDemandControlContext,
-            getReferrer(widget.displayType),
-            mepSetting,
-            samplingMode
-          )
+        return config.getSeriesRequest!(
+          api,
+          widget,
+          index,
+          organization,
+          selection,
+          onDemandControlContext,
+          getReferrer(widget.displayType),
+          mepSetting,
+          samplingMode
         );
       })
     );


### PR DESCRIPTION
Some users are experiencing 429s due to the HTTP protocol being http/3 and blasting all of the dashboards requests at once (http/1.1 used to process up to 6 requests and queue the rest, avoiding this issue). We have this code to retry but it doesn't seem to be executing.

The problem is that the retry would happen so quickly, it occurred _while_ requests were actively resolving, meaning we'd request again even if we have the same number of concurrent requests. The solution is to add a global class that manages the active state and tracks in-flight requests.

If there are `<maxConcurrent` requests ongoing, we'll just make the request and add it to the set of active requests with a unique ID and a start time so we can query for the size of active requests. If we're at the limit, the request will just be pushed onto an array that acts like a queue. As requests finish, they will pop off the front of the queue and get processed. This way we only ever have 15 _active_ requests at the same time. In terms of dashboards usage, we just need to wrap the request with the `execute` function call.