### PR TITLE
fix(search-bar): Stop submitting query when initially selecting operator

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -318,7 +318,7 @@ function modifyFilterOperator(
     ...state,
     focusOverride: action.focusOverride ?? null,
     query: newQuery,
-    committedQuery: action.shouldCommitQuery ? newQuery : state.committedQuery,
+    committedQuery: (action.shouldCommitQuery ?? true) ? newQuery : state.committedQuery,
   };
 }
 

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -179,6 +179,7 @@ type UpdateFilterOpAction = {
   token: TokenResult<Token.FILTER>;
   type: 'UPDATE_FILTER_OP';
   focusOverride?: FocusOverride;
+  shouldCommitQuery?: boolean;
 };
 
 type UpdateTokenValueAction = {
@@ -317,7 +318,7 @@ function modifyFilterOperator(
     ...state,
     focusOverride: action.focusOverride ?? null,
     query: newQuery,
-    committedQuery: newQuery,
+    committedQuery: action.shouldCommitQuery ? newQuery : state.committedQuery,
   };
 }
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -933,10 +933,8 @@ describe('SearchQueryBuilder', () => {
       expect(await screen.findByRole('row', {name: 'foo'})).toBeInTheDocument();
       expect(await screen.findByRole('row', {name: 'a:b'})).toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(mockOnChange).toHaveBeenCalledWith('foo a:b', expect.anything());
-      });
-      expect(mockOnChange).toHaveBeenCalledTimes(2);
+      expect(mockOnChange).toHaveBeenCalledTimes(1);
+      expect(mockOnChange).toHaveBeenCalledWith('foo a:b', expect.anything());
     });
 
     it('adds default value for filter when typing <filter>:', async () => {
@@ -1003,7 +1001,7 @@ describe('SearchQueryBuilder', () => {
       expect(screen.getByRole('row', {name: 'browser.name:Firefox'})).toBeInTheDocument();
 
       // Now we call onChange
-      expect(mockOnChange).toHaveBeenCalledTimes(2);
+      expect(mockOnChange).toHaveBeenCalledTimes(1);
       expect(mockOnChange).toHaveBeenCalledWith(
         'browser.name:Firefox',
         expect.anything()

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -293,6 +293,7 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
           search_operator: option.value,
           filter_key: getKeyName(token.key),
         });
+
         dispatch({
           type: 'UPDATE_FILTER_OP',
           token,
@@ -303,6 +304,7 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
                 part: 'value',
               }
             : undefined,
+          shouldCommitQuery: !initialOpSettingRef.current,
         });
         initialOpSettingRef.current = false;
         setAutoFocus(false);

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -149,7 +149,10 @@ describe('SpansSearchBar', () => {
     const searchInput = await screen.findByRole('combobox', {
       name: 'Add a search term',
     });
-    await userEvent.type(searchInput, 'span.op:function{enter}');
+    await userEvent.type(searchInput, 'span.op:');
+    await userEvent.keyboard('{enter}');
+    await userEvent.keyboard('function');
+    await userEvent.keyboard('{enter}');
 
     await waitFor(() => {
       expect(onClose).toHaveBeenCalled();


### PR DESCRIPTION
This PR adjusts the `UPDATE_FILTER_OP` action for the query builder state to accept a param `shouldCommitQuery` that will determine whether we submit the query or not.

As well, this updates the `filterOperator` to make use of this new param, and just re-using a ref that we're using to check whether or not this is the initial setting of the operator.