### PR TITLE
fix(releases): fix new issue count on releases index

### DIFF
--- a/static/app/views/projectDetail/projectIssues.tsx
+++ b/static/app/views/projectDetail/projectIssues.tsx
@@ -36,7 +36,7 @@ enum IssuesType {
   ALL = 'all',
 }
 
-export enum IssuesQuery {
+enum IssuesQuery {
   NEW = 'is:unresolved is:for_review',
   UNHANDLED = 'error.unhandled:true is:unresolved',
   REGRESSED = 'regressed_in_release:latest',

--- a/static/app/views/projectDetail/projectIssues.tsx
+++ b/static/app/views/projectDetail/projectIssues.tsx
@@ -36,7 +36,7 @@ enum IssuesType {
   ALL = 'all',
 }
 
-enum IssuesQuery {
+export enum IssuesQuery {
   NEW = 'is:unresolved is:for_review',
   UNHANDLED = 'error.unhandled:true is:unresolved',
   REGRESSED = 'regressed_in_release:latest',

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -91,7 +91,7 @@ describe('ReleasesList', () => {
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues-count/',
-      body: [],
+      body: {},
     });
 
     MockApiClient.addMockResponse({

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -90,6 +90,11 @@ describe('ReleasesList', () => {
     });
 
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues-count/',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
       url: `/projects/org-slug/${projects[0]!.slug}/`,
       body: [],
     });

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -28,6 +28,7 @@ import useFinalizeRelease from 'sentry/views/releases/components/useFinalizeRele
 import type {ReleasesDisplayOption} from 'sentry/views/releases/list/releasesDisplayOptions';
 import type {ReleasesRequestRenderProps} from 'sentry/views/releases/list/releasesRequest';
 import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
+import {useReleaseIssueCountsByProject} from 'sentry/views/releases/utils/useReleaseIssueCountsByProject';
 
 import ReleaseCardCommits from './releaseCardCommits';
 import ReleaseCardProjectRow from './releaseCardProjectRow';
@@ -88,9 +89,16 @@ function ReleaseCard({
     dateCreated,
     versionInfo,
     adoptionStages,
-    newGroups,
     projects,
   } = release;
+
+  // Fetch issue counts for each project in this release
+  const issueCountsByProject = useReleaseIssueCountsByProject({
+    organization,
+    projects,
+    releaseVersion: version,
+    selection,
+  });
 
   const [projectsToShow, projectsToHide] = useMemo(() => {
     // sort health rows inside release card alphabetically by project name,
@@ -257,6 +265,8 @@ function ReleaseCard({
           >
             {projectsToShow.map((project, index) => {
               const key = `${project.slug}-${version}`;
+              const newGroups = issueCountsByProject[project.id] || 0;
+
               return (
                 <ReleaseCardProjectRow
                   key={`${key}-row`}

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -16,6 +16,7 @@ import NotAvailable from 'sentry/components/notAvailable';
 import {extractSelectionParameters} from 'sentry/components/organizations/pageFilters/utils';
 import PanelItem from 'sentry/components/panels/panelItem';
 import Placeholder from 'sentry/components/placeholder';
+import QueryCount from 'sentry/components/queryCount';
 import {IconCheckmark, IconFire, IconWarning} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -208,7 +209,12 @@ function ReleaseCardProjectRow({
             <GlobalSelectionLink
               to={getReleaseNewIssuesUrl(organization.slug, project.id, releaseVersion)}
             >
-              <Count value={newGroups || 0} />
+              <QueryCount
+                count={newGroups || 0}
+                max={100}
+                hideParens
+                hideIfEmpty={false}
+              />
             </GlobalSelectionLink>
           </Tooltip>
         </NewIssuesColumn>

--- a/static/app/views/releases/utils/useReleaseIssueCountsByProject.tsx
+++ b/static/app/views/releases/utils/useReleaseIssueCountsByProject.tsx
@@ -1,0 +1,69 @@
+import type {PageFilters} from 'sentry/types/core';
+import type {Organization} from 'sentry/types/organization';
+import type {ReleaseProject} from 'sentry/types/release';
+import {useApiQueries} from 'sentry/utils/queryClient';
+
+interface UseReleaseIssueCountsByProjectOptions {
+  organization: Organization;
+  projects: ReleaseProject[];
+  releaseVersion: string;
+  selection: PageFilters;
+  issueQuery?: string;
+}
+
+/**
+ * Fetch issue counts for projects in a release
+ * Returns a map of project ID to issue count
+ *
+ * Note: Counts are limited to 100 per project due to API constraints.
+ */
+export function useReleaseIssueCountsByProject({
+  organization,
+  projects,
+  releaseVersion,
+  selection,
+  issueQuery = `first-release:"${releaseVersion}"`,
+}: UseReleaseIssueCountsByProjectOptions): Record<number, number> {
+  // Only include projects that are both in the release AND in the selected projects
+  const validProjects =
+    selection.projects.length > 0 && !selection.projects.includes(-1)
+      ? projects.filter(p => selection.projects.includes(p.id))
+      : projects;
+
+  const issueCountQueryKeys = validProjects.map(
+    project =>
+      [
+        `/organizations/${organization.slug}/issues-count/`,
+        {
+          query: {
+            query: [issueQuery],
+            project: [project.id],
+            environment: selection.environments,
+            statsPeriod: selection.datetime.period,
+            start: selection.datetime.start
+              ? new Date(selection.datetime.start).toISOString()
+              : undefined,
+            end: selection.datetime.end
+              ? new Date(selection.datetime.end).toISOString()
+              : undefined,
+          },
+        },
+      ] as const
+  );
+
+  const issueCountResults = useApiQueries<Record<string, number>>(issueCountQueryKeys, {
+    staleTime: 180000, // 3 minutes
+  });
+
+  // Map project ID to new issue count
+  const issueCountsByProject = validProjects.reduce(
+    (acc, project, index) => {
+      const result = issueCountResults[index];
+      acc[project.id] = result?.data?.[issueQuery] || 0;
+      return acc;
+    },
+    {} as Record<number, number>
+  );
+
+  return issueCountsByProject;
+}


### PR DESCRIPTION
## before:

<img width="621" height="575" alt="SCR-20251002-qckf" src="https://github.com/user-attachments/assets/6e7ca720-9128-4aae-969e-5c4f956a7380" />

**customer reported bug:** the number of new issues on the releases page is incorrect -- for some reason it shows the same number for all the projects in that release.

**the root cause:** the number is the same right now because it's the total number of new issues across all projects for that release (comes from `release.newGroups` returned from the `/releases/` endpoint).

 we didn't have immediate access to the # of new issues per project per release. the value being returned by `release.projects[x].newGroups` (also returned from the `/releases/` endpoint) is the sum of new groups across ALL releases for that project -- it's not filtered by release. the value displayed under the new issues column _used_ to be that originally — which was also wrong (it was "fixed" [here](https://github.com/getsentry/sentry/pull/99555/files)). 

see below for an illustrated explanation of this since this is confusing.

## after:

**the solution:** to fix that new issues number and make it distinct for each project, we have to make an additional query to `/issues-count/` for each selected project -- to get the number of new groups for that project, filtered by that release. 

also note that if the `/issues-count/` result is greater than 100 (the api limits to 100), then we will display 100+ (see image below)

also, finally, the number shown in the "new issues" column matches the number of issues you see once you click into the "new issues" link. (unless the # of new issues > 100) yay

<img width="1339" height="373" alt="SCR-20251002-rbij" src="https://github.com/user-attachments/assets/c07aa734-a37b-4868-9f1a-14e2e64ac5d7" />



## the data & the solution drawn out, in case the above description was confusing.


<img width="783" height="558" alt="SCR-20251002-rlhc" src="https://github.com/user-attachments/assets/6ca551a2-c919-4903-acae-f85df7df9abb" />

<img width="484" height="419" alt="SCR-20251002-rmyd" src="https://github.com/user-attachments/assets/7b2c20d8-ea66-456b-94ed-03377079a0fb" />

<img width="468" height="411" alt="SCR-20251002-rnai" src="https://github.com/user-attachments/assets/a3967172-a342-479e-87e5-439eb16b7a28" />
<img width="447" height="374" alt="SCR-20251002-rnbc" src="https://github.com/user-attachments/assets/4b397480-3f2a-48ab-9c2f-bba348c82fa2" />


closes https://linear.app/getsentry/issue/REPLAY-761/incorrect-new-issues-count-in-release-views-for-all-projects

