### PR TITLE
chore(eslint): Remove await rule exclusion

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -805,7 +805,6 @@ export default typescript.config([
     name: 'files/sentry-test',
     files: ['**/*.spec.{ts,js,tsx,jsx}', 'tests/js/**/*.{ts,js,tsx,jsx}'],
     rules: {
-      '@typescript-eslint/await-thenable': 'off', // For awaiting act(...)
       'no-loss-of-precision': 'off', // Sometimes we have wild numbers hard-coded in tests
       'no-restricted-imports': [
         'error',


### PR DESCRIPTION
We're able to remove this because we removed as it was added in for a specific case, however that case had the incorrect types so it's not needed.

It turns out the setter from `nuqs`, returns promise, see: https://github.com/getsentry/sentry/pull/100869#discussion_r2401716140.