### PR TITLE
fix(tests): Replace direct Model.objects.create with factory method

### DIFF
--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -16,7 +16,6 @@ from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity, OpenP
 from sentry.testutils.cases import APITestCase
 from sentry.types.activity import ActivityType
 from sentry.types.group import PriorityLevel
-from sentry.workflow_engine.models.detector_group import DetectorGroup
 
 
 class OrganizationOpenPeriodsTest(APITestCase):
@@ -35,7 +34,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
         self.group.save()
 
         # Link detector to group
-        DetectorGroup.objects.create(detector=self.detector, group=self.group)
+        self.create_detector_group(detector=self.detector, group=self.group)
 
         self.group_open_period = GroupOpenPeriod.objects.get(group=self.group)
 


### PR DESCRIPTION
Replace DetectorGroup.objects.create() with create_detector_group() factory method in test_organization_open_periods.py to comply with Sentry testing standards.

The test was violating the mandatory Python testing rule that prohibits direct Model.objects.create() calls. This change:

- Uses the proper factory method from sentry.testutils.fixtures.Fixtures
- Maintains identical test behavior and coverage
- Follows Sentry's testing best practices
- Ensures proper test setup logic is applied

Files changed:
- tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py

Testing:
- All existing tests pass with no modifications to test logic
- No linter errors introduced


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
