### PR TITLE
fix(search): Avoid double-wildcards in  search

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -5,7 +5,7 @@ import re
 from collections.abc import Callable, Generator, Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeIs, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeIs, overload
 
 from django.utils.functional import cached_property
 from parsimonious.exceptions import IncompleteParseError
@@ -479,8 +479,10 @@ class SearchValue(NamedTuple):
     def value(self) -> Any:
         if self.use_raw_value:
             return self.raw_value
-        elif self.is_wildcard():
-            return translate_wildcard(cast(str, self.raw_value))
+        elif self.is_wildcard() and isinstance(self.raw_value, str):
+            return translate_wildcard(self.raw_value)
+        elif self.is_wildcard() and isinstance(self.raw_value, (list, tuple)):
+            return f"({"|".join(map(translate_wildcard, self.raw_value))})"
         elif isinstance(self.raw_value, str):
             return translate_escape_sequences(self.raw_value)
         return self.raw_value


### PR DESCRIPTION
Using the `contains` check was failing with more than one value. It turns out that that's because we were lying to the type system (through `cast`) and handing `list` objects to `translate_wildcard`... which then did little more than join them together.

Before:
<img width="1461" height="268" alt="Screenshot 2025-10-02 at 3 27 35 PM" src="https://github.com/user-attachments/assets/99bb2090-d66d-45c2-b268-87f4515cf0a8" />

After:
<img width="1463" height="324" alt="Screenshot 2025-10-02 at 3 28 18 PM" src="https://github.com/user-attachments/assets/f56d7b02-3cd8-4b73-a532-5e7d32b16a8d" />
