### PR TITLE
fix(billing): Mark Zendesk link as external link

### DIFF
--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -9,6 +9,7 @@ import moment from 'moment-timezone';
 
 import type {Client} from 'sentry/api';
 import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex, Grid, Stack} from 'sentry/components/core/layout';
 import {ExternalLink, Link} from 'sentry/components/core/link';
@@ -936,15 +937,9 @@ class AMCheckout extends Component<Props, State> {
                     <ExternalLink href="https://sentry.zendesk.com/hc/en-us/categories/17135853065755-Account-Billing" />
                   ),
                   contact: hasZendesk() ? (
-                    <ZendeskStyledLink
-                      href="#"
-                      onClick={e => {
-                        e.preventDefault();
-                        activateZendesk();
-                      }}
-                    >
+                    <ZendeskButton priority="link" onClick={activateZendesk}>
                       <Text variant="accent">{t('ask Support')}</Text>
-                    </ZendeskStyledLink>
+                    </ZendeskButton>
                   ) : (
                     <ZendeskLink subject="Billing Question" source="checkout">
                       {t('ask Support')}
@@ -1121,7 +1116,7 @@ const CheckoutStepsContainer = styled('div')<{isNewCheckout: boolean}>`
     `}
 `;
 
-const ZendeskStyledLink = styled(ExternalLink)`
+const ZendeskButton = styled(Button)`
   padding: 0;
   font-weight: ${p => p.theme.fontWeight.normal};
 `;

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -9,7 +9,6 @@ import moment from 'moment-timezone';
 
 import type {Client} from 'sentry/api';
 import {Alert} from 'sentry/components/core/alert';
-import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex, Grid, Stack} from 'sentry/components/core/layout';
 import {ExternalLink, Link} from 'sentry/components/core/link';
@@ -937,9 +936,15 @@ class AMCheckout extends Component<Props, State> {
                     <ExternalLink href="https://sentry.zendesk.com/hc/en-us/categories/17135853065755-Account-Billing" />
                   ),
                   contact: hasZendesk() ? (
-                    <ZendeskButton borderless onClick={activateZendesk}>
+                    <ZendeskStyledLink
+                      href="#"
+                      onClick={e => {
+                        e.preventDefault();
+                        activateZendesk();
+                      }}
+                    >
                       <Text variant="accent">{t('ask Support')}</Text>
-                    </ZendeskButton>
+                    </ZendeskStyledLink>
                   ) : (
                     <ZendeskLink subject="Billing Question" source="checkout">
                       {t('ask Support')}
@@ -1116,7 +1121,7 @@ const CheckoutStepsContainer = styled('div')<{isNewCheckout: boolean}>`
     `}
 `;
 
-const ZendeskButton = styled(Button)`
+const ZendeskStyledLink = styled(ExternalLink)`
   padding: 0;
   font-weight: ${p => p.theme.fontWeight.normal};
 `;


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1621/hover-state-inconsistent-between-links-in-have-a-question-footer