### PR TITLE
chore(notif-platform): UI Updates for Previews

### DIFF
--- a/static/app/debug/notifications/components/debugNotificationsPreview.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsPreview.tsx
@@ -1,4 +1,7 @@
-import {Container, Flex} from 'sentry/components/core/layout';
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Disclosure} from 'sentry/components/core/disclosure';
 import {Heading} from 'sentry/components/core/text';
 
 export function DebugNotificationsPreview({
@@ -11,14 +14,30 @@ export function DebugNotificationsPreview({
   actions?: React.ReactNode;
 }) {
   return (
-    <Container>
-      <Flex justify="between" gap="md" padding="md 0">
-        <Heading as="h2">{title}</Heading>
-        <Flex>{actions}</Flex>
-      </Flex>
-      <Flex direction="column" gap="sm">
-        {children}
-      </Flex>
-    </Container>
+    <Fragment>
+      <PreviewDisclosure defaultExpanded>
+        <Disclosure.Title trailingItems={actions}>
+          <Heading as="h2">{title}</Heading>
+        </Disclosure.Title>
+        <Disclosure.Content>{children}</Disclosure.Content>
+      </PreviewDisclosure>
+      <Divider />
+    </Fragment>
   );
 }
+
+const PreviewDisclosure = styled(Disclosure)`
+  flex: 0;
+  pre,
+  code {
+    white-space: pre-wrap;
+  }
+`;
+
+const Divider = styled('hr')`
+  border-top: 1px solid ${p => p.theme.border};
+  width: 100%;
+  &:last-child {
+    display: none;
+  }
+`;

--- a/static/app/debug/notifications/previews/slackPreview.tsx
+++ b/static/app/debug/notifications/previews/slackPreview.tsx
@@ -1,23 +1,48 @@
-import {Link} from 'sentry/components/core/link';
+import {CodeSnippet} from 'sentry/components/codeSnippet';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {Container, Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import {DebugNotificationsPreview} from 'sentry/debug/notifications/components/debugNotificationsPreview';
 import {
   NotificationProviderKey,
   type NotificationTemplateRegistration,
 } from 'sentry/debug/notifications/types';
+import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
+
+const SLACK_PREVIEW_BASE_URL = 'https://app.slack.com/block-kit-builder/';
 
 export function SlackPreview({
   registration,
 }: {
   registration: NotificationTemplateRegistration;
 }) {
-  const slackBlockKitBuilderBaseURL = 'https://app.slack.com/block-kit-builder/#';
-
-  const blocks = JSON.stringify(registration.previews[NotificationProviderKey.SLACK]);
-  const blockKitPreviewLink = `${slackBlockKitBuilderBaseURL}${blocks}`;
-
+  const blocks = registration.previews[NotificationProviderKey.SLACK];
+  const previewLink = `${SLACK_PREVIEW_BASE_URL}#${JSON.stringify(blocks)}`;
   return (
-    <DebugNotificationsPreview title="Slack">
-      <Link to={blockKitPreviewLink}>Preview in Block Kit Builder</Link>
+    <DebugNotificationsPreview
+      title="Slack"
+      actions={
+        <LinkButton
+          to={previewLink}
+          size="xs"
+          icon={<PluginIcon pluginId="slack" size={24} />}
+          target="_blank"
+        >
+          BlockKit Builder
+        </LinkButton>
+      }
+    >
+      <Container border="primary" radius="md">
+        <Flex direction="column" padding="xl" align="start" gap="xl">
+          <Text>
+            Below is the BlockKit JSON payload that will be sent to Slack. To preview it,
+            use the builder link above.
+          </Text>
+          <CodeSnippet language="json">
+            {blocks ? JSON.stringify(blocks, null, 2) : ''}
+          </CodeSnippet>
+        </Flex>
+      </Container>
     </DebugNotificationsPreview>
   );
 }

--- a/static/app/debug/notifications/previews/teamsPreview.tsx
+++ b/static/app/debug/notifications/previews/teamsPreview.tsx
@@ -1,51 +1,68 @@
-import {useState} from 'react';
-import styled from '@emotion/styled';
-
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import {Button} from 'sentry/components/core/button';
-import {ExternalLink} from 'sentry/components/core/link';
+import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
+import {Container, Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import {DebugNotificationsPreview} from 'sentry/debug/notifications/components/debugNotificationsPreview';
 import {
   NotificationProviderKey,
   type NotificationTemplateRegistration,
 } from 'sentry/debug/notifications/types';
-import {IconChevron} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {IconCopy} from 'sentry/icons';
+import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
+import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
+
+const MSTEAMS_PREVIEW_URL = 'https://adaptivecards.microsoft.com/designer.html';
 
 export function TeamsPreview({
   registration,
 }: {
   registration: NotificationTemplateRegistration;
 }) {
-  const [showJson, setShowJson] = useState(false);
   const card = registration.previews[NotificationProviderKey.TEAMS];
 
+  const {onClick} = useCopyToClipboard({
+    text: JSON.stringify(card, null, 2),
+    onCopy: () => {
+      addSuccessMessage('Copied AdaptiveCard JSON');
+    },
+    onError: () => {
+      addErrorMessage('Failed to copy AdaptiveCard JSON');
+    },
+  });
+
   return (
-    <DebugNotificationsPreview title="MS Teams">
-      <div>
-        {t('Copy the JSON below into the')}
-        <ExternalLink href="https://adaptivecards.microsoft.com/designer.html">
-          {t(' MSTeams Previewer')}
-        </ExternalLink>
-      </div>
-      <ToggleButton
-        size="xs"
-        onClick={() => setShowJson(!showJson)}
-        priority="default"
-        icon={<IconChevron direction={showJson ? 'up' : 'down'} />}
-      >
-        {showJson ? 'Hide JSON' : 'Show JSON'}
-      </ToggleButton>
-      {showJson && (
-        <CodeSnippet language="json">
-          {card ? JSON.stringify(card, null, 2) : ''}
-        </CodeSnippet>
-      )}
+    <DebugNotificationsPreview
+      title="MS Teams"
+      actions={
+        <ButtonBar>
+          <Button size="xs" onClick={onClick} icon={<IconCopy />}>
+            Copy JSON
+          </Button>
+          <LinkButton
+            to={MSTEAMS_PREVIEW_URL}
+            size="xs"
+            icon={<PluginIcon pluginId="msteams" size={24} />}
+            target="_blank"
+          >
+            Designer
+          </LinkButton>
+        </ButtonBar>
+      }
+    >
+      <Container border="primary" radius="md">
+        <Flex direction="column" padding="xl" align="start" gap="xl">
+          <Text>
+            Below is the AdaptiveCard JSON payload that will be sent to MS Teams. To
+            preview it, copy the JSON and paste it into the Designer linked above.
+          </Text>
+          <CodeSnippet language="json">
+            {card ? JSON.stringify(card, null, 2) : ''}
+          </CodeSnippet>
+        </Flex>
+      </Container>
     </DebugNotificationsPreview>
   );
 }
-
-const ToggleButton = styled(Button)`
-  align-self: flex-start;
-  width: fit-content;
-`;

--- a/static/app/debug/notifications/views/index.tsx
+++ b/static/app/debug/notifications/views/index.tsx
@@ -54,8 +54,13 @@ export default function DebugNotificationsIndex() {
                     <Tag type="success">{selectedRegistration.category}</Tag>
                   </Flex>
                 </Heading>
-                <Grid columns="1fr 375px" gap="2xl" position="relative">
-                  <Flex direction="column" gap="2xl" position="relative" minWidth="0">
+                <Grid columns="1fr 300px" gap="2xl" position="relative">
+                  <Flex
+                    direction="column"
+                    position="relative"
+                    minWidth="0"
+                    justify="start"
+                  >
                     <EmailPreview registration={selectedRegistration} />
                     <SlackPreview registration={selectedRegistration} />
                     <DiscordPreview />


### PR DESCRIPTION
Some UI Updates for the previewing sections, using the disclosure components to be able to fold everything and giving the previews more horizontal space.

<img width="815" height="779" alt="image" src="https://github.com/user-attachments/assets/9e4773a3-e116-4aad-a193-8cde7abe16be" />
