### PR TITLE
chore(aci): Add timer to track Detector evaluation duration

### DIFF
--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -241,7 +241,10 @@ def process_detectors[T](
             tags={"detector_type": detector.type},
         )
 
-        detector_results = handler.evaluate(data_packet)
+        with metrics.timer(
+            "workflow_engine.process_detectors.evaluate", tags={"detector_type": detector.type}
+        ):
+            detector_results = handler.evaluate(data_packet)
 
         if detector_results is None:
             return results


### PR DESCRIPTION
It'll be nice to have fine-grained per detector-type data on evaluation duration distributions.