### PR TITLE
chore(sentry-apps): move sentry apps to async deletion

### DIFF
--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
@@ -9,6 +9,7 @@ from sentry.analytics.events.sentry_app_schema_validation_error import (
     SentryAppSchemaValidationError,
 )
 from sentry.constants import SentryAppStatus
+from sentry.deletions.tasks.scheduled import run_scheduled_deletions_control
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmember import OrganizationMember
 from sentry.sentry_apps.api.endpoints.sentry_app_details import PARTNERSHIP_RESTRICTED_ERROR_MESSAGE
@@ -791,6 +792,8 @@ class DeleteSentryAppDetailsTest(SentryAppDetailsTest):
             self.unpublished_app.slug,
             status_code=204,
         )
+        with self.tasks():
+            run_scheduled_deletions_control()
 
         assert AuditLogEntry.objects.filter(
             event=audit_log.get_event_id("SENTRY_APP_REMOVE")
@@ -815,6 +818,8 @@ class DeleteSentryAppDetailsTest(SentryAppDetailsTest):
             self.unpublished_app.slug,
             status_code=204,
         )
+        with self.tasks():
+            run_scheduled_deletions_control()
 
         assert AuditLogEntry.objects.filter(
             event=audit_log.get_event_id("SENTRY_APP_REMOVE")

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -15,6 +15,7 @@ from sentry.auth.providers.dummy import (
 )
 from sentry.auth.providers.saml2.generic.provider import GenericSAML2Provider
 from sentry.auth.providers.saml2.provider import Attributes
+from sentry.deletions.tasks.scheduled import run_scheduled_deletions_control
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
@@ -603,6 +604,9 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
                     "default_role": "member",
                 },
             )
+
+        with self.tasks():
+            run_scheduled_deletions_control()
 
         assert resp.status_code == 200
         auth_provider = AuthProvider.objects.get(organization_id=organization.id)


### PR DESCRIPTION
This is needed for https://github.com/getsentry/sentry/pull/100813 because we are now making a RPC call when deleting Sentry apps, and they are not allowed within transactions.