### PR TITLE
fix(workflow_engine): Migrate dataSource => dataSources

### DIFF
--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -125,7 +125,10 @@ class MetricIssueConditionGroupValidator(BaseDataConditionGroupValidator):
 
 
 class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
-    data_source = SnubaQueryValidator(required=True, timeWindowSeconds=True)
+    data_source = SnubaQueryValidator(required=False, timeWindowSeconds=True)
+    data_sources = serializers.ListField(
+        child=SnubaQueryValidator(timeWindowSeconds=True), required=False
+    )
     condition_group = MetricIssueConditionGroupValidator(required=True)
 
     def validate(self, attrs):

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -657,7 +657,8 @@ class MonitorIncidentDetectorValidator(BaseDetectorTypeValidator):
     data_source field (MonitorDataSourceValidator).
     """
 
-    data_source = MonitorDataSourceValidator(required=True)
+    data_source = MonitorDataSourceValidator(required=False)
+    data_sources = serializers.ListField(child=MonitorDataSourceValidator(), required=False)
 
     def update(self, instance: Detector, validated_data: dict[str, Any]) -> Detector:
         super().update(instance, validated_data)

--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -456,7 +456,8 @@ class UptimeMonitorDataSourceValidator(BaseDataSourceValidator[UptimeSubscriptio
 
 
 class UptimeDomainCheckFailureValidator(BaseDetectorTypeValidator):
-    data_source = UptimeMonitorDataSourceValidator(required=True)
+    data_source = UptimeMonitorDataSourceValidator(required=False)
+    data_sources = serializers.ListField(child=UptimeMonitorDataSourceValidator(), required=False)
 
     def update(self, instance: Detector, validated_data: dict[str, Any]) -> Detector:
         super().update(instance, validated_data)

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -65,7 +65,15 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
         return type
 
     @property
-    def data_source(self) -> BaseDataSourceValidator:
+    def data_source(self) -> BaseDataSourceValidator | None:
+        # Moving this field to optional
+        return None
+
+    @property
+    def data_sources(self) -> serializers.ListField:
+        # TODO - improve typing here to enforce that the child is the correct type
+        # otherwise, can look at creating a custom field.
+        # This should be a list of `BaseDataSourceValidator`s
         raise NotImplementedError
 
     @property
@@ -133,6 +141,17 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
         )
         return instance
 
+    def _create_data_source(self, validated_data_source, detector: Detector):
+        data_source_creator = validated_data_source["_creator"]
+        data_source = data_source_creator.create()
+
+        detector_data_source = DataSource.objects.create(
+            organization_id=self.context["project"].organization_id,
+            source_id=data_source.id,
+            type=validated_data_source["data_source_type"],
+        )
+        DataSourceDetector.objects.create(data_source=detector_data_source, detector=detector)
+
     def create(self, validated_data):
         # If quotas are exceeded, we will prevent creation of new detectors.
         # Do not disable or prevent the users from updating existing detectors.
@@ -143,13 +162,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
                 logic_type=DataConditionGroup.Type.ANY,
                 organization_id=self.context["organization"].id,
             )
-            data_source_creator = validated_data["data_source"]["_creator"]
-            data_source = data_source_creator.create()
-            detector_data_source = DataSource.objects.create(
-                organization_id=self.context["project"].organization_id,
-                source_id=data_source.id,
-                type=validated_data["data_source"]["data_source_type"],
-            )
+
             if "condition_group" in validated_data:
                 for condition in validated_data["condition_group"]["conditions"]:
                     DataCondition.objects.create(
@@ -178,7 +191,14 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
                 owner_team_id=owner_team_id,
                 created_by_id=self.context["request"].user.id,
             )
-            DataSourceDetector.objects.create(data_source=detector_data_source, detector=detector)
+
+            if "data_source" in validated_data:
+                validated_data_source = validated_data["data_source"]
+                self._create_data_source(validated_data_source, detector)
+
+            if "data_sources" in validated_data:
+                for validated_data_source in validated_data["data_sources"]:
+                    self._create_data_source(validated_data_source, detector)
 
             create_audit_entry(
                 request=self.context["request"],

--- a/tests/sentry/monitors/test_validators.py
+++ b/tests/sentry/monitors/test_validators.py
@@ -896,11 +896,13 @@ class MonitorIncidentDetectorValidatorTest(BaseMonitorValidatorTestCase):
         data = {
             "type": "monitor_check_in_failure",
             "name": "Test Monitor Detector",
-            "dataSource": {
-                "name": "Test Monitor",
-                "slug": "test-monitor",
-                "config": self._get_base_config(),
-            },
+            "dataSources": [
+                {
+                    "name": "Test Monitor",
+                    "slug": "test-monitor",
+                    "config": self._get_base_config(),
+                }
+            ],
         }
         data.update(overrides)
         return data
@@ -918,10 +920,11 @@ class MonitorIncidentDetectorValidatorTest(BaseMonitorValidatorTestCase):
         assert validator.is_valid(), validator.errors
         validated_data = validator.validated_data
         assert validated_data["name"] == "Test Monitor Detector"
-        assert "data_source" in validated_data
-        assert validated_data["data_source"]["name"] == "Test Monitor"
-        assert validated_data["data_source"]["slug"] == "test-monitor"
+        assert "data_sources" in validated_data
+        assert validated_data["data_sources"][0]["name"] == "Test Monitor"
+        assert validated_data["data_sources"][0]["slug"] == "test-monitor"
 
+    @pytest.mark.skip("Not required yet, migrating to dataSources")
     def test_detector_requires_data_source(self):
         data = {
             "type": "monitor_check_in_failure",
@@ -929,7 +932,7 @@ class MonitorIncidentDetectorValidatorTest(BaseMonitorValidatorTestCase):
         }
         validator = self._create_validator(data)
         assert not validator.is_valid()
-        assert "dataSource" in validator.errors
+        assert "dataSources" in validator.errors
 
     def test_create_detector_validates_data_source(self):
         condition_group = DataConditionGroup.objects.create(
@@ -942,5 +945,5 @@ class MonitorIncidentDetectorValidatorTest(BaseMonitorValidatorTestCase):
             context=context,
         )
         assert validator.is_valid(), validator.errors
-        assert "_creator" in validator.validated_data["data_source"]
-        assert validator.validated_data["data_source"]["data_source_type"] == "cron_monitor"
+        assert "_creator" in validator.validated_data["data_sources"][0]
+        assert validator.validated_data["data_sources"][0]["data_source_type"] == "cron_monitor"

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -57,7 +57,6 @@ class OrganizationDetectorIndexBaseTest(APITestCase):
 
 @region_silo_test
 class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
-
     def test_simple(self) -> None:
         detector = self.create_detector(
             project_id=self.project.id, name="Test Detector", type=MetricIssue.slug
@@ -707,15 +706,17 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             "name": "Test Detector",
             "type": MetricIssue.slug,
             "projectId": self.project.id,
-            "dataSource": {
-                "queryType": SnubaQuery.Type.ERROR.value,
-                "dataset": Dataset.Events.name.lower(),
-                "query": "test query",
-                "aggregate": "count()",
-                "timeWindow": 3600,
-                "environment": self.environment.name,
-                "eventTypes": [SnubaQueryEventType.EventType.ERROR.name.lower()],
-            },
+            "dataSources": [
+                {
+                    "queryType": SnubaQuery.Type.ERROR.value,
+                    "dataset": Dataset.Events.name.lower(),
+                    "query": "test query",
+                    "aggregate": "count()",
+                    "timeWindow": 3600,
+                    "environment": self.environment.name,
+                    "eventTypes": [SnubaQueryEventType.EventType.ERROR.name.lower()],
+                }
+            ],
             "conditionGroup": {
                 "id": self.data_condition_group.id,
                 "organizationId": self.organization.id,
@@ -739,7 +740,9 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
     def test_reject_upsampled_count_aggregate(self) -> None:
         """Users should not be able to submit upsampled_count() directly in ACI."""
         data = {**self.valid_data}
-        data["dataSource"] = {**self.valid_data["dataSource"], "aggregate": "upsampled_count()"}
+        data["dataSources"] = [
+            {**self.valid_data["dataSources"][0], "aggregate": "upsampled_count()"}
+        ]
 
         response = self.get_error_response(
             self.organization.slug,
@@ -943,7 +946,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
 
     def test_empty_query_string(self) -> None:
         data = {**self.valid_data}
-        data["dataSource"]["query"] = ""
+        data["dataSources"][0]["query"] = ""
 
         with self.tasks():
             response = self.get_success_response(


### PR DESCRIPTION
# Description
Since the result of the GET request is a list of `dataSources` we should be consistent with the POST body as well.

This will make `dataSource` and `dataSources` optional params while we migrate to dataSources (this will hopefully keep us from dropping anything already running)