### PR TITLE
Update stored github team mappings on rename

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -224,8 +224,8 @@ from sentry.integrations.api.endpoints.doc_integrations_index import DocIntegrat
 from sentry.integrations.api.endpoints.external_team_details import ExternalTeamDetailsEndpoint
 from sentry.integrations.api.endpoints.external_team_index import ExternalTeamEndpoint
 from sentry.integrations.api.endpoints.external_user_details import ExternalUserDetailsEndpoint
-from sentry.integrations.api.endpoints.github_team_sync import OrganizationGitHubTeamSyncEndpoint
 from sentry.integrations.api.endpoints.external_user_index import ExternalUserEndpoint
+from sentry.integrations.api.endpoints.github_team_sync import OrganizationGitHubTeamSyncEndpoint
 from sentry.integrations.api.endpoints.integration_features import IntegrationFeaturesEndpoint
 from sentry.integrations.api.endpoints.integration_proxy import InternalIntegrationProxyEndpoint
 from sentry.integrations.api.endpoints.organization_code_mapping_codeowners import (

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -224,6 +224,7 @@ from sentry.integrations.api.endpoints.doc_integrations_index import DocIntegrat
 from sentry.integrations.api.endpoints.external_team_details import ExternalTeamDetailsEndpoint
 from sentry.integrations.api.endpoints.external_team_index import ExternalTeamEndpoint
 from sentry.integrations.api.endpoints.external_user_details import ExternalUserDetailsEndpoint
+from sentry.integrations.api.endpoints.github_team_sync import OrganizationGitHubTeamSyncEndpoint
 from sentry.integrations.api.endpoints.external_user_index import ExternalUserEndpoint
 from sentry.integrations.api.endpoints.integration_features import IntegrationFeaturesEndpoint
 from sentry.integrations.api.endpoints.integration_proxy import InternalIntegrationProxyEndpoint
@@ -1890,6 +1891,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/integrations/(?P<integration_id>[^/]+)/serverless-functions/$",
         OrganizationIntegrationServerlessFunctionsEndpoint.as_view(),
         name="sentry-api-0-organization-integration-serverless-functions",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/github-team-sync/$",
+        OrganizationGitHubTeamSyncEndpoint.as_view(),
+        name="sentry-api-0-organization-github-team-sync",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/members/$",

--- a/src/sentry/integrations/api/endpoints/github_team_sync.py
+++ b/src/sentry/integrations/api/endpoints/github_team_sync.py
@@ -1,0 +1,90 @@
+"""
+API endpoint for manually triggering GitHub team synchronization.
+"""
+import logging
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.permissions import OrganizationPermission
+from sentry.integrations.models.external_actor import ExternalActor
+from sentry.integrations.types import ExternalProviders
+from sentry.tasks.github_team_sync import sync_github_teams_for_organization
+
+logger = logging.getLogger(__name__)
+
+
+class OrganizationGitHubTeamSyncPermission(OrganizationPermission):
+    scope_map = {
+        "POST": ["org:integrations"],
+    }
+
+
+@region_silo_endpoint
+class OrganizationGitHubTeamSyncEndpoint(OrganizationEndpoint):
+    """
+    API endpoint to manually trigger GitHub team synchronization for an organization.
+
+    This endpoint allows administrators to manually sync GitHub team names with
+    stored ExternalActor mappings, which is useful for immediate updates or
+    troubleshooting synchronization issues.
+    """
+
+    owner = ApiOwner.ENTERPRISE
+    permission_classes = (OrganizationGitHubTeamSyncPermission,)
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+
+    def post(self, request: Request, organization) -> Response:
+        """
+        Manually trigger GitHub team synchronization for the organization.
+
+        This will queue a background task to sync all GitHub team mappings
+        for the organization.
+        """
+        # Check if the organization has any GitHub team mappings
+        github_providers = [
+            ExternalProviders.GITHUB.value,
+            ExternalProviders.GITHUB_ENTERPRISE.value,
+        ]
+
+        has_github_teams = ExternalActor.objects.filter(
+            organization=organization,
+            provider__in=github_providers,
+            team__isnull=False,
+        ).exists()
+
+        if not has_github_teams:
+            return Response(
+                {
+                    "detail": "No GitHub team mappings found for this organization.",
+                    "organization_id": organization.id,
+                },
+                status=404,
+            )
+
+        # Queue the sync task
+        sync_github_teams_for_organization.delay(organization.id)
+
+        logger.info(
+            "github_team_sync.manual_trigger",
+            extra={
+                "organization_id": organization.id,
+                "organization_slug": organization.slug,
+                "triggered_by": request.user.id if request.user.is_authenticated else None,
+            }
+        )
+
+        return Response(
+            {
+                "detail": "GitHub team synchronization has been queued.",
+                "organization_id": organization.id,
+                "organization_slug": organization.slug,
+            },
+            status=202,
+        )

--- a/src/sentry/integrations/api/endpoints/github_team_sync.py
+++ b/src/sentry/integrations/api/endpoints/github_team_sync.py
@@ -1,6 +1,7 @@
 """
 API endpoint for manually triggering GitHub team synchronization.
 """
+
 import logging
 
 from rest_framework.request import Request
@@ -77,7 +78,7 @@ class OrganizationGitHubTeamSyncEndpoint(OrganizationEndpoint):
                 "organization_id": organization.id,
                 "organization_slug": organization.slug,
                 "triggered_by": request.user.id if request.user.is_authenticated else None,
-            }
+            },
         )
 
         return Response(

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -369,6 +369,13 @@ class GitHubBaseClient(
         """
         return self.get(f"/repos/{repo}")
 
+    def get_organization_teams(self, org: str) -> Sequence[Any]:
+        """
+        Get all teams in an organization.
+        https://docs.github.com/en/rest/teams/teams#list-teams
+        """
+        return self.get_cached(f"/orgs/{org}/teams", params={"per_page": 100})
+
     # https://docs.github.com/en/rest/rate-limit?apiVersion=2022-11-28
     def get_rate_limit(self, specific_resource: str = "core") -> GithubRateLimitInfo:
         """This gives information of the current rate limit"""

--- a/src/sentry/tasks/github_team_sync.py
+++ b/src/sentry/tasks/github_team_sync.py
@@ -4,6 +4,7 @@ Task for synchronizing GitHub team names with stored ExternalActor mappings.
 This task periodically fetches team information from GitHub and updates the
 external_name field in ExternalActor records when teams are renamed.
 """
+
 import logging
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -66,8 +67,7 @@ def schedule_github_team_sync() -> None:
         scheduled_count += 1
 
     logger.info(
-        "github_team_sync.schedule_complete",
-        extra={"scheduled_organizations": scheduled_count}
+        "github_team_sync.schedule_complete", extra={"scheduled_organizations": scheduled_count}
     )
     metrics.incr("github_team_sync.organizations_scheduled", amount=scheduled_count)
 
@@ -96,8 +96,7 @@ def sync_github_teams_for_organization(organization_id: int) -> None:
         organization = Organization.objects.get(id=organization_id)
     except Organization.DoesNotExist:
         logger.error(
-            "github_team_sync.organization_not_found",
-            extra={"organization_id": organization_id}
+            "github_team_sync.organization_not_found", extra={"organization_id": organization_id}
         )
         return
 
@@ -106,7 +105,7 @@ def sync_github_teams_for_organization(organization_id: int) -> None:
         extra={
             "organization_id": organization_id,
             "organization_slug": organization.slug,
-        }
+        },
     )
 
     # Get all GitHub integrations for this organization
