### PR TITLE
feat(grouping): Add `key` property to components and variants

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -525,6 +525,21 @@ class RootGroupingComponent(BaseGroupingComponent[ContributingComponent]):
     def id(self) -> str:
         return self.variant_name
 
+    @property
+    def key(self) -> str:
+        variant_name = self.variant_name
+
+        if not self.values:  # Insurance - shouldn't ever happen
+            return variant_name
+
+        # Variant root components which don't contribute won't have any contributing children, but
+        # we can find the component which would be the contributing component, were the root
+        # component itself contributing. Strategies are run in descending order of priority, and
+        # added into `values` in order, so the highest-priority option will always be first.
+        would_be_contributing_component = self.values[0]
+
+        return would_be_contributing_component.key
+
     def __repr__(self) -> str:
         base_repr = super().__repr__()
         # Fake the class name so that instead of showing as `RootGroupingComponent` in the repr it

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -456,6 +456,19 @@ class CSPGroupingComponent(
 ):
     id: str = "csp"
 
+    @property
+    def key(self) -> str:
+        key = "csp"
+        local_script_violation = self.get_subcomponent("violation")
+        url = self.get_subcomponent("uri")
+
+        if local_script_violation and local_script_violation.contributes:
+            key += "_local_script_violation"
+        elif url and url.contributes:
+            key += "_url"
+
+        return key
+
 
 class ExpectCTGroupingComponent(
     BaseGroupingComponent[HostnameGroupingComponent | SaltGroupingComponent]

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -437,6 +437,7 @@ class ChainedExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingC
 
 class ThreadsGroupingComponent(BaseGroupingComponent[StacktraceGroupingComponent]):
     id: str = "threads"
+    key: str = "thread_stacktrace"
     frame_counts: Counter[str]
 
     def __init__(

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -76,6 +76,10 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]](
     def name(self) -> str | None:
         return KNOWN_MAJOR_COMPONENT_NAMES.get(self.id)
 
+    @property
+    def key(self) -> str:
+        return self.name or self.id
+
     @cached_property
     def description(self) -> str:
         """

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -34,6 +34,10 @@ class BaseVariant(ABC):
         return None
 
     @property
+    def key(self) -> str:
+        return self.type
+
+    @property
     def description(self) -> str:
         return self.type
 
@@ -119,6 +123,18 @@ class ComponentVariant(BaseVariant):
         self.config = strategy_config
         self.contributing_component = contributing_component
         self.variant_name = self.root_component.id  # "app", "system", or "default"
+
+    @property
+    def key(self) -> str:
+        """
+        Create a key for this variant in the grouping info dictionary.
+        """
+        key = self.root_component.key
+
+        if self.variant_name in ["app", "system"]:
+            key = f"{self.variant_name}_{key}"
+
+        return key
 
     @property
     def description(self) -> str:
@@ -231,6 +247,10 @@ class SaltedComponentVariant(ComponentVariant):
         super().__init__(root_component, contributing_component, strategy_config)
         self.values = fingerprint
         self.fingerprint_info = fingerprint_info
+
+    @property
+    def key(self) -> str:
+        return super().key + "_hybrid_fingerprint"
 
     @property
     def description(self) -> str:


### PR DESCRIPTION
As part of the grouping info section improvements, we want to split each potential grouping method (exception stacktrace and threads stacktrace, for example) into its own variant. (Currently they live together under a single `app` or `system` variant.) This means each will need to have its own key in the grouping info JSON.

Another change we'll make is to fix some of the problems with the way we describe each variant (using the `description` property). For example, if a variant doesn't contribute, it's just listed as `app` or  `system`, rather than `app exception stacktrace` or `system exception stacktrace`. Some methods also just come out listed as `default` (rather than `message`, for example).

In order to solve both of these problems, without (for the moment) touching the actual machinery of grouping, this PR introduces a new property on both components and variants called `key`, which is different for each possible grouping method a variant can represent. This will not only let us distinguish our split variants in the JSON, but will allow us to better tailor our descriptions in the UI.

The full set of possible keys generated by the key methods is included below for reference. Component keys just track grouping method, whereas variant keys also track variant and hybrid fingerprint status.

Possible component keys:

```python
# Stacktrace methods
'stacktrace'
'exception_stacktrace'
'chained_exception_stacktrace'
'thread_stacktrace'

# Other exception-based methods
'exception_message'
'chained_exception_message'
'exception_type'
'chained_exception_type'
'ns_error'

# Security methods
'csp_local_script_violation'
'csp_url'
'expect_ct'
'expect_staple'
'hpkp'

# Other methods
'message'
'template'
```

Possible variant keys:

```python
# Non-component variants
'checksum'
'hashed_checksum'
'fallback'

# Fingerprint variants
'built_in_fingerprint'
'custom_fingerprint'

# For component variants, keys take the form
#   {variant_name_if_not_default}_{method}_{hybrid_fingerprint_flag_if_applicable}
# where method alues can be any of the component keys listed above.
#
# For example:
'message'
'csp_local_script_violation'
'app_exception_stacktrace'
'system_chained_exception_message'
'app_ns_error_hybrid_fingerprint'
'csp_url_hybrid_fingerprint'
```
