### PR TITLE
feat(pr-page): Add size analysis info to PR page if available

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2480,7 +2480,7 @@ function buildRoutes(): RouteObject[] {
   ];
 
   const pullRequestRoutes: SentryRouteObject = {
-    path: '/pull/',
+    path: ':projectId/pull/',
     component: make(() => import('sentry/views/pullRequest/index')),
     withOrgPath: true,
     children: pullRequestChildren,

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2480,7 +2480,7 @@ function buildRoutes(): RouteObject[] {
   ];
 
   const pullRequestRoutes: SentryRouteObject = {
-    path: ':projectId/pull/',
+    path: 'pull/',
     component: make(() => import('sentry/views/pullRequest/index')),
     withOrgPath: true,
     children: pullRequestChildren,

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2480,7 +2480,7 @@ function buildRoutes(): RouteObject[] {
   ];
 
   const pullRequestRoutes: SentryRouteObject = {
-    path: 'pull/',
+    path: '/pull/',
     component: make(() => import('sentry/views/pullRequest/index')),
     withOrgPath: true,
     children: pullRequestChildren,

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -103,10 +103,7 @@ export default function BuildDetails() {
             </BuildDetailsSide>
             <BuildDetailsMain>
               <BuildDetailsMainContent
-                appSizeData={appSizeQuery.data}
-                isAppSizePending={appSizeQuery.isPending}
-                isAppSizeError={appSizeQuery.isError}
-                appSizeError={appSizeQuery.error}
+                appSizeQuery={appSizeQuery}
                 buildDetailsData={buildDetailsQuery.data}
                 isBuildDetailsPending={buildDetailsQuery.isPending}
               />

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -95,15 +95,20 @@ export default function BuildDetails() {
           <UrlParamBatchProvider>
             <BuildDetailsSide>
               <BuildDetailsSidebarContent
-                buildDetailsQuery={buildDetailsQuery}
+                buildDetailsData={buildDetailsQuery.data}
+                isBuildDetailsPending={buildDetailsQuery.isPending}
                 artifactId={artifactId}
                 projectId={projectId}
               />
             </BuildDetailsSide>
             <BuildDetailsMain>
               <BuildDetailsMainContent
-                appSizeQuery={appSizeQuery}
-                buildDetailsQuery={buildDetailsQuery}
+                appSizeData={appSizeQuery.data}
+                isAppSizePending={appSizeQuery.isPending}
+                isAppSizeError={appSizeQuery.isError}
+                appSizeError={appSizeQuery.error}
+                buildDetailsData={buildDetailsQuery.data}
+                isBuildDetailsPending={buildDetailsQuery.isPending}
               />
             </BuildDetailsMain>
           </UrlParamBatchProvider>

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -11,7 +11,6 @@ import Placeholder from 'sentry/components/placeholder';
 import {IconClose, IconGrid, IconSearch} from 'sentry/icons';
 import {IconGraphCircle} from 'sentry/icons/iconGraphCircle';
 import {t} from 'sentry/locale';
-import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
 import {AppSizeInsights} from 'sentry/views/preprod/buildDetails/main/insights/appSizeInsights';
@@ -34,7 +33,7 @@ interface LoadingContentProps {
 
 function LoadingContent({showSkeleton, children}: LoadingContentProps) {
   return (
-    <Flex direction="column" gap="lg" minHeight="700px">
+    <Flex direction="column" gap="lg" minHeight="700px" width="100%">
       <Grid
         columns="1fr"
         rows="1fr"
@@ -74,22 +73,26 @@ function LoadingContent({showSkeleton, children}: LoadingContentProps) {
 }
 
 interface BuildDetailsMainContentProps {
-  appSizeQuery: UseApiQueryResult<AppSizeApiResponse, RequestError>;
-  buildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError>;
+  appSizeData?: AppSizeApiResponse | null;
+  appSizeError?: RequestError | null;
+  buildDetailsData?: BuildDetailsApiResponse | null;
+  isAppSizeError?: boolean;
+  isAppSizePending?: boolean;
+  isBuildDetailsPending?: boolean;
 }
 
 export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
   const {
-    data: appSizeData,
-    isPending: isAppSizePending,
-    isError: isAppSizeError,
-    error: appSizeError,
-  } = props.appSizeQuery;
+    appSizeData,
+    isAppSizePending = false,
+    isAppSizeError = false,
+    appSizeError,
+    buildDetailsData,
+    isBuildDetailsPending = false,
+  } = props;
 
   // If the main data fetch fails, this component will not be rendered
   // so we don't handle 'isBuildDetailsError'.
-  const {isPending: isBuildDetailsPending, data: buildDetailsData} =
-    props.buildDetailsQuery;
 
   const [selectedContentParam, setSelectedContentParam] = useQueryParamState<
     'treemap' | 'categories'
@@ -236,7 +239,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
   }
 
   return (
-    <Flex direction="column" gap="lg" minHeight="700px">
+    <Flex direction="column" gap="lg" minHeight="700px" width="100%">
       <Flex align="center" gap="md">
         {categoriesEnabled && (
           <SegmentedControl value={selectedContent} onChange={handleContentChange}>

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -11,6 +11,7 @@ import Placeholder from 'sentry/components/placeholder';
 import {IconClose, IconGrid, IconSearch} from 'sentry/icons';
 import {IconGraphCircle} from 'sentry/icons/iconGraphCircle';
 import {t} from 'sentry/locale';
+import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
 import {AppSizeInsights} from 'sentry/views/preprod/buildDetails/main/insights/appSizeInsights';
@@ -73,23 +74,19 @@ function LoadingContent({showSkeleton, children}: LoadingContentProps) {
 }
 
 interface BuildDetailsMainContentProps {
-  appSizeData?: AppSizeApiResponse | null;
-  appSizeError?: RequestError | null;
+  appSizeQuery: UseApiQueryResult<AppSizeApiResponse, RequestError>;
   buildDetailsData?: BuildDetailsApiResponse | null;
-  isAppSizeError?: boolean;
-  isAppSizePending?: boolean;
   isBuildDetailsPending?: boolean;
 }
 
 export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
+  const {appSizeQuery, buildDetailsData, isBuildDetailsPending = false} = props;
   const {
-    appSizeData,
-    isAppSizePending = false,
-    isAppSizeError = false,
-    appSizeError,
-    buildDetailsData,
-    isBuildDetailsPending = false,
-  } = props;
+    data: appSizeData,
+    isPending: isAppSizePending,
+    isError: isAppSizeError,
+    error: appSizeError,
+  } = appSizeQuery;
 
   // If the main data fetch fails, this component will not be rendered
   // so we don't handle 'isBuildDetailsError'.

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -60,15 +60,11 @@ function getLabels(platform: Platform | undefined): Labels {
 interface BuildDetailsSidebarAppInfoProps {
   appInfo: BuildDetailsAppInfo;
   artifactId: string;
-  projectId: string;
+  projectId: string | null;
   sizeInfo?: BuildDetailsSizeInfo;
 }
 
 export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProps) {
-  const handleInstallClick = () => {
-    openInstallModal(props.projectId, props.artifactId);
-  };
-
   const labels = getLabels(props.appInfo.platform ?? undefined);
 
   return (
@@ -156,8 +152,14 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
             <IconLink />
           </InfoIcon>
           <Text>
-            {props.appInfo.is_installable ? (
-              <InstallableLink onClick={handleInstallClick}>Installable</InstallableLink>
+            {props.projectId && props.appInfo.is_installable ? (
+              <InstallableLink
+                onClick={() => {
+                  openInstallModal(props.projectId!, props.artifactId);
+                }}
+              >
+                Installable
+              </InstallableLink>
             ) : (
               'Not Installable'
             )}

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx
@@ -3,7 +3,6 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {useApiQuery} from 'sentry/utils/queryClient';
 import {BuildDetailsSidebarContent} from 'sentry/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {BuildDetailsState} from 'sentry/views/preprod/types/buildDetailsTypes';
@@ -35,19 +34,23 @@ const mockBuildDetailsData: BuildDetailsApiResponse = {
   },
 };
 
-function TestComponent({artifactId, projectId}: {artifactId: string; projectId: string}) {
-  const buildDetailsQuery = useApiQuery<BuildDetailsApiResponse>(
-    [`/projects/${projectId}/preprodartifacts/${artifactId}/build-details/`],
-    {
-      staleTime: 0,
-    }
-  );
-
+function TestComponent({
+  artifactId,
+  projectId,
+  buildDetailsData,
+  isBuildDetailsPending,
+}: {
+  artifactId: string;
+  projectId: string;
+  buildDetailsData?: BuildDetailsApiResponse | null;
+  isBuildDetailsPending?: boolean;
+}) {
   return (
     <BuildDetailsSidebarContent
       artifactId={artifactId}
       projectId={projectId}
-      buildDetailsQuery={buildDetailsQuery}
+      buildDetailsData={buildDetailsData}
+      isBuildDetailsPending={isBuildDetailsPending}
     />
   );
 }
@@ -67,13 +70,7 @@ describe('BuildDetailsSidebarContent', () => {
   });
 
   it('renders loading skeleton when data is pending', () => {
-    MockApiClient.addMockResponse({
-      url: `/projects/${defaultProps.projectId}/preprodartifacts/${defaultProps.artifactId}/build-details/`,
-      method: 'GET',
-      body: new Promise(() => {}), // Never resolves
-    });
-
-    render(<TestComponent {...defaultProps} />, {
+    render(<TestComponent {...defaultProps} isBuildDetailsPending />, {
       organization,
     });
 
@@ -81,16 +78,12 @@ describe('BuildDetailsSidebarContent', () => {
   });
 
   it('renders app info section when artifact state is PROCESSED', async () => {
-    MockApiClient.addMockResponse({
-      url: `/projects/${defaultProps.projectId}/preprodartifacts/${defaultProps.artifactId}/build-details/`,
-      method: 'GET',
-      body: {
-        ...mockBuildDetailsData,
-        state: BuildDetailsState.PROCESSED,
-      },
-    });
+    const buildDetailsData = {
+      ...mockBuildDetailsData,
+      state: BuildDetailsState.PROCESSED,
+    };
 
-    render(<TestComponent {...defaultProps} />, {
+    render(<TestComponent {...defaultProps} buildDetailsData={buildDetailsData} />, {
       organization,
     });
 
@@ -110,16 +103,12 @@ describe('BuildDetailsSidebarContent', () => {
   });
 
   it('hides app info section when artifact state is UPLOADED', async () => {
-    MockApiClient.addMockResponse({
-      url: `/projects/${defaultProps.projectId}/preprodartifacts/${defaultProps.artifactId}/build-details/`,
-      method: 'GET',
-      body: {
-        ...mockBuildDetailsData,
-        state: BuildDetailsState.UPLOADED,
-      },
-    });
+    const buildDetailsData = {
+      ...mockBuildDetailsData,
+      state: BuildDetailsState.UPLOADED,
+    };
 
-    render(<TestComponent {...defaultProps} />, {
+    render(<TestComponent {...defaultProps} buildDetailsData={buildDetailsData} />, {
       organization,
     });
 
@@ -139,16 +128,12 @@ describe('BuildDetailsSidebarContent', () => {
   });
 
   it('hides app info section when artifact state is UPLOADING', async () => {
-    MockApiClient.addMockResponse({
-      url: `/projects/${defaultProps.projectId}/preprodartifacts/${defaultProps.artifactId}/build-details/`,
-      method: 'GET',
-      body: {
-        ...mockBuildDetailsData,
-        state: BuildDetailsState.UPLOADING,
-      },
-    });
+    const buildDetailsData = {
+      ...mockBuildDetailsData,
+      state: BuildDetailsState.UPLOADING,
+    };
 
-    render(<TestComponent {...defaultProps} />, {
+    render(<TestComponent {...defaultProps} buildDetailsData={buildDetailsData} />, {
       organization,
     });
 
@@ -168,16 +153,12 @@ describe('BuildDetailsSidebarContent', () => {
   });
 
   it('hides app info section when artifact state is FAILED', async () => {
-    MockApiClient.addMockResponse({
-      url: `/projects/${defaultProps.projectId}/preprodartifacts/${defaultProps.artifactId}/build-details/`,
-      method: 'GET',
-      body: {
-        ...mockBuildDetailsData,
-        state: BuildDetailsState.FAILED,
-      },
-    });
+    const buildDetailsData = {
+      ...mockBuildDetailsData,
+      state: BuildDetailsState.FAILED,
+    };
 
-    render(<TestComponent {...defaultProps} />, {
+    render(<TestComponent {...defaultProps} buildDetailsData={buildDetailsData} />, {
       organization,
     });
 

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
@@ -20,7 +20,7 @@ import {
 
 interface BuildDetailsSidebarContentProps {
   artifactId: string;
-  projectId: string;
+  projectId: string | null;
   buildDetailsData?: BuildDetailsApiResponse | null;
   isBuildDetailsPending?: boolean;
 }

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
@@ -8,8 +8,6 @@ import {
 } from 'sentry/components/keyValueData';
 import Placeholder from 'sentry/components/placeholder';
 import {space} from 'sentry/styles/space';
-import type {UseApiQueryResult} from 'sentry/utils/queryClient';
-import type RequestError from 'sentry/utils/requestError/requestError';
 import {BuildDetailsSidebarAppInfo} from 'sentry/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {BuildDetailsState} from 'sentry/views/preprod/types/buildDetailsTypes';
@@ -22,13 +20,13 @@ import {
 
 interface BuildDetailsSidebarContentProps {
   artifactId: string;
-  buildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError>;
   projectId: string;
+  buildDetailsData?: BuildDetailsApiResponse | null;
+  isBuildDetailsPending?: boolean;
 }
 
 export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProps) {
-  const {data: buildDetailsData, isPending: isBuildDetailsPending} =
-    props.buildDetailsQuery;
+  const {buildDetailsData, isBuildDetailsPending = false, artifactId, projectId} = props;
 
   if (isBuildDetailsPending || !buildDetailsData) {
     return <SidebarLoadingSkeleton data-testid="sidebar-loading-skeleton" />;
@@ -128,8 +126,8 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
         <BuildDetailsSidebarAppInfo
           appInfo={buildDetailsData.app_info}
           sizeInfo={buildDetailsData.size_info}
-          projectId={props.projectId}
-          artifactId={props.artifactId}
+          projectId={projectId}
+          artifactId={artifactId}
         />
       )}
 

--- a/static/app/views/pullRequest/details/main/pullRequestDetailsSizeContent.tsx
+++ b/static/app/views/pullRequest/details/main/pullRequestDetailsSizeContent.tsx
@@ -1,0 +1,120 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+
+import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {Flex, Grid, Stack} from 'sentry/components/core/layout';
+import {Heading} from 'sentry/components/core/text';
+import {t} from 'sentry/locale';
+import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import {BuildDetailsMainContent} from 'sentry/views/preprod/buildDetails/main/buildDetailsMainContent';
+import {BuildDetailsSidebarContent} from 'sentry/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent';
+import type {AppSizeApiResponse} from 'sentry/views/preprod/types/appSizeTypes';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+interface PullRequestDetailsSizeContentProps {
+  buildDetails: BuildDetailsApiResponse[];
+}
+
+export function PullRequestDetailsSizeContent({
+  buildDetails,
+}: PullRequestDetailsSizeContentProps) {
+  const organization = useOrganization();
+  const {projectId} = useParams<{
+    projectId: string;
+  }>();
+  const [selectedBuildId, setSelectedBuildId] = useState<string | undefined>(
+    buildDetails[0]?.id
+  );
+
+  const appSizeQuery: UseApiQueryResult<AppSizeApiResponse, RequestError> =
+    useApiQuery<AppSizeApiResponse>(
+      [
+        `/projects/${organization.slug}/${projectId}/files/preprodartifacts/${selectedBuildId}/size-analysis/`,
+      ],
+      {
+        staleTime: 0,
+        enabled: !!projectId && !!selectedBuildId,
+      }
+    );
+
+  if (buildDetails.length === 0 || !selectedBuildId) {
+    return <div>No build details found</div>;
+  }
+
+  const getBuildDetailsLabel = (buildDetail: BuildDetailsApiResponse) => {
+    const {id, app_info} = buildDetail;
+    let label = `#${id}`;
+
+    if (app_info?.app_id) {
+      label += ` ${app_info.app_id}`;
+    }
+    if (app_info?.version) {
+      label += ` v${app_info.version}`;
+    }
+    if (app_info?.build_number) {
+      label += ` (${app_info.build_number})`;
+    }
+    if (app_info?.build_configuration) {
+      label += ` ${app_info.build_configuration}`;
+    }
+    return label;
+  };
+
+  const selectOptions = buildDetails.map(buildDetail => ({
+    label: getBuildDetailsLabel(buildDetail),
+    value: buildDetail.id.toString(),
+    buildDetail,
+  }));
+  const selectedBuildDetail = buildDetails.find(
+    buildDetail => buildDetail.id === selectedBuildId
+  );
+
+  return (
+    <Stack gap="2xl" padding="md">
+      {buildDetails.length > 1 && (
+        <Flex align="center" gap="md">
+          <Heading as="h2">{t('Builds (%s)', buildDetails.length)}</Heading>
+          <SelectContainer>
+            <CompactSelect
+              size="md"
+              value={selectedBuildId}
+              onChange={(option: any) => {
+                setSelectedBuildId(option?.value);
+              }}
+              options={selectOptions}
+              aria-label={t('Select build')}
+            />
+          </SelectContainer>
+        </Flex>
+      )}
+      <Grid areas={`"main sidebar"`} columns="1fr 325px" gap="3xl">
+        <Flex area="sidebar">
+          {buildDetails.length > 0 && (
+            <BuildDetailsSidebarContent
+              buildDetailsData={selectedBuildDetail}
+              artifactId={selectedBuildId}
+              projectId={projectId}
+            />
+          )}
+        </Flex>
+        <Flex area="main" width="100%" justify="center">
+          <BuildDetailsMainContent
+            buildDetailsData={selectedBuildDetail}
+            appSizeData={appSizeQuery.data}
+            isAppSizePending={appSizeQuery.isPending}
+            isAppSizeError={appSizeQuery.isError}
+            appSizeError={appSizeQuery.error}
+          />
+        </Flex>
+      </Grid>
+    </Stack>
+  );
+}
+
+const SelectContainer = styled('div')`
+  flex: 1;
+  max-width: 300px;
+`;

--- a/static/app/views/pullRequest/details/main/pullRequestDetailsSizeContent.tsx
+++ b/static/app/views/pullRequest/details/main/pullRequestDetailsSizeContent.tsx
@@ -42,16 +42,16 @@ export function PullRequestDetailsSizeContent({
     const {id, app_info} = buildDetail;
     let label = `#${id}`;
 
-    if (app_info?.app_id) {
+    if (app_info?.app_id !== null) {
       label += ` ${app_info.app_id}`;
     }
-    if (app_info?.version) {
+    if (app_info?.version !== null) {
       label += ` v${app_info.version}`;
     }
-    if (app_info?.build_number) {
+    if (app_info?.build_number !== null) {
       label += ` (${app_info.build_number})`;
     }
-    if (app_info?.build_configuration) {
+    if (app_info?.build_configuration !== null) {
       label += ` ${app_info.build_configuration}`;
     }
     return label;
@@ -90,6 +90,7 @@ export function PullRequestDetailsSizeContent({
             <BuildDetailsSidebarContent
               buildDetailsData={selectedBuildDetail}
               artifactId={selectedBuildId}
+              projectId={null}
             />
           )}
         </Flex>

--- a/static/app/views/pullRequest/details/main/pullRequestDetailsSizeContent.tsx
+++ b/static/app/views/pullRequest/details/main/pullRequestDetailsSizeContent.tsx
@@ -97,10 +97,7 @@ export function PullRequestDetailsSizeContent({
         <Flex area="main" width="100%" justify="center">
           <BuildDetailsMainContent
             buildDetailsData={selectedBuildDetail}
-            appSizeData={appSizeQuery.data}
-            isAppSizePending={appSizeQuery.isPending}
-            isAppSizeError={appSizeQuery.isError}
-            appSizeError={appSizeQuery.error}
+            appSizeQuery={appSizeQuery}
           />
         </Flex>
       </Grid>

--- a/static/app/views/pullRequest/details/main/pullRequestDetailsSizeContent.tsx
+++ b/static/app/views/pullRequest/details/main/pullRequestDetailsSizeContent.tsx
@@ -8,7 +8,6 @@ import {t} from 'sentry/locale';
 import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useParams} from 'sentry/utils/useParams';
 import {BuildDetailsMainContent} from 'sentry/views/preprod/buildDetails/main/buildDetailsMainContent';
 import {BuildDetailsSidebarContent} from 'sentry/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent';
 import type {AppSizeApiResponse} from 'sentry/views/preprod/types/appSizeTypes';
@@ -22,21 +21,16 @@ export function PullRequestDetailsSizeContent({
   buildDetails,
 }: PullRequestDetailsSizeContentProps) {
   const organization = useOrganization();
-  const {projectId} = useParams<{
-    projectId: string;
-  }>();
   const [selectedBuildId, setSelectedBuildId] = useState<string | undefined>(
     buildDetails[0]?.id
   );
 
   const appSizeQuery: UseApiQueryResult<AppSizeApiResponse, RequestError> =
     useApiQuery<AppSizeApiResponse>(
-      [
-        `/projects/${organization.slug}/${projectId}/files/preprodartifacts/${selectedBuildId}/size-analysis/`,
-      ],
+      [`projects/${organization.slug}/pull-requests/size-analysis/${selectedBuildId}/`],
       {
         staleTime: 0,
-        enabled: !!projectId && !!selectedBuildId,
+        enabled: !!selectedBuildId,
       }
     );
 
@@ -96,7 +90,6 @@ export function PullRequestDetailsSizeContent({
             <BuildDetailsSidebarContent
               buildDetailsData={selectedBuildDetail}
               artifactId={selectedBuildId}
-              projectId={projectId}
             />
           )}
         </Flex>

--- a/static/app/views/pullRequest/details/pullRequestDetails.tsx
+++ b/static/app/views/pullRequest/details/pullRequestDetails.tsx
@@ -3,6 +3,7 @@ import {TabList} from 'sentry/components/core/tabs';
 import {Heading, Text} from 'sentry/components/core/text';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
 import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
@@ -102,9 +103,9 @@ export default function PullRequestDetails() {
         <PullRequestDetailsHeaderContent pullRequest={prSuccessData} />
         <Layout.HeaderTabs value={selectedTab || 'files'} onChange={setSelectedTab}>
           <TabList>
-            <TabList.Item key="files">Files</TabList.Item>
+            <TabList.Item key="files">{t('Files')}</TabList.Item>
             {hasSizeAnalysis ? (
-              <TabList.Item key="size_analysis">Size Analysis</TabList.Item>
+              <TabList.Item key="size_analysis">{t('Size Analysis')}</TabList.Item>
             ) : null}
           </TabList>
         </Layout.HeaderTabs>

--- a/static/app/views/pullRequest/index.tsx
+++ b/static/app/views/pullRequest/index.tsx
@@ -3,6 +3,7 @@ import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {t} from 'sentry/locale';
+import {UrlParamBatchProvider} from 'sentry/utils/url/urlParamBatchContext';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
@@ -26,7 +27,9 @@ function PullRequestContainer({children}: Props) {
         </Layout.Page>
       )}
     >
-      <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
+      <NoProjectMessage organization={organization}>
+        <UrlParamBatchProvider>{children}</UrlParamBatchProvider>
+      </NoProjectMessage>
     </Feature>
   );
 }

--- a/static/app/views/pullRequest/types/pullRequestDetailsTypes.ts
+++ b/static/app/views/pullRequest/types/pullRequestDetailsTypes.ts
@@ -1,3 +1,5 @@
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+
 export type PullRequestState = 'open' | 'closed' | 'merged' | 'draft';
 type PullRequestFileStatus = 'added' | 'modified' | 'removed' | 'renamed';
 
@@ -40,6 +42,7 @@ interface PullRequestFileChange {
 }
 
 export interface PullRequestDetailsSuccessResponse {
+  build_details: BuildDetailsApiResponse[];
   files: PullRequestFileChange[];
   pull_request: PullRequestDetails;
 }


### PR DESCRIPTION
Adds size analysis info as a tab in the PR page if available.

<img width="1560" height="1000" alt="Screenshot 2025-10-02 at 4 01 20 PM" src="https://github.com/user-attachments/assets/a2334a35-976d-426e-a913-54f29d0537b7" />

Unfortunately also adds our route to use `:projectId` which I'll try to remove in upcoming PRs, but for now we're tied to needing project for querying size data from the backend.