### PR TITLE
fix(data_export): Batch large queries in Issues by Tag exports

### DIFF
--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -223,7 +223,19 @@ class DataExportQuerySerializer(serializers.Serializer[dict[str, Any]]):
                 sentry_sdk.capture_exception(err)
                 raise serializers.ValidationError("Invalid table query")
 
+        elif data["query_type"] == ExportQueryType.ISSUES_BY_TAG_STR:
+            issues_by_tag_validate(query_info)
+
         return data
+
+
+def issues_by_tag_validate(query_info: dict[str, Any]) -> None:
+    group = query_info.get("group")
+    if group is not None:
+        try:
+            query_info["group"] = int(group)
+        except (ValueError, TypeError):
+            raise serializers.ValidationError("Invalid group ID")
 
 
 @region_silo_endpoint

--- a/src/sentry/data_export/processors/issues_by_tag.py
+++ b/src/sentry/data_export/processors/issues_by_tag.py
@@ -24,7 +24,7 @@ class IssuesByTagProcessor:
     def __init__(
         self,
         project_id: int,
-        group_id: int,
+        group_id: int | str,
         key: str,
         environment_id: int | None,
         tenant_ids: dict[str, str | int] | None = None,
@@ -52,7 +52,7 @@ class IssuesByTagProcessor:
             raise ExportError("Requested project does not exist")
 
     @staticmethod
-    def get_group(group_id: int, project: Project) -> Group:
+    def get_group(group_id: int | str, project: Project) -> Group:
         try:
             group, _ = get_group_with_redirect(
                 group_id, queryset=Group.objects.filter(project=project)

--- a/src/sentry/utils/eventuser.py
+++ b/src/sentry/utils/eventuser.py
@@ -320,7 +320,6 @@ class EventUser:
         projects = Project.objects.filter(id=project_id)
         result = {}
 
-        # If we have too many values, batch them to avoid query size limits
         if len(values) <= MAX_TAG_VALUES_BATCH_SIZE:
             # Process normally for small batches
             return cls._process_tag_batch(projects, values)

--- a/src/sentry/utils/eventuser.py
+++ b/src/sentry/utils/eventuser.py
@@ -63,6 +63,8 @@ KEYWORD_MAP = BidirectionalMapping(
 MAX_QUERY_TRIES = 5
 OVERFETCH_FACTOR = 10
 MAX_FETCH_SIZE = 10_000
+# Maximum number of tag values to process in a single query to avoid ClickHouse query size limits
+MAX_TAG_VALUES_BATCH_SIZE = 100
 
 
 def get_ip_address_conditions(ip_addresses: list[str]) -> list[Condition]:
@@ -316,7 +318,28 @@ class EventUser:
         Return a dictionary of {tag_value: event_user}.
         """
         projects = Project.objects.filter(id=project_id)
+        result = {}
 
+        # If we have too many values, batch them to avoid query size limits
+        if len(values) <= MAX_TAG_VALUES_BATCH_SIZE:
+            # Process normally for small batches
+            return cls._process_tag_batch(projects, values)
+
+        # Process in batches to avoid ClickHouse query size limits
+        for i in range(0, len(values), MAX_TAG_VALUES_BATCH_SIZE):
+            batch_values = values[i : i + MAX_TAG_VALUES_BATCH_SIZE]
+            batch_result = cls._process_tag_batch(projects, batch_values)
+            result.update(batch_result)
+
+        return result
+
+    @classmethod
+    def _process_tag_batch(
+        cls, projects: QuerySet[Project], values: list[str]
+    ) -> dict[str, EventUser]:
+        """
+        Process a single batch of tag values and return the matching EventUser objects.
+        """
         result = {}
         keyword_filters: dict[str, Any] = {}
         for value in values:

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -663,23 +663,3 @@ class DataExportTest(APITestCase):
         data_export = ExportedData.objects.get(id=response.data["id"])
         query_info = data_export.query_info
         assert query_info["sort"] == ["-timestamp"]
-
-    def test_issues_by_tag_string_group_id_conversion(self) -> None:
-        """
-        Ensures that string group IDs in Issues-by-Tag exports are converted to integers
-        """
-        group = self.create_group(project=self.project)
-        payload = self.make_payload("issue", {"group": str(group.id), "key": "user"})
-        response = self.get_success_response(self.org.slug, status_code=201, **payload)
-        data_export = ExportedData.objects.get(id=response.data["id"])
-        # The group ID should be converted from string to integer
-        # assert isinstance(data_export.query_info["group"], int)
-        assert data_export.query_info["group"] == group.id
-
-    def test_issues_by_tag_invalid_group_id_rejection(self) -> None:
-        """
-        Ensures that invalid group IDs in Issues-by-Tag exports are properly rejected
-        """
-        payload = self.make_payload("issue", {"group": "invalid_group_id", "key": "user"})
-        response = self.get_error_response(self.org.slug, status_code=400, **payload)
-        assert response.data == {"non_field_errors": ["Invalid group ID"]}

--- a/tests/sentry/utils/test_eventuser.py
+++ b/tests/sentry/utils/test_eventuser.py
@@ -11,7 +11,7 @@ from sentry.analytics.events.eventuser_snuba_query import EventUserSnubaQuery
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.analytics import assert_analytics_events_recorded
 from sentry.testutils.helpers.datetime import before_now, freeze_time
-from sentry.utils.eventuser import EventUser
+from sentry.utils.eventuser import MAX_TAG_VALUES_BATCH_SIZE, EventUser
 
 now = before_now(days=1).replace(minute=10, second=0, microsecond=0, tzinfo=None)
 
@@ -489,7 +489,7 @@ class EventUserTestCase(APITestCase, SnubaTestCase):
         tag_values.extend(["id:myminion", "id:2"])
 
         # Add many non-existent values to simulate a large batch
-        for i in range(200):  # More than MAX_TAG_VALUES_BATCH_SIZE (100)
+        for i in range(MAX_TAG_VALUES_BATCH_SIZE + 1):  # More than MAX_TAG_VALUES_BATCH_SIZE (100)
             tag_values.append(f"id:nonexistent{i}")
 
         # This should work without raising SnubaError about query size


### PR DESCRIPTION
Main change:
- Add batching logic to EventUser.for_tags to avoid ClickHouse query size limits

A customer request is failing with:
> dataexport.error: After processing, query is 341491 bytes, which is too long for ClickHouse to process. Max size is 131072 bytes.

Drive-by changes:
- Add validation to convert string group IDs to integers in Issues by Tag exports
- Update type hints to accept both string and integer group IDs in processors

Fixes [RTC-1221](https://linear.app/getsentry/issue/RTC-1221).