### PR TITLE
feat(spans-migration): make explore URL in widget serializer

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -237,7 +237,7 @@ class DashboardWidgetSerializer(Serializer):
                         {
                             "groupBy": group,
                         }
-                    ).replace(" ", "")
+                    )
                     for group in group_by
                 ] + [
                     json.dumps(
@@ -245,7 +245,7 @@ class DashboardWidgetSerializer(Serializer):
                             "yAxes": [y_axis],
                             "chartType": chart_type,
                         }
-                    ).replace(" ", "")
+                    )
                     for y_axis in y_axes
                 ]
             else:
@@ -255,7 +255,7 @@ class DashboardWidgetSerializer(Serializer):
                             "yAxes": [y_axis],
                             "chartType": chart_type,
                         }
-                    ).replace(" ", "")
+                    )
                     for y_axis in y_axes
                 ]
 

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -197,9 +197,10 @@ class DashboardWidgetSerializer(Serializer):
             y_axis_fields = []
             for function in y_axes:
                 match = is_function(function)
-                args_string = match.group("columns") if match else ""
-                args = parse_arguments(match.group("columns"), args_string)
-                y_axis_fields.extend(args)
+                if match:
+                    args_string = match.group("columns")
+                    args = parse_arguments(match.group("columns"), args_string)
+                    y_axis_fields.extend(args)
 
             fields = list(set(group_by + y_axis_fields))
 

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -219,8 +219,11 @@ class DashboardWidgetSerializer(Serializer):
                 equations = [field for field in spans_query.fields if is_equation(field)]
                 equation_index = get_equation_alias_index(sort_column)
                 if equation_index is not None:
-                    orderby = equations[equation_index]
-                    sort = f"{sort_direction}{orderby}"
+                    try:
+                        orderby = equations[equation_index]
+                        sort = f"{sort_direction}{orderby}"
+                    except IndexError:
+                        sort = None
                 else:
                     sort = None
             elif not is_function(sort_column) and not is_equation(sort_column):

--- a/src/sentry/apidocs/examples/dashboard_examples.py
+++ b/src/sentry/apidocs/examples/dashboard_examples.py
@@ -63,6 +63,7 @@ DASHBOARD_OBJECT = {
             "limit": None,
             "widgetType": "transaction-like",
             "layout": {"w": 2, "y": 0, "h": 2, "minH": 2, "x": 0},
+            "exploreUrls": None,
         }
     ],
     "projects": [1],

--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -419,3 +419,11 @@ def categorize_columns(columns) -> tuple[list[str], list[str]]:
 
 def is_equation_alias(alias: str) -> bool:
     return EQUATION_ALIAS_REGEX.match(alias) is not None
+
+
+def get_equation_alias_index(alias: str) -> int | None:
+    """Extract the index from an equation alias like 'equation[5]' -> 5"""
+    match = re.match(r"^equation\[(\d+)\]$", alias)
+    if match:
+        return int(match.group(1))
+    return None

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any
 from unittest import mock
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from django.urls import reverse
@@ -455,6 +456,82 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         response = self.do_request("get", self.url(self.dashboard.id))
         assert response.status_code == 200
         assert response.data["isFavorited"] is True
+
+    def test_explore_url_for_transaction_widget(self) -> None:
+        with self.feature("organizations:transaction-widget-deprecation-explore-view"):
+            dashboard_deprecation = Dashboard.objects.create(
+                title="Dashboard With Transaction Widget",
+                created_by_id=self.user.id,
+                organization=self.organization,
+            )
+            widget_deprecation = DashboardWidget.objects.create(
+                dashboard=dashboard_deprecation,
+                title="transaction widget",
+                display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+                widget_type=DashboardWidgetTypes.TRANSACTION_LIKE,
+                interval="1d",
+                detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+            )
+
+            DashboardWidgetQuery.objects.create(
+                widget=widget_deprecation,
+                fields=["count()", "transaction"],
+                columns=["transaction"],
+                aggregates=["count()"],
+                conditions="count():>50",
+                orderby="-count",
+                order=0,
+            )
+            response = self.do_request("get", self.url(dashboard_deprecation.id))
+            assert response.status_code == 200
+            explore_url = response.data["widgets"][0]["exploreUrls"][0]
+            assert "http://testserver/explore/traces/" in explore_url
+
+            params = dict(parse_qs(urlsplit(response.data["widgets"][0]["exploreUrls"][0]).query))
+            assert params["query"] == ["(count(span.duration):>50) AND is_transaction:1"]
+            assert params["sort"] == ["-count(span.duration)"]
+            assert params["mode"] == ["aggregate"]
+            assert params["aggregateField"] == [
+                '{"groupBy":"transaction"}',
+                '{"yAxes":["count(span.duration)"],"chartType":1}',
+            ]
+
+    def test_explore_url_for_table_widget(self) -> None:
+        with self.feature("organizations:transaction-widget-deprecation-explore-view"):
+            dashboard_deprecation = Dashboard.objects.create(
+                title="Dashboard With Transaction Widget",
+                created_by_id=self.user.id,
+                organization=self.organization,
+            )
+            widget_deprecation = DashboardWidget.objects.create(
+                dashboard=dashboard_deprecation,
+                title="table widget",
+                display_type=DashboardWidgetDisplayTypes.TABLE,
+                widget_type=DashboardWidgetTypes.TRANSACTION_LIKE,
+                interval="1d",
+                detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+            )
+
+            DashboardWidgetQuery.objects.create(
+                widget=widget_deprecation,
+                fields=["id", "title"],
+                columns=["id", "title"],
+                aggregates=[],
+                order=0,
+            )
+
+            response = self.do_request("get", self.url(dashboard_deprecation.id))
+            assert response.status_code == 200
+            explore_url = response.data["widgets"][0]["exploreUrls"][0]
+            assert "http://testserver/explore/traces/" in explore_url
+
+            params = dict(parse_qs(urlsplit(response.data["widgets"][0]["exploreUrls"][0]).query))
+            assert params["query"] == ["is_transaction:1"]
+            assert "sort" not in params
+            assert params["mode"] == ["samples"]
+            # need to sort because fields order is not guaranteed
+            assert params["field"].sort() == ["id", "transaction"].sort()
+            assert "aggregateField" not in params
 
 
 class OrganizationDashboardDetailsDeleteTest(OrganizationDashboardDetailsTestCase):


### PR DESCRIPTION
Before migration we are planning to put warning signs on transaction widgets as well as link out to an explore query that will reflect how the translated widget could look. For this we added an `exploreUrl` return field in the serializer so that we can build the url in the backend where we have the translation layer. In order to do this I've done a couple things

1. translate transaction widget to spans widget and then map out the widget -> explore fields and chosen the explore mode using the same conversion logic we have in the frontend
2. extracted a query translation function in the dashboards translation layer into its own function so we can reuse
3. created some tests to ensure that the params in the links were getting translated and mapped out properly

contributes to https://linear.app/getsentry/issue/EXP-534/add-warning-icons-and-links-for-migrating-compatible-widgets


