### PR TITLE
feat(crons): Add a button to see setup docs

### DIFF
--- a/static/app/views/insights/crons/components/detailsSidebar.tsx
+++ b/static/app/views/insights/crons/components/detailsSidebar.tsx
@@ -4,8 +4,11 @@ import styled from '@emotion/styled';
 import {SectionHeading} from 'sentry/components/charts/styles';
 import {Alert} from 'sentry/components/core/alert';
 import {ActorAvatar} from 'sentry/components/core/avatar/actorAvatar';
+import {Button} from 'sentry/components/core/button';
 import {Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
+import useDrawer from 'sentry/components/globalDrawer';
+import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
 import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCopy, IconJson} from 'sentry/icons';
@@ -16,6 +19,8 @@ import {DetailsTimelineLegend} from 'sentry/views/insights/crons/components/deta
 import type {Monitor, MonitorEnvironment} from 'sentry/views/insights/crons/types';
 import {ScheduleType} from 'sentry/views/insights/crons/types';
 import {scheduleAsText} from 'sentry/views/insights/crons/utils/scheduleAsText';
+
+import MonitorQuickStartGuide from './monitorQuickStartGuide';
 
 interface Props {
   monitor: Monitor;
@@ -29,6 +34,9 @@ interface Props {
 export function DetailsSidebar({monitorEnv, monitor, showUnknownLegend}: Props) {
   const {checkin_margin, schedule, schedule_type, max_runtime, timezone} = monitor.config;
   const {onClick, label} = useCopyToClipboard({text: monitor.slug});
+  const openDocsPanel = useDocsPanel(monitor);
+
+  const hasCheckIns = monitor.environments.some(e => e.lastCheckIn);
 
   const slug = (
     <Tooltip title={label}>
@@ -128,8 +136,33 @@ export function DetailsSidebar({monitorEnv, monitor, showUnknownLegend}: Props) 
           </Alert>
         </Alert.Container>
       )}
+      {hasCheckIns && (
+        <Button size="xs" onClick={openDocsPanel}>
+          {t('Show Setup Docs')}
+        </Button>
+      )}
     </Fragment>
   );
+}
+
+function useDocsPanel(monitor: Monitor) {
+  const {openDrawer} = useDrawer();
+
+  const contents = (
+    <Fragment>
+      <DrawerHeader hideBar />
+      <DrawerBody>
+        <MonitorQuickStartGuide project={monitor.project} monitorSlug={monitor.slug} />
+      </DrawerBody>
+    </Fragment>
+  );
+
+  return () =>
+    openDrawer(() => contents, {
+      ariaLabel: t('See Setup Docs'),
+      drawerKey: 'cron-docs',
+      resizable: true,
+    });
 }
 
 const CheckIns = styled('div')`

--- a/static/app/views/insights/crons/components/monitorQuickStartGuide.tsx
+++ b/static/app/views/insights/crons/components/monitorQuickStartGuide.tsx
@@ -1,10 +1,11 @@
 import {useState} from 'react';
-import styled from '@emotion/styled';
 import partition from 'lodash/partition';
 
 import {CompactSelect} from 'sentry/components/core/compactSelect';
-import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
+import {Flex} from 'sentry/components/core/layout';
+import {ExternalLink} from 'sentry/components/core/link';
+import {Text} from 'sentry/components/core/text';
+import {t, tct} from 'sentry/locale';
 import type {PlatformKey, Project, ProjectKey} from 'sentry/types/project';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -205,12 +206,24 @@ export default function MonitorQuickStartGuide({monitorSlug, project}: Props) {
   const {Guide} = onboardingGuides[selectedGuide]!;
 
   return (
-    <Container>
+    <Flex gap="xl" direction="column">
+      <Text>
+        {tct(
+          'Select an integration method for your monitor. For in-depth instructions on integrating Crons, view [docsLink:our complete documentation].',
+          {
+            docsLink: (
+              <ExternalLink href="https://docs.sentry.io/product/crons/getting-started/" />
+            ),
+          }
+        )}
+      </Text>
       <CompactSelect
+        triggerProps={{prefix: t('Guide')}}
         searchable
         options={exampleOptions}
         value={selectedGuide}
         onChange={({value}) => setSelectedGuide(value)}
+        size="sm"
       />
       <Guide
         slug={monitorSlug}
@@ -220,12 +233,6 @@ export default function MonitorQuickStartGuide({monitorSlug, project}: Props) {
         cronsUrl={projectKeys?.[0]!.dsn.crons}
         dsnKey={projectKeys?.[0]!.dsn.public}
       />
-    </Container>
+    </Flex>
   );
 }
-
-const Container = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(2)};
-`;

--- a/static/app/views/insights/crons/components/onboarding.tsx
+++ b/static/app/views/insights/crons/components/onboarding.tsx
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled';
 
-import {ExternalLink} from 'sentry/components/core/link';
 import OnboardingPanel from 'sentry/components/onboardingPanel';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import pulsingIndicatorStyles from 'sentry/styles/pulsingIndicator';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
@@ -18,16 +17,6 @@ export function MonitorOnboarding({monitorSlug, project}: Props) {
   return (
     <OnboardingPanel noCenter>
       <h3>{t('Instrument your monitor')}</h3>
-      <p>
-        {tct(
-          'Select an integration method for your new monitor. For in-depth instructions on integrating Crons, view [docsLink:our complete documentation].',
-          {
-            docsLink: (
-              <ExternalLink href="https://docs.sentry.io/product/crons/getting-started/" />
-            ),
-          }
-        )}
-      </p>
       <MonitorQuickStartGuide monitorSlug={monitorSlug} project={project} />
       <WaitingNotice>
         <WaitingIndicator />


### PR DESCRIPTION
Fixes [NEW-546: Add ability to see setup snippets for existing cron monitors](https://linear.app/getsentry/issue/NEW-546/add-ability-to-see-setup-snippets-for-existing-cron-monitors)