### PR TITLE
feat(sub v3): Receipts page + component updates

### DIFF
--- a/static/gsApp/views/subscriptionPage/paymentHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/paymentHistory.tsx
@@ -239,7 +239,7 @@ function ReceiptGrid({
                 {payment.id}
               </Text>
               <Flex justify="end">
-                <LinkButton icon={<IconDownload />} to={payment.receipt.url}>
+                <LinkButton icon={<IconDownload />} href={payment.receipt.url}>
                   {isMobile ? undefined : t('Download PDF')}
                 </LinkButton>
               </Flex>

--- a/static/gsApp/views/subscriptionPage/paymentHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/paymentHistory.tsx
@@ -1,24 +1,37 @@
 import {Fragment, useEffect} from 'react';
-import styled from '@emotion/styled';
+import {useTheme} from '@emotion/react';
+import moment from 'moment-timezone';
 
+import {Tag} from 'sentry/components/core/badge/tag';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {Container, Flex, Grid} from 'sentry/components/core/layout';
 import {Link} from 'sentry/components/core/link';
-import {DateTime} from 'sentry/components/dateTime';
+import {Text} from 'sentry/components/core/text';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
-import {PanelTable} from 'sentry/components/panels/panelTable';
-import {IconDownload} from 'sentry/icons';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {
+  IconCheckmark,
+  IconClose,
+  IconDownload,
+  IconTimer,
+  IconWarning,
+} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {capitalize} from 'sentry/utils/string/capitalize';
 import {useLocation} from 'sentry/utils/useLocation';
+import useMedia from 'sentry/utils/useMedia';
 import withOrganization from 'sentry/utils/withOrganization';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 import withSubscription from 'getsentry/components/withSubscription';
 import type {InvoiceBase, Subscription} from 'getsentry/types';
 import {InvoiceStatus} from 'getsentry/types';
+import {hasNewBillingUI} from 'getsentry/utils/billing';
 import formatCurrency from 'getsentry/utils/formatCurrency';
 import ContactBillingMembers from 'getsentry/views/contactBillingMembers';
 import SubscriptionPageContainer from 'getsentry/views/subscriptionPage/components/subscriptionPageContainer';
@@ -35,6 +48,7 @@ type Props = {
  * Invoice/Payment list view.
  */
 function PaymentHistory({organization, subscription}: Props) {
+  const isNewBillingUI = hasNewBillingUI(organization);
   const location = useLocation();
 
   useEffect(() => {
@@ -58,108 +72,166 @@ function PaymentHistory({organization, subscription}: Props) {
     }
   );
 
+  const hasBillingPerms = organization.access?.includes('org:billing');
   const paymentsPageLinks = getResponseHeader?.('Link');
 
-  if (isPending) {
-    return (
-      <SubscriptionPageContainer background="primary" organization={organization}>
-        <SubscriptionHeader subscription={subscription} organization={organization} />
-        <LoadingIndicator />
-      </SubscriptionPageContainer>
-    );
-  }
+  if (!isNewBillingUI) {
+    if (isPending) {
+      return (
+        <SubscriptionPageContainer background="primary" organization={organization}>
+          <SubscriptionHeader subscription={subscription} organization={organization} />
+          <LoadingIndicator />
+        </SubscriptionPageContainer>
+      );
+    }
 
-  if (isError) {
-    return (
-      <SubscriptionPageContainer background="primary" organization={organization}>
-        <LoadingError />
-      </SubscriptionPageContainer>
-    );
-  }
+    if (isError) {
+      return (
+        <SubscriptionPageContainer background="primary" organization={organization}>
+          <LoadingError />
+        </SubscriptionPageContainer>
+      );
+    }
 
-  const hasBillingPerms = organization.access?.includes('org:billing');
-  if (!hasBillingPerms) {
+    if (!hasBillingPerms) {
+      return (
+        <SubscriptionPageContainer background="primary" organization={organization}>
+          <ContactBillingMembers />
+        </SubscriptionPageContainer>
+      );
+    }
+
     return (
       <SubscriptionPageContainer background="primary" organization={organization}>
-        <ContactBillingMembers />
+        <SubscriptionHeader organization={organization} subscription={subscription} />
+        <ReceiptGrid
+          payments={payments}
+          organization={organization}
+          paymentsPageLinks={paymentsPageLinks}
+        />
       </SubscriptionPageContainer>
     );
   }
 
   return (
     <SubscriptionPageContainer background="primary" organization={organization}>
-      <SubscriptionHeader organization={organization} subscription={subscription} />
-      <div className="ref-payment-list" data-test-id="payment-list">
-        <PanelTable
-          headers={[
-            t('Date'),
-            <RightAlign key="amount">{t('Amount')}</RightAlign>,
-            <RightAlign key="status">{t('Status')}</RightAlign>,
-            <CenterAlign key="status">{t('Receipt')}</CenterAlign>,
-          ]}
-        >
-          {payments.map((payment, i) => {
-            const url = `/settings/${organization.slug}/billing/receipts/${payment.id}/`;
-            return (
-              <Fragment key={i}>
-                <Column>
-                  <Link to={url}>
-                    <DateTime date={payment.dateCreated} dateOnly year />
-                  </Link>
-                </Column>
-                <RightAlign>
-                  <div>{formatCurrency(payment.amountBilled ?? 0)}</div>
-                  {!!payment.amountRefunded && (
-                    <small>
-                      {tct('[amount] refunded', {
-                        amount: formatCurrency(payment.amountRefunded),
-                      })}
-                    </small>
-                  )}
-                </RightAlign>
-                <Status>
-                  {payment.isPaid
-                    ? InvoiceStatus.PAID
-                    : payment.isClosed
-                      ? InvoiceStatus.CLOSED
-                      : InvoiceStatus.AWAITING_PAYMENT}
-                </Status>
-                <CenterAlign>
-                  <div>
-                    <LinkButton
-                      size="sm"
-                      icon={<IconDownload size="sm" />}
-                      href={payment.receipt.url}
-                      aria-label={t('Download')}
-                    />
-                  </div>
-                </CenterAlign>
-              </Fragment>
-            );
-          })}
-        </PanelTable>
-
-        {paymentsPageLinks && <Pagination pageLinks={paymentsPageLinks} />}
-      </div>
+      <SentryDocumentTitle title={t('Receipts')} orgSlug={organization.slug} />
+      <SettingsPageHeader title={t('Receipts')} />
+      {isPending ? (
+        <LoadingIndicator />
+      ) : isError ? (
+        <LoadingError />
+      ) : hasBillingPerms ? (
+        <ReceiptGrid
+          payments={payments}
+          organization={organization}
+          paymentsPageLinks={paymentsPageLinks}
+        />
+      ) : (
+        <ContactBillingMembers />
+      )}
     </SubscriptionPageContainer>
   );
 }
 
-const Column = styled('div')`
-  display: grid;
-  align-items: center;
-`;
+function ReceiptGrid({
+  payments,
+  organization,
+  paymentsPageLinks,
+}: {
+  organization: Organization;
+  payments: InvoiceBase[];
+  paymentsPageLinks: string | null | undefined;
+}) {
+  const theme = useTheme();
+  const isMobile = useMedia(`(width < ${theme.breakpoints.md})`);
 
-const RightAlign = styled(Column)`
-  text-align: right;
-`;
-
-const CenterAlign = styled(Column)`
-  text-align: center;
-`;
-
-const Status = styled(RightAlign)`
-  text-transform: capitalize;
-`;
+  return (
+    <Fragment>
+      <Flex border="primary" radius="md" direction="column" background="primary">
+        <Grid
+          align="center"
+          columns={isMobile ? 'repeat(5, 1fr)' : 'repeat(4, 1fr) 2fr'}
+          gap="xl"
+          padding="xl"
+        >
+          <Text bold>{t('Date')}</Text>
+          <Text bold align="right">
+            {t('Amount')}
+          </Text>
+          <Text bold>{t('Status')}</Text>
+          <Text bold>{t('Receipt ID')}</Text>
+          <div />
+        </Grid>
+        {payments.map(payment => {
+          const url = `/settings/${organization.slug}/billing/receipts/${payment.id}/`;
+          return (
+            <Grid
+              key={payment.id}
+              align="center"
+              columns={isMobile ? 'repeat(5, 1fr)' : 'repeat(4, 1fr) 2fr'}
+              gap="xl"
+              borderTop="primary"
+              padding="xl"
+            >
+              <Link to={url}>{moment(payment.dateCreated).format('MMM D, YYYY')}</Link>
+              <Container>
+                <Text align="right">{formatCurrency(payment.amountBilled ?? 0)}</Text>
+                {!!payment.amountRefunded && (
+                  <Text size="sm">
+                    {tct('[amount] refunded', {
+                      amount: formatCurrency(payment.amountRefunded),
+                    })}
+                  </Text>
+                )}
+              </Container>
+              <Container>
+                <Tag
+                  icon={
+                    payment.amountRefunded ? (
+                      <IconTimer />
+                    ) : payment.isPaid ? (
+                      <IconCheckmark />
+                    ) : payment.isClosed ? (
+                      <IconClose />
+                    ) : (
+                      <IconWarning />
+                    )
+                  }
+                  type={
+                    payment.amountRefunded
+                      ? 'promotion'
+                      : payment.isPaid
+                        ? 'success'
+                        : payment.isClosed
+                          ? 'error'
+                          : 'warning'
+                  }
+                >
+                  {capitalize(
+                    payment.isPaid
+                      ? InvoiceStatus.PAID
+                      : payment.isClosed
+                        ? InvoiceStatus.CLOSED
+                        : InvoiceStatus.AWAITING_PAYMENT
+                  )}
+                </Tag>
+              </Container>
+              <Text monospace ellipsis>
+                {payment.id}
+              </Text>
+              <Flex justify="end">
+                <LinkButton icon={<IconDownload />} to={payment.receipt.url}>
+                  {isMobile ? undefined : t('Download PDF')}
+                </LinkButton>
+              </Flex>
+            </Grid>
+          );
+        })}
+      </Flex>
+      {paymentsPageLinks && <Pagination pageLinks={paymentsPageLinks} />}
+    </Fragment>
+  );
+}
 
 export default withOrganization(withSubscription(PaymentHistory));


### PR DESCRIPTION
<img width="1411" height="804" alt="Screenshot 2025-10-02 at 5 40 44 PM" src="https://github.com/user-attachments/assets/c80d49b8-80bf-4c08-a80f-ebc7bdfd76d4" />

New receipt grid will be available immediately regardless of whether the `subscriptions-v3` flag is enabled. New page will be gated behind the flag.