@@ -117,10 +116,7 @@ def sync_github_teams_for_organization(organization_id: int) -> None:
     )
 
     if not github_integrations:
-        logger.info(
-            "github_team_sync.no_integrations",
-            extra={"organization_id": organization_id}
-        )
+        logger.info("github_team_sync.no_integrations", extra={"organization_id": organization_id})
         return
 
     total_synced = 0
@@ -139,7 +135,7 @@ def sync_github_teams_for_organization(organization_id: int) -> None:
                     "organization_id": organization_id,
                     "integration_id": integration.id,
                     "error": str(e),
-                }
+                },
             )
             total_errors += 1
 
@@ -151,7 +147,7 @@ def sync_github_teams_for_organization(organization_id: int) -> None:
             "teams_synced": total_synced,
             "teams_updated": total_updated,
             "integration_errors": total_errors,
-        }
+        },
     )
 
     metrics.incr("github_team_sync.teams_synced", amount=total_synced)
@@ -182,7 +178,7 @@ def _sync_teams_for_integration(organization: Organization, integration) -> tupl
                     "organization_id": organization.id,
                     "integration_id": integration.id,
                     "integration_type": type(install).__name__,
-                }
+                },
             )
             return 0, 0
 
@@ -195,7 +191,7 @@ def _sync_teams_for_integration(organization: Organization, integration) -> tupl
                 "organization_id": organization.id,
                 "integration_id": integration.id,
                 "error": str(e),
-            }
+            },
         )
         return 0, 0
 
@@ -219,7 +215,7 @@ def _sync_teams_for_integration(organization: Organization, integration) -> tupl
             extra={
                 "organization_id": organization.id,
                 "integration_id": integration.id,
-            }
+            },
         )
         return 0, 0
 
