### PR TITLE
feat(crons): Pass incident resolution time in status update

### DIFF
--- a/src/sentry/monitors/logic/incident_occurrence.py
+++ b/src/sentry/monitors/logic/incident_occurrence.py
@@ -280,6 +280,7 @@ def resolve_incident_group(incident: MonitorIncident, project_id: int) -> None:
         project_id=project_id,
         new_status=GroupStatus.RESOLVED,
         new_substatus=None,
+        update_date=incident.resolving_timestamp,
     )
     produce_occurrence_to_kafka(
         payload_type=PayloadType.STATUS_CHANGE,

--- a/src/sentry/monitors/logic/incidents.py
+++ b/src/sentry/monitors/logic/incidents.py
@@ -170,11 +170,11 @@ def try_incident_resolution(ok_checkin: MonitorCheckIn) -> bool:
 
     incident = monitor_env.active_incident
     if incident:
-        resolve_incident_group(incident, ok_checkin.monitor.project_id)
         incident.update(
             resolving_checkin=ok_checkin,
             resolving_timestamp=ok_checkin.date_added,
         )
+        resolve_incident_group(incident, ok_checkin.monitor.project_id)
         logger.info(
             "monitors.logic.mark_ok.resolving_incident",
             extra={

--- a/tests/sentry/monitors/logic/test_mark_ok.py
+++ b/tests/sentry/monitors/logic/test_mark_ok.py
@@ -240,6 +240,7 @@ class MarkOkTestCase(TestCase):
                 "project_id": monitor.project_id,
                 "new_status": GroupStatus.RESOLVED,
                 "new_substatus": None,
+                "update_date": last_checkin.date_added,
             },
         ) == dict(status_change)
 


### PR DESCRIPTION
When a cron monitor incident resolves and the group is resolved, specify
the update time as the same time the incident was resolved.

Part of [NEW-538: Update Crons/Uptime issue occurrences timings should match the actual downtime/recovery times](https://linear.app/getsentry/issue/NEW-538/update-cronsuptime-issue-occurrences-timings-should-match-the-actual)