### PR TITLE
fix(issues): Wrap + compress event nav based on container size

### DIFF
--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -1,6 +1,7 @@
-import {Fragment} from 'react';
+import {Fragment, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import {useResizeObserver} from '@react-aria/utils';
 
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
@@ -20,7 +21,6 @@ import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {keepPreviousData} from 'sentry/utils/queryClient';
 import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
 import {useLocation} from 'sentry/utils/useLocation';
-import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {useGroupEventAttachments} from 'sentry/views/issueDetails/groupEventAttachments/useGroupEventAttachments';
@@ -54,7 +54,19 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
   const {eventCount} = useIssueDetails();
   const issueTypeConfig = getConfigForIssueType(group, group.project);
   const theme = useTheme();
-  const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.sm})`);
+
+  function checkNavIsSmall() {
+    const navEl = navigationRef.current;
+    return !!navEl && navEl.clientWidth < parseInt(theme.breakpoints.sm, 10);
+  }
+
+  const navigationRef = useRef<HTMLDivElement>(null);
+  const [isSmallNav, setSmallNav] = useState(checkNavIsSmall);
+
+  useResizeObserver({
+    ref: navigationRef,
+    onResize: () => setSmallNav(checkNavIsSmall),
+  });
 
   const hideDropdownButton =
     !issueTypeConfig.pages.attachments.enabled &&
@@ -96,7 +108,7 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
   const isListView = LIST_VIEW_TABS.has(currentTab);
 
   return (
-    <EventNavigationWrapper role="navigation">
+    <EventNavigationWrapper role="navigation" ref={navigationRef}>
       <LargeDropdownButtonWrapper>
         <DropdownMenu
           onAction={key => {
@@ -210,7 +222,11 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
         <NavigationWrapper>
           {currentTab === Tab.DETAILS && (
             <Fragment>
-              <IssueDetailsEventNavigation event={event} group={group} />
+              <IssueDetailsEventNavigation
+                event={event}
+                group={group}
+                isSmallNav={isSmallNav}
+              />
               {issueTypeConfig.pages.events.enabled && (
                 <LinkButton
                   to={{
@@ -221,7 +237,7 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
                   analyticsEventKey="issue_details.all_events_clicked"
                   analyticsEventName="Issue Details: All Events Clicked"
                 >
-                  {isSmallScreen
+                  {isSmallNav
                     ? t('More %s', issueTypeConfig.customCopy.eventUnits)
                     : t('View More %s', issueTypeConfig.customCopy.eventUnits)}
                 </LinkButton>
@@ -236,7 +252,7 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
                   analyticsEventKey="issue_details.all_open_periods_clicked"
                   analyticsEventName="Issue Details: All Open Periods Clicked"
                 >
-                  {isSmallScreen ? t('More Open Periods') : t('View More Open Periods')}
+                  {isSmallNav ? t('More Open Periods') : t('View More Open Periods')}
                 </LinkButton>
               )}
               {issueTypeConfig.pages.checkIns.enabled && (
@@ -249,7 +265,7 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
                   analyticsEventKey="issue_details.all_checks_ins_clicked"
                   analyticsEventName="Issue Details: All Checks-Ins Clicked"
                 >
-                  {isSmallScreen ? t('More Check-Ins') : t('View More Check-Ins')}
+                  {isSmallNav ? t('More Check-Ins') : t('View More Check-Ins')}
                 </LinkButton>
               )}
               {issueTypeConfig.pages.uptimeChecks.enabled && (
@@ -262,7 +278,7 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
                   analyticsEventKey="issue_details.all_uptime_checks_clicked"
                   analyticsEventName="Issue Details: All Uptime Checks Clicked"
                 >
-                  {isSmallScreen ? t('More Uptime Checks') : t('View More Uptime Checks')}
+                  {isSmallNav ? t('More Uptime Checks') : t('View More Uptime Checks')}
                 </LinkButton>
               )}
             </Fragment>
@@ -307,6 +323,7 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
 
 const LargeDropdownButtonWrapper = styled('div')`
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   gap: ${space(0.25)};
 `;
@@ -334,6 +351,7 @@ const LargeInThisIssueText = styled('div')`
 const EventNavigationWrapper = styled('div')`
   flex-grow: 1;
   display: flex;
+  flex-wrap: wrap;
   flex-direction: column;
   justify-content: space-between;
   font-size: ${p => p.theme.fontSize.sm};

--- a/static/app/views/issueDetails/streamline/issueDetailsEventNavigation.spec.tsx
+++ b/static/app/views/issueDetails/streamline/issueDetailsEventNavigation.spec.tsx
@@ -6,8 +6,6 @@ import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import * as useMedia from 'sentry/utils/useMedia';
-
 import {IssueDetailsEventNavigation} from './issueDetailsEventNavigation';
 
 describe('IssueDetailsEventNavigation', () => {
@@ -41,9 +39,7 @@ describe('IssueDetailsEventNavigation', () => {
 
   describe('recommended event tabs', () => {
     it('can navigate to the oldest event', async () => {
-      jest.spyOn(useMedia, 'default').mockReturnValue(true);
-
-      render(<IssueDetailsEventNavigation {...defaultProps} />, {
+      render(<IssueDetailsEventNavigation {...defaultProps} isSmallNav />, {
         router,
         deprecatedRouterMocks: true,
       });
@@ -57,9 +53,7 @@ describe('IssueDetailsEventNavigation', () => {
     });
 
     it('can navigate to the latest event', async () => {
-      jest.spyOn(useMedia, 'default').mockReturnValue(true);
-
-      render(<IssueDetailsEventNavigation {...defaultProps} />, {
+      render(<IssueDetailsEventNavigation {...defaultProps} isSmallNav />, {
         router,
         deprecatedRouterMocks: true,
       });
@@ -73,8 +67,6 @@ describe('IssueDetailsEventNavigation', () => {
     });
 
     it('can navigate to the recommended event', async () => {
-      jest.spyOn(useMedia, 'default').mockReturnValue(true);
-
       const recommendedEventRouter = RouterFixture({
         params: {eventId: 'latest'},
         location: LocationFixture({
@@ -82,7 +74,7 @@ describe('IssueDetailsEventNavigation', () => {
         }),
       });
 
-      render(<IssueDetailsEventNavigation {...defaultProps} />, {
+      render(<IssueDetailsEventNavigation {...defaultProps} isSmallNav />, {
         router: recommendedEventRouter,
         deprecatedRouterMocks: true,
       });

--- a/static/app/views/issueDetails/streamline/issueDetailsEventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/issueDetailsEventNavigation.tsx
@@ -14,7 +14,6 @@ import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
-import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useGroupEvent} from 'sentry/views/issueDetails/useGroupEvent';
@@ -37,18 +36,19 @@ const EventNavOrder = [
 interface IssueDetailsEventNavigationProps {
   event: Event | undefined;
   group: Group;
+  isSmallNav?: boolean;
 }
 
 export function IssueDetailsEventNavigation({
   event,
   group,
+  isSmallNav,
 }: IssueDetailsEventNavigationProps) {
   const organization = useOrganization();
   const location = useLocation();
   const params = useParams<{eventId?: string}>();
   const theme = useTheme();
   const defaultIssueEvent = useDefaultIssueEvent();
-  const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.sm})`);
   const [shouldPreload, setShouldPreload] = useState({next: false, previous: false});
 
   // Reset shouldPreload when the groupId changes
