### PR TITLE
feat(ci): Force pytest stdout flushing

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -49,7 +49,7 @@ runs:
 
         ### pytest configuration ###
         echo "PY_COLORS=1" >> "$GITHUB_ENV"
-        echo "PYTEST_ADDOPTS=--reruns=5 --durations=10 --fail-slow=60s" >> $GITHUB_ENV
+        echo "PYTEST_ADDOPTS=--reruns=5 --durations=10 --fail-slow=60s --capture=tee-sys" >> $GITHUB_ENV
         echo "COVERAGE_CORE=sysmon" >> "$GITHUB_ENV"
 
         ### pytest-sentry configuration ###

--- a/tests/sentry/deletions/test_cleanup.py
+++ b/tests/sentry/deletions/test_cleanup.py
@@ -1,0 +1,140 @@
+from sentry.models.group import Group, GroupStatus
+from sentry.models.grouphash import GroupHash
+from sentry.runner.commands.cleanup import (
+    _STOP_WORKER,
+    _cleanup,
+    multiprocess_worker,
+    start_pool,
+    stop_pool,
+)
+from sentry.services.eventstore.models import Event
+from sentry.testutils.cases import TransactionTestCase
+from sentry.testutils.helpers.datetime import before_now
+
+RETENTION_DAYS = 2
+LESS_THAN_RETENTION_DAYS = before_now(days=RETENTION_DAYS - 1).isoformat()
+MORE_THAN_RETENTION_DAYS = before_now(days=RETENTION_DAYS + 1).isoformat()
+
+
+# TransactionTestCase is needed to ensure that the events are stored in the same transaction
+# as the cleanup process since it uses raw SQL queries and cannot see test transactions
+class TestGroupDeletion(TransactionTestCase):
+    """Test cleanup with disable_multiprocessing=True."""
+
+    def _create_group(
+        self,
+        fingerprint: str,
+        timestamp: str,
+        status: int = GroupStatus.UNRESOLVED,
+        project_id: int | None = None,
+    ) -> Event:
+        if project_id is None:
+            project_id = self.project.id
+        event = self.store_event(
+            data={"fingerprint": [fingerprint], "timestamp": timestamp}, project_id=project_id
+        )
+        assert event.group is not None
+
+        if status != GroupStatus.UNRESOLVED:
+            event.group.status = status
+            event.group.substatus = None
+            event.group.save()
+
+        assert event.group.status == status
+
+        return event
+
+    def test_only_deletes_old_groups(self) -> None:
+        """Test cleanup only deletes old groups."""
+        young_event = self._create_group("group1", LESS_THAN_RETENTION_DAYS)
+        assert young_event.group is not None
+        group_id = young_event.group.id
+        self._create_group("group2", MORE_THAN_RETENTION_DAYS)
+        assert Group.objects.count() == 2
+        assert GroupHash.objects.count() == 2
+
+        _cleanup(
+            model=("Group",),
+            days=RETENTION_DAYS,
+            router="default",
+            silent=True,
+            disable_multiprocessing=True,
+        )
+
+        assert Group.objects.filter(id=group_id).exists()
+        assert Group.objects.count() == 1
+        assert GroupHash.objects.count() == 1
+
+    def test_delete_old_pending_groups(self) -> None:
+        """Test cleanup does not delete pending deletion groups."""
+        self._create_group("group1", MORE_THAN_RETENTION_DAYS, GroupStatus.PENDING_DELETION)
+
+        assert GroupHash.objects.count() == 1
+        assert Group.objects.count() == 1
+
+        _cleanup(
+            model=("Group",),
+            days=RETENTION_DAYS,
+            router="default",
+            silent=True,
+            disable_multiprocessing=True,
+        )
+
+        assert Group.objects.count() == 0
+        assert GroupHash.objects.count() == 0
+
+    def test_delete_old_pending_groups_for_multiple_projects(self) -> None:
+        """Test cleanup deletes old pending groups for multiple projects."""
+        self._create_group("group1", MORE_THAN_RETENTION_DAYS, GroupStatus.PENDING_DELETION)
+        project2 = self.create_project(name="Project 2")
+        self._create_group(
+            "group1", MORE_THAN_RETENTION_DAYS, GroupStatus.PENDING_DELETION, project2.id
+        )
+
+        assert GroupHash.objects.count() == 2
+        assert Group.objects.count() == 2
+
+        _cleanup(
+            model=("Group",),
+            days=RETENTION_DAYS,
+            router="default",
+            silent=True,
+            disable_multiprocessing=True,
+        )
+
+        assert Group.objects.count() == 0
+        assert GroupHash.objects.count() == 0
+
+
+class TestCleanupMultiprocessing(TransactionTestCase):
+    """Test the multiprocessing functionality in cleanup."""
+
+    def test_starting_and_stopping_pool(self) -> None:
+        """Test that starting and stopping the pool works."""
+        pool, task_queue = start_pool(1)
+        stop_pool(pool, task_queue)
+
+    def test_multiprocess_worker_handles_exceptions(self) -> None:
+        """Test that multiprocess_worker handles exceptions gracefully."""
+        pool, task_queue = start_pool(1)
+
+        # Queue an invalid task that should cause an exception
+        task_queue.put(("invalid.model.name", (999999,)))
+        task_queue.put(_STOP_WORKER)
+
+        # This should not raise an exception despite the invalid task
+        multiprocess_worker(task_queue)
+        stop_pool(pool, task_queue)
+
+    def test_worker_queue_empty_behavior(self) -> None:
+        """Test worker behavior when queue becomes empty."""
+        pool, task_queue = start_pool(1)
+
+        # Only put stop signal
+        task_queue.put(_STOP_WORKER)
+
+        # Worker should exit cleanly
+        multiprocess_worker(task_queue)
+        stop_pool(pool, task_queue)
+        # Queue should be empty and properly task_done() called
+        assert task_queue.empty()


### PR DESCRIPTION
Add `--capture=tee-sys` to `PYTEST_ADDOPTS` to stream live pytest output in CI while retaining capture features.

This change allows real-time visibility into which test is currently running, which is crucial for diagnosing hanging CI jobs where output was previously buffered and not immediately visible in the logs. `--capture=tee-sys` provides this live output without disabling pytest's capture entirely, thus preserving detailed failure reports and the functionality of fixtures like `capfd`.

---
[Slack Thread](https://sentry.slack.com/archives/CTJL7358X/p1758901721422079?thread_ts=1758901721.422079&cid=CTJL7358X)

<a href="https://cursor.com/background-agent?bcId=bc-4684b9e7-4b66-4781-bd47-196147b7dcb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4684b9e7-4b66-4781-bd47-196147b7dcb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

