### PR TITLE
fix(dashboards): Increase timeouts and retry count

### DIFF
--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -6,8 +6,8 @@ import type {EventQuery} from 'sentry/actionCreators/events';
 import type {ResponseMeta} from 'sentry/api';
 import {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
-import type {ImmutableEventView, LocationQuery} from 'sentry/utils/discover/eventView';
 import type EventView from 'sentry/utils/discover/eventView';
+import type {ImmutableEventView, LocationQuery} from 'sentry/utils/discover/eventView';
 import {isAPIPayloadSimilar} from 'sentry/utils/discover/eventView';
 import {PerformanceEventViewContext} from 'sentry/utils/performance/contexts/performanceEventViewContext';
 import type {UseQueryOptions} from 'sentry/utils/queryClient';
@@ -317,8 +317,8 @@ type RetryOptions = {
   timeoutMultiplier?: number;
 };
 
-const BASE_TIMEOUT = 200;
-const TIMEOUT_MULTIPLIER = 2;
+const BASE_TIMEOUT = 500;
+const TIMEOUT_MULTIPLIER = 1.75;
 const wait = (duration: any) => new Promise(resolve => setTimeout(resolve, duration));
 
 export async function doDiscoverQuery<T>(

--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -228,7 +228,7 @@ function getEventsRequest(
     {
       retry: {
         statusCodes: [429],
-        tries: 3,
+        tries: 10,
       },
     }
   );

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -508,7 +508,7 @@ function getEventsRequest(
     {
       retry: {
         statusCodes: [429],
-        tries: 3,
+        tries: 10,
       },
     }
   );

--- a/static/app/views/dashboards/datasetConfig/logs.tsx
+++ b/static/app/views/dashboards/datasetConfig/logs.tsx
@@ -361,7 +361,7 @@ function getEventsRequest(
     {
       retry: {
         statusCodes: [429],
-        tries: 3,
+        tries: 10,
       },
     }
   );

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -368,7 +368,7 @@ function getEventsRequest(
     {
       retry: {
         statusCodes: [429],
-        tries: 3,
+        tries: 10,
       },
     }
   );

--- a/static/app/views/dashboards/datasetConfig/transactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/transactions.tsx
@@ -217,7 +217,7 @@ function getEventsRequest(
     {
       retry: {
         statusCodes: [429],
-        tries: 3,
+        tries: 10,
       },
     }
   );


### PR DESCRIPTION
The base timeout and retry count were too short to properly retry. Tweak the multiplier so we have better retry intervals and also increase the cap because sometimes requests can take longer than what would originally be the upper bound.