@@ -233,7 +229,7 @@ def _sync_teams_for_integration(organization: Organization, integration) -> tupl
                 "organization_id": organization.id,
                 "integration_id": integration.id,
                 "error": str(e),
-            }
+            },
         )
         raise
 
@@ -258,7 +254,7 @@ def _sync_teams_for_integration(organization: Organization, integration) -> tupl
                     "integration_id": integration.id,
                     "external_id": stored_team.external_id,
                     "stored_name": stored_team.external_name,
-                }
+                },
             )
             teams_synced += 1
             continue
@@ -274,7 +270,7 @@ def _sync_teams_for_integration(organization: Organization, integration) -> tupl
                     "external_id": stored_team.external_id,
                     "old_name": stored_team.external_name,
                     "new_name": github_name,
-                }
+                },
             )
 
             # Update the stored team name
@@ -313,6 +309,6 @@ def _fetch_github_teams(client, integration) -> Sequence[Mapping[str, Any]]:
             extra={
                 "integration_id": integration.id,
                 "error": str(e),
-            }
+            },
         )
         raise

--- a/src/sentry/tasks/github_team_sync.py
+++ b/src/sentry/tasks/github_team_sync.py
@@ -1,0 +1,318 @@
+"""
+Task for synchronizing GitHub team names with stored ExternalActor mappings.
+
+This task periodically fetches team information from GitHub and updates the
+external_name field in ExternalActor records when teams are renamed.
+"""
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from sentry.integrations.models.external_actor import ExternalActor
+from sentry.integrations.services.integration.service import integration_service
+from sentry.integrations.types import ExternalProviders
+from sentry.models.organization import Organization
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.namespaces import integrations_tasks
+from sentry.taskworker.retry import Retry
+from sentry.utils import metrics
+from sentry.utils.query import RangeQuerySetWrapper
+
+logger = logging.getLogger(__name__)
+
+
+@instrumented_task(
+    name="sentry.tasks.github_team_sync.schedule_github_team_sync",
+    queue="integrations.github_team_sync",
+    max_retries=3,
+    default_retry_delay=60,
+    acks_late=True,
+    silo_mode=SiloMode.REGION,
+    taskworker_config=TaskworkerConfig(
+        namespace=integrations_tasks,
+        retry=Retry(times=3, delay=60),
+        processing_deadline_duration=30 * 60,  # 30 minutes
+    ),
+)
+def schedule_github_team_sync() -> None:
+    """
+    Schedule GitHub team sync for all organizations with GitHub integrations.
+
+    This task is triggered periodically (e.g., daily) and spawns individual
+    sync tasks for each organization with GitHub integrations.
+    """
+    logger.info("github_team_sync.schedule_start")
+
+    # Find all organizations with GitHub integrations that have team mappings
+    github_providers = [
+        ExternalProviders.GITHUB.value,
+        ExternalProviders.GITHUB_ENTERPRISE.value,
+    ]
+
+    organizations_with_teams = (
+        ExternalActor.objects.filter(
+            provider__in=github_providers,
+            team__isnull=False,
+        )
+        .values_list("organization_id", flat=True)
+        .distinct()
+    )
+
+    scheduled_count = 0
+    for organization_id in organizations_with_teams:
+        sync_github_teams_for_organization.delay(organization_id)
+        scheduled_count += 1
+
+    logger.info(
+        "github_team_sync.schedule_complete",
+        extra={"scheduled_organizations": scheduled_count}
+    )
+    metrics.incr("github_team_sync.organizations_scheduled", amount=scheduled_count)
+
+
+@instrumented_task(
+    name="sentry.tasks.github_team_sync.sync_github_teams_for_organization",
+    queue="integrations.github_team_sync",
+    max_retries=5,
+    default_retry_delay=300,  # 5 minutes
+    acks_late=True,
+    silo_mode=SiloMode.REGION,
+    taskworker_config=TaskworkerConfig(
+        namespace=integrations_tasks,
+        retry=Retry(times=5, delay=300),
+        processing_deadline_duration=15 * 60,  # 15 minutes
+    ),
+)
+def sync_github_teams_for_organization(organization_id: int) -> None:
+    """
+    Synchronize GitHub team names for a specific organization.
+
+    Args:
+        organization_id: ID of the organization to sync teams for
+    """
+    try:
+        organization = Organization.objects.get(id=organization_id)
+    except Organization.DoesNotExist:
+        logger.error(
+            "github_team_sync.organization_not_found",
+            extra={"organization_id": organization_id}
+        )
+        return
+
+    logger.info(
+        "github_team_sync.sync_start",
+        extra={
+            "organization_id": organization_id,
+            "organization_slug": organization.slug,
+        }
+    )
+
+    # Get all GitHub integrations for this organization
+    github_integrations = integration_service.get_integrations(
+        organization_id=organization_id,
+        providers=["github", "github_enterprise"],
+        status=1,  # ACTIVE
+    )
+
+    if not github_integrations:
+        logger.info(
+            "github_team_sync.no_integrations",
+            extra={"organization_id": organization_id}
+        )
+        return
+
+    total_synced = 0
+    total_updated = 0
+    total_errors = 0
+
+    for integration in github_integrations:
+        try:
+            synced, updated = _sync_teams_for_integration(organization, integration)
+            total_synced += synced
+            total_updated += updated
+        except Exception as e:
+            logger.exception(
+                "github_team_sync.integration_sync_error",
+                extra={
+                    "organization_id": organization_id,
+                    "integration_id": integration.id,
+                    "error": str(e),
+                }
+            )
+            total_errors += 1
+
+    logger.info(
+        "github_team_sync.sync_complete",
+        extra={
+            "organization_id": organization_id,
+            "organization_slug": organization.slug,
+            "teams_synced": total_synced,
+            "teams_updated": total_updated,
+            "integration_errors": total_errors,
+        }
+    )
+
+    metrics.incr("github_team_sync.teams_synced", amount=total_synced)
+    metrics.incr("github_team_sync.teams_updated", amount=total_updated)
+    metrics.incr("github_team_sync.integration_errors", amount=total_errors)
+
+
+def _sync_teams_for_integration(organization: Organization, integration) -> tuple[int, int]:
+    """
+    Sync teams for a specific GitHub integration.
+
+    Args:
+        organization: The organization
+        integration: The GitHub integration
+
+    Returns:
+        Tuple of (teams_synced, teams_updated)
+    """
+    from sentry.integrations.github.integration import GitHubIntegration
+
+    # Get the integration installation
+    try:
+        install = integration.get_installation(organization_id=organization.id)
+        if not isinstance(install, GitHubIntegration):
+            logger.error(
+                "github_team_sync.invalid_integration_type",
+                extra={
+                    "organization_id": organization.id,
+                    "integration_id": integration.id,
+                    "integration_type": type(install).__name__,
+                }
+            )
+            return 0, 0
+
+        client = install.get_client()
+
+    except Exception as e:
+        logger.exception(
+            "github_team_sync.client_error",
+            extra={
+                "organization_id": organization.id,
+                "integration_id": integration.id,
+                "error": str(e),
+            }
+        )
+        return 0, 0
+
+    # Get stored team mappings for this integration
+    provider = (
+        ExternalProviders.GITHUB.value
+        if integration.provider == "github"
+        else ExternalProviders.GITHUB_ENTERPRISE.value
+    )
+
+    stored_teams = ExternalActor.objects.filter(
+        organization=organization,
+        integration_id=integration.id,
+        provider=provider,
+        team__isnull=False,
+    )
+
+    if not stored_teams.exists():
+        logger.info(
+            "github_team_sync.no_stored_teams",
+            extra={
+                "organization_id": organization.id,
+                "integration_id": integration.id,
+            }
+        )
+        return 0, 0
+
+    # Fetch current teams from GitHub
+    try:
+        github_teams = _fetch_github_teams(client, integration)
+    except Exception as e:
+        logger.exception(
+            "github_team_sync.fetch_teams_error",
+            extra={
+                "organization_id": organization.id,
+                "integration_id": integration.id,
+                "error": str(e),
+            }
+        )
+        raise
+
+    # Create lookup map of GitHub teams by external_id
+    github_teams_by_id = {str(team["id"]): team for team in github_teams}
+
+    teams_synced = 0
+    teams_updated = 0
+
+    # Check each stored team mapping for name changes
+    for stored_team in stored_teams:
+        if not stored_team.external_id:
+            # Skip teams without external_id (shouldn't happen but be safe)
+            continue
+
+        github_team = github_teams_by_id.get(stored_team.external_id)
+        if not github_team:
+            logger.warning(
+                "github_team_sync.team_not_found_on_github",
+                extra={
+                    "organization_id": organization.id,
+                    "integration_id": integration.id,
+                    "external_id": stored_team.external_id,
+                    "stored_name": stored_team.external_name,
+                }
+            )
+            teams_synced += 1
+            continue
+
+        # Check if the team name has changed
+        github_name = f"@{github_team['name']}"  # External names start with @
+        if stored_team.external_name != github_name:
+            logger.info(
+                "github_team_sync.team_name_changed",
+                extra={
+                    "organization_id": organization.id,
+                    "integration_id": integration.id,
+                    "external_id": stored_team.external_id,
+                    "old_name": stored_team.external_name,
+                    "new_name": github_name,
+                }
+            )
+
+            # Update the stored team name
+            stored_team.external_name = github_name
+            stored_team.save(update_fields=["external_name", "date_updated"])
+            teams_updated += 1
+
+        teams_synced += 1
+
+    return teams_synced, teams_updated
+
+
+def _fetch_github_teams(client, integration) -> Sequence[Mapping[str, Any]]:
+    """
+    Fetch all teams from GitHub for the integration.
+
+    Args:
+        client: GitHub API client
+        integration: The GitHub integration
+
+    Returns:
+        List of team data from GitHub API
+    """
+    try:
+        # Get the organization name from integration metadata
+        org_name = integration.metadata.get("account", {}).get("login")
+        if not org_name:
+            raise ValueError("No organization name found in integration metadata")
+
+        teams = client.get_organization_teams(org_name)
+        return teams
+
+    except Exception as e:
+        logger.exception(
+            "github_team_sync.api_error",
+            extra={
+                "integration_id": integration.id,
+                "error": str(e),
+            }
+        )
+        raise

