### PR TITLE
fix(ui): Update docs to MCP insights

### DIFF
--- a/static/app/views/insights/mcp/components/groupedDurationWidget.tsx
+++ b/static/app/views/insights/mcp/components/groupedDurationWidget.tsx
@@ -87,7 +87,9 @@ export default function GroupedDurationWidget(props: GroupedDurationWidgetProps)
           message={tct(
             'No MCP spans found. Try updating your filters or learn more about MCP monitoring in our [link:documentation].',
             {
-              link: <ExternalLink href="https://docs.sentry.io/product/insights/mcp/" />,
+              link: (
+                <ExternalLink href="https://docs.sentry.io/product/insights/ai/mcp/" />
+              ),
             }
           )}
         />

--- a/static/app/views/insights/mcp/components/groupedErrorRateWidget.tsx
+++ b/static/app/views/insights/mcp/components/groupedErrorRateWidget.tsx
@@ -87,7 +87,9 @@ export default function GroupedErrorRateWidget(props: GroupedErrorRateWidgetProp
           message={tct(
             'No MCP spans found. Try updating your filters or learn more about MCP monitoring in our [link:documentation].',
             {
-              link: <ExternalLink href="https://docs.sentry.io/product/insights/mcp/" />,
+              link: (
+                <ExternalLink href="https://docs.sentry.io/product/insights/ai/mcp/" />
+              ),
             }
           )}
         />

--- a/static/app/views/insights/mcp/components/groupedTrafficWidget.tsx
+++ b/static/app/views/insights/mcp/components/groupedTrafficWidget.tsx
@@ -87,7 +87,9 @@ export default function GroupedTrafficWidget(props: GroupedTrafficWidgetProps) {
           message={tct(
             'No MCP spans found. Try updating your filters or learn more about MCP monitoring in our [link:documentation].',
             {
-              link: <ExternalLink href="https://docs.sentry.io/product/insights/mcp/" />,
+              link: (
+                <ExternalLink href="https://docs.sentry.io/product/insights/ai/mcp/" />
+              ),
             }
           )}
         />

--- a/static/app/views/insights/mcp/settings.ts
+++ b/static/app/views/insights/mcp/settings.ts
@@ -6,6 +6,6 @@ export const BASE_URL = 'mcp';
 export const DATA_TYPE = t('MCP');
 export const DATA_TYPE_PLURAL = t('MCPs');
 
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/mcp/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/ai/mcp/';
 
 export const MODULE_FEATURES = [];


### PR DESCRIPTION
We changed the route in the docs for MCP monitoring setup. it's now in [https://docs.sentry.io/product/insights/ai/mcp/](https://docs.sentry.io/product/insights/ai/mcp/), we added `/ai/` to it.

This PR update links to MCP docs showed in MCP insights.