### PR TITLE
Position sidebar above treemap content on mobile

### DIFF
--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import * as Layout from 'sentry/components/layouts/thirds';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
@@ -89,25 +91,45 @@ export default function BuildDetails() {
           />
         </Layout.Header>
 
-        <Layout.Body>
+        <BuildDetailsBody>
           <UrlParamBatchProvider>
-            <Layout.Main>
-              <BuildDetailsMainContent
-                appSizeQuery={appSizeQuery}
-                buildDetailsQuery={buildDetailsQuery}
-              />
-            </Layout.Main>
-
-            <Layout.Side>
+            <BuildDetailsSide>
               <BuildDetailsSidebarContent
                 buildDetailsQuery={buildDetailsQuery}
                 artifactId={artifactId}
                 projectId={projectId}
               />
-            </Layout.Side>
+            </BuildDetailsSide>
+            <BuildDetailsMain>
+              <BuildDetailsMainContent
+                appSizeQuery={appSizeQuery}
+                buildDetailsQuery={buildDetailsQuery}
+              />
+            </BuildDetailsMain>
           </UrlParamBatchProvider>
-        </Layout.Body>
+        </BuildDetailsBody>
       </Layout.Page>
     </SentryDocumentTitle>
   );
 }
+
+const BuildDetailsBody = styled(Layout.Body)`
+  @media (min-width: ${p => p.theme.breakpoints.lg}) {
+    display: flex;
+    flex-direction: row-reverse;
+    gap: ${p => p.theme.space['3xl']};
+  }
+`;
+
+const BuildDetailsMain = styled(Layout.Main)`
+  @media (min-width: ${p => p.theme.breakpoints.lg}) {
+    width: 100%;
+  }
+`;
+
+const BuildDetailsSide = styled(Layout.Side)`
+  @media (min-width: ${p => p.theme.breakpoints.lg}) {
+    min-width: 325px;
+    max-width: 325px;
+  }
+`;


### PR DESCRIPTION
Mobile (scrollable)
<img width="454" height="769" alt="Screenshot 2025-10-01 at 3 21 45 PM" src="https://github.com/user-attachments/assets/b602110a-23e4-4e0a-8560-412ff3696aba" />

Md
<img width="979" height="1116" alt="Screenshot 2025-10-01 at 3 21 54 PM" src="https://github.com/user-attachments/assets/5c867116-dae4-4036-a2d6-16643143afa0" />

Lg
<img width="1802" height="824" alt="Screenshot 2025-10-01 at 3 22 00 PM" src="https://github.com/user-attachments/assets/ced82447-3821-4b77-85aa-6f363db0415f" />

Resolves EME-307