### PR TITLE
chore(preprod): Add new GET comparison run endpoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -94,11 +94,17 @@
   // Avoid relative imports
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "editor.tabSize": 4,
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
   "python.testing.pytestArgs": ["tests"],
   "python.analysis.autoImportCompletions": true,
+  "python.analysis.extraPaths": ["${workspaceFolder}/src"],
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportMissingImports": "none"
+  },
+  "python.languageServer": "Pylance",
   "prettier.configPath": "prettier.config.mjs",
   "biome.enabled": false,
   "cursorpyright.analysis.autoImportCompletions": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -94,17 +94,11 @@
   // Avoid relative imports
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "editor.tabSize": 4,
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
   "python.testing.pytestArgs": ["tests"],
   "python.analysis.autoImportCompletions": true,
-  "python.analysis.extraPaths": ["${workspaceFolder}/src"],
-  "python.analysis.diagnosticSeverityOverrides": {
-    "reportMissingImports": "none"
-  },
-  "python.languageServer": "Pylance",
   "prettier.configPath": "prettier.config.mjs",
   "biome.enabled": false,
   "cursorpyright.analysis.autoImportCompletions": true

--- a/src/sentry/preprod/analytics.py
+++ b/src/sentry/preprod/analytics.py
@@ -84,6 +84,15 @@ class PreprodArtifactApiSizeAnalysisCompareGetEvent(analytics.Event):
     base_artifact_id: str
 
 
+@analytics.eventclass("preprod_artifact.api.size_analysis_compare.run.get")
+class PreprodArtifactApiSizeAnalysisCompareRunGetEvent(analytics.Event):
+    organization_id: int
+    project_id: int
+    user_id: int | None = None
+    head_artifact_id: str
+    base_artifact_id: str
+
+
 @analytics.eventclass("preprod_artifact.api.size_analysis_compare.post")
 class PreprodArtifactApiSizeAnalysisComparePostEvent(analytics.Event):
     organization_id: int
@@ -122,5 +131,6 @@ analytics.register(PreprodArtifactApiAdminGetInfoEvent)
 analytics.register(PreprodArtifactApiAdminBatchDeleteEvent)
 analytics.register(PreprodArtifactApiDeleteEvent)
 analytics.register(PreprodArtifactApiSizeAnalysisCompareGetEvent)
