### PR TITLE
fix(feedback): dont track categories error response if no seer ack

### DIFF
--- a/static/app/components/feedback/summaryCategories/feedbackCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackCategories.tsx
@@ -55,7 +55,7 @@ export default function FeedbackCategories() {
 
   useEffect(() => {
     // Analytics for the rendered state. Should match the conditions below.
-    if (isPending || isOrgSeerSetupPending) {
+    if (isPending || isOrgSeerSetupPending || !setupAcknowledgement.orgHasAcknowledged) {
       return;
     }
     if (isError) {
@@ -70,7 +70,7 @@ export default function FeedbackCategories() {
       trackAnalytics('feedback.summary.categories-empty', {
         organization,
       });
-    } else if (setupAcknowledgement.orgHasAcknowledged) {
+    } else {
       trackAnalytics('feedback.summary.categories-rendered', {
         organization,
         num_categories: categories.length,


### PR DESCRIPTION
The errors we're seeing right now are only from lack of seer acknowledgement, since that's checked on the [backend](https://github.com/getsentry/sentry/blob/da7e3359f92403d099b011d789d0bde522009bbc/src/sentry/feedback/endpoints/organization_feedback_categories.py#L120-L127) too and we 403 if it's missing. This event's already tracked in FeedbackSummary component, so can return null here