### PR TITLE
fix(crons): Correctly handle partial updates

### DIFF
--- a/tests/sentry/monitors/test_validators.py
+++ b/tests/sentry/monitors/test_validators.py
@@ -1,14 +1,16 @@
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 from django.conf import settings
 from django.test import RequestFactory
 from django.test.utils import override_settings
+from django.utils import timezone
 
 from sentry.analytics.events.cron_monitor_created import CronMonitorCreated, FirstCronMonitorCreated
 from sentry.constants import ObjectStatus
 from sentry.models.rule import Rule, RuleSource
-from sentry.monitors.models import Monitor, MonitorLimitsExceeded, ScheduleType
+from sentry.monitors.models import Monitor, MonitorLimitsExceeded, MonitorStatus, ScheduleType
 from sentry.monitors.validators import (
     MonitorDataSourceValidator,
     MonitorIncidentDetectorValidator,
@@ -399,6 +401,46 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert updated_monitor.config["checkin_margin"] == 10
         assert updated_monitor.config["max_runtime"] == 60
         assert updated_monitor.config["timezone"] == "America/New_York"
+
+    def test_partial_config_update_different_field(self):
+        """Test that updating a config field doesn't trigger false positive margin/runtime changes."""
+        now = timezone.now().replace(second=0, microsecond=0)
+        env = self.create_monitor_environment(
+            monitor=self.monitor,
+            environment_id=self.environment.id,
+            status=MonitorStatus.OK,
+            last_checkin=now,
+            next_checkin=now + timedelta(hours=1),
+            next_checkin_latest=now + timedelta(hours=1, minutes=5),
+        )
+        original_next_checkin_latest = env.next_checkin_latest
+
+        # Update only timezone, NOT checkin_margin
+        validator = MonitorValidator(
+            instance=self.monitor,
+            data={"config": {"timezone": "America/New_York"}},
+            partial=True,
+            context={
+                "organization": self.organization,
+                "access": self.access,
+                "request": self.request,
+            },
+        )
+        assert validator.is_valid()
+
+        updated_monitor = validator.save()
+        assert updated_monitor.config["timezone"] == "America/New_York"
+        assert updated_monitor.config["checkin_margin"] == 5
+
+        # With buggy code, checking the partial
+        # new_config.get("checkin_margin") would return None, when comparing
+        # that with the existing checkin_margin we would consider it as having
+        # "changed" and would have recomputed the next_checkin_latest
+
+        # Verify that because checkin_margin was not changed we did not
+        # recompute the next_checkin_latest
+        env.refresh_from_db()
+        assert env.next_checkin_latest == original_next_checkin_latest
 
     def test_update_owner_to_user(self):
         """Test updating monitor owner to a user."""


### PR DESCRIPTION
When updating a monitor config with partial data (e.g., only timezone),
the validator was incorrectly detecting changes to checkin_margin and
max_runtime. This occurred because it compared the partial request
config (where unspecified fields are None) against the existing full config.

For example, updating only timezone would compare:
- new_config.get("checkin_margin") -> None
- existing_margin -> 5
- None != 5 -> incorrectly triggers next_checkin_latest update

Fixed by comparing instance.config (merged config after update) instead
of validated_data["config"] (partial request data), ensuring comparisons
are always between complete configs.

Added test that verifies updating timezone doesn't trigger false
positive margin/runtime updates.

This was never actually a problem in our UI, since we would always send
full updates and include all the fields from the fronted.