### PR TITLE
feat(pr-page): Add pullrequest analysis download endpoint and refactor existing download endpoint to share underlying object

### DIFF
--- a/src/sentry/preprod/analytics.py
+++ b/src/sentry/preprod/analytics.py
@@ -110,10 +110,33 @@ class PreprodArtifactApiSizeAnalysisCompareDownloadEvent(analytics.Event):
     base_size_metric_id: str
 
 
+# PR page
+@analytics.eventclass("preprod_artifact.api.pr_page.details")
+class PreprodApiPrPageDetailsEvent(analytics.Event):
+    organization_id: int
+    user_id: int | None = None
+    repo_name: str
+    pr_number: str
+
+
+@analytics.eventclass("preprod_artifact.api.pr_page.size_analysis_download")
+class PreprodApiPrPageSizeAnalysisDownloadEvent(analytics.Event):
+    organization_id: int
+    user_id: int | None = None
+    artifact_id: str
+
+
+@analytics.eventclass("preprod_artifact.api.pr_page.comments")
+class PreprodApiPrPageCommentsEvent(analytics.Event):
+    organization_id: int
+    user_id: int | None = None
+    repo_name: str
+    pr_number: str
+
+
 analytics.register(PreprodArtifactApiAssembleEvent)
 analytics.register(PreprodArtifactApiUpdateEvent)
 analytics.register(PreprodArtifactApiAssembleGenericEvent)
-analytics.register(PreprodArtifactApiSizeAnalysisDownloadEvent)
 analytics.register(PreprodArtifactApiGetBuildDetailsEvent)
 analytics.register(PreprodArtifactApiListBuildsEvent)
 analytics.register(PreprodArtifactApiInstallDetailsEvent)
@@ -121,6 +144,12 @@ analytics.register(PreprodArtifactApiRerunAnalysisEvent)
 analytics.register(PreprodArtifactApiAdminGetInfoEvent)
 analytics.register(PreprodArtifactApiAdminBatchDeleteEvent)
 analytics.register(PreprodArtifactApiDeleteEvent)
+# Size analysis
+analytics.register(PreprodArtifactApiSizeAnalysisDownloadEvent)
 analytics.register(PreprodArtifactApiSizeAnalysisCompareGetEvent)
 analytics.register(PreprodArtifactApiSizeAnalysisComparePostEvent)
 analytics.register(PreprodArtifactApiSizeAnalysisCompareDownloadEvent)
+# PR page
+analytics.register(PreprodApiPrPageDetailsEvent)
+analytics.register(PreprodApiPrPageSizeAnalysisDownloadEvent)
+analytics.register(PreprodApiPrPageCommentsEvent)

--- a/src/sentry/preprod/api/bases/preprod_artifact_endpoint.py
+++ b/src/sentry/preprod/api/bases/preprod_artifact_endpoint.py
@@ -8,6 +8,11 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.preprod.models import PreprodArtifact
 
 
+class PreprodArtifactResourceDoesNotExist(APIException):
+    status_code = status.HTTP_404_NOT_FOUND
+    default_detail = "The requested preprod artifact does not exist"
+
+
 class HeadPreprodArtifactResourceDoesNotExist(APIException):
     status_code = status.HTTP_404_NOT_FOUND
     default_detail = "The requested head preprod artifact does not exist"

--- a/src/sentry/preprod/api/endpoints/pull_request/organization_pullrequest_details.py
+++ b/src/sentry/preprod/api/endpoints/pull_request/organization_pullrequest_details.py
@@ -9,7 +9,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.models.organization import Organization
-from sentry.models.repository import Repository
 from sentry.preprod.analytics import PreprodApiPrPageDetailsEvent
 from sentry.preprod.integration_utils import get_github_client
 from sentry.preprod.pull_request.adapters import PullRequestDataAdapter

