### PR TITLE
fix(logs): Order logs by item id if needed

### DIFF
--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -41,16 +41,25 @@ class OurLogs(rpc_dataset_common.RPCBase):
         debug: bool = False,
     ) -> EAPResponse:
         """timestamp_precise is always displayed in the UI in lieu of timestamp but since the TraceItem table isn't a DateTime64
-        so we need to always order by it regardless of what is actually passed to the orderby"""
+        so we need to always order by it regardless of what is actually passed to the orderby.
+        Additionally, to ensure a strict order in the flex time sampling mode, we also order
+        by the item id."""
         if (
             orderby is not None
             and len(orderby) == 1
             and orderby[0].lstrip("-") == constants.TIMESTAMP_ALIAS
         ):
-            desc = orderby[0][0] == "-"
-            orderby.append(("-" if desc else "") + constants.TIMESTAMP_PRECISE_ALIAS)
+            direction = "-" if orderby[0][0] == "-" else ""
+            orderby.append(direction + constants.TIMESTAMP_PRECISE_ALIAS)
             if constants.TIMESTAMP_PRECISE_ALIAS not in selected_columns:
                 selected_columns.append(constants.TIMESTAMP_PRECISE_ALIAS)
+
+            # When using highest accuracy flex time sampling, we make sure we sort by
+            # the item id as well to ensure we have a strict ordering.
+            if sampling_mode == "HIGHEST_ACCURACY_FLEX_TIME":
+                orderby.append(direction + "id")
+                if "id" not in selected_columns:
+                    selected_columns.append("id")
 
         return cls._run_table_query(
             rpc_dataset_common.TableQuery(

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3393,6 +3393,7 @@ class OurLogTestCase(BaseTestCase):
         project: Project | None = None,
         timestamp: datetime | None = None,
         attributes: dict[str, Any] | None = None,
+        log_id: str | None = None,
     ) -> TraceItem:
         if organization is None:
             organization = self.organization
@@ -3404,6 +3405,12 @@ class OurLogTestCase(BaseTestCase):
             attributes = {}
         if extra_data is None:
             extra_data = {}
+        if log_id is None:
+            item_id = uuid4()
+        else:
+            # There's some flipping of bytes when ingesting the item id
+            # this ensures that the final item we get back is what we send
+            item_id = UUID(bytes=bytes(reversed(UUID(log_id).bytes)))
 
         trace_id = extra_data.pop("trace_id", uuid4().hex)
 
@@ -3444,7 +3451,7 @@ class OurLogTestCase(BaseTestCase):
             item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
             timestamp=timestamp_proto,
             trace_id=trace_id,
-            item_id=uuid4().bytes,
+            item_id=item_id.bytes,
             received=timestamp_proto,
             retention_days=90,
             attributes=attributes_proto,


### PR DESCRIPTION
For high accuracy flex time sampling, we require a strict ordering so ensure we also order by the item_id at the end.