### PR TITLE
fix: Add validation for span alert time window

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -184,6 +184,13 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
             )
             self._validate_critical_warning_triggers(threshold_type, critical, warning)
 
+        if data.get("dataset") == Dataset.EventsAnalyticsPlatform:
+            time_window = data["time_window"]
+            if time_window < 5:
+                raise serializers.ValidationError(
+                    "Time window for this alert type must be at least 5 minutes."
+                )
+
         return data
 
     def _translate_thresholds(self, threshold_type, comparison_delta, triggers, data):

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -188,7 +188,7 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
             time_window = data["time_window"]
             if time_window < 5:
                 raise serializers.ValidationError(
-                    "Time window for this alert type must be at least 5 minutes."
+                    "Invalid Time Window: Time window for this alert type must be at least 5 minutes."
                 )
 
         return data

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -344,6 +344,11 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
                     "Invalid Time Window: Allowed time windows for crash rate alerts are: "
                     "30min, 1h, 2h, 4h, 12h and 24h"
                 )
+        if dataset == Dataset.EventsAnalyticsPlatform:
+            if time_window_seconds < 300:
+                raise serializers.ValidationError(
+                    "Invalid Time Window: Time window for this alert type must be at least 5 minutes."
+                )
         return time_window_seconds
 
     def _validate_performance_dataset(self, dataset):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -1821,6 +1821,18 @@ class AlertRuleCreateEndpointTestCrashRateAlert(AlertRuleIndexBase):
         }
         mock_find_channel_id_for_alert_rule.assert_called_once_with(kwargs=kwargs)
 
+    def test_eap_alert_with_invalid_time_window(self) -> None:
+        data = deepcopy(self.alert_rule_dict)
+        data["dataset"] = "events_analytics_platform"
+        data["alertType"] = "eap_metrics"
+        data["timeWindow"] = 1
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            resp = self.get_error_response(self.organization.slug, status_code=400, **data)
+        assert (
+            resp.data["nonFieldErrors"][0]
+            == "Invalid Time Window: Time window for this alert type must be at least 5 minutes."
+        )
+
 
 @freeze_time()
 class MetricsCrashRateAlertCreationTest(AlertRuleCreateEndpointTestCrashRateAlert):

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -170,6 +170,19 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
             {"time_window": 0}, {"timeWindow": ["Ensure this value is greater than or equal to 1."]}
         )
 
+    def test_span_alert_time_window_validation(self) -> None:
+        params = self.valid_params.copy()
+        params["dataset"] = Dataset.EventsAnalyticsPlatform.value
+        params["event_types"] = [SnubaQueryEventType.EventType.TRACE_ITEM_SPAN.name.lower()]
+        params["time_window"] = 1
+        params["query"] = "span.op:http.client"
+        params["aggregate"] = "count()"
+
+        self.run_fail_validation_test(
+            params,
+            {"nonFieldErrors": ["Time window for this alert type must be at least 5 minutes."]},
+        )
+
     def test_dataset(self) -> None:
         invalid_values = ["Invalid dataset, valid values are %s" % [item.value for item in Dataset]]
         self.run_fail_validation_test({"dataset": "events_wrong"}, {"dataset": invalid_values})

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -180,7 +180,11 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
 
         self.run_fail_validation_test(
             params,
-            {"nonFieldErrors": ["Time window for this alert type must be at least 5 minutes."]},
+            {
+                "nonFieldErrors": [
+                    "Invalid Time Window: Time window for this alert type must be at least 5 minutes."
+                ]
+            },
         )
 
     def test_dataset(self) -> None:


### PR DESCRIPTION
We don't allow <5 min windows in the UI for EAP alerts