### PR TITLE
fix(crons): No non-ASCII in cron expressions

### DIFF
--- a/static/app/views/insights/crons/components/monitorForm.spec.tsx
+++ b/static/app/views/insights/crons/components/monitorForm.spec.tsx
@@ -282,4 +282,24 @@ describe('MonitorForm', () => {
       })
     );
   });
+
+  it('filters non-ASCII characters from crontab schedule', async () => {
+    render(
+      <MonitorForm
+        apiMethod="POST"
+        apiEndpoint={`/organizations/${organization.slug}/monitors/`}
+        onSubmitSuccess={jest.fn()}
+      />,
+      {organization}
+    );
+
+    const schedule = screen.getByRole('textbox', {name: 'Crontab Schedule'});
+
+    // Type schedule with emoji and Unicode characters
+    await userEvent.clear(schedule);
+    await userEvent.type(schedule, '5 * * * *😀中文');
+
+    // Non-ASCII characters should be filtered out, leaving only valid ASCII
+    expect(schedule).toHaveValue('5 * * * *');
+  });
 });

--- a/static/app/views/insights/crons/components/monitorForm.tsx
+++ b/static/app/views/insights/crons/components/monitorForm.tsx
@@ -358,6 +358,11 @@ function MonitorForm({
                       hideLabel
                       placeholder="* * * * *"
                       defaultValue={DEFAULT_CRONTAB}
+                      transformInput={(value: string) =>
+                        // Remove non-ASCII characters from crontab schedule
+                        // eslint-disable-next-line no-control-regex
+                        value.replace(/[^\x00-\x7F]/g, '')
+                      }
                       css={css`
                         input {
                           font-family: ${theme.text.familyMono};


### PR DESCRIPTION
Fixes [NEW-118: Disable emoji/special characters in crontab form](https://linear.app/getsentry/issue/NEW-118/disable-emojispecial-characters-in-crontab-form)