### PR TITLE
ref(ts): typings for data-test-id

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -110,7 +110,7 @@ function EventOrGroupHeader({
     const {status} = data as Group;
 
     const commonEleProps = {
-      'data-test-id': status === 'resolved' ? 'resolved-issue' : null,
+      'data-test-id': status === 'resolved' ? 'resolved-issue' : undefined,
     };
 
     if (isTombstone(data)) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issueSummary.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issueSummary.tsx
@@ -55,7 +55,7 @@ interface IssueTitleProps {
 function IssueTitle(props: IssueTitleProps) {
   const organization = useOrganization();
   const commonEleProps = {
-    'data-test-id': status === 'resolved' ? 'resolved-issue' : null,
+    'data-test-id': status === 'resolved' ? 'resolved-issue' : undefined,
   };
 
   if (isTombstone(props.data)) {

--- a/static/gsAdmin/components/dropdownActions.tsx
+++ b/static/gsAdmin/components/dropdownActions.tsx
@@ -83,12 +83,10 @@ function DropdownActions({actions, label}: Props) {
           onConfirm: action.onAction,
         });
       }}
-      triggerProps={
-        {
-          'data-test-id': 'detail-actions',
-          children: label,
-        } as any
-      }
+      triggerProps={{
+        'data-test-id': 'detail-actions',
+        children: label,
+      }}
     />
   );
 }

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -34,6 +34,12 @@ declare global {
      */
     pendo?: any; // TODO: use types package
   }
+
+  namespace React {
+    interface DOMAttributes<T> {
+      'data-test-id'?: string;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
I noticed that passing `data-test-id` to `triggerProps` yields a type-error, and that’s because passing `data-*` to JSX is allowed, but not when using the object type.

see: https://www.typescriptlang.org/docs/handbook/jsx.html#attribute-type-checking

> Note: If an attribute name is not a valid JS identifier (like a data-* attribute), it is not considered to be an error if it is not found in the element attributes type.

The initial idea was to augment to allow all `data-*` attributes with:

```
interface DOMAttributes<T> {
  [key: `data-${string}`]: string | undefined;
}
```

but this yields type-error for excessively deep types in `Container` (@JonasBa FYI). So I’ve settled for typing `data-test-id` because I think it’s the only one we use anyways.