### PR TITLE
ref(performance): clean up `performance-transaction-summary-cleanup`

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -175,15 +175,7 @@ function TransactionSummaryCharts({
     organization
   );
 
-  const hasTransactionSummaryCleanupFlag = organization.features.includes(
-    'performance-transaction-summary-cleanup'
-  );
-
-  const displayOptions = generateDisplayOptions(currentFilter).filter(
-    option =>
-      (hasTransactionSummaryCleanupFlag && option.value !== DisplayModes.USER_MISERY) ||
-      !hasTransactionSummaryCleanupFlag
-  );
+  const displayOptions = generateDisplayOptions(currentFilter);
 
   return (
     <Panel>

--- a/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
@@ -46,9 +46,6 @@ function UserStats({
   transactionName,
   eventView,
 }: Props) {
-  const hasTransactionSummaryCleanupFlag = organization.features.includes(
-    'performance-transaction-summary-cleanup'
-  );
   const webVitalsUrl = useModuleURL(ModuleName.VITAL, false, 'frontend');
 
   const hasWebVitalsFlag = organization.features.includes('insight-modules');
@@ -140,28 +137,26 @@ function UserStats({
           <SidebarSpacer />
         </Fragment>
       )}
-      {!hasTransactionSummaryCleanupFlag && (
-        <Fragment>
-          <DemoTourElement
-            id={DemoTourStep.PERFORMANCE_USER_MISERY}
-            title={t('Identify the root cause')}
-            description={t(
-              `Dive into the details behind a slow transaction.
+      <Fragment>
+        <DemoTourElement
+          id={DemoTourStep.PERFORMANCE_USER_MISERY}
+          title={t('Identify the root cause')}
+          description={t(
+            `Dive into the details behind a slow transaction.
               See User Misery, Apdex, and more metrics, along with related events and suspect spans.`
-            )}
-          >
-            <SectionHeading>
-              {t('User Misery')}
-              <QuestionTooltip
-                position="top"
-                title={getTermHelp(organization, PerformanceTerm.USER_MISERY)}
-                size="sm"
-              />
-            </SectionHeading>
-          </DemoTourElement>
-          {userMisery}
-        </Fragment>
-      )}
+          )}
+        >
+          <SectionHeading>
+            {t('User Misery')}
+            <QuestionTooltip
+              position="top"
+              title={getTermHelp(organization, PerformanceTerm.USER_MISERY)}
+              size="sm"
+            />
+          </SectionHeading>
+        </DemoTourElement>
+        {userMisery}
+      </Fragment>
 
       <SidebarSpacer />
     </Fragment>


### PR DESCRIPTION
Remove `performance-transaction-summary-cleanup`, which hasn't been used for >a year, and was only rolled out internally.