### PR TITLE
ref(settings): Remove usage of `deprecatedRouteProps` from `ProjectTeams` settings

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -528,7 +528,6 @@ function buildRoutes(): RouteObject[] {
       path: 'teams/',
       name: t('Teams'),
       component: make(() => import('sentry/views/settings/project/projectTeams')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'alerts/',

--- a/static/app/views/settings/project/projectTeams.spec.tsx
+++ b/static/app/views/settings/project/projectTeams.spec.tsx
@@ -10,6 +10,7 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -45,6 +46,7 @@ describe('ProjectTeams', () => {
       access: ['project:admin', 'project:write', 'project:admin'],
     };
 
+    ProjectsStore.loadInitialData([project]);
     TeamStore.loadInitialData([team1WithAdmin, team2WithAdmin]);
 
     MockApiClient.addMockResponse({
@@ -89,7 +91,13 @@ describe('ProjectTeams', () => {
       statusCode: 200,
     });
 
-    render(<ProjectTeams organization={org} project={project} />);
+    render(<ProjectTeams />, {
+      organization: org,
+      initialRouterConfig: {
+        location: {pathname: `/settings/projects/${project.slug}/teams/`},
+        route: '/settings/projects/:projectId/teams/',
+      },
+    });
 
     expect(await screen.findByText('Project Teams for project-slug')).toBeInTheDocument();
 
@@ -145,7 +153,13 @@ describe('ProjectTeams', () => {
       statusCode: 200,
     });
 
-    render(<ProjectTeams organization={org} project={project} />);
+    render(<ProjectTeams />, {
+      organization: org,
+      initialRouterConfig: {
+        location: {pathname: `/settings/projects/${project.slug}/teams/`},
+        route: '/settings/projects/:projectId/teams/',
+      },
+    });
 
     expect(await screen.findByText('Project Teams for project-slug')).toBeInTheDocument();
 
@@ -193,7 +207,13 @@ describe('ProjectTeams', () => {
       body: [team3NoAdmin],
     });
 
-    render(<ProjectTeams organization={org} project={project} />);
+    render(<ProjectTeams />, {
+      organization: org,
+      initialRouterConfig: {
+        location: {pathname: `/settings/projects/${project.slug}/teams/`},
+        route: '/settings/projects/:projectId/teams/',
+      },
+    });
 
     expect(await screen.findByText('Project Teams for project-slug')).toBeInTheDocument();
 
@@ -240,7 +260,13 @@ describe('ProjectTeams', () => {
       statusCode: 200,
     });
 
-    render(<ProjectTeams organization={org} project={project} />);
+    render(<ProjectTeams />, {
+      organization: org,
+      initialRouterConfig: {
+        location: {pathname: `/settings/projects/${project.slug}/teams/`},
+        route: '/settings/projects/:projectId/teams/',
+      },
+    });
 
     expect(await screen.findByText('Project Teams for project-slug')).toBeInTheDocument();
 
@@ -279,7 +305,13 @@ describe('ProjectTeams', () => {
       body: TeamFixture({slug: 'new-team'}),
     });
 
-    render(<ProjectTeams project={project} organization={org} />);
+    render(<ProjectTeams />, {
+      organization: org,
+      initialRouterConfig: {
+        location: {pathname: `/settings/projects/${project.slug}/teams/`},
+        route: '/settings/projects/:projectId/teams/',
+      },
+    });
 
     expect(await screen.findByText('Project Teams for project-slug')).toBeInTheDocument();
 

--- a/static/app/views/settings/project/projectTeams.tsx
+++ b/static/app/views/settings/project/projectTeams.tsx
@@ -12,25 +12,26 @@ import Pagination from 'sentry/components/pagination';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import TeamStore from 'sentry/stores/teamStore';
-import type {Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
 import {decodeScalar} from 'sentry/utils/queryString';
 import routeTitleGen from 'sentry/utils/routeTitle';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import useProjects from 'sentry/utils/useProjects';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TeamSelectForProject from 'sentry/views/settings/components/teamSelect/teamSelectForProject';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 
-type ProjectTeamsProps = {
-  organization: Organization;
-  project: Project;
-};
-
-function ProjectTeams({organization, project}: ProjectTeamsProps) {
+export default function ProjectTeams() {
   const navigate = useNavigate();
   const location = useLocation();
+
+  const organization = useOrganization();
+  const {projectId} = useParams<{projectId: string}>();
+  const {projects} = useProjects();
+  const project = projects.find(p => p.slug === projectId)!;
 
   const {
     data: projectTeams,
@@ -116,5 +117,3 @@ function ProjectTeams({organization, project}: ProjectTeamsProps) {
     </SentryDocumentTitle>
   );
 }
-
-export default ProjectTeams;

--- a/static/app/views/settings/project/projectTeams.tsx
+++ b/static/app/views/settings/project/projectTeams.tsx
@@ -30,7 +30,7 @@ export default function ProjectTeams() {
 
   const organization = useOrganization();
   const {projectId} = useParams<{projectId: string}>();
-  const {projects} = useProjects();
+  const {projects} = useProjects({slugs: [projectId]});
   const project = projects.find(p => p.slug === projectId)!;
 
   const {


### PR DESCRIPTION
Migrates usage of `deprecatedRouteProps` for `ProjectTeams` - `sentry/views/settings/project/projectTeams`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7