### PR TITLE
fix(aci): conditionally show trigger logic type selector on automation edit

### DIFF
--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -30,7 +30,7 @@ import {useSendTestNotification} from 'sentry/views/automations/hooks';
 import {findConflictingConditions} from 'sentry/views/automations/hooks/utils';
 
 export default function AutomationBuilder() {
-  const {state, actions} = useAutomationBuilderContext();
+  const {state, actions, showTriggerLogicTypeSelector} = useAutomationBuilderContext();
   const {mutationErrors} = useAutomationBuilderErrorContext();
   const organization = useOrganization();
   const api = useApi();
@@ -49,10 +49,9 @@ export default function AutomationBuilder() {
       <Flex direction="column" gap="md">
         <Step>
           <StepLead>
-            {/* TODO: Only make this a selector of "all" is originally selected */}
             {tct('[when:When] [selector] of the following occur', {
               when: <ConditionBadge />,
-              selector: (
+              selector: showTriggerLogicTypeSelector ? (
                 <EmbeddedWrapper>
                   <EmbeddedSelectField
                     styles={{
@@ -76,6 +75,8 @@ export default function AutomationBuilder() {
                     size="xs"
                   />
                 </EmbeddedWrapper>
+              ) : (
+                t('any')
               ),
             })}
           </StepLead>

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -169,6 +169,7 @@ interface AutomationActions {
 
 export const AutomationBuilderContext = createContext<{
   actions: AutomationActions;
+  // Selector is only shown for existing automations with the "All" logic type
   showTriggerLogicTypeSelector: boolean;
   state: AutomationBuilderState;
 } | null>(null);

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -169,6 +169,7 @@ interface AutomationActions {
 
 export const AutomationBuilderContext = createContext<{
   actions: AutomationActions;
+  showTriggerLogicTypeSelector: boolean;
   state: AutomationBuilderState;
 } | null>(null);
 

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -15,6 +15,7 @@ import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import type {Automation, NewAutomation} from 'sentry/types/workflowEngine/automations';
+import {DataConditionGroupLogicType} from 'sentry/types/workflowEngine/dataConditions';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -176,7 +177,14 @@ function AutomationEditForm({automation}: {automation: Automation}) {
                 mutationErrors: error?.responseJSON,
               }}
             >
-              <AutomationBuilderContext.Provider value={{state, actions}}>
+              <AutomationBuilderContext.Provider
+                value={{
+                  state,
+                  actions,
+                  showTriggerLogicTypeSelector:
+                    state.triggers.logicType === DataConditionGroupLogicType.ALL,
+                }}
+              >
                 <AutomationForm model={model} />
               </AutomationBuilderContext.Provider>
             </AutomationBuilderErrorContext.Provider>

--- a/static/app/views/automations/new-settings.tsx
+++ b/static/app/views/automations/new-settings.tsx
@@ -142,7 +142,13 @@ export default function AutomationNewSettings() {
                 mutationErrors: error?.responseJSON,
               }}
             >
-              <AutomationBuilderContext.Provider value={{state, actions}}>
+              <AutomationBuilderContext.Provider
+                value={{
+                  state,
+                  actions,
+                  showTriggerLogicTypeSelector: false,
+                }}
+              >
                 <AutomationForm model={model} />
               </AutomationBuilderContext.Provider>
             </AutomationBuilderErrorContext.Provider>


### PR DESCRIPTION
since we've changed the trigger condition options, all of the new conditions conflict when using the "all" logic type, and only the "any" logic type can be used

<img width="402" height="206" alt="Google Keep Note" src="https://github.com/user-attachments/assets/067b69f3-1834-4f21-8f13-514e04b648f9" />

therefore, we only want the "all" logic type to be available if the automation has already selected it previously (this is only possible if it was migrated from an issue alert rule)

when creating a new automation or editing an existing automation that has the "any" logic type:

<img width="303" height="124" alt="Screenshot 2025-10-01 at 11 51 43 AM" src="https://github.com/user-attachments/assets/2d69e426-212f-4c02-b582-e97a50b6aa9e" />

when editing an existing automation that has the "all" logic type:
<img width="348" height="179" alt="Screenshot 2025-10-01 at 11 52 22 AM" src="https://github.com/user-attachments/assets/4018b898-c43b-4e2c-afbc-88be151cf964" />
