### PR TITLE
ref(ui): Only reload page on primary nav clicks when frontend is stale

### DIFF
--- a/static/app/components/core/link/link.spec.tsx
+++ b/static/app/components/core/link/link.spec.tsx
@@ -1,7 +1,6 @@
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {ExternalLink, Link} from 'sentry/components/core/link';
-import {FrontendVersionProvider} from 'sentry/components/frontendVersionContext';
 
 describe('Link', () => {
   // Note: Links should not support a disabled option, as disabled links are just text elements
@@ -21,38 +20,6 @@ describe('Link', () => {
     // eslint-disable-next-line no-restricted-syntax
     render(<Link to="https://www.sentry.io/">Link</Link>);
     expect(screen.getByText('Link')).toHaveAttribute('href', 'https://www.sentry.io/');
-  });
-
-  it('links do not do a full page reload when the frontend version is current', async () => {
-    const {router} = render(
-      <FrontendVersionProvider releaseVersion="frontend@abc123" force="current">
-        <Link to="/issues/">Link</Link>
-      </FrontendVersionProvider>
-    );
-
-    // Normal router navigation
-    await userEvent.click(screen.getByRole('link'));
-    expect(router.location.pathname).toBe('/issues/');
-  });
-
-  it('links do full page reload when frontend is outdated', () => {
-    render(
-      <FrontendVersionProvider releaseVersion="frontend@abc123" force="stale">
-        <Link to="/issues/">Link</Link>
-      </FrontendVersionProvider>
-    );
-
-    const link = screen.getByRole('link');
-
-    const event = new MouseEvent('click', {
-      view: window,
-      bubbles: true,
-      cancelable: true,
-    });
-    act(() => link.dispatchEvent(event));
-
-    // react router did not prevent default, the link was clicked as normal
-    expect(event.defaultPrevented).toBe(false);
   });
 });
 

--- a/static/app/components/core/link/link.tsx
+++ b/static/app/components/core/link/link.tsx
@@ -7,14 +7,16 @@ import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
-import {useFrontendVersion} from 'sentry/components/frontendVersionContext';
 import {locationDescriptorToTo} from 'sentry/utils/reactRouter6Compat/location';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 
 export interface LinkProps
   extends React.RefAttributes<HTMLAnchorElement>,
-    Pick<ReactRouterLinkProps, 'to' | 'replace' | 'preventScrollReset' | 'state'>,
+    Pick<
+      ReactRouterLinkProps,
+      'to' | 'replace' | 'preventScrollReset' | 'state' | 'reloadDocument'
+    >,
     Omit<
       React.DetailedHTMLProps<React.HTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
       'href' | 'target' | 'as' | 'css'
@@ -72,20 +74,12 @@ const Anchor = styled('a', {
 export const Link = styled(({disabled, to, ...props}: LinkProps) => {
   const location = useLocation();
 
-  // If the frontend app is stale we can force the link to reload the page,
-  // loading the new version of sentry.
-  const {state: appState} = useFrontendVersion();
-
   if (disabled || !location) {
     return <Anchor {...props} />;
   }
 
   return (
-    <RouterLink
-      reloadDocument={appState === 'stale'}
-      to={locationDescriptorToTo(normalizeUrl(to, location))}
-      {...props}
-    />
+    <RouterLink to={locationDescriptorToTo(normalizeUrl(to, location))} {...props} />
   );
 })`
   ${getLinkStyles}

--- a/static/app/views/nav/index.spec.tsx
+++ b/static/app/views/nav/index.spec.tsx
@@ -3,6 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {
+  act,
   render,
   renderGlobalModal,
   screen,
@@ -12,6 +13,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 import {mockMatchMedia} from 'sentry-test/utils';
 
+import {FrontendVersionProvider} from 'sentry/components/frontendVersionContext';
 import ConfigStore from 'sentry/stores/configStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import Nav from 'sentry/views/nav';
@@ -326,6 +328,82 @@ describe('Nav', () => {
           item: 'issues',
         })
       );
+    });
+  });
+
+  describe('frontend version handling', () => {
+    it('does not reload page on navigation when frontend is current', () => {
+      render(
+        <FrontendVersionProvider releaseVersion="frontend@abc123" force="current">
+          <NavContextProvider>
+            <Nav />
+            <div id="main" />
+          </NavContextProvider>
+        </FrontendVersionProvider>,
+        {
+          organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
+          initialRouterConfig: {
+            location: {
+              pathname: '/organizations/org-slug/issues/',
+              query: {query: 'is:unresolved'},
+            },
+          },
+        }
+      );
+
+      const exploreLink = screen.getByRole('link', {name: 'Explore'});
+
+      const event = new MouseEvent('click', {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+      });
+      act(() => exploreLink.dispatchEvent(event));
+
+      // React Router prevented default - normal navigation
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('reloads page on primary navigation when frontend is stale', async () => {
+      render(
+        <FrontendVersionProvider releaseVersion="frontend@abc123" force="stale">
+          <NavContextProvider>
+            <Nav />
+            <div id="main" />
+          </NavContextProvider>
+        </FrontendVersionProvider>,
+        {
+          organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
+          initialRouterConfig: {
+            location: {
+              pathname: '/organizations/org-slug/issues/',
+              query: {query: 'is:unresolved'},
+            },
+          },
+        }
+      );
+
+      const exploreLink = screen.getByRole('link', {name: 'Explore'});
+
+      // XXX(epurkhiser): Clicking the anchor is going to trigger a jsdom
+      // error: Error: Not implemented: navigation (except hash changes). I'm
+      // having a really hard time figuring out how to stop it from doing this
+      // unfortunately.
+      //
+      // This test is mostly a copy from
+      // https://github.com/remix-run/react-router/blob/20d8307d4a51c219f6e13e0b66461e7162d944e4/packages/react-router/__tests__/dom/link-click-test.tsx#L246-L278
+      jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
+      const event = new MouseEvent('click', {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+      });
+      act(() => exploreLink.dispatchEvent(event));
+      await tick();
+
+      // React Router did not prevent default - page will reload
+      expect(event.defaultPrevented).toBe(false);
     });
   });
 

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -9,6 +9,7 @@ import InteractionStateLayer from 'sentry/components/core/interactionStateLayer'
 import {Link} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
+import {useFrontendVersion} from 'sentry/components/frontendVersionContext';
 import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
@@ -177,9 +178,13 @@ function SidebarNavLink({
   const isActive = isLinkActive(normalizeUrl(activeTo, location), location.pathname);
   const label = PRIMARY_NAV_GROUP_CONFIG[group].label;
 
+  // Reload the page when the frontend is stale to ensure users get the latest version
+  const {state: appState} = useFrontendVersion();
+
   return (
     <NavLink
       to={to}
+      reloadDocument={appState === 'stale'}
       state={{source: SIDEBAR_NAVIGATION_SOURCE}}
       aria-selected={activePrimaryNavGroup === group ? true : isActive}
       aria-current={isActive ? 'page' : undefined}


### PR DESCRIPTION
Previously, every link in the app would reload the page when the frontend
was stale. This was disruptive for users clicking around within the same
section.

Now, only primary navigation links (Issues, Explore, Dashboards, Insights,
Settings) will trigger a page reload when the frontend is stale. This
ensures users get the latest version when switching between major sections,
while maintaining smooth navigation within sections.

The frontend version check logic was moved from the Link component to the
primary navigation components where it's actually used.