### PR TITLE
ref(test): forward queryString to NuqsTestingProvider

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -805,6 +805,7 @@ export default typescript.config([
     name: 'files/sentry-test',
     files: ['**/*.spec.{ts,js,tsx,jsx}', 'tests/js/**/*.{ts,js,tsx,jsx}'],
     rules: {
+      '@typescript-eslint/await-thenable': 'off', // For awaiting act(...)
       'no-loss-of-precision': 'off', // Sometimes we have wild numbers hard-coded in tests
       'no-restricted-imports': [
         'error',

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -64,6 +64,7 @@ interface ProviderOptions {
    * Sets the OrganizationContext. You may pass null to provide no organization
    */
   organization?: Partial<Organization> | null;
+  query?: string;
   /**
    * Sets the RouterContext.
    */
@@ -173,11 +174,18 @@ function patchBrowserHistoryMocksEnabled(history: MemoryHistory, router: Injecte
   });
 }
 
-function NuqsTestingAdapterWithNavigate({children}: {children: React.ReactNode}) {
+function NuqsTestingAdapterWithNavigate({
+  children,
+  query,
+}: {
+  children: React.ReactNode;
+  query: string;
+}) {
   const location = useLocation();
   const navigate = useNavigate();
   return (
     <NuqsTestingAdapter
+      searchParams={new URLSearchParams(query)}
       defaultOptions={{shallow: false}}
       onUrlUpdate={({queryString, options: nuqsOptions}) => {
         // Pass navigation events to the test router
@@ -235,7 +243,7 @@ function makeAllTheProviders(options: ProviderOptions) {
     return (
       <CacheProvider value={{...cache, compat: true}}>
         <QueryClientProvider client={makeTestQueryClient()}>
-          <NuqsTestingAdapterWithNavigate>
+          <NuqsTestingAdapterWithNavigate query={options.query ?? ''}>
             <ThemeProvider theme={ThemeFixture()}>{wrappedContent}</ThemeProvider>
           </NuqsTestingAdapterWithNavigate>
         </QueryClientProvider>
@@ -359,14 +367,21 @@ function parseLocationConfig(location: LocationConfig | undefined): InitialEntry
   }
 
   if (location.query) {
-    const queryString = qs.stringify(location.query);
     return {
       pathname: location.pathname,
-      search: queryString ? `?${queryString}` : '',
+      search: parseQueryString(location.query),
     };
   }
 
   return location.pathname;
+}
+
+function parseQueryString(query: Record<string, string | number | string[]> | undefined) {
+  if (!query) {
+    return '';
+  }
+  const queryString = qs.stringify(query);
+  return queryString ? `?${queryString}` : '';
 }
 
 function getInitialRouterConfig<T extends boolean = true>(
@@ -426,6 +441,10 @@ function render<T extends boolean = false>(
     router: legacyRouterConfig,
     deprecatedRouterMocks: options.deprecatedRouterMocks,
     history,
+    query:
+      typeof config?.location === 'string'
+        ? ''
+        : parseQueryString(config?.location?.query),
   });
 
   const memoryRouter = makeRouter({
@@ -483,6 +502,10 @@ function renderHookWithProviders<Result = unknown, Props = unknown>(
     router: legacyRouterConfig,
     deprecatedRouterMocks: false,
     history,
+    query:
+      typeof config?.location === 'string'
+        ? ''
+        : parseQueryString(config?.location?.query),
   });
 
   let memoryRouter: Router | null = null;


### PR DESCRIPTION
nuqs must need to know about the query string we set to our router, so we have to forward them to the NuqsTestingProvider