### PR TITLE
ref(ui): Add reloadIfStale prop to Link component

### DIFF
--- a/static/app/components/core/link/link.spec.tsx
+++ b/static/app/components/core/link/link.spec.tsx
@@ -35,10 +35,24 @@ describe('Link', () => {
     expect(router.location.pathname).toBe('/issues/');
   });
 
-  it('links do full page reload when frontend is outdated', () => {
-    render(
+  it('links do NOT do full page reload when frontend is outdated and reloadIfStale is false', async () => {
+    const {router} = render(
       <FrontendVersionProvider releaseVersion="frontend@abc123" force="stale">
         <Link to="/issues/">Link</Link>
+      </FrontendVersionProvider>
+    );
+
+    // Normal router navigation even when stale
+    await userEvent.click(screen.getByRole('link'));
+    expect(router.location.pathname).toBe('/issues/');
+  });
+
+  it('links do full page reload when frontend is outdated and reloadIfStale is true', () => {
+    render(
+      <FrontendVersionProvider releaseVersion="frontend@abc123" force="stale">
+        <Link to="/issues/" reloadIfStale>
+          Link
+        </Link>
       </FrontendVersionProvider>
     );
 

--- a/static/app/components/core/link/link.tsx
+++ b/static/app/components/core/link/link.tsx
@@ -33,6 +33,12 @@ export interface LinkProps
    * Indicator if the link should be disabled
    */
   disabled?: boolean;
+  /**
+   * If true, will reload the page when the frontend app is stale.
+   * Use this for primary navigation links where you want to ensure
+   * the user gets the latest version of the app.
+   */
+  reloadIfStale?: boolean;
 }
 
 const getLinkStyles = ({
@@ -69,7 +75,7 @@ const Anchor = styled('a', {
  * A context-aware version of Link (from react-router) that falls
  * back to <a> if there is no router present
  */
-export const Link = styled(({disabled, to, ...props}: LinkProps) => {
+export const Link = styled(({disabled, to, reloadIfStale, ...props}: LinkProps) => {
   const location = useLocation();
 
   // If the frontend app is stale we can force the link to reload the page,
@@ -82,7 +88,7 @@ export const Link = styled(({disabled, to, ...props}: LinkProps) => {
 
   return (
     <RouterLink
-      reloadDocument={appState === 'stale'}
+      reloadDocument={reloadIfStale && appState === 'stale'}
       to={locationDescriptorToTo(normalizeUrl(to, location))}
       {...props}
     />

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -180,6 +180,7 @@ function SidebarNavLink({
   return (
     <NavLink
       to={to}
+      reloadIfStale
       state={{source: SIDEBAR_NAVIGATION_SOURCE}}
       aria-selected={activePrimaryNavGroup === group ? true : isActive}
       aria-current={isActive ? 'page' : undefined}


### PR DESCRIPTION
Instead of reloading the page on every link click when the frontend
is stale, only reload when the reloadIfStale prop is set to true.
This provides better control over when page reloads occur.

Updated primary navigation links to use reloadIfStale so that
navigating between major sections (Issues, Explore, Dashboards, etc.)
will reload the page when needed, while keeping normal link behavior
for all other links in the application.