### PR TITLE
ref(settings): Remove usage of `deprecatedRouteProps` from `TeamProjects` settings view

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1016,7 +1016,6 @@ function buildRoutes(): RouteObject[] {
               component: make(
                 () => import('sentry/views/settings/organizationTeams/teamProjects')
               ),
-              deprecatedRouteProps: true,
             },
             {
               path: 'settings/',

--- a/static/app/views/settings/organizationTeams/teamProjects.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamProjects.spec.tsx
@@ -5,6 +5,7 @@ import {TeamFixture} from 'sentry-fixture/team';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import TeamStore from 'sentry/stores/teamStore';
 import OrganizationTeamProjects from 'sentry/views/settings/organizationTeams/teamProjects';
 
 describe('OrganizationTeamProjects', () => {
@@ -25,13 +26,23 @@ describe('OrganizationTeamProjects', () => {
     access: ['project:read', 'project:write', 'project:admin'],
   });
 
-  const {routerProps, organization} = initializeOrg({
+  const {organization} = initializeOrg({
     organization: OrganizationFixture({slug: 'org-slug'}),
     projects: [project, project2],
-    router: {params: {teamId: team.slug}},
   });
 
+  const initialRouterConfig = {
+    location: {
+      pathname: `/settings/${organization.slug}/teams/${team.slug}/projects/`,
+    },
+    route: '/settings/:orgId/teams/:teamId/projects/',
+  };
+
   beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    TeamStore.reset();
+
+    TeamStore.loadInitialData([team]);
     getMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
       body: [project, project2],
@@ -58,13 +69,10 @@ describe('OrganizationTeamProjects', () => {
     });
   });
 
-  afterEach(() => {
-    MockApiClient.clearMockResponses();
-  });
-
   it('should fetch linked and unlinked projects', async () => {
-    render(<OrganizationTeamProjects {...routerProps} team={team} />, {
+    render(<OrganizationTeamProjects />, {
       organization,
+      initialRouterConfig,
     });
 
     expect(await screen.findByText('project-slug')).toBeInTheDocument();
@@ -76,8 +84,9 @@ describe('OrganizationTeamProjects', () => {
   });
 
   it('should allow bookmarking', async () => {
-    render(<OrganizationTeamProjects {...routerProps} team={team} />, {
+    render(<OrganizationTeamProjects />, {
       organization,
+      initialRouterConfig,
     });
 
     const stars = await screen.findAllByRole('button', {name: 'Bookmark'});
@@ -98,8 +107,9 @@ describe('OrganizationTeamProjects', () => {
   });
 
   it('should allow adding and removing projects', async () => {
-    render(<OrganizationTeamProjects {...routerProps} team={team} />, {
+    render(<OrganizationTeamProjects />, {
       organization,
+      initialRouterConfig,
     });
 
     expect(getMock).toHaveBeenCalledTimes(2);
@@ -117,8 +127,9 @@ describe('OrganizationTeamProjects', () => {
   });
 
   it('handles filtering unlinked projects', async () => {
-    render(<OrganizationTeamProjects {...routerProps} team={team} />, {
+    render(<OrganizationTeamProjects />, {
       organization,
+      initialRouterConfig,
     });
 
     expect(getMock).toHaveBeenCalledTimes(2);

--- a/static/app/views/settings/organizationTeams/teamProjects.tsx
+++ b/static/app/views/settings/organizationTeams/teamProjects.tsx
@@ -19,25 +19,27 @@ import {IconFlag, IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {space} from 'sentry/styles/space';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import type {Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {sortProjects} from 'sentry/utils/project/sortProjects';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import {useTeamsById} from 'sentry/utils/useTeamsById';
 import ProjectListItem from 'sentry/views/settings/components/settingsProjectItem';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
-interface TeamProjectsProps extends RouteComponentProps<{teamId: string}> {
-  team: Team;
-}
-
-function TeamProjects({team, location, params}: TeamProjectsProps) {
+export default function TeamProjects() {
   const organization = useOrganization();
   const api = useApi({persistInFlight: true});
+  const location = useLocation();
   const [query, setQuery] = useState<string>('');
-  const teamId = params.teamId;
+
+  const {teamId} = useParams<{teamId: string}>();
+  const {teams, isLoading: isTeamsLoading} = useTeamsById({slugs: [teamId]});
+  const team = teams.find(tm => tm.slug === teamId);
+
   const {
     data: linkedProjects,
     isError: linkedProjectsError,
@@ -101,6 +103,14 @@ function TeamProjects({team, location, params}: TeamProjectsProps) {
         hideCheck: true,
       }));
   }, [unlinkedProjects]);
+
+  if (isTeamsLoading) {
+    return <LoadingIndicator />;
+  }
+
+  if (!team) {
+    return null;
+  }
 
   return (
     <Fragment>
@@ -186,5 +196,3 @@ const StyledPanelItem = styled(PanelItem)`
   padding: ${space(2)};
   max-width: 100%;
 `;
-
-export default TeamProjects;


### PR DESCRIPTION
Migrates usage of `deprecatedRouteProps` for `TeamProjects` - `sentry/views/settings/organizationTeams/teamProjects`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7