### PR TITLE
feat(uptime): Add polling to checks table + stats

### DIFF
--- a/static/app/views/alerts/rules/uptime/detailsTimeline.tsx
+++ b/static/app/views/alerts/rules/uptime/detailsTimeline.tsx
@@ -31,10 +31,16 @@ export function DetailsTimeline({uptimeDetector, onStatsLoaded}: Props) {
 
   const timeWindowConfig = useTimeWindowConfig({timelineWidth});
 
-  const {data: uptimeStats} = useUptimeMonitorStats({
-    detectorIds: [String(uptimeDetector.id)],
-    timeWindowConfig,
-  });
+  const {data: uptimeStats} = useUptimeMonitorStats(
+    {
+      detectorIds: [String(uptimeDetector.id)],
+      timeWindowConfig,
+    },
+    {
+      refetchOnWindowFocus: true,
+      refetchInterval: 60_000,
+    }
+  );
 
   useEffect(
     () => uptimeStats?.[id] && onStatsLoaded?.(uptimeStats[id]),

--- a/static/app/views/alerts/rules/uptime/uptimeChecksTable.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksTable.tsx
@@ -37,14 +37,20 @@ export function UptimeChecksTable({
     isPending,
     getResponseHeader,
     refetch,
-  } = useUptimeChecks({
-    orgSlug: organization.slug,
-    projectSlug,
-    detectorId,
-    cursor: decodeScalar(location.query.cursor),
-    ...timeRange,
-    limit: 10,
-  });
+  } = useUptimeChecks(
+    {
+      orgSlug: organization.slug,
+      projectSlug,
+      detectorId,
+      cursor: decodeScalar(location.query.cursor),
+      ...timeRange,
+      limit: 10,
+    },
+    {
+      refetchOnWindowFocus: true,
+      refetchInterval: 60_000,
+    }
+  );
 
   if (isError) {
     return <LoadingError message={t('Failed to load uptime checks')} onRetry={refetch} />;

--- a/static/app/views/insights/uptime/utils/useUptimeChecks.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeChecks.tsx
@@ -46,7 +46,7 @@ export function useUptimeChecks(
 ) {
   // TODO(Leander): Add querying and sorting, when the endpoint supports it
   return useApiQuery<UptimeCheck[]>(makeUptimeChecksQueryKey(params), {
-    staleTime: 10000,
+    staleTime: 10_000,
     retry: true,
     ...options,
   });

--- a/static/app/views/insights/uptime/utils/useUptimeMonitorStats.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeMonitorStats.tsx
@@ -1,5 +1,5 @@
 import type {TimeWindowConfig} from 'sentry/components/checkInTimeline/types';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {useApiQuery, type UseApiQueryOptions} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {CheckStatusBucket} from 'sentry/views/alerts/rules/uptime/types';
 
@@ -15,10 +15,15 @@ interface Options {
   timeWindowConfig: TimeWindowConfig;
 }
 
+type Result = Record<string, CheckStatusBucket[]>;
+
 /**
  * Fetches Uptime Monitor stats
  */
-export function useUptimeMonitorStats({detectorIds, timeWindowConfig}: Options) {
+export function useUptimeMonitorStats(
+  {detectorIds, timeWindowConfig}: Options,
+  options: Partial<UseApiQueryOptions<Result>> = {}
+) {
   const {start, end, rollupConfig} = timeWindowConfig;
 
   const selectionQuery = {
@@ -30,7 +35,7 @@ export function useUptimeMonitorStats({detectorIds, timeWindowConfig}: Options) 
   const organization = useOrganization();
   const monitorStatsQueryKey = `/organizations/${organization.slug}/uptime-stats/`;
 
-  return useApiQuery<Record<string, CheckStatusBucket[]>>(
+  return useApiQuery<Result>(
     [
       monitorStatsQueryKey,
       {
@@ -43,6 +48,7 @@ export function useUptimeMonitorStats({detectorIds, timeWindowConfig}: Options) 
     {
       staleTime: 0,
       enabled: rollupConfig.totalBuckets > 0,
+      ...options,
     }
   );
 }


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/100749, but simpler.

This just adds a refetch interval to the timeWindowConfig and the checks table. Unlike crons there's no 'last check time' that can drive the refetch across components.

Part of [NEW-545: Add polling to Crons and Uptime details page](https://linear.app/getsentry/issue/NEW-545/add-polling-to-crons-and-uptime-details-page)