### PR TITLE
Optionally store attachment metadata in `processing_store`

### DIFF
--- a/src/sentry/attachments/__init__.py
+++ b/src/sentry/attachments/__init__.py
@@ -1,11 +1,90 @@
-__all__ = ["attachment_cache", "CachedAttachment", "MissingAttachmentChunks"]
+from __future__ import annotations
 
+__all__ = [
+    "attachment_cache",
+    "store_attachments_for_event",
+    "get_attachments_for_event",
+    "delete_ratelimited_attachments",
+    "CachedAttachment",
+    "MissingAttachmentChunks",
+]
+
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any
+
+import sentry_sdk
 from django.conf import settings
 
+from sentry.objectstore import Client as ObjectstoreClient
+from sentry.objectstore import attachments as objectstore_attachments
+from sentry.options.rollout import in_random_rollout
+from sentry.utils.cache import cache_key_for_event
 from sentry.utils.imports import import_string
 
 from .base import BaseAttachmentCache, CachedAttachment, MissingAttachmentChunks
 
+if TYPE_CHECKING:
+    from sentry.models.project import Project
+
 attachment_cache: BaseAttachmentCache = import_string(settings.SENTRY_ATTACHMENTS)(
     **settings.SENTRY_ATTACHMENTS_OPTIONS
 )
+
+
+@sentry_sdk.trace
+def store_attachments_for_event(event: Any, attachments: list[CachedAttachment], timeout=None):
+    """
+    Stores the given list of `attachments` belonging to `event` for processing.
+
+    Depending on feature flags:
+    - the attachments themselves are stored in either `attachment_cache` or `objectstore` (still TODO)
+    - the attachment metadata is stored in `attachment_cache` or the `event` (mutating the parameter)
+    """
+
+    put_metadata_into_event = in_random_rollout("objectstore.processing_store.attachments")
+    cache_key = cache_key_for_event(event)
+    attachments_metadata = attachment_cache.set(
+        cache_key,
+        attachments,
+        timeout=timeout,
+        set_metadata=not put_metadata_into_event,
+    )
+    event.pop("_attachments", None)
+    if put_metadata_into_event:
+        event["_attachments"] = attachments_metadata
+
+
+def get_attachments_for_event(event: Any) -> Generator[CachedAttachment]:
+    """
+    Retrieves the attachments belonging to the given `event`.
+
+    These come either from the `attachment_cache`, or are embedded within the `event`, depending on feature flags.
+    """
+
+    if "_attachments" in event:
+        return (
+            CachedAttachment(cache=attachment_cache, **attachment)
+            for attachment in event["_attachments"]
+        )
+    cache_key = cache_key_for_event(event)
+    return attachment_cache.get(cache_key)
+
+
+def delete_ratelimited_attachments(
+    project: Project, event: Any, attachments: list[CachedAttachment]
+):
+    """
+    This deletes all the attachments that are `rate_limited` from `objectstore` in case they are stored,
+    and it will also remove all the attachments from the attachments cache as well.
+    """
+    client: ObjectstoreClient | None = None
+    for attachment in attachments:
+        if attachment.rate_limited and attachment.stored_id:
+            if client is None:
+                client = objectstore_attachments.for_project(project.organization_id, project.id)
+            client.delete(attachment.stored_id)
+
+    # all other attachments which only exist in the cache but are not stored will
+    # be cleaned up here:
+    cache_key = cache_key_for_event(event)
+    attachment_cache.delete(cache_key)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -32,7 +32,7 @@ from sentry import (
     reprocessing2,
     tsdb,
 )