+analytics.register(PreprodArtifactApiSizeAnalysisCompareRunGetEvent)
 analytics.register(PreprodArtifactApiSizeAnalysisComparePostEvent)
 analytics.register(PreprodArtifactApiSizeAnalysisCompareDownloadEvent)

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare_run.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare_run.py
@@ -1,0 +1,201 @@
+import logging
+
+from django.http.response import HttpResponseBase
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import analytics, features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.preprod.analytics import PreprodArtifactApiSizeAnalysisCompareRunGetEvent
+from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactEndpoint
+from sentry.preprod.api.models.size_analysis.project_preprod_size_analysis_compare_models import (
+    SizeAnalysisCompareRunGETResponse,
+    SizeAnalysisComparison,
+)
+from sentry.preprod.models import PreprodArtifactSizeComparison, PreprodArtifactSizeMetrics
+from sentry.preprod.size_analysis.tasks import manual_size_analysis_comparison
+from sentry.preprod.size_analysis.utils import can_compare_size_metrics
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class ProjectPreprodArtifactSizeAnalysisCompareRunEndpoint(PreprodArtifactEndpoint):
+    owner = ApiOwner.EMERGE_TOOLS
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+
+    def get(
+        self,
+        request: Request,
+        project,
+        head_artifact_id,
+        base_artifact_id,
+        head_artifact,
+        base_artifact,
+    ) -> HttpResponseBase:
+        """
+        Run size analysis comparison for a preprod artifact
+        ````````````````````````````````````````````````````
+
+        Run size analysis comparison for a preprod artifact. Will run comparisons async for all size metrics.
+        Intentionally a GET endpoint as users should be able to trigger comparisons without elevated project write permissions.
+
+        :pparam string organization_id_or_slug: the id or slug of the organization the
+                                          artifact belongs to.
+        :pparam string project_id_or_slug: the id or slug of the project to retrieve the
+                                     artifact from.
+        :pparam string head_artifact_id: the ID of the head preprod artifact to trigger size analysis comparison for.
+        :pparam string base_artifact_id: the ID of the base preprod artifact to trigger size analysis comparison for.
+        :auth: required
+        """
+
+        analytics.record(
+            PreprodArtifactApiSizeAnalysisCompareRunGetEvent(
+                organization_id=project.organization_id,
+                project_id=project.id,
+                user_id=request.user.id,
+                head_artifact_id=head_artifact_id,
+                base_artifact_id=base_artifact_id,
+            )
+        )
+
+        if not features.has(
+            "organizations:preprod-frontend-routes", project.organization, actor=request.user
+        ):
+            return Response({"error": "Feature not enabled"}, status=403)
+
+        logger.info(
+            "preprod.size_analysis.compare.api.run.get",
+            extra={"head_artifact_id": head_artifact_id, "base_artifact_id": base_artifact_id},
+        )
+
+        if head_artifact.build_configuration != base_artifact.build_configuration:
+            return Response(
+                {"error": "Head and base build configurations must be the same."}, status=400
+            )
+
+        head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
+            preprod_artifact_id__in=[head_artifact.id],
+            preprod_artifact__project=project,
+        ).select_related("preprod_artifact")
+
+        if head_size_metrics_qs.count() == 0:
+            return Response(
+                {"detail": f"Head PreprodArtifact with id {head_artifact_id} has no size metrics."},
+                status=404,
+            )
+
+        # Check if any of the size metrics are not completed
+        if (
+            head_size_metrics_qs.filter(
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
+            ).count()
+            == 0
+        ):
+            body = SizeAnalysisCompareRunGETResponse(
+                status="processing",
+                message=f"Head PreprodArtifact with id {head_artifact_id} has no completed size metrics yet. Size analysis may still be processing. Please try again later.",
+            )
+            return Response(
+                body.dict(),
+                status=202,  # Accepted, processing not complete
+            )
+
+        base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
+            preprod_artifact_id__in=[base_artifact.id],
+            preprod_artifact__project=project,
+        ).select_related("preprod_artifact")
+        if base_size_metrics_qs.count() == 0:
+            return Response(
+                {"detail": f"Base PreprodArtifact with id {base_artifact_id} has no size metrics."},
+                status=404,
+            )
+
+        if (
+            base_size_metrics_qs.filter(
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
+            ).count()
+            == 0
+        ):
+            body = SizeAnalysisCompareRunGETResponse(
+                status="processing",
+                message=f"Base PreprodArtifact with id {base_artifact_id} has no completed size metrics yet. Size analysis may still be processing. Please try again later.",
+            )
+            return Response(
+                body.dict(),
+                status=202,  # Accepted, processing not complete
+            )
+
+        head_size_metrics = list(head_size_metrics_qs)
+        base_size_metrics = list(base_size_metrics_qs)
+
+        # Check if the size metrics can be compared
+        if not can_compare_size_metrics(head_size_metrics, base_size_metrics):
+            return Response(
+                {"detail": "Head and base size metrics cannot be compared."},
+                status=400,
+            )
+
+        existing_comparisons = PreprodArtifactSizeComparison.objects.filter(
+            head_size_analysis__in=head_size_metrics,
+            base_size_analysis__in=base_size_metrics,
+        )
+        if existing_comparisons.exists():
+            # Build SizeAnalysisComparison models for each existing comparison
+            comparison_models = []
+            for comparison in existing_comparisons:
+                comparison_models.append(
+                    SizeAnalysisComparison(
+                        head_size_metric_id=comparison.head_size_analysis.id,
+                        base_size_metric_id=comparison.base_size_analysis.id,
+                        metrics_artifact_type=comparison.head_size_analysis.metrics_artifact_type,
+                        identifier=comparison.head_size_analysis.identifier,
+                        state=comparison.state,
+                        comparison_id=(
+                            comparison.id
+                            if comparison.state == PreprodArtifactSizeComparison.State.SUCCESS
+                            else None
+                        ),
+                        error_code=(
+                            str(comparison.error_code)
+                            if comparison.state == PreprodArtifactSizeComparison.State.FAILED
+                            and comparison.error_code is not None
+                            else None
+                        ),
+                        error_message=(
+                            comparison.error_message
+                            if comparison.state == PreprodArtifactSizeComparison.State.FAILED
+                            else None
+                        ),
+                    )
+                )
+            body = SizeAnalysisCompareRunGETResponse(
+                status="exists",
+                message="A comparison already exists for the head and base size metrics.",
+                existing_comparisons=comparison_models,
+            )
+            return Response(body.dict(), status=200)
+
+        logger.info(
+            "preprod.size_analysis.compare.api.run.get.running_comparison",
+            extra={"head_artifact_id": head_artifact.id, "base_artifact_id": base_artifact.id},
+        )
+
+        manual_size_analysis_comparison.apply_async(
+            kwargs={
+                "project_id": project.id,
+                "org_id": project.organization_id,
+                "head_artifact_id": head_artifact.id,
+                "base_artifact_id": base_artifact.id,
+            }
+        )
+
+        logger.info(
+            "preprod.size_analysis.compare.api.run.get.success",
+            extra={"head_artifact_id": head_artifact_id, "base_artifact_id": base_artifact_id},
+        )
+        return Response(status=200)

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -6,6 +6,9 @@ from sentry.preprod.api.endpoints.size_analysis.project_preprod_size_analysis_co
 from sentry.preprod.api.endpoints.size_analysis.project_preprod_size_analysis_compare_download import (
     ProjectPreprodArtifactSizeAnalysisCompareDownloadEndpoint,
 )
