### PR TITLE
ref(settings): Remove usage of `deprecatedRouteProps` from `OrganizationTeams` settings

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -983,7 +983,6 @@ function buildRoutes(): RouteObject[] {
         {
           index: true,
           component: make(() => import('sentry/views/settings/organizationTeams')),
-          deprecatedRouteProps: true,
         },
         {
           path: ':teamId/',

--- a/static/app/views/settings/organizationTeams/index.tsx
+++ b/static/app/views/settings/organizationTeams/index.tsx
@@ -5,7 +5,6 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import TeamStore from 'sentry/stores/teamStore';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {AccessRequest} from 'sentry/types/organization';
 import {
   setApiQueryData,
@@ -18,7 +17,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 import OrganizationTeams from './organizationTeams';
 
-function OrganizationTeamsContainer(props: RouteComponentProps) {
+export default function OrganizationTeamsContainer() {
   const api = useApi();
   const organization = useOrganization({allowNull: true});
   const queryClient = useQueryClient();
@@ -89,14 +88,11 @@ function OrganizationTeamsContainer(props: RouteComponentProps) {
 
   return (
     <OrganizationTeams
-      {...props}
+      organization={organization}
       access={new Set(organization?.access)}
       features={new Set(organization?.features)}
-      organization={organization}
       requestList={requestList}
       onRemoveAccessRequest={handleRemoveAccessRequest}
     />
   );
 }
-
-export default OrganizationTeamsContainer;

--- a/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
@@ -19,7 +19,7 @@ jest.mock('sentry/actionCreators/modal', () => ({
 
 describe('OrganizationTeams', () => {
   describe('Open Membership', () => {
-    const {organization, project, routerProps} = initializeOrg({
+    const {organization} = initializeOrg({
       organization: {
         openMembership: true,
       },
@@ -30,13 +30,11 @@ describe('OrganizationTeams', () => {
     ) =>
       render(
         <OrganizationTeams
-          {...routerProps}
-          onRemoveAccessRequest={() => {}}
-          requestList={[]}
-          params={{projectId: project.slug}}
-          features={new Set(['open-membership'])}
-          access={new Set(['project:admin'])}
           organization={organization}
+          access={new Set(['project:admin'])}
+          features={new Set(['open-membership'])}
+          requestList={[]}
+          onRemoveAccessRequest={() => {}}
           {...props}
         />
       );
@@ -122,7 +120,7 @@ describe('OrganizationTeams', () => {
   });
 
   describe('Closed Membership', () => {
-    const {organization, project, routerProps} = initializeOrg({
+    const {organization} = initializeOrg({
       organization: {
         openMembership: false,
       },
@@ -132,13 +130,11 @@ describe('OrganizationTeams', () => {
     ) =>
       render(
         <OrganizationTeams
-          {...routerProps}
-          onRemoveAccessRequest={() => {}}
-          requestList={[]}
-          params={{projectId: project.slug}}
-          features={new Set([])}
-          access={new Set([])}
           organization={organization}
+          access={new Set([])}
+          features={new Set([])}
+          requestList={[]}
+          onRemoveAccessRequest={() => {}}
           {...props}
         />
       );
@@ -198,7 +194,7 @@ describe('OrganizationTeams', () => {
   });
 
   describe('Team Requests', () => {
-    const {organization, project, routerProps} = initializeOrg({
+    const {organization} = initializeOrg({
       organization: {
         openMembership: false,
       },
@@ -220,13 +216,11 @@ describe('OrganizationTeams', () => {
     ) =>
       render(
         <OrganizationTeams
-          {...routerProps}
-          onRemoveAccessRequest={() => {}}
-          params={{projectId: project.slug}}
-          features={new Set([])}
-          access={new Set([])}
           organization={organization}
+          access={new Set([])}
+          features={new Set([])}
           requestList={requestList}
+          onRemoveAccessRequest={() => {}}
           {...props}
         />
       );
@@ -298,18 +292,16 @@ describe('OrganizationTeams', () => {
     const access = new Set<string>();
 
     it('does not render alert without feature flag', () => {
-      const {organization, project, routerProps} = initializeOrg({
+      const {organization} = initializeOrg({
         organization: {orgRole: 'admin'},
       });
       render(
         <OrganizationTeams
-          {...routerProps}
+          organization={organization}
+          access={access}
+          features={new Set()}
           requestList={[]}
           onRemoveAccessRequest={() => {}}
-          params={{projectId: project.slug}}
-          features={new Set()}
-          access={access}
-          organization={organization}
         />
       );
 
@@ -317,18 +309,16 @@ describe('OrganizationTeams', () => {
     });
 
     it('renders alert with elevated org role', () => {
-      const {organization, project, routerProps} = initializeOrg({
+      const {organization} = initializeOrg({
         organization: {orgRole: 'admin'},
       });
       render(
         <OrganizationTeams
-          {...routerProps}
+          organization={organization}
+          access={access}
+          features={features}
           requestList={[]}
           onRemoveAccessRequest={() => {}}
-          params={{projectId: project.slug}}
-          features={features}
-          access={access}
-          organization={organization}
         />
       );
 
@@ -341,18 +331,16 @@ describe('OrganizationTeams', () => {
     });
 
     it('does not render alert with lowest org role', () => {
-      const {organization, project, routerProps} = initializeOrg({
+      const {organization} = initializeOrg({
         organization: {orgRole: 'member'},
       });
       render(
         <OrganizationTeams
-          {...routerProps}
+          organization={organization}
+          access={access}
+          features={features}
           requestList={[]}
           onRemoveAccessRequest={() => {}}
-          params={{projectId: project.slug}}
-          features={features}
-          access={access}
-          organization={organization}
         />
       );
 

--- a/static/app/views/settings/organizationTeams/organizationTeams.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.tsx
@@ -16,7 +16,6 @@ import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {AccessRequest, Organization} from 'sentry/types/organization';
 import {useTeams} from 'sentry/utils/useTeams';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
@@ -32,9 +31,9 @@ type Props = {
   onRemoveAccessRequest: (id: string, isApproved: boolean) => void;
   organization: Organization;
   requestList: AccessRequest[];
-} & RouteComponentProps;
+};
 
-function OrganizationTeams({
+export default function OrganizationTeams({
   organization,
   access,
   features,
@@ -162,5 +161,3 @@ const LoadMoreWrapper = styled('div')`
   justify-content: end;
   grid-auto-flow: column;
 `;
-
-export default OrganizationTeams;


### PR DESCRIPTION
Migrates usage of `deprecatedRouteProps` for `OrganizationTeams` - `sentry/views/settings/organizationTeams`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7