### PR TITLE
Investigate and fix group deletion

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -661,7 +661,9 @@ def cleanup_stuck_deletion_in_progress_groups(
 
     # Only clean up stuck groups if Group model is not filtered
     if is_filtered(Group):
-        debug_output(">> Skipping cleanup of stuck DELETION_IN_PROGRESS groups (Group model filtered)")
+        debug_output(
+            ">> Skipping cleanup of stuck DELETION_IN_PROGRESS groups (Group model filtered)"
+        )
         return
 
     models_attempted.add(Group.__name__.lower())
@@ -682,16 +684,19 @@ def cleanup_stuck_deletion_in_progress_groups(
 
     count = old_stuck_groups.count()
     if count > 0:
-        debug_output(f"Force-deleting {count} groups stuck in DELETION_IN_PROGRESS status for >{days} days")
+        debug_output(
+            f"Force-deleting {count} groups stuck in DELETION_IN_PROGRESS status for >{days} days"
+        )
 
         # Use the regular deletion mechanism but without skipping Groups
-        from sentry import deletions
         from uuid import uuid4
+
+        from sentry import deletions
 
         # Process in smaller batches to avoid overwhelming the system
         batch_size = 100
         for batch_start in range(0, count, batch_size):
-            batch_groups = list(old_stuck_groups[batch_start:batch_start + batch_size])
+            batch_groups = list(old_stuck_groups[batch_start : batch_start + batch_size])
             if not batch_groups:
                 break
 

--- a/tests/sentry/runner/commands/test_cleanup.py
+++ b/tests/sentry/runner/commands/test_cleanup.py
@@ -1,0 +1,273 @@
+from datetime import datetime, timedelta
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+from django.utils import timezone
+
+from sentry.models.group import Group, GroupStatus
+from sentry.models.project import Project
+from sentry.runner.commands.cleanup import cleanup_stuck_deletion_in_progress_groups
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import before_now
+
+
+class TestCleanupStuckDeletionInProgressGroups(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.project = self.create_project()
+
+    def test_cleanup_old_stuck_groups(self):
+        """Test that groups stuck in DELETION_IN_PROGRESS status for longer than the cleanup threshold get force-deleted."""
+
+        # Create a group that's been stuck in DELETION_IN_PROGRESS for 100 days (longer than 95-day threshold)
+        old_stuck_group = self.create_group(
+            project=self.project,
+            status=GroupStatus.DELETION_IN_PROGRESS,
+        )
+        old_stuck_group.last_seen = before_now(days=100)
+        old_stuck_group.save()
+
+        # Create a group that's been stuck for only 5 days (within grace period)
+        recent_stuck_group = self.create_group(
+            project=self.project,
+            status=GroupStatus.DELETION_IN_PROGRESS,
+        )
+        recent_stuck_group.last_seen = before_now(days=5)
+        recent_stuck_group.save()
+
+        # Create a normal old group that should not be affected
+        normal_old_group = self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+        )
+        normal_old_group.last_seen = before_now(days=100)
+        normal_old_group.save()
+
+        # Mock is_filtered to not filter any models
+        def mock_is_filtered(model):
+            return False
+
+        models_attempted = set()
+
+        # Run cleanup with 95-day threshold
+        cleanup_stuck_deletion_in_progress_groups(
+            is_filtered=mock_is_filtered,
+            days=95,
+            models_attempted=models_attempted,
+        )
+
+        # Old stuck group should be deleted
+        assert not Group.objects.filter(id=old_stuck_group.id).exists()
+
+        # Recent stuck group should still exist (within grace period)
+        assert Group.objects.filter(id=recent_stuck_group.id).exists()
+
+        # Normal old group should still exist (different status)
+        assert Group.objects.filter(id=normal_old_group.id).exists()
+
+        # Should track that Group model was attempted
+        assert 'group' in models_attempted
+
+    def test_no_cleanup_within_grace_period(self):
+        """Test that groups stuck in DELETION_IN_PROGRESS but older than cleanup threshold are not deleted if within grace period."""
+
+        # Create a group stuck for 8 days (beyond grace period but within cleanup threshold)
+        stuck_group = self.create_group(
+            project=self.project,
+            status=GroupStatus.DELETION_IN_PROGRESS,
+        )
+        stuck_group.last_seen = before_now(days=8)
+        stuck_group.save()
+
+        def mock_is_filtered(model):
+            return False
+
+        models_attempted = set()
+
+        # Run cleanup with 95-day threshold - this group is only 8 days old, so it shouldn't be deleted
+        cleanup_stuck_deletion_in_progress_groups(
+            is_filtered=mock_is_filtered,
+            days=95,
+            models_attempted=models_attempted,
+        )
+
+        # Group should still exist (not old enough for cleanup threshold)
+        assert Group.objects.filter(id=stuck_group.id).exists()
+
+    def test_cleanup_respects_model_filtering(self):
+        """Test that cleanup respects model filtering and skips when Group model is filtered."""
+
+        # Create an old stuck group
+        old_stuck_group = self.create_group(
+            project=self.project,
+            status=GroupStatus.DELETION_IN_PROGRESS,
+        )
+        old_stuck_group.last_seen = before_now(days=100)
+        old_stuck_group.save()
+
+        # Mock is_filtered to filter Group model
+        def mock_is_filtered(model):
+            from sentry.models.group import Group
+            return model is Group
+
+        models_attempted = set()
+
+        # Run cleanup
+        cleanup_stuck_deletion_in_progress_groups(
+            is_filtered=mock_is_filtered,
+            days=95,
+            models_attempted=models_attempted,
+        )
+
+        # Group should still exist (model was filtered)
+        assert Group.objects.filter(id=old_stuck_group.id).exists()
+
+        # Should not track Group model as attempted since it was filtered
+        assert 'group' not in models_attempted
+
+    def test_cleanup_handles_empty_result_set(self):
+        """Test that cleanup handles the case where no stuck groups are found."""
+
+        # Create only normal groups, no stuck ones
+        normal_group = self.create_group(project=self.project)
+
+        def mock_is_filtered(model):
+            return False
+
+        models_attempted = set()
+
+        # Run cleanup - should complete without errors
+        cleanup_stuck_deletion_in_progress_groups(
+            is_filtered=mock_is_filtered,
+            days=95,
+            models_attempted=models_attempted,
+        )
+
+        # Normal group should still exist
+        assert Group.objects.filter(id=normal_group.id).exists()
+
+        # Should still track that Group model was attempted
+        assert 'group' in models_attempted
+
+    def test_cleanup_processes_large_batches(self):
+        """Test that cleanup can handle large numbers of stuck groups by processing in batches."""
+
+        # Create 250 old stuck groups (more than the 100 batch size)
+        old_stuck_groups = []
+        for i in range(250):
+            group = self.create_group(
+                project=self.project,
+                status=GroupStatus.DELETION_IN_PROGRESS,
+            )
+            group.last_seen = before_now(days=100)
+            group.save()
+            old_stuck_groups.append(group)
+
+        def mock_is_filtered(model):
+            return False
+
+        models_attempted = set()
+
+        # Run cleanup
+        cleanup_stuck_deletion_in_progress_groups(
+            is_filtered=mock_is_filtered,
+            days=95,
+            models_attempted=models_attempted,
+        )
+
+        # All stuck groups should be deleted
+        for group in old_stuck_groups:
+            assert not Group.objects.filter(id=group.id).exists()
+
+        assert 'group' in models_attempted
+
+    def test_cleanup_continues_on_batch_failure(self):
+        """Test that cleanup continues processing other batches even if one batch fails."""
+
+        # Create multiple stuck groups
+        stuck_groups = []
+        for i in range(5):
+            group = self.create_group(
+                project=self.project,
+                status=GroupStatus.DELETION_IN_PROGRESS,
+            )
+            group.last_seen = before_now(days=100)
+            group.save()
+            stuck_groups.append(group)
+
+        def mock_is_filtered(model):
+            return False
+
+        models_attempted = set()
+
+        # Mock the deletions.get to fail on first call but succeed on subsequent calls
+        call_count = 0
+        original_deletions_get = None
+
+        def mock_deletions_get(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("Simulated deletion failure")
+            # For subsequent calls, we still want to properly delete the groups
+            # So we'll use a simple approach - mark them as deleted by changing status
+            query = kwargs.get('query', {})
+            group_ids = query.get('id__in', [])
+            Group.objects.filter(id__in=group_ids).delete()
+
+            # Return a mock task that does nothing
+            class MockTask:
+                def chunk(self, apply_filter=True):
+                    return False
+            return MockTask()
+
+        with mock.patch('sentry.runner.commands.cleanup.deletions') as mock_deletions:
+            mock_deletions.get = mock_deletions_get
+
+            # Run cleanup - should not raise exception despite first batch failure
+            cleanup_stuck_deletion_in_progress_groups(
+                is_filtered=mock_is_filtered,
+                days=95,
+                models_attempted=models_attempted,
+            )
+
+        # Should have tried to process batches despite the first failure
+        assert call_count >= 1
+        assert 'group' in models_attempted
+
+    def test_edge_case_exactly_at_thresholds(self):
+        """Test edge cases where groups are exactly at the threshold boundaries."""
+
+        # Group exactly at 7-day grace period boundary
+        grace_period_group = self.create_group(
+            project=self.project,
+            status=GroupStatus.DELETION_IN_PROGRESS,
+        )
+        grace_period_group.last_seen = before_now(days=7)
+        grace_period_group.save()
+
+        # Group exactly at 95-day cleanup threshold
+        cleanup_threshold_group = self.create_group(
+            project=self.project,
+            status=GroupStatus.DELETION_IN_PROGRESS,
+        )
+        cleanup_threshold_group.last_seen = before_now(days=95)
+        cleanup_threshold_group.save()
+
+        def mock_is_filtered(model):
+            return False
+
+        models_attempted = set()
+
+        cleanup_stuck_deletion_in_progress_groups(
+            is_filtered=mock_is_filtered,
+            days=95,
+            models_attempted=models_attempted,
+        )
+
+        # Grace period group should still exist (exactly at boundary, not past it)
+        assert Group.objects.filter(id=grace_period_group.id).exists()
+
+        # Cleanup threshold group should be deleted (exactly at boundary, qualifies for deletion)
+        assert not Group.objects.filter(id=cleanup_threshold_group.id).exists()

--- a/tests/sentry/runner/commands/test_cleanup.py
+++ b/tests/sentry/runner/commands/test_cleanup.py
@@ -67,7 +67,7 @@ class TestCleanupStuckDeletionInProgressGroups(TestCase):
         assert Group.objects.filter(id=normal_old_group.id).exists()
 
         # Should track that Group model was attempted
-        assert 'group' in models_attempted
+        assert "group" in models_attempted
 
     def test_no_cleanup_within_grace_period(self):
         """Test that groups stuck in DELETION_IN_PROGRESS but older than cleanup threshold are not deleted if within grace period."""
@@ -109,6 +109,7 @@ class TestCleanupStuckDeletionInProgressGroups(TestCase):
         # Mock is_filtered to filter Group model
         def mock_is_filtered(model):
             from sentry.models.group import Group
+
             return model is Group
 
         models_attempted = set()
@@ -124,7 +125,7 @@ class TestCleanupStuckDeletionInProgressGroups(TestCase):
         assert Group.objects.filter(id=old_stuck_group.id).exists()
 
         # Should not track Group model as attempted since it was filtered
-        assert 'group' not in models_attempted
+        assert "group" not in models_attempted
 
     def test_cleanup_handles_empty_result_set(self):
         """Test that cleanup handles the case where no stuck groups are found."""
@@ -148,7 +149,7 @@ class TestCleanupStuckDeletionInProgressGroups(TestCase):
         assert Group.objects.filter(id=normal_group.id).exists()
 
         # Should still track that Group model was attempted
-        assert 'group' in models_attempted
+        assert "group" in models_attempted
 
     def test_cleanup_processes_large_batches(self):
         """Test that cleanup can handle large numbers of stuck groups by processing in batches."""
@@ -180,7 +181,7 @@ class TestCleanupStuckDeletionInProgressGroups(TestCase):
         for group in old_stuck_groups:
             assert not Group.objects.filter(id=group.id).exists()
 
-        assert 'group' in models_attempted
+        assert "group" in models_attempted
 
     def test_cleanup_continues_on_batch_failure(self):
         """Test that cleanup continues processing other batches even if one batch fails."""
@@ -212,17 +213,18 @@ class TestCleanupStuckDeletionInProgressGroups(TestCase):
                 raise Exception("Simulated deletion failure")
             # For subsequent calls, we still want to properly delete the groups
             # So we'll use a simple approach - mark them as deleted by changing status
-            query = kwargs.get('query', {})
-            group_ids = query.get('id__in', [])
+            query = kwargs.get("query", {})
+            group_ids = query.get("id__in", [])
             Group.objects.filter(id__in=group_ids).delete()
 
             # Return a mock task that does nothing
             class MockTask:
                 def chunk(self, apply_filter=True):
                     return False
+
             return MockTask()
 
-        with mock.patch('sentry.runner.commands.cleanup.deletions') as mock_deletions:
+        with mock.patch("sentry.runner.commands.cleanup.deletions") as mock_deletions:
             mock_deletions.get = mock_deletions_get
 
             # Run cleanup - should not raise exception despite first batch failure
@@ -234,7 +236,7 @@ class TestCleanupStuckDeletionInProgressGroups(TestCase):
 
         # Should have tried to process batches despite the first failure
         assert call_count >= 1
-        assert 'group' in models_attempted
+        assert "group" in models_attempted
 
     def test_edge_case_exactly_at_thresholds(self):
         """Test edge cases where groups are exactly at the threshold boundaries."""


### PR DESCRIPTION
<!-- Describe your PR here. -->
This PR fixes an issue where `Group` objects with `DELETION_IN_PROGRESS` status were not being cleaned up by the `cleanup` script, even when older than the specified threshold (e.g., 95 days). The root cause was that `Group` models are explicitly skipped by the `multiprocess_worker` during general cleanup.

The solution introduces a new function, `cleanup_stuck_deletion_in_progress_groups`, which:
- Targets `Group` objects in `DELETION_IN_PROGRESS` status.
- Applies a 7-day grace period before considering a group "stuck".
- Force-deletes groups that are both "stuck" and older than the main cleanup threshold.
- Uses the `deletions` framework with `skip_models=[]` to ensure these specific groups are processed.
- Includes batch processing and error handling.

Comprehensive tests have been added to validate the fix.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/D09259VQFAP/p1759418672012189?thread_ts=1759418672.012189&cid=D09259VQFAP)

<a href="https://cursor.com/background-agent?bcId=bc-8d30ed42-56b3-4a8b-8636-b569784f3124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d30ed42-56b3-4a8b-8636-b569784f3124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

