### PR TITLE
fix(ui): remove additional places where FrontendHeader gets rendered

### DIFF
--- a/static/app/views/insights/pages/frontend/am1OverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/am1OverviewPage.tsx
@@ -33,9 +33,7 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_ALLOWED_OPS} from 'sentry/views/insights/pages/backend/settings';
-import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {
-  FRONTEND_LANDING_TITLE,
   FRONTEND_PLATFORMS,
   OVERVIEW_PAGE_ALLOWED_OPS,
 } from 'sentry/views/insights/pages/frontend/settings';
@@ -206,7 +204,6 @@ export function Am1FrontendOverviewPage() {
       organization={organization}
       renderDisabled={NoAccess}
     >
-      <FrontendHeader headerTitle={FRONTEND_LANDING_TITLE} />
       <Layout.Body>
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.spec.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.spec.tsx
@@ -2,7 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture, PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -39,17 +39,16 @@ describe('FrontendOverviewPage', () => {
     it('fetches correct data with unknown + frontend platform', async () => {
       render(<FrontendOverviewPage />, {organization});
 
-      expect(await screen.findByRole('heading', {level: 1})).toHaveTextContent(
-        'Frontend'
-      );
-      expect(mainTableApiCall).toHaveBeenCalledWith(
-        '/organizations/org-slug/events/',
-        expect.objectContaining({
-          query: expect.objectContaining({
-            query:
-              '( ( transaction.op:pageload OR transaction.op:navigation OR transaction.op:ui.render OR transaction.op:interaction ) OR project.id:[1] ) !transaction.op:http.server event.type:transaction',
-          }),
-        })
+      await waitFor(() =>
+        expect(mainTableApiCall).toHaveBeenCalledWith(
+          '/organizations/org-slug/events/',
+          expect.objectContaining({
+            query: expect.objectContaining({
+              query:
+                '( ( transaction.op:pageload OR transaction.op:navigation OR transaction.op:ui.render OR transaction.op:interaction ) OR project.id:[1] ) !transaction.op:http.server event.type:transaction',
+            }),
+          })
+        )
       );
     });
 
@@ -65,17 +64,16 @@ describe('FrontendOverviewPage', () => {
       );
       render(<FrontendOverviewPage />, {organization});
 
-      expect(await screen.findByRole('heading', {level: 1})).toHaveTextContent(
-        'Frontend'
-      );
-      expect(mainTableApiCall).toHaveBeenCalledWith(
-        '/organizations/org-slug/events/',
-        expect.objectContaining({
-          query: expect.objectContaining({
-            query:
-              '( ( transaction.op:pageload OR transaction.op:navigation OR transaction.op:ui.render OR transaction.op:interaction ) ) !transaction.op:http.server event.type:transaction',
-          }),
-        })
+      await waitFor(() =>
+        expect(mainTableApiCall).toHaveBeenCalledWith(
+          '/organizations/org-slug/events/',
+          expect.objectContaining({
+            query: expect.objectContaining({
+              query:
+                '( ( transaction.op:pageload OR transaction.op:navigation OR transaction.op:ui.render OR transaction.op:interaction ) ) !transaction.op:http.server event.type:transaction',
+            }),
+          })
+        )
       );
     });
   });

--- a/static/app/views/insights/pages/platform/shared/layout.tsx
+++ b/static/app/views/insights/pages/platform/shared/layout.tsx
@@ -16,8 +16,6 @@ import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
 import {BACKEND_LANDING_TITLE} from 'sentry/views/insights/pages/backend/settings';
-import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
-import {FRONTEND_LANDING_TITLE} from 'sentry/views/insights/pages/frontend/settings';
 import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import {LegacyOnboarding} from 'sentry/views/performance/onboarding';
 import {getTransactionSearchQuery} from 'sentry/views/performance/utils';
@@ -60,9 +58,7 @@ export function PlatformLandingPageLayout({
     >
       {performanceType === 'backend' ? (
         <BackendHeader headerTitle={BACKEND_LANDING_TITLE} />
-      ) : (
-        <FrontendHeader headerTitle={FRONTEND_LANDING_TITLE} />
-      )}
+      ) : null}
       <Layout.Body>
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>


### PR DESCRIPTION
follow up to

- #100915 

which accidentally introduced duplicate tabs, as there are more places that weren’t accessible to me that also rendered the `<FrontendHeader>` and should’ve been removed in that PR.

fixes:
<img width="1367" height="358" alt="Screenshot 2025-10-06 at 09 41 13" src="https://github.com/user-attachments/assets/2cf628fa-b316-49d6-a134-b19c9504a9d4" />