+from sentry.preprod.api.endpoints.size_analysis.project_preprod_size_analysis_compare_run import (
+    ProjectPreprodArtifactSizeAnalysisCompareRunEndpoint,
+)
 from sentry.preprod.api.endpoints.size_analysis.project_preprod_size_analysis_download import (
     ProjectPreprodArtifactSizeAnalysisDownloadEndpoint,
 )
@@ -82,6 +85,11 @@ preprod_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/size-analysis/compare/(?P<head_artifact_id>[^/]+)/(?P<base_artifact_id>[^/]+)/$",
         ProjectPreprodArtifactSizeAnalysisCompareEndpoint.as_view(),
         name="sentry-api-0-project-preprod-artifact-size-analysis-compare",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/size-analysis/compare/(?P<head_artifact_id>[^/]+)/(?P<base_artifact_id>[^/]+)/run/$",
+        ProjectPreprodArtifactSizeAnalysisCompareRunEndpoint.as_view(),
+        name="sentry-api-0-project-preprod-artifact-size-analysis-compare-run",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/size-analysis/compare/(?P<head_size_metric_id>[^/]+)/(?P<base_size_metric_id>[^/]+)/download/$",

--- a/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
+++ b/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
@@ -30,3 +30,9 @@ class SizeAnalysisComparePOSTResponse(BaseModel):
     status: str
     message: str
     existing_comparisons: list[SizeAnalysisComparison] | None
