### PR TITLE
fix(explore): Check span.description is valid url

### DIFF
--- a/static/app/utils/string/isValidUrl.tsx
+++ b/static/app/utils/string/isValidUrl.tsx
@@ -1,4 +1,10 @@
+import {isUrl} from 'sentry/utils/string/isUrl';
+
 export function isValidUrl(str: any): boolean {
+  // javascript:void(0) is a valid url so ensure it starts with http:// or https://
+  if (!isUrl(str)) {
+    return false;
+  }
   try {
     return !!new URL(str);
   } catch {

--- a/static/app/utils/string/isValidUrl.tsx
+++ b/static/app/utils/string/isValidUrl.tsx
@@ -1,0 +1,7 @@
+export function isValidUrl(str: any): boolean {
+  try {
+    return !!new URL(str);
+  } catch {
+    return false;
+  }
+}

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -17,7 +17,7 @@ import {Container} from 'sentry/utils/discover/styles';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {getShortEventId} from 'sentry/utils/events';
 import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
-import {isUrl} from 'sentry/utils/string/isUrl';
+import {isValidUrl} from 'sentry/utils/string/isValidUrl';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -243,7 +243,7 @@ function spanDescriptionRenderFunc(projects: Record<string, Project>) {
               />
             )}
             <WrappingText>
-              {isUrl(value) ? (
+              {isValidUrl(value) ? (
                 <ExternalLink href={value}>{value}</ExternalLink>
               ) : (
                 nullableValue(value)


### PR DESCRIPTION
Checking the span.description starts with http:// and https:// is not enough to determine if it's a valid url. So use a more strict check to ensure it looks like a valid url.