### PR TITLE
ref(test): disallow location as a string

### DIFF
--- a/static/app/components/globalDrawer/index.spec.tsx
+++ b/static/app/components/globalDrawer/index.spec.tsx
@@ -83,7 +83,7 @@ describe('GlobalDrawer', () => {
           },
         }}
       />,
-      {initialRouterConfig: {location: '/my-modal-view/'}}
+      {initialRouterConfig: {location: {pathname: '/my-modal-view/'}}}
     );
 
     await userEvent.click(screen.getByTestId('drawer-test-open'));

--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -77,7 +77,7 @@ describe('LogsPage', () => {
     render(<LogsPage />, {
       organization,
       initialRouterConfig: {
-        location: `/organizations/${organization.slug}/explore/logs/`,
+        location: {pathname: `/organizations/${organization.slug}/explore/logs/`},
       },
     });
 
@@ -141,7 +141,7 @@ describe('LogsPage', () => {
     render(<LogsPage />, {
       organization,
       initialRouterConfig: {
-        location: `/organizations/${organization.slug}/explore/logs/`,
+        location: {pathname: `/organizations/${organization.slug}/explore/logs/`},
       },
     });
 
@@ -157,7 +157,7 @@ describe('LogsPage', () => {
     render(<LogsPage />, {
       organization,
       initialRouterConfig: {
-        location: `/organizations/${organization.slug}/explore/logs/`,
+        location: {pathname: `/organizations/${organization.slug}/explore/logs/`},
       },
     });
 

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -1114,7 +1114,7 @@ describe('Customer Details', () => {
 
     render(<CustomerDetails />, {
       initialRouterConfig: {
-        location: `/customers/${organization.slug}`,
+        location: {pathname: `/customers/${organization.slug}`},
         route: `/customers/:orgId`,
       },
       organization,
@@ -1128,7 +1128,7 @@ describe('Customer Details', () => {
 
     render(<CustomerDetails />, {
       initialRouterConfig: {
-        location: `/customers/${organization.slug}`,
+        location: {pathname: `/customers/${organization.slug}`},
         route: `/customers/:orgId`,
       },
       organization,
@@ -1168,7 +1168,7 @@ describe('Customer Details', () => {
 
     render(<CustomerDetails />, {
       initialRouterConfig: {
-        location: `/customers/${organization.slug}`,
+        location: {pathname: `/customers/${organization.slug}`},
         route: `/customers/:orgId`,
       },
       organization,
@@ -1213,7 +1213,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -1245,7 +1245,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${softCapOrg.slug}`,
+          location: {pathname: `/customers/${softCapOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: softCapOrg,
@@ -1268,7 +1268,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${softCapOrg.slug}`,
+          location: {pathname: `/customers/${softCapOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: softCapOrg,
@@ -1297,7 +1297,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${softCapOrg.slug}`,
+          location: {pathname: `/customers/${softCapOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: softCapOrg,
@@ -1342,7 +1342,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${softCapOrg.slug}`,
+          location: {pathname: `/customers/${softCapOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: softCapOrg,
@@ -1394,7 +1394,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${softCapOrg.slug}`,
+          location: {pathname: `/customers/${softCapOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: softCapOrg,
@@ -1421,7 +1421,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${softCapOrg.slug}`,
+          location: {pathname: `/customers/${softCapOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: softCapOrg,
@@ -1454,7 +1454,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${softCapOrg.slug}`,
+          location: {pathname: `/customers/${softCapOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: softCapOrg,
@@ -1502,7 +1502,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${noNotificationsOrg.slug}`,
+          location: {pathname: `/customers/${noNotificationsOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: noNotificationsOrg,
@@ -1544,7 +1544,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${pendingChangesOrg.slug}`,
+          location: {pathname: `/customers/${pendingChangesOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: pendingChangesOrg,
@@ -1566,7 +1566,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -1592,7 +1592,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${cannotTrialOrg.slug}`,
+          location: {pathname: `/customers/${cannotTrialOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: cannotTrialOrg,
@@ -1614,7 +1614,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -1636,7 +1636,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -1664,7 +1664,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${cannotTrialOrg.slug}`,
+          location: {pathname: `/customers/${cannotTrialOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: cannotTrialOrg,
@@ -1706,7 +1706,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${gracePeriodOrg.slug}`,
+          location: {pathname: `/customers/${gracePeriodOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: gracePeriodOrg,
@@ -1728,7 +1728,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -1764,7 +1764,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${gracePeriodOrg.slug}`,
+          location: {pathname: `/customers/${gracePeriodOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: gracePeriodOrg,
@@ -1812,7 +1812,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${terminateOrg.slug}`,
+          location: {pathname: `/customers/${terminateOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: terminateOrg,
@@ -1855,7 +1855,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${terminateOrg.slug}`,
+          location: {pathname: `/customers/${terminateOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: terminateOrg,
@@ -1893,7 +1893,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${terminateOrg.slug}`,
+          location: {pathname: `/customers/${terminateOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: terminateOrg,
@@ -1938,7 +1938,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -1999,7 +1999,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -2068,7 +2068,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -2107,7 +2107,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -2180,7 +2180,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -2229,7 +2229,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${cancelSubOrg.slug}`,
+          location: {pathname: `/customers/${cancelSubOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: cancelSubOrg,
@@ -2256,7 +2256,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${cancelSubOrg.slug}`,
+          location: {pathname: `/customers/${cancelSubOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: cancelSubOrg,
@@ -2330,7 +2330,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -2378,7 +2378,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -2416,7 +2416,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -2447,7 +2447,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${trialOrg.slug}`,
+          location: {pathname: `/customers/${trialOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: trialOrg,
@@ -2485,7 +2485,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -2534,7 +2534,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${onDemandInvoicedOrg.slug}`,
+          location: {pathname: `/customers/${onDemandInvoicedOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: onDemandInvoicedOrg,
@@ -2569,7 +2569,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${onDemandInvoicedOrg.slug}`,
+          location: {pathname: `/customers/${onDemandInvoicedOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: onDemandInvoicedOrg,
@@ -2604,7 +2604,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${onDemandInvoicedOrg.slug}`,
+          location: {pathname: `/customers/${onDemandInvoicedOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: onDemandInvoicedOrg,
@@ -2644,7 +2644,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${invoicedOrg.slug}`,
+          location: {pathname: `/customers/${invoicedOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: invoicedOrg,
@@ -2700,7 +2700,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${onDemandInvoicedOrg.slug}`,
+          location: {pathname: `/customers/${onDemandInvoicedOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: onDemandInvoicedOrg,
@@ -2746,7 +2746,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -2812,7 +2812,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -2861,7 +2861,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -2888,7 +2888,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -2923,7 +2923,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -2979,7 +2979,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -3037,7 +3037,7 @@ describe('Customer Details', () => {
 
     render(<CustomerDetails />, {
       initialRouterConfig: {
-        location: `/customers/${organization.slug}`,
+        location: {pathname: `/customers/${organization.slug}`},
         route: `/customers/:orgId`,
       },
       organization,
@@ -3094,7 +3094,7 @@ describe('Customer Details', () => {
 
     render(<CustomerDetails />, {
       initialRouterConfig: {
-        location: `/customers/${organization.slug}`,
+        location: {pathname: `/customers/${organization.slug}`},
         route: `/customers/:orgId`,
       },
       organization,
@@ -3150,7 +3150,7 @@ describe('Customer Details', () => {
 
     render(<CustomerDetails />, {
       initialRouterConfig: {
-        location: `/customers/${organization.slug}`,
+        location: {pathname: `/customers/${organization.slug}`},
         route: `/customers/:orgId`,
       },
       organization,
@@ -3175,7 +3175,7 @@ describe('Customer Details', () => {
 
     render(<CustomerDetails />, {
       initialRouterConfig: {
-        location: `/customers/${organization.slug}`,
+        location: {pathname: `/customers/${organization.slug}`},
         route: `/customers/:orgId`,
       },
       organization,
@@ -3201,7 +3201,7 @@ describe('Customer Details', () => {
 
     render(<CustomerDetails />, {
       initialRouterConfig: {
-        location: `/customers/${organization.slug}`,
+        location: {pathname: `/customers/${organization.slug}`},
         route: `/customers/:orgId`,
       },
       organization,
@@ -3266,7 +3266,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${invoicedOrg.slug}`,
+          location: {pathname: `/customers/${invoicedOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: invoicedOrg,
@@ -3292,7 +3292,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${invoicedOrg.slug}`,
+          location: {pathname: `/customers/${invoicedOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: invoicedOrg,
@@ -3324,7 +3324,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${suspendedOrg.slug}`,
+          location: {pathname: `/customers/${suspendedOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: suspendedOrg,
@@ -3352,7 +3352,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${suspendedOrg.slug}`,
+          location: {pathname: `/customers/${suspendedOrg.slug}`},
           route: `/customers/:orgId`,
         },
         organization: suspendedOrg,
@@ -3396,7 +3396,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -3452,7 +3452,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -3475,7 +3475,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -3504,7 +3504,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${organization.slug}`,
+          location: {pathname: `/customers/${organization.slug}`},
           route: `/customers/:orgId`,
         },
         organization,
@@ -3564,7 +3564,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${orgWithDeleteFeature.slug}`,
+          location: {pathname: `/customers/${orgWithDeleteFeature.slug}`},
           route: `/customers/:orgId`,
         },
         organization: orgWithDeleteFeature,
@@ -3591,7 +3591,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${orgWithoutDeleteFeature.slug}`,
+          location: {pathname: `/customers/${orgWithoutDeleteFeature.slug}`},
           route: `/customers/:orgId`,
         },
         organization: orgWithoutDeleteFeature,
@@ -3617,7 +3617,7 @@ describe('Customer Details', () => {
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
-          location: `/customers/${org.slug}`,
+          location: {pathname: `/customers/${org.slug}`},
           route: `/customers/:orgId`,
         },
         organization: org,
@@ -3705,7 +3705,7 @@ describe('Gift Categories Availability', () => {
 
     render(<CustomerDetails />, {
       initialRouterConfig: {
-        location: `/customers/${organization.slug}`,
+        location: {pathname: `/customers/${organization.slug}`},
         route: `/customers/:orgId`,
       },
       organization,
@@ -3731,7 +3731,7 @@ describe('Gift Categories Availability', () => {
 
     render(<CustomerDetails />, {
       initialRouterConfig: {
-        location: `/customers/${organization.slug}`,
+        location: {pathname: `/customers/${organization.slug}`},
         route: `/customers/:orgId`,
       },
       organization,
@@ -3757,7 +3757,7 @@ describe('Gift Categories Availability', () => {
 
     render(<CustomerDetails />, {
       initialRouterConfig: {
-        location: `/customers/${organization.slug}`,
+        location: {pathname: `/customers/${organization.slug}`},
         route: `/customers/:orgId`,
       },
       organization,
@@ -3783,7 +3783,7 @@ describe('Gift Categories Availability', () => {
 
     render(<CustomerDetails />, {
       initialRouterConfig: {
-        location: `/customers/${organization.slug}`,
+        location: {pathname: `/customers/${organization.slug}`},
         route: `/customers/:orgId`,
       },
       organization,
@@ -3810,7 +3810,7 @@ describe('Gift Categories Availability', () => {
 
     render(<CustomerDetails />, {
       initialRouterConfig: {
-        location: `/customers/${organization.slug}`,
+        location: {pathname: `/customers/${organization.slug}`},
         route: `/customers/:orgId`,
       },
       organization,
@@ -3835,7 +3835,7 @@ describe('Gift Categories Availability', () => {
     setUpMocks(organization, customSubscription);
     render(<CustomerDetails />, {
       initialRouterConfig: {
-        location: `/customers/${organization.slug}`,
+        location: {pathname: `/customers/${organization.slug}`},
         route: `/customers/:orgId`,
       },
       organization,

--- a/tests/js/sentry-test/reactTestingLibrary.spec.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.spec.tsx
@@ -38,7 +38,7 @@ describe('rerender', () => {
 describe('disableRouterMocks', () => {
   it('starts with the correct initial location', () => {
     const {router} = render(<div />, {
-      initialRouterConfig: {location: '/foo/'},
+      initialRouterConfig: {location: {pathname: '/foo/'}},
     });
 
     expect(router.location.pathname).toBe('/foo/');
@@ -127,7 +127,7 @@ describe('disableRouterMocks', () => {
     render(<TestComp />, {
       initialRouterConfig: {
         route: '/projects/:projectId/',
-        location: '/projects/123/',
+        location: {pathname: '/projects/123/'},
       },
     });
 

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -82,9 +82,10 @@ interface BaseRenderOptions<T extends boolean = boolean>
   deprecatedRouterMocks?: T;
 }
 
-type LocationConfig =
-  | string
-  | {pathname: string; query?: Record<string, string | number | string[]>};
+type LocationConfig = {
+  pathname: string;
+  query?: Record<string, string | number | string[]>;
+};
 
 type RouterConfig = {
   /**
@@ -362,10 +363,6 @@ function parseLocationConfig(location: LocationConfig | undefined): InitialEntry
     return LocationFixture().pathname;
   }
 
-  if (typeof location === 'string') {
-    return location;
-  }
-
   if (location.query) {
     return {
       pathname: location.pathname,
@@ -441,10 +438,7 @@ function render<T extends boolean = false>(
     router: legacyRouterConfig,
     deprecatedRouterMocks: options.deprecatedRouterMocks,
     history,
-    query:
-      typeof config?.location === 'string'
-        ? ''
-        : parseQueryString(config?.location?.query),
+    query: parseQueryString(config?.location?.query),
   });
 
   const memoryRouter = makeRouter({
@@ -502,10 +496,7 @@ function renderHookWithProviders<Result = unknown, Props = unknown>(
     router: legacyRouterConfig,
     deprecatedRouterMocks: false,
     history,
-    query:
-      typeof config?.location === 'string'
-        ? ''
-        : parseQueryString(config?.location?.query),
+    query: parseQueryString(config?.location?.query),
   });
 
   let memoryRouter: Router | null = null;


### PR DESCRIPTION
it's unclear if this location string could contain query params or not, and there were only a handful of usages
