### PR TITLE
feat(issues): Remove tags from issue query sanitization

### DIFF
--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
@@ -15,7 +15,7 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useEventQuery} from 'sentry/views/issueDetails/streamline/eventSearch';
+import {useEventQuery} from 'sentry/views/issueDetails/streamline/hooks/useEventQuery';
 import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
@@ -38,7 +38,7 @@ function GroupEventAttachments({project, group}: GroupEventAttachmentsProps) {
   const location = useLocation();
   const organization = useOrganization();
   const hasStreamlinedUI = useHasStreamlinedUI();
-  const eventQuery = useEventQuery({groupId: group.id});
+  const eventQuery = useEventQuery();
   const eventView = useIssueDetailsEventView({group});
   const navigate = useNavigate();
   const [previouslyUsedAttachmentsTab, setPreviouslyUsedAttachmentsTab] =

--- a/static/app/views/issueDetails/groupEventAttachments/useGroupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/useGroupEventAttachments.tsx
@@ -7,7 +7,7 @@ import {
 } from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useEventQuery} from 'sentry/views/issueDetails/streamline/eventSearch';
+import {useEventQuery} from 'sentry/views/issueDetails/streamline/hooks/useEventQuery';
 import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
@@ -108,7 +108,7 @@ export function useGroupEventAttachments({
   const hasStreamlinedUI = useHasStreamlinedUI();
   const location = useLocation();
   const organization = useOrganization();
-  const eventQuery = useEventQuery({groupId: group.id});
+  const eventQuery = useEventQuery();
   const eventView = useIssueDetailsEventView({group});
 
   const hasSetStatsPeriod =

--- a/static/app/views/issueDetails/groupEvents.tsx
+++ b/static/app/views/issueDetails/groupEvents.tsx
@@ -6,7 +6,6 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
-import {ISSUE_PROPERTY_FIELDS} from 'sentry/utils/fields';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useCleanQueryParamsOnRouteLeave from 'sentry/utils/useCleanQueryParamsOnRouteLeave';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -15,6 +14,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {EventList} from 'sentry/views/issueDetails/streamline/eventList';
 import {EventSearch} from 'sentry/views/issueDetails/streamline/eventSearch';
+import {ALL_EVENTS_EXCLUDED_TAGS} from 'sentry/views/issueDetails/streamline/hooks/useEventQuery';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
 import {
   useEnvironmentsFromUrl,
@@ -22,14 +22,6 @@ import {
 } from 'sentry/views/issueDetails/utils';
 
 import AllEventsTable from './allEventsTable';
-
-export const ALL_EVENTS_EXCLUDED_TAGS = [
-  'environment',
-  'performance.issue_ids',
-  'transaction.op',
-  'transaction.status',
-  ...ISSUE_PROPERTY_FIELDS,
-];
 
 interface GroupEventsProps {
   group: Group;

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -26,10 +26,8 @@ import {
 import {MetricIssueChart} from 'sentry/views/issueDetails/metricIssues/metricIssueChart';
 import {useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 import {EventGraph} from 'sentry/views/issueDetails/streamline/eventGraph';
-import {
-  EventSearch,
-  useEventQuery,
-} from 'sentry/views/issueDetails/streamline/eventSearch';
+import {EventSearch} from 'sentry/views/issueDetails/streamline/eventSearch';
+import {useEventQuery} from 'sentry/views/issueDetails/streamline/hooks/useEventQuery';
 import {IssueCronCheckTimeline} from 'sentry/views/issueDetails/streamline/issueCronCheckTimeline';
 import IssueTagsPreview from 'sentry/views/issueDetails/streamline/issueTagsPreview';
 import {IssueUptimeCheckTimeline} from 'sentry/views/issueDetails/streamline/issueUptimeCheckTimeline';
@@ -55,7 +53,7 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
   const location = useLocation();
   const theme = useTheme();
   const environments = useEnvironmentsFromUrl();
-  const searchQuery = useEventQuery({groupId: group.id});
+  const searchQuery = useEventQuery();
   const issueTypeConfig = getConfigForIssueType(group, project);
   const {dispatch} = useIssueDetails();
   const groupReprocessingStatus = getGroupReprocessingStatus(group);

--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -11,7 +11,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import {useEventColumns} from 'sentry/views/issueDetails/allEventsTable';
-import {ALL_EVENTS_EXCLUDED_TAGS} from 'sentry/views/issueDetails/groupEvents';
 import {
   EventListTable,
   Header,
@@ -20,6 +19,7 @@ import {
   PaginationText,
   Title,
 } from 'sentry/views/issueDetails/streamline/eventListTable';
+import {ALL_EVENTS_EXCLUDED_TAGS} from 'sentry/views/issueDetails/streamline/hooks/useEventQuery';
 import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
 import EventsTable from 'sentry/views/performance/transactionSummary/transactionEvents/eventsTable';
 

--- a/static/app/views/issueDetails/streamline/eventSearch.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventSearch.spec.tsx
@@ -1,24 +1,12 @@
 import {GroupFixture} from 'sentry-fixture/group';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TagsFixture} from 'sentry-fixture/tags';
 
-import {
-  makeAllTheProviders,
-  render,
-  renderHook,
-  screen,
-  userEvent,
-  waitFor,
-} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import OrganizationStore from 'sentry/stores/organizationStore';
-import {
-  EventSearch,
-  useEventQuery,
-} from 'sentry/views/issueDetails/streamline/eventSearch';
+import {EventSearch} from 'sentry/views/issueDetails/streamline/eventSearch';
 
 const mockHandleSearch = jest.fn();
 
@@ -73,73 +61,4 @@ describe('EventSearch', () => {
       expect.anything()
     );
   }, 10_000);
-
-  it('filters issue tokens from event queries', () => {
-    const validQuery = `${tagKey}:${tagValue} device.family:[iphone,pixel]`;
-
-    const {result: onlyIssueTokens} = renderHook(
-      () => useEventQuery({groupId: group.id}),
-      {
-        wrapper: makeAllTheProviders({
-          deprecatedRouterMocks: true,
-          organization,
-          router: RouterFixture({
-            location: LocationFixture({
-              query: {query: 'is:resolved assigned:[me,#issues] issue.priority:high'},
-            }),
-          }),
-        }),
-      }
-    );
-    expect(onlyIssueTokens.current).toBe('');
-
-    const {result: combinedTokens} = renderHook(
-      () => useEventQuery({groupId: group.id}),
-      {
-        wrapper: makeAllTheProviders({
-          deprecatedRouterMocks: true,
-          organization,
-          router: RouterFixture({
-            location: LocationFixture({
-              query: {query: `is:resolved assigned:[me,#issues] ${validQuery}`},
-            }),
-          }),
-        }),
-      }
-    );
-    expect(combinedTokens.current).toBe(validQuery);
-
-    const {result: onlyEventTokens} = renderHook(
-      () => useEventQuery({groupId: group.id}),
-      {
-        wrapper: makeAllTheProviders({
-          deprecatedRouterMocks: true,
-          organization,
-          router: RouterFixture({
-            location: LocationFixture({
-              query: {query: validQuery},
-            }),
-          }),
-        }),
-      }
-    );
-    expect(onlyEventTokens.current).toBe(validQuery);
-
-    const {result: unrecognizedFilterKey} = renderHook(
-      () => useEventQuery({groupId: group.id}),
-      {
-        wrapper: makeAllTheProviders({
-          deprecatedRouterMocks: true,
-          organization,
-          router: RouterFixture({
-            location: LocationFixture({
-              // This isn't in the TagsFixture or ISSUE_EVENT_PROPERTY_FIELDS
-              query: {query: `${validQuery} organization.slug:sentry`},
-            }),
-          }),
-        }),
-      }
-    );
-    expect(unrecognizedFilterKey.current).toBe(validQuery);
-  });
 });

--- a/static/app/views/issueDetails/streamline/eventSearch.tsx
+++ b/static/app/views/issueDetails/streamline/eventSearch.tsx
@@ -7,26 +7,15 @@ import {
   type SearchQueryBuilderProps,
 } from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
-import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
-import {joinQuery, Token} from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
 import type {Group, Tag, TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
-import {
-  FieldKind,
-  getFieldDefinition,
-  ISSUE_EVENT_PROPERTY_FIELDS,
-} from 'sentry/utils/fields';
+import {FieldKind, ISSUE_EVENT_PROPERTY_FIELDS} from 'sentry/utils/fields';
 import useApi from 'sentry/utils/useApi';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
-import {ALL_EVENTS_EXCLUDED_TAGS} from 'sentry/views/issueDetails/groupEvents';
-import {
-  useGroupTags,
-  type GroupTag,
-} from 'sentry/views/issueDetails/groupTags/useGroupTags';
+import {useGroupTags} from 'sentry/views/issueDetails/groupTags/useGroupTags';
+import {ALL_EVENTS_EXCLUDED_TAGS} from 'sentry/views/issueDetails/streamline/hooks/useEventQuery';
 import {
   mergeAndSortTagValues,
   useHasStreamlinedUI,
@@ -40,74 +29,6 @@ interface EventSearchProps {
   query: string;
   className?: string;
   queryBuilderProps?: Partial<SearchQueryBuilderProps>;
-}
-
-export function useEventQuery({groupId}: {groupId: string}): string {
-  const {selection} = usePageFilters();
-  const location = useLocation();
-  const environments = selection.environments;
-  const {query: locationQuery} = location.query;
-
-  let eventQuery = '';
-  if (Array.isArray(locationQuery)) {
-    eventQuery = locationQuery.join(' ');
-  } else if (typeof locationQuery === 'string') {
-    eventQuery = locationQuery;
-  }
-
-  const {data = []} = useGroupTags({
-    groupId,
-    environment: environments,
-  });
-  const filterKeys = useEventSearchFilterKeys(data);
-  const parsedQuery = useMemo(
-    () =>
-      parseQueryBuilderValue(eventQuery, getFieldDefinition, {
-        filterKeys,
-      }) ?? [],
-    [eventQuery, filterKeys]
-  );
-
-  // Removes invalid tokens from an issue stream query in an attempt to convert it to an event query.
-  // For example: "is:unresolved browser.name:firefox" -> "browser.name:firefox"
-  // Note: This is _probably_ not accounting for MANY invalid filters which could come in from the
-  // issue stream. Will likely have to refine this in the future.
-  const validQuery = parsedQuery.filter((token: any) => {
-    if (token.type === Token.FREE_TEXT) {
-      return false;
-    }
-    if (token.type === Token.FILTER) {
-      let tagKey = token.key.text;
-      if (tagKey.startsWith('tags[')) {
-        tagKey = tagKey.slice(5, -1);
-      }
-      if (!filterKeys.hasOwnProperty(tagKey)) {
-        return false;
-      }
-    }
-    return true;
-  });
-
-  return joinQuery(validQuery, false, true);
-}
-
-function useEventSearchFilterKeys(data: GroupTag[]): TagCollection {
-  const filterKeys = useMemo<TagCollection>(() => {
-    const tags = [
-      ...data.map(tag => ({...tag, kind: FieldKind.TAG})),
-      ...ISSUE_EVENT_PROPERTY_FIELDS.map(tag => ({
-        key: tag,
-        name: tag,
-        kind: FieldKind.EVENT_FIELD,
-      })),
-    ].filter(tag => !ALL_EVENTS_EXCLUDED_TAGS.includes(tag.key));
-
-    return tags.reduce<TagCollection>((acc, tag) => {
-      acc[tag.key] = tag;
-      return acc;
-    }, {});
-  }, [data]);
-  return filterKeys;
 }
 
 function getFilterKeySections(tags: TagCollection): FilterKeySection[] {
@@ -150,12 +71,33 @@ export function EventSearch({
   const organization = useOrganization();
   const hasStreamlinedUI = useHasStreamlinedUI();
 
-  const {data = []} = useGroupTags({
-    groupId: group.id,
-    environment: environments,
-  });
+  const groupTagsQuery = useGroupTags(
+    {groupId: group.id, environment: environments},
+    {enabled: true}
+  );
 
-  const filterKeys = useEventSearchFilterKeys(data);
+  const filterKeys = useMemo<TagCollection>(() => {
+    const acc: TagCollection = {};
+    const keys = ISSUE_EVENT_PROPERTY_FIELDS.filter(
+      tag => !ALL_EVENTS_EXCLUDED_TAGS.includes(tag)
+    );
+    for (const key of keys) {
+      acc[key] = {key, name: key, kind: FieldKind.EVENT_FIELD};
+    }
+    const groupTags = groupTagsQuery.data ?? [];
+    for (const tag of groupTags) {
+      if (ALL_EVENTS_EXCLUDED_TAGS.includes(tag.key)) {
+        continue;
+      }
+      acc[tag.key] = {
+        key: tag.key,
+        name: tag.name,
+        totalValues: tag.totalValues,
+        kind: FieldKind.TAG,
+      };
+    }
+    return acc;
+  }, [groupTagsQuery.data]);
 
   const tagValueLoader = useCallback(
     async (key: string, search: string) => {

--- a/static/app/views/issueDetails/streamline/hooks/useEventQuery.spec.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useEventQuery.spec.tsx
@@ -1,0 +1,63 @@
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {
+  getEventSearchFromIssueQuery,
+  useEventQuery,
+} from 'sentry/views/issueDetails/streamline/hooks/useEventQuery';
+
+describe('useEventQuery', () => {
+  const [tagKey, tagValue] = ['user.email', 'leander@s.io'];
+
+  it('filters issue tokens from event queries', () => {
+    const validQuery = `${tagKey}:${tagValue} device.family:[iphone,pixel]`;
+
+    const {result: onlyIssueTokens} = renderHookWithProviders(() => useEventQuery(), {
+      initialRouterConfig: {
+        location: {
+          pathname: '/issues/1234/',
+          query: {query: 'is:resolved assigned:[me,#issues] issue.priority:high'},
+        },
+        route: '/issues/:issueId/',
+      },
+    });
+    expect(onlyIssueTokens.current).toBe('');
+
+    const {result: combinedTokens} = renderHookWithProviders(() => useEventQuery(), {
+      initialRouterConfig: {
+        location: {
+          pathname: '/issues/1234/',
+          query: {query: `is:resolved assigned:[me,#issues] ${validQuery}`},
+        },
+        route: '/issues/:issueId/',
+      },
+    });
+    expect(combinedTokens.current).toBe(validQuery);
+
+    const {result: onlyEventTokens} = renderHookWithProviders(() => useEventQuery(), {
+      initialRouterConfig: {
+        location: {
+          pathname: '/issues/1234/',
+          query: {query: validQuery},
+        },
+        route: '/issues/:issueId/',
+      },
+    });
+    expect(onlyEventTokens.current).toBe(validQuery);
+  });
+});
+
+describe('sanitizeEventQuery', () => {
+  it('should remove basic issue filters from query', () => {
+    const query = `is:unresolved level:error`;
+    const sanitizedQuery = getEventSearchFromIssueQuery(query);
+    expect(sanitizedQuery).toBe('level:error');
+  });
+
+  it('handles has/!has by removing disallowed fields and keeping allowed ones', () => {
+    // environment is excluded; user.email is an allowed event field
+    const query = `has:environment has:user.email !has:transaction.status !has:user.id`;
+    const sanitizedQuery = getEventSearchFromIssueQuery(query);
+    // Should drop has:environment and !has:transaction.status, keep has:user.email and !has:user.id
+    expect(sanitizedQuery).toBe('has:user.email !has:user.id');
+  });
+});

--- a/static/app/views/issueDetails/streamline/hooks/useEventQuery.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useEventQuery.tsx
@@ -1,0 +1,54 @@
+import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
+import {ISSUE_PROPERTY_FIELDS} from 'sentry/utils/fields';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+
+export const ALL_EVENTS_EXCLUDED_TAGS = [
+  'environment',
+  'performance.issue_ids',
+  'transaction.op',
+  'transaction.status',
+  ...ISSUE_PROPERTY_FIELDS,
+];
+
+/**
+ * Converts an issues level search query into an event level search query
+ * Removes all free text and issue level filters.
+ */
+export function getEventSearchFromIssueQuery(query: string): string {
+  const search = new MutableSearch(query);
+
+  // Drop all free text parts
+  search.setFreeText([]);
+
+  // Remove disallowed normal filters
+  for (const key of search.getFilterKeys()) {
+    if (key === 'has' || key === '!has') {
+      continue; // handled below
+    }
+    if (ALL_EVENTS_EXCLUDED_TAGS.includes(key)) {
+      search.removeFilter(key);
+    }
+  }
+
+  // Validate has/!has filters by referenced field values
+  for (const existsKey of ['has', '!has'] as const) {
+    const values = search.getFilterValues(existsKey);
+    if (values.length === 0) {
+      continue;
+    }
+    for (const field of values) {
+      if (ALL_EVENTS_EXCLUDED_TAGS.includes(field)) {
+        search.removeFilterValue(existsKey, field);
+      }
+    }
+  }
+
+  return search.toString();
+}
+
+export function useEventQuery(): string {
+  const location = useLocation();
+  const locationQuery = decodeScalar(location.query.query) ?? '';
+  return getEventSearchFromIssueQuery(locationQuery);
+}

--- a/static/app/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery.tsx
@@ -12,7 +12,7 @@ import {getPeriod} from 'sentry/utils/duration/getPeriod';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useEventQuery} from 'sentry/views/issueDetails/streamline/eventSearch';
+import {useEventQuery} from 'sentry/views/issueDetails/streamline/hooks/useEventQuery';
 import {useGroupDefaultStatsPeriod} from 'sentry/views/issueDetails/useGroupDefaultStatsPeriod';
 
 export function useIssueDetailsEventView({
@@ -26,7 +26,7 @@ export function useIssueDetailsEventView({
   pageFilters?: PageFilters;
   queryProps?: Partial<SavedQuery>;
 }) {
-  const searchQuery = useEventQuery({groupId: group.id});
+  const searchQuery = useEventQuery();
 
   const location = useLocation();
   const hasSetStatsPeriod =

--- a/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
@@ -27,7 +27,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import type {GroupTag} from 'sentry/views/issueDetails/groupTags/useGroupTags';
 import {useGroupTagsReadable} from 'sentry/views/issueDetails/groupTags/useGroupTags';
-import {useEventQuery} from 'sentry/views/issueDetails/streamline/eventSearch';
+import {useEventQuery} from 'sentry/views/issueDetails/streamline/hooks/useEventQuery';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 import {usePrefetchTagValues} from 'sentry/views/issueDetails/utils';
@@ -224,7 +224,7 @@ export default function IssueTagsPreview({
   groupId: string;
   project: Project;
 }) {
-  const searchQuery = useEventQuery({groupId});
+  const searchQuery = useEventQuery();
   const organization = useOrganization();
   const theme = useTheme();
   const isScreenSmall = useMedia(`(max-width: ${theme.breakpoints.sm})`);

--- a/static/app/views/issueDetails/useGroupEvent.tsx
+++ b/static/app/views/issueDetails/useGroupEvent.tsx
@@ -4,7 +4,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {useEventQuery} from 'sentry/views/issueDetails/streamline/eventSearch';
+import {useEventQuery} from 'sentry/views/issueDetails/streamline/hooks/useEventQuery';
 import {
   getGroupEventQueryKey,
   useDefaultIssueEvent,
@@ -34,7 +34,7 @@ export function useGroupEvent({
   const defaultIssueEvent = useDefaultIssueEvent();
   const hasStreamlinedUI = useHasStreamlinedUI();
   const environments = useEnvironmentsFromUrl();
-  const eventQuery = useEventQuery({groupId});
+  const eventQuery = useEventQuery();
   const eventId = eventIdProp ?? defaultIssueEvent;
 
   const isReservedEventId = RESERVED_EVENT_IDS.has(eventId);

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -197,7 +197,45 @@ export function useEnvironmentsFromUrl(): string[] {
   return envsArray;
 }
 
-// merged into getGroupEventQueryKey
+function getGroupEventDetailsQueryData({
+  environments,
+  query,
+  start,
+  end,
+  statsPeriod,
+}: {
+  query: string | undefined;
+  end?: string;
+  environments?: string[];
+  start?: string;
+  statsPeriod?: string;
+}): Record<string, string | string[]> {
+  const params: Record<string, string | string[]> = {
+    collapse: ['fullRelease'],
+  };
+
+  if (query) {
+    params.query = query;
+  }
+
+  if (environments && environments.length > 0) {
+    params.environment = environments;
+  }
+
+  if (start) {
+    params.start = start;
+  }
+
+  if (end) {
+    params.end = end;
+  }
+
+  if (statsPeriod) {
+    params.statsPeriod = statsPeriod;
+  }
+
+  return params;
+}
 
 export function getGroupEventQueryKey({
   orgSlug,
@@ -221,27 +259,13 @@ export function getGroupEventQueryKey({
   return [
     `/organizations/${orgSlug}/issues/${groupId}/events/${eventId}/`,
     {
-      query: (function () {
-        const params: Record<string, string | string[]> = {
-          collapse: ['fullRelease'],
-        };
-        if (query) {
-          params.query = query;
-        }
-        if (environments && environments.length > 0) {
-          params.environment = environments;
-        }
-        if (start) {
-          params.start = start;
-        }
-        if (end) {
-          params.end = end;
-        }
-        if (statsPeriod) {
-          params.statsPeriod = statsPeriod;
-        }
-        return params;
-      })(),
+      query: getGroupEventDetailsQueryData({
+        environments,
+        query,
+        start,
+        end,
+        statsPeriod,
+      }),
     },
   ];
 }

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -197,45 +197,7 @@ export function useEnvironmentsFromUrl(): string[] {
   return envsArray;
 }
 
-export function getGroupEventDetailsQueryData({
-  environments,
-  query,
-  start,
-  end,
-  statsPeriod,
-}: {
-  query: string | undefined;
-  end?: string;
-  environments?: string[];
-  start?: string;
-  statsPeriod?: string;
-}): Record<string, string | string[]> {
-  const params: Record<string, string | string[]> = {
-    collapse: ['fullRelease'],
-  };
-
-  if (query) {
-    params.query = query;
-  }
-
-  if (environments && environments.length > 0) {
-    params.environment = environments;
-  }
-
-  if (start) {
-    params.start = start;
-  }
-
-  if (end) {
-    params.end = end;
-  }
-
-  if (statsPeriod) {
-    params.statsPeriod = statsPeriod;
-  }
-
-  return params;
-}
+// merged into getGroupEventQueryKey
 
 export function getGroupEventQueryKey({
   orgSlug,
@@ -259,13 +221,27 @@ export function getGroupEventQueryKey({
   return [
     `/organizations/${orgSlug}/issues/${groupId}/events/${eventId}/`,
     {
-      query: getGroupEventDetailsQueryData({
-        environments,
-        query,
-        start,
-        end,
-        statsPeriod,
-      }),
+      query: (function () {
+        const params: Record<string, string | string[]> = {
+          collapse: ['fullRelease'],
+        };
+        if (query) {
+          params.query = query;
+        }
+        if (environments && environments.length > 0) {
+          params.environment = environments;
+        }
+        if (start) {
+          params.start = start;
+        }
+        if (end) {
+          params.end = end;
+        }
+        if (statsPeriod) {
+          params.statsPeriod = statsPeriod;
+        }
+        return params;
+      })(),
     },
   ];
 }

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -549,5 +549,4 @@ export {
   // eslint-disable-next-line import/export
   fireEvent,
   waitForDrawerToHide,
-  makeAllTheProviders,
 };


### PR DESCRIPTION
We preserve the issues search query when navigating to issue details. We then are doing an event level query and need to remove the issue level filters like `is:unresolved`.

We were using the group's tags as a method of validation, however this was leading to making 2x requests when loading the page and we were not able to sanitize the stacktrace preview request leading to an additional wasted request.

This should fix preloading from the issues stream and the 2x requests made on page load.
