### PR TITLE
fix(ACI): Delete Detector even if AlertRuleWorkflow is not found

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -857,12 +857,14 @@ def dual_delete_migrated_alert_rule(alert_rule: AlertRule) -> None:
             "AlertRuleWorkflow not found for AlertRule, workflow may be orphaned",
             extra={"detector_id": detector.id},
         )
-
-    RegionScheduledDeletion.schedule(instance=detector, days=0)
-
     if alert_rule_workflow:
         workflow: Workflow = alert_rule_workflow.workflow
-        RegionScheduledDeletion.schedule(instance=workflow, days=0)
+        with transaction.atomic(router.db_for_write(Detector)):
+            RegionScheduledDeletion.schedule(instance=detector, days=0)
+            RegionScheduledDeletion.schedule(instance=workflow, days=0)
+
+    else:
+        RegionScheduledDeletion.schedule(instance=detector, days=0)
 
     return
 

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -854,7 +854,7 @@ def dual_delete_migrated_alert_rule(alert_rule: AlertRule) -> None:
         alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule_id=alert_rule.id)
     except AlertRuleWorkflow.DoesNotExist:
         logger.exception(
-            "AlertRuleWorkflow not found for AlertRule, workflow will be orphaned",
+            "AlertRuleWorkflow not found for AlertRule, workflow may be orphaned",
             extra={"detector_id": detector.id},
         )
 

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -846,13 +846,22 @@ def dual_delete_migrated_alert_rule(alert_rule: AlertRule) -> None:
             extra={"alert_rule_id": alert_rule.id},
         )
         return
-    alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule_id=alert_rule.id)
 
-    workflow: Workflow = alert_rule_workflow.workflow
     detector: Detector = alert_rule_detector.detector
+    alert_rule_workflow = None
 
-    with transaction.atomic(router.db_for_write(Detector)):
-        RegionScheduledDeletion.schedule(instance=detector, days=0)
+    try:
+        alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule_id=alert_rule.id)
+    except AlertRuleWorkflow.DoesNotExist:
+        logger.exception(
+            "AlertRuleWorkflow not found for AlertRule, workflow will be orphaned",
+            extra={"detector_id": detector.id},
+        )
+
+    RegionScheduledDeletion.schedule(instance=detector, days=0)
+
+    if alert_rule_workflow:
+        workflow: Workflow = alert_rule_workflow.workflow
         RegionScheduledDeletion.schedule(instance=workflow, days=0)
 
     return

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -658,6 +658,18 @@ class DualDeleteAlertRuleTest(BaseMetricAlertMigrationTest):
             run_scheduled_deletions()
         assert not Detector.objects.filter(id=self.detector.id).exists()
 
+    def test_dual_delete_missing_workflow(self) -> None:
+        """
+        Test that if we are missing the Workflow and AlertRuleWorkflow models that we still delete the detector
+        """
+        self.workflow.delete()
+        self.alert_rule_workflow.delete()
+
+        dual_delete_migrated_alert_rule(self.metric_alert)
+        with self.tasks():
+            run_scheduled_deletions()
+        assert not Detector.objects.filter(id=self.detector.id).exists()
+
 
 class DualUpdateAlertRuleTest(BaseMetricAlertMigrationTest):
     def setUp(self) -> None:


### PR DESCRIPTION
We appear to have run into some deletion edge cases where some parts of deletion failed leaving us in an incomplete state - this will allow the rule and detector to be deleted even if we can't find the previously associated workflow through the alert rule workflow table. In these specific cases this is fine because we know the workflows have already been deleted.

Fixes https://sentry.sentry.io/issues/6910634838/