### PR TITLE
Dump stack trace during consumer shutdown

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3500,3 +3500,14 @@ register(
     default="plaintext",
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Lists all the consumers we want to dump the stacktrace upon shutdown.
+# We have seen some consumers hanging after restart. This should help
+# us to identify where they get stuck.
+# The consumer name is the ones defined in sentry.consumers.KAFKA_CONSUMERS.
+register(
+    "consumer.dump_stacktrace_on_shutdown",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -573,6 +573,7 @@ def basic_consumer(
     """
     from sentry.consumers import get_stream_processor
     from sentry.metrics.middleware import add_global_tags
+    from sentry.options import get
 
     log_level = options.pop("log_level", None)
     if log_level is not None:
@@ -594,7 +595,11 @@ def basic_consumer(
     if not quantized_rebalance_delay_secs and consumer_name == "ingest-generic-metrics":
         quantized_rebalance_delay_secs = options.get("sentry-metrics.synchronized-rebalance-delay")
 
-    run_processor_with_signals(processor, quantized_rebalance_delay_secs)
+    dump_stacktrace_on_shutdown = consumer_name in get("consumer.dump_stacktrace_on_shutdown", [])
+
+    run_processor_with_signals(
+        processor, quantized_rebalance_delay_secs, dump_stacktrace_on_shutdown
+    )
 
 
 @run.command("dev-consumer")


### PR DESCRIPTION
We have been seeing a number of cases where, on small workloads, upon consumer restart,
a parallel Kafka Consuemr may hang right after partitions are assigned.
In this scenario the consumer does not pick up any work and, after 30 seconds is kicked
out of the consumer group. 

The consumer is then restarted by the liveness probe 5 minutes later.

This PR dumps the stack trace of all threads upon SIGINT if the consumer
is listed in a specific option `consumer.dump_stacktrace_on_shutdown`.

This way we should be able to see where the consumer gets stuck, thus find a fix.
