### PR TITLE
ref(settings): Use `useParams` in `ProjectTags` instead of `deprecatedRouteProps`

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -585,7 +585,6 @@ function buildRoutes(): RouteObject[] {
       path: 'tags/',
       name: t('Tags & Context'),
       component: make(() => import('sentry/views/settings/projectTags')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'issue-tracking/',

--- a/static/app/views/settings/projectTags/index.spec.tsx
+++ b/static/app/views/settings/projectTags/index.spec.tsx
@@ -12,7 +12,7 @@ import {
 import ProjectTags from 'sentry/views/settings/projectTags';
 
 describe('ProjectTags', () => {
-  const {organization: org, project, routerProps} = initializeOrg();
+  const {organization: org, project} = initializeOrg();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -33,7 +33,15 @@ describe('ProjectTags', () => {
   });
 
   it('renders', () => {
-    render(<ProjectTags {...routerProps} />);
+    render(<ProjectTags />, {
+      organization: org,
+      initialRouterConfig: {
+        location: {
+          pathname: `/settings/projects/${project.slug}/tags/`,
+        },
+        route: '/settings/projects/:projectId/tags/',
+      },
+    });
   });
 
   it('renders empty', async () => {
@@ -49,13 +57,27 @@ describe('ProjectTags', () => {
       body: [],
     });
 
-    render(<ProjectTags {...routerProps} />);
+    render(<ProjectTags />, {
+      organization: org,
+      initialRouterConfig: {
+        location: {
+          pathname: `/settings/projects/${project.slug}/tags/`,
+        },
+        route: '/settings/projects/:projectId/tags/',
+      },
+    });
     expect(await screen.findByTestId('empty-message')).toBeInTheDocument();
   });
 
   it('disables delete button for users without access', async () => {
-    render(<ProjectTags {...routerProps} />, {
+    render(<ProjectTags />, {
       organization: OrganizationFixture({access: []}),
+      initialRouterConfig: {
+        location: {
+          pathname: `/settings/projects/${project.slug}/tags/`,
+        },
+        route: '/settings/projects/:projectId/tags/',
+      },
     });
 
     (await screen.findAllByRole('button', {name: 'Remove tag'})).forEach(button =>
@@ -64,7 +86,15 @@ describe('ProjectTags', () => {
   });
 
   it('deletes tag', async () => {
-    render(<ProjectTags {...routerProps} />);
+    render(<ProjectTags />, {
+      organization: org,
+      initialRouterConfig: {
+        location: {
+          pathname: `/settings/projects/${project.slug}/tags/`,
+        },
+        route: '/settings/projects/:projectId/tags/',
+      },
+    });
 
     // First tag exists
     const tagCount = (await screen.findAllByTestId('tag-row')).length;

--- a/static/app/views/settings/projectTags/index.tsx
+++ b/static/app/views/settings/projectTags/index.tsx
@@ -20,7 +20,6 @@ import {IconDelete} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {TagWithTopValues} from 'sentry/types/group';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {
   setApiQueryData,
   useApiQuery,
@@ -31,20 +30,19 @@ import type RequestError from 'sentry/utils/requestError/requestError';
 import routeTitleGen from 'sentry/utils/routeTitle';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 
-type Props = RouteComponentProps<{projectId: string}>;
-
 type DeleteTagResponse = unknown;
 type DeleteTagVariables = {key: TagWithTopValues['key']};
 
-function ProjectTags(props: Props) {
+export default function ProjectTags() {
   const organization = useOrganization();
   const {projects} = useProjects();
-  const {projectId} = props.params;
+  const {projectId} = useParams<{projectId: string}>();
 
   const project = projects.find(p => p.slug === projectId);
 
@@ -152,8 +150,6 @@ function ProjectTags(props: Props) {
     </Fragment>
   );
 }
-
-export default ProjectTags;
 
 const TagPanelItem = styled(PanelItem)`
   padding: 0;


### PR DESCRIPTION
Migrates usage of `deprecatedRouteProps` for `ProjectTags` - `sentry/views/settings/projectTags`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7