### PR TITLE
fix(auto_source): Move scala extensions under Java

### DIFF
--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -31,7 +31,6 @@ PLATFORMS_CONFIG: dict[str, Mapping[str, Any]] = {
     "php": {"extensions": ["php"]},
     "python": {"extensions": ["py"]},
     "ruby": {"extensions": ["rb", "rake"]},
-    "scala": {"extensions": ["scala", "sc"]},
     "clojure": {"extensions": ["clj", "cljs", "cljc"]},
     "groovy": {"extensions": ["groovy"]},
 }

--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -24,7 +24,7 @@ PLATFORMS_CONFIG: dict[str, Mapping[str, Any]] = {
         # e.g. com.foo.bar.Baz$handle$1, Baz.kt -> com/foo/bar/Baz.kt
         "extract_filename_from_module": True,
         "create_in_app_stack_trace_rules": True,
-        "extensions": ["kt", "kts", "java", "jsp", "scala"],
+        "extensions": ["kt", "kts", "java", "jsp", "scala", "sc"],
     },
     "javascript": {"extensions": ["js", "jsx", "mjs", "tsx", "ts"]},
     "node": {"extensions": ["js", "jsx", "mjs", "tsx", "ts"]},

--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -24,7 +24,7 @@ PLATFORMS_CONFIG: dict[str, Mapping[str, Any]] = {
         # e.g. com.foo.bar.Baz$handle$1, Baz.kt -> com/foo/bar/Baz.kt
         "extract_filename_from_module": True,
         "create_in_app_stack_trace_rules": True,
-        "extensions": ["kt", "kts", "java", "jsp"],
+        "extensions": ["kt", "kts", "java", "jsp", "scala"],
     },
     "javascript": {"extensions": ["js", "jsx", "mjs", "tsx", "ts"]},
     "node": {"extensions": ["js", "jsx", "mjs", "tsx", "ts"]},


### PR DESCRIPTION
Scala is a Java platform (`event.platform`), thus, it needs to be listed under the Java configuration.

This is preventing deriving code mappings for Scala projects.