### PR TITLE
feat(billing): Disable submission form button when adding/removing credits

### DIFF
--- a/static/gsAdmin/components/changeBalanceAction.spec.tsx
+++ b/static/gsAdmin/components/changeBalanceAction.spec.tsx
@@ -154,8 +154,9 @@ describe('BalanceChangeAction', () => {
     const submitButton = screen.getByRole('button', {name: 'Submit'});
     await userEvent.click(submitButton);
 
-    // During submission, button should show "Submitting..." and fields should be disabled
+    // During submission, button should show "Submitting...", be disabled, and fields should be disabled
     expect(submitButton).toHaveTextContent('Submitting...');
+    expect(submitButton).toBeDisabled();
     expect(creditInput).toBeDisabled();
     expect(screen.getByTestId('url-field')).toBeDisabled();
     expect(screen.getByTestId('notes-field')).toBeDisabled();
@@ -190,8 +191,9 @@ describe('BalanceChangeAction', () => {
     // state, so if one is enabled, all should be enabled.
     await waitFor(() => expect(creditInput).toBeEnabled());
 
-    // Verify all fields are re-enabled
+    // Verify all fields and submit button are re-enabled
     expect(urlField).toBeEnabled();
     expect(notesField).toBeEnabled();
+    expect(submitButton).toBeEnabled();
   });
 });

--- a/static/gsAdmin/components/changeBalanceAction.spec.tsx
+++ b/static/gsAdmin/components/changeBalanceAction.spec.tsx
@@ -107,4 +107,82 @@ describe('BalanceChangeAction', () => {
       })
     );
   });
+
+  it('prevents double submission', async () => {
+    const updateMock = MockApiClient.addMockResponse({
+      url: `/_admin/customers/${organization.slug}/balance-changes/`,
+      method: 'POST',
+      body: OrganizationFixture(),
+    });
+
+    triggerChangeBalanceModal({subscription, ...modalProps});
+
+    renderGlobalModal();
+    await userEvent.type(screen.getByRole('spinbutton', {name: 'Credit Amount'}), '10');
+
+    const submitButton = screen.getByRole('button', {name: 'Submit'});
+
+    // Rapidly click submit button multiple times
+    await userEvent.click(submitButton);
+    await userEvent.click(submitButton);
+    await userEvent.click(submitButton);
+
+    // Should only call API once (double-clicks prevented)
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables form fields during submission', async () => {
+    // Mock with delay to keep isSubmitting true during test
+    MockApiClient.addMockResponse({
+      url: `/_admin/customers/${organization.slug}/balance-changes/`,
+      method: 'POST',
+      body: OrganizationFixture(),
+      asyncDelay: 100,
+    });
+
+    triggerChangeBalanceModal({subscription, ...modalProps});
+
+    renderGlobalModal();
+    const creditInput = screen.getByRole('spinbutton', {name: 'Credit Amount'});
+    await userEvent.type(creditInput, '10');
+
+    const submitButton = screen.getByRole('button', {name: 'Submit'});
+    await userEvent.click(submitButton);
+
+    // During submission, button should show "Submitting..." and fields should be disabled
+    expect(submitButton).toHaveTextContent('Submitting...');
+    expect(creditInput).toBeDisabled();
+    expect(screen.getByTestId('url-field')).toBeDisabled();
+    expect(screen.getByTestId('notes-field')).toBeDisabled();
+  });
+
+  it('re-enables form after error', async () => {
+    MockApiClient.addMockResponse({
+      url: `/_admin/customers/${organization.slug}/balance-changes/`,
+      method: 'POST',
+      statusCode: 400,
+      body: {detail: 'Invalid amount'},
+    });
+
+    triggerChangeBalanceModal({subscription, ...modalProps});
+
+    renderGlobalModal();
+    const creditInput = screen.getByRole('spinbutton', {name: 'Credit Amount'});
+    await userEvent.type(creditInput, '10');
+
+    // Wait for button to be available after typing (prevents CI timing issues)
+    const submitButton = await screen.findByRole('button', {name: 'Submit'});
+    await userEvent.click(submitButton);
+
+    // Wait for error to be processed and button to return to "Submit" state
+    await screen.findByRole('button', {name: 'Submit'});
+
+    // After error, form should be re-enabled
+    expect(creditInput).toBeEnabled();
+    expect(screen.getByTestId('url-field')).toBeEnabled();
+    expect(screen.getByTestId('notes-field')).toBeEnabled();
+    expect(screen.getByRole('button', {name: 'Submit'})).not.toHaveTextContent(
+      'Submitting...'
+    );
+  });
 });

--- a/static/gsAdmin/components/changeBalanceAction.tsx
+++ b/static/gsAdmin/components/changeBalanceAction.tsx
@@ -86,6 +86,7 @@ function ChangeBalanceModal({
           onSubmit={onSubmit}
           onCancel={closeModal}
           submitLabel={isSubmitting ? 'Submitting...' : 'Submit'}
+          submitDisabled={isSubmitting}
           cancelLabel="Cancel"
           footerClass="modal-footer"
         >

--- a/static/gsAdmin/components/changeBalanceAction.tsx
+++ b/static/gsAdmin/components/changeBalanceAction.tsx
@@ -32,6 +32,7 @@ function ChangeBalanceModal({
 }: ModalProps) {
   const [ticketUrl, setTicketUrl] = useState('');
   const [notes, setNotes] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const api = useApi();
 
   function coerceValue(value: number) {
@@ -47,6 +48,12 @@ function ChangeBalanceModal({
       return;
     }
 
+    // Prevent concurrent submissions
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
     try {
       await api.requestPromise(`/_admin/customers/${orgId}/balance-changes/`, {
         method: 'POST',
@@ -60,6 +67,8 @@ function ChangeBalanceModal({
       onSubmitError({
         responseJSON: err.responseJSON,
       });
+    } finally {
+      setIsSubmitting(false);
     }
   }
 
@@ -76,7 +85,7 @@ function ChangeBalanceModal({
         <Form
           onSubmit={onSubmit}
           onCancel={closeModal}
-          submitLabel="Submit"
+          submitLabel={isSubmitting ? 'Submitting...' : 'Submit'}
           cancelLabel="Cancel"
           footerClass="modal-footer"
         >
@@ -84,6 +93,7 @@ function ChangeBalanceModal({
             label="Credit Amount"
             name="creditAmount"
             help="Add or remove credit, in dollars"
+            disabled={isSubmitting}
           />
           <AuditFields>
             <InputField
@@ -94,6 +104,7 @@ function ChangeBalanceModal({
               inline={false}
               stacked
               flexibleControlStateSize
+              disabled={isSubmitting}
               onChange={(ticketUrlInput: any) => setTicketUrl(ticketUrlInput)}
             />
             <TextField
@@ -104,6 +115,7 @@ function ChangeBalanceModal({
               stacked
               flexibleControlStateSize
               maxLength={500}
+              disabled={isSubmitting}
               onChange={(notesInput: any) => setNotes(notesInput)}
             />
           </AuditFields>


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-232/credit-to-a-subscription-can-sometimes-get-duplicated-via-admin

 Disable submission form button when adding/removing credits. This should prevent accidental double-clicks to add multiple credits.