### PR TITLE
ref(workflow_engine): update dataSource => dataSources in ui

### DIFF
--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -195,22 +195,22 @@ export interface BaseDetectorUpdatePayload {
 
 export interface UptimeDetectorUpdatePayload extends BaseDetectorUpdatePayload {
   config: UptimeDetectorConfig;
-  dataSource: UpdateUptimeDataSourcePayload;
+  dataSources: UpdateUptimeDataSourcePayload[];
   type: 'uptime_domain_failure';
 }
 
 export interface MetricDetectorUpdatePayload extends BaseDetectorUpdatePayload {
   conditionGroup: UpdateConditionGroupPayload;
   config: MetricDetectorConfig;
-  dataSource: UpdateSnubaDataSourcePayload;
+  dataSources: UpdateSnubaDataSourcePayload[];
   type: 'metric_issue';
 }
 
 export interface CronDetectorUpdatePayload extends BaseDetectorUpdatePayload {
-  dataSource: {
+  dataSources: Array<{
     config: MonitorConfig;
     name: string;
-  };
+  }>;
   type: 'monitor_check_in_failure';
 }
 

--- a/static/app/views/detectors/components/forms/cron/fields.tsx
+++ b/static/app/views/detectors/components/forms/cron/fields.tsx
@@ -81,10 +81,12 @@ export function cronFormDataToEndpointPayload(
     owner: data.owner,
     projectId: data.projectId,
     workflowIds: data.workflowIds,
-    dataSource: {
-      name: data.name,
-      config,
-    },
+    dataSources: [
+      {
+        name: data.name,
+        config,
+      },
+    ],
   };
 }
 

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -122,7 +122,7 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
       owner: detector.owner ? `${detector.owner?.type}:${detector.owner?.id}` : '',
       projectId: detector.projectId,
       workflowIds: data.workflowIds,
-      dataSource: {},
+      dataSources: [],
       conditionGroup: {},
     }),
   });

--- a/static/app/views/detectors/components/forms/metric/metricFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricFormData.tsx
@@ -342,7 +342,7 @@ export function metricDetectorFormDataToEndpointPayload(
       conditions,
     },
     config,
-    dataSource,
+    dataSources: [dataSource],
     workflowIds: data.workflowIds,
   };
 }

