### PR TITLE
feat(agent-monitoring): Add instructions for missing IO attributes

### DIFF
--- a/static/app/views/insights/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/agents/components/aiSpanList.tsx
@@ -18,6 +18,8 @@ import {
   getIsAiCreateAgentSpan,
   getIsAiGenerationSpan,
   getIsAiRunSpan,
+  getIsExecuteToolSpan,
+  getIsHandoffSpan,
 } from 'sentry/views/insights/agents/utils/query';
 import type {AITraceSpanNode} from 'sentry/views/insights/agents/utils/types';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -356,13 +358,13 @@ function getNodeInfo(node: AITraceSpanNode, colors: readonly string[]) {
       );
     }
     nodeInfo.color = colors[2];
-  } else if (op === 'gen_ai.execute_tool') {
+  } else if (getIsExecuteToolSpan({op})) {
     const toolName = getNodeAttribute(SpanFields.GEN_AI_TOOL_NAME);
     nodeInfo.icon = <IconTool size="md" />;
     nodeInfo.title = toolName || truncatedOp;
     nodeInfo.subtitle = toolName ? truncatedOp : '';
     nodeInfo.color = colors[5];
-  } else if (op === 'gen_ai.handoff') {
+  } else if (getIsHandoffSpan({op})) {
     nodeInfo.icon = <IconChevron size="md" isDouble direction="right" />;
     nodeInfo.subtitle = node.value.description || '';
     nodeInfo.color = colors[4];

--- a/static/app/views/insights/agents/components/drawer.tsx
+++ b/static/app/views/insights/agents/components/drawer.tsx
@@ -25,7 +25,7 @@ import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceD
 import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 
 const LEFT_PANEL_WIDTH = 400;
-const RIGHT_PANEL_WIDTH = 400;
+const RIGHT_PANEL_WIDTH = 500;
 const DRAWER_WIDTH = LEFT_PANEL_WIDTH + RIGHT_PANEL_WIDTH;
 
 interface UseTraceViewDrawerProps {

--- a/static/app/views/insights/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/agents/utils/aiTraceNodes.tsx
@@ -1,7 +1,13 @@
 import type {EventTransaction} from 'sentry/types/event';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
-import {getIsAiRunSpan, getIsAiSpan} from 'sentry/views/insights/agents/utils/query';
+import {
+  getIsAiGenerationSpan,
+  getIsAiRunSpan,
+  getIsAiSpan,
+  getIsExecuteToolSpan,
+  getIsHandoffSpan,
+} from 'sentry/views/insights/agents/utils/query';
 import type {AITraceSpanNode} from 'sentry/views/insights/agents/utils/types';
 import {
   isEAPSpanNode,
@@ -82,3 +88,5 @@ function createGetIsAiNode(predicate: ({op}: {op?: string}) => boolean) {
 
 export const getIsAiNode = createGetIsAiNode(getIsAiSpan);
 export const getIsAiRunNode = createGetIsAiNode(getIsAiRunSpan);
+export const getIsAiGenerationNode = createGetIsAiNode(getIsAiGenerationSpan);
+export const getIsExecuteToolNode = createGetIsAiNode(getIsExecuteToolSpan);

--- a/static/app/views/insights/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/agents/utils/aiTraceNodes.tsx
@@ -6,7 +6,6 @@ import {
   getIsAiRunSpan,
   getIsAiSpan,
   getIsExecuteToolSpan,
-  getIsHandoffSpan,
 } from 'sentry/views/insights/agents/utils/query';
 import type {AITraceSpanNode} from 'sentry/views/insights/agents/utils/types';
 import {

--- a/static/app/views/insights/agents/utils/query.tsx
+++ b/static/app/views/insights/agents/utils/query.tsx
@@ -56,6 +56,14 @@ export function getIsAiGenerationSpan({op = 'default'}: {op?: string}) {
   return op.startsWith('gen_ai.') && !NON_GENERATION_OPS.includes(op);
 }
 
+export function getIsExecuteToolSpan({op = 'default'}: {op?: string}) {
+  return op === 'gen_ai.execute_tool';
+}
+
+export function getIsHandoffSpan({op = 'default'}: {op?: string}) {
+  return op === 'gen_ai.handoff';
+}
+
 export function getIsAiCreateAgentSpan({op = 'default'}: {op?: string}) {
   return AI_CREATE_AGENT_OPS.includes(op);
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
@@ -157,7 +157,7 @@ function PythonContent({spanOrigin}: {spanOrigin?: string}) {
 );`}
       </CodeSnippet>
       <Prose>
-        {tct('For more details, see the [link:integrationdocs].', {
+        {tct('For more details, see the [link:integration docs].', {
           link: <ExternalLink href={integrationLink} />,
         })}
       </Prose>
@@ -244,7 +244,5 @@ const StyledCode = styled('code')`
 `;
 
 const codeSnippetStyles = css`
-  && {
-    margin: 0;
-  }
+  margin: 0 !important;
 `;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
@@ -128,7 +128,18 @@ export function AIIOAlert({
   );
 }
 
-function PythonContent() {
+type PythonSpanOrigin = (typeof knownSpanOrigins.python)[number];
+const pythonIntegrationLinks: Record<PythonSpanOrigin, string> = {
+  'auto.ai.langchain': 'https://docs.sentry.io/platforms/python/integrations/langchain/',
+  'auto.ai.openai_agents':
+    'https://docs.sentry.io/platforms/python/integrations/openai-agents/',
+  'auto.ai.openai': 'https://docs.sentry.io/platforms/python/integrations/openai/',
+  'auto.ai.langgraph': 'https://docs.sentry.io/platforms/python/integrations/langgraph/',
+  'auto.ai.anthropic': 'https://docs.sentry.io/platforms/python/integrations/anthropic/',
+};
+
+function PythonContent({spanOrigin}: {spanOrigin?: string}) {
+  const integrationLink = pythonIntegrationLinks[spanOrigin as PythonSpanOrigin];
   return (
     <Fragment>
       <Prose>
@@ -146,10 +157,8 @@ function PythonContent() {
 );`}
       </CodeSnippet>
       <Prose>
-        {tct('For more details, see the [link:docs].', {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module/" />
-          ),
+        {tct('For more details, see the [link:integrationdocs].', {
+          link: <ExternalLink href={integrationLink} />,
         })}
       </Prose>
     </Fragment>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
@@ -1,0 +1,241 @@
+import {Fragment} from 'react';
+import {css, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {CodeSnippet} from 'sentry/components/codeSnippet';
+import {Alert} from 'sentry/components/core/alert';
+import {Stack} from 'sentry/components/core/layout';
+import {ExternalLink} from 'sentry/components/core/link';
+import {Heading, Prose} from 'sentry/components/core/text';
+import {t, tct} from 'sentry/locale';
+import type {EventTransaction} from 'sentry/types/event';
+import {isChonkTheme} from 'sentry/utils/theme/withChonk';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {
+  getIsAiGenerationNode,
+  getIsAiRunNode,
+  getIsExecuteToolNode,
+  getTraceNodeAttribute,
+} from 'sentry/views/insights/agents/utils/aiTraceNodes';
+import {hasAIInputAttribute} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput';
+import {hasAIOutputAttribute} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
+
+type SupportedSDKLanguage = 'javascript' | 'python';
+
+const knownSpanOrigins = {
+  python: [
+    'auto.ai.langchain',
+    'auto.ai.openai_agents',
+    'auto.ai.openai',
+    'auto.ai.langgraph',
+    'auto.ai.anthropic',
+  ],
+  javascript: ['auto.ai.anthropic', 'auto.ai.openai', 'auto.vercel.otel'],
+} as const;
+
+function getSDKLanguage(sdkName?: string): SupportedSDKLanguage | 'other' {
+  if (sdkName?.startsWith('sentry.python')) {
+    return 'python';
+  }
+  if (sdkName?.startsWith('sentry.javascript') || sdkName?.startsWith('sentry.node')) {
+    return 'javascript';
+  }
+  return 'other';
+}
+
+function getInstrumentationType(
+  sdkLanguage: SupportedSDKLanguage | 'other',
+  spanOrigin?: string
+): 'automatic' | 'manual' {
+  if (sdkLanguage === 'other') {
+    return 'manual';
+  }
+
+  if (knownSpanOrigins[sdkLanguage].includes(spanOrigin as any)) {
+    return 'automatic';
+  }
+
+  return 'manual';
+}
+
+const contentComponents = {
+  python: PythonContent,
+  javascript: JavaScriptContent,
+} as const;
+
+export function AIIOAlert({
+  node,
+  attributes,
+  event,
+}: {
+  node: TraceTreeNode<TraceTree.EAPSpan | TraceTree.Span | TraceTree.Transaction>;
+  attributes?: TraceItemResponseAttribute[];
+  event?: EventTransaction;
+}) {
+  const theme = useTheme();
+  const isChonk = isChonkTheme(theme);
+  const {dismiss, isDismissed} = useDismissAlert({key: 'genai-io-alert-dismissed'});
+
+  const isSupportedNodeType =
+    getIsAiRunNode(node) || getIsAiGenerationNode(node) || getIsExecuteToolNode(node);
+  const hasData =
+    hasAIInputAttribute(node, attributes, event) ||
+    hasAIOutputAttribute(node, attributes, event);
+
+  if (isDismissed || !isSupportedNodeType || hasData) {
+    return null;
+  }
+
+  const spanOrigin = getTraceNodeAttribute('origin', node, event, attributes)?.toString();
+  const sdkName = getTraceNodeAttribute('sdk.name', node, event, attributes)?.toString();
+
+  const sdkLanguage = getSDKLanguage(sdkName);
+  const instrumentationType = getInstrumentationType(sdkLanguage, spanOrigin);
+
+  if (sdkLanguage === 'other') {
+    return null;
+  }
+
+  const ContentComponent = contentComponents[sdkLanguage];
+
+  return (
+    <Alert.Container>
+      <Alert type="info">
+        <Stack direction="column" gap="md" paddingTop="2xs">
+          <Heading
+            as="h4"
+            variant="accent"
+            style={{
+              color: isChonk ? undefined : 'inherit',
+            }}
+          >
+            {t('Missing the input and output of your AI model?')}
+          </Heading>
+          {instrumentationType === 'automatic' ? (
+            <ContentComponent spanOrigin={spanOrigin} />
+          ) : (
+            <ManualContent language={sdkLanguage} />
+          )}
+          <Stack direction="row" paddingTop="xs" justify="start">
+            <Alert.Button onClick={dismiss}>Dismiss</Alert.Button>
+          </Stack>
+        </Stack>
+      </Alert>
+    </Alert.Container>
+  );
+}
+
+function PythonContent() {
+  return (
+    <Fragment>
+      <Prose>
+        {tct(
+          'Simply enable [code:send_default_pii] in your Sentry init call to start capturing it:',
+          {
+            code: <StyledCode />,
+          }
+        )}
+      </Prose>
+      <CodeSnippet dark language="python" linesToHighlight={[3]} css={codeSnippetStyles}>
+        {`sentry_sdk.init(
+  # ...
+  send_default_pii=True,
+);`}
+      </CodeSnippet>
+      <Prose>
+        {tct('For more details, see the [link:docs].', {
+          link: (
+            <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module/" />
+          ),
+        })}
+      </Prose>
+    </Fragment>
+  );
+}
+
+type JavascriptSpanOrigin = (typeof knownSpanOrigins.javascript)[number];
+const jsIntegrationNames: Record<JavascriptSpanOrigin, string> = {
+  'auto.ai.anthropic': 'anthropicAIIntegration',
+  'auto.ai.openai': 'openAIIntegration',
+  'auto.vercel.otel': 'vercelAIIntegration',
+};
+const jsIntegrationLinks: Record<JavascriptSpanOrigin, string> = {
+  'auto.ai.anthropic': 'https://docs.sentry.io/platforms/python/integrations/anthropic/',
+  'auto.ai.openai':
+    'https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/openai/',
+  'auto.vercel.otel':
+    'https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/vercelai/',
+};
+
+function JavaScriptContent({spanOrigin}: {spanOrigin?: string}) {
+  const integrationName = jsIntegrationNames[spanOrigin as JavascriptSpanOrigin];
+  return (
+    <Fragment>
+      <Prose>
+        {tct(
+          'Simply set [code:recordInputs] and [code:recordOutputs] to [code:true] when initializing the SDK integration:',
+          {
+            code: <StyledCode />,
+          }
+        )}
+      </Prose>
+      <CodeSnippet
+        dark
+        language="javascript"
+        linesToHighlight={[5, 6]}
+        css={codeSnippetStyles}
+      >
+        {`Sentry.init({
+  // ...
+  integrations: [
+    Sentry.${integrationName}({
+      recordInputs: true,
+      recordOutputs: true,
+    }),
+  ],
+});`}
+      </CodeSnippet>
+      <Prose>
+        {tct('For more details, see the [link:integration docs].', {
+          link: (
+            <ExternalLink href={jsIntegrationLinks[spanOrigin as JavascriptSpanOrigin]} />
+          ),
+        })}
+      </Prose>
+    </Fragment>
+  );
+}
+
+function ManualContent({language}: {language: SupportedSDKLanguage}) {
+  return (
+    <Fragment>
+      <Prose>
+        {tct('Check out the [link:AI instrumentation docs] for more details.', {
+          link: (
+            <ExternalLink
+              href={
+                language === 'javascript'
+                  ? 'https://docs.sentry.io/platforms/javascript/guides/node/tracing/instrumentation/ai-agents-module/'
+                  : 'https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module/'
+              }
+            />
+          ),
+        })}
+      </Prose>
+    </Fragment>
+  );
+}
+
+// TODO(aknaus): Remove this once the Prose component adds styling for code elements
+const StyledCode = styled('code')`
+  color: ${p => p.theme.pink400};
+`;
+
+const codeSnippetStyles = css`
+  && {
+    margin: 0;
+  }
+`;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
@@ -115,9 +115,9 @@ export function AIIOAlert({
             {t('Missing the input and output of your AI model?')}
           </Heading>
           {instrumentationType === 'automatic' ? (
-            <ContentComponent spanOrigin={spanOrigin} />
+            <ContentComponent spanOrigin={spanOrigin} sdkLanguage={sdkLanguage} />
           ) : (
-            <ManualContent language={sdkLanguage} />
+            <ManualContent sdkLanguage={sdkLanguage} />
           )}
           <Stack direction="row" paddingTop="xs" justify="start">
             <Alert.Button onClick={dismiss}>Dismiss</Alert.Button>
@@ -138,8 +138,17 @@ const pythonIntegrationLinks: Record<PythonSpanOrigin, string> = {
   'auto.ai.anthropic': 'https://docs.sentry.io/platforms/python/integrations/anthropic/',
 };
 
-function PythonContent({spanOrigin}: {spanOrigin?: string}) {
+function PythonContent({
+  spanOrigin,
+  sdkLanguage,
+}: {
+  sdkLanguage: SupportedSDKLanguage;
+  spanOrigin?: string;
+}) {
   const integrationLink = pythonIntegrationLinks[spanOrigin as PythonSpanOrigin];
+  if (!integrationLink) {
+    return <ManualContent sdkLanguage={sdkLanguage} />;
+  }
   return (
     <Fragment>
       <Prose>
@@ -180,8 +189,17 @@ const jsIntegrationLinks: Record<JavascriptSpanOrigin, string> = {
     'https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/vercelai/',
 };
 
-function JavaScriptContent({spanOrigin}: {spanOrigin?: string}) {
+function JavaScriptContent({
+  spanOrigin,
+  sdkLanguage,
+}: {
+  sdkLanguage: SupportedSDKLanguage;
+  spanOrigin?: string;
+}) {
   const integrationName = jsIntegrationNames[spanOrigin as JavascriptSpanOrigin];
+  if (!integrationName) {
+    return <ManualContent sdkLanguage={sdkLanguage} />;
+  }
   return (
     <Fragment>
       <Prose>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
@@ -172,7 +172,8 @@ const jsIntegrationNames: Record<JavascriptSpanOrigin, string> = {
   'auto.vercel.otel': 'vercelAIIntegration',
 };
 const jsIntegrationLinks: Record<JavascriptSpanOrigin, string> = {
-  'auto.ai.anthropic': 'https://docs.sentry.io/platforms/python/integrations/anthropic/',
+  'auto.ai.anthropic':
+    'https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/anthropic/',
   'auto.ai.openai':
     'https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/openai/',
   'auto.vercel.otel':
@@ -218,7 +219,7 @@ function JavaScriptContent({spanOrigin}: {spanOrigin?: string}) {
   );
 }
 
-function ManualContent({language}: {language: SupportedSDKLanguage}) {
+function ManualContent({sdkLanguage}: {sdkLanguage: SupportedSDKLanguage}) {
   return (
     <Fragment>
       <Prose>
@@ -226,7 +227,7 @@ function ManualContent({language}: {language: SupportedSDKLanguage}) {
           link: (
             <ExternalLink
               href={
-                language === 'javascript'
+                sdkLanguage === 'javascript'
                   ? 'https://docs.sentry.io/platforms/javascript/guides/node/tracing/instrumentation/ai-agents-module/'
                   : 'https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module/'
               }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -131,6 +131,7 @@ export function hasAIInputAttribute(
 ) {
   return (
     getTraceNodeAttribute('gen_ai.request.messages', node, event, attributes) ||
+    getTraceNodeAttribute('gen_ai.tool.input', node, event, attributes) ||
     getTraceNodeAttribute('ai.input_messages', node, event, attributes) ||
     getTraceNodeAttribute('ai.prompt', node, event, attributes)
   );

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -124,6 +124,18 @@ function transformPrompt(prompt: string) {
   }
 }
 
+export function hasAIInputAttribute(
+  node: TraceTreeNode<TraceTree.EAPSpan | TraceTree.Span | TraceTree.Transaction>,
+  attributes?: TraceItemResponseAttribute[],
+  event?: EventTransaction
+) {
+  return (
+    getTraceNodeAttribute('gen_ai.request.messages', node, event, attributes) ||
+    getTraceNodeAttribute('ai.input_messages', node, event, attributes) ||
+    getTraceNodeAttribute('ai.prompt', node, event, attributes)
+  );
+}
+
 export function AIInputSection({
   node,
   attributes,
@@ -135,6 +147,10 @@ export function AIInputSection({
 }) {
   const organization = useOrganization();
   if (!hasAgentInsightsFeature(organization) && getIsAiNode(node)) {
+    return null;
+  }
+
+  if (!hasAIInputAttribute(node, attributes, event)) {
     return null;
   }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -32,6 +32,19 @@ function renderAIResponse(text: string) {
   );
 }
 
+export function hasAIOutputAttribute(
+  node: TraceTreeNode<TraceTree.EAPSpan | TraceTree.Span | TraceTree.Transaction>,
+  attributes?: TraceItemResponseAttribute[],
+  event?: EventTransaction
+) {
+  return (
+    getTraceNodeAttribute('gen_ai.response.text', node, event, attributes) ||
+    getTraceNodeAttribute('gen_ai.response.object', node, event, attributes) ||
+    getTraceNodeAttribute('gen_ai.response.tool_calls', node, event, attributes) ||
+    getTraceNodeAttribute('gen_ai.tool.output', node, event, attributes)
+  );
+}
+
 export function AIOutputSection({
   node,
   attributes,
@@ -43,6 +56,9 @@ export function AIOutputSection({
 }) {
   const organization = useOrganization();
   if (!hasAgentInsightsFeature(organization) && getIsAiNode(node)) {
+    return null;
+  }
+  if (!hasAIOutputAttribute(node, attributes, event)) {
     return null;
   }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -35,6 +35,7 @@ import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnal
 import {useTransaction} from 'sentry/views/performance/newTraceDetails/traceApi/useTransaction';
 import {IssueList} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/issues/issues';
 import {AIInputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput';
+import {AIIOAlert} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert';
 import {AIOutputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput';
 import {Attributes} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes';
 import {Contexts} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/contexts';
@@ -283,6 +284,7 @@ function SpanNodeDetailsContent({
           location={location}
           hideNodeActions={hideNodeActions}
         />
+        <AIIOAlert node={node} />
         <AIInputSection node={node} />
         <AIOutputSection node={node} />
         <MCPInputSection node={node} />
@@ -479,6 +481,7 @@ function EAPSpanNodeDetailsContent({
           avgSpanDuration={avgSpanDuration}
           hideNodeActions={hideNodeActions}
         />
+        <AIIOAlert node={node} attributes={attributes} />
         <AIInputSection node={node} attributes={attributes} />
         <AIOutputSection node={node} attributes={attributes} />
         <MCPInputSection node={node} attributes={attributes} />

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
@@ -26,6 +26,7 @@ import {useTransaction} from 'sentry/views/performance/newTraceDetails/traceApi/
 import {getCustomInstrumentationLink} from 'sentry/views/performance/newTraceDetails/traceConfigurations';
 import {IssueList} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/issues/issues';
 import {AIInputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput';
+import {AIIOAlert} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert';
 import {AIOutputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput';
 import {MCPInputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/mcpInput';
 import {MCPOutputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/mcpOutput';
@@ -166,6 +167,7 @@ export function TransactionNodeDetails({
           hideNodeActions={hideNodeActions}
         />
 
+        <AIIOAlert node={node} event={event} />
         <AIInputSection node={node} event={event} />
         <AIOutputSection node={node} event={event} />
         <MCPInputSection node={node} event={event} />


### PR DESCRIPTION
Add inline instructions for sending input and output attributes for `gen_ai` spans that are missing those.
The alert detects which sdk + integration was used and displays instructions accordingly.
The alert may be shown only on spans that support input / output (`gen_ai.invoke_agent`, `gen_ai.execute_tool` & any generation span)
Dismissing the alert is permanent action.

### Manual instrumented span
We simply link to the docs of the given programming language (python / js)
<img width="901" height="485" alt="Screenshot 2025-10-02 at 09 04 25" src="https://github.com/user-attachments/assets/23e5046f-e7e1-426e-b781-b0e1107d47a9" />

### Python SDK span
For python we only need to set `send_default_pii=True` + link to the integration docs.
<img width="901" height="653" alt="Screenshot 2025-10-02 at 09 22 00" src="https://github.com/user-attachments/assets/9525ddbf-2683-425a-b9f0-0242e2dccf3e" />

### JS / Node SDK span
Here we display the init of the used SDK integration + the options to set.
<img width="901" height="758" alt="Screenshot 2025-10-02 at 09 05 09" src="https://github.com/user-attachments/assets/dd34a510-670c-4723-823f-f49be46f89a8" />

## Theme variations
### Default UI
<table>
<tr>
 <th>Light Theme</th>
 <th>Dark Theme</th>
 </tr>
<tr>
 <td>
<img width="487" height="278" alt="Screenshot 2025-10-02 at 09 24 39" src="https://github.com/user-attachments/assets/069a28be-c3c3-4950-a52d-cd8ba434f3ca" />
 </td>
 <td>
<img width="487" height="278" alt="Screenshot 2025-10-02 at 09 24 35" src="https://github.com/user-attachments/assets/62575104-fab3-4534-9a93-1da9dd437303" />
 </td>
 </tr>
</table>

### Chonk UI
<table>
<tr>
 <th>Light Theme</th>
 <th>Dark Theme</th>
 </tr>
<tr>
 <td>
<img width="485" height="268" alt="Screenshot 2025-10-02 at 09 24 57" src="https://github.com/user-attachments/assets/6a683b05-6379-435b-abb6-9c2ed73c03c8" />

 </td>
 <td>
<img width="485" height="268" alt="Screenshot 2025-10-02 at 09 24 54" src="https://github.com/user-attachments/assets/d282842c-c705-4987-94c4-bd0957f740c5" />

 </td>
 </tr>
</table>
