### PR TITLE
feat(trace-eap-waterfall): Ignoring txn detail load failure for eap span details

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -389,6 +389,7 @@ function EAPSpanNodeDetails(props: EAPSpanNodeDetailsProps) {
     return <LoadingIndicator />;
   }
 
+  // We ignore the error from the transaction detail query because it's not critical for EAP span details.
   if (isTraceItemError) {
     return <LoadingError message={t('Failed to fetch span details')} />;
   }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -377,11 +377,7 @@ function EAPSpanNodeDetails(props: EAPSpanNodeDetailsProps) {
   const transaction_event_id =
     node.value.transaction_id ??
     TraceTree.ParentEAPTransaction(node)?.value.transaction_id;
-  const {
-    data: eventTransaction,
-    isLoading: isEventTransactionLoading,
-    isError: isEventTransactionError,
-  } = useTransaction({
+  const {data: eventTransaction, isLoading: isEventTransactionLoading} = useTransaction({
     event_id: transaction_event_id,
     project_slug: node.value.project_slug,
     organization,
@@ -393,7 +389,7 @@ function EAPSpanNodeDetails(props: EAPSpanNodeDetailsProps) {
     return <LoadingIndicator />;
   }
 
-  if (isTraceItemError || isEventTransactionError) {
+  if (isTraceItemError) {
     return <LoadingError message={t('Failed to fetch span details')} />;
   }
 


### PR DESCRIPTION
We still need to fetch the corresponding nodestore transaction event for EAP Spans with `is_transaction=true `, since contexts are not yet fully supported by EAP. 

However this isn't critical for EAP span details, we can still display attributes when the transaction query fails for any reason. 