--- a/src/sentry/preprod/api/endpoints/pull_request/organization_pullrequest_size_analysis_download.py
+++ b/src/sentry/preprod/api/endpoints/pull_request/organization_pullrequest_size_analysis_download.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.conf import settings
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -9,9 +8,10 @@ from sentry import analytics, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.models.project import Project
-from sentry.preprod.analytics import PreprodArtifactApiSizeAnalysisDownloadEvent
-from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactEndpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models.organization import Organization
+from sentry.preprod.analytics import PreprodApiPrPageSizeAnalysisDownloadEvent
+from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactResourceDoesNotExist
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.size_analysis.download import (
     SizeAnalysisError,
@@ -23,49 +23,49 @@ logger = logging.getLogger(__name__)
 
 
 @region_silo_endpoint
-class ProjectPreprodArtifactSizeAnalysisDownloadEndpoint(PreprodArtifactEndpoint):
+class OrganizationPullRequestSizeAnalysisDownloadEndpoint(OrganizationEndpoint):
     owner = ApiOwner.EMERGE_TOOLS
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
 
     def get(
-        self,
-        request: Request,
-        project: Project,
-        head_artifact_id: str,
-        head_artifact: PreprodArtifact,
+        self, request: Request, organization: Organization, artifact_id: str
     ) -> HttpResponseBase:
         """
         Download size analysis results for a preprod artifact
         ````````````````````````````````````````````````````
 
-        Download the size analysis results for a preprod artifact.
+        Download the size analysis results for a preprod artifact. This is separate from the
+        ProjectPreprodArtifactSizeAnalysisDownloadEndpoint as PR page is not tied to a project.
 
         :pparam string organization_id_or_slug: the id or slug of the organization the
                                           artifact belongs to.
-        :pparam string project_id_or_slug: the id or slug of the project to retrieve the
-                                     artifact from.
-        :pparam string head_artifact_id: the ID of the preprod artifact to download size analysis for.
+        :pparam string artifact_id: the ID of the preprod artifact to download size analysis for.
         :auth: required
         """
 
         analytics.record(
-            PreprodArtifactApiSizeAnalysisDownloadEvent(
-                organization_id=project.organization_id,
-                project_id=project.id,
+            PreprodApiPrPageSizeAnalysisDownloadEvent(
+                organization_id=organization.id,
                 user_id=request.user.id,
-                artifact_id=head_artifact_id,
+                artifact_id=artifact_id,
             )
         )
 
-        if not settings.IS_DEV and not features.has(
-            "organizations:preprod-artifact-assemble", project.organization, actor=request.user
-        ):
+        if not features.has("organizations:pr-page", organization, actor=request.user):
             return Response({"error": "Feature not enabled"}, status=403)
 
         try:
-            size_metrics_qs = head_artifact.get_size_metrics()
+            artifact = PreprodArtifact.objects.get(
+                id=int(artifact_id),
+                project__organization_id=organization.id,
+            )
+        except (PreprodArtifact.DoesNotExist, ValueError):
+            raise PreprodArtifactResourceDoesNotExist
+
+        try:
+            size_metrics_qs = artifact.get_size_metrics()
             size_metrics_count = size_metrics_qs.count()
             if size_metrics_count == 0:
                 return Response(
@@ -82,13 +82,12 @@ class ProjectPreprodArtifactSizeAnalysisDownloadEndpoint(PreprodArtifactEndpoint
             if size_metrics is None or size_metrics.analysis_file_id is None:
                 logger.info(
                     "preprod.size_analysis.download.no_size_metrics",
-                    extra={"artifact_id": head_artifact_id},
+                    extra={"artifact_id": artifact_id},
                 )
                 return Response(
                     {"error": "Size analysis not found"},
                     status=404,
                 )
-
             return get_size_analysis_file_response(size_metrics)
         except SizeAnalysisError as e:
             return get_size_analysis_error_response(e)

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -11,8 +11,6 @@ from sentry.preprod.api.endpoints.size_analysis.project_preprod_size_analysis_do
 )
 
 from .organization_preprod_artifact_assemble import ProjectPreprodArtifactAssembleEndpoint
-from .organization_pullrequest_comments import OrganizationPrCommentsEndpoint
-from .organization_pullrequest_details import OrganizationPullRequestDetailsEndpoint
 from .preprod_artifact_admin_batch_delete import PreprodArtifactAdminBatchDeleteEndpoint
 from .preprod_artifact_admin_info import PreprodArtifactAdminInfoEndpoint
 from .preprod_artifact_admin_rerun_analysis import PreprodArtifactAdminRerunAnalysisEndpoint
@@ -31,18 +29,13 @@ from .project_preprod_size import (
     ProjectPreprodSizeEndpoint,
     ProjectPreprodSizeWithIdentifierEndpoint,
 )
+from .pull_request.organization_pullrequest_comments import OrganizationPrCommentsEndpoint
+from .pull_request.organization_pullrequest_details import OrganizationPullRequestDetailsEndpoint
+from .pull_request.organization_pullrequest_size_analysis_download import (
+    OrganizationPullRequestSizeAnalysisDownloadEndpoint,
+)
 
 preprod_urlpatterns = [
-    re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/pr-comments/(?P<repo_name>.+?)/(?P<pr_number>\d+)/$",
-        OrganizationPrCommentsEndpoint.as_view(),
-        name="sentry-api-0-organization-pr-comments",
-    ),
-    re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/pullrequest-details/(?P<repo_name>.+?)/(?P<pr_number>\d+)/$",
-        OrganizationPullRequestDetailsEndpoint.as_view(),
-        name="sentry-api-0-organization-pullrequest-details",
-    ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/assemble/$",
         ProjectPreprodArtifactAssembleEndpoint.as_view(),
@@ -93,6 +86,22 @@ preprod_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/size-analysis/compare/(?P<head_size_metric_id>[^/]+)/(?P<base_size_metric_id>[^/]+)/download/$",
         ProjectPreprodArtifactSizeAnalysisCompareDownloadEndpoint.as_view(),
         name="sentry-api-0-project-preprod-artifact-size-analysis-compare-download",
+    ),
+    # PR page
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/pullrequest-details/(?P<repo_name>.+?)/(?P<pr_number>\d+)/$",
+        OrganizationPullRequestDetailsEndpoint.as_view(),
+        name="sentry-api-0-organization-pullrequest-details",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/pull-requests/size-analysis/(?P<artifact_id>[^/]+)/$",
+        OrganizationPullRequestSizeAnalysisDownloadEndpoint.as_view(),
+        name="sentry-api-0-organization-pullrequest-size-analysis-download",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/pr-comments/(?P<repo_name>.+?)/(?P<pr_number>\d+)/$",
+        OrganizationPrCommentsEndpoint.as_view(),
+        name="sentry-api-0-organization-pr-comments",
     ),
 ]
 

