### PR TITLE
fix(replay): fix useEffect to start initial timeouts

### DIFF
--- a/static/app/utils/useTimeout.spec.tsx
+++ b/static/app/utils/useTimeout.spec.tsx
@@ -77,7 +77,7 @@ describe('useTimeout', () => {
     expect(result.current.start).not.toBe(firstRender.start);
   });
 
-  it('should return a new start() and end() method when onTimeout changes', () => {
+  it('should not return a new start() and end() method when onTimeout changes', () => {
     const {result, rerender} = renderHook(useTimeout, {
       initialProps: {timeMs, onTimeout},
     });
@@ -88,8 +88,8 @@ describe('useTimeout', () => {
 
     expect(result.current.cancel).toBe(firstRender.cancel);
 
-    expect(result.current.start).not.toBe(firstRender.start);
-    expect(result.current.end).not.toBe(firstRender.end);
+    expect(result.current.start).toBe(firstRender.start);
+    expect(result.current.end).toBe(firstRender.end);
   });
 
   it('should not exec the callback after unmount', () => {

--- a/static/app/utils/useTimeout.tsx
+++ b/static/app/utils/useTimeout.tsx
@@ -8,6 +8,12 @@ interface Options {
 export default function useTimeout({timeMs, onTimeout}: Options) {
   const timeoutRef = useRef<number | null>(null);
 
+  // Using a ref to stabilize the callbacks.
+  const onTimeoutRef = useRef(onTimeout);
+  useEffect(() => {
+    onTimeoutRef.current = onTimeout;
+  });
+
   const saveTimeout = useCallback((timeout: number | null) => {
     if (timeoutRef.current) {
       window.clearTimeout(timeoutRef.current);
@@ -17,8 +23,8 @@ export default function useTimeout({timeMs, onTimeout}: Options) {
 
   const start = useCallback(() => {
     saveTimeout(null);
-    saveTimeout(window.setTimeout(onTimeout, timeMs));
-  }, [onTimeout, saveTimeout, timeMs]);
+    saveTimeout(window.setTimeout(() => onTimeoutRef.current(), timeMs));
+  }, [saveTimeout, timeMs]);
 
   const cancel = useCallback(() => {
     saveTimeout(null);
@@ -26,8 +32,8 @@ export default function useTimeout({timeMs, onTimeout}: Options) {
 
   const end = useCallback(() => {
     saveTimeout(null);
-    onTimeout();
-  }, [onTimeout, saveTimeout]);
+    onTimeoutRef.current();
+  }, [saveTimeout]);
 
   // Cancel the timeout on unmount
   useEffect(() => cancel, [cancel]);

--- a/static/app/views/replays/detail/ai/useReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useReplaySummary.tsx
@@ -109,7 +109,7 @@ export function useReplaySummary(
   });
 
   // Start initial timeouts in case auto-start request is not made.
-  // The callbacks are stable so this should only run on mount.
+  // Should only run on mount. startSummaryRequest will cancel and restart the timeouts.
   useEffect(() => {
     startStartTimeout();
     startTotalTimeout();
@@ -118,7 +118,8 @@ export function useReplaySummary(
       cancelTotalTimeout();
       cancelStartTimeout();
     };
-  }, [startStartTimeout, startTotalTimeout, cancelStartTimeout, cancelTotalTimeout]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const {
     mutate: startSummaryRequestMutate,

--- a/static/app/views/replays/detail/ai/useReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useReplaySummary.tsx
@@ -108,8 +108,8 @@ export function useReplaySummary(
     },
   });
 
-  // Start initial timeouts in case auto-start request is not made.
-  // Should only run on mount. startSummaryRequest will cancel and restart the timeouts.
+  // Start initial timeouts in case auto-start request is not made. startSummaryRequest will cancel and restart them.
+  // Should only run on mount since the callbacks are stable.
   useEffect(() => {
     startStartTimeout();
     startTotalTimeout();
@@ -118,8 +118,7 @@ export function useReplaySummary(
       cancelTotalTimeout();
       cancelStartTimeout();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [startStartTimeout, startTotalTimeout, cancelTotalTimeout, cancelStartTimeout]);
 
   const {
     mutate: startSummaryRequestMutate,


### PR DESCRIPTION
The callbacks weren't stable like we expected so the timeouts are getting restarted even when data is available. This causes timeouts after the summary's already loaded

Stabilizes them using a ref for `onTimeout`