### PR TITLE
typing(unmerge): Fix failing type issue

### DIFF
--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -421,9 +421,11 @@ def collect_tsdb_data(
 
         user = event.data.get("user")
         if user:
-            sets[event.datetime][TSDBModel.users_affected_by_group][
-                (event.group_id, environment.id)
-            ].add(get_event_user_from_interface(user, project).tag_value)
+            tag_value = get_event_user_from_interface(user, project).tag_value
+            if tag_value is not None:
+                sets[event.datetime][TSDBModel.users_affected_by_group][
+                    (event.group_id, environment.id)
+                ].add(tag_value)
 
         frequencies[event.datetime][TSDBModel.frequent_environments_by_group][str(event.group_id)][
             str(environment.id)


### PR DESCRIPTION
Appears master is failing type-checks, I believe due to a bad merge from https://github.com/getsentry/sentry/pull/100492

Curious how that passed, nonetheless this should fix master tests and we can address further if needed in follow ups