--- a/src/sentry/preprod/size_analysis/download.py
+++ b/src/sentry/preprod/size_analysis/download.py
@@ -1,0 +1,57 @@
+import logging
+
+from django.http.response import FileResponse
+from rest_framework.response import Response
+
+from sentry.models.files.file import File
+from sentry.preprod.models import PreprodArtifactSizeMetrics
+
+logger = logging.getLogger(__name__)
+
+
+class SizeAnalysisError(Exception):
+    def __init__(self, message: str, status_code: int):
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+
+class SizeAnalysisMultipleResultsError(SizeAnalysisError):
+    def __init__(self, message: str = "Multiple size analysis results found for this artifact"):
+        super().__init__(message, 409)
+
+
+class SizeAnalysisInternalError(SizeAnalysisError):
+    def __init__(
+        self, message: str = "An internal error occurred while retrieving size analysis results"
+    ):
+        super().__init__(message, 500)
+
+
+class SizeAnalysisNotFoundError(SizeAnalysisError):
+    def __init__(self, message: str = "Size analysis not found"):
+        super().__init__(message, 404)
+
+
+def get_size_analysis_file_response(size_metrics: PreprodArtifactSizeMetrics) -> FileResponse:
+    try:
+        file_obj = File.objects.get(id=size_metrics.analysis_file_id)
+    except File.DoesNotExist:
+        raise SizeAnalysisNotFoundError()
+
+    try:
+        fp = file_obj.getfile()
+    except Exception as e:
+        logger.exception("Uncaught error getting size analysis file", extra={"error": e})
+        raise SizeAnalysisInternalError()
+
+    response = FileResponse(
+        fp,
+        content_type="application/json",
+    )
+    response["Content-Length"] = file_obj.size
+    return response
+
+
+def get_size_analysis_error_response(error: SizeAnalysisError) -> Response:
+    return Response({"error": error.message}, status=error.status_code)

--- a/tests/sentry/preprod/api/endpoints/pull_request/test_organization_pullrequest_comments.py
+++ b/tests/sentry/preprod/api/endpoints/pull_request/test_organization_pullrequest_comments.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from rest_framework.test import APIRequestFactory
 
 from sentry.models.repository import Repository
