### PR TITLE
core(image) add core image component

### DIFF
--- a/static/.cursor/BUGBOT.md
+++ b/static/.cursor/BUGBOT.md
@@ -195,3 +195,24 @@ function Content() {
   );
 }
 ```
+
+Use the core component <Image/> component instead of intrinsic img.
+
+```tsx
+// ❌ Do not use raw intrinsic elements or static paths
+function Component() {
+  return (
+    <img src="/path/to/image.jpg" />
+  );
+}
+
+// ✅ Use Image component and src loader
+import {Image} from 'sentry/componetn/core/image';
+import image from 'sentry-images/example.jpg';
+
+function Component() {
+  return (
+    <Image src={imagePath} alt="Descriptive Alt Attribute">
+  );
+}
+```

--- a/static/app/components/core/image/image.mdx
+++ b/static/app/components/core/image/image.mdx
@@ -66,7 +66,7 @@ import image from 'sentry-images/image.png';
 
 ## Object Fit
 
-The `fit` prop controls how the image content is sized within its container. It accepts `'contain'` (default) or `'cover'` values, which map to the CSS `object-fit` property.
+The `objectFit` prop controls how the image content is sized within its container. It accepts `'contain'` (default) or `'cover'` values, which map to the CSS `object-fit` property.
 
 ### Contain (Default)
 
@@ -77,7 +77,7 @@ The image is scaled to maintain its aspect ratio while fitting within the elemen
     <Image
       src={image}
       alt="Sentry logo contained"
-      fit="contain"
+      objectFit="contain"
       width="100%"
       height="100%"
     />
@@ -85,7 +85,13 @@ The image is scaled to maintain its aspect ratio while fitting within the elemen
 </Storybook.Demo>
 ```jsx import image from 'sentry-images/image.png';
 
-<Image src={image} alt="Sentry logo contained" fit="contain" width="100%" height="100%" />
+<Image
+  src={image}
+  alt="Sentry logo contained"
+  objectFit="contain"
+  width="100%"
+  height="100%"
+/>
 ```
 
 ### Cover
@@ -94,12 +100,24 @@ The image is sized to maintain its aspect ratio while filling the element's enti
 
 <Storybook.Demo>
   <Container width="400px" height="200px" border="primary">
-    <Image src={image} alt="Sentry logo covered" fit="cover" width="100%" height="100%" />
+    <Image
+      src={image}
+      alt="Sentry logo covered"
+      objectFit="cover"
+      width="100%"
+      height="100%"
+    />
   </Container>
 </Storybook.Demo>
 ```jsx import image from 'sentry-images/image.png';
 
-<Image src={image} alt="Sentry logo covered" fit="cover" width="100%" height="100%" />
+<Image
+  src={image}
+  alt="Sentry logo covered"
+  objectFit="cover"
+  width="100%"
+  height="100%"
+/>
 ```
 
 ## Loading Behavior

--- a/static/app/components/core/image/image.mdx
+++ b/static/app/components/core/image/image.mdx
@@ -142,6 +142,27 @@ import sentryLogo from 'sentry-images/logo-sentry.svg';
 <Image src={sentryLogo} alt="Eagerly loaded Sentry logo" loading="eager" />;
 ```
 
+## Image Fallback
+
+Use the `onError` callback to handle failed image loads by providing a fallback image. This is useful when displaying user-generated content or external images that might not be available.
+
+```jsx
+import {useState} from 'react';
+
+import sentryLogo from 'sentry-images/logo-sentry.svg';
+import fallbackImage from 'sentry-images/spot/feedback-empty-state.svg';
+
+function ImageWithFallback() {
+  const [imageSrc, setImageSrc] = useState('https://example.com/broken-image.jpg');
+
+  return (
+    <Image src={imageSrc} alt="User avatar" onError={() => setImageSrc(fallbackImage)} />
+  );
+}
+```
+
+In this example, if the primary image fails to load, the `onError` callback updates the `src` to use a local fallback image.
+
 ## Responsive Images
 
 Use the `srcSet` and `sizes` attributes for responsive images that adapt to different screen sizes and pixel densities. Import each image size using the webpack path loader.

