### PR TITLE
chore(preprod): Add ProjectPreprodArtifactPermission with project:read permission for use with compare API

### DIFF
--- a/src/sentry/preprod/api/bases/preprod_artifact_endpoint.py
+++ b/src/sentry/preprod/api/bases/preprod_artifact_endpoint.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from rest_framework.exceptions import APIException
 from rest_framework.request import Request
 
-from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.preprod.models import PreprodArtifact
 
 
@@ -16,6 +16,16 @@ class HeadPreprodArtifactResourceDoesNotExist(APIException):
 class BasePreprodArtifactResourceDoesNotExist(APIException):
     status_code = status.HTTP_404_NOT_FOUND
     default_detail = "The requested base preprod artifact does not exist"
+
+
+class ProjectPreprodArtifactPermission(ProjectPermission):
+    scope_map = {
+        "GET": ["project:read", "project:write", "project:admin"],
+        # Some simple actions, like triggering comparisons, should be allowed
+        "POST": ["project:read", "project:write", "project:admin"],
+        "PUT": ["project:read", "project:write", "project:admin"],
+        "DELETE": ["project:admin"],
+    }
 
 
 class PreprodArtifactEndpoint(ProjectEndpoint):

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -12,7 +12,10 @@ from sentry.preprod.analytics import (
     PreprodArtifactApiSizeAnalysisCompareGetEvent,
     PreprodArtifactApiSizeAnalysisComparePostEvent,
 )
-from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactEndpoint
+from sentry.preprod.api.bases.preprod_artifact_endpoint import (
+    PreprodArtifactEndpoint,
+    ProjectPreprodArtifactPermission,
+)
 from sentry.preprod.api.models.project_preprod_build_details_models import (
     transform_preprod_artifact_to_build_details,
 )
@@ -35,6 +38,7 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
         "GET": ApiPublishStatus.EXPERIMENTAL,
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
+    permission_classes = (ProjectPreprodArtifactPermission,)
 
     def get(
         self,


### PR DESCRIPTION
Adds `ProjectPreprodArtifactPermission` with `project:read` permission needed for POST requests, which will allow users to trigger comparisons with the compare endpoint's POST method. This allows users who are non-admin/non-write users to still trigger comparisons, which is fine given our planned compare usage.