### PR TITLE
tests(alerts): Increase test coverage in incident chart test

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1697,9 +1697,9 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)
-    def create_incident_activity(incident, type, comment=None, user_id=None):
+    def create_incident_activity(incident, type, comment=None, user_id=None, **kwargs):
         return IncidentActivity.objects.create(
-            incident=incident, type=type, comment=comment, user_id=user_id
+            incident=incident, type=type, comment=comment, user_id=user_id, **kwargs
         )
 
     @staticmethod

--- a/tests/sentry/incidents/test_charts.py
+++ b/tests/sentry/incidents/test_charts.py
@@ -162,10 +162,10 @@ class FetchOpenPeriodsTest(TestCase):
         detected_activity_resp = chart_data[0]["activities"][0]
         created_activity_resp = chart_data[0]["activities"][1]
 
-        assert detected_activity_resp["incidentIdentifier"] == str(incident.id)
+        assert detected_activity_resp["incidentIdentifier"] == str(incident.identifier)
         assert detected_activity_resp["type"] == IncidentActivityType.DETECTED.value
         assert detected_activity_resp["dateCreated"] == detected_activity.date_added
 
-        assert created_activity_resp["incidentIdentifier"] == str(incident.id)
+        assert created_activity_resp["incidentIdentifier"] == str(incident.identifier)
         assert created_activity_resp["type"] == IncidentActivityType.CREATED.value
         assert created_activity_resp["dateCreated"] == created_activity.date_added

--- a/tests/sentry/incidents/test_charts.py
+++ b/tests/sentry/incidents/test_charts.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -19,7 +19,7 @@ from sentry.incidents.endpoints.serializers.incident import (
     DetailedIncidentSerializerResponse,
 )
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
-from sentry.incidents.models.incident import Incident
+from sentry.incidents.models.incident import Incident, IncidentActivityType, IncidentStatus
 from sentry.incidents.typings.metric_detector import AlertContext, OpenPeriodContext
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
@@ -128,30 +128,44 @@ class BuildMetricAlertChartTest(TestCase):
 
 class FetchOpenPeriodsTest(TestCase):
     @freeze_time(frozen_time)
-    @patch("sentry.incidents.charts.client.get")
+    @with_feature("organizations:incidents")
     @with_feature("organizations:workflow-engine-single-process-metric-issues")
-    def test_get_incidents_from_detector(self, mock_client_get: MagicMock) -> None:
+    def test_get_incidents_from_detector(self) -> None:
         self.create_detector()  # dummy so detector ID != alert rule ID
         detector = self.create_detector(project=self.project)
         alert_rule = self.create_alert_rule(organization=self.organization, projects=[self.project])
         self.create_alert_rule_detector(detector=detector, alert_rule_id=alert_rule.id)
-        incident = Incident(
+        incident = self.create_incident(
             date_started=must_parse_datetime("2022-05-16T18:55:00Z"),
-            date_closed=None,
+            status=IncidentStatus.CRITICAL.value,
             alert_rule=alert_rule,
         )
+        # create incident activity the same way we do in logic.py create_incident
+        detected_activity = self.create_incident_activity(
+            incident,
+            IncidentActivityType.DETECTED.value,
+            date_added=incident.date_started,
+        )
+        created_activity = self.create_incident_activity(
+            incident,
+            IncidentActivityType.CREATED.value,
+        )
+
         time_period = incident_date_range(60, incident.date_started, incident.date_closed)
 
-        fetch_metric_issue_open_periods(self.organization, detector.id, time_period)
-        mock_client_get.assert_called_with(
-            auth=ANY,
-            user=ANY,
-            path="/organizations/baz/incidents/",
-            params={
-                "alertRule": alert_rule.id,
-                "expand": "activities",
-                "includeSnapshots": True,
-                "project": -1,
-                **time_period,
-            },
-        )
+        chart_data = fetch_metric_issue_open_periods(self.organization, detector.id, time_period)
+        assert chart_data[0]["alertRule"]["id"] == str(alert_rule.id)
+        assert chart_data[0]["projects"] == [self.project.slug]
+        assert chart_data[0]["dateStarted"] == incident.date_started
+
+        assert len(chart_data[0]["activities"]) == 2
+        detected_activity_resp = chart_data[0]["activities"][0]
+        created_activity_resp = chart_data[0]["activities"][1]
+
+        assert detected_activity_resp["incidentIdentifier"] == str(incident.id)
+        assert detected_activity_resp["type"] == IncidentActivityType.DETECTED.value
+        assert detected_activity_resp["dateCreated"] == detected_activity.date_added
+
+        assert created_activity_resp["incidentIdentifier"] == str(incident.id)
+        assert created_activity_resp["type"] == IncidentActivityType.CREATED.value
+        assert created_activity_resp["dateCreated"] == created_activity.date_added


### PR DESCRIPTION
While working on https://getsentry.atlassian.net/browse/ACI-482 I was not able to find a test that asserted the output of `fetch_metric_issue_open_periods`. Since I'll be changing the response I wanted a test to be able to compare against and this one only checked that it was called with the expected params.

This is a little futile since we'll be moving away from this but it's helpful as a starting point. 