--- a/static/app/components/core/image/image.mdx
+++ b/static/app/components/core/image/image.mdx
@@ -10,7 +10,7 @@ import {Container, Flex} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import * as Storybook from 'sentry/stories';
 
-import sentryLogo from 'sentry-images/logo-sentry.svg';
+import image from 'sentry-images/spot/habitsSuccessfulCustomer.jpg';
 
 import {Image} from './image';
 
@@ -20,16 +20,18 @@ export const types = {Image: APIReference.Image};
 
 The `Image` component is a styled wrapper around the HTML `<img>` element that provides sensible defaults for lazy loading and object-fit behavior. It extends all standard HTML image attributes while adding additional functionality for modern web applications.
 
+An Image requires a `src` and `alt` prop for accessibility and functionality. Read here for more information on [alt descriptions](https://www.w3.org/WAI/tutorials/images/decision-tree/) and how to write good alt descriptions for [informative](https://www.w3.org/WAI/tutorials/images/informative/) and [complex](https://www.w3.org/WAI/tutorials/images/complex/) images.
+
 ## Basic Usage
 
 The `Image` component requires `src` and `alt` props for accessibility and functionality.
 
 <Storybook.Demo>
-  <Image src={sentryLogo} alt="Sentry logo" />
+  <Image src={image} alt="Sentry logo" />
 </Storybook.Demo>
-```jsx import sentryLogo from 'sentry-images/logo-sentry.svg';
+```jsx import image from 'sentry-images/image.png';
 
-<Image src={sentryLogo} alt="Sentry logo" />
+<Image src={image} alt="Sentry logo" />
 ```
 
 ## Using Local Images via Path Loader
@@ -37,7 +39,7 @@ The `Image` component requires `src` and `alt` props for accessibility and funct
 For local images in the codebase, you must use the path loader by importing the image file. The `sentry-images` alias resolves to the static images directory and returns a URL that can be passed to the `src` prop.
 
 ```jsx
-import emptyState from 'sentry-images/spot/feedback-empty-state.svg';
+import emptyState from 'sentry-images/spot/habitsSuccessfulCustomer.png';
 
 <Image src={emptyState} alt="Empty state illustration" />;
 ```
@@ -52,14 +54,14 @@ This approach ensures that:
 
 ```jsx
 // ❌ WRONG: Don't use relative paths
-<Image src="../../images/logo-sentry.svg" alt="Sentry logo" />
+<Image src="../../images/image.png" alt="Sentry logo" />
 
 // ❌ WRONG: Don't use string paths to static files
-<Image src="/static/images/logo-sentry.svg" alt="Sentry logo" />
+<Image src="/static/images/image.png" alt="Sentry logo" />
 
 // ✅ CORRECT: Import the image first
-import sentryLogo from 'sentry-images/logo-sentry.svg';
-<Image src={sentryLogo} alt="Sentry logo" />
+import image from 'sentry-images/image.png';
+<Image src={image} alt="Sentry logo" />
 ```
 
 ## Object Fit
@@ -73,7 +75,7 @@ The image is scaled to maintain its aspect ratio while fitting within the elemen
 <Storybook.Demo>
   <Container width="400px" height="200px" border="primary">
     <Image
-      src={sentryLogo}
+      src={image}
       alt="Sentry logo contained"
       fit="contain"
       width="100%"
@@ -81,15 +83,9 @@ The image is scaled to maintain its aspect ratio while fitting within the elemen
     />
   </Container>
 </Storybook.Demo>
-```jsx import sentryLogo from 'sentry-images/logo-sentry.svg';
+```jsx import image from 'sentry-images/image.png';
 
-<Image
-  src={sentryLogo}
-  alt="Sentry logo contained"
-  fit="contain"
-  width="100%"
-  height="100%"
-/>
+<Image src={image} alt="Sentry logo contained" fit="contain" width="100%" height="100%" />
 ```
 
 ### Cover
@@ -98,24 +94,12 @@ The image is sized to maintain its aspect ratio while filling the element's enti
 
 <Storybook.Demo>
   <Container width="400px" height="200px" border="primary">
-    <Image
-      src={sentryLogo}
-      alt="Sentry logo covered"
-      fit="cover"
-      width="100%"
-      height="100%"
-    />
+    <Image src={image} alt="Sentry logo covered" fit="cover" width="100%" height="100%" />
   </Container>
 </Storybook.Demo>
-```jsx import sentryLogo from 'sentry-images/logo-sentry.svg';
+```jsx import image from 'sentry-images/image.png';
 
-<Image
-  src={sentryLogo}
-  alt="Sentry logo covered"
-  fit="cover"
-  width="100%"
-  height="100%"
-/>
+<Image src={image} alt="Sentry logo covered" fit="cover" width="100%" height="100%" />
 ```
 
 ## Loading Behavior
@@ -127,9 +111,9 @@ The `loading` prop controls when the browser should load the image. By default, 
 Images are loaded only when they're about to enter the viewport, reducing initial page load time and bandwidth usage.
 
 ```jsx
-import sentryLogo from 'sentry-images/logo-sentry.svg';
+import image from 'sentry-images/image.png';
 
-<Image src={sentryLogo} alt="Lazy loaded Sentry logo" loading="lazy" />;
+<Image src={image} alt="Lazy loaded Sentry logo" loading="lazy" />;
 ```
 
 ### Eager Loading
@@ -137,9 +121,9 @@ import sentryLogo from 'sentry-images/logo-sentry.svg';
 Images are loaded immediately, regardless of their position in the viewport. Use this for above-the-fold images or critical content.
 
 ```jsx
-import sentryLogo from 'sentry-images/logo-sentry.svg';
+import image from 'sentry-images/image.png';
 
-<Image src={sentryLogo} alt="Eagerly loaded Sentry logo" loading="eager" />;
+<Image src={image} alt="Eagerly loaded Sentry logo" loading="eager" />;
 ```
 
 ## Image Fallback
@@ -149,14 +133,16 @@ Use the `onError` callback to handle failed image loads by providing a fallback 
 ```jsx
 import {useState} from 'react';
 
-import sentryLogo from 'sentry-images/logo-sentry.svg';
-import fallbackImage from 'sentry-images/spot/feedback-empty-state.svg';
+import image from 'sentry-images/image.png';
+import fallbackImage from 'sentry-images/spot/habitsSuccessfulCustomer.png';
 
 function ImageWithFallback() {
-  const [imageSrc, setImageSrc] = useState('https://example.com/broken-image.jpg');
-
   return (
-    <Image src={imageSrc} alt="User avatar" onError={() => setImageSrc(fallbackImage)} />
+    <Image
+      src={image}
+      alt="User avatar"
+      onError={e => (e.currentTarget.src = fallbackImage)}
+    />
   );
 }
 ```
@@ -168,8 +154,8 @@ In this example, if the primary image fails to load, the `onError` callback upda
 Use the `srcSet` and `sizes` attributes for responsive images that adapt to different screen sizes and pixel densities. Import each image size using the webpack path loader.
 
 ```jsx
-import logoSmall from 'sentry-images/logos/sentry-wordmark-dark-400x100.svg';
-import logoLarge from 'sentry-images/logos/sentry-wordmark-dark-800x200.svg';
+import logoSmall from 'sentry-images/logos/sentry-wordmark-dark-400x100.png';
+import logoLarge from 'sentry-images/logos/sentry-wordmark-dark-800x200.png';
 
 <Image
   src={logoSmall}
@@ -179,15 +165,15 @@ import logoLarge from 'sentry-images/logos/sentry-wordmark-dark-800x200.svg';
 />;
 ```
 
-**Note:** For SVG images, `srcSet` is typically not needed since SVGs are vector graphics and scale perfectly at any resolution. Use `srcSet` primarily for raster images (PNG, JPG) when you have multiple resolutions available.
-
 ## Accessibility
 
 Always provide meaningful `alt` text for images. The `alt` prop is required to ensure proper accessibility support for screen readers.
 
+[Read here about alt descriptions](https://www.w3.org/WAI/tutorials/images/decision-tree/) and how to write good alt descriptions for [informative](https://www.w3.org/WAI/tutorials/images/informative/) and [complex](https://www.w3.org/WAI/tutorials/images/complex/) images.
+
 ```jsx
-import sentryLogo from 'sentry-images/logo-sentry.svg';
-import emptyState from 'sentry-images/spot/feedback-empty-state.svg';
+import image from 'sentry-images/image.png';
+import emptyState from 'sentry-images/spot/habitsSuccessfulCustomer.jpg';
 
 // Good: Descriptive alt text
 <Image
@@ -196,5 +182,5 @@ import emptyState from 'sentry-images/spot/feedback-empty-state.svg';
 />
 
 // Bad: Generic or missing alt text
-<Image src={sentryLogo} alt="image" />
+<Image src={image} alt="image" />
 ```

--- a/static/app/components/core/image/image.mdx
+++ b/static/app/components/core/image/image.mdx
@@ -1,0 +1,179 @@
+---
+title: Image
+description: A flexible image component with built-in lazy loading, object-fit support, and error handling capabilities.
+source: 'sentry/components/core/image'
+resources:
+  js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/image/image.tsx
+---
+
+import {Container, Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
+import * as Storybook from 'sentry/stories';
+
+import sentryLogo from 'sentry-images/logo-sentry.svg';
+
+import {Image} from './image';
+
+import APIReference from '!!type-loader!sentry/components/core/image/image';
+
+export const types = {Image: APIReference.Image};
+
+The `Image` component is a styled wrapper around the HTML `<img>` element that provides sensible defaults for lazy loading and object-fit behavior. It extends all standard HTML image attributes while adding additional functionality for modern web applications.
+
+## Basic Usage
+
+The `Image` component requires `src` and `alt` props for accessibility and functionality.
+
+<Storybook.Demo>
+  <Image src={sentryLogo} alt="Sentry logo" />
+</Storybook.Demo>
+```jsx import sentryLogo from 'sentry-images/logo-sentry.svg';
+
+<Image src={sentryLogo} alt="Sentry logo" />
+```
+
+## Using Local Images via Path Loader
+
+For local images in the codebase, you must use the path loader by importing the image file. The `sentry-images` alias resolves to the static images directory and returns a URL that can be passed to the `src` prop.
+
+```jsx
+import emptyState from 'sentry-images/spot/feedback-empty-state.svg';
+
+<Image src={emptyState} alt="Empty state illustration" />;
+```
+
+This approach ensures that:
+
+- Images are properly bundled and optimized during the build process
+- Image URLs are correctly versioned and cache-busted
+- TypeScript can validate that image files exist at compile time
+
+**Important:** Always use the webpack import pattern for local images. Do not use relative paths or string literals pointing to local files:
+
+```jsx
+// ❌ WRONG: Don't use relative paths
+<Image src="../../images/logo-sentry.svg" alt="Sentry logo" />
+
+// ❌ WRONG: Don't use string paths to static files
+<Image src="/static/images/logo-sentry.svg" alt="Sentry logo" />
+
+// ✅ CORRECT: Import the image first
+import sentryLogo from 'sentry-images/logo-sentry.svg';
+<Image src={sentryLogo} alt="Sentry logo" />
+```
+
+## Object Fit
+
+The `fit` prop controls how the image content is sized within its container. It accepts `'contain'` (default) or `'cover'` values, which map to the CSS `object-fit` property.
+
+### Contain (Default)
+
+The image is scaled to maintain its aspect ratio while fitting within the element's content box. The entire image is made visible.
+
+<Storybook.Demo>
+  <Container width="400px" height="200px" border="primary">
+    <Image
+      src={sentryLogo}
+      alt="Sentry logo contained"
+      fit="contain"
+      width="100%"
+      height="100%"
+    />
+  </Container>
+</Storybook.Demo>
+```jsx import sentryLogo from 'sentry-images/logo-sentry.svg';
+
+<Image
+  src={sentryLogo}
+  alt="Sentry logo contained"
+  fit="contain"
+  width="100%"
+  height="100%"
+/>
+```
+
+### Cover
+
+The image is sized to maintain its aspect ratio while filling the element's entire content box. The image may be clipped to fit.
+
+<Storybook.Demo>
+  <Container width="400px" height="200px" border="primary">
+    <Image
+      src={sentryLogo}
+      alt="Sentry logo covered"
+      fit="cover"
+      width="100%"
+      height="100%"
+    />
+  </Container>
+</Storybook.Demo>
+```jsx import sentryLogo from 'sentry-images/logo-sentry.svg';
+
+<Image
+  src={sentryLogo}
+  alt="Sentry logo covered"
+  fit="cover"
+  width="100%"
+  height="100%"
+/>
+```
+
+## Loading Behavior
+
+The `loading` prop controls when the browser should load the image. By default, images are lazy-loaded to improve initial page performance.
+
+### Lazy Loading (Default)
+
+Images are loaded only when they're about to enter the viewport, reducing initial page load time and bandwidth usage.
+
+```jsx
+import sentryLogo from 'sentry-images/logo-sentry.svg';
+
+<Image src={sentryLogo} alt="Lazy loaded Sentry logo" loading="lazy" />;
+```
+
+### Eager Loading
+
+Images are loaded immediately, regardless of their position in the viewport. Use this for above-the-fold images or critical content.
+
+```jsx
+import sentryLogo from 'sentry-images/logo-sentry.svg';
+
+<Image src={sentryLogo} alt="Eagerly loaded Sentry logo" loading="eager" />;
+```
+
+## Responsive Images
+
+Use the `srcSet` and `sizes` attributes for responsive images that adapt to different screen sizes and pixel densities. Import each image size using the webpack path loader.
+
+```jsx
+import logoSmall from 'sentry-images/logos/sentry-wordmark-dark-400x100.svg';
+import logoLarge from 'sentry-images/logos/sentry-wordmark-dark-800x200.svg';
+
+<Image
+  src={logoSmall}
+  srcSet={`${logoSmall} 1x, ${logoLarge} 2x`}
+  alt="Sentry wordmark logo"
+  sizes="(max-width: 600px) 100vw, 50vw"
+/>;
+```
+
+**Note:** For SVG images, `srcSet` is typically not needed since SVGs are vector graphics and scale perfectly at any resolution. Use `srcSet` primarily for raster images (PNG, JPG) when you have multiple resolutions available.
+
+## Accessibility
+
+Always provide meaningful `alt` text for images. The `alt` prop is required to ensure proper accessibility support for screen readers.
+
+```jsx
+import sentryLogo from 'sentry-images/logo-sentry.svg';
+import emptyState from 'sentry-images/spot/feedback-empty-state.svg';
+
+// Good: Descriptive alt text
+<Image
+  src={emptyState}
+  alt="Illustration showing empty feedback inbox with mailbox"
+/>
+
+// Bad: Generic or missing alt text
+<Image src={sentryLogo} alt="image" />
+```

--- a/static/app/components/core/image/image.spec.tsx
+++ b/static/app/components/core/image/image.spec.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {Image} from './image';
+
+describe('Image', () => {
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLImageElement>();
+    render(<Image src="https://example.com/image.png" alt="Example Image" ref={ref} />);
+    expect(screen.getByRole('img')).toBeInTheDocument();
+    expect(ref.current).toBeInTheDocument();
+  });
+
+  it('renders the image with the src attribute', () => {
+    render(<Image src="https://example.com/image.png" alt="Example Image" />);
+    expect(screen.getByRole('img')).toHaveAttribute(
+      'src',
+      'https://example.com/image.png'
+    );
+  });
+});

--- a/static/app/components/core/image/image.spec.tsx
+++ b/static/app/components/core/image/image.spec.tsx
@@ -19,4 +19,21 @@ describe('Image', () => {
       'https://example.com/image.png'
     );
   });
+
+  it('calls onError callback when image fails to load', () => {
+    render(
+      <Image
+        src="https://example.com/broken-image.png"
+        alt="Example Image"
+        onError={e => {
+          (e.target as HTMLImageElement).src = 'https://example.com/image.png';
+        }}
+      />
+    );
+
+    const img = screen.getByAltText('Example Image');
+    img.dispatchEvent(new Event('error'));
+
+    expect(img).toHaveAttribute('src', 'https://example.com/image.png');
+  });
 });

--- a/static/app/components/core/image/image.tsx
+++ b/static/app/components/core/image/image.tsx
@@ -20,8 +20,8 @@ export function Image({loading, ...props}: ImageProps) {
 }
 
 const Img = styled('img')<ImageProps>`
-  object-fit: ${p => p.objectFit ?? 'contain'};
   width: ${p => p.width ?? '100%'};
-  height: ${p => p.height ?? '100%'};
+  height: ${p => p.height ?? 'auto'};
+  object-fit: ${p => p.objectFit};
   object-position: ${p => p.objectPosition};
 `;

--- a/static/app/components/core/image/image.tsx
+++ b/static/app/components/core/image/image.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  alt: string;
+  src: string;
+  fit?: 'contain' | 'cover';
+  height?: string;
+  /**
+   * Determines if the image should be loaded eagerly or lazily.
+   * @default 'lazy'
+   */
+  loading?: 'eager' | 'lazy';
+  ref?: React.Ref<HTMLImageElement>;
+  width?: string;
+}
+
+export function Image(props: ImageProps) {
+  return (
+    <Img
+      loading={props.loading ?? 'lazy'}
+      width={props.width}
+      height={props.height}
+      {...props}
+    />
+  );
+}
+
+const Img = styled('img')<ImageProps>`
+  object-fit: ${p => p.fit ?? 'contain'};
+  width: ${p => p.width ?? '100%'};
+  height: ${p => p.height ?? '100%'};
+`;

--- a/static/app/components/core/image/image.tsx
+++ b/static/app/components/core/image/image.tsx
@@ -14,15 +14,8 @@ interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   width?: string;
 }
 
-export function Image(props: ImageProps) {
-  return (
-    <Img
-      loading={props.loading ?? 'lazy'}
-      width={props.width}
-      height={props.height}
-      {...props}
-    />
-  );
+export function Image({loading, ...props}: ImageProps) {
+  return <Img loading={loading ?? 'lazy'} {...props} />;
 }
 
 const Img = styled('img')<ImageProps>`

--- a/static/app/components/core/image/image.tsx
+++ b/static/app/components/core/image/image.tsx
@@ -3,13 +3,14 @@ import styled from '@emotion/styled';
 interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   alt: string;
   src: string;
-  fit?: 'contain' | 'cover';
   height?: string;
   /**
    * Determines if the image should be loaded eagerly or lazily.
    * @default 'lazy'
    */
   loading?: 'eager' | 'lazy';
+  objectFit?: 'contain' | 'cover';
+  objectPosition?: 'center' | 'top' | 'bottom' | 'left' | 'right' | (string & {});
   ref?: React.Ref<HTMLImageElement>;
   width?: string;
 }
