### PR TITLE
fix(ui): make sure drawer headers don't shrink

### DIFF
--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -167,6 +167,7 @@ const Header = styled('header')<{hideBar?: boolean; hideCloseButton?: boolean}>`
   background: ${p => p.theme.background};
   justify-content: flex-start;
   display: flex;
+  flex-shrink: 0;
   gap: ${p => (p.hideBar ? space(1) : 0)};
   padding: ${space(1.5)};
   box-shadow: ${p => p.theme.border} 0 1px;


### PR DESCRIPTION
when there isn’t enough vertical space, drawer header collapsed to be unreadable.

before:
<img width="1353" height="339" alt="Screenshot 2025-10-06 at 15 50 47" src="https://github.com/user-attachments/assets/614add4b-e651-41c8-ad26-e8b3cdeacbb8" />

after:
<img width="1353" height="339" alt="Screenshot 2025-10-06 at 15 50 38" src="https://github.com/user-attachments/assets/4c2faa30-4e6b-4490-abd3-aa220777bdf3" />

note: I think the change for this would only be necessary in `EventDrawerHeader`:

https://github.com/getsentry/sentry/blob/1f0ab46a826824cc3237c7e8210a203ebfb12d1a/static/app/components/events/eventDrawer.tsx#L49

because the `height: 100%` of the `FullHeightWrapper` causes the issue (@gggritso FYI):

https://github.com/getsentry/sentry/blob/0e5250ad4c7e28570b5e40d0d6327d6145187142/static/app/views/insights/common/utils/useSamplesDrawer.tsx#L105-L106

But I _think_ we never want the header of a drawer to shrink?

also @getsentry/design-engineering: should we move the `drawer` to core-components ?
