### PR TITLE
fix(insights): slow ssr widget incorrect tooltip

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -348,7 +348,8 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           return defined(sampleId) ? sampleId.toString() : seriesName;
         }
 
-        return aliases[seriesName] ?? seriesName;
+        const name = aliases[seriesName] ?? seriesName;
+        return truncationFormatter(name, true);
       },
       valueFormatter: function (value, _field, valueFormatterParams) {
         // Use the series to figure out the corresponding `Plottable`, and get the field type. From that, use whichever unit we chose for that field type.
@@ -375,7 +376,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
 
         return formatTooltipValue(value, fieldType, unitForType[fieldType] ?? undefined);
       },
-      truncate: true,
+      truncate: false,
       utc: utc ?? false,
     })(deDupedParams, asyncTicket);
   };

--- a/static/app/views/insights/common/components/widgets/overviewSlowNextjsSSRWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowNextjsSSRWidget.tsx
@@ -55,7 +55,7 @@ export default function OverviewSlowNextjsSSRWidget(props: LoadableChartWidgetPr
     {
       ...pageFilterChartParams,
       query: `span.group:[${spansRequest.data?.map(item => `"${item['span.group']}"`).join(',')}]`,
-      groupBy: [SpanFields.SPAN_GROUP],
+      groupBy: [SpanFields.SPAN_DESCRIPTION],
       yAxis: ['avg(span.duration)'],
       sort: {field: 'avg(span.duration)', kind: 'desc'},
       topEvents: 4,


### PR DESCRIPTION
This Pr fixes two issues

1. Group by `Span description` in the slow ssr widget so that we show the right tooltip.

| Before | After |
|--------|--------|
| <img width="412" height="422" alt="image" src="https://github.com/user-attachments/assets/58cfce5a-473d-455e-86fd-e5c828e90176" /> | <img width="751" height="440" alt="image" src="https://github.com/user-attachments/assets/bc02d651-3a4b-43be-ba7a-a1576f3b08dd" /> |

2. Fixes a bug where the tooltip name formatter would already truncate the `seriesName`, and we would incorrectly lookup the alias

| Before | After |
|--------|--------|
| <img width="1368" height="422" alt="image" src="https://github.com/user-attachments/assets/1e511d14-1f48-46d5-bc7a-d627536abd54" /> | <img width="751" height="440" alt="image" src="https://github.com/user-attachments/assets/bc02d651-3a4b-43be-ba7a-a1576f3b08dd" /> | 

