### PR TITLE
fix(detectors): exclude `gen_ai.chat` spans from consecutive http detector 

### DIFF
--- a/src/sentry/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/performance_issues/detectors/consecutive_http_detector.py
@@ -35,7 +35,7 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
 
         self.consecutive_http_spans: list[Span] = []
         self.lcp = None
-        self.gen_ai_chat_spans: list[Span] = []
+        self.gen_ai_chat_spans: list[str] = []
 
         lcp_value = get_path(self.event(), "measurements", "lcp", "value")
         lcp_unit = get_path(self.event(), "measurements", "lcp", "unit")

--- a/src/sentry/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/performance_issues/detectors/consecutive_http_detector.py
@@ -38,7 +38,7 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         self.gen_ai_chat_spans: list[str] = [
             span.get("span_id")
             for span in event.get("spans", [])
-            if span.get("op") == "gen_ai.chat" and span.get("span_id")
+            if span.get("op") == "gen_ai.chat"
         ]
 
         lcp_value = get_path(self.event(), "measurements", "lcp", "value")

--- a/tests/sentry/performance_issues/test_consecutive_http_detector.py
+++ b/tests/sentry/performance_issues/test_consecutive_http_detector.py
@@ -393,3 +393,31 @@ class ConsecutiveHTTPSpansDetectorTest(TestCase):
         spans = [modify_span_start(span, span_duration * spans.index(span)) for span in spans]
         problems = self.find_problems(create_event(spans))
         assert len(problems) == 0
+
+    def test_ignores_http_spans_with_gen_ai_parent(self) -> None:
+        """Test that HTTP spans with gen_ai.chat parent spans are ignored."""
+        span_duration = 2000
+
+        # Create a gen_ai.chat span first
+        gen_ai_span = create_span("gen_ai.chat", 1000, "AI Chat", "gen_ai_hash")
+        gen_ai_span_id = gen_ai_span["span_id"]
+
+        # Create HTTP spans that are children of the gen_ai span
+        http_spans = [
+            create_span("http.client", span_duration, "GET /api/endpoint1", "hash1"),
+            create_span("http.client", span_duration, "GET /api/endpoint2", "hash2"),
+            create_span("http.client", span_duration, "GET /api/endpoint3", "hash3"),
+        ]
+
+        # Set the parent_span_id to the gen_ai span
+        for span in http_spans:
+            span["parent_span_id"] = gen_ai_span_id
+
+        # Ensure spans don't overlap
+        all_spans = [gen_ai_span] + http_spans
+        all_spans = [
+            modify_span_start(span, span_duration * all_spans.index(span)) for span in all_spans
+        ]
+
+        problems = self.find_problems(create_event(all_spans))
+        assert len(problems) == 0


### PR DESCRIPTION
this pr exclude llm chat spans from consecutive http detection - the actual spans that we flag are `http.client` not `gen_ai.chat` so we have to look at the span's parent to see if it is LLM chat span 

https://linear.app/getsentry/issue/ID-903/excempt-llm-chat-spans-in-consecutive-http-detection