### PR TITLE
fix(preprod): align header items to center

### DIFF
--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -49,7 +49,7 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
     <Flex direction="column" gap="lg" style={{padding: `0 0 ${theme.space.lg} 0`}}>
       <Breadcrumbs crumbs={breadcrumbs} />
       <Heading as="h1">Build comparison</Heading>
-      <Flex gap="lg" wrap="wrap" align="start">
+      <Flex gap="lg" wrap="wrap" align="center">
         <Flex gap="sm" align="center">
           <AppIcon>
             <AppIconPlaceholder>


### PR DESCRIPTION
Before:
<img width="603" height="88" alt="Screenshot 2025-10-01 at 4 14 30 PM" src="https://github.com/user-attachments/assets/8de136e6-353a-47dd-be32-f1fab364bebe" />

After:
<img width="608" height="85" alt="Screenshot 2025-10-01 at 4 14 49 PM" src="https://github.com/user-attachments/assets/b3ad0c5a-7fe8-4aa9-8249-fe9ba42c0e9b" />
