### PR TITLE
feat(uptime): Use SimpleTable for the uptime checks in uptime monitor page

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -348,6 +348,9 @@ function CheckInBodyCell({
       );
     }
     default:
+      if (check[column] === undefined) {
+        return <Cell />;
+      }
       return <Cell>{check[column]}</Cell>;
   }
 }

--- a/static/app/views/alerts/rules/uptime/uptimeChecksTable.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksTable.tsx
@@ -52,11 +52,11 @@ export function UptimeChecksTable({
 
   return (
     <Fragment>
-      {isPending ? (
-        <LoadingIndicator />
-      ) : (
-        <UptimeChecksGrid traceSampling={traceSampling} uptimeChecks={uptimeChecks} />
-      )}
+      <UptimeChecksGrid
+        traceSampling={traceSampling}
+        uptimeChecks={uptimeChecks}
+        isPending={isPending}
+      />
       <Pagination pageLinks={getResponseHeader?.('Link')} />
     </Fragment>
   );

--- a/static/app/views/alerts/rules/uptime/uptimeChecksTable.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksTable.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 
 import LoadingError from 'sentry/components/loadingError';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
 import {decodeScalar} from 'sentry/utils/queryString';

--- a/static/app/views/issueDetails/groupUptimeChecks.spec.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.spec.tsx
@@ -74,7 +74,7 @@ describe('GroupUptimeChecks', () => {
     });
     expect(await screen.findByText('All Uptime Checks')).toBeInTheDocument();
     for (const column of ['Timestamp', 'Status', 'Duration', 'Trace', 'Region']) {
-      expect(screen.getByText(column)).toBeInTheDocument();
+      expect(await screen.findByText(column)).toBeInTheDocument();
     }
     expect(screen.getByText('No matching uptime checks found')).toBeInTheDocument();
   });
@@ -101,7 +101,9 @@ describe('GroupUptimeChecks', () => {
     });
     expect(await screen.findByText('All Uptime Checks')).toBeInTheDocument();
     expect(screen.queryByText('No matching uptime checks found')).not.toBeInTheDocument();
-    expect(screen.getByText('Showing 1-1 matching uptime checks')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Showing 1-1 matching uptime checks')
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Previous Page'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Next Page'})).toBeInTheDocument();
 

--- a/static/app/views/issueDetails/groupUptimeChecks.tsx
+++ b/static/app/views/issueDetails/groupUptimeChecks.tsx
@@ -1,6 +1,5 @@
 import {usePageFilterDates} from 'sentry/components/checkInTimeline/hooks/useMonitorDates';
 import LoadingError from 'sentry/components/loadingError';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
@@ -53,14 +52,12 @@ export default function GroupUptimeChecks() {
     return <LoadingError onRetry={refetchGroup} />;
   }
 
-  if (isGroupPending || uptimeChecks === undefined || uptimeDetector === undefined) {
-    return <LoadingIndicator />;
-  }
-
+  const isPending =
+    isGroupPending || uptimeChecks === undefined || uptimeDetector === undefined;
   const links = parseLinkHeader(getResponseHeader?.('Link') ?? '');
   const previousDisabled = links?.previous?.results === false;
   const nextDisabled = links?.next?.results === false;
-  const pageCount = uptimeChecks.length;
+  const pageCount = uptimeChecks?.length ?? 0;
 
   return (
     <EventListTable
@@ -74,8 +71,10 @@ export default function GroupUptimeChecks() {
       }}
     >
       <UptimeChecksGrid
-        traceSampling={uptimeDetector.dataSources[0].queryObj.traceSampling}
+        traceSampling={uptimeDetector?.dataSources[0].queryObj.traceSampling ?? false}
+        isPending={isPending}
         uptimeChecks={uptimeChecks}
+        resizable
       />
     </EventListTable>
   );


### PR DESCRIPTION
The uptime checks table was using GridEditable, which does not match the rest of the new monitor UI. Refactored to use SimpleTable and added container queries to handle responsive column hiding.

This component was being used in issue details which requires the resizable columns, so I kept that under the option `resizable`.

Before:

<img width="760" height="709" alt="CleanShot 2025-10-01 at 11 51 49" src="https://github.com/user-attachments/assets/040e1496-2be6-4230-8995-024f8f3bf5a4" />

After:

<img width="757" height="606" alt="CleanShot 2025-10-01 at 11 51 21" src="https://github.com/user-attachments/assets/008c9058-7de7-4fcf-a9ef-48c987997a55" />
