### PR TITLE
feat(deletions): Add query filter for commits so that we can start deleting them

### DIFF
--- a/src/sentry/deletions/defaults/commit.py
+++ b/src/sentry/deletions/defaults/commit.py
@@ -47,7 +47,7 @@ class CommitDeletionTask(ModelDeletionTask[Commit]):
             LatestRepoReleaseEnvironment.objects.filter(commit_id=OuterRef("id"))
         )
 
-        return Q(date_added__lt=cutoff) & ~(
+        return Q(date_added__lt=cutoff) & ~Q(
             releasecommit_exists
             | releaseheadcommit_exists
             | groupreaction_exists

--- a/src/sentry/deletions/defaults/commit.py
+++ b/src/sentry/deletions/defaults/commit.py
@@ -1,8 +1,62 @@
+from datetime import timedelta
+
+from django.db.models import Exists, OuterRef, Q
+from django.utils import timezone
+
 from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
 from sentry.models.commit import Commit
 
 
 class CommitDeletionTask(ModelDeletionTask[Commit]):
+    def get_query_filter(self) -> Q:
+        """
+        Returns a Q object that filters for unused commits.
+        Only targets commits that are:
+        1. Not referenced by any ReleaseCommit (not part of any release)
+        2. Not referenced by any ReleaseHeadCommit (not a head commit of any release)
+        3. Not referenced by any GroupReaction (not reacted to by any group)
+        4. Not referenced by any CommitComparison (not part of any comparison)
+        5. Not referenced by any GroupCommitResolution (not resolving any group)
+        7. Not referenced by any LatestRepoReleaseEnvironment.commit_id
+        8. Older than 90 days
+        """
+        from sentry.models.commitcomparison import CommitComparison
+        from sentry.models.groupcommitresolution import GroupCommitResolution
+        from sentry.models.groupreaction import GroupReaction
+        from sentry.models.latestreporeleaseenvironment import LatestRepoReleaseEnvironment
+        from sentry.models.releasecommit import ReleaseCommit
+        from sentry.models.releaseheadcommit import ReleaseHeadCommit
+
+        cutoff = timezone.now() - timedelta(days=90)
+
+        releasecommit_exists = Exists(ReleaseCommit.objects.filter(commit_id=OuterRef("id")))
+        releaseheadcommit_exists = Exists(
+            ReleaseHeadCommit.objects.filter(commit_id=OuterRef("id"))
+        )
+        groupreaction_exists = Exists(GroupReaction.objects.filter(commit_id=OuterRef("id")))
+        commitcomparison_head_exists = Exists(
+            CommitComparison.objects.filter(head_commit_id=OuterRef("id"))
+        )
+        commitcomparison_base_exists = Exists(
+            CommitComparison.objects.filter(base_commit_id=OuterRef("id"))
+        )
+        groupcommitresolution_exists = Exists(
+            GroupCommitResolution.objects.filter(commit_id=OuterRef("id"))
+        )
+        latestrepo_exists = Exists(
+            LatestRepoReleaseEnvironment.objects.filter(commit_id=OuterRef("id"))
+        )
+
+        return Q(date_added__lt=cutoff) & ~(
+            releasecommit_exists
+            | releaseheadcommit_exists
+            | groupreaction_exists
+            | commitcomparison_head_exists
+            | commitcomparison_base_exists
+            | groupcommitresolution_exists
+            | latestrepo_exists
+        )
+
     def get_child_relations(self, instance: Commit) -> list[BaseRelation]:
         from sentry.models.commitfilechange import CommitFileChange
         from sentry.models.releasecommit import ReleaseCommit

--- a/tests/sentry/deletions/test_commit.py
+++ b/tests/sentry/deletions/test_commit.py
@@ -1,0 +1,131 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry.deletions.defaults.commit import CommitDeletionTask
+from sentry.models.commit import Commit
+from sentry.models.commitcomparison import CommitComparison
+from sentry.models.groupcommitresolution import GroupCommitResolution
+from sentry.models.groupreaction import GroupReaction, GroupReactionType
+from sentry.models.latestreporeleaseenvironment import LatestRepoReleaseEnvironment
+from sentry.models.releasecommit import ReleaseCommit
+from sentry.models.releaseheadcommit import ReleaseHeadCommit
+from sentry.testutils.cases import TestCase
+
+
+class CommitDeletionTaskTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.repo = self.create_repo(project=self.project)
+        self.old_date = timezone.now() - timedelta(days=91)
+
+    def _create_old_commit(self, key="abc123"):
+        return Commit.objects.create(
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+            key=key,
+            date_added=self.old_date,
+        )
+
+    def _get_filtered_commits(self):
+        task = CommitDeletionTask(
+            manager=None,  # type: ignore[arg-type]
+            model=Commit,
+            query={},
+        )
+        query_filter = task.get_query_filter()
+        return Commit.objects.filter(query_filter)
+
+    def test_get_query_filter_orphaned_commit(self) -> None:
+        """Test that orphaned commits are selected for deletion"""
+        orphaned_commit = self._create_old_commit()
+        commits_to_delete = self._get_filtered_commits()
+        assert orphaned_commit in commits_to_delete
+
+    def test_get_query_filter_does_not_select_commit_in_release(self) -> None:
+        """Test that commits referenced by ReleaseCommit are NOT selected"""
+        commit = self._create_old_commit()
+        release = self.create_release(project=self.project)
+        ReleaseCommit.objects.create(
+            organization_id=self.organization.id,
+            release=release,
+            commit=commit,
+            order=0,
+        )
+        commits_to_delete = self._get_filtered_commits()
+        assert commit not in commits_to_delete
+
+    def test_get_query_filter_does_not_select_head_commit(self) -> None:
+        """Test that commits referenced by ReleaseHeadCommit are NOT selected"""
+        commit = self._create_old_commit()
+        release = self.create_release(project=self.project)
+        ReleaseHeadCommit.objects.create(
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+            release=release,
+            commit=commit,
+        )
+        commits_to_delete = self._get_filtered_commits()
+        assert commit not in commits_to_delete
+
+    def test_get_query_filter_does_not_select_commit_with_group_reaction(self) -> None:
+        """Test that commits with GroupReaction are NOT selected"""
+        commit = self._create_old_commit()
+        group = self.create_group(project=self.project)
+        GroupReaction.objects.create(
+            group=group,
+            commit=commit,
+            reaction=True,
+            project=self.project,
+            source=GroupReactionType.USER_SUSPECT_COMMIT_REACTION.value,
+        )
+        commits_to_delete = self._get_filtered_commits()
+        assert commit not in commits_to_delete
+
+    def test_get_query_filter_does_not_select_commit_in_comparison(self) -> None:
+        """Test that commits in CommitComparison are NOT selected"""
+        head_commit = self._create_old_commit(key="head123")
+        base_commit = self._create_old_commit(key="base123")
+        CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha=head_commit.key,
+            head_repo_name="owner/repo",
+            head_commit=head_commit,
+            base_commit=base_commit,
+        )
+        commits_to_delete = self._get_filtered_commits()
+        assert head_commit not in commits_to_delete
+        assert base_commit not in commits_to_delete
+
+    def test_get_query_filter_does_not_select_commit_resolving_group(self) -> None:
+        """Test that commits in GroupCommitResolution are NOT selected"""
+        commit = self._create_old_commit()
+        group = self.create_group(project=self.project)
+        GroupCommitResolution.objects.create(group_id=group.id, commit_id=commit.id)
+        commits_to_delete = self._get_filtered_commits()
+        assert commit not in commits_to_delete
+
+    def test_get_query_filter_does_not_select_latest_repo_commit(self) -> None:
+        """Test that commits in LatestRepoReleaseEnvironment are NOT selected"""
+        commit = self._create_old_commit()
+        release = self.create_release(project=self.project)
+        environment = self.create_environment(project=self.project)
+        LatestRepoReleaseEnvironment.objects.create(
+            repository_id=self.repo.id,
+            environment_id=environment.id,
+            release_id=release.id,
+            commit_id=commit.id,
+        )
+        commits_to_delete = self._get_filtered_commits()
+        assert commit not in commits_to_delete
+
+    def test_get_query_filter_does_not_select_recent_commits(self) -> None:
+        """Test that recent commits are NOT selected even if orphaned"""
+        recent_commit = Commit.objects.create(
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+            key="recent123",
+            date_added=timezone.now() - timedelta(days=30),
+        )
+        commits_to_delete = self._get_filtered_commits()
+        assert recent_commit not in commits_to_delete

--- a/tests/sentry/deletions/test_commit.py
+++ b/tests/sentry/deletions/test_commit.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from django.utils import timezone
 
+from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.deletions.defaults.commit import CommitDeletionTask
 from sentry.models.commit import Commit
 from sentry.models.commitcomparison import CommitComparison
@@ -14,12 +15,12 @@ from sentry.testutils.cases import TestCase
 
 
 class CommitDeletionTaskTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.repo = self.create_repo(project=self.project)
         self.old_date = timezone.now() - timedelta(days=91)
 
-    def _create_old_commit(self, key="abc123"):
+    def _create_old_commit(self, key: str = "abc123") -> Commit:
         return Commit.objects.create(
             organization_id=self.organization.id,
             repository_id=self.repo.id,
@@ -27,7 +28,7 @@ class CommitDeletionTaskTest(TestCase):
             date_added=self.old_date,
         )
 
-    def _get_filtered_commits(self):
+    def _get_filtered_commits(self) -> BaseQuerySet[Commit, Commit]:
         task = CommitDeletionTask(
             manager=None,  # type: ignore[arg-type]
             model=Commit,


### PR DESCRIPTION
We've seen that we can delete data from tables extremely quickly using `BulkModelDeletionTask`. So it might be possible to just delete all the data from `CommitFileChange` and not worry about the dual write. Adding in a query filter so we can try this out.

<!-- Describe your PR here. -->