### PR TITLE
feat(prevent): Add feedback widget to Tests page

### DIFF
--- a/static/app/views/prevent/tests/testsWrapper.tsx
+++ b/static/app/views/prevent/tests/testsWrapper.tsx
@@ -2,6 +2,7 @@ import {Outlet} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PreventQueryParamsProvider from 'sentry/components/prevent/container/preventParamsProvider';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -20,6 +21,14 @@ export default function TestAnalyticsPageWrapper() {
               {TESTS_PAGE_TITLE}
               <FeatureBadge type="beta" />
             </Layout.Title>
+            <FeedbackWidgetButton
+              optionOverrides={{
+                tags: {
+                  'feedback.source': 'prevent.tests',
+                  'feedback.owner': 'prevent-team',
+                },
+              }}
+            />
           </HeaderContentBar>
         </Layout.HeaderContent>
       </Layout.Header>


### PR DESCRIPTION
Add FeedbackWidgetButton to the Tests page header to allow users to provide feedback directly from the Prevent Tests page. The widget is tagged with 'prevent.tests' source and 'prevent-team' owner for proper categorization.

Note: need to test if this is working correctly.
<img width="1309" height="819" alt="Screenshot 2025-10-01 at 3 00 56 PM" src="https://github.com/user-attachments/assets/694e4957-b0fe-4c31-b9cd-22918bb7cbe3" />

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
