### PR TITLE
ref(workflow_engine): Use `dataSources` attribute along with `dataSource` in API

### DIFF
--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -243,10 +243,14 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
             if query_subscriptions:
                 enable_disable_subscriptions(query_subscriptions, enabled)
 
+        data_source: SnubaQueryDataSourceType | None
         if "data_source" in validated_data:
             data_source: SnubaQueryDataSourceType = validated_data.pop("data_source")
-            if data_source:
-                self.update_data_source(instance, data_source)
+        elif "data_sources" in validated_data:
+            data_source: SnubaQueryDataSourceType = validated_data.pop("data_sources")[0]
+
+        if data_source is not None:
+            self.update_data_source(instance, data_source)
 
         instance.save()
 

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -245,9 +245,9 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
 
         data_source: SnubaQueryDataSourceType | None
         if "data_source" in validated_data:
-            data_source: SnubaQueryDataSourceType = validated_data.pop("data_source")
+            data_source = validated_data.pop("data_source")
         elif "data_sources" in validated_data:
-            data_source: SnubaQueryDataSourceType = validated_data.pop("data_sources")[0]
+            data_source = validated_data.pop("data_sources")[0]
 
         if data_source is not None:
             self.update_data_source(instance, data_source)

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -128,7 +128,6 @@ class MetricIssueConditionGroupValidator(BaseDataConditionGroupValidator):
 
 
 class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
-    data_source = SnubaQueryValidator(required=False, timeWindowSeconds=True)
     data_sources = serializers.ListField(
         child=SnubaQueryValidator(timeWindowSeconds=True), required=False
     )
@@ -243,7 +242,8 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
             if query_subscriptions:
                 enable_disable_subscriptions(query_subscriptions, enabled)
 
-        data_source: SnubaQueryDataSourceType | None
+        data_source: SnubaQueryDataSourceType | None = None
+
         if "data_source" in validated_data:
             data_source = validated_data.pop("data_source")
         elif "data_sources" in validated_data:

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -128,6 +128,7 @@ class MetricIssueConditionGroupValidator(BaseDataConditionGroupValidator):
 
 
 class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
+    data_source = SnubaQueryValidator(required=False, timeWindowSeconds=True)
     data_sources = serializers.ListField(
         child=SnubaQueryValidator(timeWindowSeconds=True), required=False
     )

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -690,8 +690,13 @@ class MonitorIncidentDetectorValidator(BaseDetectorTypeValidator):
     def update(self, instance: Detector, validated_data: dict[str, Any]) -> Detector:
         super().update(instance, validated_data)
 
+        data_source_data = None
         if "data_source" in validated_data:
             data_source_data = validated_data.pop("data_source")
+        elif "data_sources" in validated_data:
+            data_source_data = validated_data.pop("data_sources")[0]
+
+        if data_source_data is not None:
             data_source = DataSource.objects.get(detectors=instance)
             monitor = Monitor.objects.get(id=data_source.source_id)
 

--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -466,7 +466,13 @@ class UptimeDomainCheckFailureValidator(BaseDetectorTypeValidator):
     def update(self, instance: Detector, validated_data: dict[str, Any]) -> Detector:
         super().update(instance, validated_data)
 
+        data_source = None
         if "data_source" in validated_data:
+            data_source = validated_data.pop("data_source")
+        elif "data_sources" in validated_data:
+            data_source = validated_data.pop("data_sources")[0]
+
+        if data_source is not None:
             data_source = validated_data.pop("data_source")
             if data_source:
                 self.update_data_source(instance, data_source)

--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -473,9 +473,8 @@ class UptimeDomainCheckFailureValidator(BaseDetectorTypeValidator):
             data_source = validated_data.pop("data_sources")[0]
 
         if data_source is not None:
-            data_source = validated_data.pop("data_source")
-            if data_source:
-                self.update_data_source(instance, data_source)
+            self.update_data_source(instance, data_source)
+
         return instance
 
     def update_data_source(self, instance: Detector, data_source: dict[str, Any]):

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -620,5 +620,8 @@ class TestMetricAlertDetectorDataSourcesValidator(TestMetricAlertsDetectorValida
         super().setUp()
 
         data_source = self.valid_data["dataSource"]
-        self.valid_data["dataSources"] = [data_source]
+
+        # This is a temporary line of code; works fine when inlining the [] which
+        # is the longer term solution.
+        self.valid_data["dataSources"] = [data_source]  # type: ignore[list-item]
         del self.valid_data["dataSource"]

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -611,6 +611,7 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
         ):
             update_validator.save()
 
+
 class TestMetricAlertDetectorDataSourcesValidator(TestMetricAlertsDetectorValidator):
     def setUp(self) -> None:
         """

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -610,3 +610,15 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
             with_feature("organizations:discover-saved-queries-deprecation"),
         ):
             update_validator.save()
+
+class TestMetricAlertDetectorDataSourcesValidator(TestMetricAlertsDetectorValidator):
+    def setUp(self) -> None:
+        """
+        These are a temporary suite of tests that run the same ones as `TestMetricAlertsDetectorValidator`
+        but changes the dataSource attribute to dataSources.
+        """
+        super().setUp()
+
+        data_source = self.valid_data["dataSource"]
+        self.valid_data["dataSources"] = [data_source]
+        del self.valid_data["dataSource"]

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -153,15 +153,17 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
             "type": MetricIssue.slug,
             "dateCreated": self.detector.date_added,
             "dateUpdated": timezone.now(),
-            "dataSource": {
-                "queryType": self.snuba_query.type,
-                "dataset": self.snuba_query.dataset,
-                "query": "updated query",
-                "aggregate": self.snuba_query.aggregate,
-                "timeWindow": 300,
-                "environment": self.environment.name,
-                "eventTypes": [event_type.name for event_type in self.snuba_query.event_types],
-            },
+            "dataSources": [
+                {
+                    "queryType": self.snuba_query.type,
+                    "dataset": self.snuba_query.dataset,
+                    "query": "updated query",
+                    "aggregate": self.snuba_query.aggregate,
+                    "timeWindow": 300,
+                    "environment": self.environment.name,
+                    "eventTypes": [event_type.name for event_type in self.snuba_query.event_types],
+                }
+            ],
             "conditionGroup": {
                 "id": self.data_condition_group.id,
                 "organizationId": self.organization.id,


### PR DESCRIPTION
# Description
Update the validators to consume the data sources side if available