### PR TITLE
fix(project-creation): Search being reset on patform select

### DIFF
--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -253,15 +253,7 @@ function PlatformPicker({
                     organization: organization ?? null,
                   });
 
-                  const itemCategories = categoryList
-                    .filter(cat => cat.platforms.has(item.id))
-                    .map(cat => cat.id);
-
-                  if (itemCategories.includes(category)) {
-                    setPlatform({...item, category});
-                  } else {
-                    setPlatform({...item, category: itemCategories[0] ?? 'all'});
-                  }
+                  setPlatform({...item, category});
                 }}
               />
             </div>

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import debounce from 'lodash/debounce';
@@ -20,9 +20,9 @@ import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
 import {useCreateProjectAndRules} from 'sentry/components/onboarding/useCreateProjectAndRules';
-import type {Category, Platform} from 'sentry/components/platformPicker';
-import PlatformPicker from 'sentry/components/platformPicker';
+import PlatformPicker, {type Platform} from 'sentry/components/platformPicker';
 import TeamSelector from 'sentry/components/teamSelector';
+import {categoryList} from 'sentry/data/platformPickerCategories';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {IssueAlertRule} from 'sentry/types/alerts';
@@ -155,7 +155,6 @@ export function CreateProject() {
     'created-project-context',
     null
   );
-
   const autoFill = useMemo(() => {
     return referrer === 'getting-started' && projectId === createdProject?.id;
   }, [referrer, projectId, createdProject?.id]);
@@ -190,6 +189,7 @@ export function CreateProject() {
   }, [autoFill, defaultTeam, createdProject]);
 
   const [formData, setFormData] = useState<FormData>(initialData);
+  const pickerKeyRef = useRef<'create-project' | 'auto-fill'>('create-project');
 
   const canCreateTeam = organization.access.includes('project:admin');
   const isOrgMemberWithNoAccess = accessTeams.length === 0 && !canCreateTeam;
@@ -431,10 +431,7 @@ export function CreateProject() {
   const handlePlatformChange = useCallback(
     (value: Platform | null) => {
       if (!value) {
-        updateFormData('platform', {
-          // By unselecting a platform, we don't want to jump to another category
-          category: formData.platform?.category,
-        });
+        updateFormData('platform', undefined);
         return;
       }
 
@@ -444,10 +441,6 @@ export function CreateProject() {
           enabledConsolePlatforms: organization.enabledConsolePlatforms,
         })
       ) {
-        // By selecting a console platform, we don't want to jump to another category when its closed
-        updateFormData('platform', {
-          category: formData.platform?.category,
-        });
         openConsoleModal({
           organization,
           selectedPlatform: {
@@ -474,16 +467,19 @@ export function CreateProject() {
 
       updateFormData('projectName', newName);
     },
-    [
-      updateFormData,
-      formData.projectName,
-      formData.platform?.key,
-      formData.platform?.category,
-      organization,
-    ]
+    [updateFormData, formData.projectName, formData.platform?.key, organization]
   );
 
-  const category: Category = formData.platform?.category ?? 'popular';
+  const platform = formData.platform?.key;
+  const defaultCategory = platform
+    ? categoryList.find(({platforms}) => platforms.has(platform))?.id
+    : 'popular';
+
+  // Workaround to force PlatformPicker to re-render when users go back in the flow and fields should be pre-filled.
+  // Without this, the selected platform might not be visible depending on the active tab.
+  if (autoFill && platform && pickerKeyRef.current === 'create-project') {
+    pickerKeyRef.current = 'auto-fill';
+  }
 
   return (
     <Access access={canUserCreateProject ? ['project:read'] : ['project:admin']}>
@@ -502,9 +498,9 @@ export function CreateProject() {
           </HelpText>
           <StyledListItem>{t('Choose your platform')}</StyledListItem>
           <PlatformPicker
-            key={category}
-            platform={formData.platform?.key}
-            defaultCategory={formData.platform?.category}
+            key={pickerKeyRef.current}
+            platform={platform}
+            defaultCategory={defaultCategory}
             setPlatform={handlePlatformChange}
             organization={organization}
             showOther


### PR DESCRIPTION
**Problem**
The search bar resets whenever a platform is selected.

**Root Cause**
This happens because the PlatformPicker component re-renders every time the category updates after selecting a new platform.

When that re-render occurs, the noAutoFilter flag is set to true, which resets the search filter (useState value) to an empty string.


https://github.com/user-attachments/assets/bbc76c81-b372-4a20-9d60-dfc62d752b93



**Solution**
We only need the PlatformPicker to re-render once - when users navigate back in the flow after a probject has being creatwed - so that fields can be pre-filled correctly.

The changes in this PR ensure the component only re-renders in that specific case, preventing unnecessary resets.

https://github.com/user-attachments/assets/09e1d7dc-eefa-4774-9481-1408717a1167




Closes https://linear.app/getsentry/issue/TET-1180/platform-search-resets-on-platform-selection