### PR TITLE
ref(grouping): Check `date_updated` to see if metadata needs refresh

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -216,7 +216,9 @@ def create_or_update_grouphash_metadata_if_needed(
             updated_data.update(
                 get_grouphash_metadata_data(event, project, variants, grouping_config_id)
             )
-            db_hit_metadata.update({"reason": "stale"})
+            db_hit_metadata.update(
+                {"reason": ("stale" if not db_hit_metadata.get("reason") else "stale_and_schema")}
+            )
 
         # Only hit the DB if there's something to change
         if updated_data:

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -209,7 +209,10 @@ def create_or_update_grouphash_metadata_if_needed(
             )
 
         # If metadata is older than 90 days, update the event id
-        if grouphash.metadata.date_updated < timezone.now() - timedelta(days=90):
+        if (
+            not grouphash.metadata.date_updated
+            or grouphash.metadata.date_updated < timezone.now() - timedelta(days=90)
+        ):
             updated_data["event_id"] = event.event_id
 
         # Only hit the DB if there's something to change

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -8,7 +8,7 @@ the `GroupHash` model file, so that existing records will get updated with the n
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, TypeIs, cast
 
 from django.utils import timezone
@@ -207,6 +207,10 @@ def create_or_update_grouphash_metadata_if_needed(
                     "new_version": GROUPHASH_METADATA_SCHEMA_VERSION,
                 }
             )
+
+        # If metadata is older than 90 days, update the event id
+        if grouphash.metadata.date_updated < timezone.now() - timedelta(days=90):
+            updated_data["event_id"] = event.event_id
 
         # Only hit the DB if there's something to change
         if updated_data:

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -217,7 +217,7 @@ def create_or_update_grouphash_metadata_if_needed(
                 get_grouphash_metadata_data(event, project, variants, grouping_config_id)
             )
             db_hit_metadata.update(
-                {"reason": ("stale" if not db_hit_metadata.get("reason") else "stale_and_schema")}
+                {"reason": ("stale" if not db_hit_metadata.get("reason") else "stale_and_config")}
             )
 
         # Only hit the DB if there's something to change

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -209,7 +209,10 @@ def create_or_update_grouphash_metadata_if_needed(
             )
         # If the metadata is more than 90 days old, the event upon which it's based will have aged
         # out, so refresh the data with this new event
-        elif grouphash.metadata.date_updated < timezone.now() - timedelta(days=90):
+        elif (
+            grouphash.metadata.date_updated
+            and grouphash.metadata.date_updated < timezone.now() - timedelta(days=90)
+        ):
             updated_data.update(
                 get_grouphash_metadata_data(event, project, variants, grouping_config_id)
             )

--- a/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
@@ -395,10 +395,7 @@ class GroupHashMetadataTest(TestCase):
             project=self.project, hash=event1.get_primary_hash()
         ).first()
         assert grouphash and grouphash.metadata
-
-        # Set the date_updated to be new
-        now = timezone.now()
-        grouphash.metadata.update(date_updated=now, event_id="old_event_id")
+        current_date_updated = grouphash.metadata.date_updated
 
         # Create a new event with the same hash
         event2 = save_new_event({"message": "Dogs are great!"}, self.project)

--- a/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
@@ -382,6 +382,7 @@ class GroupHashMetadataTest(TestCase):
         # Verify that the event_id was updated to the new event's ID
         assert grouphash.metadata.event_id == event2.event_id
         # Verify that date_updated was also updated
+        assert grouphash.metadata.date_updated is not None
         assert grouphash.metadata.date_updated > old_date
 
     def test_no_updates_event_id_when_date_updated_newer_than_90_days(self) -> None:
@@ -407,7 +408,8 @@ class GroupHashMetadataTest(TestCase):
         # Refresh the grouphash to get updated metadata
         grouphash.refresh_from_db()
 
