### PR TITLE
fix(eap-alerts): mark eap metrics dataset as spans

### DIFF
--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -264,7 +264,7 @@ export const AlertWizardRuleTemplates: Record<
   eap_metrics: {
     aggregate: 'count(span.duration)',
     dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-    eventTypes: EventTypes.TRANSACTION,
+    eventTypes: EventTypes.TRACE_ITEM_SPAN,
   },
   trace_item_throughput: {
     aggregate: 'count(span.duration)',


### PR DESCRIPTION
Mark the event type as span for eap metrics