### PR TITLE
ref(grouping): Use variant hint directly in grouping info section

### DIFF
--- a/static/app/components/events/groupingInfo/groupingVariant.spec.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.spec.tsx
@@ -41,6 +41,7 @@ describe('Grouping Variant', () => {
     description: 'performance issue',
     hash: 'hash3',
     hashMismatch: false,
+    hint: null,
     key: 'perf-issue',
     evidence: {
       desc: 'performance issue',

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -158,7 +158,7 @@ function GroupingVariant({event, variant, showNonContributing}: GroupingVariantP
   const renderTitle = () => {
     const isContributing = variant.hash !== null;
 
-    const hint = 'component' in variant ? variant.component?.hint : undefined;
+    const hint = variant.hint;
 
     return (
       <VariantTitle>

--- a/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
@@ -31,6 +31,7 @@ function generatePerformanceGroupInfo({
           description: t('performance problem'),
           hash: event.occurrence?.fingerprint[0] || '',
           hashMismatch: false,
+          hint: null,
           key: group.issueType,
           type: EventGroupVariantType.PERFORMANCE_PROBLEM,
           evidence: {

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -61,6 +61,7 @@ interface BaseVariant {
   description: string | null;
   hash: string | null;
   hashMismatch: boolean;
+  hint: string | null;
   key: string;
   type: string;
 }


### PR DESCRIPTION
As of https://github.com/getsentry/sentry/pull/100259, grouping variants in the grouping info JSON sent to the front end have a `hint` property. And as of https://github.com/getsentry/sentry/pull/100255, we now show hints in line with the variant title. This PR takes advantage of both of those changes, by getting the in-line hint value directly from the variant itself, rather than from its root component.