### PR TITLE
feat(tracemetrics): Add stub page for metrics

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2192,6 +2192,13 @@ function buildRoutes(): RouteObject[] {
     traceView,
   ];
 
+  const metricsChildren: SentryRouteObject[] = [
+    {
+      index: true,
+      component: make(() => import('sentry/views/explore/metrics/content')),
+    },
+  ];
+
   const profilingChildren: SentryRouteObject[] = [
     {
       index: true,
@@ -2275,6 +2282,11 @@ function buildRoutes(): RouteObject[] {
       path: 'logs/',
       component: make(() => import('sentry/views/explore/logs')),
       children: logsChildren,
+    },
+    {
+      path: 'metrics/',
+      component: make(() => import('sentry/views/explore/metrics')),
+      children: metricsChildren,
     },
     {
       path: 'saved-queries/',

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2998,7 +2998,8 @@ export const getFieldDefinition = (
     | 'feedback'
     | 'span'
     | 'log'
-    | 'uptime' = 'event',
+    | 'uptime'
+    | 'tracemetrics' = 'event',
   kind?: FieldKind
 ): FieldDefinition | null => {
   switch (type) {

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -87,6 +87,9 @@ const WIDGET_TRACE_ITEM_TO_URL_FUNCTION: Record<
   [TraceItemDataset.LOGS]: getWidgetExploreUrlWithDataset(TraceItemDataset.LOGS),
   [TraceItemDataset.SPANS]: getWidgetExploreUrlWithDataset(TraceItemDataset.SPANS),
   [TraceItemDataset.UPTIME_RESULTS]: undefined,
+  [TraceItemDataset.TRACEMETRICS]: getWidgetExploreUrlWithDataset(
+    TraceItemDataset.TRACEMETRICS
+  ),
 };
 
 export function getWidgetLogURL(

--- a/static/app/views/explore/components/breadcrumb.tsx
+++ b/static/app/views/explore/components/breadcrumb.tsx
@@ -3,6 +3,7 @@ import Breadcrumbs from 'sentry/components/breadcrumbs';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeLogsPathname} from 'sentry/views/explore/logs/utils';
+import {makeMetricsPathname} from 'sentry/views/explore/metrics/utils';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {makeTracesPathname} from 'sentry/views/traces/pathnames';
 
@@ -19,6 +20,12 @@ function ExploreBreadcrumb({traceItemDataset}: {traceItemDataset: TraceItemDatas
     crumbs.push({
       to: makeLogsPathname({organizationSlug: organization.slug, path: '/'}),
       label: t('Logs'),
+    });
+  }
+  if (traceItemDataset === TraceItemDataset.TRACEMETRICS) {
+    crumbs.push({
+      to: makeMetricsPathname({organizationSlug: organization.slug, path: '/'}),
+      label: t('Metrics'),
     });
   }
   crumbs.push({

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -38,10 +38,11 @@ const getFunctionTags = (supportedAggregates?: AggregationKey[]) => {
   }, {} as TagCollection);
 };
 
-const typeMap: Record<TraceItemDataset, 'span' | 'log' | 'uptime'> = {
+const typeMap: Record<TraceItemDataset, 'span' | 'log' | 'uptime' | 'tracemetrics'> = {
   [TraceItemDataset.SPANS]: 'span',
   [TraceItemDataset.LOGS]: 'log',
   [TraceItemDataset.UPTIME_RESULTS]: 'uptime',
+  [TraceItemDataset.TRACEMETRICS]: 'tracemetrics',
 };
 
 function getTraceItemFieldDefinitionFunction(

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -1,0 +1,91 @@
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import {Button} from 'sentry/components/core/button';
+import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import * as Layout from 'sentry/components/layouts/thirds';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {IconMegaphone} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
+import useOrganization from 'sentry/utils/useOrganization';
+import {MetricsTabContent} from 'sentry/views/explore/metrics/metricsTab';
+
+function FeedbackButton() {
+  const openForm = useFeedbackForm();
+
+  if (!openForm) {
+    return null;
+  }
+  return (
+    <Button
+      size="xs"
+      aria-label="trace-metrics-feedback"
+      icon={<IconMegaphone size="xs" />}
+      onClick={() =>
+        openForm?.({
+          messagePlaceholder: t('How can we make metrics work better for you?'),
+          tags: {
+            ['feedback.source']: 'metrics-listing',
+            ['feedback.owner']: 'performance',
+          },
+        })
+      }
+    >
+      {t('Give Feedback')}
+    </Button>
+  );
+}
+
+export default function MetricsContent() {
+  const organization = useOrganization();
+
+  return (
+    <SentryDocumentTitle title={t('Metrics')} orgSlug={organization?.slug}>
+      <PageFiltersContainer
+        // TODO(nar): Setup maxPickableDays and other date selection constraints
+        defaultSelection={{
+          datetime: {
+            period: '24h',
+            start: null,
+            end: null,
+            utc: null,
+          },
+        }}
+      >
+        <Layout.Page>
+          <MetricsHeader />
+          <MetricsTabContent
+            defaultPeriod="24h"
+            maxPickableDays={7}
+            relativeOptions={({arbitraryOptions}) => ({
+              ...arbitraryOptions,
+              '24h': t('Last 24 hours'),
+              '7d': t('Last 7 days'),
+              '14d': t('Last 14 days'),
+              '30d': t('Last 30 days'),
+              '90d': t('Last 90 days'),
+            })}
+          />
+        </Layout.Page>
+      </PageFiltersContainer>
+    </SentryDocumentTitle>
+  );
+}
+
+function MetricsHeader() {
+  return (
+    <Layout.Header unified>
+      <Layout.HeaderContent unified>
+        <Layout.Title>
+          {t('Metrics')}
+          <FeatureBadge type="alpha" />
+        </Layout.Title>
+      </Layout.HeaderContent>
+      <Layout.HeaderActions>
+        <ButtonBar>
+          <FeedbackButton />
+        </ButtonBar>
+      </Layout.HeaderActions>
+    </Layout.Header>
+  );
+}

--- a/static/app/views/explore/metrics/index.tsx
+++ b/static/app/views/explore/metrics/index.tsx
@@ -1,0 +1,22 @@
+import {Outlet} from 'react-router-dom';
+
+import Feature from 'sentry/components/acl/feature';
+import {NoAccess} from 'sentry/components/noAccess';
+import NoProjectMessage from 'sentry/components/noProjectMessage';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export default function MetricsPage() {
+  const organization = useOrganization();
+
+  return (
+    <Feature
+      features={['tracemetrics-enabled']}
+      organization={organization}
+      renderDisabled={NoAccess}
+    >
+      <NoProjectMessage organization={organization}>
+        <Outlet />
+      </NoProjectMessage>
+    </Feature>
+  );
+}

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -1,0 +1,54 @@
+import * as Layout from 'sentry/components/layouts/thirds';
+import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
+import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
+import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
+import {t} from 'sentry/locale';
+import {useSearchQueryBuilderProps} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
+import {
+  BottomSectionBody,
+  FilterBarContainer,
+  StyledPageFilterBar,
+  TopSectionBody,
+} from 'sentry/views/explore/logs/styles';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+import type {PickableDays} from 'sentry/views/explore/utils';
+
+type LogsTabProps = PickableDays;
+
+export function MetricsTabContent({
+  defaultPeriod,
+  maxPickableDays,
+  relativeOptions,
+}: LogsTabProps) {
+  const searchQueryBuilderProviderProps = useSearchQueryBuilderProps({
+    itemType: TraceItemDataset.TRACEMETRICS,
+    numberAttributes: {},
+    stringAttributes: {},
+    numberSecondaryAliases: {},
+    stringSecondaryAliases: {},
+    initialQuery: '',
+    searchSource: 'ourmetrics',
+  });
+  return (
+    <SearchQueryBuilderProvider {...searchQueryBuilderProviderProps}>
+      <TopSectionBody noRowGap>
+        <Layout.Main fullWidth>
+          <FilterBarContainer>
+            <StyledPageFilterBar condensed>
+              <ProjectPageFilter />
+              <EnvironmentPageFilter />
+              <DatePageFilter
+                defaultPeriod={defaultPeriod}
+                maxPickableDays={maxPickableDays}
+                relativeOptions={relativeOptions}
+                searchPlaceholder={t('Custom range: 2h, 4d, 3w')}
+              />
+            </StyledPageFilterBar>
+          </FilterBarContainer>
+        </Layout.Main>
+      </TopSectionBody>
+      <BottomSectionBody sidebarOpen={false}>Currently in development</BottomSectionBody>
+    </SearchQueryBuilderProvider>
+  );
+}

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -1,0 +1,11 @@
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+
+export function makeMetricsPathname({
+  organizationSlug,
+  path,
+}: {
+  organizationSlug: string;
+  path: string;
+}) {
+  return normalizeUrl(`/organizations/${organizationSlug}/explore/metrics${path}`);
+}

--- a/static/app/views/explore/types.tsx
+++ b/static/app/views/explore/types.tsx
@@ -4,6 +4,7 @@ export enum TraceItemDataset {
   LOGS = 'logs',
   SPANS = 'spans',
   UPTIME_RESULTS = 'uptime_results',
+  TRACEMETRICS = 'tracemetrics',
 }
 
 export interface UseTraceItemAttributeBaseProps {

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -745,6 +745,7 @@ const TRACE_ITEM_TO_URL_FUNCTION: Record<
   [TraceItemDataset.LOGS]: getLogsUrlFromSavedQueryUrl,
   [TraceItemDataset.SPANS]: getExploreUrlFromSavedQueryUrl,
   [TraceItemDataset.UPTIME_RESULTS]: undefined,
+  [TraceItemDataset.TRACEMETRICS]: undefined,
 };
 
 /**

--- a/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
@@ -65,6 +65,15 @@ export function ExploreSecondaryNav() {
               {t('Logs')}
             </SecondaryNav.Item>
           </Feature>
+          <Feature features="tracemetrics-enabled">
+            <SecondaryNav.Item
+              to={`${baseUrl}/metrics/`}
+              analyticsItemName="explore_metrics"
+              trailingItems={<FeatureBadge type="alpha" />}
+            >
+              {t('Metrics')}
+            </SecondaryNav.Item>
+          </Feature>
           <Feature
             features="discover-basic"
             hookName="feature-disabled:discover2-sidebar-item"


### PR DESCRIPTION
Hooks up the basic routes and adds a stub page for building out the metrics page.

<img width="1917" height="965" alt="Screenshot 2025-10-03 at 2 24 33 PM" src="https://github.com/user-attachments/assets/e9e148f7-a0ab-44d4-b2fc-53e299747a60" />
