### PR TITLE
feat: Add a copy DSN button to the getting started docs

### DIFF
--- a/static/app/views/projectInstall/dsnSection.tsx
+++ b/static/app/views/projectInstall/dsnSection.tsx
@@ -48,10 +48,8 @@ export function DsnSection({organization, project, platform}: Props) {
 
   return (
     <SimpleContainer>
-      <StyledTextCopyInput onCopy={handleCopyDsn}>
-        {dsn.public}
-      </StyledTextCopyInput>
-      <SnarkyText>{t("TL;DR, if you just need the DSN, there you go.")}</SnarkyText>
+      <StyledTextCopyInput onCopy={handleCopyDsn}>{dsn.public}</StyledTextCopyInput>
+      <SnarkyText>{t('TL;DR, if you just need the DSN, there you go.')}</SnarkyText>
     </SimpleContainer>
   );
 }

--- a/static/app/views/projectInstall/dsnSection.tsx
+++ b/static/app/views/projectInstall/dsnSection.tsx
@@ -1,0 +1,71 @@
+import styled from '@emotion/styled';
+
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import TextCopyInput from 'sentry/components/textCopyInput';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Organization} from 'sentry/types/organization';
+import type {PlatformIntegration, Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useProjectKeys} from 'sentry/utils/useProjectKeys';
+
+type Props = {
+  organization: Organization;
+  platform?: PlatformIntegration;
+  project?: Project;
+};
+
+export function DsnSection({organization, project, platform}: Props) {
+  const projectKeys = useProjectKeys({
+    orgSlug: organization.slug,
+    projSlug: project?.slug,
+  });
+
+  if (!project) {
+    return null;
+  }
+
+  if (projectKeys.isPending) {
+    return (
+      <SimpleContainer>
+        <LoadingIndicator mini />
+      </SimpleContainer>
+    );
+  }
+
+  const dsn = projectKeys.data?.[0]?.dsn;
+
+  if (!dsn) {
+    return null;
+  }
+
+  const handleCopyDsn = () => {
+    trackAnalytics('onboarding.dsn-copied', {
+      organization,
+      platform: platform?.name ?? 'unknown',
+    });
+  };
+
+  return (
+    <SimpleContainer>
+      <StyledTextCopyInput onCopy={handleCopyDsn}>
+        {dsn.public}
+      </StyledTextCopyInput>
+      <SnarkyText>{t("TL;DR, if you just need the DSN, there you go.")}</SnarkyText>
+    </SimpleContainer>
+  );
+}
+
+const SimpleContainer = styled('div')`
+  margin-bottom: ${space(3)};
+`;
+
+const SnarkyText = styled('p')`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSize.sm};
+  margin: ${space(1)} 0 0 0;
+`;
+
+const StyledTextCopyInput = styled(TextCopyInput)`
+  width: 100%;
+`;

--- a/static/app/views/projectInstall/gettingStarted.tsx
+++ b/static/app/views/projectInstall/gettingStarted.tsx
@@ -39,14 +39,14 @@ function GettingStarted({params}: Props) {
         {loadingProjects ? (
           <LoadingIndicator />
         ) : project ? (
-          <>
+          <React.Fragment>
             <DsnSection
               organization={organization}
               project={project}
               platform={currentPlatform}
             />
             <ProjectInstallPlatform project={project} platform={currentPlatform} />
-          </>
+          </React.Fragment>
         ) : (
           <Redirect
             to={makeProjectsPathname({

--- a/static/app/views/projectInstall/gettingStarted.tsx
+++ b/static/app/views/projectInstall/gettingStarted.tsx
@@ -11,6 +11,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
+import {DsnSection} from './dsnSection';
 import {ProjectInstallPlatform} from './platform';
 
 type Props = RouteComponentProps<{projectId: string}>;
@@ -38,7 +39,14 @@ function GettingStarted({params}: Props) {
         {loadingProjects ? (
           <LoadingIndicator />
         ) : project ? (
-          <ProjectInstallPlatform project={project} platform={currentPlatform} />
+          <>
+            <DsnSection
+              organization={organization}
+              project={project}
+              platform={currentPlatform}
+            />
+            <ProjectInstallPlatform project={project} platform={currentPlatform} />
+          </>
         ) : (
           <Redirect
             to={makeProjectsPathname({


### PR DESCRIPTION
Adding a convenient way to just copy the DSN when creating a new project.
Needs some design tweaks.

<img width="1150" height="812" alt="image" src="https://github.com/user-attachments/assets/4ad4aad0-209c-4f46-9a0d-30fc438e552a" />
