### PR TITLE
fix(crons): Do not display backend-invalid cron expressions

### DIFF
--- a/static/app/views/insights/crons/utils/crontabAsText.spec.tsx
+++ b/static/app/views/insights/crons/utils/crontabAsText.spec.tsx
@@ -25,4 +25,27 @@ describe('crontabAsText', () => {
       'At 0 minutes past the hour, every * hours, starting at 05:00, January through May'
     );
   });
+
+  it('returns null for unsupported "no specific value" marker (?)', () => {
+    expect(crontabAsText('0 0 ? * *')).toBeNull();
+    expect(crontabAsText('0 0 * * ?')).toBeNull();
+  });
+
+  it('returns null for unsupported weekday marker (W)', () => {
+    expect(crontabAsText('0 0 15W * *')).toBeNull();
+    expect(crontabAsText('0 0 LW * *')).toBeNull();
+  });
+
+  it('returns null for expressions with more than 5 fields', () => {
+    expect(crontabAsText('0 0 * * * *')).toBeNull();
+    expect(crontabAsText('0 0 0 * * * *')).toBeNull();
+  });
+
+  it('returns null for invalid expressions', () => {
+    expect(crontabAsText('invalid')).toBeNull();
+  });
+
+  it('returns null for null input', () => {
+    expect(crontabAsText(null)).toBeNull();
+  });
 });

--- a/static/app/views/insights/crons/utils/crontabAsText.tsx
+++ b/static/app/views/insights/crons/utils/crontabAsText.tsx
@@ -9,15 +9,25 @@ export function crontabAsText(crontabInput: string | null): string | null {
   if (!crontabInput) {
     return null;
   }
-  let parsedSchedule: string;
+
+  // The backend does not support "no specific value" markers or the "weekday"
+  // markers (from the Java quarts job scheduler). Do not parse these to avoid confusion
+  if (['?', 'W'].some(marker => crontabInput.includes(marker))) {
+    return null;
+  }
+
+  // The backend does not support expressions with more than 5 fields. Do not
+  // parse these to avoid confusion
+  if (crontabInput.split(' ').length > 5) {
+    return null;
+  }
+
   try {
-    parsedSchedule = cronstrue.toString(crontabInput, {
+    return cronstrue.toString(crontabInput, {
       verbose: false,
       use24HourTimeFormat: shouldUse24Hours(),
     });
   } catch (_e) {
     return null;
   }
-
-  return parsedSchedule;
 }


### PR DESCRIPTION
On the frontend the cronstrue library we use for parsing cron
expressions and displaying them as text is more feature-rich than the
cronsim library we use on the frontend.

This adds some simple logic to avoid parsing some special cases that the
backend doesn't support

Fixes [NEW-143: Frontend allows cron expression, but backend says it's not parsable](https://linear.app/getsentry/issue/NEW-143/frontend-allows-cron-expression-but-backend-says-its-not-parsable)