-        # Verify that the event_id was updated to the new event's ID
-        assert grouphash.metadata.event_id == event2.event_id
+        # Verify that the event_id was NOT updated (should still be old_event_id)
+        assert grouphash.metadata.event_id == "old_event_id"
         # Verify that date_updated was also updated
+        assert grouphash.metadata.date_updated is not None
         assert grouphash.metadata.date_updated == now

--- a/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
@@ -384,7 +384,7 @@ class GroupHashMetadataTest(TestCase):
         # Verify that date_updated was also updated
         assert grouphash.metadata.date_updated and grouphash.metadata.date_updated > old_date
 
-    def test_no_updates_event_id_when_date_updated_newer_than_90_days(self) -> None:
+    def test_does_not_update_event_id_when_date_updated_newer_than_90_days(self) -> None:
         """Test that event_id is not updated when date_updated is newwer than 90 days."""
 
         from django.utils import timezone

--- a/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
@@ -382,8 +382,7 @@ class GroupHashMetadataTest(TestCase):
         # Verify that the event_id was updated to the new event's ID
         assert grouphash.metadata.event_id == event2.event_id
         # Verify that date_updated was also updated
-        assert grouphash.metadata.date_updated is not None
-        assert grouphash.metadata.date_updated > old_date
+        assert grouphash.metadata.date_updated and grouphash.metadata.date_updated > old_date
 
     def test_no_updates_event_id_when_date_updated_newer_than_90_days(self) -> None:
         """Test that event_id is not updated when date_updated is newwer than 90 days."""

--- a/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
@@ -407,8 +407,6 @@ class GroupHashMetadataTest(TestCase):
         # Refresh the grouphash to get updated metadata
         grouphash.refresh_from_db()
 
-        # Verify that the event_id was NOT updated (should still be old_event_id)
-        assert grouphash.metadata.event_id == "old_event_id"
-        # Verify that date_updated was also updated
-        assert grouphash.metadata.date_updated is not None
-        assert grouphash.metadata.date_updated == now
+        # Verify that neither the event_id or the update timestamp were changed
+        assert grouphash.metadata.event_id == event1.event_id
+        assert grouphash.metadata.date_updated == current_date_updated

--- a/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
@@ -370,7 +370,7 @@ class GroupHashMetadataTest(TestCase):
 
         # Set the date_updated to be older than 90 days
         old_date = timezone.now() - timedelta(days=91)
-        grouphash.metadata.update(date_updated=old_date, event_id="old_event_id")
+        grouphash.metadata.update(date_updated=old_date)
 
         # Create a new event with the same hash
         event2 = save_new_event({"message": "Dogs are great!"}, self.project)

--- a/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from time import time
 from typing import Any
 from unittest.mock import ANY, MagicMock, patch
+
+from django.utils import timezone
 
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.grouping.ingest.grouphash_metadata import create_or_update_grouphash_metadata_if_needed
@@ -357,9 +360,6 @@ class GroupHashMetadataTest(TestCase):
 
     def test_updates_event_id_when_date_updated_older_than_90_days(self) -> None:
         """Test that event_id is updated when date_updated is older than 90 days."""
-        from datetime import timedelta
-
-        from django.utils import timezone
 
         # Create an event and grouphash with metadata
         event1 = save_new_event({"message": "Dogs are great!"}, self.project)
@@ -386,8 +386,6 @@ class GroupHashMetadataTest(TestCase):
 
     def test_does_not_update_event_id_when_date_updated_newer_than_90_days(self) -> None:
         """Test that event_id is not updated when date_updated is newwer than 90 days."""
-
-        from django.utils import timezone
 
         # Create an event and grouphash with metadata
         event1 = save_new_event({"message": "Dogs are great!"}, self.project)


### PR DESCRIPTION
As of #100519, added `event_id` to grouphash metadata. If an event is older than 90 days it is deleted. Add check to see when the metadata was updated last, and update it if it has been longer than 90 days. 