### PR TITLE
fix(crons): Fix check-in chart colors

### DIFF
--- a/static/app/views/insights/crons/components/monitorStats.tsx
+++ b/static/app/views/insights/crons/components/monitorStats.tsx
@@ -96,7 +96,7 @@ export function MonitorStats({monitor, monitorEnvs}: Props) {
     missed.data.push({name: timestamp, value: p.missed});
     duration.data.push({name: timestamp, value: Math.trunc(p.duration)});
   });
-  const colors = [theme.green200, theme.red200, theme.red200, theme.yellow200];
+  const colors = [theme.green300, theme.red400, theme.red200, theme.yellow300];
 
   const height = 150;
   const getYAxisOptions = (aggregateType: AggregationOutputType) => ({


### PR DESCRIPTION
Before

<img alt="clipboard.png" width="1051" src="https://i.imgur.com/tteYq5K.png" />

After

<img alt="clipboard.png" width="1062" src="https://i.imgur.com/vGBIHML.png" />

Fixes [NEW-549: Fix cron check-in bar chart colors in UI2](https://linear.app/getsentry/issue/NEW-549/fix-cron-check-in-bar-chart-colors-in-ui2)