### PR TITLE
fix(deletions): Try smaller batches when bulk deleting rows

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -270,7 +270,9 @@ def cleanup(
                     order_by=order_by,
                 )
 
-                for chunk in q.iterator(chunk_size=100, use_range_wrapper=use_range_wrapper):
+                for chunk in q.iterator(
+                    chunk_size=100, batch_size=10000, use_range_wrapper=use_range_wrapper
+                ):
                     task_queue.put((imp, chunk))
 
                 task_queue.join()


### PR DESCRIPTION
We're seeing occasional query timeouts using the range wrapper. We don't really need a batch size of 100k, dropping down to 10k for more manageable queries.

<!-- Describe your PR here. -->