### PR TITLE
chore(feedback): Remove user-feedback-ui flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1333,7 +1333,6 @@ SENTRY_EARLY_FEATURES = {
     "organizations:performance-new-widget-designs": "Enable updated landing page widget designs",
     "organizations:performance-transaction-name-only-search-indexed": "Enable transaction name only search on indexed",
     "organizations:profiling-global-suspect-functions": "Enable global suspect functions in profiling",
-    "organizations:user-feedback-ui": "Enable User Feedback v2 UI",
 }
 
 # NOTE: Features can have their default value set when calling


### PR DESCRIPTION
First step for removing user-feedback-ui flag (GA at 100).

Relates To: https://linear.app/getsentry/issue/REPLAY-656/identify-and-cleanup-any-fully-released-feature-flags-owned-by-team


