### PR TITLE
ref(analytics): Simplify event recording method by removing deprecated overloads

### DIFF
--- a/src/sentry/analytics/base.py
+++ b/src/sentry/analytics/base.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, overload
-from warnings import deprecated
 
 from sentry.analytics.event import Event, EventEnvelope
 from sentry.utils.services import Service
@@ -17,8 +15,7 @@ class Analytics(Service, abc.ABC):
 
     event_manager = default_manager
 
-    @overload
-    def record(self, event_or_type: Event) -> None:
+    def record(self, event: Event) -> None:
         """
         Record an event. Must be an instance of a subclass of `Event`.
 
@@ -29,35 +26,6 @@ class Analytics(Service, abc.ABC):
         ...     )
         ... )
         """
-        ...
-
-    @overload
-    @deprecated("Use the `record` method with an event class instead.")
-    def record(self, event_or_type: str, instance: Any | None = None, **kwargs: Any) -> None:
-        """
-        Record an event, using its `type` name and kwargs. Deprecated, the version of this function
-        where an event is directly passed is preferred, as it is more type-safe.
-
-        >>> analytics.record(
-        ...     "my-event",
-        ...     some_id=123,
-        ...     some_prop="abc"
-        ... )
-        """
-        ...
-
-    def record(
-        self,
-        event_or_type: Event | str,
-        instance: Any = None,
-        **kwargs: Any,
-    ) -> None:
-        if isinstance(event_or_type, str):
-            event_cls = self.event_manager.get(event_or_type)
-            event = event_cls.from_instance(instance, **kwargs)
-        else:
-            event = event_or_type
-
         self.record_event_envelope(EventEnvelope(event=event))
 
     def record_event_envelope(self, envelope: EventEnvelope) -> None:

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -171,9 +171,6 @@ class BaseNotification(abc.ABC):
         """
         return None
 
-    def record_analytics(self, event_name: str, *args: Any, **kwargs: Any) -> None:
-        analytics.record(event_name, *args, **kwargs)
-
     def record_notification_sent(self, recipient: Actor, provider: ExternalProviders) -> None:
         from sentry.integrations.discord.analytics import DiscordIntegrationNotificationSent
         from sentry.integrations.msteams.analytics import MSTeamsIntegrationNotificationSent

--- a/tests/sentry/analytics/test_base.py
+++ b/tests/sentry/analytics/test_base.py
@@ -1,5 +1,6 @@
 from sentry.analytics import Analytics
 from sentry.analytics.event import EventEnvelope
+from sentry.analytics.events.organization_created import OrganizationCreatedEvent
 from sentry.testutils.cases import TestCase
 
 
@@ -18,7 +19,13 @@ class AnalyticsTest(TestCase):
     def test_record(self) -> None:
         organization = self.create_organization()
         provider = DummyAnalytics()
-        provider.record("organization.created", organization)
+        provider.record(
+            OrganizationCreatedEvent(
+                id=organization.id,
+                name=organization.name,
+                slug=organization.slug,
+            )
+        )
         assert len(provider.events) == 1
         event = provider.events.pop(0)
         envelope = provider.event_envelopes.pop(0)
@@ -26,15 +33,3 @@ class AnalyticsTest(TestCase):
         assert event.type == "organization.created"
         assert event.slug == organization.slug
         assert not event.actor_id
-
-    def test_record_with_attrs(self) -> None:
-        organization = self.create_organization()
-        provider = DummyAnalytics()
-        provider.record("organization.created", organization, actor_id=1)
-        assert len(provider.events) == 1
-        event = provider.events.pop(0)
-        envelope = provider.event_envelopes.pop(0)
-        assert event.type == "organization.created"
-        assert envelope.datetime
-        assert event.slug == organization.slug
-        assert event.actor_id == 1


### PR DESCRIPTION
The `record` method has been streamlined to accept a single `Event` instance, enhancing type safety. Deprecated overloads for recording events by type and instance have been removed to simplify the API.

Closes https://linear.app/getsentry/issue/TET-1232/analytics-remove-record-overloads