### PR TITLE
ref(grouping): Combine variants with matching hashes

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -388,7 +388,10 @@ def _get_stacktrace_hashing_metadata(
     ),
 ) -> StacktraceHashingMetadata:
     return {
-        "stacktrace_type": "in_app" if contributing_variant.variant_name == "app" else "system",
+        # When the app and system stacktraces match (because all frames are in-app), we switch the
+        # variant name to `default` so the UI stops specifying one or the other, but we still want
+        # those to count as in-app
+        "stacktrace_type": "system" if contributing_variant.variant_name == "system" else "in_app",
         "stacktrace_location": (
             "exception"
             if "exception" in contributing_variant.description

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:33.915264+00:00'
+created: '2025-10-01T21:37:17.552754+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,12 +23,12 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  app*
+  default*
     hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
     contributing component: threads
     root_component:
-      app*
-        threads*
+      default*
+        threads* (app and system hashes match)
           stacktrace*
             frame* (marked in-app by the client)
               function*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.378793+00:00'
+created: '2025-10-01T21:37:18.065568+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,12 +23,12 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  app*
+  default*
     hash: "9509e122c6175606d52862fa4f64853c"
     contributing component: exception
     root_component:
-      app*
-        exception*
+      default*
+        exception* (app and system hashes match)
           stacktrace*
             frame* (marked in-app by the client)
               filename*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.396686+00:00'
+created: '2025-10-01T21:37:18.083814+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,12 +23,12 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  app*
+  default*
     hash: "669cb6664e0f5fed38665da04e464f7e"
     contributing component: chained_exception
     root_component:
-      app*
-        chained_exception*
+      default*
+        chained_exception* (app and system hashes match)
           exception*
             stacktrace*
               frame* (marked in-app by the client)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.283947+00:00'
+created: '2025-10-01T21:37:19.947264+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -21,12 +21,12 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  app*
+  default*
     hash: "be36642f41f047346396f018f62375d3"
     contributing component: exception
     root_component:
-      app*
-        exception*
+      default*
+        exception* (app and system hashes match)
           type*
             "Error"
           value*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.028808+00:00'
+created: '2025-10-01T21:37:20.559698+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -21,12 +21,12 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  app*
+  default*
     hash: "be36642f41f047346396f018f62375d3"
     contributing component: exception
     root_component:
-      app*
-        exception*
+      default*
+        exception* (app and system hashes match)
           type*
             "Error"
           value*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.337256+00:00'
+created: '2025-10-01T21:37:20.859276+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,12 +23,12 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  app*
+  default*
     hash: "659ad79e2e70c822d30a53d7d889529e"
     contributing component: stacktrace
     root_component:
-      app*
-        stacktrace*
+      default*
+        stacktrace* (app and system hashes match)
           frame* (marked in-app by the client)
             filename*
               "foo.py"

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.463442+00:00'
+created: '2025-10-01T21:37:20.985482+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,12 +23,12 @@ metrics with tags: {
 }
 ---
 contributing variants:
-  app*
+  default*
     hash: "1a11687556cf74559f0ae90b1c87e2fd"
     contributing component: threads
     root_component:
-      app*
-        threads*
+      default*
+        threads* (app and system hashes match)
           stacktrace*
             frame* (marked in-app by the client)
               filename*

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,19 +1,19 @@
 ---
-created: '2025-09-24T22:53:02.095327+00:00'
+created: '2025-10-01T21:31:20.738148+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "default": {
     "component": {
       "contributes": true,
       "hint": null,
-      "id": "app",
-      "name": "in-app",
+      "id": "default",
+      "name": null,
       "values": [
         {
           "contributes": true,
-          "hint": null,
+          "hint": "app and system hashes match",
           "id": "threads",
           "name": "thread",
           "values": [
@@ -119,45 +119,10 @@ source: tests/sentry/grouping/test_grouping_info.py
               ]
             }
           ]
-        }
-      ]
-    },
-    "config": {
-      "base": "BASE_CONFIG",
-      "delegates": [
-        "frame:v1",
-        "single-exception:v1",
-        "stacktrace:v1"
-      ],
-      "id": "newstyle:2023-01-11",
-      "strategies": [
-        "chained-exception:v1",
-        "csp:v1",
-        "expect-ct:v1",
-        "expect-staple:v1",
-        "hpkp:v1",
-        "message:v1",
-        "stacktrace:v1",
-        "template:v1",
-        "threads:v1"
-      ]
-    },
-    "description": "in-app thread stacktrace",
-    "hash": "ff6c4ee7c54f118a9647ee86f0c2b0b0",
-    "hint": null,
-    "key": "app",
-    "type": "component"
-  },
-  "default": {
-    "component": {
-      "contributes": false,
-      "hint": "ignored because app threads take precedence",
-      "id": "default",
-      "name": null,
-      "values": [
+        },
         {
           "contributes": false,
-          "hint": "ignored because app threads take precedence",
+          "hint": "ignored because threads take precedence",
           "id": "message",
           "name": "message",
           "values": [
@@ -186,154 +151,10 @@ source: tests/sentry/grouping/test_grouping_info.py
         "threads:v1"
       ]
     },
-    "description": "default",
-    "hash": null,
-    "hint": "ignored because app threads take precedence",
+    "description": "thread stacktrace",
+    "hash": "ff6c4ee7c54f118a9647ee86f0c2b0b0",
+    "hint": null,
     "key": "default",
-    "type": "component"
-  },
-  "system": {
-    "component": {
-      "contributes": false,
-      "hint": "ignored because app threads take precedence",
-      "id": "system",
-      "name": null,
-      "values": [
-        {
-          "contributes": false,
-          "hint": "ignored because hash matches app variant",
-          "id": "threads",
-          "name": "thread",
-          "values": [
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": [
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "frame",
-                  "name": null,
-                  "values": [
-                    {
-                      "contributes": false,
-                      "hint": null,
-                      "id": "module",
-                      "name": null,
-                      "values": []
-                    },
-                    {
-                      "contributes": false,
-                      "hint": null,
-                      "id": "filename",
-                      "name": null,
-                      "values": []
-                    },
-                    {
-                      "contributes": true,
-                      "hint": null,
-                      "id": "function",
-                      "name": null,
-                      "values": [
-                        "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "frame",
-                  "name": null,
-                  "values": [
-                    {
-                      "contributes": false,
-                      "hint": null,
-                      "id": "module",
-                      "name": null,
-                      "values": []
-                    },
-                    {
-                      "contributes": false,
-                      "hint": null,
-                      "id": "filename",
-                      "name": null,
-                      "values": []
-                    },
-                    {
-                      "contributes": true,
-                      "hint": null,
-                      "id": "function",
-                      "name": null,
-                      "values": [
-                        "__99+[Something else]_block_invoke_2"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored by stack trace rule (category:internals -group)",
-                  "id": "frame",
-                  "name": null,
-                  "values": [
-                    {
-                      "contributes": false,
-                      "hint": null,
-                      "id": "module",
-                      "name": null,
-                      "values": []
-                    },
-                    {
-                      "contributes": false,
-                      "hint": null,
-                      "id": "filename",
-                      "name": null,
-                      "values": []
-                    },
-                    {
-                      "contributes": true,
-                      "hint": null,
-                      "id": "function",
-                      "name": null,
-                      "values": [
-                        "__00+[Something else]_block_invoke_2"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    "config": {
-      "base": "BASE_CONFIG",
-      "delegates": [
-        "frame:v1",
-        "single-exception:v1",
-        "stacktrace:v1"
-      ],
-      "id": "newstyle:2023-01-11",
-      "strategies": [
-        "chained-exception:v1",
-        "csp:v1",
-        "expect-ct:v1",
-        "expect-staple:v1",
-        "hpkp:v1",
-        "message:v1",
-        "stacktrace:v1",
-        "template:v1",
-        "threads:v1"
-      ]
-    },
-    "description": "system",
-    "hash": null,
-    "hint": "ignored because app threads take precedence",
-    "key": "system",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,19 +1,19 @@
 ---
-created: '2025-09-24T22:53:02.653190+00:00'
+created: '2025-10-01T21:31:21.174186+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "default": {
     "component": {
       "contributes": true,
       "hint": null,
-      "id": "app",
-      "name": "in-app",
+      "id": "default",
+      "name": null,
       "values": [
         {
           "contributes": true,
-          "hint": null,
+          "hint": "app and system hashes match",
           "id": "exception",
           "name": "exception",
           "values": [
@@ -98,110 +98,10 @@ source: tests/sentry/grouping/test_grouping_info.py
         "threads:v1"
       ]
     },
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace",
     "hash": "9509e122c6175606d52862fa4f64853c",
     "hint": null,
-    "key": "app",
-    "type": "component"
-  },
-  "system": {
-    "component": {
-      "contributes": false,
-      "hint": "ignored because app exception takes precedence",
-      "id": "system",
-      "name": null,
-      "values": [
-        {
-          "contributes": false,
-          "hint": "ignored because hash matches app variant",
-          "id": "exception",
-          "name": "exception",
-          "values": [
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": [
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "frame",
-                  "name": null,
-                  "values": [
-                    {
-                      "contributes": false,
-                      "hint": null,
-                      "id": "module",
-                      "name": null,
-                      "values": []
-                    },
-                    {
-                      "contributes": true,
-                      "hint": null,
-                      "id": "filename",
-                      "name": null,
-                      "values": [
-                        "baz.py"
-                      ]
-                    },
-                    {
-                      "contributes": false,
-                      "hint": null,
-                      "id": "function",
-                      "name": null,
-                      "values": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "ValueError"
-              ]
-            },
-            {
-              "contributes": false,
-              "hint": "ignored because stacktrace takes precedence",
-              "id": "value",
-              "name": null,
-              "values": [
-                "hello world"
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    "config": {
-      "base": "BASE_CONFIG",
-      "delegates": [
-        "frame:v1",
-        "single-exception:v1",
-        "stacktrace:v1"
-      ],
-      "id": "newstyle:2023-01-11",
-      "strategies": [
-        "chained-exception:v1",
-        "csp:v1",
-        "expect-ct:v1",
-        "expect-staple:v1",
-        "hpkp:v1",
-        "message:v1",
-        "stacktrace:v1",
-        "template:v1",
-        "threads:v1"
-      ]
-    },
-    "description": "system",
-    "hash": null,
-    "hint": "ignored because app exception takes precedence",
-    "key": "system",
+    "key": "default",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,192 +1,19 @@
 ---
-created: '2025-09-24T22:53:02.674586+00:00'
+created: '2025-10-01T21:31:21.190795+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "default": {
     "component": {
       "contributes": true,
       "hint": null,
-      "id": "app",
-      "name": "in-app",
-      "values": [
-        {
-          "contributes": true,
-          "hint": null,
-          "id": "chained_exception",
-          "name": null,
-          "values": [
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "exception",
-              "name": "exception",
-              "values": [
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": [
-                    {
-                      "contributes": true,
-                      "hint": "marked in-app by the client",
-                      "id": "frame",
-                      "name": null,
-                      "values": [
-                        {
-                          "contributes": false,
-                          "hint": null,
-                          "id": "module",
-                          "name": null,
-                          "values": []
-                        },
-                        {
-                          "contributes": true,
-                          "hint": null,
-                          "id": "filename",
-                          "name": null,
-                          "values": [
-                            "baz.py"
-                          ]
-                        },
-                        {
-                          "contributes": false,
-                          "hint": null,
-                          "id": "function",
-                          "name": null,
-                          "values": []
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "ValueError"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "hello world"
-                  ]
-                }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "exception",
-              "name": "exception",
-              "values": [
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "stacktrace",
-                  "name": "stacktrace",
-                  "values": [
-                    {
-                      "contributes": true,
-                      "hint": "marked in-app by the client",
-                      "id": "frame",
-                      "name": null,
-                      "values": [
-                        {
-                          "contributes": false,
-                          "hint": null,
-                          "id": "module",
-                          "name": null,
-                          "values": []
-                        },
-                        {
-                          "contributes": true,
-                          "hint": null,
-                          "id": "filename",
-                          "name": null,
-                          "values": [
-                            "baz.py"
-                          ]
-                        },
-                        {
-                          "contributes": false,
-                          "hint": null,
-                          "id": "function",
-                          "name": null,
-                          "values": []
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "type",
-                  "name": null,
-                  "values": [
-                    "ValueError"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored because stacktrace takes precedence",
-                  "id": "value",
-                  "name": null,
-                  "values": [
-                    "hello world"
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    "config": {
-      "base": "BASE_CONFIG",
-      "delegates": [
-        "frame:v1",
-        "single-exception:v1",
-        "stacktrace:v1"
-      ],
-      "id": "newstyle:2023-01-11",
-      "strategies": [
-        "chained-exception:v1",
-        "csp:v1",
-        "expect-ct:v1",
-        "expect-staple:v1",
-        "hpkp:v1",
-        "message:v1",
-        "stacktrace:v1",
-        "template:v1",
-        "threads:v1"
-      ]
-    },
-    "description": "in-app exception stacktrace",
-    "hash": "669cb6664e0f5fed38665da04e464f7e",
-    "hint": null,
-    "key": "app",
-    "type": "component"
-  },
-  "system": {
-    "component": {
-      "contributes": false,
-      "hint": "ignored because app exception takes precedence",
-      "id": "system",
+      "id": "default",
       "name": null,
       "values": [
         {
-          "contributes": false,
-          "hint": "ignored because hash matches app variant",
+          "contributes": true,
+          "hint": "app and system hashes match",
           "id": "chained_exception",
           "name": null,
           "values": [
@@ -204,7 +31,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     {
                       "contributes": true,
-                      "hint": null,
+                      "hint": "marked in-app by the client",
                       "id": "frame",
                       "name": null,
                       "values": [
@@ -269,7 +96,7 @@ source: tests/sentry/grouping/test_grouping_info.py
                   "values": [
                     {
                       "contributes": true,
-                      "hint": null,
+                      "hint": "marked in-app by the client",
                       "id": "frame",
                       "name": null,
                       "values": [
@@ -344,10 +171,10 @@ source: tests/sentry/grouping/test_grouping_info.py
         "threads:v1"
       ]
     },
-    "description": "system",
-    "hash": null,
-    "hint": "ignored because app exception takes precedence",
-    "key": "system",
+    "description": "exception stacktrace",
+    "hash": "669cb6664e0f5fed38665da04e464f7e",
+    "hint": null,
+    "key": "default",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,19 +1,19 @@
 ---
-created: '2025-09-24T22:53:04.588879+00:00'
+created: '2025-10-01T21:31:22.919394+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "default": {
     "component": {
       "contributes": true,
       "hint": null,
-      "id": "app",
-      "name": "in-app",
+      "id": "default",
+      "name": null,
       "values": [
         {
           "contributes": true,
-          "hint": null,
+          "hint": "app and system hashes match",
           "id": "exception",
           "name": "exception",
           "values": [
@@ -166,178 +166,10 @@ source: tests/sentry/grouping/test_grouping_info.py
         "threads:v1"
       ]
     },
-    "description": "in-app exception",
+    "description": "exception",
     "hash": "be36642f41f047346396f018f62375d3",
     "hint": null,
-    "key": "app",
-    "type": "component"
-  },
-  "system": {
-    "component": {
-      "contributes": false,
-      "hint": "ignored because app exception takes precedence",
-      "id": "system",
-      "name": null,
-      "values": [
-        {
-          "contributes": false,
-          "hint": "ignored because hash matches app variant",
-          "id": "exception",
-          "name": "exception",
-          "values": [
-            {
-              "contributes": false,
-              "hint": "ignored because it contains no contributing frames",
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": [
-                {
-                  "contributes": false,
-                  "hint": "ignored by stack trace rule (module:@babel/** -group)",
-                  "id": "frame",
-                  "name": null,
-                  "values": [
-                    {
-                      "contributes": true,
-                      "hint": null,
-                      "id": "module",
-                      "name": null,
-                      "values": [
-                        "@babel/runtime/helpers/asyncToGenerator"
-                      ]
-                    },
-                    {
-                      "contributes": false,
-                      "hint": null,
-                      "id": "filename",
-                      "name": null,
-                      "values": []
-                    },
-                    {
-                      "contributes": false,
-                      "hint": "ignored unknown function name",
-                      "id": "function",
-                      "name": null,
-                      "values": [
-                        "<anonymous>"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored by stack trace rule (module:core-js/** -group)",
-                  "id": "frame",
-                  "name": null,
-                  "values": [
-                    {
-                      "contributes": true,
-                      "hint": null,
-                      "id": "module",
-                      "name": null,
-                      "values": [
-                        "core-js/internals/task"
-                      ]
-                    },
-                    {
-                      "contributes": false,
-                      "hint": null,
-                      "id": "filename",
-                      "name": null,
-                      "values": []
-                    },
-                    {
-                      "contributes": true,
-                      "hint": null,
-                      "id": "function",
-                      "name": null,
-                      "values": [
-                        "listener"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored by stack trace rule (module:tslib/** -group)",
-                  "id": "frame",
-                  "name": null,
-                  "values": [
-                    {
-                      "contributes": true,
-                      "hint": null,
-                      "id": "module",
-                      "name": null,
-                      "values": [
-                        "tslib/tslib.es6"
-                      ]
-                    },
-                    {
-                      "contributes": false,
-                      "hint": null,
-                      "id": "filename",
-                      "name": null,
-                      "values": []
-                    },
-                    {
-                      "contributes": true,
-                      "hint": "trimmed javascript function",
-                      "id": "function",
-                      "name": null,
-                      "values": [
-                        "sent"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    "config": {
-      "base": "BASE_CONFIG",
-      "delegates": [
-        "frame:v1",
-        "single-exception:v1",
-        "stacktrace:v1"
-      ],
-      "id": "newstyle:2023-01-11",
-      "strategies": [
-        "chained-exception:v1",
-        "csp:v1",
-        "expect-ct:v1",
-        "expect-staple:v1",
-        "hpkp:v1",
-        "message:v1",
-        "stacktrace:v1",
-        "template:v1",
-        "threads:v1"
-      ]
-    },
-    "description": "system",
-    "hash": null,
-    "hint": "ignored because app exception takes precedence",
-    "key": "system",
+    "key": "default",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,19 +1,19 @@
 ---
-created: '2025-09-24T22:53:05.299328+00:00'
+created: '2025-10-01T21:31:23.648140+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "default": {
     "component": {
       "contributes": true,
       "hint": null,
-      "id": "app",
-      "name": "in-app",
+      "id": "default",
+      "name": null,
       "values": [
         {
           "contributes": true,
-          "hint": null,
+          "hint": "app and system hashes match",
           "id": "exception",
           "name": "exception",
           "values": [
@@ -135,147 +135,10 @@ source: tests/sentry/grouping/test_grouping_info.py
         "threads:v1"
       ]
     },
-    "description": "in-app exception",
+    "description": "exception",
     "hash": "be36642f41f047346396f018f62375d3",
     "hint": null,
-    "key": "app",
-    "type": "component"
-  },
-  "system": {
-    "component": {
-      "contributes": false,
-      "hint": "ignored because app exception takes precedence",
-      "id": "system",
-      "name": null,
-      "values": [
-        {
-          "contributes": false,
-          "hint": "ignored because hash matches app variant",
-          "id": "exception",
-          "name": "exception",
-          "values": [
-            {
-              "contributes": false,
-              "hint": "ignored because it contains no contributing frames",
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": [
-                {
-                  "contributes": false,
-                  "hint": "ignored by stack trace rule (function:processTicksAndRejections -group)",
-                  "id": "frame",
-                  "name": null,
-                  "values": [
-                    {
-                      "contributes": true,
-                      "hint": null,
-                      "id": "module",
-                      "name": null,
-                      "values": [
-                        "task_queues"
-                      ]
-                    },
-                    {
-                      "contributes": false,
-                      "hint": "ignored because module takes precedence",
-                      "id": "filename",
-                      "name": null,
-                      "values": [
-                        "task_queues"
-                      ]
-                    },
-                    {
-                      "contributes": true,
-                      "hint": null,
-                      "id": "function",
-                      "name": null,
-                      "values": [
-                        "processTicksAndRejections"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": "ignored by stack trace rule (function:runMicrotasks -group)",
-                  "id": "frame",
-                  "name": null,
-                  "values": [
-                    {
-                      "contributes": false,
-                      "hint": null,
-                      "id": "module",
-                      "name": null,
-                      "values": []
-                    },
-                    {
-                      "contributes": true,
-                      "hint": null,
-                      "id": "filename",
-                      "name": null,
-                      "values": [
-                        "axiosinterceptor.js"
-                      ]
-                    },
-                    {
-                      "contributes": true,
-                      "hint": null,
-                      "id": "function",
-                      "name": null,
-                      "values": [
-                        "runMicrotasks"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "type",
-              "name": null,
-              "values": [
-                "Error"
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "value",
-              "name": null,
-              "values": [
-                "bad"
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    "config": {
-      "base": "BASE_CONFIG",
-      "delegates": [
-        "frame:v1",
-        "single-exception:v1",
-        "stacktrace:v1"
-      ],
-      "id": "newstyle:2023-01-11",
-      "strategies": [
-        "chained-exception:v1",
-        "csp:v1",
-        "expect-ct:v1",
-        "expect-staple:v1",
-        "hpkp:v1",
-        "message:v1",
-        "stacktrace:v1",
-        "template:v1",
-        "threads:v1"
-      ]
-    },
-    "description": "system",
-    "hash": null,
-    "hint": "ignored because app exception takes precedence",
-    "key": "system",
+    "key": "default",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,130 +1,25 @@
 ---
-created: '2025-09-24T22:53:05.599318+00:00'
+created: '2025-10-01T21:31:23.965609+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "default": {
     "component": {
       "contributes": true,
       "hint": null,
-      "id": "app",
-      "name": "in-app",
-      "values": [
-        {
-          "contributes": true,
-          "hint": null,
-          "id": "stacktrace",
-          "name": "stacktrace",
-          "values": [
-            {
-              "contributes": true,
-              "hint": "marked in-app by the client",
-              "id": "frame",
-              "name": null,
-              "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "module",
-                  "name": null,
-                  "values": []
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "filename",
-                  "name": null,
-                  "values": [
-                    "foo.py"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "function",
-                  "name": null,
-                  "values": []
-                }
-              ]
-            },
-            {
-              "contributes": true,
-              "hint": "marked in-app by the client",
-              "id": "frame",
-              "name": null,
-              "values": [
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "module",
-                  "name": null,
-                  "values": []
-                },
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "filename",
-                  "name": null,
-                  "values": [
-                    "bar.py"
-                  ]
-                },
-                {
-                  "contributes": false,
-                  "hint": null,
-                  "id": "function",
-                  "name": null,
-                  "values": []
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    "config": {
-      "base": "BASE_CONFIG",
-      "delegates": [
-        "frame:v1",
-        "single-exception:v1",
-        "stacktrace:v1"
-      ],
-      "id": "newstyle:2023-01-11",
-      "strategies": [
-        "chained-exception:v1",
-        "csp:v1",
-        "expect-ct:v1",
-        "expect-staple:v1",
-        "hpkp:v1",
-        "message:v1",
-        "stacktrace:v1",
-        "template:v1",
-        "threads:v1"
-      ]
-    },
-    "description": "in-app stacktrace",
-    "hash": "659ad79e2e70c822d30a53d7d889529e",
-    "hint": null,
-    "key": "app",
-    "type": "component"
-  },
-  "system": {
-    "component": {
-      "contributes": false,
-      "hint": "ignored because app stacktrace takes precedence",
-      "id": "system",
+      "id": "default",
       "name": null,
       "values": [
         {
-          "contributes": false,
-          "hint": "ignored because hash matches app variant",
+          "contributes": true,
+          "hint": "app and system hashes match",
           "id": "stacktrace",
           "name": "stacktrace",
           "values": [
             {
               "contributes": true,
-              "hint": null,
+              "hint": "marked in-app by the client",
               "id": "frame",
               "name": null,
               "values": [
@@ -155,7 +50,7 @@ source: tests/sentry/grouping/test_grouping_info.py
             },
             {
               "contributes": true,
-              "hint": null,
+              "hint": "marked in-app by the client",
               "id": "frame",
               "name": null,
               "values": [
@@ -208,10 +103,10 @@ source: tests/sentry/grouping/test_grouping_info.py
         "threads:v1"
       ]
     },
-    "description": "system",
-    "hash": null,
-    "hint": "ignored because app stacktrace takes precedence",
-    "key": "system",
+    "description": "stacktrace",
+    "hash": "659ad79e2e70c822d30a53d7d889529e",
+    "hint": null,
+    "key": "default",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,19 +1,19 @@
 ---
-created: '2025-09-24T22:53:05.723099+00:00'
+created: '2025-10-01T21:31:24.109257+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "default": {
     "component": {
       "contributes": true,
       "hint": null,
-      "id": "app",
-      "name": "in-app",
+      "id": "default",
+      "name": null,
       "values": [
         {
           "contributes": true,
-          "hint": null,
+          "hint": "app and system hashes match",
           "id": "threads",
           "name": "thread",
           "values": [
@@ -82,94 +82,10 @@ source: tests/sentry/grouping/test_grouping_info.py
         "threads:v1"
       ]
     },
-    "description": "in-app thread stacktrace",
+    "description": "thread stacktrace",
     "hash": "1a11687556cf74559f0ae90b1c87e2fd",
     "hint": null,
-    "key": "app",
-    "type": "component"
-  },
-  "system": {
-    "component": {
-      "contributes": false,
-      "hint": "ignored because app threads take precedence",
-      "id": "system",
-      "name": null,
-      "values": [
-        {
-          "contributes": false,
-          "hint": "ignored because hash matches app variant",
-          "id": "threads",
-          "name": "thread",
-          "values": [
-            {
-              "contributes": true,
-              "hint": null,
-              "id": "stacktrace",
-              "name": "stacktrace",
-              "values": [
-                {
-                  "contributes": true,
-                  "hint": null,
-                  "id": "frame",
-                  "name": null,
-                  "values": [
-                    {
-                      "contributes": false,
-                      "hint": null,
-                      "id": "module",
-                      "name": null,
-                      "values": []
-                    },
-                    {
-                      "contributes": true,
-                      "hint": null,
-                      "id": "filename",
-                      "name": null,
-                      "values": [
-                        "baz.c"
-                      ]
-                    },
-                    {
-                      "contributes": true,
-                      "hint": null,
-                      "id": "function",
-                      "name": null,
-                      "values": [
-                        "main"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    "config": {
-      "base": "BASE_CONFIG",
-      "delegates": [
-        "frame:v1",
-        "single-exception:v1",
-        "stacktrace:v1"
-      ],
-      "id": "newstyle:2023-01-11",
-      "strategies": [
-        "chained-exception:v1",
-        "csp:v1",
-        "expect-ct:v1",
-        "expect-staple:v1",
-        "hpkp:v1",
-        "message:v1",
-        "stacktrace:v1",
-        "template:v1",
-        "threads:v1"
-      ]
-    },
-    "description": "system",
-    "hash": null,
-    "hint": "ignored because app threads take precedence",
-    "key": "system",
+    "key": "default",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2025-09-24T20:27:05.512364+00:00'
+created: '2025-10-01T21:31:45.886956+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-app:
+default:
   hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
   contributing component: threads
   root_component:
-    app*
-      threads*
+    default*
+      threads* (app and system hashes match)
         stacktrace*
           frame* (marked in-app by the client)
             function*
@@ -19,28 +19,5 @@ app:
           frame (marked out of app by the client)
             function*
               "__00+[Something else]_block_invoke_2"
---------------------------------------------------------------------------
-default:
-  hash: null
-  contributing component: null
-  root_component:
-    default (ignored because app threads take precedence)
-      message (ignored because app threads take precedence)
+      message (ignored because threads take precedence)
         "Foo"
---------------------------------------------------------------------------
-system:
-  hash: null
-  contributing component: null
-  root_component:
-    system (ignored because app threads take precedence)
-      threads (ignored because hash matches app variant)
-        stacktrace*
-          frame*
-            function*
-              "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame*
-            function*
-              "__99+[Something else]_block_invoke_2"
-          frame (ignored by stack trace rule (category:internals -group))
-            function*
-              "__00+[Something else]_block_invoke_2"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,31 +1,16 @@
 ---
-created: '2025-09-24T20:27:06.018498+00:00'
+created: '2025-10-01T21:31:46.363058+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-app:
+default:
   hash: "9509e122c6175606d52862fa4f64853c"
   contributing component: exception
   root_component:
-    app*
-      exception*
+    default*
+      exception* (app and system hashes match)
         stacktrace*
           frame* (marked in-app by the client)
-            filename*
-              "baz.py"
-        type*
-          "ValueError"
-        value (ignored because stacktrace takes precedence)
-          "hello world"
---------------------------------------------------------------------------
-system:
-  hash: null
-  contributing component: null
-  root_component:
-    system (ignored because app exception takes precedence)
-      exception (ignored because hash matches app variant)
-        stacktrace*
-          frame*
             filename*
               "baz.py"
         type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2025-09-24T20:27:06.036292+00:00'
+created: '2025-10-01T21:31:46.379981+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-app:
+default:
   hash: "669cb6664e0f5fed38665da04e464f7e"
   contributing component: chained_exception
   root_component:
-    app*
-      chained_exception*
+    default*
+      chained_exception* (app and system hashes match)
         exception*
           stacktrace*
             frame* (marked in-app by the client)
@@ -21,31 +21,6 @@ app:
         exception*
           stacktrace*
             frame* (marked in-app by the client)
-              filename*
-                "baz.py"
-          type*
-            "ValueError"
-          value (ignored because stacktrace takes precedence)
-            "hello world"
---------------------------------------------------------------------------
-system:
-  hash: null
-  contributing component: null
-  root_component:
-    system (ignored because app exception takes precedence)
-      chained_exception (ignored because hash matches app variant)
-        exception*
-          stacktrace*
-            frame*
-              filename*
-                "baz.py"
-          type*
-            "ValueError"
-          value (ignored because stacktrace takes precedence)
-            "hello world"
-        exception*
-          stacktrace*
-            frame*
               filename*
                 "baz.py"
           type*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2025-09-24T20:27:07.888908+00:00'
+created: '2025-10-01T21:31:48.214026+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-app:
+default:
   hash: "be36642f41f047346396f018f62375d3"
   contributing component: exception
   root_component:
-    app*
-      exception*
+    default*
+      exception* (app and system hashes match)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (module:@babel/** -app))
             module*
@@ -21,33 +21,6 @@ app:
             function*
               "listener"
           frame (marked out of app by stack trace rule (module:tslib/** -app))
-            module*
-              "tslib/tslib.es6"
-            function* (trimmed javascript function)
-              "sent"
-        type*
-          "Error"
-        value*
-          "bad"
---------------------------------------------------------------------------
-system:
-  hash: null
-  contributing component: null
-  root_component:
-    system (ignored because app exception takes precedence)
-      exception (ignored because hash matches app variant)
-        stacktrace (ignored because it contains no contributing frames)
-          frame (ignored by stack trace rule (module:@babel/** -group))
-            module*
-              "@babel/runtime/helpers/asyncToGenerator"
-            function (ignored unknown function name)
-              "<anonymous>"
-          frame (ignored by stack trace rule (module:core-js/** -group))
-            module*
-              "core-js/internals/task"
-            function*
-              "listener"
-          frame (ignored by stack trace rule (module:tslib/** -group))
             module*
               "tslib/tslib.es6"
             function* (trimmed javascript function)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2025-09-24T20:27:08.656302+00:00'
+created: '2025-10-01T21:31:48.817587+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-app:
+default:
   hash: "be36642f41f047346396f018f62375d3"
   contributing component: exception
   root_component:
-    app*
-      exception*
+    default*
+      exception* (app and system hashes match)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (function:processTicksAndRejections -app))
             module*
@@ -18,30 +18,6 @@ app:
             function*
               "processTicksAndRejections"
           frame (marked out of app by stack trace rule (function:runMicrotasks -app))
-            filename*
-              "axiosinterceptor.js"
-            function*
-              "runMicrotasks"
-        type*
-          "Error"
-        value*
-          "bad"
---------------------------------------------------------------------------
-system:
-  hash: null
-  contributing component: null
-  root_component:
-    system (ignored because app exception takes precedence)
-      exception (ignored because hash matches app variant)
-        stacktrace (ignored because it contains no contributing frames)
-          frame (ignored by stack trace rule (function:processTicksAndRejections -group))
-            module*
-              "task_queues"
-            filename (ignored because module takes precedence)
-              "task_queues"
-            function*
-              "processTicksAndRejections"
-          frame (ignored by stack trace rule (function:runMicrotasks -group))
             filename*
               "axiosinterceptor.js"
             function*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,30 +1,17 @@
 ---
-created: '2025-09-24T20:27:08.960999+00:00'
+created: '2025-10-01T21:31:49.111014+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-app:
+default:
   hash: "659ad79e2e70c822d30a53d7d889529e"
   contributing component: stacktrace
   root_component:
-    app*
-      stacktrace*
+    default*
+      stacktrace* (app and system hashes match)
         frame* (marked in-app by the client)
           filename*
             "foo.py"
         frame* (marked in-app by the client)
-          filename*
-            "bar.py"
---------------------------------------------------------------------------
-system:
-  hash: null
-  contributing component: null
-  root_component:
-    system (ignored because app stacktrace takes precedence)
-      stacktrace (ignored because hash matches app variant)
-        frame*
-          filename*
-            "foo.py"
-        frame*
           filename*
             "bar.py"

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,29 +1,16 @@
 ---
-created: '2025-09-24T20:27:09.089493+00:00'
+created: '2025-10-01T21:31:49.256725+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-app:
+default:
   hash: "1a11687556cf74559f0ae90b1c87e2fd"
   contributing component: threads
   root_component:
-    app*
-      threads*
+    default*
+      threads* (app and system hashes match)
         stacktrace*
           frame* (marked in-app by the client)
-            filename*
-              "baz.c"
-            function*
-              "main"
---------------------------------------------------------------------------
-system:
-  hash: null
-  contributing component: null
-  root_component:
-    system (ignored because app threads take precedence)
-      threads (ignored because hash matches app variant)
-        stacktrace*
-          frame*
             filename*
               "baz.c"
             function*


### PR DESCRIPTION
In our current grouping algorithm, when all frames in a stacktrace are in-app, the `app` and `system` variants produce the same hash, because they're both using the full stacktrace. When that happens, we dedupe the variants by marking the system variant as non-contributing and giving the stacktrace container component (exception or threads) the hint `ignored because hash matches app variant`.

The problem with this is that it's confusing, because on the one hand we say we're not using the "system" (in other words, "full") stacktrace, but on the other hand the stacktrace we say we are using (the in-app one) contains every frame. There is the aforementioned hint, but it's buried in small print partway into the component tree, so it's easy to miss.

This PR aims to clear up that confusion by switching it so that rather than keeping the system variant and saying we're not using its hash (even though, of course, we are, since it's the same hash as the app variant), we instead combine the two variants into one, and adding a hint noting the match. Because in this case there's no distinction between in-app and full stacktraces, it also switches the variant from `app` to `default`.

Note that this has no effect on actual grouping, because all it does is remove variants which we already weren't using.

Before:

<img width="722" height="599" alt="image" src="https://github.com/user-attachments/assets/59849c63-37e9-425b-9442-0427175f9e31" />

After:

<img width="680" height="328" alt="image" src="https://github.com/user-attachments/assets/a601be2c-b4c9-4385-92e9-0eaeaa91dc78" />