-from sentry.preprod.api.endpoints.organization_pullrequest_comments import (
+from sentry.preprod.api.endpoints.pull_request.organization_pullrequest_comments import (
     OrganizationPrCommentsEndpoint,
 )
 from sentry.shared_integrations.exceptions import ApiError

--- a/tests/sentry/preprod/api/endpoints/pull_request/test_organization_pullrequest_details.py
+++ b/tests/sentry/preprod/api/endpoints/pull_request/test_organization_pullrequest_details.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from rest_framework.test import APIRequestFactory
 
 from sentry.models.repository import Repository
-from sentry.preprod.api.endpoints.organization_pullrequest_details import (
+from sentry.preprod.api.endpoints.pull_request.organization_pullrequest_details import (
     OrganizationPullRequestDetailsEndpoint,
 )
 from sentry.shared_integrations.exceptions import ApiError

--- a/tests/sentry/preprod/api/endpoints/pull_request/test_organization_pullrequest_size_analysis_download.py
+++ b/tests/sentry/preprod/api/endpoints/pull_request/test_organization_pullrequest_size_analysis_download.py
@@ -1,0 +1,153 @@
+from django.urls import reverse
+
+from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
+from sentry.testutils.cases import TestCase
+
+
+class OrganizationPullRequestSizeAnalysisDownloadEndpointTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+        self.login_as(user=self.user)
+
+        # Create test files
+        self.analysis_file = self.create_file(
+            name="size_analysis.json",
+            type="application/json",
+        )
+
+        # Create a preprod artifact
+        self.preprod_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.APK,
+        )
+
+        # Create size analysis metrics
+        self.size_metrics = PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.preprod_artifact,
+            analysis_file_id=self.analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="main",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+    def _get_url(self, organization_id_or_slug=None, artifact_id=None):
+        org = organization_id_or_slug or self.organization.slug
+        artifact = artifact_id or self.preprod_artifact.id
+        return reverse(
+            "sentry-api-0-organization-pullrequest-size-analysis-download",
+            args=[org, artifact],
+        )
+
+    def test_size_analysis_download_success(self) -> None:
+        with self.feature("organizations:pr-page"):
+            url = self._get_url()
+            response = self.client.get(url)
+
+            assert response.status_code == 200
+            assert response["Content-Type"] == "application/json"
+            assert response["Content-Length"] == str(self.analysis_file.size)
+
+    def test_size_analysis_download_feature_not_enabled(self) -> None:
+        # Test without the feature flag
+        url = self._get_url()
+        response = self.client.get(url)
+
+        assert response.status_code == 403
+        assert response.json()["error"] == "Feature not enabled"
+
+    def test_size_analysis_download_artifact_not_found(self) -> None:
+        with self.feature("organizations:pr-page"):
+            url = self._get_url(artifact_id=999999)
+            response = self.client.get(url)
+
+            assert response.status_code == 404
+            assert "The requested preprod artifact does not exist" in response.json()["detail"]
+
+    def test_size_analysis_download_invalid_artifact_id(self) -> None:
+        with self.feature("organizations:pr-page"):
+            url = self._get_url(artifact_id="invalid-id")
+            response = self.client.get(url)
+
+            assert response.status_code == 404
+            assert "The requested preprod artifact does not exist" in response.json()["detail"]
+
+    def test_size_analysis_download_artifact_from_different_organization(self) -> None:
+        # Create another organization and artifact
+        other_user = self.create_user()
+        other_org = self.create_organization(owner=other_user)
+        other_project = self.create_project(organization=other_org)
+        other_artifact = PreprodArtifact.objects.create(
+            project=other_project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.APK,
+        )
+
+        with self.feature("organizations:pr-page"):
+            # Try to access artifact from different org
+            url = self._get_url(artifact_id=other_artifact.id)
+            response = self.client.get(url)
+
+            assert response.status_code == 404
+            assert "The requested preprod artifact does not exist" in response.json()["detail"]
+
+    def test_size_analysis_download_no_size_metrics(self) -> None:
+        # Create artifact without size metrics
+        artifact_without_metrics = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.APK,
+        )
+
+        with self.feature("organizations:pr-page"):
+            url = self._get_url(artifact_id=artifact_without_metrics.id)
+            response = self.client.get(url)
+
+            assert response.status_code == 404
+            assert (
+                response.json()["error"] == "Size analysis results not available for this artifact"
+            )
+
+    def test_size_analysis_download_multiple_size_metrics(self) -> None:
+        # Create another size metrics for the same artifact
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.preprod_artifact,
+            analysis_file_id=self.analysis_file.id,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        with self.feature("organizations:pr-page"):
+            url = self._get_url()
+            response = self.client.get(url)
+
+            assert response.status_code == 409
+            assert (
+                response.json()["error"] == "Multiple size analysis results found for this artifact"
+            )
+
+    def test_size_analysis_download_no_analysis_file(self) -> None:
+        # Create artifact with size metrics but no analysis file
+        artifact_no_file = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.APK,
+        )
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact_no_file,
+            analysis_file_id=None,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="main",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        with self.feature("organizations:pr-page"):
+            url = self._get_url(artifact_id=artifact_no_file.id)
+            response = self.client.get(url)
+
+            assert response.status_code == 404
+            assert response.json()["error"] == "Size analysis not found"


### PR DESCRIPTION
Adds a separate size analysis download endpoint to be used by the PR page. This was to work around the project requirement for the existing size analysis download endpoint, as PR pages won't be scoped under a specific project.

Adds some code to allow us to share the underlying size download logic (and handle errors/responses in the same manner). Also moves a bit of code around for organization purposes since pr-page is getting a few more endpoints now.