### PR TITLE
ci(jest): Upload jest-balance results to github as an artifact

### DIFF
--- a/.github/workflows/jest-balance.yml
+++ b/.github/workflows/jest-balance.yml
@@ -37,6 +37,11 @@ jobs:
           GITHUB_PR_REF: ${{ github.event.pull_request.head.ref || github.ref }}
         run: JEST_TEST_BALANCER=1 pnpm run test-ci
 
+      - uses: actions/upload-artifact@master
+        with:
+          name: jest-balance.json
+          path: tests/js/test-balancer/jest-balance.json
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@b4d51739f96fca8047ad065eccef63442d8e99f7 # v4.2.0
         with:

--- a/.github/workflows/jest-balance.yml
+++ b/.github/workflows/jest-balance.yml
@@ -37,7 +37,7 @@ jobs:
           GITHUB_PR_REF: ${{ github.event.pull_request.head.ref || github.ref }}
         run: JEST_TEST_BALANCER=1 pnpm run test-ci
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
         with:
           name: jest-balance.json
           path: tests/js/test-balancer/jest-balance.json


### PR DESCRIPTION
By using artifacts we might be able to skip the "create a PR" step, and instead have the jest CI step pull down and always use the latest balance data automatically
