### PR TITLE
style(replay): fix scubbber alignment

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -87,7 +87,6 @@ export default function ReplayTimeline() {
 
 const CenteredStack = styled(Stacked)`
   align-items: center;
-  position: absolute;
 `;
 
 const VisibleStack = styled(Stacked)`


### PR DESCRIPTION
before:
seems like `position: absolute` was messing up the grid layout
<img width="972" height="566" alt="SCR-20251003-oylw" src="https://github.com/user-attachments/assets/b6dc845b-d095-4673-9918-7f5dca904a42" />
<img width="1059" height="507" alt="Screenshot 2025-10-03 at 5 04 21 PM" src="https://github.com/user-attachments/assets/538f432e-c07f-47b4-a9ed-3da4a8f05176" />

after:
<img width="965" height="558" alt="SCR-20251003-oypw" src="https://github.com/user-attachments/assets/d4171900-1e06-4059-9e15-6d7d559a5ba4" />
<img width="1059" height="507" alt="Screenshot 2025-10-03 at 5 03 43 PM" src="https://github.com/user-attachments/assets/1f033e3c-db97-4016-8ad0-16786d7f722f" />
