### PR TITLE
feat(sub v3): Create remaining subpages

### DIFF
--- a/static/gsApp/views/subscriptionPage/usageHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.tsx
@@ -1,9 +1,10 @@
-import {useEffect, useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import {Container} from 'sentry/components/core/layout';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -12,6 +13,7 @@ import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import PanelItem from 'sentry/components/panels/panelItem';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconChevron, IconDownload} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -21,6 +23,7 @@ import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 import withSubscription from 'getsentry/components/withSubscription';
 import {RESERVED_BUDGET_QUOTA, UNLIMITED, UNLIMITED_ONDEMAND} from 'getsentry/constants';
@@ -36,6 +39,7 @@ import {
   formatReservedWithUnits,
   formatUsageWithUnits,
   getSoftCapType,
+  hasNewBillingUI,
 } from 'getsentry/utils/billing';
 import {getPlanCategoryName, sortCategories} from 'getsentry/utils/dataCategory';
 import {displayPriceWithCents} from 'getsentry/views/amCheckout/utils';
@@ -85,6 +89,7 @@ function getCategoryDisplay({
 function UsageHistory({subscription}: Props) {
   const organization = useOrganization();
   const location = useLocation();
+  const isNewBillingUI = hasNewBillingUI(organization);
 
   useEffect(() => {
     trackSubscriptionView(organization, subscription, 'usage');
@@ -108,46 +113,71 @@ function UsageHistory({subscription}: Props) {
     }
   );
 
-  if (isPending) {
+  const usageListPageLinks = getResponseHeader?.('Link');
+  const hasBillingPerms = organization.access?.includes('org:billing');
+
+  if (!isNewBillingUI) {
+    if (isPending) {
+      return (
+        <SubscriptionPageContainer background="primary" organization={organization}>
+          <SubscriptionHeader subscription={subscription} organization={organization} />
+          <LoadingIndicator />
+        </SubscriptionPageContainer>
+      );
+    }
+
+    if (isError) {
+      return (
+        <SubscriptionPageContainer background="primary" organization={organization}>
+          <LoadingError onRetry={refetch} />
+        </SubscriptionPageContainer>
+      );
+    }
+
+    if (!hasBillingPerms) {
+      return (
+        <SubscriptionPageContainer background="primary" organization={organization}>
+          <ContactBillingMembers />
+        </SubscriptionPageContainer>
+      );
+    }
+
     return (
       <SubscriptionPageContainer background="primary" organization={organization}>
         <SubscriptionHeader subscription={subscription} organization={organization} />
-        <LoadingIndicator />
-      </SubscriptionPageContainer>
-    );
-  }
-
-  if (isError) {
-    return (
-      <SubscriptionPageContainer background="primary" organization={organization}>
-        <LoadingError onRetry={refetch} />
-      </SubscriptionPageContainer>
-    );
-  }
-
-  const usageListPageLinks = getResponseHeader?.('Link');
-
-  const hasBillingPerms = organization.access?.includes('org:billing');
-  if (!hasBillingPerms) {
-    return (
-      <SubscriptionPageContainer background="primary" organization={organization}>
-        <ContactBillingMembers />
+        <Panel>
+          <PanelHeader>{t('Usage History')}</PanelHeader>
+          <PanelBody data-test-id="history-table">
+            {usageList.map(row => (
+              <UsageHistoryRow key={row.id} history={row} subscription={subscription} />
+            ))}
+          </PanelBody>
+        </Panel>
+        {usageListPageLinks && <Pagination pageLinks={usageListPageLinks} />}
       </SubscriptionPageContainer>
     );
   }
 
   return (
     <SubscriptionPageContainer background="primary" organization={organization}>
-      <SubscriptionHeader subscription={subscription} organization={organization} />
-      <Panel>
-        <PanelHeader>{t('Usage History')}</PanelHeader>
-        <PanelBody data-test-id="history-table">
-          {usageList.map(row => (
-            <UsageHistoryRow key={row.id} history={row} subscription={subscription} />
-          ))}
-        </PanelBody>
-      </Panel>
-      {usageListPageLinks && <Pagination pageLinks={usageListPageLinks} />}
+      <SentryDocumentTitle title={t('Usage History')} orgSlug={organization.slug} />
+      <SettingsPageHeader title={t('Usage History')} />
+      {isPending ? (
+        <LoadingIndicator />
+      ) : isError ? (
+        <LoadingError onRetry={refetch} />
+      ) : hasBillingPerms ? (
+        <Fragment>
+          <Container background="primary" border="primary" radius="md">
+            {usageList.map(row => (
+              <UsageHistoryRow key={row.id} history={row} subscription={subscription} />
+            ))}
+          </Container>
+          {usageListPageLinks && <Pagination pageLinks={usageListPageLinks} />}
+        </Fragment>
+      ) : (
+        <ContactBillingMembers />
+      )}
     </SubscriptionPageContainer>
   );
 }

--- a/static/gsApp/views/subscriptionPage/usageLog.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageLog.spec.tsx
@@ -17,6 +17,7 @@ describe('Subscription Usage Log', () => {
   const mockLocation = LocationFixture();
 
   beforeEach(() => {
+    organization.features = [];
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/billing-config/`,
@@ -80,6 +81,29 @@ describe('Subscription Usage Log', () => {
     render(<UsageLog location={mockLocation} subscription={sub} />, {organization});
 
     await screen.findByText(/Select Action/i);
+    expect(
+      screen.queryByRole('heading', {name: /Activity Logs/i})
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/cancelled plan/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sentry Staff/i)).toBeInTheDocument();
+    expect(screen.getByText(/Jun/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByText(/Select Action/i));
+    expect(screen.getByText(/Trial Extended/i)).toBeInTheDocument();
+  });
+
+  it('renders usage log in new billing UI', async () => {
+    organization.features = ['subscriptions-v3'];
+
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/subscription/usage-logs/`,
+      method: 'GET',
+      body: {rows: [UsageLogFixture()], eventNames},
+    });
+
+    render(<UsageLog location={mockLocation} subscription={sub} />, {organization});
+
+    await screen.findByText(/Select Action/i);
+    expect(screen.getByRole('heading', {name: /Activity Logs/i})).toBeInTheDocument();
     expect(screen.getByText(/cancelled plan/i)).toBeInTheDocument();
     expect(screen.getByText(/Sentry Staff/i)).toBeInTheDocument();
     expect(screen.getByText(/Jun/i)).toBeInTheDocument();

--- a/static/gsApp/views/subscriptionPage/usageLog.tsx
+++ b/static/gsApp/views/subscriptionPage/usageLog.tsx
@@ -12,6 +12,7 @@ import LoadingError from 'sentry/components/loadingError';
 import type {CursorHandler} from 'sentry/components/pagination';
 import Pagination from 'sentry/components/pagination';
 import {PanelTable} from 'sentry/components/panels/panelTable';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {AuditLog} from 'sentry/types/organization';
@@ -22,9 +23,11 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {useMemoWithPrevious} from 'sentry/utils/useMemoWithPrevious';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 import withSubscription from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
+import {hasNewBillingUI} from 'getsentry/utils/billing';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 import SubscriptionPageContainer from 'getsentry/views/subscriptionPage/components/subscriptionPageContainer';
 
@@ -158,10 +161,10 @@ function UsageLog({location, subscription}: Props) {
       value: type,
     })) ?? [];
   const selectedEventName = decodeScalar(location.query.event);
+  const isNewBillingUI = hasNewBillingUI(organization);
 
-  return (
-    <SubscriptionPageContainer background="primary" organization={organization}>
-      <SubscriptionHeader subscription={subscription} organization={organization} />
+  const usageLogContent = (
+    <Fragment>
       <UsageLogContainer>
         <CompactSelect
           searchable
@@ -214,6 +217,23 @@ function UsageLog({location, subscription}: Props) {
         )}
       </UsageLogContainer>
       <Pagination pageLinks={getResponseHeader?.('Link')} onCursor={handleCursor} />
+    </Fragment>
+  );
+
+  if (!isNewBillingUI) {
+    return (
+      <SubscriptionPageContainer background="primary" organization={organization}>
+        <SubscriptionHeader subscription={subscription} organization={organization} />
+        {usageLogContent}
+      </SubscriptionPageContainer>
+    );
+  }
+
+  return (
+    <SubscriptionPageContainer background="primary" organization={organization}>
+      <SentryDocumentTitle title={t('Activity Logs')} orgSlug={organization.slug} />
+      <SettingsPageHeader title={t('Activity Logs')} />
+      {usageLogContent}
     </SubscriptionPageContainer>
   );
 }


### PR DESCRIPTION
This PR creates the remaining subpages for the new subscription settings. Later PRs will address design changes to the components within these pages.

<img width="1512" height="859" alt="Screenshot 2025-10-03 at 11 05 44 AM" src="https://github.com/user-attachments/assets/893767a5-8fb2-4d0b-8953-f2ec2eb3eb71" />

<img width="1512" height="858" alt="Screenshot 2025-10-03 at 11 05 29 AM" src="https://github.com/user-attachments/assets/679af1c8-3ff5-43ea-9a3a-6a7aa2229f6f" />