--- a/tests/sentry/integrations/api/endpoints/test_github_team_sync.py
+++ b/tests/sentry/integrations/api/endpoints/test_github_team_sync.py
@@ -1,0 +1,178 @@
+"""
+Tests for GitHub team synchronization API endpoint.
+"""
+from unittest.mock import patch
+
+from sentry.integrations.models.external_actor import ExternalActor
+from sentry.integrations.types import ExternalProviders
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import with_feature
+
+
+class OrganizationGitHubTeamSyncEndpointTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user, name="Test Org")
+        self.team = self.create_team(organization=self.organization, name="test-team")
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id="12345",
+            provider="github",
+            name="test-org",
+            metadata={
+                "account": {"login": "test-org", "id": 54321},
+                "installation": {"id": 12345},
+            },
+        )
+        self.path = f"/api/0/organizations/{self.organization.slug}/github-team-sync/"
+
+    def test_requires_org_integrations_permission(self):
+        """Test that the endpoint requires org:integrations permission."""
+        member = self.create_user()
+        self.create_member(organization=self.organization, user=member, role="member")
+        self.login_as(user=member)
+
+        response = self.client.post(self.path)
+        assert response.status_code == 403
+
+    def test_returns_404_when_no_github_teams(self):
+        """Test that endpoint returns 404 when organization has no GitHub team mappings."""
+        self.login_as(user=self.user)
+
+        response = self.client.post(self.path)
+        
+        assert response.status_code == 404
+        assert "No GitHub team mappings found" in response.data["detail"]
+        assert response.data["organization_id"] == self.organization.id
+
+    @patch("sentry.tasks.github_team_sync.sync_github_teams_for_organization.delay")
+    def test_queues_sync_task_when_github_teams_exist(self, mock_delay):
+        """Test that sync task is queued when organization has GitHub team mappings."""
+        # Create a GitHub team mapping
+        ExternalActor.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            provider=ExternalProviders.GITHUB.value,
+            external_name="@test-team",
+            external_id="team-123",
+            team=self.team,
+        )
+
+        self.login_as(user=self.user)
+
+        response = self.client.post(self.path)
+
+        assert response.status_code == 202
+        assert "synchronization has been queued" in response.data["detail"]
+        assert response.data["organization_id"] == self.organization.id
+        assert response.data["organization_slug"] == self.organization.slug
+
+        mock_delay.assert_called_once_with(self.organization.id)
+
+    @patch("sentry.tasks.github_team_sync.sync_github_teams_for_organization.delay")
+    def test_works_with_github_enterprise_teams(self, mock_delay):
+        """Test that endpoint works with GitHub Enterprise team mappings."""
+        # Create a GitHub Enterprise team mapping
+        ExternalActor.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            provider=ExternalProviders.GITHUB_ENTERPRISE.value,
+            external_name="@enterprise-team",
+            external_id="team-456",
+            team=self.team,
+        )
+
+        self.login_as(user=self.user)
+
+        response = self.client.post(self.path)
+
+        assert response.status_code == 202
+        mock_delay.assert_called_once_with(self.organization.id)
+
+    def test_only_accepts_post_requests(self):
+        """Test that endpoint only accepts POST requests."""
+        # Create a GitHub team mapping
+        ExternalActor.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            provider=ExternalProviders.GITHUB.value,
+            external_name="@test-team",
+            external_id="team-123",
+            team=self.team,
+        )
+
+        self.login_as(user=self.user)
+
+        # Test unsupported methods
+        response = self.client.get(self.path)
+        assert response.status_code == 405
+
+        response = self.client.put(self.path)
+        assert response.status_code == 405
+
+        response = self.client.delete(self.path)
+        assert response.status_code == 405
+
+    def test_requires_authentication(self):
+        """Test that endpoint requires authentication."""
+        response = self.client.post(self.path)
+        assert response.status_code == 401
+
+    @patch("sentry.tasks.github_team_sync.sync_github_teams_for_organization.delay")
+    def test_ignores_user_mappings(self, mock_delay):
+        """Test that endpoint ignores GitHub user mappings and only considers team mappings."""
+        # Create a GitHub user mapping (should be ignored)
+        ExternalActor.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            provider=ExternalProviders.GITHUB.value,
+            external_name="@github-user",
+            external_id="user-123",
+            user_id=self.user.id,  # User mapping, not team
+        )
+
+        self.login_as(user=self.user)
+
+        response = self.client.post(self.path)
+
+        # Should return 404 because no team mappings exist
+        assert response.status_code == 404
+        assert "No GitHub team mappings found" in response.data["detail"]
+        mock_delay.assert_not_called()
+
+    @patch("sentry.tasks.github_team_sync.sync_github_teams_for_organization.delay")
+    def test_handles_mixed_provider_mappings(self, mock_delay):
+        """Test that endpoint works when organization has mixed provider team mappings."""
+        # Create GitHub team mapping
+        ExternalActor.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            provider=ExternalProviders.GITHUB.value,
+            external_name="@github-team",
+            external_id="team-123",
+            team=self.team,
+        )
+
+        # Create Slack team mapping (should be ignored for GitHub sync)
+        slack_integration = self.create_integration(
+            organization=self.organization,
+            external_id="slack-123",
+            provider="slack",
+            name="slack-workspace",
+        )
+        ExternalActor.objects.create(
+            organization=self.organization,
+            integration_id=slack_integration.id,
+            provider=ExternalProviders.SLACK.value,
+            external_name="#slack-team",
+            external_id="slack-team-456",
+            team=self.team,
+        )
+
+        self.login_as(user=self.user)
+
+        response = self.client.post(self.path)
+
+        # Should queue sync because GitHub team mapping exists
+        assert response.status_code == 202
+        mock_delay.assert_called_once_with(self.organization.id)

