### PR TITLE
fix(insights): Fix Web Vitals performance score chart always using 12h intervals

### DIFF
--- a/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
@@ -53,7 +53,6 @@ export default function PerformanceScoreBreakdownChartWidget(
   } = useFetchSpanTimeSeries(
     {
       sampling: SAMPLING_MODE.HIGH_ACCURACY,
-      interval: '12h',
       query: search,
       yAxis: [
         'performance_score(measurements.score.lcp)',


### PR DESCRIPTION
The time series api request fails when the selected time range is less than 12h. Update the Web Vitals performance score chart to use the default interval.