### PR TITLE
fix(preprod): Ensure preprod flag is explicitly checked before showing builds tab

### DIFF
--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -81,22 +81,28 @@ function ReleaseHeader({
   ];
 
   const numberOfMobileBuilds = releaseMeta.preprodBuildCount;
-  if (numberOfMobileBuilds || MOBILE_PLATFORMS.includes(project.platform)) {
-    tabs.push({
-      title: tct('Builds [count]', {
-        count:
-          numberOfMobileBuilds === 0 ? (
-            <BadgeWrapper>
-              <FeatureBadge type="new" />
-            </BadgeWrapper>
-          ) : (
-            <NavTabsBadge type="default">
-              {formatAbbreviatedNumber(numberOfMobileBuilds)}
-            </NavTabsBadge>
-          ),
-      }),
-      to: `builds/`,
-    });
+
+  const buildsTab = {
+    title: tct('Builds [count]', {
+      count:
+        numberOfMobileBuilds === 0 ? (
+          <BadgeWrapper>
+            <FeatureBadge type="new" />
+          </BadgeWrapper>
+        ) : (
+          <NavTabsBadge type="default">
+            {formatAbbreviatedNumber(numberOfMobileBuilds)}
+          </NavTabsBadge>
+        ),
+    }),
+    to: `builds/`,
+  };
+
+  if (
+    organization.features?.includes('preprod-frontend-routes') &&
+    (numberOfMobileBuilds || MOBILE_PLATFORMS.includes(project.platform))
+  ) {
+    tabs.push(buildsTab);
   }
 
   const getTabUrl = (path: string) =>


### PR DESCRIPTION
The tab was initially written to only up if `releaseMeta.preprodBuildCount > 0`, which is only be possible if you're treated for the preprod flag already since you need to have it enabled to do preprod uploads in the first place. 

We then made a change to add a `|| MOBILE_PLATFORMS.includes(project.platform)` check into the conditional, which broke the flag assumption. 

This explicitly checks for the flag being enabled.