### PR TITLE
fix(dashboards): Ensures env filter is still passed even if empty

### DIFF
--- a/static/app/views/dashboards/utils.spec.tsx
+++ b/static/app/views/dashboards/utils.spec.tsx
@@ -7,6 +7,7 @@ import {
   constructWidgetFromQuery,
   eventViewFromWidget,
   flattenErrors,
+  getCurrentPageFilters,
   getDashboardsMEPQueryParams,
   getFieldsFromEquations,
   getNumEquations,
@@ -426,6 +427,79 @@ describe('isWidgetUsingTransactionName', () => {
       );
       const widget = constructWidgetFromQuery(baseQuery)!;
       expect(isUsingPerformanceScore(widget)).toBe(true);
+    });
+  });
+
+  describe('getCurrentPageFilters', () => {
+    it('returns empty array for environment when not defined in location query', () => {
+      const location = LocationFixture({
+        query: {
+          project: '1',
+          statsPeriod: '7d',
+        },
+      });
+
+      const result = getCurrentPageFilters(location);
+
+      expect(result.environment).toEqual([]);
+      expect(result.projects).toEqual([1]);
+      expect(result.period).toBe('7d');
+    });
+
+    it('returns empty array for environment when environment is undefined', () => {
+      const location = LocationFixture({
+        query: {
+          project: '1',
+          environment: undefined,
+          statsPeriod: '7d',
+        },
+      });
+
+      const result = getCurrentPageFilters(location);
+
+      expect(result.environment).toEqual([]);
+    });
+
+    it('returns empty array for environment when environment is null', () => {
+      const location = LocationFixture({
+        query: {
+          project: '1',
+          environment: null,
+          statsPeriod: '7d',
+        },
+      });
+
+      const result = getCurrentPageFilters(location);
+
+      expect(result.environment).toEqual([]);
+    });
+
+    it('converts single environment string to array', () => {
+      const location = LocationFixture({
+        query: {
+          project: '1',
+          environment: 'production',
+          statsPeriod: '7d',
+        },
+      });
+
+      const result = getCurrentPageFilters(location);
+
+      expect(result.environment).toEqual(['production']);
+    });
+
+    it('preserves environment array when already an array', () => {
+      const location = LocationFixture({
+        query: {
+          project: '1',
+          environment: ['production', 'staging'],
+          statsPeriod: '7d',
+        },
+      });
+
+      const result = getCurrentPageFilters(location);
+
+      expect(result.environment).toEqual(['production', 'staging']);
     });
   });
 });

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -437,7 +437,7 @@ export function hasSavedPageFilters(
 ) {
   return !(
     (dashboard.projects === undefined || dashboard.projects.length === 0) &&
-    dashboard.environment === undefined &&
+    (dashboard.environment === undefined || dashboard.environment.length === 0) &&
     dashboard.start === undefined &&
     dashboard.end === undefined &&
     dashboard.period === undefined
@@ -533,8 +533,7 @@ export function getCurrentPageFilters(
         : typeof project === 'string'
           ? [Number(project)]
           : project.map(Number),
-    environment:
-      typeof environment === 'string' ? [environment] : (environment ?? undefined),
+    environment: decodeList(environment),
     period: statsPeriod as string | undefined,
     start: defined(start) ? normalizeDateTimeString(start as string) : undefined,
     end: defined(end) ? normalizeDateTimeString(end as string) : undefined,


### PR DESCRIPTION
If the env filter isn't passed, then the dashboard won't update it in the PUT request and you can't clear the filter, so we make sure an empty array is passed even if the key is undefined

I added the `decodeList` helper because it does what we need it to do by checking the type of `environment` and ensuring it's an array when the request to update the dashboard is made.