### PR TITLE
fix(explore): Improve improvement of conversion to `TimeSeries`

### DIFF
--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -292,5 +292,5 @@ export function convertEventsStatsToTimeSeriesData(
     delayedTimeSeries.meta.order = order;
   }
 
-  return [timeSeries.meta.order ?? 0, timeSeries];
+  return [timeSeries.meta.order ?? 0, delayedTimeSeries];
 }

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -222,7 +222,7 @@ export function transformToSeriesMap(
         const [, timeSeries] = convertEventsStatsToTimeSeriesData(
           axis,
           seriesData,
-          seriesData.order
+          groupData.order as unknown as number // `order` is always present
         );
 
         if (fields) {

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -199,9 +199,7 @@ export function transformToSeriesMap(
           const groupByFields = fields.filter(field => !yAxis.includes(field));
           const groupBy = parseGroupBy(groupName, groupByFields);
           timeSeries.groupBy = groupBy;
-          if (groupName === 'Other') {
-            timeSeries.meta.isOther = true;
-          }
+          timeSeries.meta.isOther = groupName === 'Other';
         }
 
         allTimeSeries.push(timeSeries);
@@ -231,9 +229,7 @@ export function transformToSeriesMap(
           const groupByFields = fields.filter(field => !yAxis.includes(field));
           const groupBy = parseGroupBy(groupName, groupByFields);
           timeSeries.groupBy = groupBy;
-          if (groupName === 'Other') {
-            timeSeries.meta.isOther = true;
-          }
+          timeSeries.meta.isOther = groupName === 'Other';
         }
 
         allTimeSeries.push(timeSeries);

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -291,5 +291,5 @@ export function convertEventsStatsToTimeSeriesData(
     delayedTimeSeries.meta.order = order;
   }
 
-  return [timeSeries.meta.order ?? 0, delayedTimeSeries];
+  return [delayedTimeSeries.meta.order ?? 0, delayedTimeSeries];
 }

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -29,7 +29,6 @@ import {
 import type {
   TimeSeries,
   TimeSeriesItem,
-  TimeSeriesMeta,
 } from 'sentry/views/dashboards/widgets/common/types';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {FALLBACK_SERIES_NAME} from 'sentry/views/explore/settings';


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/100532, with a few small fixes:

- Always assign `isOther`, if it's a `groupBy`
- Use `groupData` for order rather than the event data
- Mark delayed data

Supports ENG-5608