### PR TITLE
test(ui): Hook up nuqs testing adapter to test router

### DIFF
--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -183,11 +183,7 @@ function NuqsTestingAdapterWithNavigate({children}: {children: React.ReactNode})
         // Pass navigation events to the test router
         const newParams = qs.parse(queryString);
         const newLocation = {...location, query: newParams};
-        if (nuqsOptions.history === 'replace') {
-          navigate(newLocation, {replace: true});
-        } else {
-          navigate(newLocation, {replace: false});
-        }
+        navigate(newLocation, {replace: nuqsOptions.history === 'replace'});
       }}
     >
       {children}


### PR DESCRIPTION
Passes navigation changes to our existing method of testing route changes

allows using our existing `expect(router.location).toBe()` in tests