### PR TITLE
chore(tasks) Remove usage of taskworker_config pt1

### DIFF
--- a/src/sentry/debug_files/tasks.py
+++ b/src/sentry/debug_files/tasks.py
@@ -1,14 +1,10 @@
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import attachments_tasks
 
 
 @instrumented_task(
     name="sentry.debug_files.tasks.refresh_artifact_bundles_in_use",
-    queue="assemble",
-    taskworker_config=TaskworkerConfig(
-        namespace=attachments_tasks,
-    ),
+    namespace=attachments_tasks,
 )
 def refresh_artifact_bundles_in_use() -> None:
     from .artifact_bundles import refresh_artifact_bundles_in_use as do_refresh
@@ -18,10 +14,7 @@ def refresh_artifact_bundles_in_use() -> None:
 
 @instrumented_task(
     name="sentry.debug_files.tasks.backfill_artifact_bundle_db_indexing",
-    queue="assemble",
-    taskworker_config=TaskworkerConfig(
-        namespace=attachments_tasks,
-    ),
+    namespace=attachments_tasks,
 )
 def backfill_artifact_bundle_db_indexing(organization_id: int, release: str, dist: str) -> None:
     from .artifact_bundles import backfill_artifact_bundle_db_indexing as do_backfill

--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -10,25 +10,15 @@ from sentry.exceptions import DeleteAborted
 from sentry.models.group import Group
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
-from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import deletion_tasks
 from sentry.taskworker.retry import Retry
 
 
 @instrumented_task(
     name="sentry.deletions.tasks.groups.delete_groups_for_project",
-    queue="cleanup",
-    default_retry_delay=60 * 5,
-    max_retries=MAX_RETRIES,
-    acks_late=True,
+    namespace=deletion_tasks,
+    retry=Retry(times=MAX_RETRIES, delay=60 * 5),
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(
-        namespace=deletion_tasks,
-        retry=Retry(
-            times=MAX_RETRIES,
-            delay=60 * 5,
-        ),
-    ),
 )
 @retry(exclude=(DeleteAborted,))
 @track_group_async_operation

--- a/src/sentry/deletions/tasks/hybrid_cloud.py
+++ b/src/sentry/deletions/tasks/hybrid_cloud.py
@@ -29,7 +29,6 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 from sentry.models.tombstone import TombstoneBase
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import deletion_control_tasks, deletion_tasks
 from sentry.taskworker.task import Task
 from sentry.utils import json, metrics, redis
