### PR TITLE
chore(eco): async deletions for sentry app installations 

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -595,14 +595,17 @@ class SentryAppStatus:
 class SentryAppInstallationStatus:
     PENDING = 0
     INSTALLED = 1
+    PENDING_DELETION = 2
     PENDING_STR = "pending"
     INSTALLED_STR = "installed"
+    PENDING_DELETION_STR = "pending_deletion"
 
     @classmethod
     def as_choices(cls) -> Sequence[tuple[int, str]]:
         return (
             (cls.PENDING, cls.PENDING_STR),
             (cls.INSTALLED, cls.INSTALLED_STR),
+            (cls.PENDING_DELETION, cls.PENDING_DELETION_STR),
         )
 
     @classmethod
@@ -611,6 +614,8 @@ class SentryAppInstallationStatus:
             return cls.PENDING_STR
         elif status == cls.INSTALLED:
             return cls.INSTALLED_STR
+        elif status == cls.PENDING_DELETION:
+            return cls.PENDING_DELETION_STR
         else:
             raise ValueError(f"Not a SentryAppInstallationStatus int: {status!r}")
 

--- a/src/sentry/sentry_apps/api/endpoints/installation_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_details.py
@@ -10,6 +10,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.serializers import serialize
+from sentry.constants import SentryAppInstallationStatus
 from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
 from sentry.sentry_apps.api.bases.sentryapps import SentryAppInstallationBaseEndpoint
 from sentry.sentry_apps.api.parsers.sentry_app_installation import SentryAppInstallationParser
@@ -57,6 +58,7 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
             # if the error is from a request exception, log the error and continue
             except RequestException as exc:
                 sentry_sdk.capture_exception(exc)
+            sentry_app_installation.update(status=SentryAppInstallationStatus.PENDING_DELETION)
             ScheduledDeletion.schedule(sentry_app_installation, days=0, actor=request.user)
             create_audit_entry(
                 request=request,

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
@@ -230,7 +230,6 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                             SentryAppInstallationNotifier(
                                 sentry_app_installation=install, user=request.user, action="deleted"
                             ).run()
-                            ScheduledDeletion.schedule(install, days=0, actor=request.user)
                     except RequestException as exc:
                         sentry_sdk.capture_exception(exc)
 

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
@@ -8,7 +8,7 @@ from requests import RequestException
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, audit_log, deletions, features
+from sentry import analytics, audit_log, features
 from sentry.analytics.events.sentry_app_deleted import SentryAppDeletedEvent
 from sentry.analytics.events.sentry_app_schema_validation_error import (
     SentryAppSchemaValidationError,
@@ -230,7 +230,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                             SentryAppInstallationNotifier(
                                 sentry_app_installation=install, user=request.user, action="deleted"
                             ).run()
-                            deletions.exec_sync(install)
+                            ScheduledDeletion.schedule(install, days=0, actor=request.user)
                     except RequestException as exc:
                         sentry_sdk.capture_exception(exc)
 

--- a/tests/acceptance/test_organization_sentry_app_detailed_view.py
+++ b/tests/acceptance/test_organization_sentry_app_detailed_view.py
@@ -1,6 +1,7 @@
 from fixtures.page_objects.organization_integration_settings import (
     OrganizationSentryAppDetailViewPage,
 )
+from sentry.deletions.tasks.scheduled import run_scheduled_deletions_control
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.silo import no_silo_test
@@ -49,6 +50,10 @@ class OrganizationSentryAppDetailedView(AcceptanceTestCase):
 
         detail_view_page.uninstall()
         self.browser.wait_until('[data-test-id="toast-success"]')
+
+        with self.tasks():
+            run_scheduled_deletions_control()
+
         assert not SentryAppInstallation.objects.filter(
             organization_id=self.organization.id, sentry_app=self.sentry_app
         )


### PR DESCRIPTION
Deleting a sentry app installation should use async deletions.

The tests for async sentry app deletion cover the below case:
- Sentry app installations are already collected when we delete the sentry app so we shouldn't need to have extra deletions queued up / done before the task.

https://github.com/getsentry/sentry/blob/e49b651754eaad16f271ce8ddf7e97a457f64cf3/src/sentry/deletions/defaults/sentry_app.py#L14

Required for https://github.com/getsentry/sentry/pull/100813