### PR TITLE
fix(replay): fix feedback breadcrumb from malformed event

### DIFF
--- a/static/app/utils/replays/hydrateFrames.tsx
+++ b/static/app/utils/replays/hydrateFrames.tsx
@@ -25,7 +25,12 @@ export default function hydrateFrames(attachments: unknown[]) {
       return;
     }
     if (isBreadcrumbFrameEvent(attachment)) {
-      if (attachment.data.payload.category !== 'sentry.feedback') {
+      // Do not include feedback frames as breadcrumb frames.
+      // They are now fetched and hydrated the same way as error frames.
+      if (
+        attachment.data.payload.category !== 'sentry.feedback' &&
+        attachment.data.payload.category !== 'feedback'
+      ) {
         breadcrumbFrames.push(attachment.data.payload);
       }
     } else if (isSpanFrameEvent(attachment)) {


### PR DESCRIPTION
fixes JAVASCRIPT-33QC

this seems like a rare case and i'm not sure why/how it happened, but many malformed events with `category: feedback` came through to this org's replay and each one was attempting to render as a crumb, but it didn't have all the valid fields like `projectSlug` etc so the whole row errored. none of these malformed events were hydrated as feedback frames in `hydrateErrors`, meaning the frame wasn't being fetched the same way as feedbacks (and errors) normally should be. in that case, it's probably just bad data, so my proposal is to hide it from display rather than show all these errored rows:

<img width="914" height="337" alt="SCR-20251001-oinp" src="https://github.com/user-attachments/assets/55be70bf-98d8-4db2-81d0-211ac1df6468" />

example of bad data:

<img width="343" height="200" alt="SCR-20251001-nzqu" src="https://github.com/user-attachments/assets/9a4b8a4e-c8d0-47be-af65-1bc782f8b02d" />