@@ -19,7 +20,8 @@ export function Image({loading, ...props}: ImageProps) {
 }
 
 const Img = styled('img')<ImageProps>`
-  object-fit: ${p => p.fit ?? 'contain'};
+  object-fit: ${p => p.objectFit ?? 'contain'};
   width: ${p => p.width ?? '100%'};
   height: ${p => p.height ?? '100%'};
+  object-position: ${p => p.objectPosition};
 `;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -4,6 +4,7 @@ import type {Location} from 'history';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
+import {Image} from 'sentry/components/core/image/image';
 import {Link} from 'sentry/components/core/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import LinkHint from 'sentry/components/structuredEventData/linkHint';
@@ -284,16 +285,15 @@ function ResourceImage(props: {
       </FilenameContainer>
       {showImage && !hasError ? (
         <ImageWrapper>
-          <img
+          <Image
             data-test-id="sample-image"
+            alt="Resource Image"
             onError={() => setHasError(true)}
             src={src}
-            style={{
-              width: '100%',
-              height: '100%',
-              objectFit: 'contain',
-              objectPosition: 'center',
-            }}
+            objectFit="contain"
+            objectPosition="center"
+            width="100%"
+            height="100%"
           />
         </ImageWrapper>
       ) : (


### PR DESCRIPTION
Adds a core Image component to the codebase. The main win here is that we want to defer image loading and default to lazy loaded images + require alt texts to be added to each image.