### PR TITLE
fix(billing): Use receipt instead of invoice

### DIFF
--- a/static/gsApp/hooks/settingsRoutes.tsx
+++ b/static/gsApp/hooks/settingsRoutes.tsx
@@ -86,7 +86,7 @@ const settingsRoutes = (): SentryRouteObject => ({
         },
         {
           path: 'receipts/:invoiceGuid/',
-          name: 'Invoice Details',
+          name: 'Receipt Details',
           component: errorHandler(SubscriptionContext),
           deprecatedRouteProps: true,
           children: [

--- a/static/gsApp/views/invoiceDetails/actions.tsx
+++ b/static/gsApp/views/invoiceDetails/actions.tsx
@@ -86,7 +86,7 @@ function InvoiceDetailsActions({organization, invoice, reloadInvoice}: Props) {
 
   const isSelfServePartner =
     'isSelfServePartner' in invoice.customer && invoice.customer.isSelfServePartner;
-  const showPayNowButton = true; // !invoice.isPaid && !invoice.isClosed && !isSelfServePartner;
+  const showPayNowButton = !invoice.isPaid && !invoice.isClosed && !isSelfServePartner;
 
   return (
     <Fragment>

--- a/static/gsApp/views/invoiceDetails/actions.tsx
+++ b/static/gsApp/views/invoiceDetails/actions.tsx
@@ -86,7 +86,7 @@ function InvoiceDetailsActions({organization, invoice, reloadInvoice}: Props) {
 
   const isSelfServePartner =
     'isSelfServePartner' in invoice.customer && invoice.customer.isSelfServePartner;
-  const showPayNowButton = !invoice.isPaid && !invoice.isClosed && !isSelfServePartner;
+  const showPayNowButton = true; // !invoice.isPaid && !invoice.isClosed && !isSelfServePartner;
 
   return (
     <Fragment>

--- a/static/gsApp/views/invoiceDetails/index.spec.tsx
+++ b/static/gsApp/views/invoiceDetails/index.spec.tsx
@@ -191,7 +191,7 @@ describe('InvoiceDetails', () => {
 
     await waitFor(() => expect(mockapiInvoice).toHaveBeenCalled());
 
-    expect(screen.getByText(/Invoice Details/)).toBeInTheDocument();
+    expect(screen.getByText(/Receipt Details/)).toBeInTheDocument();
     expect(screen.getByText(/AWAITING PAYMENT/)).toBeInTheDocument();
     expect(screen.queryByText(/Pay Now/)).not.toBeInTheDocument();
   });
@@ -272,9 +272,9 @@ describe('InvoiceDetails', () => {
     await waitFor(() => expect(mockapiInvoice).toHaveBeenCalled());
     await waitFor(() => expect(mockapiPayments).toHaveBeenCalled());
 
-    expect(screen.getByText(/Invoice Details/)).toBeInTheDocument();
+    expect(screen.getByText(/Receipt Details/)).toBeInTheDocument();
     expect(screen.getAllByText(/Pay Now/)).toHaveLength(2);
-    expect(screen.getByText(/Pay Invoice/)).toBeInTheDocument();
+    expect(screen.getByText(/Pay Bill/)).toBeInTheDocument();
     expect(screen.getByText(/Card Details/)).toBeInTheDocument();
     expect(screen.getByTestId('modal-backdrop')).toBeInTheDocument();
     expect(screen.getByTestId('cancel')).toBeInTheDocument();

--- a/static/gsApp/views/invoiceDetails/index.tsx
+++ b/static/gsApp/views/invoiceDetails/index.tsx
@@ -61,8 +61,8 @@ function InvoiceDetails({params}: Props) {
 
   return (
     <SubscriptionPageContainer background="secondary" organization={organization}>
-      <SettingsPageHeader title={t('Invoice Details')}>
-        {t('Invoice Details')}
+      <SettingsPageHeader title={t('Receipt Details')}>
+        {t('Receipt Details')}
       </SettingsPageHeader>
       <Panel>
         {isInvoiceLoading || isBillingDetailsLoading ? (

--- a/static/gsApp/views/invoiceDetails/paymentForm.spec.tsx
+++ b/static/gsApp/views/invoiceDetails/paymentForm.spec.tsx
@@ -62,7 +62,7 @@ describe('InvoiceDetails > Payment Form', () => {
     );
 
     await waitFor(() => expect(mockget).toHaveBeenCalled());
-    expect(screen.getByText('Pay Invoice')).toBeInTheDocument();
+    expect(screen.getByText('Pay Bill')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Pay Now'})).toBeInTheDocument();
     expect(
@@ -91,7 +91,7 @@ describe('InvoiceDetails > Payment Form', () => {
     );
 
     await waitFor(() => expect(mockget).toHaveBeenCalled());
-    expect(screen.getByText('Pay Invoice')).toBeInTheDocument();
+    expect(screen.getByText('Pay Bill')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Pay Now'})).toBeInTheDocument();
     expect(
@@ -122,7 +122,7 @@ describe('InvoiceDetails > Payment Form', () => {
     await waitFor(() => expect(mockget).toHaveBeenCalled());
     expect(mockget).toHaveBeenCalled();
 
-    expect(screen.getByText('Pay Invoice')).toBeInTheDocument();
+    expect(screen.getByText('Pay Bill')).toBeInTheDocument();
 
     let error = screen.getByText(/Unable to initialize payment/);
     expect(error).toBeInTheDocument();
@@ -156,7 +156,7 @@ describe('InvoiceDetails > Payment Form', () => {
     await waitFor(() => expect(mockget).toHaveBeenCalled());
     expect(mockget).toHaveBeenCalled();
 
-    expect(screen.getByText('Pay Invoice')).toBeInTheDocument();
+    expect(screen.getByText('Pay Bill')).toBeInTheDocument();
 
     const button = screen.getByRole('button', {name: 'Pay Now'});
     await userEvent.click(button);

--- a/static/gsApp/views/invoiceDetails/paymentForm.tsx
+++ b/static/gsApp/views/invoiceDetails/paymentForm.tsx
@@ -96,7 +96,7 @@ function InvoiceDetailsPaymentForm({
 
   return (
     <Fragment>
-      <Header>{t('Pay Invoice')}</Header>
+      <Header>{t('Pay Bill')}</Header>
       <Body>
         <Flex direction="column" gap="sm">
           <Text as="p">


### PR DESCRIPTION
Replaces usage of `invoice` in in-app UI with `receipt`. I didn't change any of the file/component names since we still use `invoice` on the backend but if anyone has strong opinions about it I can update those too.

Context: `invoice` is not the proper terminology for what we show