### PR TITLE
fix(demo-mode): Treat demo user as unauthenticated user in auth pipelines

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -21,7 +21,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from sentry import audit_log, features
+from sentry import audit_log, features, options
 from sentry.api.invite_helper import ApiInviteHelper, remove_invite_details_from_session
 from sentry.audit_log.services.log import AuditLogEvent, log_service
 from sentry.auth.email import AmbiguousUserFromEmail, resolve_email_to_user
@@ -37,7 +37,7 @@ from sentry.auth.providers.fly.provider import FlyOAuth2Provider
 from sentry.auth.store import FLOW_LOGIN, FLOW_SETUP_PROVIDER, AuthHelperSessionStore
 from sentry.auth.superuser import is_active_superuser
 from sentry.auth.view import AuthView
-from sentry.demo_mode.utils import is_demo_org, is_demo_user
+from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_org, is_demo_user
 from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.locks import locks
 from sentry.models.authidentity import AuthIdentity
@@ -451,6 +451,13 @@ class AuthIdentityHandler:
     @property
     def _logged_in_user(self) -> User | None:
         """The user, if they have authenticated on this session."""
+        if (
+            options.get("demo-user.auth.pipelines.always.unauthenticated.enabled")
+            and is_demo_mode_enabled()
+            and is_demo_user(self.request.user)
+        ):
+            return None
+
         return self.request.user if self.request.user.is_authenticated else None
 
     @property

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3511,3 +3511,12 @@ register(
     default=[],
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Killswitch for treating demo user as unauthenticated
+# in our auth pipelines.
+register(
+    "demo-user.auth.pipelines.always.unauthenticated.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -3,6 +3,7 @@ from unittest import mock
 from urllib.parse import quote as urlquote
 from urllib.parse import urlencode
 
+from django.contrib.auth import get_user
 from django.test import override_settings
 from django.urls import reverse
 
@@ -1275,11 +1276,11 @@ class OrganizationAuthLoginNoPasswordTest(AuthProviderTestCase):
 class OrganizationAuthLoginDemoModeTest(AuthProviderTestCase):
 
     def setUp(self) -> None:
-        self.demo_user = self.create_user(id=1)
-        self.demo_org = self.create_organization(id=1, owner=self.demo_user)
+        self.demo_user = self.create_user()
+        self.demo_org = self.create_organization(owner=self.demo_user)
 
-        self.normal_user = self.create_user(id=2)
-        self.normal_org = self.create_organization(id=2, owner=self.normal_user)
+        self.normal_user = self.create_user()
+        self.normal_org = self.create_organization(owner=self.normal_user)
 
     def is_logged_in_to_org(self, response, org):
         return response.status_code == 200 and response.redirect_chain == [
@@ -1293,26 +1294,115 @@ class OrganizationAuthLoginDemoModeTest(AuthProviderTestCase):
             follow=True,
         )
 
-    @override_options({"demo-mode.enabled": False, "demo-mode.users": [1], "demo-mode.orgs": [1]})
     def test_auto_login_demo_mode_disabled(self) -> None:
-        resp = self.fetch_org_login_page(self.demo_org)
-        assert not self.is_logged_in_to_org(resp, self.demo_org)
+        with override_options(
+            {
+                "demo-mode.enabled": False,
+                "demo-mode.users": [self.demo_user.id],
+                "demo-mode.orgs": [self.demo_org.id],
+            }
+        ):
+            resp = self.fetch_org_login_page(self.demo_org)
+            assert not self.is_logged_in_to_org(resp, self.demo_org)
 
-        resp = self.fetch_org_login_page(self.normal_org)
-        assert not self.is_logged_in_to_org(resp, self.normal_org)
+            resp = self.fetch_org_login_page(self.normal_org)
+            assert not self.is_logged_in_to_org(resp, self.normal_org)
 
-    @override_options({"demo-mode.enabled": True, "demo-mode.users": [1], "demo-mode.orgs": [1]})
     def test_auto_login_demo_mode(self) -> None:
-        resp = self.fetch_org_login_page(self.demo_org)
-        assert self.is_logged_in_to_org(resp, self.demo_org)
+        with override_options(
+            {
+                "demo-mode.enabled": True,
+                "demo-mode.users": [self.demo_user.id],
+                "demo-mode.orgs": [self.demo_org.id],
+            }
+        ):
+            resp = self.fetch_org_login_page(self.demo_org)
+            assert self.is_logged_in_to_org(resp, self.demo_org)
 
-        resp = self.fetch_org_login_page(self.normal_org)
-        assert not self.is_logged_in_to_org(resp, self.normal_org)
+            resp = self.fetch_org_login_page(self.normal_org)
+            assert not self.is_logged_in_to_org(resp, self.normal_org)
 
-    @override_options({"demo-mode.enabled": True, "demo-mode.users": [], "demo-mode.orgs": []})
     def test_auto_login_not_demo_org(self) -> None:
-        resp = self.fetch_org_login_page(self.demo_org)
-        assert not self.is_logged_in_to_org(resp, self.demo_org)
+        with override_options(
+            {"demo-mode.enabled": True, "demo-mode.users": [], "demo-mode.orgs": []}
+        ):
+            resp = self.fetch_org_login_page(self.demo_org)
+            assert not self.is_logged_in_to_org(resp, self.demo_org)
 
-        resp = self.fetch_org_login_page(self.normal_org)
-        assert not self.is_logged_in_to_org(resp, self.normal_org)
+            resp = self.fetch_org_login_page(self.normal_org)
+            assert not self.is_logged_in_to_org(resp, self.normal_org)
+
+    def test_demo_user_joins_existing_sso_organization(self) -> None:
+        """
+        Test that when a demo user is logged in and tries to join an existing SSO organization,
+        they are logged in as a new user with a proper auth identity linked.
+
+        This can happen in production when a user visits the sandbox, gets logged in as a demo user,
+        and then attempts to join an organization that has SSO configured (e.g., via invite link).
+
+        The demo user's session is treated as unauthenticated for the SSO pipeline
+        but the user property still resolves to the demo user as a fallback.
+        When the user chooses "newuser", a completely new account is created with SSO identity.
+        """
+        with override_options(
+            {
+                "demo-mode.enabled": True,
+                "demo-mode.users": [self.demo_user.id],
+                "demo-mode.orgs": [self.demo_org.id],
+                "demo-user.auth.pipelines.always.unauthenticated.enabled": True,
+            }
+        ):
+            sso_org = self.create_organization(name="sso-org", owner=self.normal_user)
+            # Create an organization with SSO (not the demo org)
+            auth_provider = AuthProvider.objects.create(
+                organization_id=sso_org.id, provider="dummy"
+            )
+
+            # Log in as demo user
+            self.login_as(self.demo_user)
+
+            # Initiate SSO flow
+            path = reverse("sentry-auth-organization", args=[sso_org.slug])
+            resp = self.client.post(path, {"init": True})
+
+            assert resp.status_code == 200
+            assert PLACEHOLDER_TEMPLATE in resp.content.decode("utf-8")
+
+            # Complete SSO with a new email
+            sso_path = reverse("sentry-auth-sso")
+            new_email = "newuser@example.com"
+            resp = self.client.post(sso_path, {"email": new_email})
+
+            # Even though demo user is logged in, they're treated as unauthenticated in pipeline
+            # So we get auth-confirm-identity screen, but existing_user still shows the demo user
+            # as a fallback (because user property returns request.user when email doesn't match)
+            self.assertTemplateUsed(resp, "sentry/auth-confirm-identity.html")
+            assert resp.status_code == 200
+
+            # Create new user account
+            resp = self.client.post(sso_path, {"op": "newuser"}, follow=True)
+
+            # Should redirect and log in as the new user
+            assert resp.status_code == 200
+
+            # Verify a new user was created (not the demo user)
+            auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
+            new_user = auth_identity.user
+
+            # Verify it's not the demo user
+            assert new_user.id != self.demo_user.id
+            assert new_user.email == new_email
+
+            logged_in_user = get_user(self.client)
+            assert logged_in_user.id == new_user.id
+
+            # Verify demo user has NO auth identity linked to this provider
+            assert not AuthIdentity.objects.filter(
+                auth_provider=auth_provider, user_id=self.demo_user.id
+            ).exists()
+
+            # Verify the new user has organization membership with SSO linked
+            with assume_test_silo_mode(SiloMode.REGION):
+                member = OrganizationMember.objects.get(organization=sso_org, user_id=new_user.id)
+            assert getattr(member.flags, "sso:linked")
+            assert not getattr(member.flags, "sso:invalid")


### PR DESCRIPTION
In the auth pipelines, which are activated when user clicks on register or sign in - we have to treat demo user as unauthenticated user, otherwise we will try to link the accounts wrongly.