### PR TITLE
feat(logs): Handle numeric log parameter labels

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -35,7 +35,7 @@ from sentry.utils import snuba_rpc
 
 
 def as_tag_key(name: str, type: Literal["string", "number"]):
-    key, _ = translate_internal_to_public_alias(name, type, SupportedTraceItemType.SPANS)
+    key, _, _ = translate_internal_to_public_alias(name, type, SupportedTraceItemType.SPANS)
 
     if key is not None:
         name = key

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -161,15 +161,19 @@ def resolve_attribute_values_referrer(item_type: str) -> Referrer:
 def as_attribute_key(
     name: str, type: Literal["string", "number"], item_type: SupportedTraceItemType
 ) -> TraceItemAttributeKey:
-    key, attribute_source = translate_internal_to_public_alias(name, type, item_type)
+    public_key, public_name, attribute_source = translate_internal_to_public_alias(
+        name, type, item_type
+    )
     secondary_aliases = get_secondary_aliases(name, item_type)
 
-    if key is not None:
-        name = key
+    if public_key is not None and public_name is not None:
+        pass
     elif type == "number":
-        key = f"tags[{name},number]"
+        public_key = f"tags[{name},number]"
+        public_name = name
     else:
-        key = name
+        public_key = name
+        public_name = name
 
     serialized_source: dict[str, str | bool] = {
         "source_type": attribute_source["source_type"].value
@@ -179,9 +183,9 @@ def as_attribute_key(
 
     attribute_key: TraceItemAttributeKey = {
         # key is what will be used to query the API
-        "key": key,
+        "key": public_key,
         # name is what will be used to display the tag nicely in the UI
-        "name": name,
+        "name": public_name,
         # source of the attribute, used to determine whether to show the sentry icon etc. and helps delineate between sentry and user attributes when the names are identical
         # eg. sentry.environment and environment set by the user both have the same alias (name).
         "attributeSource": serialized_source,

--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -65,7 +65,7 @@ def convert_rpc_attribute_to_json(
                 else:
                     raise BadRequest(f"unknown column type in protobuf: {val_type}")
 
-                external_name, _ = translate_internal_to_public_alias(
+                external_name, _, _ = translate_internal_to_public_alias(
                     internal_name, column_type, trace_item_type
                 )
 
@@ -148,7 +148,7 @@ def serialize_meta(
                     item_type = "number"
                 else:
                     item_type = "string"
-                external_name, _ = translate_internal_to_public_alias(
+                external_name, _, _ = translate_internal_to_public_alias(
                     field_key, item_type, trace_item_type
                 )
                 if external_name:

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -91,17 +91,21 @@ def translate_internal_to_public_alias(
     internal_alias: str,
     type: Literal["string", "number"],
     item_type: SupportedTraceItemType,
-) -> tuple[str | None, AttributeSource]:
+) -> tuple[str | None, str | None, AttributeSource]:
     mapping = INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS.get(item_type, {}).get(type, {})
     public_alias = mapping.get(internal_alias)
     if public_alias is not None:
-        return public_alias, {"source_type": AttributeSourceType.SENTRY}
+        return public_alias, public_alias, {"source_type": AttributeSourceType.SENTRY}
 
     resolved_column = PUBLIC_ALIAS_TO_INTERNAL_MAPPING.get(item_type, {}).get(internal_alias)
     if resolved_column is not None:
         # if there is a known public alias with this exact name, it means we need to wrap
         # it in the explicitly typed tags syntax in order for it to reference the correct column
-        return f"tags[{internal_alias},{type}]", {"source_type": AttributeSourceType.SENTRY}
+        return (
+            f"tags[{internal_alias},{type}]",
+            internal_alias,
+            {"source_type": AttributeSourceType.SENTRY},
+        )
 
     definitions = TRACE_ITEM_TYPE_DEFINITIONS.get(item_type)
     if definitions is not None:
@@ -109,16 +113,24 @@ def translate_internal_to_public_alias(
             column = definitions.column_to_alias(internal_alias)
             if column is not None:
                 if type == "string":
-                    return column, {
+                    return (
+                        column,
+                        column,
+                        {
+                            "source_type": AttributeSourceType.SENTRY,
+                            "is_transformed_alias": True,
+                        },
+                    )
+                return (
+                    f"tags[{column},{type}]",
+                    column,
+                    {
                         "source_type": AttributeSourceType.SENTRY,
                         "is_transformed_alias": True,
-                    }
-                return f"tags[{column},{type}]", {
-                    "source_type": AttributeSourceType.SENTRY,
-                    "is_transformed_alias": True,
-                }
+                    },
+                )
 
-    return None, {"source_type": AttributeSourceType.USER}
+    return None, None, {"source_type": AttributeSourceType.USER}
 
 
 def get_secondary_aliases(

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -201,6 +201,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                     "sentry.message.parameter.0": {"bool_value": 1},
                     "sentry.message.parameter.1": {"int_value": 5},
                     "sentry.message.parameter.2": {"double_value": 10},
+                    "sentry.message.parameter.value": {"double_value": 15},
                 },
             ),
         ]
@@ -210,15 +211,15 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         response = self.do_request(query={"attributeType": "string"})
 
         assert response.status_code == 200, response.content
-        keys = {item["key"] for item in response.data}
+        keys = {(item["key"], item["name"]) for item in response.data}
         assert keys == {
-            "project",
-            "message",
-            "severity",
-            "message.parameter.username",
-            "message.parameter.ip",
-            "message.parameter.0",
-            "message.parameter.1",
+            ("project", "project"),
+            ("message", "message"),
+            ("severity", "severity"),
+            ("message.parameter.username", "message.parameter.username"),
+            ("message.parameter.ip", "message.parameter.ip"),
+            ("message.parameter.0", "message.parameter.0"),
+            ("message.parameter.1", "message.parameter.1"),
         }
 
         sources = {item["attributeSource"]["source_type"] for item in response.data}
@@ -233,14 +234,15 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         response = self.do_request(query={"attributeType": "number"})
 
         assert response.status_code == 200, response.content
-        keys = {item["key"] for item in response.data}
+        keys = {(item["key"], item["name"]) for item in response.data}
         assert keys == {
-            "tags[message.parameter.0,number]",
-            "tags[message.parameter.1,number]",
-            "tags[message.parameter.2,number]",
-            "severity_number",
-            "observed_timestamp",
-            "timestamp_precise",
+            ("tags[message.parameter.0,number]", "message.parameter.0"),
+            ("tags[message.parameter.1,number]", "message.parameter.1"),
+            ("tags[message.parameter.2,number]", "message.parameter.2"),
+            ("tags[message.parameter.value,number]", "message.parameter.value"),
+            ("severity_number", "severity_number"),
+            ("observed_timestamp", "observed_timestamp"),
+            ("timestamp_precise", "timestamp_precise"),
         }
 
         sources = {item["attributeSource"]["source_type"] for item in response.data}

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -211,16 +211,63 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         response = self.do_request(query={"attributeType": "string"})
 
         assert response.status_code == 200, response.content
-        keys = {(item["key"], item["name"]) for item in response.data}
-        assert keys == {
-            ("project", "project"),
-            ("message", "message"),
-            ("severity", "severity"),
-            ("message.parameter.username", "message.parameter.username"),
-            ("message.parameter.ip", "message.parameter.ip"),
-            ("message.parameter.0", "message.parameter.0"),
-            ("message.parameter.1", "message.parameter.1"),
-        }
+        assert sorted(response.data, key=lambda key: key["key"]) == [
+            {
+                "key": "message",
+                "name": "message",
+                "attributeSource": {
+                    "source_type": "sentry",
+                },
+                "secondaryAliases": ["log.body"],
+            },
+            {
+                "key": "message.parameter.0",
+                "name": "message.parameter.0",
+                "attributeSource": {
+                    "source_type": "sentry",
+                    "is_transformed_alias": True,
+                },
+            },
+            {
+                "key": "message.parameter.1",
+                "name": "message.parameter.1",
+                "attributeSource": {
+                    "source_type": "sentry",
+                    "is_transformed_alias": True,
+                },
+            },
+            {
+                "key": "message.parameter.ip",
+                "name": "message.parameter.ip",
+                "attributeSource": {
+                    "source_type": "sentry",
+                    "is_transformed_alias": True,
+                },
+            },
+            {
+                "key": "message.parameter.username",
+                "name": "message.parameter.username",
+                "attributeSource": {
+                    "source_type": "sentry",
+                    "is_transformed_alias": True,
+                },
+            },
+            {
+                "key": "project",
+                "name": "project",
+                "attributeSource": {
+                    "source_type": "sentry",
+                },
+            },
+            {
+                "key": "severity",
+                "name": "severity",
+                "attributeSource": {
+                    "source_type": "sentry",
+                },
+                "secondaryAliases": ["log.severity_text", "severity_text"],
+            },
+        ]
 
         sources = {item["attributeSource"]["source_type"] for item in response.data}
         assert sources == {"sentry"}
@@ -234,25 +281,62 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         response = self.do_request(query={"attributeType": "number"})
 
         assert response.status_code == 200, response.content
-        keys = {(item["key"], item["name"]) for item in response.data}
-        assert keys == {
-            ("tags[message.parameter.0,number]", "message.parameter.0"),
-            ("tags[message.parameter.1,number]", "message.parameter.1"),
-            ("tags[message.parameter.2,number]", "message.parameter.2"),
-            ("tags[message.parameter.value,number]", "message.parameter.value"),
-            ("severity_number", "severity_number"),
-            ("observed_timestamp", "observed_timestamp"),
-            ("timestamp_precise", "timestamp_precise"),
-        }
-
-        sources = {item["attributeSource"]["source_type"] for item in response.data}
-        assert sources == {"sentry"}
-
-        message_param_items = [
-            item for item in response.data if item["key"].startswith("tags[message.parameter.")
+        assert sorted(response.data, key=lambda key: key["key"]) == [
+            {
+                "key": "observed_timestamp",
+                "name": "observed_timestamp",
+                "attributeSource": {
+                    "source_type": "sentry",
+                },
+            },
+            {
+                "key": "severity_number",
+                "name": "severity_number",
+                "attributeSource": {
+                    "source_type": "sentry",
+                },
+                "secondaryAliases": ["log.severity_number"],
+            },
+            {
+                "key": "tags[message.parameter.0,number]",
+                "name": "message.parameter.0",
+                "attributeSource": {
+                    "source_type": "sentry",
+                    "is_transformed_alias": True,
+                },
+            },
+            {
+                "key": "tags[message.parameter.1,number]",
+                "name": "message.parameter.1",
+                "attributeSource": {
+                    "source_type": "sentry",
+                    "is_transformed_alias": True,
+                },
+            },
+            {
+                "key": "tags[message.parameter.2,number]",
+                "name": "message.parameter.2",
+                "attributeSource": {
+                    "source_type": "sentry",
+                    "is_transformed_alias": True,
+                },
+            },
+            {
+                "key": "tags[message.parameter.value,number]",
+                "name": "message.parameter.value",
+                "attributeSource": {
+                    "source_type": "sentry",
+                    "is_transformed_alias": True,
+                },
+            },
+            {
+                "key": "timestamp_precise",
+                "name": "timestamp_precise",
+                "attributeSource": {
+                    "source_type": "sentry",
+                },
+            },
         ]
-        for item in message_param_items:
-            assert item["attributeSource"]["is_transformed_alias"] is True
 
     def test_attribute_collision(self) -> None:
         logs = [

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -657,12 +657,12 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             },
             {
                 "key": "tags[span.duration,string]",
-                "name": "tags[span.duration,string]",
+                "name": "span.duration",
                 "attributeSource": {"source_type": "sentry"},
             },
             {
                 "key": "tags[span.op,string]",
-                "name": "tags[span.op,string]",
+                "name": "span.op",
                 "attributeSource": {"source_type": "sentry"},
             },
         ]


### PR DESCRIPTION
This ensures that numeric log parameters like `message.paramter.0` are not formatted with `tags[...,number]` unnecessarily in the UI.