### PR TITLE
ref(analytics): Refactor EventManager to extend Registry for event registration

### DIFF
--- a/src/sentry/analytics/event_manager.py
+++ b/src/sentry/analytics/event_manager.py
@@ -10,4 +10,4 @@ class EventManager(Registry[type[Event]]):
         return super().register(event_cls.type)(event_cls)
 
 
-default_manager = EventManager()
+default_manager = EventManager(allow_reregistration=True)

--- a/src/sentry/analytics/event_manager.py
+++ b/src/sentry/analytics/event_manager.py
@@ -1,24 +1,13 @@
 __all__ = ("default_manager", "EventManager")
 
-from collections.abc import MutableMapping
-from typing import Any
 
 from sentry.analytics.event import Event
+from sentry.utils.registry import Registry
 
 
-class EventManager:
-    def __init__(self) -> None:
-        self._event_types: MutableMapping[Any, type[Event]] = {}
-
+class EventManager(Registry[type[Event]]):
     def register(self, event_cls: type[Event]) -> None:
-        event_type = event_cls.type
-        if event_type in self._event_types:
-            assert self._event_types[event_type] == event_cls
-        else:
-            self._event_types[event_type] = event_cls
-
-    def get(self, type: str) -> type[Event]:
-        return self._event_types[type]
+        return super().register(event_cls.type)(event_cls)
 
 
 default_manager = EventManager()

--- a/src/sentry/utils/registry.py
+++ b/src/sentry/utils/registry.py
@@ -17,23 +17,28 @@ class Registry[T]:
     If you have duplicate values, you may want to disable reverse lookup.
     """
 
-    def __init__(self, enable_reverse_lookup: bool = True) -> None:
+    def __init__(
+        self, enable_reverse_lookup: bool = True, allow_reregistration: bool = False
+    ) -> None:
         self.registrations: dict[str, T] = {}
         self.reverse_lookup: dict[T, str] = {}
         self.enable_reverse_lookup = enable_reverse_lookup
+        self.allow_reregistration = allow_reregistration
 
     def register(self, key: str) -> Callable[[T], T]:
         def inner(item: T) -> T:
             if key in self.registrations:
-                raise AlreadyRegisteredError(
-                    f"A registration already exists for {key}: {self.registrations[key]}"
-                )
+                if not self.allow_reregistration or self.registrations[key] != item:
+                    raise AlreadyRegisteredError(
+                        f"A registration already exists for {key}: {self.registrations[key]}"
+                    )
 
             if self.enable_reverse_lookup:
                 if item in self.reverse_lookup:
-                    raise AlreadyRegisteredError(
-                        f"A registration already exists for {item}: {self.reverse_lookup[item]}"
-                    )
+                    if not self.allow_reregistration or self.reverse_lookup[item] != key:
+                        raise AlreadyRegisteredError(
+                            f"A registration already exists for {item}: {self.reverse_lookup[item]}"
+                        )
                 self.reverse_lookup[item] = key
 
             self.registrations[key] = item

--- a/tests/sentry/utils/test_registry.py
+++ b/tests/sentry/utils/test_registry.py
@@ -53,3 +53,28 @@ class RegistryTest(TestCase):
 
         test_registry.register("something else")(registered_func)
         assert test_registry.get("something else") == registered_func
+
+    def test_allow_reregistration(self) -> None:
+        test_registry = Registry[Callable[[], None]](allow_reregistration=True)
+
+        @test_registry.register("something")
+        def registered_func():
+            raise NotImplementedError
+
+        test_registry.register("something")(registered_func)
+        assert test_registry.get("something") == registered_func
+        assert test_registry.get_key(registered_func) == "something"
+
+        test_registry.register("something")(registered_func)
+
+    def test_allow_reregistration_with_reverse_lookup(self) -> None:
+        test_registry = Registry[Callable[[], None]](
+            enable_reverse_lookup=True, allow_reregistration=True
+        )
+
+        @test_registry.register("something")
+        def registered_func():
+            raise NotImplementedError
+
+        with pytest.raises(AlreadyRegisteredError):
+            test_registry.register("something 2")(registered_func)


### PR DESCRIPTION
The EventManager class has been simplified by extending the Registry class, allowing for more efficient event type registration. The previous manual management of event types has been removed in favor of leveraging the Registry's built-in functionality.
