### PR TITLE
chore(aci milestone 3): add timestamps to open period activity serializer

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/group_open_period_serializer.py
@@ -13,6 +13,7 @@ class GroupOpenPeriodActivityResponse(TypedDict):
     id: str
     type: str
     value: str | None
+    dateCreated: datetime
 
 
 class GroupOpenPeriodResponse(TypedDict):
@@ -34,6 +35,7 @@ class GroupOpenPeriodActivitySerializer(Serializer):
             id=str(obj.id),
             type=OpenPeriodActivityType(obj.type).to_str(),
             value=PriorityLevel(obj.value).to_str() if obj.value else None,
+            dateCreated=obj.date_added,
         )
 
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -74,6 +74,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
             "id": str(self.opened_gopa.id),
             "type": OpenPeriodActivityType.OPENED.to_str(),
             "value": PriorityLevel(self.group.priority).to_str(),
+            "dateCreated": self.opened_gopa.date_added,
         }
 
     def test_open_periods_group_id(self) -> None:
@@ -109,6 +110,7 @@ class OrganizationOpenPeriodsTest(APITestCase):
             "id": str(self.opened_gopa.id),
             "type": OpenPeriodActivityType.OPENED.to_str(),
             "value": PriorityLevel(self.group.priority).to_str(),
+            "dateCreated": self.opened_gopa.date_added,
         }
 
     def test_open_periods_resolved_group(self) -> None:
@@ -151,11 +153,13 @@ class OrganizationOpenPeriodsTest(APITestCase):
             "id": str(self.opened_gopa.id),
             "type": OpenPeriodActivityType.OPENED.to_str(),
             "value": PriorityLevel(self.group.priority).to_str(),
+            "dateCreated": self.opened_gopa.date_added,
         }
         assert resp["activities"][1] == {
             "id": str(closed_gopa.id),
             "type": OpenPeriodActivityType.CLOSED.to_str(),
             "value": None,
+            "dateCreated": closed_gopa.date_added,
         }
 
     def test_open_periods_unresolved_group(self) -> None:
@@ -235,11 +239,13 @@ class OrganizationOpenPeriodsTest(APITestCase):
             "id": str(opened_gopa2.id),
             "type": OpenPeriodActivityType.OPENED.to_str(),
             "value": PriorityLevel(self.group.priority).to_str(),
+            "dateCreated": opened_gopa2.date_added,
         }
         assert resp["activities"][1] == {
             "id": str(closed_gopa2.id),
             "type": OpenPeriodActivityType.CLOSED.to_str(),
             "value": None,
+            "dateCreated": closed_gopa2.date_added,
         }
 
         assert resp2["id"] == str(open_period.id)
@@ -255,11 +261,13 @@ class OrganizationOpenPeriodsTest(APITestCase):
             "id": str(self.opened_gopa.id),
             "type": OpenPeriodActivityType.OPENED.to_str(),
             "value": PriorityLevel(self.group.priority).to_str(),
+            "dateCreated": self.opened_gopa.date_added,
         }
         assert resp2["activities"][1] == {
             "id": str(closed_gopa.id),
             "type": OpenPeriodActivityType.CLOSED.to_str(),
             "value": None,
+            "dateCreated": closed_gopa.date_added,
         }
 
     def test_open_periods_limit(self) -> None:


### PR DESCRIPTION
Add dateCreated to the open period activity serializer.