--- a/tests/sentry/integrations/api/endpoints/test_github_team_sync.py
+++ b/tests/sentry/integrations/api/endpoints/test_github_team_sync.py
@@ -1,6 +1,7 @@
 """
 Tests for GitHub team synchronization API endpoint.
 """
+
 from unittest.mock import patch
 
 from sentry.integrations.models.external_actor import ExternalActor
@@ -40,7 +41,7 @@ class OrganizationGitHubTeamSyncEndpointTest(APITestCase):
         self.login_as(user=self.user)
 
         response = self.client.post(self.path)
-        
+
         assert response.status_code == 404
         assert "No GitHub team mappings found" in response.data["detail"]
         assert response.data["organization_id"] == self.organization.id

--- a/tests/sentry/tasks/test_github_team_sync.py
+++ b/tests/sentry/tasks/test_github_team_sync.py
@@ -1,0 +1,265 @@
+"""
+Tests for GitHub team synchronization tasks.
+"""
+import pytest
+from unittest.mock import Mock, patch
+
+from sentry.integrations.models.external_actor import ExternalActor
+from sentry.integrations.types import ExternalProviders
+from sentry.models.organization import Organization
+from sentry.models.team import Team
+from sentry.tasks.github_team_sync import (
+    _fetch_github_teams,
+    _sync_teams_for_integration,
+    schedule_github_team_sync,
+    sync_github_teams_for_organization,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.factories import Factories
+from sentry.testutils.helpers.datetime import freeze_time
+
+
+class GitHubTeamSyncTestCase(TestCase):
+    def setUp(self):
+        self.organization = self.create_organization(slug="test-org")
+        self.team = self.create_team(organization=self.organization, name="test-team")
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id="12345",
+            provider="github",
+            name="test-org",
+            metadata={
+                "account": {"login": "test-org", "id": 54321},
+                "installation": {"id": 12345},
+            },
+        )
+
+
+class TestScheduleGitHubTeamSync(GitHubTeamSyncTestCase):
+    @patch("sentry.tasks.github_team_sync.sync_github_teams_for_organization.delay")
+    def test_schedules_sync_for_organizations_with_github_teams(self, mock_delay):
+        """Test that sync is scheduled only for organizations with GitHub team mappings."""
+        # Create GitHub team mapping
+        ExternalActor.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            provider=ExternalProviders.GITHUB.value,
+            external_name="@test-team",
+            external_id="team-123",
+            team=self.team,
+        )
+
+        # Create organization without GitHub teams
+        other_org = self.create_organization(slug="no-teams-org")
+
+        schedule_github_team_sync()
+
+        # Should only schedule sync for organization with GitHub teams
+        mock_delay.assert_called_once_with(self.organization.id)
+
+    @patch("sentry.tasks.github_team_sync.sync_github_teams_for_organization.delay")
+    def test_handles_multiple_organizations(self, mock_delay):
+        """Test scheduling sync for multiple organizations."""
+        # Create another organization with GitHub teams
+        other_org = self.create_organization(slug="other-org")
+        other_team = self.create_team(organization=other_org, name="other-team")
+        other_integration = self.create_integration(
+            organization=other_org,
+            external_id="67890",
+            provider="github",
+            name="other-org",
+        )
+
+        # Create team mappings for both organizations
+        ExternalActor.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            provider=ExternalProviders.GITHUB.value,
+            external_name="@test-team",
+            external_id="team-123",
+            team=self.team,
+        )
+        ExternalActor.objects.create(
+            organization=other_org,
+            integration_id=other_integration.id,
+            provider=ExternalProviders.GITHUB.value,
+            external_name="@other-team",
+            external_id="team-456",
+            team=other_team,
+        )
+
+        schedule_github_team_sync()
+
+        # Should schedule sync for both organizations
+        assert mock_delay.call_count == 2
+        called_org_ids = {call[0][0] for call in mock_delay.call_args_list}
+        assert called_org_ids == {self.organization.id, other_org.id}
+
+
+class TestSyncGitHubTeamsForOrganization(GitHubTeamSyncTestCase):
+    @patch("sentry.tasks.github_team_sync._sync_teams_for_integration")
+    @patch("sentry.integrations.services.integration.service.integration_service")
+    def test_syncs_all_github_integrations(self, mock_service, mock_sync_teams):
+        """Test that sync processes all GitHub integrations for an organization."""
+        mock_integration = Mock()
+        mock_integration.id = self.integration.id
+        mock_service.get_integrations.return_value = [mock_integration]
+        mock_sync_teams.return_value = (5, 2)  # (synced, updated)
+
+        sync_github_teams_for_organization(self.organization.id)
+
+        mock_service.get_integrations.assert_called_once_with(
+            organization_id=self.organization.id,
+            providers=["github", "github_enterprise"],
+            status=1,
+        )
+        mock_sync_teams.assert_called_once_with(self.organization, mock_integration)
+
+    def test_handles_nonexistent_organization(self):
+        """Test handling of nonexistent organization ID."""
+        with pytest.raises(Organization.DoesNotExist):
+            sync_github_teams_for_organization(99999)
+
+    @patch("sentry.integrations.services.integration.service.integration_service")
+    def test_handles_no_integrations(self, mock_service):
+        """Test handling when organization has no GitHub integrations."""
+        mock_service.get_integrations.return_value = []
+
+        # Should complete without error
+        sync_github_teams_for_organization(self.organization.id)
+
+        mock_service.get_integrations.assert_called_once()
+
+
+class TestSyncTeamsForIntegration(GitHubTeamSyncTestCase):
+    def setUp(self):
+        super().setUp()
+        self.external_actor = ExternalActor.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            provider=ExternalProviders.GITHUB.value,
+            external_name="@old-team-name",
+            external_id="team-123",
+            team=self.team,
+        )
+
+    @patch("sentry.tasks.github_team_sync._fetch_github_teams")
+    def test_updates_team_name_when_changed(self, mock_fetch):
+        """Test that team names are updated when they change on GitHub."""
+        # Mock GitHub API response with new team name
+        mock_fetch.return_value = [
+            {"id": "team-123", "name": "new-team-name", "slug": "new-team-name"}
+        ]
+
+        mock_integration = Mock()
+        mock_integration.id = self.integration.id
+        mock_integration.provider = "github"
+        mock_integration.get_installation.return_value.get_client.return_value = Mock()
+
+        synced, updated = _sync_teams_for_integration(self.organization, mock_integration)
+
+        # Refresh from database
+        self.external_actor.refresh_from_db()
+
+        assert self.external_actor.external_name == "@new-team-name"
+        assert synced == 1
+        assert updated == 1
+
+    @patch("sentry.tasks.github_team_sync._fetch_github_teams")
+    def test_no_update_when_name_unchanged(self, mock_fetch):
+        """Test that no update occurs when team name is unchanged."""
+        # Mock GitHub API response with same team name
+        mock_fetch.return_value = [
+            {"id": "team-123", "name": "old-team-name", "slug": "old-team-name"}
+        ]
+
+        mock_integration = Mock()
+        mock_integration.id = self.integration.id
+        mock_integration.provider = "github"
+        mock_integration.get_installation.return_value.get_client.return_value = Mock()
+
+        synced, updated = _sync_teams_for_integration(self.organization, mock_integration)
+
+        # Should remain unchanged
+        self.external_actor.refresh_from_db()
+        assert self.external_actor.external_name == "@old-team-name"
+        assert synced == 1
+        assert updated == 0
+
+    @patch("sentry.tasks.github_team_sync._fetch_github_teams")
+    def test_handles_team_not_found_on_github(self, mock_fetch):
+        """Test handling when a stored team is not found on GitHub."""
+        # Mock GitHub API response without our team
+        mock_fetch.return_value = [
+            {"id": "other-team-456", "name": "other-team", "slug": "other-team"}
+        ]
+
+        mock_integration = Mock()
+        mock_integration.id = self.integration.id
+        mock_integration.provider = "github"
+        mock_integration.get_installation.return_value.get_client.return_value = Mock()
+
+        synced, updated = _sync_teams_for_integration(self.organization, mock_integration)
+
+        # Should not update the external actor
+        self.external_actor.refresh_from_db()
+        assert self.external_actor.external_name == "@old-team-name"
+        assert synced == 1
+        assert updated == 0
+
+    def test_handles_no_stored_teams(self):
+        """Test handling when organization has no stored GitHub teams."""
+        # Delete the external actor
+        self.external_actor.delete()
+
+        mock_integration = Mock()
+        mock_integration.id = self.integration.id
+        mock_integration.provider = "github"
+
+        synced, updated = _sync_teams_for_integration(self.organization, mock_integration)
+
+        assert synced == 0
+        assert updated == 0
+
+
+class TestFetchGitHubTeams(GitHubTeamSyncTestCase):
+    def test_fetches_teams_from_github_api(self):
+        """Test fetching teams from GitHub API."""
+        mock_client = Mock()
+        mock_client.get_organization_teams.return_value = [
+            {"id": "team-123", "name": "team-one", "slug": "team-one"},
+            {"id": "team-456", "name": "team-two", "slug": "team-two"},
+        ]
+
+        mock_integration = Mock()
+        mock_integration.id = self.integration.id
+        mock_integration.metadata = {"account": {"login": "test-org"}}
+
+        teams = _fetch_github_teams(mock_client, mock_integration)
+
+        mock_client.get_organization_teams.assert_called_once_with("test-org")
+        assert len(teams) == 2
+        assert teams[0]["name"] == "team-one"
+        assert teams[1]["name"] == "team-two"
+
+    def test_handles_missing_organization_name(self):
+        """Test handling when integration metadata is missing organization name."""
+        mock_client = Mock()
+        mock_integration = Mock()
+        mock_integration.id = self.integration.id
+        mock_integration.metadata = {}
+
+        with pytest.raises(ValueError, match="No organization name found"):
+            _fetch_github_teams(mock_client, mock_integration)
+
+    def test_handles_api_error(self):
+        """Test handling GitHub API errors."""
+        mock_client = Mock()
+        mock_client.get_organization_teams.side_effect = Exception("API Error")
+
+        mock_integration = Mock()
+        mock_integration.id = self.integration.id
+        mock_integration.metadata = {"account": {"login": "test-org"}}
+
+        with pytest.raises(Exception, match="API Error"):
+            _fetch_github_teams(mock_client, mock_integration)

--- a/tests/sentry/tasks/test_github_team_sync.py
+++ b/tests/sentry/tasks/test_github_team_sync.py
@@ -1,8 +1,10 @@
 """
 Tests for GitHub team synchronization tasks.
 """
-import pytest
+
 from unittest.mock import Mock, patch
+
+import pytest
 
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.types import ExternalProviders


### PR DESCRIPTION
This PR resolves the issue where Sentry's stored GitHub team names (`ExternalActor.external_name`) become stale when a GitHub team is renamed.

Since GitHub does not provide webhook events for team renames, this solution implements a periodic synchronization mechanism.

Key changes include:
- A new background task to periodically fetch GitHub team names and update corresponding `ExternalActor` records.
- Extension of the GitHub client to fetch organization teams.
- A new API endpoint to manually trigger this synchronization for an organization.

This ensures that team-based permissions and notifications remain accurate by reflecting the current GitHub team names.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/D09259VQFAP/p1759432104785769?thread_ts=1759432104.785769&cid=D09259VQFAP)

<a href="https://cursor.com/background-agent?bcId=bc-b8ca64d9-8092-4fcc-8863-e0a4c5b12ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b8ca64d9-8092-4fcc-8863-e0a4c5b12ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

