### PR TITLE
chore(aci): expect AlertRuleWorkflow to always exist during Rule deletion

### DIFF
--- a/src/sentry/deletions/defaults/rule.py
+++ b/src/sentry/deletions/defaults/rule.py
@@ -1,8 +1,11 @@
+import logging
 from collections.abc import Sequence
 
 from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
 from sentry.models.rule import Rule
 from sentry.workflow_engine.models import Workflow
+
+logger = logging.getLogger(__name__)
 
 
 class RuleDeletionTask(ModelDeletionTask[Rule]):
@@ -17,11 +20,16 @@ class RuleDeletionTask(ModelDeletionTask[Rule]):
             ModelRelation(RuleFireHistory, {"rule_id": instance.id}),
             ModelRelation(RuleActivity, {"rule_id": instance.id}),
             ModelRelation(AlertRuleDetector, {"rule_id": instance.id}),
-            ModelRelation(AlertRuleWorkflow, {"rule_id": instance.id}),
         ]
 
-        alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=instance.id)
-        model_relations.append(ModelRelation(Workflow, {"id": alert_rule_workflow.workflow_id}))
+        alert_rule_workflow = AlertRuleWorkflow.objects.filter(rule_id=instance.id).first()
+        if alert_rule_workflow:
+            model_relations.append(ModelRelation(Workflow, {"id": alert_rule_workflow.workflow_id}))
+        else:
+            logger.error(
+                "No AlertRuleWorkflow found for rule, skipping", extra={"rule_id": instance.id}
+            )
+        model_relations.append(ModelRelation(AlertRuleWorkflow, {"rule_id": instance.id}))
 
         return model_relations
 

--- a/src/sentry/deletions/defaults/rule.py
+++ b/src/sentry/deletions/defaults/rule.py
@@ -20,10 +20,8 @@ class RuleDeletionTask(ModelDeletionTask[Rule]):
             ModelRelation(AlertRuleWorkflow, {"rule_id": instance.id}),
         ]
 
-        alert_rule_workflow = AlertRuleWorkflow.objects.filter(rule_id=instance.id).first()
-
-        if alert_rule_workflow:
-            model_relations.append(ModelRelation(Workflow, {"id": alert_rule_workflow.workflow.id}))
+        alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=instance.id)
+        model_relations.append(ModelRelation(Workflow, {"id": alert_rule_workflow.workflow_id}))
 
         return model_relations
 


### PR DESCRIPTION
We are seeing some odd cases where `Workflows` still exist but their associated `Rule` and `AlertRuleWorkflow` objects are deleted. My current theory is that there is some chunking in the `Rule` deletion task (possibly as a result of other deletion cascades like project deletion) and the `AlertRuleWorkflow` object is deleted and we can no longer use it to delete the associated Workflow.

In any case, a `Rule` should always have an `AlertRuleWorkflow` object when we try to delete a `Rule`. If it doesn't, we want to know about it.

UPDATE: modified to delete the Workflow before AlertRuleWorkflow