### PR TITLE
ref(groupingInfo): Preserve folded state for stacktrace subsections

### DIFF
--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {Activity, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -46,14 +46,14 @@ function GroupingComponent({component, showNonContributing}: Props) {
           {component.hint && <GroupingHint>{` (${component.hint})`}</GroupingHint>}
         </span>
 
-        {!folded && (
+        <Activity mode={folded ? 'hidden' : 'visible'}>
           <GroupingComponentList isInline={shouldInlineValue} hasFold={canFold}>
             <GroupingComponentListItems
               component={component}
               showNonContributing={showNonContributing}
             />
           </GroupingComponentList>
-        )}
+        </Activity>
       </GroupingComponentWrapper>
     </CollapseButtonWrapper>
   );


### PR DESCRIPTION
As of #100361, the groupingInfo stacktrace has code folding functionality. Use `<Activity>` to preserve the state when parent components are collapse/uncollapsed. 


https://github.com/user-attachments/assets/032f7c58-00a8-41b3-aefe-5998a431488e
