### PR TITLE
fix(aci): Cleanly handle date parse failures

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_workflow_stats.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_stats.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from drf_spectacular.utils import extend_schema
+from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -11,6 +12,7 @@ from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.parameters import GlobalParams, WorkflowParams
+from sentry.exceptions import InvalidParams
 from sentry.models.organization import Organization
 from sentry.workflow_engine.endpoints.organization_workflow_index import (
     OrganizationWorkflowEndpoint,
@@ -46,6 +48,9 @@ class OrganizationWorkflowStatsEndpoint(OrganizationWorkflowEndpoint):
         """
         Note that results are returned in hourly buckets.
         """
-        start, end = get_date_range_from_params(request.GET)
+        try:
+            start, end = get_date_range_from_params(request.GET)
+        except InvalidParams:
+            raise ParseError(detail="Invalid date range")
         results = fetch_workflow_hourly_stats(workflow, start, end)
         return Response(serialize(results, request.user, TimeSeriesValueSerializer()))

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_stats.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_stats.py
@@ -71,3 +71,12 @@ class WorkflowStatsEndpointTest(APITestCase):
             {"date": now - timedelta(hours=1), "count": 1},
             {"date": now, "count": 0},
         ]
+
+    def test_invalid_dates_error(self) -> None:
+        self.get_error_response(
+            self.organization.slug,
+            self.workflow.id,
+            start="This is not a date",
+            end=before_now(days=6),
+            status_code=400,
+        )


### PR DESCRIPTION
Malformed parameters shouldn't generate a 500.

Fixes SENTRY-4CKD.