### PR TITLE
chore(detectors): Add logging for Consecutive HTTP detections with multiple url hosts

### DIFF
--- a/src/sentry/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/performance_issues/detectors/consecutive_http_detector.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
+from urllib.parse import urlparse
 
 from sentry.issues.grouptype import PerformanceConsecutiveHTTPQueriesGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
@@ -97,6 +99,14 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         return total_time - max_span_duration
 
     def _store_performance_problem(self) -> None:
+        # Check if spans are from multiple hosts
+        hosts = {self._extract_host_from_span(span) for span in self.consecutive_http_spans}
+        if len(hosts) > 1:
+            logging.info(
+                "Consecutive HTTP Spans with Multiple Hosts",
+                extra={"host_count": len(hosts), "project": self._event.get("project")},
+            )
+
         fingerprint = self._fingerprint()
         offender_span_ids = [span["span_id"] for span in self.consecutive_http_spans]
         desc: str = self.consecutive_http_spans[0].get("description", "")
@@ -170,6 +180,11 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
             return False
 
         return True
+
+    def _extract_host_from_span(self, span: Span) -> str:
+        """Extract the host from a span's URL."""
+        url = get_url_from_span(span)
+        return urlparse(url).netloc
 
     def _fingerprint(self) -> str:
         hashed_url_paths = fingerprint_http_spans(self.consecutive_http_spans)


### PR DESCRIPTION
we noticed consecutive http detection creating issues with multiple hosts for the span urls - there's a few options of how we can tackle this, but adding some logging so we can better understand what kind of issues we are creating with this problem