### PR TITLE
feat(tracemetrics): Add stub UI for chart and related info

### DIFF
--- a/static/app/views/explore/metrics/metricGraph.tsx
+++ b/static/app/views/explore/metrics/metricGraph.tsx
@@ -1,0 +1,132 @@
+import {Fragment, useMemo} from 'react';
+
+import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {IconClock, IconGraph} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
+import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {ChartVisualization} from 'sentry/views/explore/components/chart/chartVisualization';
+import {
+  ChartIntervalUnspecifiedStrategy,
+  useChartInterval,
+} from 'sentry/views/explore/hooks/useChartInterval';
+import {TOP_EVENTS_LIMIT} from 'sentry/views/explore/hooks/useTopEvents';
+import {useMetricVisualize} from 'sentry/views/explore/metrics/metricsQueryParams';
+import {useQueryParamsTopEventsLimit} from 'sentry/views/explore/queryParams/context';
+import {EXPLORE_CHART_TYPE_OPTIONS} from 'sentry/views/explore/spans/charts';
+import {
+  combineConfidenceForSeries,
+  prettifyAggregation,
+} from 'sentry/views/explore/utils';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+import type {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
+
+interface MetricsGraphProps {
+  timeseriesResult: ReturnType<typeof useSortedTimeSeries>;
+}
+
+export function MetricsGraph({timeseriesResult}: MetricsGraphProps) {
+  const visualize = useMetricVisualize();
+
+  // Stub functions for chart interactions - not fully implemented yet
+  function handleChartTypeChange(_chartType: ChartType) {
+    // TODO: Implement chart type change for metrics
+  }
+
+  return (
+    <Graph
+      visualize={visualize}
+      timeseriesResult={timeseriesResult}
+      onChartTypeChange={handleChartTypeChange}
+    />
+  );
+}
+
+interface GraphProps extends MetricsGraphProps {
+  onChartTypeChange: (chartType: ChartType) => void;
+  visualize: ReturnType<typeof useMetricVisualize>;
+}
+
+function Graph({onChartTypeChange, timeseriesResult, visualize}: GraphProps) {
+  const aggregate = visualize.yAxis;
+  const topEventsLimit = useQueryParamsTopEventsLimit();
+
+  const [interval, setInterval, intervalOptions] = useChartInterval({
+    unspecifiedStrategy: ChartIntervalUnspecifiedStrategy.USE_SMALLEST,
+  });
+
+  const chartInfo = useMemo(() => {
+    const series = timeseriesResult.data[aggregate] ?? [];
+    const isTopEvents = defined(topEventsLimit);
+    const samplingMeta = determineSeriesSampleCountAndIsSampled(series, isTopEvents);
+    return {
+      chartType: visualize.chartType,
+      series,
+      timeseriesResult,
+      yAxis: aggregate,
+      confidence: combineConfidenceForSeries(series),
+      dataScanned: samplingMeta.dataScanned,
+      isSampled: samplingMeta.isSampled,
+      sampleCount: samplingMeta.sampleCount,
+      samplingMode: undefined,
+      topEvents: isTopEvents ? TOP_EVENTS_LIMIT : undefined,
+    };
+  }, [visualize.chartType, timeseriesResult, aggregate, topEventsLimit]);
+
+  const Title = (
+    <Widget.WidgetTitle title={prettifyAggregation(aggregate) ?? aggregate} />
+  );
+
+  const chartIcon =
+    visualize.chartType === ChartType.LINE
+      ? 'line'
+      : visualize.chartType === ChartType.AREA
+        ? 'area'
+        : 'bar';
+
+  const Actions = (
+    <Fragment>
+      <Tooltip title={t('Type of chart displayed in this visualization (ex. line)')}>
+        <CompactSelect
+          triggerProps={{
+            icon: <IconGraph type={chartIcon} />,
+            borderless: true,
+            showChevron: false,
+            size: 'xs',
+          }}
+          value={visualize.chartType}
+          menuTitle="Type"
+          options={EXPLORE_CHART_TYPE_OPTIONS}
+          onChange={option => onChartTypeChange(option.value)}
+        />
+      </Tooltip>
+      <Tooltip title={t('Time interval displayed in this visualization (ex. 5m)')}>
+        <CompactSelect
+          value={interval}
+          onChange={({value}) => setInterval(value)}
+          triggerProps={{
+            icon: <IconClock />,
+            borderless: true,
+            showChevron: false,
+            size: 'xs',
+          }}
+          menuTitle="Interval"
+          options={intervalOptions}
+        />
+      </Tooltip>
+    </Fragment>
+  );
+
+  return (
+    <Widget
+      Title={Title}
+      Actions={Actions}
+      Visualization={visualize.visible && <ChartVisualization chartInfo={chartInfo} />}
+      height={visualize.visible ? 200 : 50}
+      revealActions="always"
+      borderless
+    />
+  );
+}

--- a/static/app/views/explore/metrics/metricInfoTabs.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs.tsx
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled';
+
+import {TabList, TabPanels, TabStateProvider} from 'sentry/components/core/tabs';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+enum MetricsInfoTab {
+  AGGREGATES = 'aggregates',
+  ERRORS = 'errors',
+  LOGS = 'logs',
+  TRACES = 'traces',
+}
+
+export default function MetricInfoTabs() {
+  return (
+    <Container>
+      <TabStateProvider<MetricsInfoTab> defaultValue={MetricsInfoTab.AGGREGATES}>
+        <TabList>
+          <TabList.Item key={MetricsInfoTab.AGGREGATES}>{t('Aggregates')}</TabList.Item>
+          <TabList.Item key={MetricsInfoTab.ERRORS}>{t('Errors')}</TabList.Item>
+          <TabList.Item key={MetricsInfoTab.LOGS}>{t('Logs')}</TabList.Item>
+          <TabList.Item key={MetricsInfoTab.TRACES}>{t('Traces')}</TabList.Item>
+        </TabList>
+
+        <StyledTabPanels>
+          <TabPanels.Item key={MetricsInfoTab.AGGREGATES}>
+            <EmptyStateWarning>
+              <p>{t('No aggregates data available')}</p>
+            </EmptyStateWarning>
+          </TabPanels.Item>
+          <TabPanels.Item key={MetricsInfoTab.ERRORS}>
+            <EmptyStateWarning>
+              <p>{t('No errors data available')}</p>
+            </EmptyStateWarning>
+          </TabPanels.Item>
+          <TabPanels.Item key={MetricsInfoTab.LOGS}>
+            <EmptyStateWarning>
+              <p>{t('No logs data available')}</p>
+            </EmptyStateWarning>
+          </TabPanels.Item>
+          <TabPanels.Item key={MetricsInfoTab.TRACES}>
+            <EmptyStateWarning>
+              <p>{t('No traces data available')}</p>
+            </EmptyStateWarning>
+          </TabPanels.Item>
+        </StyledTabPanels>
+      </TabStateProvider>
+    </Container>
+  );
+}
+
+const Container = styled('div')`
+  display: grid;
+  grid-template-rows: max-content 1fr;
+  height: 100%;
+  gap: ${space(2)};
+`;
+
+const StyledTabPanels = styled(TabPanels)`
+  display: flex;
+  flex-direction: column;
+`;

--- a/static/app/views/explore/metrics/metricInfoTabs.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs.tsx
@@ -1,9 +1,8 @@
-import styled from '@emotion/styled';
+import {Fragment} from 'react';
 
 import {TabList, TabPanels, TabStateProvider} from 'sentry/components/core/tabs';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 
 enum MetricsInfoTab {
   AGGREGATES = 'aggregates',
@@ -14,7 +13,7 @@ enum MetricsInfoTab {
 
 export default function MetricInfoTabs() {
   return (
-    <Container>
+    <Fragment>
       <TabStateProvider<MetricsInfoTab> defaultValue={MetricsInfoTab.AGGREGATES}>
         <TabList>
           <TabList.Item key={MetricsInfoTab.AGGREGATES}>{t('Aggregates')}</TabList.Item>
@@ -23,7 +22,7 @@ export default function MetricInfoTabs() {
           <TabList.Item key={MetricsInfoTab.TRACES}>{t('Traces')}</TabList.Item>
         </TabList>
 
-        <StyledTabPanels>
+        <TabPanels>
           <TabPanels.Item key={MetricsInfoTab.AGGREGATES}>
             <EmptyStateWarning>
               <p>{t('No aggregates data available')}</p>
@@ -44,20 +43,8 @@ export default function MetricInfoTabs() {
               <p>{t('No traces data available')}</p>
             </EmptyStateWarning>
           </TabPanels.Item>
-        </StyledTabPanels>
+        </TabPanels>
       </TabStateProvider>
-    </Container>
+    </Fragment>
   );
 }
-
-const Container = styled('div')`
-  display: grid;
-  grid-template-rows: max-content 1fr;
-  height: 100%;
-  gap: ${space(2)};
-`;
-
-const StyledTabPanels = styled(TabPanels)`
-  display: flex;
-  flex-direction: column;
-`;

--- a/static/app/views/explore/metrics/metricPanel.tsx
+++ b/static/app/views/explore/metrics/metricPanel.tsx
@@ -1,0 +1,68 @@
+import {useRef} from 'react';
+
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import PanelHeader from 'sentry/components/panels/panelHeader';
+import SplitPanel from 'sentry/components/splitPanel';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useDimensions} from 'sentry/utils/useDimensions';
+import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
+import {MetricsGraph} from 'sentry/views/explore/metrics/metricGraph';
+import MetricInfoTabs from 'sentry/views/explore/metrics/metricInfoTabs';
+import {MetricRow} from 'sentry/views/explore/metrics/metricRow';
+import {useMetricVisualize} from 'sentry/views/explore/metrics/metricsQueryParams';
+import {type TraceMetric} from 'sentry/views/explore/metrics/traceMetric';
+import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
+
+interface MetricPanelProps {
+  traceMetric: TraceMetric;
+}
+
+const MIN_LEFT_WIDTH = 400;
+const MIN_RIGHT_WIDTH = 400;
+
+export function MetricPanel({traceMetric}: MetricPanelProps) {
+  const visualize = useMetricVisualize();
+  const measureRef = useRef<HTMLDivElement>(null);
+  const {width} = useDimensions({elementRef: measureRef});
+  const [interval] = useChartInterval();
+
+  const timeseriesResult = useSortedTimeSeries(
+    {
+      search: new MutableSearch(''),
+      yAxis: [visualize.yAxis],
+      interval,
+      fields: [],
+      enabled: true,
+    },
+    'api.explore.metrics-stats',
+    DiscoverDatasets.SPANS
+  );
+
+  const hasSize = width > 0;
+
+  return (
+    <Panel>
+      <PanelHeader>
+        <MetricRow traceMetric={traceMetric} />
+      </PanelHeader>
+      <PanelBody>
+        <div ref={measureRef}>
+          {hasSize ? (
+            <SplitPanel
+              availableSize={width}
+              left={{
+                content: <MetricsGraph timeseriesResult={timeseriesResult} />,
+                default: width * 0.65,
+                min: MIN_LEFT_WIDTH,
+                max: width - MIN_RIGHT_WIDTH,
+              }}
+              right={<MetricInfoTabs />}
+            />
+          ) : null}
+        </div>
+      </PanelBody>
+    </Panel>
+  );
+}

--- a/static/app/views/explore/metrics/metricRow.tsx
+++ b/static/app/views/explore/metrics/metricRow.tsx
@@ -1,6 +1,9 @@
 import {useMemo} from 'react';
 
+import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {Flex} from 'sentry/components/core/layout';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
+import {t} from 'sentry/locale';
 import {
   TraceItemSearchQueryBuilder,
   useSearchQueryBuilderProps,
@@ -13,6 +16,7 @@ import {
   useQueryParamsQuery,
   useSetQueryParamsQuery,
 } from 'sentry/views/explore/queryParams/context';
+import type {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface MetricRowProps {
@@ -60,13 +64,37 @@ function MetricToolbar({
   tracesItemSearchQueryBuilderProps,
   traceMetric,
 }: MetricToolbarProps) {
-  const visualize = useMetricVisualize();
+  const visualize = useMetricVisualize() as VisualizeFunction;
   const groupBys = useQueryParamsGroupBys();
   const query = useQueryParamsQuery();
   return (
-    <div>
+    <div style={{width: '100%'}}>
       {traceMetric.name}/{visualize.yAxis}/ by {groupBys.join(',')}/ where {query}
-      <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />
+      <Flex direction="row" gap="md" align="center">
+        {t('Query')}
+        <CompactSelect
+          options={[
+            {
+              label: 'span.duration',
+              value: 'span.duration',
+            },
+          ]}
+          value={visualize.parsedFunction?.arguments?.[0] ?? ''}
+        />
+        <CompactSelect
+          options={[
+            {
+              label: 'count',
+              value: 'count',
+            },
+          ]}
+          value={visualize.parsedFunction?.name}
+        />
+        {t('by')}
+        <CompactSelect options={[]} value={groupBys[0] ?? ''} />
+        {t('where')}
+        <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />
+      </Flex>
     </div>
   );
 }

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -10,6 +10,7 @@ import {
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
 
 interface MetricsQueryParamsProviderProps {
   children: ReactNode;
@@ -29,8 +30,10 @@ export function MetricsQueryParamsProvider({children}: MetricsQueryParamsProvide
       sortBys: [{field: 'timestamp', kind: 'desc'}],
 
       aggregateCursor: '',
-      aggregateFields: [new VisualizeFunction('sum(value)')],
-      aggregateSortBys: [{field: 'sum(value)', kind: 'desc'}],
+      aggregateFields: [
+        new VisualizeFunction('count(span.duration)', {chartType: ChartType.BAR}),
+      ],
+      aggregateSortBys: [{field: 'count(span.duration)', kind: 'desc'}],
     });
   }, [query]);
 

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -1,9 +1,13 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/core/button';
+import {Flex} from 'sentry/components/core/layout';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
+import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {
   BottomSectionBody,
@@ -11,7 +15,7 @@ import {
   StyledPageFilterBar,
   TopSectionBody,
 } from 'sentry/views/explore/logs/styles';
-import {MetricRow} from 'sentry/views/explore/metrics/metricRow';
+import {MetricPanel} from 'sentry/views/explore/metrics/metricPanel';
 import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {type TraceMetric} from 'sentry/views/explore/metrics/traceMetric';
 import type {PickableDays} from 'sentry/views/explore/utils';
@@ -61,20 +65,44 @@ function MetricsTabFilterSection({
 }
 
 function MetricsTabBodySection() {
-  const traceMetrics: TraceMetric[] = useMemo(() => {
-    return [{name: 'myfirstmetric'}, {name: 'mysecondmetric'}];
-  }, []);
+  const [traceMetrics, setTraceMetrics] = useState<TraceMetric[]>([
+    {name: 'myfirstmetric'},
+    {name: 'mysecondmetric'},
+  ]);
 
   return (
     <BottomSectionBody>
-      {traceMetrics.map((traceMetric, index) => {
-        return (
-          // TODO: figure out a better `key`
-          <MetricsQueryParamsProvider key={index}>
-            <MetricRow traceMetric={traceMetric} />
-          </MetricsQueryParamsProvider>
-        );
-      })}
+      <Flex direction="column" gap="lg">
+        {traceMetrics.map((traceMetric, index) => {
+          return (
+            // TODO: figure out a better `key`
+            <MetricsQueryParamsProvider key={index}>
+              <MetricPanel traceMetric={traceMetric} />
+            </MetricsQueryParamsProvider>
+          );
+        })}
+        <AddMetricButtonContainer>
+          <Button
+            size="sm"
+            priority="default"
+            icon={<IconAdd />}
+            onClick={() => {
+              setTraceMetrics([
+                ...traceMetrics,
+                {name: `metric${traceMetrics.length + 1}`},
+              ]);
+            }}
+          >
+            {t('Add Metric')}
+          </Button>
+        </AddMetricButtonContainer>
+      </Flex>
     </BottomSectionBody>
   );
 }
+
+const AddMetricButtonContainer = styled('div')`
+  button {
+    width: 100%;
+  }
+`;


### PR DESCRIPTION
Stubs out some UI from the mockups.
- Adds a chart in a split view with a tabbed section on the right
  - I went with a resizable panel because I thought it might be nice. We can totally get rid of it and do static sections if we want.
- The charts currently do spans requests with `useSortedTimeSeries`, the data can be swapped out at a later date
- The dropdowns are also hardcoded at the moment and can be swapped out after as well.
- Can add widgets, but they're stored in state right now and I don't have delete functionality at the moment
- Chart type is mocked out with state, but should be obtained through a hook with the query params context

Follow up:
- dynamically load options for each of the selection fields
- make the chart query metrics
- render the relevant information in the tabbed info sections
- sync chart hover

https://github.com/user-attachments/assets/31d3d391-d526-4a31-8e34-b54278dfca9d