-from sentry.attachments import CachedAttachment, MissingAttachmentChunks, attachment_cache
+from sentry.attachments import CachedAttachment, MissingAttachmentChunks
 from sentry.constants import (
     DEFAULT_STORE_NORMALIZER_ARGS,
     LOG_LEVELS_MAP,
@@ -329,6 +329,14 @@ ProjectsMapping = Mapping[int, Project]
 Job = MutableMapping[str, Any]
 
 
+def resolve_project(project_id: int) -> Project:
+    project = Project.objects.get_from_cache(id=project_id)
+    project.set_cached_field_value(
+        "organization", Organization.objects.get_from_cache(id=project.organization_id)
+    )
+    return project
+
+
 class EventManager:
     """
     Handles normalization in both the store endpoint and the save task. The
@@ -416,16 +424,17 @@ class EventManager:
     def get_data(self) -> MutableMapping[str, Any]:
         return self._data
 
-    @sentry_sdk.tracing.trace
+    @sentry_sdk.trace
     def save(
         self,
-        project_id: int | None,
+        project_id: int | None = None,
+        project: Project | None = None,
         raw: bool = False,
         assume_normalized: bool = False,
         start_time: float | None = None,
         cache_key: str | None = None,
         skip_send_first_transaction: bool = False,
-        has_attachments: bool = False,
+        attachments: list[CachedAttachment] | None = None,
     ) -> Event:
         """
         After normalizing and processing an event, save adjacent models such as
@@ -445,18 +454,16 @@ class EventManager:
         (that do not hit cache first).
         """
 
+        if project is None:
+            assert project_id is not None
+            project = resolve_project(project_id)
+        projects = {project.id: project}
+
         # Normalize if needed
         if not self._normalized:
             if not assume_normalized:
-                self.normalize(project_id=project_id)
+                self.normalize(project_id=project.id)
             self._normalized = True
-
-        project = Project.objects.get_from_cache(id=project_id)
-        project.set_cached_field_value(
-            "organization", Organization.objects.get_from_cache(id=project.organization_id)
-        )
-
-        projects = {project.id: project}
 
         job: dict[str, Any] = {
             "data": self._data,
@@ -494,13 +501,7 @@ class EventManager:
             # and adds support for differentiating based on platforms
             with metrics.timer("event_manager.save_error_events", tags=metric_tags):
                 return self.save_error_events(
-                    project,
-                    job,
-                    projects,
-                    metric_tags,
-                    raw,
-                    cache_key,
-                    has_attachments=has_attachments,
+                    project, job, projects, metric_tags, attachments or [], raw, cache_key
                 )
 
     @sentry_sdk.tracing.trace
@@ -510,9 +511,9 @@ class EventManager:
         job: Job,
         projects: ProjectsMapping,
         metric_tags: MutableTags,
+        attachments: list[CachedAttachment],
         raw: bool = False,
         cache_key: str | None = None,
-        has_attachments: bool = False,
     ) -> Event:
         jobs = [job]
 
@@ -532,15 +533,6 @@ class EventManager:
         _derive_interface_tags_many(jobs)
         _derive_client_error_sampling_rate(jobs, projects)
 
-        # Load attachments first, but persist them at the very last after
-        # posting to eventstream to make sure all counters and eventstream are
-        # incremented for sure. Also wait for grouping to remove attachments
-        # based on the group counter.
-        if has_attachments:
-            attachments = get_attachments(cache_key, job)
-        else:
-            attachments = []
-
         try:
             group_info = assign_event_to_group(event=job["event"], job=job, metric_tags=metric_tags)
 
@@ -549,7 +541,6 @@ class EventManager:
                 increment_group_tombstone_hit_counter(
                     getattr(e, "tombstone_id", None), job["event"]
                 )
-            # TODO: make sure that already stored attachments are deleted
             discard_event(job, attachments)
             raise
 
@@ -568,7 +559,6 @@ class EventManager:
         _tsdb_record_all_metrics(jobs)
 
         if attachments:
-            # TODO: make sure that already stored attachments are deleted
             attachments = filter_attachments_for_group(attachments, job)
 
         # XXX: DO NOT MUTATE THE EVENT PAYLOAD AFTER THIS POINT
@@ -2253,32 +2243,6 @@ def discard_event(job: Job, attachments: Sequence[Attachment]) -> None:
 
 
 @sentry_sdk.tracing.trace
-def get_attachments(cache_key: str | None, job: Job) -> list[Attachment]:
-    """
-    Retrieves the list of attachments for this event.
-
-    This method skips attachments that have been marked for rate limiting by
-    earlier ingestion pipeline.
-
-    :param cache_key: The cache key at which the event payload is stored in the
-                      cache. This is used to retrieve attachments.
-    :param job:       The job context container.
-    """
-    if cache_key is None:
-        return []
-
-    project = job["event"].project
-    if not features.has("organizations:event-attachments", project.organization, actor=None):
-        return []
-
-    attachments = list(attachment_cache.get(cache_key))
-    if not attachments:
-        return []
-
-    return [attachment for attachment in attachments if not attachment.rate_limited]
-
-
-@sentry_sdk.tracing.trace
 def filter_attachments_for_group(attachments: list[Attachment], job: Job) -> list[Attachment]:
     """
     Removes crash reports exceeding the group-limit.
@@ -2343,6 +2307,9 @@ def filter_attachments_for_group(attachments: list[Attachment], job: Job) -> lis
 
                 # Quotas are counted with at least ``1`` for attachments.
                 refund_quantity += attachment.size or 1
+                # this instructs the attachment to be removed from storage:
+                attachment.rate_limited = True
+
                 continue
             stored_reports += 1
 

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -4,10 +4,8 @@ import time
 from collections.abc import Mapping
 from typing import Any, overload
 
-from sentry.attachments import attachment_cache
-from sentry.attachments.base import CachedAttachment
+from sentry.attachments import CachedAttachment, get_attachments_for_event
 from sentry.stacktraces.processing import StacktraceInfo
-from sentry.utils.cache import cache_key_for_event
 from sentry.utils.safe import get_path
 
 logger = logging.getLogger(__name__)
@@ -105,8 +103,7 @@ def signal_from_data(data):
 
 
 def get_event_attachment(data: Any, attachment_type: str) -> CachedAttachment | None:
-    cache_key = cache_key_for_event(data)
-    attachments = attachment_cache.get(cache_key)
+    attachments = get_attachments_for_event(data)
     return next((a for a in attachments if a.type == attachment_type), None)
 
 

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -1,5 +1,7 @@
 from sentry import options as options_store
-from sentry.objectstore.service import ClientBuilder
+from sentry.objectstore.service import Client, ClientBuilder
+
+__all__ = ["attachments", "Client", "ClientBuilder"]
 
 options = options_store.get("objectstore.config")
 attachments = ClientBuilder(options["base_url"], "attachments", options)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3499,15 +3499,17 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Whether the new objectstore implementation is being used for attachments
-register("objectstore.enable_for.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
-# Whether the new objectstore implementation is being used for attachments in a double-write
-# configuration where it writes to the new objectstore alongside the existing filestore.
-# This is mutually exclusive with the above setting.
+# Fraction of attachments that are double-written to the new objectstore alongside the existing attachments store.
+# This is mutually exclusive with the below setting.
 register("objectstore.double_write.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+# Fraction of attachments that are being stored exclusively in the new objectstore.
+register("objectstore.enable_for.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+# Fraction of events that use the processing store (the transient event payload) for attachment metadata (independant from payloads).
+register("objectstore.processing_store.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # This forces symbolication to use the "stored attachment" codepath,
 # regardless of whether the attachment has already been stored.
 register("objectstore.force-stored-symbolication", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 
 # option used to enable/disable tracking
 # rate of potential functions metrics to

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -12,7 +12,7 @@ import sentry_sdk
 from sentry_relay.processing import StoreNormalizer
 
 from sentry import options, reprocessing2
-from sentry.attachments import attachment_cache
+from sentry.attachments import delete_ratelimited_attachments, get_attachments_for_event
 from sentry.constants import DEFAULT_STORE_NORMALIZER_ARGS
 from sentry.feedback.usecases.ingest.save_event_feedback import (
     save_event_feedback as save_event_feedback_impl,
@@ -368,6 +368,8 @@ def do_process_event(
         has_changed = True
         data = new_data
 
+    attachments = data.pop("_attachments", None)
+
     # Second round of datascrubbing after stacktrace and language-specific
     # processing. First round happened as part of ingest.
     #
@@ -426,6 +428,8 @@ def do_process_event(
         # - store event timestamps that are older than our retention window
         #   (also happening with minidumps)
         data = normalize_event(data)
+        if attachments:
+            data["_attachments"] = attachments
         cache_key = processing.event_processing_store.store(data)
 
     return _continue_to_save_event()
@@ -509,7 +513,7 @@ def _do_save_event(
 
     set_current_event_project(project_id)
 
-    from sentry.event_manager import EventManager
+    from sentry.event_manager import EventManager, resolve_project
     from sentry.exceptions import HashDiscarded
 
     event_type = "none"
@@ -557,6 +561,16 @@ def _do_save_event(
             return
 
         try:
+            if cache_key and has_attachments:
+                all_attachments = list(get_attachments_for_event(data))
+                # we won’t be needing the transient attachments after this anymore
+                data.pop("_attachments", None)
+                attachments = [a for a in all_attachments if not a.rate_limited]
+            else:
+                all_attachments = []
+                attachments = []
+            project = resolve_project(project_id)
+
             if killswitch_matches_context(
                 "store.load-shed-save-event-projects",
                 {
@@ -570,11 +584,11 @@ def _do_save_event(
             manager = EventManager(data)
             # event.project.organization is populated after this statement.
             manager.save(
-                project_id,
+                project=project,
                 assume_normalized=True,
                 start_time=start_time,
                 cache_key=cache_key,
-                has_attachments=has_attachments,
+                attachments=attachments,
             )
             # Put the updated event back into the cache so that post_process
             # has the most recent data.
@@ -591,6 +605,10 @@ def _do_save_event(
             # Delete the event payload from cache since it won't show up in post-processing.
             if cache_key:
                 processing_store.delete_by_key(cache_key)
+
+            # Mark all the attachments as `rate_limited`, so they are being properly cleaned up in the `finally` block:
+            for attachment in all_attachments:
+                attachment.rate_limited = True
         except Exception:
             metrics.incr("events.save_event.exception", tags={"event_type": event_type})
             raise
@@ -608,8 +626,8 @@ def _do_save_event(
                     )
 
             reprocessing2.mark_event_reprocessed(data)
-            if cache_key and has_attachments:
-                attachment_cache.delete(cache_key)
+            if all_attachments:
+                delete_ratelimited_attachments(project, data, all_attachments)
 
             if start_time:
                 metrics.timing(

--- a/src/sentry/testutils/helpers/eventprocessing.py
+++ b/src/sentry/testutils/helpers/eventprocessing.py
@@ -28,6 +28,6 @@ def save_new_event(event_data: dict[str, Any], project: Project) -> Event:
         # This does a similar thing for syncing the DB across silos
         outbox_runner(),
     ):
-        event = EventManager(event_data).save(project.id)
+        event = EventManager(event_data).save(project=project)
 
     return event

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -6,6 +6,7 @@ import sentry_sdk
 from django.test.utils import override_settings
 from sentry_sdk import Scope
 
+from sentry.models.project import Project
 from sentry.receivers import create_default_projects
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event
@@ -85,7 +86,8 @@ def test_recursion_breaker(settings, post_event_with_sdk) -> None:
         with pytest.raises(Exception):
             post_event_with_sdk({"message": "internal client test", "event_id": event_id})
 
-    assert_mock_called_once_with_partial(save, settings.SENTRY_PROJECT, cache_key=f"e:{event_id}:1")
+    project = Project.objects.get(id=1)
+    assert_mock_called_once_with_partial(save, project=project, cache_key=f"e:{event_id}:1")
 
 
 @no_silo_test

--- a/tests/sentry/attachments/test_base.py
+++ b/tests/sentry/attachments/test_base.py
@@ -35,9 +35,10 @@ def test_meta_basic() -> None:
     # Regression test to verify that we do not add additional attributes. Note
     # that ``rate_limited`` is missing from this dict.
     assert att.meta() == {
+        "key": "c:foo",
+        "id": 123,
         "chunks": 3,
         "content_type": "text/plain",
-        "id": 123,
         "name": "lol.txt",
         "type": "event.attachment",
     }
@@ -49,9 +50,10 @@ def test_meta_rate_limited() -> None:
     )
 
     assert att.meta() == {
+        "key": "c:foo",
+        "id": 123,
         "chunks": 3,
         "content_type": "text/plain",
-        "id": 123,
         "name": "lol.txt",
         "rate_limited": True,
         "type": "event.attachment",

--- a/tests/sentry/attachments/test_redis.py
+++ b/tests/sentry/attachments/test_redis.py
@@ -46,6 +46,7 @@ def test_process_pending_one_batch(mocked_attachment_cache, mock_client) -> None
 
     (attachment,) = mocked_attachment_cache.get("foo")
     assert attachment.meta() == {
+        "key": "foo",
         "id": 0,
         "type": "event.attachment",
         "name": "foo.txt",
@@ -64,6 +65,7 @@ def test_chunked(mocked_attachment_cache, mock_client) -> None:
 
     (attachment,) = mocked_attachment_cache.get("foo")
     assert attachment.meta() == {
+        "key": "foo",
         "id": 0,
         "chunks": 3,
         "type": "event.attachment",

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2254,7 +2254,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
                 self.tasks(),
                 pytest.raises(HashDiscarded),
             ):
-                manager.save(self.project.id, cache_key=cache_key, has_attachments=True)
+                manager.save(self.project.id, cache_key=cache_key, attachments=[a1, a2])
 
             assert mock_track_outcome.call_count == 3
 
@@ -2302,7 +2302,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             ):
                 with self.feature("organizations:event-attachments"):
                     with self.tasks():
-                        manager.save(self.project.id, cache_key=cache_key, has_attachments=True)
+                        manager.save(self.project.id, cache_key=cache_key, attachments=[a1, a2])
 
         # The first minidump should be accepted, since the limit is 1
         # Event outcome goes through aggregator (1 call), attachments go through direct track_outcome (2 calls)
@@ -2332,7 +2332,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
                 with self.feature("organizations:event-attachments"):
                     with self.tasks():
                         event = manager.save(
-                            self.project.id, cache_key=cache_key, has_attachments=True
+                            self.project.id, cache_key=cache_key, attachments=[a1, a2]
                         )
 
         assert event.data["metadata"]["stripped_crash"] is True
@@ -2383,7 +2383,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
                 mock_track_outcome_aggregated,
             ):
                 with self.feature("organizations:event-attachments"):
-                    manager.save(self.project.id, cache_key=cache_key, has_attachments=True)
+                    manager.save(self.project.id, cache_key=cache_key, attachments=[a1, a3])
 
         # Event outcome goes through aggregator (1 call), attachments through direct track_outcome (2 calls)
         assert mock_track_outcome_aggregated.call_count == 1
@@ -2419,7 +2419,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
                 mock_track_outcome_aggregated,
             ):
                 with self.feature("organizations:event-attachments"):
-                    manager.save(self.project.id, cache_key=cache_key, has_attachments=True)
+                    manager.save(self.project.id, cache_key=cache_key, attachments=[a1, a3])
 
         # Event outcome goes through aggregator (1 call), attachments through direct track_outcome (2 calls)
         assert mock_track_outcome_aggregated.call_count == 1


### PR DESCRIPTION
As one step towards getting rid of the `attachment_cache`, this adds a feature flag to pass along attachment metadata with the event payload in the `processing_store`.

It also lays the groundwork to properly delete `rate_limited` / discarded attachments from `objectstore` in `save_event`.

---

This is admittedly quite complex and touches quite some code. I would love to hear some *concrete suggestions* on how to make this better and more robust instead of piling workarounds atop workarounds.
Ref FS-104