### PR TITLE
fix(replay): loosen date condition for cancelling start timeout

### DIFF
--- a/static/app/views/replays/detail/ai/useReplaySummary.tsx
+++ b/static/app/views/replays/detail/ai/useReplaySummary.tsx
@@ -223,8 +223,10 @@ export function useReplaySummary(
       summaryData &&
       summaryData.status !== ReplaySummaryStatus.NOT_STARTED &&
       (!summaryData.created_at || // note created_at should exist for started statuses
-        new Date(summaryData.created_at).getTime() > startSummaryRequestTime.current)
+        new Date(summaryData.created_at).getTime() >
+          startSummaryRequestTime.current - TOTAL_TIMEOUT_MS)
     ) {
+      // Date condition is loose because a previously started task may be in-progress.
       cancelStartTimeout();
     }
   }, [cancelStartTimeout, summaryData]);


### PR DESCRIPTION
`created_at` is the last time the task status was updated in the DB. The backend is built so new tasks won't overwrite an in-progress one, so we need to loosen this.

Impact: prevents some summaries from timing out when they shouldn't be (task is in progress)