### PR TITLE
fix(explore): attach project badge to name field for otel UI

### DIFF
--- a/static/app/views/explore/tables/fieldRenderer.spec.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.spec.tsx
@@ -1,21 +1,25 @@
 import type {Location} from 'history';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import EventView from 'sentry/utils/discover/eventView';
 
 import {FieldRenderer} from './fieldRenderer';
 
 const mockedEventData = {
   id: 'spanId',
+  project: 'project-1',
   timestamp: '2024-10-03T10:15:00',
   trace: 'traceId',
   'span.op': 'test_op',
   'transaction.id': 'transactionId',
   'transaction.span_id': 'transactionSpanId',
+  'span.description': 'GET /foo',
 };
 
 describe('FieldRenderer tests', () => {
@@ -25,7 +29,15 @@ describe('FieldRenderer tests', () => {
     query: {
       id: '42',
       name: 'best query',
-      field: ['id', 'timestamp', 'trace', 'span.op', 'transaction.id'],
+      field: [
+        'id',
+        'timestamp',
+        'trace',
+        'span.op',
+        'transaction.id',
+        'span.description',
+        'span.name',
+      ],
     },
   });
 
@@ -34,11 +46,22 @@ describe('FieldRenderer tests', () => {
   beforeAll(() => {
     const mockTimestamp = new Date('2024-10-06T00:00:00').getTime();
     setMockDate(mockTimestamp);
+
+    const projects = [
+      ProjectFixture({
+        id: '1',
+        slug: 'project-1',
+        name: 'Project 1',
+        platform: 'javascript',
+      }),
+    ];
+    ProjectsStore.loadInitialData(projects);
   });
 
   afterAll(() => {
     jest.restoreAllMocks();
     resetMockDate();
+    ProjectsStore.reset();
   });
 
   it('renders span.op', () => {
@@ -117,5 +140,63 @@ describe('FieldRenderer tests', () => {
 
     expect(screen.getByRole('time')).toBeInTheDocument();
     expect(screen.getByText('3d ago')).toBeInTheDocument();
+  });
+
+  it('renders description with project badge', () => {
+    render(
+      <FieldRenderer
+        column={eventView.getColumns()[5]}
+        data={mockedEventData}
+        meta={{}}
+      />,
+      {organization}
+    );
+    expect(screen.getByTestId('platform-icon-javascript')).toBeInTheDocument();
+  });
+
+  it('renders name without project badge', () => {
+    render(
+      <FieldRenderer
+        column={eventView.getColumns()[6]}
+        data={mockedEventData}
+        meta={{}}
+      />,
+      {organization}
+    );
+    expect(screen.queryByTestId('platform-icon-javascript')).not.toBeInTheDocument();
+  });
+
+  describe('with otel friendly UI flag', () => {
+    beforeAll(() => {
+      organization.features.push('performance-otel-friendly-ui');
+    });
+
+    afterAll(() => {
+      organization.features.pop();
+    });
+
+    it('renders description without project badge', () => {
+      render(
+        <FieldRenderer
+          column={eventView.getColumns()[5]}
+          data={mockedEventData}
+          meta={{}}
+        />,
+        {organization}
+      );
+      expect(screen.queryByTestId('platform-icon-javascript')).not.toBeInTheDocument();
+    });
+
+    it('renders name with project badge', () => {
+      render(
+        <FieldRenderer
+          column={eventView.getColumns()[6]}
+          data={mockedEventData}
+          meta={{}}
+        />,
+        {organization}
+      );
+      expect(screen.getByTestId('platform-icon-javascript')).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/explore/tables/fieldRenderer.spec.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.spec.tsx
@@ -142,37 +142,39 @@ describe('FieldRenderer tests', () => {
     expect(screen.getByText('3d ago')).toBeInTheDocument();
   });
 
-  it('renders description with project badge', () => {
-    render(
-      <FieldRenderer
-        column={eventView.getColumns()[5]}
-        data={mockedEventData}
-        meta={{}}
-      />,
-      {organization}
-    );
-    expect(screen.getByTestId('platform-icon-javascript')).toBeInTheDocument();
-  });
+  describe('without otel friendly UI flag', () => {
+    const organizationWithoutFlags = OrganizationFixture({
+      features: [],
+    });
 
-  it('renders name without project badge', () => {
-    render(
-      <FieldRenderer
-        column={eventView.getColumns()[6]}
-        data={mockedEventData}
-        meta={{}}
-      />,
-      {organization}
-    );
-    expect(screen.queryByTestId('platform-icon-javascript')).not.toBeInTheDocument();
+    it('renders description with project badge', () => {
+      render(
+        <FieldRenderer
+          column={eventView.getColumns()[5]}
+          data={mockedEventData}
+          meta={{}}
+        />,
+        {organization: organizationWithoutFlags}
+      );
+      expect(screen.getByTestId('platform-icon-javascript')).toBeInTheDocument();
+    });
+
+    it('renders name without project badge', () => {
+      render(
+        <FieldRenderer
+          column={eventView.getColumns()[6]}
+          data={mockedEventData}
+          meta={{}}
+        />,
+        {organization: organizationWithoutFlags}
+      );
+      expect(screen.queryByTestId('platform-icon-javascript')).not.toBeInTheDocument();
+    });
   });
 
   describe('with otel friendly UI flag', () => {
-    beforeAll(() => {
-      organization.features.push('performance-otel-friendly-ui');
-    });
-
-    afterAll(() => {
-      organization.features.pop();
+    const organizationWithOtelFlag = OrganizationFixture({
+      features: ['performance-otel-friendly-ui'],
     });
 
     it('renders description without project badge', () => {
@@ -182,7 +184,7 @@ describe('FieldRenderer tests', () => {
           data={mockedEventData}
           meta={{}}
         />,
-        {organization}
+        {organization: organizationWithOtelFlag}
       );
       expect(screen.queryByTestId('platform-icon-javascript')).not.toBeInTheDocument();
     });
@@ -194,7 +196,7 @@ describe('FieldRenderer tests', () => {
           data={mockedEventData}
           meta={{}}
         />,
-        {organization}
+        {organization: organizationWithOtelFlag}
       );
       expect(screen.getByTestId('platform-icon-javascript')).toBeInTheDocument();
     });

--- a/static/app/views/explore/tables/fieldRenderer.spec.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.spec.tsx
@@ -20,6 +20,7 @@ const mockedEventData = {
   'transaction.id': 'transactionId',
   'transaction.span_id': 'transactionSpanId',
   'span.description': 'GET /foo',
+  'span.name': 'HTTP GET /foo',
 };
 
 describe('FieldRenderer tests', () => {

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -33,6 +33,7 @@ import {
   useReadQueriesFromLocation,
   useUpdateQueryAtIndex,
 } from 'sentry/views/explore/multiQueryMode/locationUtils';
+import {SpanFields} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
@@ -121,7 +122,8 @@ function BaseExploreFieldRenderer({
 
   const field = String(column.key);
 
-  const renderer = getExploreFieldRenderer(field, meta, projectsMap);
+  const otelFriendlyUI = organization?.features.includes('performance-otel-friendly-ui');
+  const renderer = getExploreFieldRenderer(field, meta, projectsMap, otelFriendlyUI);
 
   let rendered = renderer(data, {
     location,
@@ -195,13 +197,17 @@ function BaseExploreFieldRenderer({
 function getExploreFieldRenderer(
   field: string,
   meta: MetaType,
-  projects: Record<string, Project>
+  projects: Record<string, Project>,
+  otelFriendlyUI: boolean
 ): ReturnType<typeof getFieldRenderer> {
   if (field === 'id' || field === 'span_id') {
     return eventIdRenderFunc(field);
   }
-  if (field === 'span.description') {
-    return spanDescriptionRenderFunc(projects);
+  if (field === 'span.description' && !otelFriendlyUI) {
+    return spanDescriptionRenderFunc('span.description', projects);
+  }
+  if (field === SpanFields.NAME && otelFriendlyUI) {
+    return spanDescriptionRenderFunc(SpanFields.NAME, projects);
   }
   return getFieldRenderer(field, meta, false);
 }
@@ -218,11 +224,11 @@ function eventIdRenderFunc(field: string) {
   return renderer;
 }
 
-function spanDescriptionRenderFunc(projects: Record<string, Project>) {
+function spanDescriptionRenderFunc(field: string, projects: Record<string, Project>) {
   function renderer(data: EventData) {
     const project = projects[data.project];
 
-    const value = data['span.description'];
+    const value = data[field];
 
     return (
       <span>


### PR DESCRIPTION
When the `performance-otel-friendly-ui` organization flag is on, the default columns in Explore [remove `span.op` and `span.description` in favor of `span.name`](https://github.com/getsentry/sentry/blob/b672b76f8818605a6d272f14b5e38b4d04e0dba0/static/app/views/explore/contexts/pageParamsContext/fields.tsx#L8-L26). `span.description` has special treatment when rendering to include a project badge with the project platform icon. When the OTel friendly flag is on, apply this special treatment to the `span.name` field instead.

<img width="1073" height="481" alt="Screenshot 2025-10-02 at 11 57 55" src="https://github.com/user-attachments/assets/7fc4b61d-cfb7-4832-b42f-79d444d4a6ab" />
