### PR TITLE
fix(aci): test email notification

### DIFF
--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -157,9 +157,6 @@ class BaseIssueAlertHandler(ABC):
             if workflow_id == TEST_NOTIFICATION_ID:
                 data["actions"][0]["legacy_rule_id"] = TEST_NOTIFICATION_ID
 
-                # mail action needs to have skipDigests set to True
-                if action.type == Action.Type.EMAIL:
-                    data["actions"][0]["skipDigests"] = True
             else:
                 try:
                     alert_rule_workflow = AlertRuleWorkflow.objects.get(
@@ -190,6 +187,10 @@ class BaseIssueAlertHandler(ABC):
         # In the new UI, we need this for to build the link to the new rule in the notification action
         else:
             data["actions"][0]["workflow_id"] = workflow_id
+
+        if workflow_id == TEST_NOTIFICATION_ID and action.type == Action.Type.EMAIL:
+            # mail action needs to have skipDigests set to True
+            data["actions"][0]["skipDigests"] = True
 
         rule = Rule(
             id=action.id,

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -156,6 +156,10 @@ class BaseIssueAlertHandler(ABC):
             # If test event, just set the legacy rule id to -1
             if workflow_id == TEST_NOTIFICATION_ID:
                 data["actions"][0]["legacy_rule_id"] = TEST_NOTIFICATION_ID
+
+                # mail action needs to have skipDigests set to True
+                if action.type == Action.Type.EMAIL:
+                    data["actions"][0]["skipDigests"] = True
             else:
                 try:
                     alert_rule_workflow = AlertRuleWorkflow.objects.get(

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -331,7 +331,7 @@ class ProjectRuleActionsEndpointWorkflowEngineTest(APITestCase, BaseWorkflowTest
         action_data = [
             {
                 "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": "1",
+                "targetIdentifier": str(self.user.id),
                 "targetType": "Member",
             }
         ]


### PR DESCRIPTION
The email action future will send emails in a digest unless `skipDigests` is passed. This is done manually for the old alerting system but needs to be added in for workflow engine.

Only the email action needs this.

https://github.com/getsentry/sentry/blob/97a51dacfb6c03285310a87eeb0bd175a40b18f4/src/sentry/api/endpoints/project_rule_actions.py#L62-L63

https://github.com/getsentry/sentry/blob/97a51dacfb6c03285310a87eeb0bd175a40b18f4/src/sentry/mail/actions.py#L53

https://github.com/getsentry/sentry/blob/97a51dacfb6c03285310a87eeb0bd175a40b18f4/src/sentry/mail/adapter.py#L79