### PR TITLE
Add proper empty state to CommitYamlPage

### DIFF
--- a/static/app/views/prevent/coverage/commits/commitYaml.tsx
+++ b/static/app/views/prevent/coverage/commits/commitYaml.tsx
@@ -1,16 +1,18 @@
 import styled from '@emotion/styled';
 
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import {t} from 'sentry/locale';
+
 import {space} from 'sentry/styles/space';
+
+import {LayoutGap} from '../layout';
 
 export default function CommitYamlPage() {
   return (
     <LayoutGap>
-      <p>Commit YAML Page</p>
+      <EmptyStateWarning>
+        <p>{t('Commit YAML configuration')}</p>
+      </EmptyStateWarning>
     </LayoutGap>
   );
 }
-
-const LayoutGap = styled('div')`
-  display: grid;
-  gap: ${space(2)};
-`;

--- a/static/app/views/prevent/coverage/commits/commitYaml.tsx
+++ b/static/app/views/prevent/coverage/commits/commitYaml.tsx
@@ -1,18 +1,21 @@
 import styled from '@emotion/styled';
 
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import {Text} from 'sentry/components/core/text';
 import {t} from 'sentry/locale';
-
 import {space} from 'sentry/styles/space';
-
-import {LayoutGap} from '../layout';
 
 export default function CommitYamlPage() {
   return (
     <LayoutGap>
       <EmptyStateWarning>
-        <p>{t('Commit YAML configuration')}</p>
+        <Text as="p">{t('Commit YAML configuration')}</Text>
       </EmptyStateWarning>
     </LayoutGap>
   );
 }
+
+const LayoutGap = styled('div')`
+  display: grid;
+  gap: ${space(2)};
+`;


### PR DESCRIPTION
## Description

Improves the user experience of the CommitYamlPage by replacing a plain text placeholder with a proper empty state component.

### Changes
- Replaced plain `<p>` tag with `EmptyStateWarning` component
- Added internationalization support using `t()` function
- Improves visual consistency with other empty states across the application

### Why
The previous implementation was just a plain text placeholder. This change provides:
- Better visual hierarchy and styling
- Consistency with Sentry's design patterns for empty states

---

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.