### PR TITLE
fix(insights): disallow web vitals ops on backend page

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -51,7 +51,7 @@ import {
   OVERVIEW_PAGE_ALLOWED_OPS as FRONTEND_OVERVIEW_PAGE_OPS,
   WEB_VITALS_OPS,
 } from 'sentry/views/insights/pages/frontend/settings';
-import {OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_OPS} from 'sentry/views/insights/pages/mobile/settings';
+import {OVERVIEW_PAGE_ALLOWED_OPS as MOBILE_OVERVIEW_PAGE_OPS} from 'sentry/views/insights/pages/mobile/settings';
 import {LaravelOverviewPage} from 'sentry/views/insights/pages/platform/laravel';
 import {useIsLaravelInsightsAvailable} from 'sentry/views/insights/pages/platform/laravel/features';
 import {NextJsOverviewPage} from 'sentry/views/insights/pages/platform/nextjs';
@@ -99,7 +99,7 @@ function EAPBackendOverviewPage() {
   const disallowedOps = [
     ...new Set([
       ...FRONTEND_OVERVIEW_PAGE_OPS,
-      ...BACKEND_OVERVIEW_PAGE_OPS,
+      ...MOBILE_OVERVIEW_PAGE_OPS,
       ...WEB_VITALS_OPS,
     ]),
   ];

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -47,7 +47,10 @@ import {
   OVERVIEW_PAGE_ALLOWED_OPS,
 } from 'sentry/views/insights/pages/backend/settings';
 import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
-import {OVERVIEW_PAGE_ALLOWED_OPS as FRONTEND_OVERVIEW_PAGE_OPS} from 'sentry/views/insights/pages/frontend/settings';
+import {
+  OVERVIEW_PAGE_ALLOWED_OPS as FRONTEND_OVERVIEW_PAGE_OPS,
+  WEB_VITALS_OPS,
+} from 'sentry/views/insights/pages/frontend/settings';
 import {OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_OPS} from 'sentry/views/insights/pages/mobile/settings';
 import {LaravelOverviewPage} from 'sentry/views/insights/pages/platform/laravel';
 import {useIsLaravelInsightsAvailable} from 'sentry/views/insights/pages/platform/laravel/features';
@@ -94,7 +97,11 @@ function EAPBackendOverviewPage() {
   });
 
   const disallowedOps = [
-    ...new Set([...FRONTEND_OVERVIEW_PAGE_OPS, ...BACKEND_OVERVIEW_PAGE_OPS]),
+    ...new Set([
+      ...FRONTEND_OVERVIEW_PAGE_OPS,
+      ...BACKEND_OVERVIEW_PAGE_OPS,
+      ...WEB_VITALS_OPS,
+    ]),
   ];
 
   const {

--- a/static/app/views/insights/pages/frontend/settings.ts
+++ b/static/app/views/insights/pages/frontend/settings.ts
@@ -18,6 +18,7 @@ export const WEB_VITALS_OPS = [
   'ui.interaction.drag',
   'ui.interaction.press',
   'ui.webvital.cls',
+  'ui.webvital.lcp',
   'ui.webvital.fcp',
   'pageload',
 ];


### PR DESCRIPTION
Web vitals are only applicable to frontend pages