+
+
+class SizeAnalysisCompareRunGETResponse(BaseModel):
+    status: str
+    message: str
+    existing_comparisons: list[SizeAnalysisComparison] | None

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare_run.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare_run.py
@@ -1,0 +1,343 @@
+from unittest.mock import patch
+
+from django.test import override_settings
+from django.urls import reverse
+
+from sentry.models.files.file import File
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactSizeComparison,
+    PreprodArtifactSizeMetrics,
+    PreprodBuildConfiguration,
+)
+from sentry.testutils.cases import APITestCase
+
+
+class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
+    endpoint = "sentry-api-0-project-preprod-artifact-size-analysis-compare-run"
+    method = "get"
+
+    def setUp(self):
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+        self.login_as(user=self.user)
+
+        # Create test files
+        self.head_file = File.objects.create(
+            name="head_artifact.apk", type="application/octet-stream"
+        )
+        self.base_file = File.objects.create(
+            name="base_artifact.apk", type="application/octet-stream"
+        )
+        self.head_analysis_file = File.objects.create(
+            name="head_analysis.json", type="application/json"
+        )
+        self.base_analysis_file = File.objects.create(
+            name="base_analysis.json", type="application/json"
+        )
+
+        # Create head artifact
+        self.head_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            file_id=self.head_file.id,
+            app_name="TestApp",
+            app_id="com.test.app",
+            build_version="2.0.0",
+            build_number=2,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        # Create base artifact
+        self.base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            file_id=self.base_file.id,
+            app_name="TestApp",
+            app_id="com.test.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        # Create size metrics for head artifact
+        self.head_size_metric = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.head_artifact,
+            analysis_file_id=self.head_analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="main",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=1000,
+            max_download_size=500,
+        )
+
+        # Create size metrics for base artifact
+        self.base_size_metric = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.base_artifact,
+            analysis_file_id=self.base_analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="main",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=1000,
+            max_download_size=500,
+        )
+
+    def _get_url(self, head_artifact_id=None, base_artifact_id=None):
+        head_artifact_id = head_artifact_id or self.head_artifact.id
+        base_artifact_id = base_artifact_id or self.base_artifact.id
+        return reverse(
+            "sentry-api-0-project-preprod-artifact-size-analysis-compare-run",
+            args=[self.organization.slug, self.project.slug, head_artifact_id, base_artifact_id],
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    @patch("sentry.preprod.size_analysis.tasks.manual_size_analysis_comparison.apply_async")
+    def test_get_comparison_run_success(self, mock_apply_async):
+        """Test GET endpoint successfully triggers comparison"""
+        self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            self.base_artifact.id,
+            method="get",
+        )
+        mock_apply_async.assert_called_once_with(
+            kwargs={
+                "project_id": self.project.id,
+                "org_id": self.organization.id,
+                "head_artifact_id": self.head_artifact.id,
+                "base_artifact_id": self.base_artifact.id,
+            }
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_run_head_artifact_not_found(self):
+        """Test GET endpoint returns 404 when head artifact doesn't exist"""
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            999999,
+            self.base_artifact.id,
+            method="get",
+            status_code=404,
+        )
+        assert "The requested head preprod artifact does not exist" in response.data["detail"]
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_run_base_artifact_not_found(self):
+        """Test GET endpoint returns 404 when base artifact doesn't exist"""
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            999999,
+            method="get",
+            status_code=404,
+        )
+        assert "The requested base preprod artifact does not exist" in response.data["detail"]
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_run_head_artifact_no_size_metrics(self):
+        """Test GET endpoint returns 404 when head artifact has no size metrics"""
+        artifact_no_metrics = PreprodArtifact.objects.create(
+            project=self.project,
+            app_name="NoMetricsApp",
+            app_id="com.nometrics.app",
+            build_version="1.0.0",
+            build_number=1,
+        )
+
+        response = self.client.get(self._get_url(head_artifact_id=artifact_no_metrics.id))
+
+        assert response.status_code == 404
+        assert (
+            f"Head PreprodArtifact with id {artifact_no_metrics.id} has no size metrics"
+            in response.json()["detail"]
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_run_base_artifact_no_size_metrics(self):
+        """Test GET endpoint returns 404 when base artifact has no size metrics"""
+        artifact_no_metrics = PreprodArtifact.objects.create(
+            project=self.project,
+            app_name="NoMetricsApp",
+            app_id="com.nometrics.app",
+            build_version="1.0.0",
+            build_number=1,
+        )
+
+        response = self.client.get(self._get_url(base_artifact_id=artifact_no_metrics.id))
+
+        assert response.status_code == 404
+        assert (
+            f"Base PreprodArtifact with id {artifact_no_metrics.id} has no size metrics"
+            in response.json()["detail"]
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_run_head_artifact_processing(self):
+        """Test GET endpoint returns 202 when head artifact size metrics are still processing"""
+        # Set head size metric to processing state
+        self.head_size_metric.state = PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
+        self.head_size_metric.save()
+
+        response = self.client.get(self._get_url())
+
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "processing"
+        assert (
+            f"Head PreprodArtifact with id {self.head_artifact.id} has no completed size metrics yet"
+            in data["message"]
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_run_base_artifact_processing(self):
+        """Test GET endpoint returns 202 when base artifact size metrics are still processing"""
+        # Set base size metric to processing state
+        self.base_size_metric.state = PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
+        self.base_size_metric.save()
+
+        response = self.client.get(self._get_url())
+
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "processing"
+        assert (
+            f"Base PreprodArtifact with id {self.base_artifact.id} has no completed size metrics yet"
+            in data["message"]
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_run_existing_comparison(self):
+        """Test GET endpoint returns existing comparison when comparison already exists"""
+        # Create an existing comparison
+        comparison = PreprodArtifactSizeComparison.objects.create(
+            head_size_analysis=self.head_size_metric,
+            base_size_analysis=self.base_size_metric,
+            organization_id=self.organization.id,
+            state=PreprodArtifactSizeComparison.State.SUCCESS,
+            file_id=12345,
+        )
+
+        response = self.client.get(self._get_url())
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "exists"
+        assert "A comparison already exists for the head and base size metrics" in data["message"]
+        assert len(data["existing_comparisons"]) == 1
+        assert data["existing_comparisons"][0]["comparison_id"] == comparison.id
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_run_existing_failed_comparison(self):
+        """Test GET endpoint returns existing failed comparison when comparison exists and failed"""
+        # Create a failed comparison
+        comparison = PreprodArtifactSizeComparison.objects.create(
+            head_size_analysis=self.head_size_metric,
+            base_size_analysis=self.base_size_metric,
+            organization_id=self.organization.id,
+            state=PreprodArtifactSizeComparison.State.FAILED,
+            error_code=PreprodArtifactSizeComparison.ErrorCode.UNKNOWN,
+            error_message="Processing failed",
+        )
+
+        response = self.client.get(self._get_url())
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "exists"
+        assert len(data["existing_comparisons"]) == 1
+        comparison_data = data["existing_comparisons"][0]
+        assert comparison_data["state"] == comparison.state
+        assert comparison_data["error_code"] == str(comparison.error_code)
+        assert comparison_data["error_message"] == comparison.error_message
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_run_cannot_compare_size_metrics(self):
+        """Test GET endpoint returns 400 when size metrics cannot be compared"""
+        # Create additional head metric to make the lists different lengths
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.head_artifact,
+            analysis_file_id=self.head_analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+        # Don't create a matching base metric, so lengths will be different
+
+        response = self.client.get(self._get_url())
+
+        assert response.status_code == 400
+        assert "Head and base size metrics cannot be compared" in response.json()["detail"]
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    @patch("sentry.preprod.size_analysis.tasks.manual_size_analysis_comparison.apply_async")
+    def test_get_comparison_run_multiple_metrics(self, mock_apply_async):
+        """Test GET endpoint handles multiple size metrics correctly"""
+        # Create additional size metrics
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.head_artifact,
+            analysis_file_id=self.head_analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.base_artifact,
+            analysis_file_id=self.base_analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        response = self.client.get(self._get_url())
+
+        assert response.status_code == 200
+
+        mock_apply_async.assert_called_once_with(
+            kwargs={
+                "project_id": self.project.id,
+                "org_id": self.organization.id,
+                "head_artifact_id": self.head_artifact.id,
+                "base_artifact_id": self.base_artifact.id,
+            }
+        )
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_run_no_matching_base_metric(self):
+        """Test GET endpoint returns 400 when head and base metrics cannot be compared"""
+        # Create head metric with different identifier that won't match base
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.head_artifact,
+            analysis_file_id=self.head_analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        response = self.client.get(self._get_url())
+
+        assert response.status_code == 400
+        assert "Head and base size metrics cannot be compared" in response.json()["detail"]
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_get_comparison_run_different_build_configurations(self):
+        """Test GET endpoint returns 400 when artifacts have different build configurations"""
+        # Create a build configuration for the base artifact
+        debug_config = PreprodBuildConfiguration.objects.create(project=self.project, name="debug")
+
+        # Update base artifact to have different build configuration
+        self.base_artifact.build_configuration = debug_config
+        self.base_artifact.save()
+
+        # Head artifact will have None/default, base will have debug config
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            self.head_artifact.id,
+            self.base_artifact.id,
+            method="get",
+            status_code=400,
+        )
+        assert response.data["error"] == "Head and base build configurations must be the same."


### PR DESCRIPTION
Adds new GET comparison run endpoint (same functionality as existing POST comparison trigger). This is intentionally added as a GET to work around project write permission needed for PUT/POST requests implemented by `ProjectEndpoint`. Users should not need write permission to trigger comparisons, so this is the simplest workaround.