### PR TITLE
feat(sub v3): new Billing Info page

### DIFF
--- a/static/gsApp/components/billingDetails/panel.tsx
+++ b/static/gsApp/components/billingDetails/panel.tsx
@@ -55,6 +55,7 @@ function BillingDetailsPanel({
   title?: string;
 }) {
   const [isEditing, setIsEditing] = useState(false);
+  const [expandInitially, setExpandInitially] = useState(shouldExpandInitially);
   const {
     data: billingDetails,
     isLoading,
@@ -70,12 +71,13 @@ function BillingDetailsPanel({
   }, [loadError]);
 
   useEffect(() => {
-    if (shouldExpandInitially && !isLoading) {
+    if (expandInitially && !isLoading) {
       if (!hasSomeBillingDetails(billingDetails)) {
         setIsEditing(true);
+        setExpandInitially(false);
       }
     }
-  }, [shouldExpandInitially, isLoading, billingDetails]);
+  }, [isLoading, billingDetails, expandInitially]);
 
   if (isLoading) {
     return <LoadingIndicator />;

--- a/static/gsApp/components/billingDetails/panel.tsx
+++ b/static/gsApp/components/billingDetails/panel.tsx
@@ -71,11 +71,9 @@ function BillingDetailsPanel({
   }, [loadError]);
 
   useEffect(() => {
-    if (expandInitially && !isLoading) {
-      if (!hasSomeBillingDetails(billingDetails)) {
-        setIsEditing(true);
-        setExpandInitially(false);
-      }
+    if (expandInitially && !isLoading && !hasSomeBillingDetails(billingDetails)) {
+      setIsEditing(true);
+      setExpandInitially(false);
     }
   }, [isLoading, billingDetails, expandInitially]);
 

--- a/static/gsApp/components/billingDetails/panel.tsx
+++ b/static/gsApp/components/billingDetails/panel.tsx
@@ -54,7 +54,7 @@ function BillingDetailsPanel({
   shouldExpandInitially?: boolean;
   title?: string;
 }) {
-  const [isEditing, setIsEditing] = useState(!!shouldExpandInitially);
+  const [isEditing, setIsEditing] = useState(false);
   const {
     data: billingDetails,
     isLoading,
@@ -68,6 +68,14 @@ function BillingDetailsPanel({
       Sentry.captureException(loadError);
     }
   }, [loadError]);
+
+  useEffect(() => {
+    if (shouldExpandInitially && !isLoading) {
+      if (!hasSomeBillingDetails(billingDetails)) {
+        setIsEditing(true);
+      }
+    }
+  }, [shouldExpandInitially, isLoading, billingDetails]);
 
   if (isLoading) {
     return <LoadingIndicator />;

--- a/static/gsApp/components/creditCardEdit/panel.tsx
+++ b/static/gsApp/components/creditCardEdit/panel.tsx
@@ -58,6 +58,7 @@ function CreditCardPanel({
   const [isEditing, setIsEditing] = useState(false);
   const [fromBillingFailure, setFromBillingFailure] = useState(false);
   const [referrer, setReferrer] = useState<string | undefined>(undefined);
+  const [expandInitially, setExpandInitially] = useState(shouldExpandInitially);
 
   const handleCardUpdated = useCallback((data: Subscription) => {
     setCardLastFourDigits(data.paymentSource?.last4 || null);
@@ -69,10 +70,11 @@ function CreditCardPanel({
     if (subscription.paymentSource) {
       setCardLastFourDigits(prev => prev ?? (subscription.paymentSource?.last4 || null));
       setCardZipCode(prev => prev ?? (subscription.paymentSource?.zipCode || null));
-    } else if (shouldExpandInitially) {
+    } else if (expandInitially) {
       setIsEditing(true);
+      setExpandInitially(false);
     }
-  }, [subscription.paymentSource, shouldExpandInitially]);
+  }, [subscription.paymentSource, expandInitially]);
 
   useEffect(() => {
     // Open credit card update form/modal and track clicks from payment failure notifications (in app, email, etc.)

--- a/static/gsApp/components/creditCardEdit/panel.tsx
+++ b/static/gsApp/components/creditCardEdit/panel.tsx
@@ -55,7 +55,7 @@ function CreditCardPanel({
 }: CreditCardPanelProps) {
   const [cardLastFourDigits, setCardLastFourDigits] = useState<string | null>(null);
   const [cardZipCode, setCardZipCode] = useState<string | null>(null);
-  const [isEditing, setIsEditing] = useState(!!shouldExpandInitially);
+  const [isEditing, setIsEditing] = useState(false);
   const [fromBillingFailure, setFromBillingFailure] = useState(false);
   const [referrer, setReferrer] = useState<string | undefined>(undefined);
 
@@ -69,8 +69,10 @@ function CreditCardPanel({
     if (subscription.paymentSource) {
       setCardLastFourDigits(prev => prev ?? (subscription.paymentSource?.last4 || null));
       setCardZipCode(prev => prev ?? (subscription.paymentSource?.zipCode || null));
+    } else if (shouldExpandInitially) {
+      setIsEditing(true);
     }
-  }, [subscription]);
+  }, [subscription, shouldExpandInitially]);
 
   useEffect(() => {
     // Open credit card update form/modal and track clicks from payment failure notifications (in app, email, etc.)

--- a/static/gsApp/components/creditCardEdit/panel.tsx
+++ b/static/gsApp/components/creditCardEdit/panel.tsx
@@ -72,7 +72,7 @@ function CreditCardPanel({
     } else if (shouldExpandInitially) {
       setIsEditing(true);
     }
-  }, [subscription, shouldExpandInitially]);
+  }, [subscription.paymentSource, shouldExpandInitially]);
 
   useEffect(() => {
     // Open credit card update form/modal and track clicks from payment failure notifications (in app, email, etc.)

--- a/static/gsApp/hooks/settingsRoutes.tsx
+++ b/static/gsApp/hooks/settingsRoutes.tsx
@@ -74,7 +74,7 @@ const settingsRoutes = (): SentryRouteObject => ({
         },
         {
           path: 'details/',
-          name: 'Billing Details',
+          name: 'Billing Information',
           component: make(() => import('../views/subscriptionPage/billingInformation')),
           deprecatedRouteProps: true,
         },

--- a/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.tsx
+++ b/static/gsApp/views/amCheckout/steps/checkoutV3/addBillingInfo.tsx
@@ -10,7 +10,6 @@ import BillingDetailsPanel from 'getsentry/components/billingDetails/panel';
 import CreditCardPanel from 'getsentry/components/creditCardEdit/panel';
 import {useBillingDetails} from 'getsentry/hooks/useBillingDetails';
 import {FTCConsentLocation} from 'getsentry/types';
-import {hasSomeBillingDetails} from 'getsentry/utils/billing';
 import StepHeader from 'getsentry/views/amCheckout/steps/stepHeader';
 import type {CheckoutV3StepProps} from 'getsentry/views/amCheckout/types';
 import {hasBillingInfo} from 'getsentry/views/amCheckout/utils';
@@ -58,7 +57,7 @@ function AddBillingInformation({
               subscription={subscription}
               isNewBillingUI
               analyticsEvent="checkout.updated_billing_details"
-              shouldExpandInitially={!hasSomeBillingDetails(billingDetails)}
+              shouldExpandInitially
             />
             <CreditCardPanel
               organization={organization}
@@ -68,7 +67,7 @@ function AddBillingInformation({
               ftcLocation={FTCConsentLocation.CHECKOUT}
               budgetTerm={activePlan.budgetTerm}
               analyticsEvent="checkout.updated_cc"
-              shouldExpandInitially={subscription.paymentSource === null}
+              shouldExpandInitially
             />
           </Fragment>
         ))}

--- a/static/gsApp/views/subscriptionPage/billingInformation.tsx
+++ b/static/gsApp/views/subscriptionPage/billingInformation.tsx
@@ -3,8 +3,12 @@ import type {Location} from 'history';
 
 import {Flex} from 'sentry/components/core/layout';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Redirect from 'sentry/components/redirect';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import withOrganization from 'sentry/utils/withOrganization';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 import BillingDetailsPanel from 'getsentry/components/billingDetails/panel';
 import CreditCardPanel from 'getsentry/components/creditCardEdit/panel';
@@ -34,26 +38,30 @@ function BillingInformation({organization, subscription, location}: Props) {
     trackSubscriptionView(organization, subscription, 'details');
   }, [organization, subscription]);
 
-  const hasBillingPerms = organization.access?.includes('org:billing');
-  if (!hasBillingPerms) {
-    return (
-      <SubscriptionPageContainer background="primary" organization={organization}>
-        <ContactBillingMembers />
-      </SubscriptionPageContainer>
-    );
-  }
-
-  if (!subscription) {
-    return (
-      <SubscriptionPageContainer background="primary" organization={organization}>
-        <LoadingIndicator />
-      </SubscriptionPageContainer>
-    );
-  }
-
   const isNewBillingUI = hasNewBillingUI(organization);
+  const hasBillingPerms = organization.access?.includes('org:billing');
+
+  if (subscription.isSelfServePartner) {
+    return <Redirect to={`/settings/${organization.slug}/billing/overview/`} />;
+  }
 
   if (!isNewBillingUI) {
+    if (!hasBillingPerms) {
+      return (
+        <SubscriptionPageContainer background="primary" organization={organization}>
+          <ContactBillingMembers />
+        </SubscriptionPageContainer>
+      );
+    }
+
+    if (!subscription) {
+      return (
+        <SubscriptionPageContainer background="primary" organization={organization}>
+          <LoadingIndicator />
+        </SubscriptionPageContainer>
+      );
+    }
+
     return (
       <SubscriptionPageContainer background="primary" organization={organization}>
         <SubscriptionHeader organization={organization} subscription={subscription} />
@@ -77,23 +85,33 @@ function BillingInformation({organization, subscription, location}: Props) {
 
   return (
     <SubscriptionPageContainer background="primary" organization={organization}>
-      <SubscriptionHeader organization={organization} subscription={subscription} />
-      <RecurringCredits displayType="discount" planDetails={subscription.planDetails} />
-      <Flex direction="column" gap="xl">
-        <CreditCardPanel
-          organization={organization}
-          subscription={subscription}
-          location={location}
-          isNewBillingUI={isNewBillingUI}
-          ftcLocation={FTCConsentLocation.BILLING_DETAILS}
-          budgetTerm={subscription.planDetails.budgetTerm}
-        />
-        <BillingDetailsPanel
-          organization={organization}
-          subscription={subscription}
-          isNewBillingUI={isNewBillingUI}
-        />
-      </Flex>
+      <SentryDocumentTitle title={t('Billing Information')} orgSlug={organization.slug} />
+      <SettingsPageHeader title={t('Billing Information')} />
+      {hasBillingPerms ? (
+        subscription ? (
+          <Flex direction="column" gap="xl">
+            <CreditCardPanel
+              organization={organization}
+              subscription={subscription}
+              location={location}
+              isNewBillingUI={isNewBillingUI}
+              ftcLocation={FTCConsentLocation.BILLING_DETAILS}
+              budgetTerm={subscription.planDetails.budgetTerm}
+              shouldExpandInitially
+            />
+            <BillingDetailsPanel
+              organization={organization}
+              subscription={subscription}
+              isNewBillingUI={isNewBillingUI}
+              shouldExpandInitially
+            />
+          </Flex>
+        ) : (
+          <LoadingIndicator />
+        )
+      ) : (
+        <ContactBillingMembers />
+      )}
     </SubscriptionPageContainer>
   );
 }

--- a/static/gsApp/views/subscriptionPage/billingInformation.tsx
+++ b/static/gsApp/views/subscriptionPage/billingInformation.tsx
@@ -41,7 +41,7 @@ function BillingInformation({organization, subscription, location}: Props) {
   const isNewBillingUI = hasNewBillingUI(organization);
   const hasBillingPerms = organization.access?.includes('org:billing');
 
-  if (subscription.isSelfServePartner) {
+  if (subscription?.isSelfServePartner) {
     return <Redirect to={`/settings/${organization.slug}/billing/overview/`} />;
   }
 


### PR DESCRIPTION
<img width="1512" height="857" alt="Screenshot 2025-10-02 at 3 07 02 PM" src="https://github.com/user-attachments/assets/b1de9c2f-e7e5-4698-80cc-fb696ac667f9" />

The panels auto-open for customers that don't have the relevant info on record.

Part of https://linear.app/getsentry/issue/BIL-1230/create-subpage-component-and-subpages