### PR TITLE
ref(settings): Remove usage of `deprecatedRouteProps` from `ProjectOwnership` settings

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -603,7 +603,6 @@ function buildRoutes(): RouteObject[] {
       path: 'ownership/',
       name: t('Ownership Rules'),
       component: make(() => import('sentry/views/settings/project/projectOwnership')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'data-forwarding/',

--- a/static/app/views/settings/project/projectOwnership/index.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.spec.tsx
@@ -5,14 +5,17 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {openModal} from 'sentry/actionCreators/modal';
+import ProjectsStore from 'sentry/stores/projectsStore';
 import ProjectOwnership from 'sentry/views/settings/project/projectOwnership';
 
 jest.mock('sentry/actionCreators/modal');
 
 describe('Project Ownership', () => {
-  const {organization, project, routerProps} = initializeOrg();
+  const {organization, project} = initializeOrg();
 
   beforeEach(() => {
+    ProjectsStore.loadInitialData([project]);
+
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/ownership/`,
       method: 'GET',
@@ -45,7 +48,13 @@ describe('Project Ownership', () => {
 
   describe('without codeowners', () => {
     it('renders', async () => {
-      render(<ProjectOwnership {...routerProps} project={project} />);
+      render(<ProjectOwnership />, {
+        organization,
+        initialRouterConfig: {
+          location: {pathname: `/settings/projects/${project.slug}/ownership/`},
+          route: '/settings/projects/:projectId/ownership/',
+        },
+      });
       expect(await screen.findByText('No ownership rules found')).toBeInTheDocument();
       // Does not render codeowners for orgs without 'integrations-codeowners' feature
       expect(
@@ -54,8 +63,12 @@ describe('Project Ownership', () => {
     });
 
     it('renders allows users to edit ownership rules', async () => {
-      render(<ProjectOwnership {...routerProps} project={project} />, {
+      render(<ProjectOwnership />, {
         organization: OrganizationFixture({access: ['project:read']}),
+        initialRouterConfig: {
+          location: {pathname: `/settings/projects/${project.slug}/ownership/`},
+          route: '/settings/projects/:projectId/ownership/',
+        },
       });
 
       expect(await screen.findByTestId('project-permission-alert')).toBeInTheDocument();
@@ -71,8 +84,12 @@ describe('Project Ownership', () => {
         features: ['integrations-codeowners'],
         access: ['org:integrations'],
       });
-      render(<ProjectOwnership {...routerProps} project={project} />, {
+      render(<ProjectOwnership />, {
         organization: org,
+        initialRouterConfig: {
+          location: {pathname: `/settings/projects/${project.slug}/ownership/`},
+          route: '/settings/projects/:projectId/ownership/',
+        },
       });
 
       // Renders button
@@ -98,7 +115,13 @@ describe('Project Ownership', () => {
         },
       });
 
-      render(<ProjectOwnership {...routerProps} project={project} />);
+      render(<ProjectOwnership />, {
+        organization,
+        initialRouterConfig: {
+          location: {pathname: `/settings/projects/${project.slug}/ownership/`},
+          route: '/settings/projects/:projectId/ownership/',
+        },
+      });
 
       // Switch to Assign To Issue Owner
       await userEvent.click(await screen.findByText('Auto-assign to suspect commits'));

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -15,7 +15,6 @@ import {IconEdit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {IssueOwnership} from 'sentry/types/group';
 import type {CodeOwner} from 'sentry/types/integrations';
-import type {Project} from 'sentry/types/project';
 import {
   setApiQueryData,
   useApiQuery,
@@ -24,6 +23,8 @@ import {
 } from 'sentry/utils/queryClient';
 import routeTitleGen from 'sentry/utils/routeTitle';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import useProjects from 'sentry/utils/useProjects';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import AddCodeOwnerModal from 'sentry/views/settings/project/projectOwnership/addCodeOwnerModal';
@@ -32,9 +33,12 @@ import {CodeOwnerFileTable} from 'sentry/views/settings/project/projectOwnership
 import {OwnershipRulesTable} from 'sentry/views/settings/project/projectOwnership/ownershipRulesTable';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 
-export default function ProjectOwnership({project}: {project: Project}) {
+export default function ProjectOwnership() {
   const theme = useTheme();
   const organization = useOrganization();
+  const {projectId} = useParams<{projectId: string}>();
+  const {projects} = useProjects();
+  const project = projects.find(p => p.slug === projectId)!;
   const queryClient = useQueryClient();
   const ownershipTitle = t('Ownership Rules');
 

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -37,7 +37,7 @@ export default function ProjectOwnership() {
   const theme = useTheme();
   const organization = useOrganization();
   const {projectId} = useParams<{projectId: string}>();
-  const {projects} = useProjects();
+  const {projects} = useProjects({slugs: [projectId]});
   const project = projects.find(p => p.slug === projectId)!;
   const queryClient = useQueryClient();
   const ownershipTitle = t('Ownership Rules');


### PR DESCRIPTION
Migrates usage of `deprecatedRouteProps` for `ProjectOwnership` - `sentry/views/settings/project/projectOwnership`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7