### PR TITLE
feat(releases): add semver resolve version to bulk issues dropdown

### DIFF
--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -213,13 +213,13 @@ describe('ResolveActions', () => {
         onUpdate={spy}
         hasRelease
         projectSlug="proj-1"
-        latestRelease={{version: 'frontend@1.2.3'}}
       />
     );
 
     await userEvent.click(screen.getByLabelText('More resolve options'));
     expect(screen.getByText('The current semver release')).toBeInTheDocument();
-    expect(screen.getByText('1.2.3')).toBeInTheDocument();
+    expect(screen.getByText('1.2.0')).toBeInTheDocument();
+    expect(screen.queryByText('The current release')).not.toBeInTheDocument();
   });
 
   it('shows resolve in latest release option when the current release version does not use semver and flag is enabled', async () => {
@@ -241,6 +241,8 @@ describe('ResolveActions', () => {
     await userEvent.click(screen.getByLabelText('More resolve options'));
     expect(screen.getByText('The current release')).toBeInTheDocument();
     expect(screen.getByText('abc123def')).toBeInTheDocument();
+    expect(screen.getByText('(non-semver)')).toBeInTheDocument();
+    expect(screen.queryByText('The current semver release')).not.toBeInTheDocument();
   });
 
   it('displays prompt to setup releases when there are no releases', async () => {

--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -21,7 +21,13 @@ describe('ResolveActions', () => {
   describe('disabled', () => {
     it('does not call onUpdate when clicked', async () => {
       render(
-        <ResolveActions onUpdate={spy} disabled hasRelease={false} projectSlug="proj-1" />
+        <ResolveActions
+          hasSemverReleaseFeature={false}
+          onUpdate={spy}
+          disabled
+          hasRelease={false}
+          projectSlug="proj-1"
+        />
       );
       const button = screen.getByRole('button', {name: 'Resolve'});
       expect(button).toBeDisabled();
@@ -34,6 +40,7 @@ describe('ResolveActions', () => {
     it('main button calls onUpdate when clicked and dropdown menu disabled', async () => {
       render(
         <ResolveActions
+          hasSemverReleaseFeature={false}
           onUpdate={spy}
           disableDropdown
           hasRelease={false}
@@ -55,6 +62,7 @@ describe('ResolveActions', () => {
     it('calls onUpdate with unresolved status when clicked', async () => {
       render(
         <ResolveActions
+          hasSemverReleaseFeature={false}
           onUpdate={spy}
           disabled
           hasRelease={false}
@@ -80,6 +88,7 @@ describe('ResolveActions', () => {
     it('cannot be unresolved manually', async () => {
       render(
         <ResolveActions
+          hasSemverReleaseFeature={false}
           onUpdate={spy}
           disabled
           hasRelease={false}
@@ -96,7 +105,14 @@ describe('ResolveActions', () => {
 
   describe('without confirmation', () => {
     it('calls spy with resolved status when clicked', async () => {
-      render(<ResolveActions onUpdate={spy} hasRelease={false} projectSlug="proj-1" />);
+      render(
+        <ResolveActions
+          hasSemverReleaseFeature={false}
+          onUpdate={spy}
+          hasRelease={false}
+          projectSlug="proj-1"
+        />
+      );
       await userEvent.click(screen.getByRole('button', {name: 'Resolve'}));
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith({
@@ -111,6 +127,7 @@ describe('ResolveActions', () => {
     it('displays confirmation modal with message provided', async () => {
       render(
         <ResolveActions
+          hasSemverReleaseFeature={false}
           onUpdate={spy}
           hasRelease={false}
           projectSlug="proj-1"
@@ -139,7 +156,14 @@ describe('ResolveActions', () => {
       url: '/projects/org-slug/project-slug/releases/',
       body: [ReleaseFixture()],
     });
-    render(<ResolveActions hasRelease projectSlug="project-slug" onUpdate={onUpdate} />);
+    render(
+      <ResolveActions
+        hasSemverReleaseFeature={false}
+        hasRelease
+        projectSlug="project-slug"
+        onUpdate={onUpdate}
+      />
+    );
     renderGlobalModal();
 
     await userEvent.click(screen.getByLabelText('More resolve options'));
@@ -160,9 +184,10 @@ describe('ResolveActions', () => {
     });
   });
 
-  it('displays if the current release version uses semver', async () => {
+  it('displays if the current release version uses semver and flag is not enabled', async () => {
     render(
       <ResolveActions
+        hasSemverReleaseFeature={false}
         onUpdate={spy}
         hasRelease
         projectSlug="proj-1"
@@ -176,8 +201,31 @@ describe('ResolveActions', () => {
     expect(screen.getByText('(semver)')).toBeInTheDocument();
   });
 
+  it('shows resolve in semver release option when the current release version uses semver and flag is enabled', async () => {
+    render(
+      <ResolveActions
+        hasSemverReleaseFeature
+        onUpdate={spy}
+        hasRelease
+        projectSlug="proj-1"
+        latestRelease={{version: 'frontend@1.2.3'}}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('More resolve options'));
+    expect(screen.getByText('The current semver release')).toBeInTheDocument();
+    expect(screen.getByText('1.2.3')).toBeInTheDocument();
+  });
+
   it('displays prompt to setup releases when there are no releases', async () => {
-    render(<ResolveActions onUpdate={spy} hasRelease={false} projectSlug="proj-1" />);
+    render(
+      <ResolveActions
+        hasSemverReleaseFeature={false}
+        onUpdate={spy}
+        hasRelease={false}
+        projectSlug="proj-1"
+      />
+    );
 
     await userEvent.click(screen.getByLabelText('More resolve options'));
     expect(screen.getByText('Resolving is better with Releases')).toBeInTheDocument();
@@ -186,6 +234,7 @@ describe('ResolveActions', () => {
   it('does not prompt to setup releases when multiple projects are selected', async () => {
     render(
       <ResolveActions
+        hasSemverReleaseFeature={false}
         onUpdate={spy}
         hasRelease={false}
         projectSlug="proj-1"
@@ -205,6 +254,7 @@ describe('ResolveActions', () => {
   it('does render more resolve options', () => {
     render(
       <ResolveActions
+        hasSemverReleaseFeature={false}
         onUpdate={spy}
         hasRelease={false}
         projectSlug="proj-1"
@@ -217,6 +267,7 @@ describe('ResolveActions', () => {
   it('does not render more resolve options', () => {
     render(
       <ResolveActions
+        hasSemverReleaseFeature={false}
         onUpdate={spy}
         hasRelease={false}
         projectSlug="proj-1"
@@ -232,7 +283,14 @@ describe('ResolveActions', () => {
       url: '/projects/org-slug/project-slug/releases/',
       body: [ReleaseFixture()],
     });
-    render(<ResolveActions hasRelease projectSlug="project-slug" onUpdate={onUpdate} />);
+    render(
+      <ResolveActions
+        hasSemverReleaseFeature={false}
+        hasRelease
+        projectSlug="project-slug"
+        onUpdate={onUpdate}
+      />
+    );
 
     await userEvent.click(screen.getByLabelText('More resolve options'));
     expect(await screen.findByText('The next release')).toBeInTheDocument();

--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -202,6 +202,11 @@ describe('ResolveActions', () => {
   });
 
   it('shows resolve in semver release option when the current release version uses semver and flag is enabled', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/',
+      body: [ReleaseFixture()],
+    });
+
     render(
       <ResolveActions
         hasSemverReleaseFeature
@@ -215,6 +220,27 @@ describe('ResolveActions', () => {
     await userEvent.click(screen.getByLabelText('More resolve options'));
     expect(screen.getByText('The current semver release')).toBeInTheDocument();
     expect(screen.getByText('1.2.3')).toBeInTheDocument();
+  });
+
+  it('shows resolve in latest release option when the current release version does not use semver and flag is enabled', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/',
+      body: [],
+    });
+
+    render(
+      <ResolveActions
+        hasSemverReleaseFeature
+        onUpdate={spy}
+        hasRelease
+        projectSlug="proj-1"
+        latestRelease={{version: 'frontend@abc123def'}}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('More resolve options'));
+    expect(screen.getByText('The current release')).toBeInTheDocument();
+    expect(screen.getByText('abc123def')).toBeInTheDocument();
   });
 
   it('displays prompt to setup releases when there are no releases', async () => {

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -302,14 +302,7 @@ function ResolveActions({
         )}
         disabledKeys={
           multipleProjectsSelected
-            ? [
-                'next-release',
-                ...(hasSemverReleaseFeature && latestSemverRelease?.version
-                  ? ['semver-release']
-                  : ['current-release']),
-                'another-release',
-                'a-commit',
-              ]
+            ? ['next-release', 'current-release', 'another-release', 'a-commit']
             : disabled || !hasRelease
               ? [
                   'next-release',

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -54,13 +54,13 @@ function SetupReleasesPrompt() {
 
 interface ResolveActionsProps {
   hasRelease: boolean;
+  hasSemverReleaseFeature: boolean;
   onUpdate: (data: GroupStatusResolution) => void;
   confirmLabel?: string;
   confirmMessage?: React.ReactNode;
   disableDropdown?: boolean;
   disableResolveInRelease?: boolean;
   disabled?: boolean;
-  hasSemverReleaseFeature?: boolean; // TODO(michellewzhang): this should be required eventually
   isAutoResolved?: boolean;
   isResolved?: boolean;
   latestRelease?: Project['latestRelease'];

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -661,6 +661,7 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
                 <GuideAnchor target="resolve" position="bottom" offset={20}>
                   <ResolveActions
                     disableResolveInRelease={!resolveInReleaseCap.enabled}
+                    hasSemverReleaseFeature={hasSemverReleaseFeature}
                     disabled={disabled}
                     disableDropdown={disabled}
                     hasRelease={hasRelease}

--- a/static/app/views/issueList/actions/resolveActions.tsx
+++ b/static/app/views/issueList/actions/resolveActions.tsx
@@ -1,5 +1,7 @@
 import ResolveActions from 'sentry/components/actions/resolve';
+import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
+import useProjectReleaseVersionIsSemver from 'sentry/views/issueDetails/useProjectReleaseVersionIsSemver';
 
 import type {getConfirm, getLabel} from './utils';
 import {ConfirmAction} from './utils';
@@ -21,6 +23,7 @@ function ResolveActionsContainer({
   confirm,
   label,
 }: Props) {
+  const organization = useOrganization();
   const {initiallyLoaded, projects, fetchError} = useProjects({
     slugs: selectedProjectSlug ? [selectedProjectSlug] : [],
   });
@@ -34,6 +37,14 @@ function ResolveActionsContainer({
 
   const latestRelease =
     project && 'latestRelease' in project ? project.latestRelease : undefined;
+
+  const projHasSemverRelease = useProjectReleaseVersionIsSemver({
+    version: project?.latestRelease?.version,
+    enabled: Boolean(project),
+  });
+
+  const hasSemverReleaseFeature =
+    organization.features?.includes('resolve-in-semver-release') && projHasSemverRelease;
 
   // resolve requires a single project to be active in an org context
   // projectId is null when 0 or >1 projects are selected.
@@ -55,6 +66,7 @@ function ResolveActionsContainer({
       disabled={resolveDisabled}
       disableDropdown={resolveDropdownDisabled}
       projectFetchError={Boolean(fetchError)}
+      hasSemverReleaseFeature={hasSemverReleaseFeature}
     />
   );
 }


### PR DESCRIPTION
- closes https://linear.app/getsentry/issue/REPLAY-726/fix-issue-resolve-in-current-release-for-semver-releases
- followup to https://github.com/getsentry/sentry/pull/100342

implement same "resolve in current release" behavior but on the bulk resolve dropdown on issue list:

## before (semver release/non semver release):
<img width="377" height="271" alt="SCR-20251003-pcui" src="https://github.com/user-attachments/assets/26035d47-7970-4236-adba-d373aeb3ecd7" />

## after (semver release):
<img width="386" height="283" alt="SCR-20251003-pdcq-2" src="https://github.com/user-attachments/assets/161d251a-cd08-46ee-b65f-c9a49c86f661" />

## after (non semver release):


<img width="366" height="263" alt="SCR-20251003-pcwm" src="https://github.com/user-attachments/assets/0630da37-abf2-463e-bffb-81c91f8499dc" />

## after (multiple proj selected):
<img width="364" height="257" alt="SCR-20251003-pczd" src="https://github.com/user-attachments/assets/41e204f0-810d-49b4-b5e1-1211038d55ff" />

