### PR TITLE
chore(search-bar): Break down query state actions

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -77,11 +77,59 @@ type DeleteTokensAction = {
   focusOverride?: FocusOverride;
 };
 
-type UpdateFreeTextAction = {
+type UpdateFreeTextActionOnSelect = {
   shouldCommitQuery: boolean;
   text: string;
   tokens: ParseResultToken[];
-  type: 'UPDATE_FREE_TEXT';
+  type: 'UPDATE_FREE_TEXT_ON_SELECT';
+  focusOverride?: FocusOverride;
+};
+
+type UpdateFreeTextActionOnBlur = {
+  shouldCommitQuery: boolean;
+  text: string;
+  tokens: ParseResultToken[];
+  type: 'UPDATE_FREE_TEXT_ON_BLUR';
+  focusOverride?: FocusOverride;
+};
+
+type UpdateFreeTextActionOnCommit = {
+  shouldCommitQuery: boolean;
+  text: string;
+  tokens: ParseResultToken[];
+  type: 'UPDATE_FREE_TEXT_ON_COMMIT';
+  focusOverride?: FocusOverride;
+};
+
+type UpdateFreeTextActionOnExit = {
+  shouldCommitQuery: boolean;
+  text: string;
+  tokens: ParseResultToken[];
+  type: 'UPDATE_FREE_TEXT_ON_EXIT';
+  focusOverride?: FocusOverride;
+};
+
+type UpdateFreeTextActionOnFunction = {
+  shouldCommitQuery: boolean;
+  text: string;
+  tokens: ParseResultToken[];
+  type: 'UPDATE_FREE_TEXT_ON_FUNCTION';
+  focusOverride?: FocusOverride;
+};
+
+type UpdateFreeTextActionOnParenthesis = {
+  shouldCommitQuery: boolean;
+  text: string;
+  tokens: ParseResultToken[];
+  type: 'UPDATE_FREE_TEXT_ON_PARENTHESIS';
+  focusOverride?: FocusOverride;
+};
+
+type UpdateFreeTextActionOnColon = {
+  shouldCommitQuery: boolean;
+  text: string;
+  tokens: ParseResultToken[];
+  type: 'UPDATE_FREE_TEXT_ON_COLON';
   focusOverride?: FocusOverride;
 };
 
@@ -153,6 +201,15 @@ type UpdateAggregateArgsAction = {
 
 type ResetClearAskSeerFeedbackAction = {type: 'RESET_CLEAR_ASK_SEER_FEEDBACK'};
 
+type UpdateFreeTextActions =
+  | UpdateFreeTextActionOnSelect
+  | UpdateFreeTextActionOnBlur
+  | UpdateFreeTextActionOnCommit
+  | UpdateFreeTextActionOnExit
+  | UpdateFreeTextActionOnFunction
+  | UpdateFreeTextActionOnParenthesis
+  | UpdateFreeTextActionOnColon;
+
 export type QueryBuilderActions =
   | ClearAction
   | CommitQueryAction
@@ -160,7 +217,13 @@ export type QueryBuilderActions =
   | ResetFocusOverrideAction
   | DeleteTokenAction
   | DeleteTokensAction
-  | UpdateFreeTextAction
+  | UpdateFreeTextActionOnSelect
+  | UpdateFreeTextActionOnBlur
+  | UpdateFreeTextActionOnCommit
+  | UpdateFreeTextActionOnExit
+  | UpdateFreeTextActionOnFunction
+  | UpdateFreeTextActionOnParenthesis
+  | UpdateFreeTextActionOnColon
   | ReplaceTokensWithTextOnPasteAction
   | ReplaceTokensWithTextOnDeleteAction
   | ReplaceTokensWithTextOnCutAction
@@ -391,7 +454,7 @@ function replaceTokensWithPadding(
 
 function updateFreeText(
   state: QueryBuilderState,
-  action: UpdateFreeTextAction
+  action: UpdateFreeTextActions
 ): QueryBuilderState {
   const newQuery = replaceTokensWithPadding(state.query, action.tokens, action.text);
 
@@ -666,7 +729,13 @@ export function useQueryBuilderState({
             clearAskSeerFeedback: displayAskSeerFeedback ? true : false,
           };
         }
-        case 'UPDATE_FREE_TEXT': {
+        case 'UPDATE_FREE_TEXT_ON_SELECT':
+        case 'UPDATE_FREE_TEXT_ON_BLUR':
+        case 'UPDATE_FREE_TEXT_ON_COMMIT':
+        case 'UPDATE_FREE_TEXT_ON_EXIT':
+        case 'UPDATE_FREE_TEXT_ON_FUNCTION':
+        case 'UPDATE_FREE_TEXT_ON_PARENTHESIS':
+        case 'UPDATE_FREE_TEXT_ON_COLON': {
           const newState = updateFreeText(state, action);
 
           return {

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -77,7 +77,7 @@ type DeleteTokensAction = {
   focusOverride?: FocusOverride;
 };
 
-type UpdateFreeTextAction = {
+export type UpdateFreeTextAction = {
   shouldCommitQuery: boolean;
   text: string;
   tokens: ParseResultToken[];
@@ -85,10 +85,38 @@ type UpdateFreeTextAction = {
   focusOverride?: FocusOverride;
 };
 
-type ReplaceTokensWithTextAction = {
+export type ReplaceTokensWithTextOnPasteAction = {
   text: string;
   tokens: ParseResultToken[];
-  type: 'REPLACE_TOKENS_WITH_TEXT';
+  type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE';
+  focusOverride?: FocusOverride;
+};
+
+type ReplaceTokensWithTextOnDeleteAction = {
+  text: string;
+  tokens: ParseResultToken[];
+  type: 'REPLACE_TOKENS_WITH_TEXT_ON_DELETE';
+  focusOverride?: FocusOverride;
+};
+
+type ReplaceTokensWithTextOnCutAction = {
+  text: string;
+  tokens: ParseResultToken[];
+  type: 'REPLACE_TOKENS_WITH_TEXT_ON_CUT';
+  focusOverride?: FocusOverride;
+};
+
+type ReplaceTokensWithTextOnKeyDownAction = {
+  text: string;
+  tokens: ParseResultToken[];
+  type: 'REPLACE_TOKENS_WITH_TEXT_ON_KEY_DOWN';
+  focusOverride?: FocusOverride;
+};
+
+type ReplaceTokensWithTextOnSelectAction = {
+  text: string;
+  tokens: ParseResultToken[];
+  type: 'REPLACE_TOKENS_WITH_TEXT_ON_SELECT';
   focusOverride?: FocusOverride;
 };
 
@@ -133,7 +161,11 @@ export type QueryBuilderActions =
   | DeleteTokenAction
   | DeleteTokensAction
   | UpdateFreeTextAction
-  | ReplaceTokensWithTextAction
+  | ReplaceTokensWithTextOnPasteAction
+  | ReplaceTokensWithTextOnDeleteAction
+  | ReplaceTokensWithTextOnCutAction
+  | ReplaceTokensWithTextOnKeyDownAction
+  | ReplaceTokensWithTextOnSelectAction
   | UpdateFilterKeyAction
   | UpdateFilterOpAction
   | UpdateTokenValueAction
@@ -643,7 +675,11 @@ export function useQueryBuilderState({
               newState.query !== state.query && displayAskSeerFeedback ? true : false,
           };
         }
-        case 'REPLACE_TOKENS_WITH_TEXT':
+        case 'REPLACE_TOKENS_WITH_TEXT_ON_CUT':
+        case 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE':
+        case 'REPLACE_TOKENS_WITH_TEXT_ON_DELETE':
+        case 'REPLACE_TOKENS_WITH_TEXT_ON_SELECT':
+        case 'REPLACE_TOKENS_WITH_TEXT_ON_KEY_DOWN':
           return replaceTokensWithText(state, {
             tokens: action.tokens,
             text: action.text,

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -77,7 +77,7 @@ type DeleteTokensAction = {
   focusOverride?: FocusOverride;
 };
 
-export type UpdateFreeTextAction = {
+type UpdateFreeTextAction = {
   shouldCommitQuery: boolean;
   text: string;
   tokens: ParseResultToken[];
@@ -85,7 +85,7 @@ export type UpdateFreeTextAction = {
   focusOverride?: FocusOverride;
 };
 
-export type ReplaceTokensWithTextOnPasteAction = {
+type ReplaceTokensWithTextOnPasteAction = {
   text: string;
   tokens: ParseResultToken[];
   type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE';

--- a/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
+++ b/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
@@ -46,7 +46,7 @@ export function SelectionKeyHandler({
       const text = e.clipboardData.getData('text/plain').replace('\n', '').trim();
 
       dispatch({
-        type: 'REPLACE_TOKENS_WITH_TEXT',
+        type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
         tokens: selectedTokens,
         text,
       });
@@ -62,7 +62,7 @@ export function SelectionKeyHandler({
           e.preventDefault();
           e.stopPropagation();
           dispatch({
-            type: 'REPLACE_TOKENS_WITH_TEXT',
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_DELETE',
             tokens: selectedTokens,
             text: '',
           });
@@ -128,7 +128,7 @@ export function SelectionKeyHandler({
               state.selectionManager.clearSelection();
               copySelectedTokens();
               dispatch({
-                type: 'REPLACE_TOKENS_WITH_TEXT',
+                type: 'REPLACE_TOKENS_WITH_TEXT_ON_CUT',
                 tokens: selectedTokens,
                 text: '',
               });
@@ -145,7 +145,7 @@ export function SelectionKeyHandler({
           // If the key pressed will generate a symbol, replace the selection with it
           if (/^.$/u.test(e.key)) {
             dispatch({
-              type: 'REPLACE_TOKENS_WITH_TEXT',
+              type: 'REPLACE_TOKENS_WITH_TEXT_ON_KEY_DOWN',
               text: e.key,
               tokens: selectedTokens,
             });

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -106,7 +106,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       }
 
       dispatch({
-        type: 'REPLACE_TOKENS_WITH_TEXT',
+        type: 'REPLACE_TOKENS_WITH_TEXT_ON_SELECT',
         tokens: [token],
         text: getInitialFilterText(keyName, newFieldDef),
         focusOverride: {

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -370,7 +370,7 @@ function SearchQueryBuilderInputInternal({
         .trim();
 
       dispatch({
-        type: 'REPLACE_TOKENS_WITH_TEXT',
+        type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
         tokens: [token],
         text: clipboardText,
       });

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -416,7 +416,7 @@ function SearchQueryBuilderInputInternal({
 
           if (option.type === 'raw-search') {
             dispatch({
-              type: 'UPDATE_FREE_TEXT',
+              type: 'UPDATE_FREE_TEXT_ON_SELECT',
               tokens: [token],
               text: option.value,
               shouldCommitQuery: true,
@@ -427,7 +427,7 @@ function SearchQueryBuilderInputInternal({
 
           if (option.type === 'filter-value' && option.textValue) {
             dispatch({
-              type: 'UPDATE_FREE_TEXT',
+              type: 'UPDATE_FREE_TEXT_ON_SELECT',
               tokens: [token],
               text: replaceFocusedWord(inputValue, selectionIndex, option.textValue),
               focusOverride: calculateNextFocusForInsertedToken(item),
@@ -439,7 +439,7 @@ function SearchQueryBuilderInputInternal({
 
           if (option.type === 'raw-search-filter-is-value' && option.textValue) {
             dispatch({
-              type: 'UPDATE_FREE_TEXT',
+              type: 'UPDATE_FREE_TEXT_ON_SELECT',
               tokens: [token],
               text: option.textValue,
               focusOverride: calculateNextFocusForInsertedToken(item),
@@ -452,7 +452,7 @@ function SearchQueryBuilderInputInternal({
           const value = option.value;
 
           dispatch({
-            type: 'UPDATE_FREE_TEXT',
+            type: 'UPDATE_FREE_TEXT_ON_SELECT',
             tokens: [token],
             text: replaceFocusedWordWithFilter(
               inputValue,
@@ -479,7 +479,7 @@ function SearchQueryBuilderInputInternal({
         }}
         onCustomValueBlurred={value => {
           dispatch({
-            type: 'UPDATE_FREE_TEXT',
+            type: 'UPDATE_FREE_TEXT_ON_BLUR',
             tokens: [token],
             text: value,
             focusOverride: calculateNextFocusForCommittedCustomValue({
@@ -499,7 +499,7 @@ function SearchQueryBuilderInputInternal({
 
           // Otherwise, commit the query (which will trigger a search)
           dispatch({
-            type: 'UPDATE_FREE_TEXT',
+            type: 'UPDATE_FREE_TEXT_ON_COMMIT',
             tokens: [token],
             text: value,
             focusOverride: calculateNextFocusForCommittedCustomValue({
@@ -513,7 +513,7 @@ function SearchQueryBuilderInputInternal({
         onExit={() => {
           if (inputValue !== token.value.trim()) {
             dispatch({
-              type: 'UPDATE_FREE_TEXT',
+              type: 'UPDATE_FREE_TEXT_ON_EXIT',
               tokens: [token],
               text: inputValue,
               shouldCommitQuery: false,
@@ -550,7 +550,7 @@ function SearchQueryBuilderInputInternal({
                 getFieldDefinition(maybeFunction.value)?.kind === FieldKind.FUNCTION
               ) {
                 dispatch({
-                  type: 'UPDATE_FREE_TEXT',
+                  type: 'UPDATE_FREE_TEXT_ON_FUNCTION',
                   tokens: [token],
                   text: replaceFocusedWordWithFilter(
                     inputValue,
@@ -571,7 +571,7 @@ function SearchQueryBuilderInputInternal({
 
             // It's not a function so treat it as just a parenthesis
             dispatch({
-              type: 'UPDATE_FREE_TEXT',
+              type: 'UPDATE_FREE_TEXT_ON_PARENTHESIS',
               tokens: [token],
               text: e.target.value,
               focusOverride: calculateNextFocusForInsertedToken(item),
@@ -591,7 +591,7 @@ function SearchQueryBuilderInputInternal({
             const filterKey = getSuggestedFilterKey(filterValue) ?? filterValue;
             const key = filterKeys[filterKey];
             dispatch({
-              type: 'UPDATE_FREE_TEXT',
+              type: 'UPDATE_FREE_TEXT_ON_COLON',
               tokens: [token],
               text: replaceFocusedWordWithFilter(
                 inputValue,


### PR DESCRIPTION
This PR breaks down the different `UPDATE_FREE_TEXT` and `REPLACE_TOKENS_TEXT` to versions with specific actions. 

This will help with work to enable replacement when a raw search key is present.