@@ -92,7 +92,7 @@ export function IssueDetailsEventNavigation({
   }, [params.eventId, defaultIssueEvent]);
 
   const EventNavLabels = {
-    [EventNavOptions.RECOMMENDED]: isSmallScreen ? t('Rec.') : t('Recommended'),
+    [EventNavOptions.RECOMMENDED]: isSmallNav ? t('Rec.') : t('Recommended'),
     [EventNavOptions.OLDEST]: t('First'),
     [EventNavOptions.LATEST]: t('Latest'),
     [EventNavOptions.CUSTOM]: t('Custom'),


### PR DESCRIPTION
- Adds flex wrap to the container, so it will never overflow out of the container

- Instead of using the screen media size, use the size of the navigation container itself to determine if we should use the shorter text variants

Fixes [NEW-550: Uptime issue details layout breaks on specific window size](https://linear.app/getsentry/issue/NEW-550/uptime-issue-details-layout-breaks-on-specific-window-size)

regular
<img width="847" height="276" alt="image" src="https://github.com/user-attachments/assets/67ccfdda-3cc1-4ca6-82a7-572cb2376e0d" />

compressed
<img width="733" height="281" alt="image" src="https://github.com/user-attachments/assets/b9e093bb-01a2-49bb-96b1-abc38df311ce" />

worst case scenario
<img width="611" height="324" alt="image" src="https://github.com/user-attachments/assets/49654112-216e-4be1-9f6f-c8d6572f0d49" />


