### PR TITLE
feat(crons): Improve polling

### DIFF
--- a/static/app/components/checkInTimeline/hooks/useMonitorDates.tsx
+++ b/static/app/components/checkInTimeline/hooks/useMonitorDates.tsx
@@ -13,13 +13,18 @@ interface UsePageFilterDatesOptions {
    * Whether to recompute dates when the window regains focus
    */
   recomputeOnWindowFocus?: boolean;
+  /**
+   * This array may be provided as a queryKey to the underlying useQuery that will
+   * force the dates to be recomputed when the key changes.
+   */
+  recomputeQueryKey?: unknown[];
 }
 
 /**
  * Computes since and until values from the current page filters
  */
 export function usePageFilterDates(options: UsePageFilterDatesOptions = {}) {
-  const {recomputeInterval, recomputeOnWindowFocus = false} = options;
+  const {recomputeInterval, recomputeOnWindowFocus = false, recomputeQueryKey} = options;
   const {selection} = usePageFilters();
   const {start, end, period} = selection.datetime;
 
@@ -41,8 +46,10 @@ export function usePageFilterDates(options: UsePageFilterDatesOptions = {}) {
     return {since, until, now};
   }
 
+  const queryKeyExtra = recomputeQueryKey ?? [];
+
   const {data} = useQuery({
-    queryKey: ['pageFilterDates', start, end, period] as const,
+    queryKey: ['pageFilterDates', start, end, period, ...queryKeyExtra] as const,
     queryFn,
     initialData: queryFn(),
     staleTime: 0,

--- a/static/app/components/checkInTimeline/hooks/useTimeWindowConfig.tsx
+++ b/static/app/components/checkInTimeline/hooks/useTimeWindowConfig.tsx
@@ -17,14 +17,24 @@ interface Options {
    * Whether to recompute dates when the window regains focus
    */
   recomputeOnWindowFocus?: boolean;
+  /**
+   * This array may be provided as a queryKey to the underlying useQuery that will
+   * force the dates to be recomputed when the key changes.
+   */
+  recomputeQueryKey?: unknown[];
 }
 
 export function useTimeWindowConfig({
   timelineWidth,
   recomputeInterval,
   recomputeOnWindowFocus,
+  recomputeQueryKey,
 }: Options) {
-  const {since, until} = usePageFilterDates({recomputeInterval, recomputeOnWindowFocus});
+  const {since, until} = usePageFilterDates({
+    recomputeInterval,
+    recomputeOnWindowFocus,
+    recomputeQueryKey,
+  });
 
   return useMemo(
     () => getConfigFromTimeRange(since, until, timelineWidth),

--- a/static/app/views/alerts/rules/crons/details.tsx
+++ b/static/app/views/alerts/rules/crons/details.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
+import moment from 'moment-timezone';
 
 import {
   deleteMonitorProcessingErrorByType,
@@ -41,7 +42,7 @@ import type {
 } from 'sentry/views/insights/crons/types';
 import {makeMonitorDetailsQueryKey} from 'sentry/views/insights/crons/utils';
 
-const DEFAULT_POLL_INTERVAL_MS = 5000;
+import {getMonitorRefetchInterval} from './utils';
 
 type Props = RouteComponentProps<{monitorSlug: string; projectId: string}>;
 
@@ -73,7 +74,7 @@ function MonitorDetails({params, location}: Props) {
         return false;
       }
       const [monitorData] = query.state.data;
-      return hasLastCheckIn(monitorData) ? false : DEFAULT_POLL_INTERVAL_MS;
+      return getMonitorRefetchInterval(monitorData, moment());
     },
   });
 

--- a/static/app/views/alerts/rules/crons/utils.spec.tsx
+++ b/static/app/views/alerts/rules/crons/utils.spec.tsx
@@ -1,0 +1,140 @@
+import moment from 'moment-timezone';
+import {CronMonitorEnvironmentFixture} from 'sentry-fixture/detectors';
+import {MonitorFixture} from 'sentry-fixture/monitor';
+
+import type {Monitor} from 'sentry/views/insights/crons/types';
+import {MonitorStatus} from 'sentry/views/insights/crons/types';
+
+import {getAggregateEnvStatus, getMonitorRefetchInterval} from './utils';
+
+describe('getAggregateEnvStatus', () => {
+  it('returns ERROR when any environment has ERROR status', () => {
+    const environments = [
+      CronMonitorEnvironmentFixture({status: MonitorStatus.OK}),
+      CronMonitorEnvironmentFixture({status: MonitorStatus.ERROR}),
+      CronMonitorEnvironmentFixture({status: MonitorStatus.ACTIVE}),
+    ];
+
+    expect(getAggregateEnvStatus(environments)).toBe(MonitorStatus.ERROR);
+  });
+
+  it('returns OK when all environments are OK or ACTIVE', () => {
+    const environments = [
+      CronMonitorEnvironmentFixture({status: MonitorStatus.OK}),
+      CronMonitorEnvironmentFixture({status: MonitorStatus.ACTIVE}),
+    ];
+
+    expect(getAggregateEnvStatus(environments)).toBe(MonitorStatus.OK);
+  });
+
+  it('returns ACTIVE when no environments have ERROR or OK status', () => {
+    const environments = [
+      CronMonitorEnvironmentFixture({status: MonitorStatus.ACTIVE}),
+      CronMonitorEnvironmentFixture({status: MonitorStatus.DISABLED}),
+    ];
+
+    expect(getAggregateEnvStatus(environments)).toBe(MonitorStatus.ACTIVE);
+  });
+
+  it('returns ACTIVE for empty array', () => {
+    expect(getAggregateEnvStatus([])).toBe(MonitorStatus.ACTIVE);
+  });
+});
+
+describe('getMonitorRefetchInterval', () => {
+  function makeMonitorWithNextCheckIns(nextCheckIns: Array<string | null>): Monitor {
+    return MonitorFixture({
+      environments: nextCheckIns.map(nextCheckIn =>
+        CronMonitorEnvironmentFixture({nextCheckIn})
+      ),
+    });
+  }
+
+  it('returns WAITING_FIRST_CHECK_IN_INTERVAL_MS when no environments exist', () => {
+    const now = moment('2024-01-01T12:00:00Z');
+    const monitor = makeMonitorWithNextCheckIns([]);
+
+    expect(getMonitorRefetchInterval(monitor, now)).toBe(5_000);
+  });
+
+  it('returns time until nextCheckIn when it is in the future', () => {
+    const now = moment('2024-01-01T12:00:00Z');
+    const futureTime = moment(now).add(10, 'minutes');
+    const monitor = makeMonitorWithNextCheckIns([futureTime.toISOString()]);
+
+    const result = getMonitorRefetchInterval(monitor, now);
+    // Should be exactly 10 minutes (600_000ms)
+    expect(result).toBe(600_000);
+  });
+
+  it('returns 5 seconds when check-in is less than 1 minute late', () => {
+    const now = moment('2024-01-01T12:00:00Z');
+    const pastTime = moment(now).subtract(30, 'seconds');
+    const monitor = makeMonitorWithNextCheckIns([pastTime.toISOString()]);
+
+    expect(getMonitorRefetchInterval(monitor, now)).toBe(5_000);
+  });
+
+  it('returns 5 seconds when check-in is exactly now', () => {
+    const now = moment('2024-01-01T12:00:00Z');
+    const monitor = makeMonitorWithNextCheckIns([now.toISOString()]);
+
+    expect(getMonitorRefetchInterval(monitor, now)).toBe(5_000);
+  });
+
+  it('returns 30 seconds when check-in is 1-5 minutes late', () => {
+    const now = moment('2024-01-01T12:00:00Z');
+    const pastTime = moment(now).subtract(3, 'minutes');
+    const monitor = makeMonitorWithNextCheckIns([pastTime.toISOString()]);
+
+    expect(getMonitorRefetchInterval(monitor, now)).toBe(30_000);
+  });
+
+  it('returns 2 minutes when check-in is 5-15 minutes late', () => {
+    const now = moment('2024-01-01T12:00:00Z');
+    const pastTime = moment(now).subtract(10, 'minutes');
+    const monitor = makeMonitorWithNextCheckIns([pastTime.toISOString()]);
+
+    expect(getMonitorRefetchInterval(monitor, now)).toBe(2 * 60_000);
+  });
+
+  it('returns 5 minutes when check-in is 15-30 minutes late', () => {
+    const now = moment('2024-01-01T12:00:00Z');
+    const pastTime = moment(now).subtract(20, 'minutes');
+    const monitor = makeMonitorWithNextCheckIns([pastTime.toISOString()]);
+
+    expect(getMonitorRefetchInterval(monitor, now)).toBe(5 * 60_000);
+  });
+
+  it('returns 10 minutes (cap) when check-in is more than 30 minutes late', () => {
+    const now = moment('2024-01-01T12:00:00Z');
+    const pastTime = moment(now).subtract(2, 'hours');
+    const monitor = makeMonitorWithNextCheckIns([pastTime.toISOString()]);
+
+    expect(getMonitorRefetchInterval(monitor, now)).toBe(10 * 60_000);
+  });
+
+  it('uses the earliest nextCheckIn when multiple environments exist', () => {
+    const now = moment('2024-01-01T12:00:00Z');
+    const earlierTime = moment(now).add(5, 'minutes');
+    const laterTime = moment(now).add(10, 'minutes');
+    const monitor = makeMonitorWithNextCheckIns([
+      laterTime.toISOString(),
+      earlierTime.toISOString(),
+    ]);
+
+    const result = getMonitorRefetchInterval(monitor, now);
+    // Should be exactly 5 minutes (300_000ms)
+    expect(result).toBe(300_000);
+  });
+
+  it('handles environment with null nextCheckIn among others', () => {
+    const now = moment('2024-01-01T12:00:00Z');
+    const futureTime = moment(now).add(10, 'minutes');
+    const monitor = makeMonitorWithNextCheckIns([null, futureTime.toISOString()]);
+
+    const result = getMonitorRefetchInterval(monitor, now);
+    // Should use the non-null nextCheckIn
+    expect(result).toBe(600_000);
+  });
+});

--- a/static/app/views/alerts/rules/crons/utils.tsx
+++ b/static/app/views/alerts/rules/crons/utils.tsx
@@ -1,4 +1,11 @@
-import {MonitorStatus, type MonitorEnvironment} from 'sentry/views/insights/crons/types';
+import sortBy from 'lodash/sortBy';
+import moment from 'moment-timezone';
+
+import {
+  MonitorStatus,
+  type Monitor,
+  type MonitorEnvironment,
+} from 'sentry/views/insights/crons/types';
 
 const MONITOR_STATUS_PRECEDENT = [
   MonitorStatus.ERROR,
@@ -16,4 +23,61 @@ export function getAggregateEnvStatus(environments: MonitorEnvironment[]): Monit
   );
 
   return status ?? MonitorStatus.ACTIVE;
+}
+
+/**
+ * Interval for polling the monitor when we're waiting for the very first
+ * check-in.
+ */
+const WAITING_FIRST_CHECK_IN_INTERVAL_MS = 5_000;
+
+/**
+ * Calculates the refetch interval for a monitor based on when the next
+ * check-in is expected.
+ *
+ * Uses exponential backoff when check-in is late:
+ * - 0-1 minute late: 5 seconds
+ * - 1-5 minutes late: 30 seconds
+ * - 5-15 minutes late: 2 minutes
+ * - 15+ minutes late: 5 minutes
+ * - Cap at 10 minutes
+ *
+ * Returns:
+ * - WAITING_FIRST_CHECK_IN_INTERVAL_MS if no check-in has been received yet
+ * - Time until next check-in if it's in the future
+ * - Backoff interval based on how late the check-in is
+ */
+export function getMonitorRefetchInterval(monitor: Monitor, now: moment.Moment) {
+  const env = sortBy(monitor.environments, e => e.nextCheckIn)[0];
+  const nextCheckIn = env?.nextCheckIn ?? null;
+
+  if (!nextCheckIn) {
+    return WAITING_FIRST_CHECK_IN_INTERVAL_MS;
+  }
+
+  const nextCheckInMoment = moment(nextCheckIn);
+
+  // Interval is the time until we expect the next check-in
+  if (nextCheckInMoment.isAfter(now)) {
+    return nextCheckInMoment.diff(now, 'milliseconds');
+  }
+
+  // Check-in is late - use exponential backoff
+  const minutesLate = now.diff(nextCheckInMoment, 'minutes');
+
+  if (minutesLate < 1) {
+    return 5_000;
+  }
+  if (minutesLate < 5) {
+    return 30_000;
+  }
+  if (minutesLate < 15) {
+    return 2 * 60_000;
+  }
+  if (minutesLate < 30) {
+    return 5 * 60_000;
+  }
+
+  // If the check-in is very late just poll once every 10 minutes
+  return 10 * 60_000;
 }

--- a/static/app/views/insights/crons/components/detailsSidebar.tsx
+++ b/static/app/views/insights/crons/components/detailsSidebar.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
+import moment from 'moment-timezone';
 
 import {SectionHeading} from 'sentry/components/charts/styles';
 import {Alert} from 'sentry/components/core/alert';
@@ -65,11 +66,15 @@ export function DetailsSidebar({monitorEnv, monitor, showUnknownLegend}: Props) 
         </div>
         <div>
           {monitor.status !== 'disabled' && monitorEnv?.nextCheckIn ? (
-            <TimeSince
-              unitStyle="regular"
-              liveUpdateInterval="second"
-              date={monitorEnv.nextCheckIn}
-            />
+            moment(monitorEnv.nextCheckIn).isAfter(moment()) ? (
+              <TimeSince
+                unitStyle="regular"
+                liveUpdateInterval="second"
+                date={monitorEnv.nextCheckIn}
+              />
+            ) : (
+              t('Expected Now')
+            )
           ) : (
             '-'
           )}

--- a/static/app/views/insights/crons/components/detailsTimeline.tsx
+++ b/static/app/views/insights/crons/components/detailsTimeline.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
+import sortBy from 'lodash/sortBy';
 
 import {
   deleteMonitorEnvironment,
@@ -45,7 +46,17 @@ export function DetailsTimeline({monitor, onStatsLoaded}: Props) {
   const {width: containerWidth} = useDimensions<HTMLDivElement>({elementRef});
   const timelineWidth = useDebouncedValue(containerWidth, 500);
 
-  const timeWindowConfig = useTimeWindowConfig({timelineWidth});
+  // Use the nextCheckIn timestamp as a queryKey for computing the
+  // timeWindowConfig. This means when the nextCheckIn date changes we will
+  // recompute the timeWindowConfig timestamps. This is important when a
+  // period is used (like last hour)
+  const nextCheckIn = sortBy(monitor.environments, e => e.nextCheckIn)[0]?.nextCheckIn;
+
+  const timeWindowConfig = useTimeWindowConfig({
+    timelineWidth,
+    recomputeQueryKey: [nextCheckIn],
+    recomputeOnWindowFocus: true,
+  });
 
   const monitorDetailsQueryKey = makeMonitorDetailsQueryKey(
     organization,

--- a/static/app/views/insights/crons/components/monitorCheckIns.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckIns.tsx
@@ -1,4 +1,5 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect} from 'react';
+import sortBy from 'lodash/sortBy';
 
 import LoadingError from 'sentry/components/loadingError';
 import Pagination from 'sentry/components/pagination';
@@ -22,11 +23,17 @@ export function MonitorCheckIns({monitorSlug, monitorEnvs, project}: Props) {
   const location = useLocation();
   const organization = useOrganization();
 
+  // Use the nextCheckIn timestamp as a key for forcing a refetch of the
+  // check-in list. We do this since we know when this value changes there are
+  // new check-ins present.
+  const nextCheckIn = sortBy(monitorEnvs, e => e.nextCheckIn)[0]?.nextCheckIn;
+
   const {
     data: checkInList,
     getResponseHeader,
     isPending,
     isError,
+    refetch,
   } = useMonitorCheckIns({
     orgSlug: organization.slug,
     projectSlug: project.slug,
@@ -36,6 +43,8 @@ export function MonitorCheckIns({monitorSlug, monitorEnvs, project}: Props) {
     environment: monitorEnvs.map(e => e.name),
     queryParams: {...location.query},
   });
+
+  useEffect(() => void refetch(), [refetch, nextCheckIn]);
 
   if (isError) {
     return <LoadingError />;

--- a/static/app/views/insights/crons/utils/useMonitorStats.tsx
+++ b/static/app/views/insights/crons/utils/useMonitorStats.tsx
@@ -1,5 +1,5 @@
 import type {TimeWindowConfig} from 'sentry/components/checkInTimeline/types';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {useApiQuery, type UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {MonitorBucket} from 'sentry/views/insights/crons/types';
@@ -19,10 +19,15 @@ interface Options {
   enabled?: boolean;
 }
 
+type Result = Record<string, MonitorBucket[]>;
+
 /**
  * Fetches Monitor stats
  */
-export function useMonitorStats({monitors, timeWindowConfig, enabled = true}: Options) {
+export function useMonitorStats(
+  {monitors, timeWindowConfig, enabled = true}: Options,
+  options: Partial<UseApiQueryOptions<Result>> = {}
+) {
   const {start, end, rollupConfig} = timeWindowConfig;
 
   const selectionQuery = {
@@ -36,7 +41,7 @@ export function useMonitorStats({monitors, timeWindowConfig, enabled = true}: Op
 
   const monitorStatsQueryKey = `/organizations/${organization.slug}/monitors-stats/`;
 
-  return useApiQuery<Record<string, MonitorBucket[]>>(
+  return useApiQuery<Result>(
     [
       monitorStatsQueryKey,
       {
@@ -51,6 +56,7 @@ export function useMonitorStats({monitors, timeWindowConfig, enabled = true}: Op
     {
       staleTime: 0,
       enabled: enabled && rollupConfig.totalBuckets > 0,
+      ...options,
     }
   );
 }


### PR DESCRIPTION
We now calculate a polling interval based on the time until the next expected check-in.

Before the check-in is expected:
- Poll at exactly the time we expect the next check-in

After the check-in is expected (late):
We use exponential backoff to avoid hammering the server while still providing timely updates:
- 0-1 minute late: Poll every 5 seconds (for momentary delays)
- 1-5 minutes late: Poll every 30 seconds
- 5-15 minutes late: Poll every 2 minutes
- 15-30 minutes late: Poll every 5 minutes
- 30+ minutes late: Poll every 10 minutes (cap)

This prevents excessive polling when monitors are consistently failing or not sending check-ins (e.g., a user leaves the page open for hours while a monitor that runs hourly never sends a check-in).

Reactive updates:
- The timeWindowConfig will be recomputed when the nextCheckIn changes, forcing the timeline to refresh
- The check-in list will be refetched when the nextCheckIn changes as well

With this change, all parts of the cron details page will update in tandem while being respectful of server resources.

Part of [NEW-545: Add polling to Crons and Uptime details page](https://linear.app/getsentry/issue/NEW-545/add-polling-to-crons-and-uptime-details-page)