### PR TITLE
fix(otel): Use org flag to control OTel-related FE changes

### DIFF
--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -70,7 +70,7 @@ export function KeySettings({
   }, [organization, api, onRemove, keyId, projectId]);
 
   const showOtlpTraces =
-    useOTelFriendlyUI() && project.features.includes('relay-otel-endpoint');
+    useOTelFriendlyUI() && organization.features.includes('relay-otlp-traces-endpoint');
   const showOtlpLogs = organization.features.includes('relay-otel-logs-endpoint');
 
   return (

--- a/static/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/static/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -48,7 +48,7 @@ function KeyRow({
   const isBrowserJavaScript = platform === 'javascript';
   const isJsPlatform = platform.startsWith('javascript');
   const showOtlpTraces =
-    useOTelFriendlyUI() && project.features.includes('relay-otel-endpoint');
+    useOTelFriendlyUI() && organization.features.includes('relay-otlp-traces-endpoint');
   const showOtlpLogs = organization.features.includes('relay-otel-logs-endpoint');
 
   return (


### PR DESCRIPTION
Project flag controlling OTLP trace endpoint acccess was replaced by an org flag in https://github.com/getsentry/sentry/pull/99155. Switch the FE to use the org version of the flag.