### PR TITLE
cursor(backend): Help Cursor write tests within existing test files

### DIFF
--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -4,7 +4,7 @@ globs: src/**/*.py,tests/**/*.py,**/test_*.py
 alwaysApply: false
 ---
 
-# Python
+# Python Environment
 
 Whenever you attempt to run a Python command (e.g. `python -c`) or Python package (e.g. `pytest`, `mypy`), enable the virtualenv by activating it with `source .venv/bin/activate`.
 
@@ -12,32 +12,40 @@ Whenever you attempt to run a Python command (e.g. `python -c`) or Python packag
 
 ## Recommended practices
 
-For function signatures, preferred to use abstract types (e.g. `Sequence` over `list`) for input parameters and use specific return types (e.g. `list` over `Sequence`).
+For function signatures, prefer to use abstract types (e.g. `Sequence` over `list`) for input parameters and use specific return types (e.g. `list` over `Sequence`).
 
-Prefer to import a type from the module `collections` rather than `typing` if it exists there (e.g. `from collections.abc import Sequence` rather than `from typing import Sequence`).
+```python
+# Good: Abstract input types, specific return types
+def process_items(items: Sequence[Item]) -> list[ProcessedItem]:
+    return [process(item) for item in items]
+
+# Avoid: Specific input types, abstract return types
+def process_items(items: list[Item]) -> Sequence[ProcessedItem]:
+    return [process(item) for item in items]
+```
+
+Prefer to import a type from the module `collections.abc` rather than `typing` if it exists there (e.g. `from collections.abc import Sequence` rather than `from typing import Sequence`).
 
 # Python tests
 
 ## Running tests
 
-Change the directory to the top of the source code and type `source .venv/bin/activate` before calling any Python commands.
-
 Run pytest with these parameters: `pytest -svv --reuse-db`
 
 ## How to determine where to add new test cases
 
-When you try to fix and error, do not place test cases in a new file but do your best to find an existing test file associated to the module.
+When you try to fix an error, do not place test cases in a new file but do your best to find an existing test file associated with the module.
 
 We normally follow this pattern. Given the code is in `src/sentry/foo/bar.py`, it is most likely you will find the tests for that module in `tests/sentry/foo/test_bar.py`. Notice that we prefix `tests/` to the path and prefix `test_` to the module name.
 
-An exception to the pattern above is when we need to ensure that changes on Snuba will not break Sentry by placing tests in `tests/snuba/`.
+An exception to the pattern above is when we need to ensure that changes on Snuba will not break Sentry by placing tests in `tests/snuba/`. The tests in this folder will run in Snuba's CI process as well.
 
 
 ## Use factories instead of directly calling `Model.objects.create`
 
 In Sentry Python tests, prefer using factory methods from `sentry.testutils.factories.Factories` @factories.py or fixture methods (e.g., `self.create_model`) provided by base classes like `sentry.testutils.fixtures.Fixtures` @fixtures.py  instead of directly calling `Model.objects.create`. This promotes consistency, reduces boilerplate, and leverages shared test setup logic defined in the factories.
 
-For example, a diff that uses a fixture instead of the directly calling `Model.objects.create`  would look like:
+For example, a diff that uses a fixture instead of directly calling `Model.objects.create` would look like:
 
 ```diff
     -        direct_project = Project.objects.create(

--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -24,6 +24,15 @@ Change the directory to the top of the source code and type `source .venv/bin/ac
 
 Run pytest with these parameters: `pytest -svv --reuse-db`
 
+## How to determine where to add new test cases
+
+When you try to fix and error, do not place test cases in a new file but do your best to find an existing test file associated to the module.
+
+We normally follow this pattern. Given the code is in `src/sentry/foo/bar.py`, it is most likely you will find the tests for that module in `tests/sentry/foo/test_bar.py`. Notice that we prefix `tests/` to the path and prefix `test_` to the module name.
+
+An exception to the pattern above is when we need to ensure that changes on Snuba will not break Sentry by placing tests in `tests/snuba/`.
+
+
 ## Use factories instead of directly calling `Model.objects.create`
 
 In Sentry Python tests, prefer using factory methods from `sentry.testutils.factories.Factories` @factories.py or fixture methods (e.g., `self.create_model`) provided by base classes like `sentry.testutils.fixtures.Fixtures` @fixtures.py  instead of directly calling `Model.objects.create`. This promotes consistency, reduces boilerplate, and leverages shared test setup logic defined in the factories.

--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -36,14 +36,14 @@ Run pytest with these parameters: `pytest -svv --reuse-db`
 
 When you try to fix an error, do not place test cases in a new file but do your best to find an existing test file associated with the module.
 
-We normally follow this pattern. Given the code is in `src/sentry/foo/bar.py`, it is most likely you will find the tests for that module in `tests/sentry/foo/test_bar.py`. Notice that we prefix `tests/` to the path and prefix `test_` to the module name.
+We normally follow this pattern. Given the code is in `src/sentry/foo/bar.py`, you will most likely find the tests for that module in `tests/sentry/foo/test_bar.py`. Notice that we prefix `tests/` to the path and prefix `test_` to the module name.
 
 An exception to the pattern above is when we need to ensure that changes on Snuba will not break Sentry by placing tests in `tests/snuba/`. The tests in this folder will run in Snuba's CI process as well.
 
 
 ## Use factories instead of directly calling `Model.objects.create`
 
-In Sentry Python tests, prefer using factory methods from `sentry.testutils.factories.Factories` @factories.py or fixture methods (e.g., `self.create_model`) provided by base classes like `sentry.testutils.fixtures.Fixtures` @fixtures.py  instead of directly calling `Model.objects.create`. This promotes consistency, reduces boilerplate, and leverages shared test setup logic defined in the factories.
+In Sentry Python tests, prefer using factory methods from `sentry.testutils.factories.Factories` @factories.py or fixture methods (e.g., `self.create_model`) provided by base classes like `sentry.testutils.fixtures.Fixtures` @fixtures.py instead of directly calling `Model.objects.create`. This promotes consistency, reduces boilerplate, and leverages shared test setup logic defined in the factories.
 
 For example, a diff that uses a fixture instead of directly calling `Model.objects.create` would look like:
 


### PR DESCRIPTION
The norm is that we place tests under `tests/` and prefix `tests_` to the filename.

Without this, Cursor tends to create a new test file.

I'm also fixing some grammar and adding some specific examples.