### PR TITLE
fix(uptime): Persist project for monitor creation

### DIFF
--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -161,7 +161,7 @@ function Create(props: Props) {
         ) : (
           <Fragment>
             {alertType === AlertRuleType.UPTIME ? (
-              <UptimeAlertForm {...props} />
+              <UptimeAlertForm />
             ) : alertType === AlertRuleType.CRONS ? (
               <MonitorForm
                 apiMethod="POST"

--- a/static/app/views/alerts/edit.tsx
+++ b/static/app/views/alerts/edit.tsx
@@ -104,7 +104,6 @@ function ProjectAlertsEditor(props: Props) {
             {alertType === CombinedAlertType.UPTIME && (
               <UptimeRulesEdit
                 {...props}
-                project={project}
                 onChangeTitle={setTitle}
                 userTeamIds={teams.map(({id}) => id)}
               />

--- a/static/app/views/alerts/rules/uptime/edit.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/edit.spec.tsx
@@ -48,7 +48,6 @@ describe('uptime/edit', () => {
         onChangeTitle={handleChangeTitle}
         userTeamIds={[]}
         organization={organization}
-        project={project}
         params={{projectId: project.slug, ruleId: uptimeRule.id}}
       />,
       {organization}
@@ -85,7 +84,6 @@ describe('uptime/edit', () => {
         onChangeTitle={handleChangeTitle}
         userTeamIds={[]}
         organization={organization}
-        project={project}
         params={{projectId: project.slug, ruleId: uptimeRule.id}}
       />,
       {organization}

--- a/static/app/views/alerts/rules/uptime/edit.tsx
+++ b/static/app/views/alerts/rules/uptime/edit.tsx
@@ -9,7 +9,6 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
 import useApi from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
@@ -24,11 +23,10 @@ type RouteParams = {
 type Props = {
   onChangeTitle: (data: string) => void;
   organization: Organization;
-  project: Project;
   userTeamIds: string[];
 } & RouteComponentProps<RouteParams>;
 
-export function UptimeRulesEdit({params, onChangeTitle, organization, project}: Props) {
+export function UptimeRulesEdit({params, onChangeTitle, organization}: Props) {
   const api = useApi();
   const navigate = useNavigate();
 
@@ -69,12 +67,7 @@ export function UptimeRulesEdit({params, onChangeTitle, organization, project}: 
 
   return (
     <Main fullWidth>
-      <UptimeAlertForm
-        organization={organization}
-        project={project}
-        rule={rule}
-        handleDelete={handleDelete}
-      />
+      <UptimeAlertForm rule={rule} handleDelete={handleDelete} />
     </Main>
   );
 }

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -26,12 +26,11 @@ import ListItem from 'sentry/components/list/listItem';
 import Panel from 'sentry/components/panels/panel';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 import type {UptimeRule} from 'sentry/views/alerts/rules/uptime/types';
@@ -40,8 +39,6 @@ import {HTTPSnippet} from './httpSnippet';
 import {UptimeHeadersField} from './uptimeHeadersField';
 
 interface Props {
-  organization: Organization;
-  project: Project;
   handleDelete?: () => void;
   rule?: UptimeRule;
 }
@@ -86,15 +83,20 @@ function getFormDataFromRule(rule: UptimeRule) {
   };
 }
 
-export function UptimeAlertForm({project, handleDelete, rule}: Props) {
+export function UptimeAlertForm({handleDelete, rule}: Props) {
   const navigate = useNavigate();
   const organization = useOrganization();
-  const {projects} = useProjects();
   const queryClient = useQueryClient();
+  const {projects} = useProjects();
+  const {selection} = usePageFilters();
+
+  const project =
+    projects.find(p => selection.projects[0]?.toString() === p.id) ??
+    (projects.length === 1 ? projects[0] : null);
 
   const initialData = rule
     ? getFormDataFromRule(rule)
-    : {projectSlug: project.slug, method: 'GET', headers: []};
+    : {projectSlug: project?.slug, method: 'GET', headers: []};
 
   const [formModel] = useState(() => new FormModel());
 

--- a/static/app/views/insights/uptime/views/overview.tsx
+++ b/static/app/views/insights/uptime/views/overview.tsx
@@ -83,10 +83,7 @@ export default function UptimeOverview() {
             <LinkButton
               size="sm"
               priority="primary"
-              to={makeAlertsPathname({
-                path: `/new/uptime/`,
-                organization,
-              })}
+              to={makeAlertsPathname({path: `/new/uptime/`, organization})}
               icon={<IconAdd isCircled />}
               disabled={!canCreateAlert}
               title={canCreateAlert ? undefined : permissionTooltipText}
@@ -133,10 +130,7 @@ export default function UptimeOverview() {
                   <LinkButton
                     size="sm"
                     priority="primary"
-                    to={makeAlertsPathname({
-                      path: `/new/uptime/`,
-                      organization,
-                    })}
+                    to={makeAlertsPathname({path: `/new/uptime/`, organization})}
                     icon={<IconAdd isCircled />}
                   >
                     {t('Add Uptime Monitor')}


### PR DESCRIPTION
Fixes [NEW-447: \[uptime\] Maintain project selection for uptime monitor creation](https://linear.app/getsentry/issue/NEW-447/uptime-maintain-project-selection-for-uptime-monitor-creation)