### PR TITLE
chore(projects): Add comment for deprecated `has_high_priority_alerts` flag

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -317,7 +317,7 @@ class Project(Model):
         # This Project has custom metrics
         has_custom_metrics: bool
 
-        # This Project has enough issue volume to use high priority alerts
+        # `has_high_priority_alerts` is DEPRECATED
         has_high_priority_alerts: bool
 
         # This Project has sent insight request spans


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/97894 and https://github.com/getsentry/sentry/pull/97861 removed usages of this flag, can't remove it because it is a bitfield flag, but adding a comment that it is deprecated