### PR TITLE
fix(launchpad): Add flag for returning AuthenticatedToken

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -652,5 +652,7 @@ class ServiceRpcSignatureAuthentication(StandardAuthentication):
             raise AuthenticationFailed("Invalid signature")
 
         sentry_sdk.get_isolation_scope().set_tag(self.sdk_tag_name, True)
-
-        return (AnonymousUser(), token)
+        if options.get("preprod.new-token.enabled"):
+            return (AnonymousUser(), AuthenticatedToken(kind="service"))
+        else:
+            return (AnonymousUser(), token)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3500,3 +3500,13 @@ register(
     default="plaintext",
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Preprod / Launchpad options
+
+# Return AuthenticatedToken from ServiceRpcSignatureAuthentication
+register(
+    "preprod.new-token.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_ALLOW_EMPTY | FLAG_BOOL,
+)


### PR DESCRIPTION
This fixes SENTRY-4CQH, an issue where `src/sentry/middleware/access_log.py`
raises an exception due to `request.auth` being a string. We adjust
`ServiceRpcSignatureAuthentication` to return an `AuthenticatedToken` as
the code `access_log.py` requires (initially behind a new flag so we can quickly
test and revert the change).

We create an `AuthenticatedToken` with:
- a new kind: 'service'
- no scopes
- no org/project/user/entity_id etc

More generally there are a number of related issues:
- Some of the codebase expects `request.auth` to be `AuthenticatedToken | None` 
   while other bits expect `AuthenticatedToken | str | None`.
- The 'RPC signature' authentication mechanism is implemented four times,
  each time the code has been copy/pasted edited resulting in subtle
  differences (`git grep 'def compare.*signature' | wc -l`).
- Only the original implementation includes the URL path as part of the
  signed content. This seems important to avoid replay attacks.
- Launchpad and Overwatch do not use the mechanism as an 'RPC' (channeling
  all calls via a single path) rather they have various internal REST endpoints
  authed via the RPC mechanism.
- None of the users integrate with the normal rest_framework permission
  mechanism (except Launchpad as of recently) instead they manually
  check for a specific authentication:

```
def get(self, request: Request) -> Response:
    if not request.auth or not isinstance(request.successful_authenticator, FooRpcSignatureAuthentication):
        raise PermissionDenied
    # ...
```
this seems like an unfortunate pattern to become common in the codebase
particularly so for those implementations (Launchpad, Overwatch) which have
multiple endpoints.

Current implementations in order of when they were added:
- src/sentry/hybridcloud/rpc/service.py (the original)
- src/sentry/seer/endpoints/seer_rpc.py (Seer)
- src/sentry/preprod/authentication.py (Launchpad)
- src/sentry/overwatch/endpoints/overwatch_rpc.py (Overwatch)

The `launchpad` implementation tried to put the common code in
`ServiceRpcSignatureAuthentication` it is the only implementation of
this class at present.

As mentioned Launchpad and Overwatch use normal REST endpoints. Seer
instead has a minimal RPC system with protobuf encoded messages and a
dictionary of handlers. Finally hybridcloud has sophisticated
mechanism for automatically exposing remote Python instances and the
requests are serialized as json. There is some evidence it understands
users (RpcUser etc) - but I don't fully understand that.

At a minimum I think Launchpad, Overwatch, and Seer:
- should normalize on a single implementation of the signature
   generation/checking within the monolith.
- that mechanism should produce `AuthenticatedToken` for setting on
   request.auth
- and their endpoints should use the normal rest_framework
   permissions mechanism.

More generally every service rolling its own RPC mechanism seems bad, we should unify on one approach.

A follow up which tries to clean everything up a bit is at https://github.com/getsentry/sentry/pull/100812