### PR TITLE
fix(insights): Fix Autofix not using Web Vital Issue Event provided trace id

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -176,15 +176,14 @@ def _get_trace_tree_for_event(event: Event | GroupEvent, project: Project) -> di
         projects_qs = Project.objects.filter(
             organization=project.organization, status=ObjectStatus.ACTIVE
         )
+        end = event.datetime + timedelta(days=1)
         projects = list(projects_qs)
         # Web Vital issues are synthetic and don't necessarily occur at the same time as associated traces
-        # Don't restrict time range in these scenarios
+        # Don't restrict time range in these scenarios, ie use 90 day range
         if event.group and event.group.issue_type.slug == WebVitalsGroup.slug:
-            start = None
-            end = None
+            start = event.datetime - timedelta(days=89)
         else:
             start = event.datetime - timedelta(days=1)
-            end = event.datetime + timedelta(days=1)
 
         snuba_params = SnubaParams(
             start=start,

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -177,8 +177,14 @@ def _get_trace_tree_for_event(event: Event | GroupEvent, project: Project) -> di
             organization=project.organization, status=ObjectStatus.ACTIVE
         )
         projects = list(projects_qs)
-        start = event.datetime - timedelta(days=1)
-        end = event.datetime + timedelta(days=1)
+        # Web Vital issues are synthetic and don't necessarily occur at the same time as associated traces
+        # Don't restrict time range in these scenarios
+        if event.group and event.group.issue_type.slug == WebVitalsGroup.slug:
+            start = None
+            end = None
+        else:
+            start = event.datetime - timedelta(days=1)
+            end = event.datetime + timedelta(days=1)
 
         snuba_params = SnubaParams(
             start=start,

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -176,8 +176,8 @@ def _get_trace_tree_for_event(event: Event | GroupEvent, project: Project) -> di
         projects_qs = Project.objects.filter(
             organization=project.organization, status=ObjectStatus.ACTIVE
         )
-        end = event.datetime + timedelta(days=1)
         projects = list(projects_qs)
+        end = event.datetime + timedelta(days=1)
         # Web Vital issues are synthetic and don't necessarily occur at the same time as associated traces
         # Don't restrict time range in these scenarios, ie use 90 day range
         if event.group and event.group.issue_type.slug == WebVitalsGroup.slug:

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -294,7 +294,7 @@ class TestConvertProfileToExecutionTree(TestCase):
 
 
 @pytest.mark.django_db
-class TestGetTraceTreeForEvent(APITestCase):
+class TestGetTraceTreeForEvent(APITestCase, OccurrenceTestMixin):
     @patch("sentry.api.endpoints.organization_trace.OrganizationTraceEndpoint.query_trace_data")
     def test_get_trace_tree_basic(self, mock_query_trace_data) -> None:
         """Test that we can get a basic trace tree."""
@@ -396,6 +396,60 @@ class TestGetTraceTreeForEvent(APITestCase):
         child_span = parent_span["children"][0]
         assert child_span["description"] == "Child Operation"
         assert child_span["parent_span"] == "aaaaaaaaaaaaaaaa"
+
+    @patch("sentry.api.endpoints.organization_trace.OrganizationTraceEndpoint.query_trace_data")
+    def test_get_trace_tree_with_web_vital_issue(self, mock_query_trace_data) -> None:
+        """Test that we can get a trace tree for a web vital issue."""
+        trace_id = "1234567890abcdef1234567890abcdef"
+        event_data = load_data("javascript")
+        event_data.update(
+            {"contexts": {"trace": {"trace_id": trace_id, "span_id": "abcdef0123456789"}}}
+        )
+
+        occurrence_data = self.build_occurrence_data(
+            project_id=self.project.id,
+            type=WebVitalsGroup.type_id,
+            issue_title="LCP score needs improvement",
+            subtitle="/test-transaction has an LCP score of 75",
+            culprit="/test-transaction",
+            evidence_data={
+                "transaction": "/test-transaction",
+                "vital": "lcp",
+                "score": 75,
+                "trace_id": trace_id,
+            },
+            level="info",
+        )
+
+        event_data["event_id"] = occurrence_data["event_id"]
+        event = self.store_event(data=event_data, project_id=self.project.id)
+
+        _, group_info = save_issue_occurrence(occurrence_data, event)
+        group = group_info.group
+        event = event.for_group(group)
+
+        mock_trace_data = [
+            {
+                "id": "aaaaaaaaaaaaaaaa",
+                "description": "Test Transaction",
+                "is_transaction": True,
+                "children": [],
+                "errors": [],
+                "occurrences": [],
+            }
+        ]
+        mock_query_trace_data.return_value = mock_trace_data
+
+        trace_tree = _get_trace_tree_for_event(event, self.project)
+
+        assert trace_tree is not None
+        assert trace_tree["trace_id"] == trace_id
+        assert trace_tree["trace"] == mock_trace_data
+        mock_query_trace_data.assert_called_once()
+        call_args = mock_query_trace_data.call_args
+        snuba_params = call_args[0][0]
+        time_range = snuba_params.end - snuba_params.start
+        assert time_range.days == 90
 
 
 @requires_snuba

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -425,6 +425,7 @@ class TestGetTraceTreeForEvent(APITestCase, OccurrenceTestMixin):
         event = self.store_event(data=event_data, project_id=self.project.id)
 
         _, group_info = save_issue_occurrence(occurrence_data, event)
+        assert group_info is not None
         group = group_info.group
         event = event.for_group(group)
 

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -427,7 +427,7 @@ class TestGetTraceTreeForEvent(APITestCase, OccurrenceTestMixin):
         _, group_info = save_issue_occurrence(occurrence_data, event)
         assert group_info is not None
         group = group_info.group
-        event = event.for_group(group)
+        group_event = event.for_group(group)
 
         mock_trace_data = [
             {
@@ -441,7 +441,7 @@ class TestGetTraceTreeForEvent(APITestCase, OccurrenceTestMixin):
         ]
         mock_query_trace_data.return_value = mock_trace_data
 
-        trace_tree = _get_trace_tree_for_event(event, self.project)
+        trace_tree = _get_trace_tree_for_event(group_event, self.project)
 
         assert trace_tree is not None
         assert trace_tree["trace_id"] == trace_id


### PR DESCRIPTION
Fix an issue with Autofix not always properly loading traces from Web Vital Issue events. Traces are fetch with a ±1 day range of the event. Web Vital issue events happen independently from traces, so it's very likely that trace fetches fail due to being out of date range. Updates start and end timerange filter to be 90 days when fetching trace on web vital autofix for this scenario.