### PR TITLE
fix(codeowners): adjust codecov codeowners name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -347,8 +347,8 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 ## End of DevToolbar
 
 ## Codecov Merge UX
-/static/app/components/codecov/  @getsentry/codecov-merge-ux
-/static/app/views/codecov/       @getsentry/codecov-merge-ux
+/static/app/components/codecov/  @getsentry/codecov-merge
+/static/app/views/codecov/       @getsentry/codecov-merge
 ## End of Codecov Merge UX
 
 /src/sentry/codecov/ @getsentry/codecov


### PR DESCRIPTION
CODEOWNERs was reporting an issue with the @getsentry/codecov-merge team name (I think @getsentry/codecov-merge-ux was consolidated into @getsentry/codecov-merge?), small fix to make this work again.