### PR TITLE
feat(seer-explorer): Make tool calling UI custom for each tool type

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -18,8 +18,18 @@ interface BlockProps {
   ref?: React.Ref<HTMLDivElement>;
 }
 
+function hasValidContent(content: string): boolean {
+  if (!content) {
+    return false;
+  }
+  const trimmed = content.trim();
+  return trimmed.length > 0 && trimmed !== '.'; // sometimes the LLM just says '.' when calling a tool
+}
+
 function BlockComponent({block, isLast, isFocused, onClick, ref}: BlockProps) {
   const toolsUsed = getToolsStringFromBlock(block);
+  const hasTools = toolsUsed.length > 0;
+  const hasContent = hasValidContent(block.message.content);
 
   return (
     <Block ref={ref} isLast={isLast} onClick={onClick}>
@@ -36,10 +46,13 @@ function BlockComponent({block, isLast, isFocused, onClick, ref}: BlockProps) {
             </BlockRow>
           ) : (
             <BlockRow>
-              <ResponseDot isLoading={block.loading} />
-              <BlockContentWrapper>
-                {block.message.content && <BlockContent text={block.message.content} />}
-                {toolsUsed.length > 0 && (
+              <ResponseDot
+                isLoading={block.loading}
+                hasOnlyTools={!hasContent && hasTools}
+              />
+              <BlockContentWrapper hasOnlyTools={!hasContent && hasTools}>
+                {hasContent && <BlockContent text={block.message.content} />}
+                {hasTools && (
                   <Stack gap="md">
                     {toolsUsed.map(tool => (
                       <Text key={tool} size="xs" variant="muted" monospace>
@@ -66,7 +79,6 @@ export default BlockComponent;
 const Block = styled('div')<{isLast?: boolean}>`
   width: 100%;
   border-bottom: ${p => (p.isLast ? 'none' : `1px solid ${p.theme.border}`)};
-  min-height: 40px;
   position: relative;
   flex-shrink: 0; /* Prevent blocks from shrinking */
   cursor: pointer;
@@ -86,11 +98,11 @@ const BlockChevronIcon = styled(IconChevron)`
   flex-shrink: 0;
 `;
 
-const ResponseDot = styled('div')<{isLoading?: boolean}>`
+const ResponseDot = styled('div')<{hasOnlyTools?: boolean; isLoading?: boolean}>`
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  margin-top: 22px;
+  margin-top: ${p => (p.hasOnlyTools ? '12px' : '22px')};
   margin-left: ${space(2)};
   flex-shrink: 0;
   background: ${p => (p.isLoading ? p.theme.pink400 : p.theme.purple400)};
@@ -107,8 +119,9 @@ const ResponseDot = styled('div')<{isLoading?: boolean}>`
   `}
 `;
 
-const BlockContentWrapper = styled('div')`
-  padding: ${space(2)};
+const BlockContentWrapper = styled('div')<{hasOnlyTools?: boolean}>`
+  padding: ${p =>
+    p.hasOnlyTools ? `${p.theme.space.md} ${p.theme.space.xl}` : p.theme.space.xl};
 `;
 
 const BlockContent = styled(MarkedText)`

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -1,10 +1,68 @@
 import type {Block} from './types';
 
-export function getToolsStringFromBlock(block: Block): string[] {
-  // TODO custom displays for each tool
-  const tools: string[] = [];
-  for (const tool of block.message.tool_calls || []) {
-    tools.push('Used ' + tool.function + ' tool');
+/**
+ * Tool formatter function type.
+ * Takes parsed args and loading state, returns the display message.
+ * Implement one for each tool that needs custom display.
+ */
+type ToolFormatter = (args: Record<string, any>, isLoading: boolean) => string;
+
+/**
+ * Registry of custom tool formatters.
+ * Add new tools here to customize their display.
+ */
+const TOOL_FORMATTERS: Record<string, ToolFormatter> = {
+  telemetry_index_list_nodes: (args, isLoading) => {
+    const keyword = args.keyword || 'items';
+    return isLoading ? `Scanning for ${keyword}...` : `Scanned for ${keyword}`;
+  },
+
+  telemetry_index_dependencies: (args, isLoading) => {
+    const title = args.title || 'item';
+    const truncatedTitle = title.length > 50 ? title.slice(0, 50) + '...' : title;
+    return isLoading
+      ? `Tracing the flow of ${truncatedTitle}...`
+      : `Traced the flow of ${truncatedTitle}`;
+  },
+
+  google_search: (args, isLoading) => {
+    const question = args.question || 'query';
+    return isLoading ? `Googling '${question}'...` : `Googled '${question}'`;
+  },
+};
+
+/**
+ * Parse JSON args safely, returning empty object on failure
+ */
+function parseToolArgs(argsString: string): Record<string, any> {
+  try {
+    return JSON.parse(argsString);
+  } catch {
+    return {};
   }
+}
+
+/**
+ * Get display strings for all tool calls in a block.
+ * Uses custom formatters from TOOL_FORMATTERS registry, falls back to generic message.
+ */
+export function getToolsStringFromBlock(block: Block): string[] {
+  const tools: string[] = [];
+  const isLoading = block.loading ?? false;
+
+  for (const tool of block.message.tool_calls || []) {
+    const formatter = TOOL_FORMATTERS[tool.function];
+
+    if (formatter) {
+      // Use custom formatter
+      const args = parseToolArgs(tool.args);
+      tools.push(formatter(args, isLoading));
+    } else {
+      // Fall back to generic message
+      const verb = isLoading ? 'Using' : 'Used';
+      tools.push(`${verb} ${tool.function} tool`);
+    }
+  }
+
   return tools;
 }


### PR DESCRIPTION
Shows custom copy that changes depending on the tool call and loading state. Also fixes a minor alignment issue with tool-call-only blocks and makes them more compact.

<img width="832" height="470" alt="Screenshot 2025-10-05 at 5 12 07 PM" src="https://github.com/user-attachments/assets/ced8316b-2f67-4a6d-b5be-ef60c18809ec" />
