### PR TITLE
feat(crons): Update next_checkin{,_latest} when edited

### DIFF
--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -24,6 +24,7 @@ from sentry.db.models.fields.slug import DEFAULT_SLUG_MAX_LENGTH
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.models.project import Project
 from sentry.monitors.constants import MAX_MARGIN, MAX_THRESHOLD, MAX_TIMEOUT
+from sentry.monitors.logic.monitor_environment import update_monitor_environment
 from sentry.monitors.models import (
     MONITOR_CONFIG,
     CheckInStatus,
@@ -392,6 +393,8 @@ class MonitorValidator(CamelSnakeSerializer):
         existing_config = instance.config.copy()
         existing_margin = existing_config.get("checkin_margin")
         existing_max_runtime = existing_config.get("max_runtime")
+        existing_schedule_type = existing_config.get("schedule_type")
+        existing_schedule = existing_config.get("schedule")
         existing_slug = instance.slug
 
         params: dict[str, Any] = {}
@@ -470,6 +473,16 @@ class MonitorValidator(CamelSnakeSerializer):
                 MonitorCheckIn.objects.filter(
                     monitor_id=instance.id, status=CheckInStatus.IN_PROGRESS
                 ).update(timeout_at=TruncMinute(F("date_added")) + get_max_runtime(max_runtime))
+
+            # If the schedule changed, recompute next_checkin and next_checkin_latest for all environments
+            schedule_type = updated_config.get("schedule_type")
+            schedule = updated_config.get("schedule")
+            if schedule_type != existing_schedule_type or schedule != existing_schedule:
+                now = timezone.now()
+                for monitor_env in MonitorEnvironment.objects.filter(monitor_id=instance.id):
+                    # Use last_checkin if available, otherwise use current time
+                    last_checkin = monitor_env.last_checkin or now
+                    update_monitor_environment(monitor_env, last_checkin, now)
 
         # Update alert rule after in case slug or name changed
         if "alert_rule" in validated_data:

--- a/tests/sentry/monitors/test_validators.py
+++ b/tests/sentry/monitors/test_validators.py
@@ -694,6 +694,135 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert updated_monitor.config["failure_issue_threshold"] == 3
         assert updated_monitor.config["recovery_threshold"] == 1
 
+    def test_update_schedule_recomputes_next_checkin(self):
+        """Test that updating the schedule recomputes next_checkin for all environments."""
+        # Create monitor environments with specific next_checkin times
+        now = timezone.now().replace(second=0, microsecond=0)
+        env1 = self.create_monitor_environment(
+            monitor=self.monitor,
+            environment_id=self.environment.id,
+            status=MonitorStatus.OK,
+            last_checkin=now,
+            next_checkin=now + timedelta(hours=1),  # Based on hourly schedule
+            next_checkin_latest=now + timedelta(hours=1, minutes=5),
+        )
+        env2_env = self.create_environment(name="production", project=self.project)
+        env2 = self.create_monitor_environment(
+            monitor=self.monitor,
+            environment_id=env2_env.id,
+            status=MonitorStatus.OK,
+            last_checkin=now,
+            next_checkin=now + timedelta(hours=1),  # Based on hourly schedule
+            next_checkin_latest=now + timedelta(hours=1, minutes=5),
+        )
+
+        # Update the schedule from hourly to daily
+        validator = MonitorValidator(
+            instance=self.monitor,
+            data={"config": {"schedule": "0 0 * * *", "schedule_type": "crontab"}},
+            partial=True,
+            context={
+                "organization": self.organization,
+                "access": self.access,
+                "request": self.request,
+            },
+        )
+        assert validator.is_valid()
+
+        updated_monitor = validator.save()
+        assert updated_monitor.config["schedule"] == "0 0 * * *"
+
+        # Verify that next_checkin was recomputed for both environments
+        env1.refresh_from_db()
+        env2.refresh_from_db()
+
+        # The next check-in should now be based on the daily schedule (next midnight)
+        expected_next_checkin = updated_monitor.get_next_expected_checkin(now)
+        expected_next_checkin_latest = updated_monitor.get_next_expected_checkin_latest(now)
+
+        assert env1.next_checkin == expected_next_checkin
+        assert env1.next_checkin_latest == expected_next_checkin_latest
+        assert env2.next_checkin == expected_next_checkin
+        assert env2.next_checkin_latest == expected_next_checkin_latest
+
+    def test_partial_config_update_does_not_trigger_schedule_recompute(self):
+        """Test that updating only checkin_margin doesn't trigger schedule recomputation."""
+        # Create a monitor environment with specific next_checkin times
+        now = timezone.now().replace(second=0, microsecond=0)
+        env = self.create_monitor_environment(
+            monitor=self.monitor,
+            environment_id=self.environment.id,
+            status=MonitorStatus.OK,
+            last_checkin=now,
+            next_checkin=now + timedelta(hours=1),
+            next_checkin_latest=now + timedelta(hours=1, minutes=5),
+        )
+
+        # Store original next_checkin time
+        original_next_checkin = env.next_checkin
+
+        # Update only checkin_margin without including schedule fields
+        validator = MonitorValidator(
+            instance=self.monitor,
+            data={"config": {"checkin_margin": 10}},  # Only updating margin, not schedule
+            partial=True,
+            context={
+                "organization": self.organization,
+                "access": self.access,
+                "request": self.request,
+            },
+        )
+        assert validator.is_valid()
+
+        updated_monitor = validator.save()
+        assert updated_monitor.config["checkin_margin"] == 10
+        # Schedule should remain unchanged
+        assert updated_monitor.config["schedule"] == "0 * * * *"
+        assert updated_monitor.config["schedule_type"] == ScheduleType.CRONTAB
+
+        # Verify that next_checkin was NOT recomputed (would have changed if schedule logic ran)
+        env.refresh_from_db()
+        assert env.next_checkin == original_next_checkin
+
+    def test_update_schedule_type_recomputes_next_checkin(self):
+        """Test that changing schedule_type from crontab to interval recomputes next_checkin."""
+        # Create a monitor environment
+        now = timezone.now().replace(second=0, microsecond=0)
+        env = self.create_monitor_environment(
+            monitor=self.monitor,
+            environment_id=self.environment.id,
+            status=MonitorStatus.OK,
+            last_checkin=now,
+            next_checkin=now + timedelta(hours=1),
+            next_checkin_latest=now + timedelta(hours=1, minutes=5),
+        )
+
+        # Change from crontab to interval schedule
+        validator = MonitorValidator(
+            instance=self.monitor,
+            data={"config": {"schedule": [10, "minute"], "schedule_type": "interval"}},
+            partial=True,
+            context={
+                "organization": self.organization,
+                "access": self.access,
+                "request": self.request,
+            },
+        )
+        assert validator.is_valid()
+
+        updated_monitor = validator.save()
+        assert updated_monitor.config["schedule_type"] == ScheduleType.INTERVAL
+        assert updated_monitor.config["schedule"] == [10, "minute"]
+
+        # Verify that next_checkin was recomputed
+        env.refresh_from_db()
+
+        expected_next_checkin = updated_monitor.get_next_expected_checkin(now)
+        expected_next_checkin_latest = updated_monitor.get_next_expected_checkin_latest(now)
+
+        assert env.next_checkin == expected_next_checkin
+        assert env.next_checkin_latest == expected_next_checkin_latest
+
 
 class BaseMonitorValidatorTestCase(MonitorTestCase):
     """Base class for monitor validator tests with common setup."""


### PR DESCRIPTION
Updates the next_checkin and next_checkin_latest when a montiors schedule is modified

Fixes [NEW-28: After updating a monitor crontab, the next check-in time does not change](https://linear.app/getsentry/issue/NEW-28/after-updating-a-monitor-crontab-the-next-check-in-time-does-not)