@@ -115,10 +114,8 @@ def _chunk_watermark_batch(
 
 @instrumented_task(
     name="sentry.deletions.tasks.hybrid_cloud.schedule_hybrid_cloud_foreign_key_jobs_control",
-    queue="cleanup.control",
-    acks_late=True,
+    namespace=deletion_control_tasks,
     silo_mode=SiloMode.CONTROL,
-    taskworker_config=TaskworkerConfig(namespace=deletion_control_tasks),
 )
 def schedule_hybrid_cloud_foreign_key_jobs_control() -> None:
     if options.get("hybrid_cloud.disable_tombstone_cleanup"):
@@ -131,10 +128,8 @@ def schedule_hybrid_cloud_foreign_key_jobs_control() -> None:
 
 @instrumented_task(
     name="sentry.deletions.tasks.hybrid_cloud.schedule_hybrid_cloud_foreign_key_jobs",
-    queue="cleanup",
-    acks_late=True,
+    namespace=deletion_tasks,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(namespace=deletion_tasks),
 )
 def schedule_hybrid_cloud_foreign_key_jobs() -> None:
     if options.get("hybrid_cloud.disable_tombstone_cleanup"):
@@ -169,10 +164,8 @@ def _schedule_hybrid_cloud_foreign_key(silo_mode: SiloMode, cascade_task: Task[A
 
 @instrumented_task(
     name="sentry.deletions.tasks.hybrid_cloud.process_hybrid_cloud_foreign_key_cascade_batch_control",
-    queue="cleanup.control",
-    acks_late=True,
+    namespace=deletion_control_tasks,
     silo_mode=SiloMode.CONTROL,
-    taskworker_config=TaskworkerConfig(namespace=deletion_control_tasks),
 )
 def process_hybrid_cloud_foreign_key_cascade_batch_control(
     app_name: str, model_name: str, field_name: str, **kwargs: Any
@@ -191,10 +184,8 @@ def process_hybrid_cloud_foreign_key_cascade_batch_control(
 
 @instrumented_task(
     name="sentry.deletions.tasks.process_hybrid_cloud_foreign_key_cascade_batch",
-    queue="cleanup",
-    acks_late=True,
+    namespace=deletion_tasks,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(namespace=deletion_tasks),
 )
 def process_hybrid_cloud_foreign_key_cascade_batch(
     app_name: str, model_name: str, field_name: str, **kwargs: Any

--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -17,7 +17,6 @@ from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
-from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import deletion_tasks
 from sentry.taskworker.retry import Retry
 from sentry.utils import metrics
@@ -34,20 +33,14 @@ class RetryTask(Exception):
 
 @instrumented_task(
     name="sentry.deletions.tasks.nodestore.delete_events_from_nodestore_and_eventstore",
-    queue="cleanup",
-    default_retry_delay=60 * 5,
-    max_retries=MAX_RETRIES,
-    acks_late=True,
-    silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(
-        namespace=deletion_tasks,
-        processing_deadline_duration=60 * 20,
-        retry=Retry(
-            on=(RetryTask,),
-            times=MAX_RETRIES,
-            delay=60 * 5,
-        ),
+    namespace=deletion_tasks,
+    processing_deadline_duration=60 * 20,
+    retry=Retry(
+        on=(RetryTask,),
+        times=MAX_RETRIES,
+        delay=60 * 5,
     ),
+    silo_mode=SiloMode.REGION,
 )
 @retry(exclude=(DeleteAborted,))
 @track_group_async_operation

--- a/src/sentry/demo_mode/tasks.py
+++ b/src/sentry/demo_mode/tasks.py
@@ -19,7 +19,6 @@ from sentry.models.files import FileBlobOwner
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import demomode_tasks
 from sentry.utils.db import atomic_transaction
 
@@ -28,8 +27,7 @@ logger = logging.getLogger(__name__)
 
 @instrumented_task(
     name="sentry.demo_mode.tasks.sync_debug_artifacts",
-    queue="demo_mode",
-    taskworker_config=TaskworkerConfig(namespace=demomode_tasks),
+    namespace=demomode_tasks,
 )
 def sync_debug_artifacts() -> None:
 

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -19,7 +19,6 @@ from sentry.silo.base import SiloMode
 from sentry.snuba.models import QuerySubscription
 from sentry.snuba.query_subscriptions.consumer import register_subscriber
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import alerts_tasks
 from sentry.taskworker.retry import Retry
 from sentry.utils import metrics
@@ -43,18 +42,10 @@ def handle_snuba_query_update(
 
 @instrumented_task(
     name="sentry.incidents.tasks.handle_trigger_action",
-    queue="incidents",
-    default_retry_delay=60,
-    max_retries=5,
+    namespace=alerts_tasks,
+    retry=Retry(times=5, delay=60),
+    processing_deadline_duration=60,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(
-        namespace=alerts_tasks,
-        retry=Retry(
-            times=5,
-            delay=60,
-        ),
-        processing_deadline_duration=60,
-    ),
 )
 def handle_trigger_action(
     action_id: int,
@@ -115,17 +106,9 @@ def handle_trigger_action(
 
 @instrumented_task(
     name="sentry.incidents.tasks.auto_resolve_snapshot_incidents",
-    queue="incidents",
-    default_retry_delay=60,
-    max_retries=2,
+    namespace=alerts_tasks,
+    retry=Retry(times=2, delay=60),
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(
-        namespace=alerts_tasks,
-        retry=Retry(
-            times=2,
-            delay=60,
-        ),
-    ),
 )
 def auto_resolve_snapshot_incidents(alert_rule_id: int, **kwargs: Any) -> None:
     from sentry.incidents.logic import update_incident_status

--- a/src/sentry/monitors/tasks/clock_pulse.py
+++ b/src/sentry/monitors/tasks/clock_pulse.py
@@ -17,7 +17,6 @@ from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.monitors.clock_dispatch import try_monitor_clock_tick
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import crons_tasks
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.kafka_config import get_kafka_admin_cluster_options, get_topic_definition
@@ -54,8 +53,8 @@ def _get_partitions() -> Mapping[int, PartitionMetadata]:
 
 @instrumented_task(
     name="sentry.monitors.tasks.clock_pulse",
+    namespace=crons_tasks,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(namespace=crons_tasks),
 )
 def clock_pulse(current_datetime=None):
     """

--- a/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
+++ b/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
@@ -26,7 +26,6 @@ from sentry.monitors.models import (
 from sentry.notifications.services import notifications_service
 from sentry.notifications.types import NotificationSettingEnum
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import crons_tasks
 from sentry.types.actor import Actor
 from sentry.utils.email import MessageBuilder
@@ -160,11 +159,8 @@ def build_open_incidents_queryset():
 
 @instrumented_task(
     name="sentry.monitors.tasks.detect_broken_monitor_envs",
-    max_retries=0,
-    time_limit=15 * 60,
-    soft_time_limit=10 * 60,
-    record_timing=True,
-    taskworker_config=TaskworkerConfig(namespace=crons_tasks, processing_deadline_duration=15 * 60),
+    namespace=crons_tasks,
+    processing_deadline_duration=15 * 60,
 )
 def detect_broken_monitor_envs():
     open_incidents_qs = build_open_incidents_queryset()
@@ -178,11 +174,8 @@ def detect_broken_monitor_envs():
 
 @instrumented_task(
     name="sentry.monitors.tasks.detect_broken_monitor_envs_for_org",
-    max_retries=0,
-    time_limit=15 * 60,
-    soft_time_limit=10 * 60,
-    record_timing=True,
-    taskworker_config=TaskworkerConfig(namespace=crons_tasks, processing_deadline_duration=15 * 60),
+    namespace=crons_tasks,
+    processing_deadline_duration=15 * 60,
 )
 def detect_broken_monitor_envs_for_org(org_id: int):
     current_time = django_timezone.now()

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -14,7 +14,6 @@ from sentry.preprod.size_analysis.models import SizeAnalysisResults
 from sentry.preprod.size_analysis.utils import build_size_metrics_map, can_compare_size_metrics
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import attachments_tasks
 from sentry.utils.json import dumps_htmlsafe
 
@@ -23,13 +22,9 @@ logger = logging.getLogger(__name__)
 
 @instrumented_task(
     name="sentry.preprod.tasks.compare_preprod_artifact_size_analysis",
-    # TODO: Consider using a dedicated compare queue
-    queue="default",
+    namespace=attachments_tasks,
+    processing_deadline_duration=30,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(
-        namespace=attachments_tasks,
-        processing_deadline_duration=30,
-    ),
 )
 def compare_preprod_artifact_size_analysis(
     project_id: int,
@@ -174,13 +169,9 @@ def compare_preprod_artifact_size_analysis(
 
 @instrumented_task(
     name="sentry.preprod.tasks.manual_size_analysis_comparison",
-    # TODO: Consider using a dedicated compare queue
-    queue="default",
+    namespace=attachments_tasks,
+    processing_deadline_duration=30,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(
-        namespace=attachments_tasks,
-        processing_deadline_duration=30,
-    ),
 )
 def manual_size_analysis_comparison(
     project_id: int,

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -42,13 +42,10 @@ logger = logging.getLogger(__name__)
 
 @instrumented_task(
     name="sentry.preprod.tasks.assemble_preprod_artifact",
-    queue="assemble",
-    silo_mode=SiloMode.REGION,
     retry=Retry(times=3),
-    taskworker_config=TaskworkerConfig(
-        namespace=attachments_tasks,
-        processing_deadline_duration=30,
-    ),
+    namespace=attachments_tasks,
+    processing_deadline_duration=30,
+    silo_mode=SiloMode.REGION,
 )
 def assemble_preprod_artifact(
     org_id: int,
@@ -456,12 +453,9 @@ def _assemble_preprod_artifact_size_analysis(
 
 @instrumented_task(
     name="sentry.preprod.tasks.assemble_preprod_artifact_size_analysis",
-    queue="assemble",
+    namespace=attachments_tasks,
+    processing_deadline_duration=30,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(
-        namespace=attachments_tasks,
-        processing_deadline_duration=30,
-    ),
 )
 def assemble_preprod_artifact_size_analysis(
     org_id,
@@ -523,12 +517,9 @@ def _assemble_preprod_artifact_installable_app(
 
 @instrumented_task(
     name="sentry.preprod.tasks.assemble_preprod_artifact_installable_app",
-    queue="assemble",
+    namespace=attachments_tasks,
+    processing_deadline_duration=30,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(
-        namespace=attachments_tasks,
-        processing_deadline_duration=30,
-    ),
 )
 def assemble_preprod_artifact_installable_app(
     org_id, project_id, checksum, chunks, artifact_id, **kwargs

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -22,7 +22,6 @@ from sentry.snuba.entity_subscription import (
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.snuba.utils import build_query_strings
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import alerts_tasks
 from sentry.taskworker.retry import Retry
 from sentry.utils import metrics, snuba_rpc
@@ -40,16 +39,8 @@ class SubscriptionError(Exception):
 
 @instrumented_task(
     name="sentry.snuba.tasks.create_subscription_in_snuba",
-    queue="subscriptions",
-    default_retry_delay=5,
-    max_retries=5,
-    taskworker_config=TaskworkerConfig(
-        namespace=alerts_tasks,
-        retry=Retry(
-            times=5,
-            delay=5,
-        ),
-    ),
+    namespace=alerts_tasks,
+    retry=Retry(times=5, delay=5),
 )
 def create_subscription_in_snuba(query_subscription_id, **kwargs):
     """
@@ -97,16 +88,8 @@ def create_subscription_in_snuba(query_subscription_id, **kwargs):
 
 @instrumented_task(
     name="sentry.snuba.tasks.update_subscription_in_snuba",
-    queue="subscriptions",
-    default_retry_delay=5,
-    max_retries=5,
-    taskworker_config=TaskworkerConfig(
-        namespace=alerts_tasks,
-        retry=Retry(
-            times=5,
-            delay=5,
-        ),
-    ),
+    namespace=alerts_tasks,
+    retry=Retry(times=5, delay=5),
 )
 def update_subscription_in_snuba(
     query_subscription_id,
@@ -178,16 +161,8 @@ def update_subscription_in_snuba(
 
 @instrumented_task(
     name="sentry.snuba.tasks.delete_subscription_from_snuba",
-    queue="subscriptions",
-    default_retry_delay=5,
-    max_retries=5,
-    taskworker_config=TaskworkerConfig(
-        namespace=alerts_tasks,
-        retry=Retry(
-            times=5,
-            delay=5,
-        ),
-    ),
+    namespace=alerts_tasks,
+    retry=Retry(times=5, delay=5),
 )
 def delete_subscription_from_snuba(query_subscription_id, **kwargs):
     """
@@ -353,8 +328,7 @@ def _delete_from_snuba(dataset: Dataset, subscription_id: str, entity_key: Entit
 
 @instrumented_task(
     name="sentry.snuba.tasks.subscription_checker",
-    queue="subscriptions",
-    taskworker_config=TaskworkerConfig(namespace=alerts_tasks),
+    namespace=alerts_tasks,
 )
 def subscription_checker(**kwargs):
     """

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -36,7 +36,6 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import attachments_tasks
 from sentry.utils import metrics, redis
 from sentry.utils.db import atomic_transaction
@@ -231,12 +230,9 @@ def delete_assemble_status(task, scope, checksum):
 
 @instrumented_task(
     name="sentry.tasks.assemble.assemble_dif",
-    queue="assemble",
+    namespace=attachments_tasks,
+    processing_deadline_duration=60 * 3,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(
-        namespace=attachments_tasks,
-        processing_deadline_duration=60 * 3,
-    ),
 )
 def assemble_dif(project_id, name, checksum, chunks, debug_id=None, **kwargs):
     """
@@ -610,12 +606,9 @@ class ArtifactBundlePostAssembler:
 
 @instrumented_task(
     name="sentry.tasks.assemble.assemble_artifacts",
-    queue="assemble",
+    namespace=attachments_tasks,
+    processing_deadline_duration=30,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(
-        namespace=attachments_tasks,
-        processing_deadline_duration=30,
-    ),
 )
 def assemble_artifacts(
     org_id,

--- a/src/sentry/tasks/auth/auth.py
+++ b/src/sentry/tasks/auth/auth.py
@@ -43,8 +43,7 @@ def email_missing_links_control(org_id: int, actor_id: int, provider_key: str, *
 
 @instrumented_task(
     name="sentry.tasks.send_sso_link_emails",
-    queue="auth",
-    taskworker_config=TaskworkerConfig(namespace=auth_tasks),
+    namespace=auth_tasks,
 )
 def email_missing_links(org_id: int, actor_id: int, provider_key: str, **kwargs):
     _email_missing_links(org_id=org_id, sending_user_id=actor_id, provider_key=provider_key)
@@ -68,9 +67,9 @@ def _email_missing_links(org_id: int, sending_user_id: int, provider_key: str) -
 
 @instrumented_task(
     name="sentry.tasks.email_unlink_notifications",
-    queue="auth",
+    namespace=auth_tasks,
+    processing_deadline_duration=90,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(namespace=auth_tasks, processing_deadline_duration=90),
 )
 def email_unlink_notifications(
     org_id: int, sending_user_email: str, provider_key: str, actor_id: int | None = None
@@ -200,16 +199,11 @@ class TwoFactorComplianceTask(OrganizationComplianceTask):
 
 @instrumented_task(
     name="sentry.tasks.remove_2fa_non_compliant_members",
-    queue="auth",
-    default_retry_delay=60 * 5,
-    max_retries=5,
-    silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(
-        namespace=auth_tasks,
-        retry=Retry(
-            delay=60 * 5,
-        ),
+    namespace=auth_tasks,
+    retry=Retry(
+        delay=60 * 5,
     ),
+    silo_mode=SiloMode.REGION,
 )
 @retry
 def remove_2fa_non_compliant_members(org_id, actor_id=None, actor_key_id=None, ip_address=None):

--- a/src/sentry/tasks/auth/check_auth.py
+++ b/src/sentry/tasks/auth/check_auth.py
@@ -16,7 +16,6 @@ from sentry.organizations.services.organization import RpcOrganizationMember, or
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import auth_control_tasks
 from sentry.utils import metrics
 from sentry.utils.env import in_test_environment
@@ -29,9 +28,8 @@ AUTH_CHECK_SKEW = 3600 * 2
 
 @instrumented_task(
     name="sentry.tasks.check_auth",
-    queue="auth.control",
+    namespace=auth_control_tasks,
     silo_mode=SiloMode.CONTROL,
-    taskworker_config=TaskworkerConfig(namespace=auth_control_tasks),
 )
 def check_auth(chunk_size=100, **kwargs):
     """
@@ -61,9 +59,8 @@ def check_auth(chunk_size=100, **kwargs):
 # Deprecate after roll out
 @instrumented_task(
     name="sentry.tasks.check_auth_identity",
-    queue="auth.control",
+    namespace=auth_control_tasks,
     silo_mode=SiloMode.CONTROL,
-    taskworker_config=TaskworkerConfig(namespace=auth_control_tasks),
 )
 def check_auth_identity(auth_identity_id: int, **kwargs):
     check_single_auth_identity(auth_identity_id)
@@ -71,11 +68,9 @@ def check_auth_identity(auth_identity_id: int, **kwargs):
 
 @instrumented_task(
     name="sentry.tasks.check_auth_identities",
-    queue="auth.control",
+    namespace=auth_control_tasks,
+    processing_deadline_duration=60,
     silo_mode=SiloMode.CONTROL,
-    taskworker_config=TaskworkerConfig(
-        namespace=auth_control_tasks, processing_deadline_duration=60
-    ),
 )
 def check_auth_identities(
     auth_identity_id: int | None = None,

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -6,7 +6,6 @@ from django.apps import apps
 
 from sentry.db.models.base import Model
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import buffer_tasks
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.locking.lock import Lock
@@ -22,8 +21,8 @@ def get_process_lock(lock_name: str) -> Lock:
 
 @instrumented_task(
     name="sentry.tasks.process_buffer.process_pending",
-    queue="buffers.process_pending",
-    taskworker_config=TaskworkerConfig(namespace=buffer_tasks, processing_deadline_duration=60),
+    namespace=buffer_tasks,
+    processing_deadline_duration=60,
 )
 def process_pending() -> None:
     """
@@ -42,11 +41,8 @@ def process_pending() -> None:
 
 @instrumented_task(
     name="sentry.tasks.process_buffer.process_pending_batch",
-    queue="buffers.process_pending_batch",
-    taskworker_config=TaskworkerConfig(
-        namespace=buffer_tasks,
-        processing_deadline_duration=40,
-    ),
+    namespace=buffer_tasks,
+    processing_deadline_duration=40,
 )
 def process_pending_batch() -> None:
     """
@@ -65,10 +61,7 @@ def process_pending_batch() -> None:
 
 @instrumented_task(
     name="sentry.tasks.process_buffer.process_incr",
-    queue="counters-0",
-    taskworker_config=TaskworkerConfig(
-        namespace=buffer_tasks,
-    ),
+    namespace=buffer_tasks,
 )
 def process_incr(
     columns: dict[str, int] | None = None,


### PR DESCRIPTION
Start removing the `taskworker_config` parameter and start passing those parameters to instrumented_task() directly. I'll be doing a few pull requests like this to keep review sizes more manageable.

Refs STREAM-435