### PR TITLE
ref(grouping): Use new key in grouping info JSON if not legacy format

### DIFF
--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -65,6 +65,9 @@ def _check_for_mismatched_hashes(
 
 def get_grouping_info_from_variants(
     variants: dict[str, BaseVariant],
+    # Shim to keep the output (which we also use for getting the Seer stacktrace string) stable
+    # until we can switch `get_stacktrace_string` to use variants directly
+    use_legacy_format: bool = True,
 ) -> dict[str, dict[str, Any]]:
     """
     Given a dictionary of variant objects, create and return a copy of the dictionary in which each

--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -75,4 +75,7 @@ def get_grouping_info_from_variants(
     key under which it lives.
     """
 
-    return {key: {"key": key, **variant.as_dict()} for key, variant in variants.items()}
+    if use_legacy_format:
+        return {key: {"key": key, **variant.as_dict()} for key, variant in variants.items()}
+
+    return {variant.key: variant.as_dict() for variant in variants.values()}

--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -20,7 +20,7 @@ def get_grouping_info(
 
     variants = event.get_grouping_variants(grouping_config, normalize_stacktraces=True)
 
-    grouping_info = get_grouping_info_from_variants(variants)
+    grouping_info = get_grouping_info_from_variants(variants, use_legacy_format=False)
 
     # One place we use this info is in the grouping info section of the event details page, and for
     # that we recalculate hashes/variants on the fly since we don't store the variants as part of

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -53,6 +53,7 @@ class BaseVariant(ABC):
     def as_dict(self) -> dict[str, Any]:
         rv = {
             "type": self.type,
+            "key": self.key,
             "description": self.description,
             "hash": self.get_hash(),
             "hint": self.hint,

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/actix.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:42.712057+00:00'
+created: '2025-10-03T22:58:44.704248+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2608,10 +2608,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "738e7d2503464bc264b4f791286f5122",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -5215,7 +5215,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "19a96e0438d28e48355653def82f887a",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/android_anr.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:42.740562+00:00'
+created: '2025-10-03T22:58:44.737894+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -3937,10 +3937,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -7873,7 +7873,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "2552498cfe69a6ddf1dcdde5440ce9c3",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/aspnetcore.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:42.762805+00:00'
+created: '2025-10-03T22:58:44.759841+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1096,10 +1096,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "228c649a3aa0901622c0a0e66ab0522c",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "default": {
+  "message": {
     "component": {
       "contributes": false,
       "hint": "ignored because app/system exception takes precedence",
@@ -1141,10 +1141,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "default",
     "hash": null,
     "hint": "ignored because app/system exception takes precedence",
-    "key": "default",
+    "key": "message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2236,7 +2236,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "4ccd0f1953483581ba360c7518f90332",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:42.779301+00:00'
+created: '2025-10-03T22:58:44.777723+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_thread_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -146,10 +146,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app thread stacktrace",
     "hash": "ff6c4ee7c54f118a9647ee86f0c2b0b0",
     "hint": null,
-    "key": "app",
+    "key": "app_thread_stacktrace",
     "type": "component"
   },
-  "default": {
+  "message": {
     "component": {
       "contributes": false,
       "hint": "ignored because app threads take precedence",
@@ -191,10 +191,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "default",
     "hash": null,
     "hint": "ignored because app threads take precedence",
-    "key": "default",
+    "key": "message",
     "type": "component"
   },
-  "system": {
+  "system_thread_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because app threads take precedence",
@@ -336,7 +336,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": "ignored because app threads take precedence",
-    "key": "system",
+    "key": "system_thread_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/bugly.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:42.797686+00:00'
+created: '2025-10-03T22:58:44.796412+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -309,10 +309,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -617,7 +617,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "d9c9b0f9ba46e32fddd7cd1512fad235",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:42.837794+00:00'
+created: '2025-10-03T22:58:44.833830+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because built-in fingerprint takes precedence",
@@ -106,7 +106,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because built-in fingerprint takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
   "built_in_fingerprint": {
@@ -121,7 +121,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       "chunkloaderror"
     ]
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because built-in fingerprint takes precedence",
@@ -223,7 +223,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": null,
     "hint": "ignored because built-in fingerprint takes precedence",
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:42.816823+00:00'
+created: '2025-10-03T22:58:44.815912+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because built-in fingerprint takes precedence",
@@ -106,7 +106,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because built-in fingerprint takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
   "built_in_fingerprint": {
@@ -125,7 +125,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       "chunkloaderror"
     ]
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because built-in fingerprint takes precedence",
@@ -227,7 +227,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": null,
     "hint": "ignored because built-in fingerprint takes precedence",
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:42.858843+00:00'
+created: '2025-10-03T22:58:44.853310+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1074,10 +1074,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "4ef1fb44d656c3be2a146971f2a222dc",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2147,7 +2147,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "47481871aa8d5ab5729cf2db78ce3032",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:42.910098+00:00'
+created: '2025-10-03T22:58:44.905507+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_thread_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -518,10 +518,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app thread stacktrace",
     "hash": "7c8a196d16b94be382add324be2605ee",
     "hint": null,
-    "key": "app",
+    "key": "app_thread_stacktrace",
     "type": "component"
   },
-  "default": {
+  "message": {
     "component": {
       "contributes": false,
       "hint": "ignored because app/system threads take precedence",
@@ -563,10 +563,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "default",
     "hash": null,
     "hint": "ignored because app/system threads take precedence",
-    "key": "default",
+    "key": "message",
     "type": "component"
   },
-  "system": {
+  "system_thread_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1080,7 +1080,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "thread stacktrace",
     "hash": "cd7f51d716fd57adc1a5ce1c112e538f",
     "hint": null,
-    "key": "system",
+    "key": "system_thread_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/connection_error.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:42.929741+00:00'
+created: '2025-10-03T22:58:44.925132+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -555,10 +555,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "6b059b9febc815ac18ac4d2082e38a9b",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "default": {
+  "message": {
     "component": {
       "contributes": false,
       "hint": "ignored because app/system exception takes precedence",
@@ -600,10 +600,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "default",
     "hash": null,
     "hint": "ignored because app/system exception takes precedence",
-    "key": "default",
+    "key": "message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1154,7 +1154,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "013d3477a774fe20c468dc8accd516f1",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:42.946955+00:00'
+created: '2025-10-03T22:58:44.943139+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -239,10 +239,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "161ce02ecc5d6685a72e8e520ab726b3",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -477,7 +477,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "c5e4b4a9ad1803c4d4ca7feee5e430ae",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:42.965702+00:00'
+created: '2025-10-03T22:58:44.962008+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -197,10 +197,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -393,7 +393,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "fe92cff6711f8a0a30cabb8b9245b1d6",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.239490+00:00'
+created: '2025-10-03T22:58:45.100616+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "csp_url": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -79,7 +79,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "URL",
     "hash": "666766514295bb52812324097cdaf53e",
     "hint": null,
-    "key": "default",
+    "key": "csp_url",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_img_src.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_img_src.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:42.982604+00:00'
+created: '2025-10-03T22:58:44.978411+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "csp_url": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -70,7 +70,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "URL",
     "hash": "1742101e08eb1608f569751dfedd0062",
     "hint": null,
-    "key": "default",
+    "key": "csp_url",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:42.998263+00:00'
+created: '2025-10-03T22:58:44.994848+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "csp_url": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -70,7 +70,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "URL",
     "hash": "efddf1cde918097259aa7d4904fb1942",
     "hint": null,
-    "key": "default",
+    "key": "csp_url",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_data_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_data_uri.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.015280+00:00'
+created: '2025-10-03T22:58:45.011120+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "csp_url": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -70,7 +70,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "URL",
     "hash": "4e6f2bce9d121aa89f4dc5e5da08afb5",
     "hint": null,
-    "key": "default",
+    "key": "csp_url",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.062307+00:00'
+created: '2025-10-03T22:58:45.027385+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "csp_local_script_violation": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -81,7 +81,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "violation",
     "hash": "56c6520f35bce2f89ed2c4e725ccef65",
     "hint": null,
-    "key": "default",
+    "key": "csp_local_script_violation",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.101609+00:00'
+created: '2025-10-03T22:58:45.042995+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "csp_local_script_violation": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -81,7 +81,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "violation",
     "hash": "d346ee37d19a2be6587e609075ca2d57",
     "hint": null,
-    "key": "default",
+    "key": "csp_local_script_violation",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_uri.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.202023+00:00'
+created: '2025-10-03T22:58:45.061647+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "csp_url": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -70,7 +70,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "URL",
     "hash": "223cdacfe5b4b830dc700b5c18cc21b4",
     "hint": null,
-    "key": "default",
+    "key": "csp_url",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_style_src_elem.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_style_src_elem.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.221548+00:00'
+created: '2025-10-03T22:58:45.081641+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "csp_url": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -79,7 +79,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "URL",
     "hash": "537a973f594c364842893e9a72af62a5",
     "hint": null,
-    "key": "default",
+    "key": "csp_url",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.290191+00:00'
+created: '2025-10-03T22:58:45.139451+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because custom client fingerprint takes precedence",
@@ -819,7 +819,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": null,
     "hint": "ignored because custom client fingerprint takes precedence",
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
   "custom_fingerprint": {
@@ -840,7 +840,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       "sentry.tasks.store.process_event"
     ]
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because custom client fingerprint takes precedence",
@@ -1655,7 +1655,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": null,
     "hint": "ignored because custom client fingerprint takes precedence",
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.264226+00:00'
+created: '2025-10-03T22:58:45.119473+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because custom server fingerprint takes precedence",
@@ -819,7 +819,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": null,
     "hint": "ignored because custom server fingerprint takes precedence",
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
   "custom_fingerprint": {
@@ -839,7 +839,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       "soft-timelimit-exceeded"
     ]
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because custom server fingerprint takes precedence",
@@ -1654,7 +1654,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": null,
     "hint": "ignored because custom server fingerprint takes precedence",
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.315683+00:00'
+created: '2025-10-03T22:58:45.160747+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because custom server fingerprint takes precedence",
@@ -819,7 +819,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": null,
     "hint": "ignored because custom server fingerprint takes precedence",
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
   "custom_fingerprint": {
@@ -834,7 +834,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       "soft-timelimit-exceeded"
     ]
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because custom server fingerprint takes precedence",
@@ -1649,7 +1649,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": null,
     "hint": "ignored because custom server fingerprint takes precedence",
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.360159+00:00'
+created: '2025-10-03T22:58:45.199295+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_ns_error": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -825,10 +825,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "029f3b967068b1539f96957b7c0451d7",
     "hint": null,
-    "key": "app",
+    "key": "app_ns_error",
     "type": "component"
   },
-  "system": {
+  "system_thread_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because app exception takes precedence",
@@ -1590,7 +1590,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": "ignored because app exception takes precedence",
-    "key": "system",
+    "key": "system_thread_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.413653+00:00'
+created: '2025-10-03T22:58:45.252631+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -70,7 +70,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "b23ee1963904c2ca87b145febf94b66c",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.378527+00:00'
+created: '2025-10-03T22:58:45.217444+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -102,10 +102,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "9509e122c6175606d52862fa4f64853c",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because app exception takes precedence",
@@ -203,7 +203,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": "ignored because app exception takes precedence",
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.396730+00:00'
+created: '2025-10-03T22:58:45.236099+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -175,10 +175,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "669cb6664e0f5fed38665da04e464f7e",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_chained_exception_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because app exception takes precedence",
@@ -349,7 +349,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": "ignored because app exception takes precedence",
-    "key": "system",
+    "key": "system_chained_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.431356+00:00'
+created: '2025-10-03T22:58:45.272452+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -144,7 +144,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "e2bf1e0628b7b1824a9b63dec7a079a3",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.466057+00:00'
+created: '2025-10-03T22:58:45.310666+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -111,7 +111,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "93b26686d00504b4e5aa1cb0244d8b37",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.448909+00:00'
+created: '2025-10-03T22:58:45.291570+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -111,7 +111,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "93b26686d00504b4e5aa1cb0244d8b37",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.481870+00:00'
+created: '2025-10-03T22:58:45.330674+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -70,7 +70,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "a4f16891fa438620699cb2d9af5cc827",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.498362+00:00'
+created: '2025-10-03T22:58:45.350137+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -111,7 +111,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "028157fe357e4592e39eacb32eafa2db",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.516373+00:00'
+created: '2025-10-03T22:58:45.449245+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -111,7 +111,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "f0078a82f351095ba595daa7d493aa3c",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.532475+00:00'
+created: '2025-10-03T22:58:45.475884+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -111,7 +111,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "93b26686d00504b4e5aa1cb0244d8b37",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.548609+00:00'
+created: '2025-10-03T22:58:45.503250+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -70,7 +70,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "0809098f9f613b63467605dd1739cc9b",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.582268+00:00'
+created: '2025-10-03T22:58:45.521457+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -70,7 +70,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "0809098f9f613b63467605dd1739cc9b",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_exception.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_exception.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.599131+00:00'
+created: '2025-10-03T22:58:45.540062+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -70,7 +70,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "a4f16891fa438620699cb2d9af5cc827",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.616959+00:00'
+created: '2025-10-03T22:58:45.557156+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -70,7 +70,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "a4f16891fa438620699cb2d9af5cc827",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.636457+00:00'
+created: '2025-10-03T22:58:45.574940+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -144,7 +144,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "17022e0561e9b6e6351723a08aa81b18",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.669689+00:00'
+created: '2025-10-03T22:58:45.610554+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -70,7 +70,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "a4f16891fa438620699cb2d9af5cc827",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.653646+00:00'
+created: '2025-10-03T22:58:45.593305+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -111,7 +111,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "f0078a82f351095ba595daa7d493aa3c",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.687108+00:00'
+created: '2025-10-03T22:58:45.629306+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -278,10 +278,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "d505dfb9059ac63c11955233323a9100",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_chained_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -522,7 +522,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "4f9cc6a81f4eb34f9e917374f281b9dc",
     "hint": null,
-    "key": "system",
+    "key": "system_chained_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.720034+00:00'
+created: '2025-10-03T22:58:45.665039+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -144,7 +144,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "bca604b98cb4637167eb6190a92e8933",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.703394+00:00'
+created: '2025-10-03T22:58:45.647578+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -144,7 +144,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "fca0fd23f09e8da4481304ef2a531100",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.738506+00:00'
+created: '2025-10-03T22:58:45.684362+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -157,10 +157,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -313,7 +313,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "26552f86ca2368e708afa1df6effc1c5",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_type.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_type.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.760064+00:00'
+created: '2025-10-03T22:58:45.700932+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -68,7 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "5eb63bbbe01eeed093cb22bb8f5acdc3",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_value.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_value.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.777453+00:00'
+created: '2025-10-03T22:58:45.717368+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_type": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -68,7 +68,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "5a2cfd89b7b171fd7b4794b08023d04f",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_type",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/expectct.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/expectct.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.884085+00:00'
+created: '2025-10-03T22:58:45.817940+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "expect_ct": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -63,7 +63,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "hostname",
     "hash": "3d2933f4b5ec459ec8d569a398fd328c",
     "hint": null,
-    "key": "default",
+    "key": "expect_ct",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.904417+00:00'
+created: '2025-10-03T22:58:45.835081+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_type": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -255,10 +255,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_type",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -509,7 +509,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "87497299851e09febfecf4e84e0d45ba",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.922483+00:00'
+created: '2025-10-03T22:58:45.852069+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "526b64456c48836a46ec1a89544fd412",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_empty_list.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.946808+00:00'
+created: '2025-10-03T22:58:45.870471+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -44,7 +44,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": null,
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
   "fallback": {
@@ -55,7 +55,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "key": "fallback",
     "type": "fallback"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -95,7 +95,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.968639+00:00'
+created: '2025-10-03T22:58:45.887991+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "7d2cc7acbf90328200d960bf78a26234",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:43.988407+00:00'
+created: '2025-10-03T22:58:45.905631+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "465d672b2d322bf6a1b44499f6dabc1f",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.010527+00:00'
+created: '2025-10-03T22:58:45.923981+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "45c0b0a8c777e7a7040d7c39233a08a5",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.032115+00:00'
+created: '2025-10-03T22:58:45.940808+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -78,7 +78,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": null,
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
   "fallback": {
@@ -89,7 +89,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "key": "fallback",
     "type": "fallback"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -163,7 +163,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.052261+00:00'
+created: '2025-10-03T22:58:45.959722+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "353e05904b48bd3ae4fa9623934a70d0",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.073109+00:00'
+created: '2025-10-03T22:58:45.977408+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "0094f39fc617031afb6c655419f4a9f2",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.093357+00:00'
+created: '2025-10-03T22:58:45.995582+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "be15ca3d511b96918e087c4f42503ca2",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.117056+00:00'
+created: '2025-10-03T22:58:46.012840+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -169,10 +169,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -337,7 +337,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "e04dce7550635e05dbd7f656102cf304",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.136722+00:00'
+created: '2025-10-03T22:58:46.029330+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "098f6bcd4621d373cade4e832627b4f6",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.158558+00:00'
+created: '2025-10-03T22:58:46.044864+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -76,7 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": null,
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
   "fallback": {
@@ -87,7 +87,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "key": "fallback",
     "type": "fallback"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -159,7 +159,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.180038+00:00'
+created: '2025-10-03T22:58:46.061837+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -87,10 +87,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -173,7 +173,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "64a0e0a34d99dce03a8c5a4c237a4b5a",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.201163+00:00'
+created: '2025-10-03T22:58:46.077728+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -87,10 +87,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -173,7 +173,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "64a0e0a34d99dce03a8c5a4c237a4b5a",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.221702+00:00'
+created: '2025-10-03T22:58:46.094498+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -80,10 +80,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -159,7 +159,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "e0e7c4713e9092dc77635d5a0d5db31d",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.239813+00:00'
+created: '2025-10-03T22:58:46.110767+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "c32a94349d9e9b72d31a46610c6c9589",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.259056+00:00'
+created: '2025-10-03T22:58:46.131451+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "be7f1b8b4014de623c533a8218dba5bd",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.280081+00:00'
+created: '2025-10-03T22:58:46.153641+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "53b9e9679a8ea25880376080b76f98ad",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.343867+00:00'
+created: '2025-10-03T22:58:46.207800+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "538bdfd8d7bb2495d0d6429c3689a420",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.300715+00:00'
+created: '2025-10-03T22:58:46.173004+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "538bdfd8d7bb2495d0d6429c3689a420",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.322214+00:00'
+created: '2025-10-03T22:58:46.190550+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "dc3d511120ce04996b1eef3496516e5c",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.378565+00:00'
+created: '2025-10-03T22:58:46.241128+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -78,7 +78,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": null,
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
   "fallback": {
@@ -89,7 +89,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "key": "fallback",
     "type": "fallback"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -163,7 +163,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.361545+00:00'
+created: '2025-10-03T22:58:46.224427+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -80,10 +80,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -159,7 +159,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "0cc175b9c0f1b6a831c399e269772661",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.400043+00:00'
+created: '2025-10-03T22:58:46.257738+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "30eb5001914d29dd8461898b5b8094fe",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.418773+00:00'
+created: '2025-10-03T22:58:46.274615+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -276,7 +276,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": null,
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
   "fallback": {
@@ -287,7 +287,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "key": "fallback",
     "type": "fallback"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -559,7 +559,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.436625+00:00'
+created: '2025-10-03T22:58:46.290367+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -78,7 +78,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": null,
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
   "fallback": {
@@ -89,7 +89,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "key": "fallback",
     "type": "fallback"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -163,7 +163,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.455589+00:00'
+created: '2025-10-03T22:58:46.306522+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -78,7 +78,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": null,
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
   "fallback": {
@@ -89,7 +89,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "key": "fallback",
     "type": "fallback"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -163,7 +163,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.492323+00:00'
+created: '2025-10-03T22:58:46.341412+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "07d1a8e5728b3c4c7aa8b8273fd0e753",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.475043+00:00'
+created: '2025-10-03T22:58:46.323178+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "09e0efcab18f545166318118ed4e0292",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.508953+00:00'
+created: '2025-10-03T22:58:46.360418+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -111,10 +111,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -221,7 +221,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "9bc326575875422d0d4ced3c35d9f916",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.525575+00:00'
+created: '2025-10-03T22:58:46.379336+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "27eed4125fc13d42163ddb0b8f357b48",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.541601+00:00'
+created: '2025-10-03T22:58:46.397915+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "4067a71d7098866f87c746a57a77b2bb",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.576625+00:00'
+created: '2025-10-03T22:58:46.433177+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -76,10 +76,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -151,7 +151,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "2f908c015ad77a50595512fcf65d344c",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.559050+00:00'
+created: '2025-10-03T22:58:46.415613+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -76,10 +76,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -151,7 +151,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "2f908c015ad77a50595512fcf65d344c",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.593719+00:00'
+created: '2025-10-03T22:58:46.450433+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -87,10 +87,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -173,7 +173,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "60e0a667027bef0d0b7c4882891df7e8",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.610076+00:00'
+created: '2025-10-03T22:58:46.469339+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "acbd18db4cc2f85cedef654fccc4a4d8",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.626663+00:00'
+created: '2025-10-03T22:58:46.488303+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -76,10 +76,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -151,7 +151,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "1effb24729ae4c43efa36b460511136a",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.645479+00:00'
+created: '2025-10-03T22:58:46.507237+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -141,10 +141,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "4b8bbc500bd2cabfcadc1f1be867e0bb",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -281,7 +281,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "348fc4026c9fa11ffba8fbfa80a134c9",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.666230+00:00'
+created: '2025-10-03T22:58:46.529274+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -1263,10 +1263,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2525,7 +2525,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "3da34e8c72dbcd4a490ac36eb7130638",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.685705+00:00'
+created: '2025-10-03T22:58:46.581498+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -815,10 +815,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1629,7 +1629,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "ca733a48a19d237df8577d09449095d9",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.704800+00:00'
+created: '2025-10-03T22:58:46.623757+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -943,10 +943,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1885,7 +1885,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "2c1bbd635b64d5adccdb64a620044075",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.723105+00:00'
+created: '2025-10-03T22:58:46.648056+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -823,10 +823,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1645,7 +1645,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "9c336f632f6764c0f082a6a66edbf22d",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.743127+00:00'
+created: '2025-10-03T22:58:46.675241+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -1292,10 +1292,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2583,7 +2583,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "49b6f72b6635cb43190c57ee56b026b0",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.763961+00:00'
+created: '2025-10-03T22:58:46.697976+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -1335,10 +1335,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2669,7 +2669,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "49b6f72b6635cb43190c57ee56b026b0",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.782371+00:00'
+created: '2025-10-03T22:58:46.717605+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -567,10 +567,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1133,7 +1133,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "aeed765d29d1a60cb094f66d2cd8efb2",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.801782+00:00'
+created: '2025-10-03T22:58:46.738513+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -590,10 +590,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1179,7 +1179,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "aeed765d29d1a60cb094f66d2cd8efb2",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.824601+00:00'
+created: '2025-10-03T22:58:46.761750+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -1900,10 +1900,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -3799,7 +3799,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "8be5979a334287a1b47457228f1d4612",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.845669+00:00'
+created: '2025-10-03T22:58:46.787548+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -1821,10 +1821,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -3641,7 +3641,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "8be5979a334287a1b47457228f1d4612",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.867471+00:00'
+created: '2025-10-03T22:58:46.814398+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -1931,10 +1931,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -3861,7 +3861,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "7e64037e487c78ce0439f750a2ef503f",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.885350+00:00'
+created: '2025-10-03T22:58:46.834614+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -381,10 +381,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -761,7 +761,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "aeed765d29d1a60cb094f66d2cd8efb2",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.908655+00:00'
+created: '2025-10-03T22:58:46.855632+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -1137,10 +1137,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2273,7 +2273,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "6148c73af04344a8597354711f5951ea",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.931286+00:00'
+created: '2025-10-03T22:58:46.875658+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -1137,10 +1137,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2273,7 +2273,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "1056f62d72ff8b4d0c3842d696dbb10a",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.953065+00:00'
+created: '2025-10-03T22:58:46.897637+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -1242,10 +1242,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2483,7 +2483,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "15526a7b64e9b5dc6d89e7ebec864260",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hpkp.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hpkp.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.972456+00:00'
+created: '2025-10-03T22:58:46.916519+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "hpkp": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -63,7 +63,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "hostname",
     "hash": "1e37a374cb33572622d02ff7a6237c44",
     "hint": null,
-    "key": "default",
+    "key": "hpkp",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:44.989012+00:00'
+created: '2025-10-03T22:58:46.934350+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message_hybrid_fingerprint": {
     "client_values": [
       "{{ default }}",
       "dogs are great"
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "modified in-app exception",
     "hash": "e3d593b4335190212ca7c18b8e967fb1",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message_hybrid_fingerprint",
     "type": "salted_component",
     "values": [
       "{{ default }}",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.007521+00:00'
+created: '2025-10-03T22:58:46.955788+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace_hybrid_fingerprint": {
     "client_values": [
       "celery",
       "SoftTimeLimitExceeded",
@@ -824,7 +824,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "modified in-app exception stacktrace",
     "hash": "19163f3ca34f5995c69d85351ce3d697",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace_hybrid_fingerprint",
     "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\"",
     "type": "salted_component",
     "values": [
@@ -832,7 +832,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       "soft-timelimit-exceeded"
     ]
   },
-  "system": {
+  "system_exception_stacktrace_hybrid_fingerprint": {
     "client_values": [
       "celery",
       "SoftTimeLimitExceeded",
@@ -1652,7 +1652,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "modified exception stacktrace",
     "hash": "847950eb44d280e6758d136c763d6ddc",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace_hybrid_fingerprint",
     "matched_rule": "type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\"",
     "type": "salted_component",
     "values": [

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.025652+00:00'
+created: '2025-10-03T22:58:46.978236+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because custom server fingerprint takes precedence",
@@ -819,7 +819,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": null,
     "hint": "ignored because custom server fingerprint takes precedence",
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
   "custom_fingerprint": {
@@ -839,7 +839,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       "soft-timelimit-exceeded"
     ]
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because custom server fingerprint takes precedence",
@@ -1654,7 +1654,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": null,
     "hint": "ignored because custom server fingerprint takes precedence",
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.042943+00:00'
+created: '2025-10-03T22:58:46.996706+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message_hybrid_fingerprint": {
     "client_values": [
       "{{ default }}",
       "adopt don't shop"
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "modified in-app exception",
     "hash": "5b5ad5a0fbb4deb5e3fc631ce42681ae",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message_hybrid_fingerprint",
     "type": "salted_component",
     "values": [
       "{{ default }}",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.059705+00:00'
+created: '2025-10-03T22:58:47.016148+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message_hybrid_fingerprint": {
     "client_values": [
       "{{ default }}",
       "dogs are great"
@@ -74,7 +74,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "modified in-app exception",
     "hash": "c5578778212497f1ff3435405e2a4a98",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message_hybrid_fingerprint",
     "type": "salted_component",
     "values": [
       "{{ default }}",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.081286+00:00'
+created: '2025-10-03T22:58:47.040499+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1157,10 +1157,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "5b032559156688c9eabe4e4bd5ae6bd4",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2313,7 +2313,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "1921b991270e24c19ea1ed6863892d71",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.104177+00:00'
+created: '2025-10-03T22:58:47.064582+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -1967,10 +1967,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_chained_exception_message",
     "type": "component"
   },
-  "default": {
+  "message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -2012,10 +2012,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "default",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "default",
+    "key": "message",
     "type": "component"
   },
-  "system": {
+  "system_chained_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -3978,7 +3978,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "1959b227a7cf6acf7f3fd401b5d9f09b",
     "hint": null,
-    "key": "system",
+    "key": "system_chained_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.126074+00:00'
+created: '2025-10-03T22:58:47.087282+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -1996,10 +1996,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "default": {
+  "message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -2041,10 +2041,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "default",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "default",
+    "key": "message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -4036,7 +4036,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "ef2555bf7958ada8eefafbfdaed1c409",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.160300+00:00'
+created: '2025-10-03T22:58:47.123667+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -70,7 +70,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "10dfd81e2df31e96fae451b9e205ad81",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.143617+00:00'
+created: '2025-10-03T22:58:47.105616+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -70,7 +70,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "b8e2a347e75266ca7bb565e2b3c0722e",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.178572+00:00'
+created: '2025-10-03T22:58:47.143373+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -467,10 +467,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -933,7 +933,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "c0f3f7d6deb17aec9d07259ac684fad0",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_message.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.211336+00:00'
+created: '2025-10-03T22:58:47.180536+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -46,7 +46,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "message",
     "hash": "4119639092e62c55ea8be348e4d9260d",
     "hint": null,
-    "key": "default",
+    "key": "message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_message_parameterization.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.194878+00:00'
+created: '2025-10-03T22:58:47.162065+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -46,7 +46,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "message",
     "hash": "f9e47f16e3b9770b440157179c47bf7a",
     "hint": null,
-    "key": "default",
+    "key": "message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.227981+00:00'
+created: '2025-10-03T22:58:47.199675+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -170,10 +170,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "be36642f41f047346396f018f62375d3",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because app exception takes precedence",
@@ -339,7 +339,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": "ignored because app exception takes precedence",
-    "key": "system",
+    "key": "system_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.244552+00:00'
+created: '2025-10-03T22:58:47.218408+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -205,10 +205,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -409,7 +409,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "6ab78545e13144405fb21dadb9045b91",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.261658+00:00'
+created: '2025-10-03T22:58:47.238807+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -397,10 +397,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -793,7 +793,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "c63e8727af1a8fe75872b6a762797113",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.278877+00:00'
+created: '2025-10-03T22:58:47.263237+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -401,10 +401,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -801,7 +801,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "c63e8727af1a8fe75872b6a762797113",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.299054+00:00'
+created: '2025-10-03T22:58:47.282632+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -366,10 +366,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -731,7 +731,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "c63e8727af1a8fe75872b6a762797113",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.317702+00:00'
+created: '2025-10-03T22:58:47.303349+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -415,10 +415,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -829,7 +829,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "b2602ad455472dede8e4c340d8a7eaba",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.335373+00:00'
+created: '2025-10-03T22:58:47.322775+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -419,10 +419,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -837,7 +837,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "b2602ad455472dede8e4c340d8a7eaba",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.371569+00:00'
+created: '2025-10-03T22:58:47.341555+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -384,10 +384,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -767,7 +767,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "b2602ad455472dede8e4c340d8a7eaba",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.391163+00:00'
+created: '2025-10-03T22:58:47.361057+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -446,10 +446,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -891,7 +891,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "b2602ad455472dede8e4c340d8a7eaba",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.410337+00:00'
+created: '2025-10-03T22:58:47.379711+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -430,10 +430,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -859,7 +859,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "c63e8727af1a8fe75872b6a762797113",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.431985+00:00'
+created: '2025-10-03T22:58:47.401270+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -863,10 +863,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "4a3cf3893b6485428dd02da116c8370e",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1725,7 +1725,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "d5456487ea8dccfe96c1968b19870978",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.451440+00:00'
+created: '2025-10-03T22:58:47.421838+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -720,10 +720,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "4a3cf3893b6485428dd02da116c8370e",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1439,7 +1439,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "0b81da6ea3d7cc82b1d4825b7aac0b8d",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.491129+00:00'
+created: '2025-10-03T22:58:47.464934+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2169,10 +2169,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "4665d486184740231357ab63f4543a8d",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -4337,7 +4337,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "107ed03036d901157372f260bc3df446",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel_anonymous.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.469707+00:00'
+created: '2025-10-03T22:58:47.441228+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -195,10 +195,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "a728cdf5d62c8e017c35c3fe04051b6e",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -389,7 +389,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "63c67781779781d9b0a442a5b2bdb976",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/logentry_prefers_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/logentry_prefers_message.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.507755+00:00'
+created: '2025-10-03T22:58:47.492037+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -46,7 +46,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "message",
     "hash": "8ec8bbc71eb6e2af7fbe5076a8534f96",
     "hint": null,
-    "key": "default",
+    "key": "message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/logentry_uses_formatted.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/logentry_uses_formatted.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.524626+00:00'
+created: '2025-10-03T22:58:47.510110+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -46,7 +46,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "message",
     "hash": "329b29efcf1f77067a063e34f56e7791",
     "hint": null,
-    "key": "default",
+    "key": "message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.545463+00:00'
+created: '2025-10-03T22:58:47.531626+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -1586,10 +1586,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -3171,7 +3171,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "b8baf791d22ac902d5f59a7eedd844fd",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.567360+00:00'
+created: '2025-10-03T22:58:47.553987+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -1950,10 +1950,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -3899,7 +3899,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "36be6e0b6123ef6ecfbef62f5cb88406",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.590246+00:00'
+created: '2025-10-03T22:58:47.577449+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -827,10 +827,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1653,7 +1653,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "70b7b816193e06eb5d6649989fbaf605",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_prefers_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_prefers_message.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.608216+00:00'
+created: '2025-10-03T22:58:47.600620+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -46,7 +46,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "message",
     "hash": "8ec8bbc71eb6e2af7fbe5076a8534f96",
     "hint": null,
-    "key": "default",
+    "key": "message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_uses_formatted.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_uses_formatted.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.625712+00:00'
+created: '2025-10-03T22:58:47.622626+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -46,7 +46,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "message",
     "hash": "d3f5e52d24e9c1eae5abe6c866cced63",
     "hint": null,
-    "key": "default",
+    "key": "message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/message_with_key_pair_values.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.643730+00:00'
+created: '2025-10-03T22:58:47.645240+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -46,7 +46,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "message",
     "hash": "d2ab1028e9cb44352a824e878951f412",
     "hint": null,
-    "key": "default",
+    "key": "message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.662735+00:00'
+created: '2025-10-03T22:58:47.665674+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_type": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -1037,10 +1037,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_type",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2073,7 +2073,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "dcfcd48a02c100bbe4023cbc783054f0",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.679698+00:00'
+created: '2025-10-03T22:58:47.684049+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -164,10 +164,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -327,7 +327,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "9b78cced1eefcd0c655a0a3d8ce2cdd2",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.697056+00:00'
+created: '2025-10-03T22:58:47.703463+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -286,10 +286,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -571,7 +571,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "2e0d26cae5986fcda5edf66612a78268",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.714339+00:00'
+created: '2025-10-03T22:58:47.723235+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -253,10 +253,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -505,7 +505,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "c85e23e804b52ea4b9f290ba838e77a0",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.731672+00:00'
+created: '2025-10-03T22:58:47.741115+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -315,10 +315,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -629,7 +629,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "784442a33bd16c15013bb8f69f68e7d6",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.749374+00:00'
+created: '2025-10-03T22:58:47.758998+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -164,10 +164,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -327,7 +327,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "8f4c7709e4af98d3c47ce3519690e6d9",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.768144+00:00'
+created: '2025-10-03T22:58:47.777846+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -257,10 +257,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -513,7 +513,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "3ff01ce959249abecc6bc8a8f1432b0b",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_no_filenames.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.786927+00:00'
+created: '2025-10-03T22:58:47.796457+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -505,10 +505,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "418120a66f7031923031f5c52aca0724",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1009,7 +1009,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "bbcdb2e1d8df09ffe0fffd30fb361d4b",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.804886+00:00'
+created: '2025-10-03T22:58:47.817462+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -164,10 +164,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -327,7 +327,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "9b78cced1eefcd0c655a0a3d8ce2cdd2",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.822459+00:00'
+created: '2025-10-03T22:58:47.835877+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -236,10 +236,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -471,7 +471,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "46b84e4da51648cc9f9741abd2bdad51",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_with_function_name.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.841447+00:00'
+created: '2025-10-03T22:58:47.856607+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -210,10 +210,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -412,7 +412,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "c29439027eafcf7642f641554ab0f0ef",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.859893+00:00'
+created: '2025-10-03T22:58:47.875575+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -493,10 +493,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "a20509269752c9a1bea6078851e4d39c",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -985,7 +985,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "252dc79eb5653bf822e2684d90734cb8",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.879247+00:00'
+created: '2025-10-03T22:58:47.894535+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -139,10 +139,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "be36642f41f047346396f018f62375d3",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because app exception takes precedence",
@@ -277,7 +277,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": "ignored because app exception takes precedence",
-    "key": "system",
+    "key": "system_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.898198+00:00'
+created: '2025-10-03T22:58:47.913043+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -175,10 +175,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "c52ebcc2d9d0780a23c7d99831678830",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_chained_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -349,7 +349,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "669cb6664e0f5fed38665da04e464f7e",
     "hint": null,
-    "key": "system",
+    "key": "system_chained_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.916369+00:00'
+created: '2025-10-03T22:58:47.932035+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -511,10 +511,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "121caa876de75ec51bf72ed4c852cd75",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1021,7 +1021,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "a5af2577d4caca8f983657c5d1919e14",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.936930+00:00'
+created: '2025-10-03T22:58:47.951011+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -511,10 +511,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1021,7 +1021,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "90888e813b09fa25061af2883c0fb9bd",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.954293+00:00'
+created: '2025-10-03T22:58:47.968542+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -203,10 +203,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "d59239f5aad3304d60beb1fde3369b78",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "default": {
+  "message": {
     "component": {
       "contributes": false,
       "hint": "ignored because app/system exception takes precedence",
@@ -248,10 +248,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "default",
     "hash": null,
     "hint": "ignored because app/system exception takes precedence",
-    "key": "default",
+    "key": "message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -450,7 +450,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "133db3f366b1327dab4e661f66dfb961",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.009893+00:00'
+created: '2025-10-03T22:58:48.023888+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -111,7 +111,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "11e6467c8358a9366c6538f95dcd7bd4",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.975625+00:00'
+created: '2025-10-03T22:58:47.984771+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -70,7 +70,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "70dd09f56349dcce62a74137b00bb571",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:45.993110+00:00'
+created: '2025-10-03T22:58:48.005821+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_chained_exception_message": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -111,7 +111,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception",
     "hash": "5f209162115f576bedbaf6f0ad30e5aa",
     "hint": null,
-    "key": "app",
+    "key": "app_chained_exception_message",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_native.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.033744+00:00'
+created: '2025-10-03T22:58:48.045146+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1026,10 +1026,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "73470e545e51eea9cff8a6c006f68f57",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2051,7 +2051,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "ecd413627f0d90a5a25cb28d1ba9c39f",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_cocoa.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.052756+00:00'
+created: '2025-10-03T22:58:48.063168+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -107,10 +107,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app stacktrace",
     "hash": "eb416f98479efa56a77c524602dc9979",
     "hint": null,
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -213,7 +213,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "1df786c8c266506e1acb6669c8df5154",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.071597+00:00'
+created: '2025-10-03T22:58:48.080134+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -290,10 +290,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -579,7 +579,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "9bdadae4fa003cef6cf460ff1325e54b",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.088349+00:00'
+created: '2025-10-03T22:58:48.096185+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -107,10 +107,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app stacktrace",
     "hash": "1effb24729ae4c43efa36b460511136a",
     "hint": null,
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -213,7 +213,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "659ad79e2e70c822d30a53d7d889529e",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_discards_seemingly_useless_stack.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_discards_seemingly_useless_stack.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.111353+00:00'
+created: '2025-10-03T22:58:48.113144+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -76,7 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": null,
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
   "fallback": {
@@ -87,7 +87,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "key": "fallback",
     "type": "fallback"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -159,7 +159,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.132914+00:00'
+created: '2025-10-03T22:58:48.130252+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -76,10 +76,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -151,7 +151,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "acbd18db4cc2f85cedef654fccc4a4d8",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_group_different_js_errors.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_group_different_js_errors.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.154712+00:00'
+created: '2025-10-03T22:58:48.146797+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -76,7 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": null,
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
   "fallback": {
@@ -87,7 +87,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "key": "fallback",
     "type": "fallback"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -159,7 +159,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.175432+00:00'
+created: '2025-10-03T22:58:48.164325+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -288,10 +288,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -575,7 +575,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "cb57cfc73cc622c2ac1386c9ea531fb9",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.197249+00:00'
+created: '2025-10-03T22:58:48.182202+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -78,10 +78,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -155,7 +155,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "cd2a9fd0cdaa8cd55ed22b101fc65882",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.214057+00:00'
+created: '2025-10-03T22:58:48.201403+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -107,10 +107,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app stacktrace",
     "hash": "659ad79e2e70c822d30a53d7d889529e",
     "hint": null,
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because app stacktrace takes precedence",
@@ -213,7 +213,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": "ignored because app stacktrace takes precedence",
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.233223+00:00'
+created: '2025-10-03T22:58:48.221461+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because system stacktrace takes precedence",
@@ -142,10 +142,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -283,7 +283,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "c5da56c71b31f34c5880d734cbc8f5bb",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.252814+00:00'
+created: '2025-10-03T22:58:48.240840+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_message": {
     "component": {
       "contributes": false,
       "hint": "ignored because system exception takes precedence",
@@ -288,10 +288,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
-    "key": "app",
+    "key": "app_exception_message",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -575,7 +575,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "eb87c1031dba55b67df86fb9fff59dc6",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.271044+00:00'
+created: '2025-10-03T22:58:48.258358+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -288,10 +288,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "eb87c1031dba55b67df86fb9fff59dc6",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -575,7 +575,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "cb57cfc73cc622c2ac1386c9ea531fb9",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.290576+00:00'
+created: '2025-10-03T22:58:48.276941+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -288,10 +288,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "eb87c1031dba55b67df86fb9fff59dc6",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -575,7 +575,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "0817e4e604fbe88c4534eff166df1db9",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.309135+00:00'
+created: '2025-10-03T22:58:48.295891+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -417,10 +417,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app stacktrace",
     "hash": "1effb24729ae4c43efa36b460511136a",
     "hint": null,
-    "key": "app",
+    "key": "app_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -833,7 +833,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "stacktrace",
     "hash": "659ad79e2e70c822d30a53d7d889529e",
     "hint": null,
-    "key": "system",
+    "key": "system_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/template_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/template_compute_hashes.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.325575+00:00'
+created: '2025-10-03T22:58:48.313858+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "default": {
+  "template": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -63,7 +63,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "template",
     "hash": "1f5bdebe3c9f414c7dbb4296a8353245",
     "hint": null,
-    "key": "default",
+    "key": "template",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.354710+00:00'
+created: '2025-10-03T22:58:48.331531+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_thread_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -86,10 +86,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app thread stacktrace",
     "hash": "1a11687556cf74559f0ae90b1c87e2fd",
     "hint": null,
-    "key": "app",
+    "key": "app_thread_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_thread_stacktrace": {
     "component": {
       "contributes": false,
       "hint": "ignored because app threads take precedence",
@@ -171,7 +171,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "system",
     "hash": null,
     "hint": "ignored because app threads take precedence",
-    "key": "system",
+    "key": "system_thread_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_no_hash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_no_hash.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.382467+00:00'
+created: '2025-10-03T22:58:48.347995+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_thread_stacktrace": {
     "component": {
       "contributes": false,
       "hint": null,
@@ -44,7 +44,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app",
     "hash": null,
     "hint": null,
-    "key": "app",
+    "key": "app_thread_stacktrace",
     "type": "component"
   },
   "fallback": {

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unity.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.403584+00:00'
+created: '2025-10-03T22:58:48.365700+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -335,10 +335,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "a12d579fed7636c2a5d2fae110c95ce5",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -669,7 +669,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "c0dbeebf0430b3310ad1f7ceb48553a6",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.427364+00:00'
+created: '2025-10-03T22:58:48.386478+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1063,10 +1063,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "ecb890e5cd60dec2b626d500cc866de4",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2125,7 +2125,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "57493ac3e558feffb778cf170a7fd986",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.447895+00:00'
+created: '2025-10-03T22:58:48.405299+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -811,10 +811,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "8c134ce2a43a0b2c55654902491307c2",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1621,7 +1621,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "f203e9bc12df86bb01fbd92a45643f86",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.471100+00:00'
+created: '2025-10-03T22:58:48.427577+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1414,10 +1414,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "c246c95d4a435b3d601044aebae72a38",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2827,7 +2827,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "d0669f63f03ddaec66ac8b9f4e3e449d",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.495493+00:00'
+created: '2025-10-03T22:58:48.451315+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2853,10 +2853,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "e7a1be23aff9a117598bb893ed4bedb4",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -5705,7 +5705,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "1bba3ace796a07d167af26959c6039c9",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.522015+00:00'
+created: '2025-10-03T22:58:48.474831+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1639,10 +1639,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app exception stacktrace",
     "hash": "4717aeb08ff642726ef6ea8f1ce55cdf",
     "hint": null,
-    "key": "app",
+    "key": "app_exception_stacktrace",
     "type": "component"
   },
-  "system": {
+  "system_exception_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -3277,7 +3277,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "exception stacktrace",
     "hash": "65244b22630821cacd0be603ebcef671",
     "hint": null,
-    "key": "system",
+    "key": "system_exception_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2025-10-03T16:56:46.544762+00:00'
+created: '2025-10-03T22:58:48.496229+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
-  "app": {
+  "app_thread_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -1324,10 +1324,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "in-app thread stacktrace",
     "hash": "54e8028fb2526cf31b12dd66c01ad9e2",
     "hint": null,
-    "key": "app",
+    "key": "app_thread_stacktrace",
     "type": "component"
   },
-  "default": {
+  "message": {
     "component": {
       "contributes": false,
       "hint": "ignored because app/system threads take precedence",
@@ -1369,10 +1369,10 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "default",
     "hash": null,
     "hint": "ignored because app/system threads take precedence",
-    "key": "default",
+    "key": "message",
     "type": "component"
   },
-  "system": {
+  "system_thread_stacktrace": {
     "component": {
       "contributes": true,
       "hint": null,
@@ -2692,7 +2692,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "description": "thread stacktrace",
     "hash": "9e04decaf79ecba9dc0314dc0edd3993",
     "hint": null,
-    "key": "system",
+    "key": "system_thread_stacktrace",
     "type": "component"
   }
 }

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.850063+00:00'
+created: '2025-10-06T17:30:32.851483+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -16,10 +16,12 @@ variants:
       hint: ignored because built-in fingerprint takes precedence
     contributes: false
     hint: ignored because built-in fingerprint takes precedence
+    key: app_exception_message
     type: component
   built_in_fingerprint:
     contributes: true
     hint: null
+    key: built_in_fingerprint
     matched_rule: family:"javascript" type:"ChunkLoadError" -> "chunkloaderror"
     type: built_in_fingerprint
     values:
@@ -30,4 +32,5 @@ variants:
       hint: ignored because built-in fingerprint takes precedence
     contributes: false
     hint: ignored because built-in fingerprint takes precedence
+    key: system_exception_stacktrace
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_abs_path.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_abs_path.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.896607+00:00'
+created: '2025-10-06T17:30:32.891767+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,10 +23,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_message
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: type:"DatabaseUnavailable" -> "{{ stack.abs_path }}"
     type: custom_fingerprint
     values:
@@ -37,4 +39,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_stacktrace
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:40.036815+00:00'
+created: '2025-10-06T17:30:33.020074+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,6 +22,7 @@ variants:
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: message:"\{\[\*\?\]\}" -> "escaped{{ message }}"
     type: custom_fingerprint
     values:
@@ -33,4 +34,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.784450+00:00'
+created: '2025-10-06T17:30:32.796442+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,6 +23,7 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_message
     type: component
   custom_fingerprint:
     client_values:
@@ -30,6 +31,7 @@ variants:
     - '{{ default }}'
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: type:"DatabaseUnavailable" -> "database-unavailable"
     type: custom_fingerprint
     values:
@@ -40,4 +42,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:40.138462+00:00'
+created: '2025-10-06T17:30:33.110054+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,6 +25,7 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_message
     type: component
   custom_fingerprint:
     client_values:
@@ -32,6 +33,7 @@ variants:
     - '{{ default }}'
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable"
     type: custom_fingerprint
     values:
@@ -42,4 +44,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.545375+00:00'
+created: '2025-10-06T17:30:32.648530+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -29,6 +29,7 @@ variants:
       hint: null
     contributes: true
     hint: null
+    key: app_exception_message_hybrid_fingerprint
     type: salted_component
     values:
     - my-route
@@ -42,6 +43,7 @@ variants:
       hint: ignored because app exception takes precedence
     contributes: false
     hint: ignored because app exception takes precedence
+    key: system_exception_message_hybrid_fingerprint
     type: salted_component
     values:
     - my-route

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.597632+00:00'
+created: '2025-10-06T17:30:32.682169+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,6 +25,7 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_message
     type: component
   custom_fingerprint:
     client_values:
@@ -32,6 +33,7 @@ variants:
     - '{{ default }}'
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: sdk:"sentry.java" type:"DatabaseUnavailable" -> "database-unavailable"
     type: custom_fingerprint
     values:
@@ -42,4 +44,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:40.002764+00:00'
+created: '2025-10-06T17:30:32.988388+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -29,6 +29,7 @@ variants:
       hint: null
     contributes: true
     hint: null
+    key: app_exception_message_hybrid_fingerprint
     type: salted_component
     values:
     - my-route
@@ -42,6 +43,7 @@ variants:
       hint: ignored because app exception takes precedence
     contributes: false
     hint: ignored because app exception takes precedence
+    key: system_exception_message_hybrid_fingerprint
     type: salted_component
     values:
     - my-route

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:40.096539+00:00'
+created: '2025-10-06T17:30:33.072004+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,10 +25,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_message
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: value:"*went wrong*" -> "something-went-wrong{{ error.value }}"
     type: custom_fingerprint
     values:
@@ -40,4 +42,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.466045+00:00'
+created: '2025-10-06T17:30:32.613822+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -28,10 +28,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_message
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       function }}"
     type: custom_fingerprint
@@ -44,4 +46,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:40.057491+00:00'
+created: '2025-10-06T17:30:33.037388+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,6 +22,7 @@ variants:
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: message:"*love*" -> "what-is-love{{ message }}"
     type: custom_fingerprint
     values:
@@ -33,4 +34,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.623948+00:00'
+created: '2025-10-06T17:30:32.700627+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,10 +25,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_message
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: message:"*love*" -> "what-is-love{{ message }}"
     type: custom_fingerprint
     values:
@@ -40,4 +42,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.827034+00:00'
+created: '2025-10-06T17:30:32.832184+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,10 +25,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_chained_exception_stacktrace
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: type:"SymCacheError" function:"symbolicator::actors::symcaches::*"
       -> "symcache-error"
     type: custom_fingerprint
@@ -40,4 +42,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_chained_exception_stacktrace
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.712294+00:00'
+created: '2025-10-06T17:30:32.756827+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,10 +25,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_chained_exception_stacktrace
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: function:"symbolicator::actors::symcaches::*" app:"true" -> "symcache-error"
     type: custom_fingerprint
     values:
@@ -39,4 +41,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_chained_exception_stacktrace
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_non_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_non_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.756477+00:00'
+created: '2025-10-06T17:30:32.780185+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,6 +25,7 @@ variants:
       hint: null
     contributes: true
     hint: null
+    key: app_chained_exception_stacktrace
     type: component
   system:
     component:
@@ -32,4 +33,5 @@ variants:
       hint: null
     contributes: true
     hint: null
+    key: system_chained_exception_stacktrace
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:40.157173+00:00'
+created: '2025-10-06T17:30:33.128190+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -28,10 +28,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_message
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       function }}"
     type: custom_fingerprint
@@ -44,4 +46,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:40.119663+00:00'
+created: '2025-10-06T17:30:33.091962+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -29,6 +29,7 @@ variants:
       hint: null
     contributes: true
     hint: null
+    key: app_exception_message_hybrid_fingerprint
     type: salted_component
     values:
     - my-route
@@ -42,6 +43,7 @@ variants:
       hint: ignored because app exception takes precedence
     contributes: false
     hint: ignored because app exception takes precedence
+    key: system_exception_message_hybrid_fingerprint
     type: salted_component
     values:
     - my-route

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.573963+00:00'
+created: '2025-10-06T17:30:32.665321+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,10 +23,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_message
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: type:"DatabaseUnavailable" -> "{{ package }}"
     type: custom_fingerprint
     values:
@@ -37,4 +39,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_stacktrace
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.680563+00:00'
+created: '2025-10-06T17:30:32.733500+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -28,10 +28,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_message
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       transaction }}"
     type: custom_fingerprint
@@ -44,4 +46,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.387168+00:00'
+created: '2025-10-06T17:30:32.569927+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,10 +27,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_stacktrace
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: function:"main" -> "{{ type }}{{ module }}{{ function }}"
     type: custom_fingerprint
     values:
@@ -43,4 +45,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_stacktrace
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:40.020080+00:00'
+created: '2025-10-06T17:30:33.004092+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -28,6 +28,7 @@ variants:
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: logger:"sentry.*" level:"ERROR" -> "log-{{ logger }}-{{ level }}"
     type: custom_fingerprint
     values:
@@ -41,4 +42,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.652223+00:00'
+created: '2025-10-06T17:30:32.716821+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,6 +20,7 @@ variants:
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: sdk:"sentry.javascript.nextjs" -> "sdk-nextjs"
     type: custom_fingerprint
     values:
@@ -30,4 +31,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.981310+00:00'
+created: '2025-10-06T17:30:32.969493+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,6 +22,7 @@ variants:
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: tags.foobar:"*stuff*" -> "foobar-matched-stuff-{{ tags.barfoo }}"
     type: custom_fingerprint
     values:
@@ -33,4 +34,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.508502+00:00'
+created: '2025-10-06T17:30:32.631839+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,6 +22,7 @@ variants:
     - client-sent
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: message:"*love*" -> "what-is-love"
     type: custom_fingerprint
     values:
@@ -32,4 +33,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.920991+00:00'
+created: '2025-10-06T17:30:32.910313+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,10 +23,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_message
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: type:"DatabaseUnavailable" -> "{{ package }}"
     type: custom_fingerprint
     values:
@@ -37,4 +39,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_stacktrace
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.432603+00:00'
+created: '2025-10-06T17:30:32.594898+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -26,10 +26,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_stacktrace
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: type:"ReadTimeout" path:"**/requests/adapters.py" -> "timeout-in-requests"
     type: custom_fingerprint
     values:
@@ -40,4 +42,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_stacktrace
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.940586+00:00'
+created: '2025-10-06T17:30:32.932473+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,6 +23,7 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_message
     type: component
   custom_fingerprint:
     client_values:
@@ -30,6 +31,7 @@ variants:
     - '{{ default }}'
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: release:"foo.bar@*" -> "foo.bar-release"
     type: custom_fingerprint
     values:
@@ -40,4 +42,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:40.077387+00:00'
+created: '2025-10-06T17:30:33.054066+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -29,10 +29,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_message
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       transaction }}" title="DatabaseUnavailable ({{ transaction }})"
     type: custom_fingerprint
@@ -45,4 +47,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_message
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_two_threads.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_two_threads.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.874347+00:00'
+created: '2025-10-06T17:30:32.871100+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,10 +23,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_thread_stacktrace
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: function:"main" -> "in-main"
     type: custom_fingerprint
     values:
@@ -37,4 +39,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_thread_stacktrace
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T17:19:39.960734+00:00'
+created: '2025-10-06T17:30:32.951058+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -28,10 +28,12 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: app_exception_message
     type: component
   custom_fingerprint:
     contributes: true
     hint: null
+    key: custom_fingerprint
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "{{ type
       }}{{ module }}"
     type: custom_fingerprint
@@ -44,4 +46,5 @@ variants:
       hint: ignored because custom server fingerprint takes precedence
     contributes: false
     hint: ignored because custom server fingerprint takes precedence
+    key: system_exception_message
     type: component

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -570,6 +570,7 @@ class BuiltInFingerprintingTest(TestCase):
         assert variants["built_in_fingerprint"].as_dict() == {
             "hash": mock.ANY,  # ignore hash as it can change for unrelated reasons
             "type": "built_in_fingerprint",
+            "key": "built_in_fingerprint",
             "contributes": True,
             "description": "Sentry defined fingerprint",
             "values": ["chunkloaderror"],

--- a/tests/sentry/grouping/test_grouping_info.py
+++ b/tests/sentry/grouping/test_grouping_info.py
@@ -16,7 +16,7 @@ from tests.sentry.grouping import run_as_grouping_inputs_snapshot_test, to_json
 def test_grouping_info(
     variants: dict[str, BaseVariant], create_snapshot: InstaSnapshotter, **kwargs: Any
 ) -> None:
-    grouping_info = get_grouping_info_from_variants(variants)
+    grouping_info = get_grouping_info_from_variants(variants, use_legacy_format=False)
     create_snapshot(to_json(grouping_info, pretty_print=True))
 
 
@@ -27,9 +27,9 @@ class GroupingInfoTest(TestCase):
 
         grouping_info = get_grouping_info(default_grouping_config, self.project, event)
 
-        assert grouping_info["default"]["type"] == "component"
-        assert grouping_info["default"]["description"] == "message"
-        assert grouping_info["default"]["component"]["contributes"] is True
-        assert grouping_info["default"]["config"]["id"] == DEFAULT_GROUPING_CONFIG
-        assert grouping_info["default"]["key"] == "default"
-        assert grouping_info["default"]["contributes"] is True
+        assert grouping_info["message"]["type"] == "component"
+        assert grouping_info["message"]["description"] == "message"
+        assert grouping_info["message"]["component"]["contributes"] is True
+        assert grouping_info["message"]["config"]["id"] == DEFAULT_GROUPING_CONFIG
+        assert grouping_info["message"]["key"] == "message"
+        assert grouping_info["message"]["contributes"] is True

--- a/tests/sentry/issues/endpoints/test_event_grouping_info.py
+++ b/tests/sentry/issues/endpoints/test_event_grouping_info.py
@@ -45,7 +45,7 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
         content = orjson.loads(response.content)
 
         assert response.status_code == 200
-        assert content["system"]["type"] == "component"
+        assert content["system_exception_stacktrace"]["type"] == "component"
 
     def test_error_event_stacktrace_order(self) -> None:
         """Test that the response stacktrace order matches the user's stacktrace order preference"""
@@ -81,7 +81,7 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
 
             # Dig into the JSON to grab the context lines, in order
             response_context_lines = []
-            exception_component = content["app"]["component"]["values"][0]
+            exception_component = content["app_exception_stacktrace"]["component"]["values"][0]
             for exception_component_subcomponent in exception_component["values"]:
                 if exception_component_subcomponent["id"] == "stacktrace":
                     stacktrace_component = exception_component_subcomponent
@@ -137,7 +137,9 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
 
             # Dig into the JSON to grab the error types, in order
             response_error_types = []
-            chained_exception_component = content["app"]["component"]["values"][0]
+            chained_exception_component = content["app_chained_exception_message"]["component"][
+                "values"
+            ][0]
             for exception_component in chained_exception_component["values"]:
                 for exception_component_subcomponent in exception_component["values"]:
                     if exception_component_subcomponent["id"] == "type":


### PR DESCRIPTION
This adds the new `variant.key` property to the variant's JSON, so that it can be used in the grouping info section. In order to preserve other uses of grouping info (specifically computation of the Seer stacktrace string), a new  `use_legacy_format` parameter has been added to `get_grouping_info_from_variants`, defaulting to `True`, so that the. new key values are opt-in. (The Seer code actually looks for particular key values (`app`, `system`, etc), so it would have to be changed to work with the new keys, whereas the front end just uses the keys as a way to differentiate variant components, and is agnostic as to the particular values used, so it will continue to work without modification.)