### PR TITLE
fix(insights) Fix timestamp for web vital issue creation

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -7,7 +7,7 @@ import {TRACE_WATERFALL_PREFERENCES_KEY} from 'sentry/components/events/interfac
 import {getEventTimestampInSeconds} from 'sentry/components/events/interfaces/utils';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
-import type {Event} from 'sentry/types/event';
+import {type Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
@@ -60,7 +60,9 @@ interface EventTraceViewInnerProps {
 }
 
 function EventTraceViewInner({event, organization, traceId}: EventTraceViewInnerProps) {
-  const timestamp = getEventTimestampInSeconds(event);
+  const timestamp = isWebVitalsEvent(event)
+    ? undefined
+    : getEventTimestampInSeconds(event);
 
   const trace = useTrace({
     timestamp,
@@ -128,6 +130,10 @@ function OneOtherIssueEvent({event}: {event: Event}) {
 const IssuesTraceContainer = styled('div')`
   position: relative;
 `;
+
+const isWebVitalsEvent = (event: Event) => {
+  return event.tags.some((tag: {key: string}) => tag?.key === 'web_vital');
+};
 
 interface EventTraceViewProps {
   event: Event;

--- a/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useRunSeerAnalysis.tsx
@@ -50,10 +50,9 @@ export function useRunSeerAnalysis({
           issueType: IssueType.WEB_VITALS,
           vital: webVital,
           score: projectScore[`${webVital}Score`],
-          value: projectData[`p75(measurements.${webVital})`],
+          value: Math.round(projectData[`p75(measurements.${webVital})`]),
           transaction,
           traceId: webVitalTraceSamples[webVital]?.trace,
-          timestamp: webVitalTraceSamples[webVital]?.timestamp,
         });
         return result.event_id;
       } catch (error) {


### PR DESCRIPTION
- Removes `timestamp` param from the web vital issue creation endpoint, to default to the current timestamp instead
- Updates trace preview to remove start and end timestamp restricting when fetching. Web Vital issue events are synthetic and do not always have a timestamp within range of the provided trace timestamp