--- a/static/app/views/detectors/components/forms/uptime/fields.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.tsx
@@ -34,13 +34,15 @@ export function uptimeFormDataToEndpointPayload(
     owner: data.owner,
     projectId: data.projectId,
     workflowIds: data.workflowIds,
-    dataSource: {
-      intervalSeconds: data.intervalSeconds,
-      method: data.method,
-      timeoutMs: data.timeoutMs,
-      traceSampling: data.traceSampling,
-      url: data.url,
-    },
+    dataSources: [
+      {
+        intervalSeconds: data.intervalSeconds,
+        method: data.method,
+        timeoutMs: data.timeoutMs,
+        traceSampling: data.traceSampling,
+        url: data.url,
+      },
+    ],
     config: {
       mode: UptimeMonitorMode.MANUAL,
       recoveryThreshold: data.recoveryThreshold ?? UPTIME_DEFAULT_RECOVERY_THRESHOLD,

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -308,15 +308,17 @@ describe('DetectorEdit', () => {
               projectId: project.id,
               type: 'metric_issue',
               workflowIds: mockDetector.workflowIds,
-              dataSource: {
-                environment: 'production',
-                aggregate: snubaQuery.aggregate,
-                dataset: snubaQuery.dataset,
-                query: snubaQuery.query,
-                timeWindow: snubaQuery.timeWindow,
-                eventTypes: ['error'],
-                queryType: 0,
-              },
+              dataSources: [
+                {
+                  environment: 'production',
+                  aggregate: snubaQuery.aggregate,
+                  dataset: snubaQuery.dataset,
+                  query: snubaQuery.query,
+                  timeWindow: snubaQuery.timeWindow,
+                  eventTypes: ['error'],
+                  queryType: 0,
+                },
+              ],
               conditionGroup: {
                 conditions: [{comparison: 8, conditionResult: 75, type: 'gt'}],
                 logicType: 'any',
@@ -727,14 +729,16 @@ describe('DetectorEdit', () => {
             expect.anything(),
             expect.objectContaining({
               data: expect.objectContaining({
-                dataSource: expect.objectContaining({
-                  // Aggreate needs to be transformed to this in order to save correctly
-                  aggregate:
-                    'percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate',
-                  dataset: Dataset.METRICS,
-                  eventTypes: [],
-                  queryType: SnubaQueryType.CRASH_RATE,
-                }),
+                dataSources: expect.arrayContaining([
+                  expect.objectContaining({
+                    // Aggreate needs to be transformed to this in order to save correctly
+                    aggregate:
+                      'percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate',
+                    dataset: Dataset.METRICS,
+                    eventTypes: [],
+                    queryType: SnubaQueryType.CRASH_RATE,
+                  }),
+                ]),
               }),
             })
           );

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -591,18 +591,20 @@ describe('DetectorEdit', () => {
             name: 'New Monitor',
             projectId: project.id,
             workflowIds: [],
-            dataSource: expect.objectContaining({
-              name: 'New Monitor',
-              config: expect.objectContaining({
-                schedule: '0 0 * * *',
-                schedule_type: 'crontab',
-                timezone: 'UTC',
-                checkin_margin: 1,
-                failure_issue_threshold: 1,
-                max_runtime: 30,
-                recovery_threshold: 1,
+            dataSources: expect.arrayContaining([
+              expect.objectContaining({
+                name: 'New Monitor',
+                config: expect.objectContaining({
+                  schedule: '0 0 * * *',
+                  schedule_type: 'crontab',
+                  timezone: 'UTC',
+                  checkin_margin: 1,
+                  failure_issue_threshold: 1,
+                  max_runtime: 30,
+                  recovery_threshold: 1,
+                }),
               }),
-            }),
+            ]),
           }),
         })
       );

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -142,15 +142,17 @@ describe('DetectorEdit', () => {
                 detectionType: 'static',
                 thresholdPeriod: 1,
               },
-              dataSource: {
-                aggregate: 'count(span.duration)',
-                dataset: 'events_analytics_platform',
-                eventTypes: ['trace_item_span'],
-                query: '',
-                queryType: 1,
-                timeWindow: 3600,
-                environment: null,
-              },
+              dataSources: [
+                {
+                  aggregate: 'count(span.duration)',
+                  dataset: 'events_analytics_platform',
+                  eventTypes: ['trace_item_span'],
+                  query: '',
+                  queryType: 1,
+                  timeWindow: 3600,
+                  environment: null,
+                },
+              ],
             }),
           })
         );
@@ -275,16 +277,18 @@ describe('DetectorEdit', () => {
                 logicType: 'any',
               },
               config: {detectionType: 'static', thresholdPeriod: 1},
-              dataSource: {
-                aggregate: 'count()',
-                dataset: 'events',
-                environment: null,
-                // Event type has moved from the query to the eventTypes field
-                eventTypes: ['error'],
-                query: '',
-                queryType: 0,
-                timeWindow: 3600,
-              },
+              dataSources: [
+                {
+                  aggregate: 'count()',
+                  dataset: 'events',
+                  environment: null,
+                  // Event type has moved from the query to the eventTypes field
+                  eventTypes: ['error'],
+                  query: '',
+                  queryType: 0,
+                  timeWindow: 3600,
+                },
+              ],
               name: 'Foo',
               owner: null,
               projectId: '2',
@@ -426,13 +430,15 @@ describe('DetectorEdit', () => {
               mode: 1,
               recoveryThreshold: 1,
             },
-            dataSource: {
-              intervalSeconds: 60,
-              method: 'GET',
-              timeoutMs: 5000,
-              traceSampling: undefined,
-              url: 'https://uptime.example.com',
-            },
+            dataSources: [
+              {
+                intervalSeconds: 60,
+                method: 'GET',
+                timeoutMs: 5000,
+                traceSampling: undefined,
+                url: 'https://uptime.example.com',
+              },
+            ],
             name: 'New MonitorUptime Monitor',
             projectId: '2',
             type: 'uptime_domain_failure',
@@ -486,13 +492,13 @@ describe('DetectorEdit', () => {
               mode: 1,
               recoveryThreshold: '4',
             },
-            dataSource: {
+            dataSources: [{
               intervalSeconds: 60,
               method: 'GET',
               timeoutMs: 5000,
               traceSampling: undefined,
               url: 'https://uptime-custom.example.com',
-            },
+            }],
             name: 'Uptime check for uptime-custom.example.com',
             projectId: '2',
             type: 'uptime_domain_failure',

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -494,13 +494,15 @@ describe('DetectorEdit', () => {
               mode: 1,
               recoveryThreshold: '4',
             },
-            dataSources: [{
-              intervalSeconds: 60,
-              method: 'GET',
-              timeoutMs: 5000,
-              traceSampling: undefined,
-              url: 'https://uptime-custom.example.com',
-            }],
+            dataSources: [
+              {
+                intervalSeconds: 60,
+                method: 'GET',
+                timeoutMs: 5000,
+                traceSampling: undefined,
+                url: 'https://uptime-custom.example.com',
+              },
+            ],
             name: 'Uptime check for uptime-custom.example.com',
             projectId: '2',
             type: 'uptime_domain_failure',

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -218,15 +218,17 @@ describe('DetectorEdit', () => {
                 logicType: 'any',
               },
               config: {detectionType: 'static', thresholdPeriod: 1},
-              dataSource: {
-                aggregate: 'count_unique(tags[sentry:user])',
-                dataset: 'events',
-                environment: 'prod',
-                eventTypes: ['error'],
-                query: '',
-                queryType: 0,
-                timeWindow: 3600,
-              },
+              dataSources: [
+                {
+                  aggregate: 'count_unique(tags[sentry:user])',
+                  dataset: 'events',
+                  environment: 'prod',
+                  eventTypes: ['error'],
+                  query: '',
+                  queryType: 0,
+                  timeWindow: 3600,
+                },
+              ],
             }),
           })
         );


### PR DESCRIPTION
# Description
Related: https://github.com/getsentry/sentry/pull/100755 -- this PR is required to be deployed before merging this PR. 🔒 

This updates the types and payloads for `dataSource` to become `dataSources`. once this PR is live, we can remove `data_source` in the detector validator.