### PR TITLE
feat(user-feedback): Use new wildcard contains op for categories

### DIFF
--- a/static/app/components/feedback/summaryCategories/feedbackCategories.spec.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackCategories.spec.tsx
@@ -10,6 +10,7 @@ import {
 
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import FeedbackCategories from 'sentry/components/feedback/summaryCategories/feedbackCategories';
+import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -23,7 +24,10 @@ const mockUseNavigate = jest.mocked(useNavigate);
 const mockUseOrganizationSeerSetup = jest.mocked(useOrganizationSeerSetup);
 
 describe('FeedbackCategories', () => {
-  const mockOrganization = OrganizationFixture({slug: 'org-slug'});
+  const mockOrganization = OrganizationFixture({
+    slug: 'org-slug',
+    features: ['search-query-builder-wildcard-operators'],
+  });
 
   const mockCategories = [
     {
@@ -197,8 +201,7 @@ describe('FeedbackCategories', () => {
     it('removes filter when selected category is clicked again', async () => {
       const locationWithFilter = LocationFixture({
         query: {
-          query:
-            'ai_categorization.labels:["*\\"Design\\"*","*\\"UI\\"*","*\\"User Interface\\"*"]',
+          query: `ai_categorization.labels:${WildcardOperators.CONTAINS}["\\"Design\\"","\\"UI\\"","\\"User Interface\\""]`,
         },
       });
 
@@ -266,7 +269,7 @@ describe('FeedbackCategories', () => {
       const queryString = navigateCall.query.query;
 
       expect(queryString).toBe(
-        'ai_categorization.labels:["*\\"Design\\"*","*\\"UI\\"*","*\\"User Interface\\"*"]'
+        `ai_categorization.labels:${WildcardOperators.CONTAINS}["\\"Design\\"","\\"UI\\"","\\"User Interface\\""]`
       );
     });
   });
@@ -487,8 +490,7 @@ describe('FeedbackCategories', () => {
       const navigateCall = mockNavigate.mock.calls[0][0];
       const queryString = navigateCall.query.query;
 
-      const expectedQuery =
-        'ai_categorization.labels:["*\\"Another \\\\\\"Label\\\\\\"\\"*","*\\"Associated\\* \\\\\\"Label\\\\\\"\\"*","*\\"Test\\* \\\\\\"Category\\\\\\"\\"*"]';
+      const expectedQuery = `ai_categorization.labels:${WildcardOperators.CONTAINS}["\\"Another \\\\\\"Label\\\\\\"\\"","\\"Associated\\* \\\\\\"Label\\\\\\"\\"","\\"Test\\* \\\\\\"Category\\\\\\"\\""]`;
 
       expect(queryString).toBe(expectedQuery);
     });

--- a/static/app/components/feedback/summaryCategories/feedbackCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackCategories.tsx
@@ -5,9 +5,10 @@ import {Tag} from 'sentry/components/core/badge/tag';
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import useFeedbackCategories from 'sentry/components/feedback/list/useFeedbackCategories';
 import Placeholder from 'sentry/components/placeholder';
+import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {escapeFilterValue, MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {escapeFilterValue} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -22,16 +23,12 @@ function getSearchTermForLabel(label: string, hasWildcardOps: boolean) {
    * Special case: if the label has a literal * (asterisk) in it, we have to escape it to indicate that we want to match the literal *
    * - The asterisk escape is added after both JSON conversions, since otherwise, the \* would be escaped to \\* and would match the wildcard instead of the literal *
    */
-
-  const exactMatchString = JSON.stringify(label);
-  let toPassToSearch = JSON.stringify(exactMatchString);
-  toPassToSearch = escapeFilterValue(toPassToSearch);
+  const toPassToSearch = escapeFilterValue(JSON.stringify(JSON.stringify(label)));
   // Now, add the wildcards to the string (second spot and second-last spot, since we want them inside the second pair of quotes)
   // The first and last quotes are added by the second JSON.stringify, we just manually add them back
-  toPassToSearch = hasWildcardOps
+  return hasWildcardOps
     ? `"${toPassToSearch.slice(1, -1)}"`
     : `"*${toPassToSearch.slice(1, -1)}*"`;
-  return toPassToSearch;
 }
 
 function getSearchTermForLabelList(labels: string[], hasWildcardOps: boolean) {
@@ -111,6 +108,19 @@ export default function FeedbackCategories() {
     return null;
   }
 
+  const isCategorySelected = (category: {
+    associatedLabels: string[];
+    primaryLabel: string;
+  }) => {
+    // Create search terms for primary label and all associated labels
+    const allLabels = [category.primaryLabel, ...category.associatedLabels];
+    const exactSearchTerm = getSearchTermForLabelList(allLabels, hasWildcardOperators);
+    const currentFilters = searchConditions.getFilterValues('ai_categorization.labels');
+
+    // Only show a tag as selected if it is the only filter, and the search term matches exactly
+    return `[${currentFilters.map(c => `"${c}"`).join(',')}]` === exactSearchTerm;
+  };
+
   const handleTagClick = (category: {
     associatedLabels: string[];
     primaryLabel: string;
@@ -124,7 +134,7 @@ export default function FeedbackCategories() {
     const newSearchConditions = new MutableSearch(currentQuery);
 
     if (isSelected) {
-      newSearchConditions.removeFilterValue('ai_categorization.labels', exactSearchTerm);
+      newSearchConditions.removeFilter('ai_categorization.labels');
     } else {
       newSearchConditions.removeFilter('ai_categorization.labels');
 
@@ -157,19 +167,6 @@ export default function FeedbackCategories() {
         query: newSearchConditions.formatString(),
       },
     });
-  };
-
-  const isCategorySelected = (category: {
-    associatedLabels: string[];
-    primaryLabel: string;
-  }) => {
-    // Create search terms for primary label and all associated labels
-    const allLabels = [category.primaryLabel, ...category.associatedLabels];
-    const exactSearchTerm = getSearchTermForLabelList(allLabels, hasWildcardOperators);
-    const currentFilters = searchConditions.getFilterValues('ai_categorization.labels');
-
-    // Only show a tag as selected if it is the only filter, and the search term matches exactly
-    return currentFilters.length === 1 && currentFilters[0] === exactSearchTerm;
   };
 
   // TODO: after all feedbacks have the .labels tag, uncomment the feedback count


### PR DESCRIPTION
This PR makes a small tweak to utilize the `contains` wildcard operator over wrapping items with asterisks. It is currently behind the wildcard op flag, which has been rolled out to EA, and will probably GA next week.