### PR TITLE
ref(grouping): Replace variant-specific root component classes with generic class

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -9,13 +9,7 @@ import sentry_sdk
 
 from sentry import options
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
-from sentry.grouping.component import (
-    AppGroupingComponent,
-    BaseGroupingComponent,
-    ContributingComponent,
-    DefaultGroupingComponent,
-    SystemGroupingComponent,
-)
+from sentry.grouping.component import ContributingComponent, RootGroupingComponent
 from sentry.grouping.enhancer import (
     DEFAULT_ENHANCEMENTS_BASE,
     EnhancementsConfig,
@@ -310,7 +304,7 @@ def _get_variants_from_strategies(
 ) -> dict[str, ComponentVariant]:
     winning_strategy: str | None = None
     precedence_hint: str | None = None
-    all_strategies_components_by_variant: dict[str, list[BaseGroupingComponent[Any]]] = {}
+    all_strategies_components_by_variant: dict[str, list[ContributingComponent]] = {}
     winning_strategy_components_by_variant = {}
 
     # `iter_strategies` presents strategies in priority order, which allows us to go with the first
@@ -358,12 +352,7 @@ def _get_variants_from_strategies(
     variants = {}
 
     for variant_name, components in all_strategies_components_by_variant.items():
-        component_class_by_variant = {
-            "app": AppGroupingComponent,
-            "default": DefaultGroupingComponent,
-            "system": SystemGroupingComponent,
-        }
-        root_component = component_class_by_variant[variant_name](values=components)
+        root_component = RootGroupingComponent(variant_name=variant_name, values=components)
 
         # The root component will pull its `contributes` value from the components it wraps - if
         # none of them contributes, it will also be marked as non-contributing. But those components

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -433,44 +433,6 @@ class TemplateGroupingComponent(
     id: str = "template"
 
 
-# Wrapper components used to link component trees to variants
-
-
-class DefaultGroupingComponent(
-    BaseGroupingComponent[
-        CSPGroupingComponent
-        | ExpectCTGroupingComponent
-        | ExpectStapleGroupingComponent
-        | HPKPGroupingComponent
-        | MessageGroupingComponent
-        | TemplateGroupingComponent
-    ]
-):
-    id: str = "default"
-
-
-class AppGroupingComponent(
-    BaseGroupingComponent[
-        ChainedExceptionGroupingComponent
-        | ExceptionGroupingComponent
-        | StacktraceGroupingComponent
-        | ThreadsGroupingComponent
-    ]
-):
-    id: str = "app"
-
-
-class SystemGroupingComponent(
-    BaseGroupingComponent[
-        ChainedExceptionGroupingComponent
-        | ExceptionGroupingComponent
-        | StacktraceGroupingComponent
-        | ThreadsGroupingComponent
-    ]
-):
-    id: str = "system"
-
-
 ContributingComponent = (
     ChainedExceptionGroupingComponent
     | ExceptionGroupingComponent

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -483,3 +483,27 @@ ContributingComponent = (
     | MessageGroupingComponent
     | TemplateGroupingComponent
 )
+
+
+# Wrapper component used to link component trees to variants
+class RootGroupingComponent(BaseGroupingComponent[ContributingComponent]):
+
+    def __init__(
+        self,
+        variant_name: str,
+        hint: str | None = None,
+        contributes: bool | None = None,
+        values: Sequence[ContributingComponent] | None = None,
+    ):
+        super().__init__(hint, contributes, values)
+        self.variant_name = variant_name
+
+    @property
+    def id(self) -> str:
+        return self.variant_name
+
+    def __repr__(self) -> str:
+        base_repr = super().__repr__()
+        # Fake the class name so that instead of showing as `RootGroupingComponent` in the repr it
+        # shows as `AppGroupingComponent`/`SystemGroupingComponent`/`DefaultGroupingComponent`
+        return base_repr.replace("Root", self.id.title())

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -4,12 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, NotRequired, Self, TypedDict
 
-from sentry.grouping.component import (
-    AppGroupingComponent,
-    ContributingComponent,
-    DefaultGroupingComponent,
-    SystemGroupingComponent,
-)
+from sentry.grouping.component import ContributingComponent, RootGroupingComponent
 from sentry.grouping.fingerprinting.rules import FingerprintRule
 from sentry.grouping.utils import hash_from_values, is_default_fingerprint_var
 
@@ -113,7 +108,7 @@ class ComponentVariant(BaseVariant):
     def __init__(
         self,
         # The root of the component tree
-        root_component: AppGroupingComponent | SystemGroupingComponent | DefaultGroupingComponent,
+        root_component: RootGroupingComponent,
         # The highest non-root contributing component in the tree, representing the overall grouping
         # method (exception, threads, message, etc.). For non-contributing variants, this will be
         # None.
@@ -225,7 +220,7 @@ class SaltedComponentVariant(ComponentVariant):
         self,
         fingerprint: list[str],
         # The root of the component tree
-        component: AppGroupingComponent | SystemGroupingComponent | DefaultGroupingComponent,
+        component: RootGroupingComponent,
         # The highest non-root contributing component in the tree, representing the overall grouping
         # method (exception, threads, message, etc.). For non-contributing variants, this will be
         # None.

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unknown_variant.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unknown_variant.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:39.412221+00:00'
+created: '2025-10-01T17:46:41.159876+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -17,4 +17,4 @@ contributing variants:
     hash: "d41d8cd98f00b204e9800998ecf8427e"
     contributing component: null
     root_component:
-      not_a_known_component_type*
+      not_a_known_variant_name*

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import patch
 
-from sentry.grouping.component import DefaultGroupingComponent, MessageGroupingComponent
+from sentry.grouping.component import MessageGroupingComponent, RootGroupingComponent
 from sentry.grouping.ingest.grouphash_metadata import (
     check_grouphashes_for_positive_fingerprint_match,
     get_grouphash_metadata_data,
@@ -58,10 +58,11 @@ def test_unknown_hash_basis(
 
     # Overwrite the component ids and create fake variants so this stops being recognizable as a
     # known grouping type
-    component = DefaultGroupingComponent(
-        contributes=True, values=[MessageGroupingComponent(contributes=True)]
+    component = RootGroupingComponent(
+        variant_name="not_a_known_variant_name",
+        contributes=True,
+        values=[MessageGroupingComponent(contributes=True)],
     )
-    component.id = "not_a_known_component_type"
     component.values[0].id = "dogs_are_great"
     variants: dict[str, BaseVariant] = {
         "dogs": ComponentVariant(component, None, StrategyConfiguration())


### PR DESCRIPTION
As part of the revamp of the grouping info section of the issue details page, one of the things we're going to do is combine app and system variants when their hashes match. To make this easier, both in terms of the code and in terms of type-checking, this PR replaces the current variant-specific root grouping component classes (`AppGroupingComponent`, `SystemGroupingComponent`, and `DefaultGroupingComponent`) with a generic `RootGroupingComponent` class which just tracks variant name as an attribute. 