### PR TITLE
ref(settings): Remove usage of `deprecatedRouteProps` from `TeamSettings` view

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1026,7 +1026,6 @@ function buildRoutes(): RouteObject[] {
               component: make(
                 () => import('sentry/views/settings/organizationTeams/teamSettings')
               ),
-              deprecatedRouteProps: true,
             },
           ],
         },

--- a/static/app/views/settings/organizationTeams/teamSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamSettings/index.spec.tsx
@@ -10,6 +10,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import TeamStore from 'sentry/stores/teamStore';
+import type {Organization, Team} from 'sentry/types/organization';
 import TeamSettings from 'sentry/views/settings/organizationTeams/teamSettings';
 
 describe('TeamSettings', () => {
@@ -17,6 +18,29 @@ describe('TeamSettings', () => {
     TeamStore.reset();
     MockApiClient.clearMockResponses();
   });
+
+  const renderTeamSettings = (
+    team: Team,
+    organization: Organization = OrganizationFixture()
+  ) => {
+    TeamStore.loadInitialData([team]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      method: 'GET',
+      body: [team],
+    });
+
+    return render(<TeamSettings />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: `/settings/${organization.slug}/teams/${team.slug}/settings/`,
+        },
+        route: '/settings/:orgId/teams/:teamId/settings/',
+      },
+    });
+  };
 
   it('can change slug', async () => {
     const organization = OrganizationFixture();
@@ -29,14 +53,7 @@ describe('TeamSettings', () => {
       },
     });
 
-    const {router} = render(<TeamSettings team={team} />, {
-      initialRouterConfig: {
-        location: {
-          pathname: `/settings/${organization.slug}/teams/${team.slug}/settings/`,
-        },
-        route: '/settings/:orgId/teams/:teamId/settings/',
-      },
-    });
+    const {router} = renderTeamSettings(team, organization);
 
     const input = screen.getByRole('textbox', {name: 'Team Slug'});
 
@@ -67,15 +84,7 @@ describe('TeamSettings', () => {
     const team = TeamFixture();
     const organization = OrganizationFixture({access: []});
 
-    render(<TeamSettings team={team} />, {
-      organization,
-      initialRouterConfig: {
-        location: {
-          pathname: `/settings/${organization.slug}/teams/${team.slug}/settings/`,
-        },
-        route: '/settings/:orgId/teams/:teamId/settings/',
-      },
-    });
+    renderTeamSettings(team, organization);
 
     expect(screen.getByTestId('button-remove-team')).toBeDisabled();
   });
@@ -87,16 +96,8 @@ describe('TeamSettings', () => {
       url: `/teams/org-slug/${team.slug}/`,
       method: 'DELETE',
     });
-    TeamStore.loadInitialData([team]);
 
-    const {router} = render(<TeamSettings team={team} />, {
-      initialRouterConfig: {
-        location: {
-          pathname: `/settings/${organization.slug}/teams/${team.slug}/settings/`,
-        },
-        route: '/settings/:orgId/teams/:teamId/settings/',
-      },
-    });
+    const {router} = renderTeamSettings(team, organization);
     renderGlobalModal();
 
     // Click "Remove Team button
@@ -123,15 +124,7 @@ describe('TeamSettings', () => {
     const team = TeamFixture({hasAccess: true, flags: {'idp:provisioned': true}});
     const organization = OrganizationFixture({access: []});
 
-    render(<TeamSettings team={team} />, {
-      organization,
-      initialRouterConfig: {
-        location: {
-          pathname: `/settings/${organization.slug}/teams/${team.slug}/settings/`,
-        },
-        route: '/settings/:orgId/teams/:teamId/settings/',
-      },
-    });
+    renderTeamSettings(team, organization);
 
     expect(
       screen.getByText(


### PR DESCRIPTION
Migrates usage of `deprecatedRouteProps` for `TeamSettings` - `sentry/views/settings/organizationTeams/teamSettings`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7