### PR TITLE
ref(groupingInfo): Preserve folded state for stacktrace subsections

### DIFF
--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -24,8 +24,12 @@ function GroupingComponent({component, showNonContributing}: Props) {
       ? GroupingComponentStacktrace
       : GroupingComponentChildren;
 
-  const [folded, setFolded] = useState(false);
+  const [folded, setFolded] = useState(component.stacktrace_folded || false);
   const canFold = !shouldInlineValue;
+  const handleToggleFold = () => {
+    setFolded(!folded);
+    component.stacktrace_folded = !folded;
+  };
 
   return (
     <CollapseButtonWrapper>
@@ -35,7 +39,7 @@ function GroupingComponent({component, showNonContributing}: Props) {
           className="collapse-button"
           priority="link"
           icon={<IconChevron direction={folded ? 'right' : 'down'} legacySize="10px" />}
-          onClick={() => setFolded(!folded)}
+          onClick={() => handleToggleFold()}
           aria-label={folded ? t('expand') : t('collapse')}
         />
       )}

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -27,6 +27,7 @@ export type EventGroupComponent = {
   id: string;
   name: string | null;
   values: EventGroupComponent[] | string[];
+  stacktrace_folded?: boolean;
 };
 export type EventGroupingConfig = {
   base: string | null;


### PR DESCRIPTION
As of #100361, the groupingInfo stacktrace has code folding functionality. This PR adds `stacktrace_folded` to event components to preserve the state when parent components are collapse/uncollapsed. 


https://github.com/user-attachments/assets/032f7c58-00a8-41b3-aefe-5998a431488e

