### PR TITLE
feat(features): add vercel log drain endpoint feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -292,6 +292,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:relay-otlp-traces-endpoint", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables OTLP Log ingestion in Relay for an entire org.
     manager.add("organizations:relay-otel-logs-endpoint", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enables Vercel Log Drain ingestion in Relay for an entire org.
+    manager.add("organizations:relay-vercel-log-drain-endpoint", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Prevent AI in the Sentry UI
     manager.add("organizations:prevent-ai", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Prevent AI Configuration Page in the Sentry UI

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -72,6 +72,7 @@ EXPOSABLE_FEATURES = [
     "organizations:indexed-spans-extraction",
     "organizations:relay-otlp-traces-endpoint",
     "organizations:relay-otel-logs-endpoint",
+    "organizations:relay-vercel-log-drain-endpoint",
     "organizations:ourlogs-ingestion",
     "organizations:tracemetrics-ingestion",
     "organizations:view-hierarchy-scrubbing",


### PR DESCRIPTION
ref https://www.notion.so/sentry/Vercel-Log-Drain-2808b10e4b5d808c95f3ebcfe2b8828a

resolves https://linear.app/getsentry/issue/LOGS-390/add-feature-flag-for-vercel-log-drains-to-sentry

We're adding support for vercel log drain: https://github.com/getsentry/sentry/issues/91726. This PR adds a feature flag for this endpoint in Relay. Relay PR: https://github.com/getsentry/relay/pull/5208