### PR TITLE
ref(grouping): Use `variant.contributes` value in grouping info section

### DIFF
--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -101,7 +101,7 @@ export default function GroupingInfo({
       {isPending && !hasPerformanceGrouping ? <LoadingIndicator /> : null}
       {hasPerformanceGrouping || isSuccess
         ? variants
-            .filter(variant => variant.hash !== null || showNonContributing)
+            .filter(variant => variant.contributes || showNonContributing)
             .map((variant, index, filteredVariants) => (
               <Fragment key={variant.key}>
                 <GroupingVariant

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -41,9 +41,12 @@ export default function GroupingInfo({
 
   const variants = groupInfo
     ? Object.values(groupInfo).sort((a, b) => {
-        // Sort variants with hashes before those without
-        if (a.hash && !b.hash) {
+        // Sort contributing variants before non-contributing ones
+        if (a.contributes && !b.contributes) {
           return -1;
+        }
+        if (b.contributes && !a.contributes) {
+          return 1;
         }
 
         // Sort by description alphabetically

--- a/static/app/components/events/groupingInfo/groupingInfoSection.spec.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfoSection.spec.tsx
@@ -31,6 +31,7 @@ describe('EventGroupingInfo', () => {
       url: `/projects/org-slug/project-slug/events/${event.id}/grouping-info/`,
       body: {
         app: {
+          contributes: true,
           description: 'variant description',
           hash: '123',
           hashMismatch: false,

--- a/static/app/components/events/groupingInfo/groupingSummary.tsx
+++ b/static/app/components/events/groupingInfo/groupingSummary.tsx
@@ -24,7 +24,7 @@ export function GroupInfoSummary({
   });
   const groupedBy = groupInfo
     ? Object.values(groupInfo)
-        .filter(variant => variant.hash !== null && variant.description !== null)
+        .filter(variant => variant.contributes && variant.description !== null)
         .map(variant => variant.description!)
         .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
         .join(', ')

--- a/static/app/components/events/groupingInfo/groupingVariant.spec.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.spec.tsx
@@ -38,6 +38,7 @@ describe('Grouping Variant', () => {
   });
   const performanceIssueVariant = {
     type: EventGroupVariantType.PERFORMANCE_PROBLEM,
+    contributes: true,
     description: 'performance issue',
     hash: 'hash3',
     hashMismatch: false,

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -156,7 +156,7 @@ function GroupingVariant({event, variant, showNonContributing}: GroupingVariantP
   };
 
   const renderTitle = () => {
-    const isContributing = variant.hash !== null;
+    const isContributing = variant.contributes;
 
     const hint = variant.hint;
 

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -74,7 +74,7 @@ function GroupingVariant({event, variant, showNonContributing}: GroupingVariantP
     const data: VariantData = [];
     let component: EventGroupComponent | undefined;
 
-    if (!showNonContributing && variant.hash === null) {
+    if (!showNonContributing && !variant.contributes) {
       return [data, component];
     }
 

--- a/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
@@ -28,6 +28,7 @@ function generatePerformanceGroupInfo({
   return group
     ? {
         [group.issueType]: {
+          contributes: true,
           description: t('performance problem'),
           hash: event.occurrence?.fingerprint[0] || '',
           hashMismatch: false,

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -58,6 +58,7 @@ export const enum EventGroupVariantType {
 }
 
 interface BaseVariant {
+  contributes: boolean;
   description: string | null;
   hash: string | null;
   hashMismatch: boolean;


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry/pull/100893, which added a `contributes` value to each variant in the grouping info JSON. In this PR, all of the places in the front end code where we've been using the presence of a hash value as a proxy for whether or not a variant contributes have been switched to use the `contributes` value directly. This will let us control visibility of variants separately, without the side effects which come along with having or not having a hash value.