### PR TITLE
Configure objectstore in tests

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2080,6 +2080,10 @@ SENTRY_USE_TASKBROKER = False
 # This flag activates the objectstore in devservices
 SENTRY_USE_OBJECTSTORE = False
 
+# Configures the objectstore in the dev environment
+if IS_DEV:
+    SENTRY_OPTIONS["objectstore.config"] = {"base_url": "http://localhost:8888/"}
+
 # Max file size for serialized file uploads in API
 SENTRY_MAX_SERIALIZED_FILE_SIZE = 5000000
 

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -258,6 +258,9 @@ def pytest_configure(config: pytest.Config) -> None:
     settings.SENTRY_OPTIONS["filestore.control.backend"] = "filesystem"
     settings.SENTRY_OPTIONS["filestore.control.options"] = {"location": "/tmp/sentry-files"}
 
+    # Configure objectstore for local development
+    settings.SENTRY_OPTIONS["objectstore.config"] = {"base_url": "http://localhost:8888/"}
+
     # This is so tests can assume this feature is off by default
     settings.SENTRY_FEATURES["organizations:performance-view"] = False
 

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -91,13 +91,7 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
     def test_doublewrite_objectstore(self) -> None:
         self.login_as(user=self.user)
 
-        with override_options(
-            {
-                # TODO: we should make sure the default works for local tests
-                "objectstore.config": {"base_url": "http://localhost:8888/"},
-                "objectstore.double_write.attachments": 1,
-            }
-        ):
+        with override_options({"objectstore.double_write.attachments": 1}):
             attachment = self.create_attachment()
 
             assert attachment.blob_path is not None
@@ -122,13 +116,7 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
     def test_download_objectstore(self) -> None:
         self.login_as(user=self.user)
 
-        with override_options(
-            {
-                # TODO: we should make sure the default works for local tests
-                "objectstore.config": {"base_url": "http://localhost:8888/"},
-                "objectstore.enable_for.attachments": 1,
-            }
-        ):
+        with override_options({"objectstore.enable_for.attachments": 1}):
             attachment = self.create_attachment()
 
             assert attachment.blob_path is not None


### PR DESCRIPTION
This adds some default configuration for the objectstore used for tests.