### PR TITLE
fix(search): Consistently use getFieldDefinition from context

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {t} from 'sentry/locale';
-import {getFieldDefinition} from 'sentry/utils/fields';
 import type {ChartType} from 'sentry/views/insights/common/components/chart';
 
 export interface QueryTokensProps {
@@ -22,7 +22,7 @@ function QueryTokens({
   visualizations,
 }: QueryTokensProps) {
   const tokens = [];
-
+  const {getFieldDefinition} = useSearchQueryBuilder();
   const parsedQuery = query ? parseQueryBuilderValue(query, getFieldDefinition) : null;
   if (query && parsedQuery?.length) {
     tokens.push(

--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -1,7 +1,10 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
+import {
+  SearchQueryBuilderProvider,
+  useSearchQueryBuilder,
+} from 'sentry/components/searchQueryBuilder/context';
 import {AggregateKeyVisual} from 'sentry/components/searchQueryBuilder/tokens/filter/aggregateKey';
 import {FilterValueText} from 'sentry/components/searchQueryBuilder/tokens/filter/filter';
 import {getOperatorInfo} from 'sentry/components/searchQueryBuilder/tokens/filter/filterOperator';
@@ -18,7 +21,7 @@ import {
 import {getKeyLabel} from 'sentry/components/searchSyntax/utils';
 import {space} from 'sentry/styles/space';
 import type {TagCollection} from 'sentry/types/group';
-import {getFieldDefinition} from 'sentry/utils/fields';
+import {getFieldDefinition as defaultGetFieldDefinition} from 'sentry/utils/fields';
 import useOrganization from 'sentry/utils/useOrganization';
 
 export type FormattedQueryProps = {
@@ -50,12 +53,18 @@ function FilterKey({token}: {token: TokenResult<Token.FILTER>}) {
 }
 
 function Filter({token}: {token: TokenResult<Token.FILTER>}) {
+  const {getFieldDefinition} = useSearchQueryBuilder();
   const hasWildcardOperators = useOrganization().features.includes(
     'search-query-builder-wildcard-operators'
   );
   const label = useMemo(
-    () => getOperatorInfo(token, hasWildcardOperators).label,
-    [hasWildcardOperators, token]
+    () =>
+      getOperatorInfo({
+        filterToken: token,
+        hasWildcardOperators,
+        fieldDefinition: getFieldDefinition(token.key.text),
+      }).label,
+    [hasWildcardOperators, token, getFieldDefinition]
   );
 
   return (
@@ -101,7 +110,7 @@ function QueryToken({token}: TokenProps) {
 export function FormattedQuery({
   className,
   query,
-  fieldDefinitionGetter = getFieldDefinition,
+  fieldDefinitionGetter = defaultGetFieldDefinition,
   filterKeys = EMPTY_FILTER_KEYS,
   filterKeyAliases = EMPTY_FILTER_KEYS,
 }: FormattedQueryProps) {
@@ -137,7 +146,7 @@ export function FormattedQuery({
 export function ProvidedFormattedQuery({
   className,
   query,
-  fieldDefinitionGetter = getFieldDefinition,
+  fieldDefinitionGetter = defaultGetFieldDefinition,
   filterKeys = EMPTY_FILTER_KEYS,
   filterKeyAliases = EMPTY_FILTER_KEYS,
 }: FormattedQueryProps) {

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -34,6 +34,7 @@ import {
 import {getKeyName} from 'sentry/components/searchSyntax/utils';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import type {FieldDefinition} from 'sentry/utils/fields';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface FilterOperatorProps {
@@ -87,16 +88,21 @@ function FilterKeyOperatorLabel({
   );
 }
 
-export function getOperatorInfo(
-  token: TokenResult<Token.FILTER>,
-  hasWildcardOperators: boolean
-): {
+export function getOperatorInfo({
+  filterToken,
+  hasWildcardOperators,
+  fieldDefinition,
+}: {
+  fieldDefinition: FieldDefinition | null;
+  filterToken: TokenResult<Token.FILTER>;
+  hasWildcardOperators: boolean;
+}): {
   label: ReactNode;
   operator: TermOperator;
   options: Array<SelectOption<TermOperator>>;
 } {
-  if (isDateToken(token)) {
-    const operator = getOperatorFromDateToken(token);
+  if (isDateToken(filterToken)) {
+    const operator = getOperatorFromDateToken(filterToken);
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     const opLabel = DATE_OP_LABELS[operator] ?? operator;
 
@@ -115,15 +121,18 @@ export function getOperatorInfo(
     };
   }
 
-  const {operator, label} = getLabelAndOperatorFromToken(token, hasWildcardOperators);
+  const {operator, label} = getLabelAndOperatorFromToken(
+    filterToken,
+    hasWildcardOperators
+  );
 
-  if (token.filter === FilterType.IS) {
+  if (filterToken.filter === FilterType.IS) {
     return {
       operator,
       label: (
         <FilterKeyOperatorLabel
-          keyValue={token.key.value}
-          keyLabel={token.key.text}
+          keyValue={filterToken.key.value}
+          keyLabel={filterToken.key.text}
           opLabel={operator === TermOperator.NOT_EQUAL ? 'not' : undefined}
           includeKeyLabel
         />
@@ -133,8 +142,8 @@ export function getOperatorInfo(
           value: TermOperator.DEFAULT,
           label: (
             <FilterKeyOperatorLabel
-              keyLabel={token.key.text}
-              keyValue={token.key.value}
+              keyLabel={filterToken.key.text}
+              keyValue={filterToken.key.value}
               includeKeyLabel
             />
           ),
@@ -144,8 +153,8 @@ export function getOperatorInfo(
           value: TermOperator.NOT_EQUAL,
           label: (
             <FilterKeyOperatorLabel
-              keyLabel={token.key.text}
-              keyValue={token.key.value}
+              keyLabel={filterToken.key.text}
+              keyValue={filterToken.key.value}
               opLabel="not"
               includeKeyLabel
             />
@@ -156,12 +165,12 @@ export function getOperatorInfo(
     };
   }
 
-  if (token.filter === FilterType.HAS) {
+  if (filterToken.filter === FilterType.HAS) {
     return {
       operator,
       label: (
         <FilterKeyOperatorLabel
-          keyValue={token.key.value}
+          keyValue={filterToken.key.value}
           keyLabel={operator === TermOperator.NOT_EQUAL ? 'does not have' : 'has'}
           includeKeyLabel
         />
@@ -172,7 +181,7 @@ export function getOperatorInfo(
           label: (
             <FilterKeyOperatorLabel
               keyLabel="has"
-              keyValue={token.key.value}
+              keyValue={filterToken.key.value}
               includeKeyLabel
             />
           ),
@@ -183,7 +192,7 @@ export function getOperatorInfo(
           label: (
             <FilterKeyOperatorLabel
               keyLabel="does not have"
-              keyValue={token.key.value}
+              keyValue={filterToken.key.value}
               includeKeyLabel
             />
           ),
@@ -193,12 +202,16 @@ export function getOperatorInfo(
     };
   }
 
-  const keyLabel = token.key.text;
+  const keyLabel = filterToken.key.text;
 
   return {
     operator,
     label: <OpLabel>{label}</OpLabel>,
-    options: getValidOpsForFilter(token, hasWildcardOperators)
+    options: getValidOpsForFilter({
+      filterToken,
+      hasWildcardOperators,
+      fieldDefinition,
+    })
       .filter(op => op !== TermOperator.EQUAL)
       .map((op): SelectOption<TermOperator> => {
         const optionOpLabel = OP_LABELS[op] ?? op;
@@ -217,15 +230,26 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
   const hasWildcardOperators = organization.features.includes(
     'search-query-builder-wildcard-operators'
   );
-
-  const {dispatch, searchSource, query, recentSearches, disabled, focusOverride} =
-    useSearchQueryBuilder();
+  const {
+    dispatch,
+    searchSource,
+    query,
+    recentSearches,
+    disabled,
+    focusOverride,
+    getFieldDefinition,
+  } = useSearchQueryBuilder();
   const filterButtonProps = useFilterButtonProps({state, item});
   const {focusWithinProps} = useFocusWithin({});
 
   const {operator, label, options} = useMemo(
-    () => getOperatorInfo(token, hasWildcardOperators),
-    [token, hasWildcardOperators]
+    () =>
+      getOperatorInfo({
+        filterToken: token,
+        hasWildcardOperators,
+        fieldDefinition: getFieldDefinition(token.key.text),
+      }),
+    [token, hasWildcardOperators, getFieldDefinition]
   );
 
   const onlyOperator = token.filter === FilterType.IS || token.filter === FilterType.HAS;

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -12,11 +12,7 @@ import {
 } from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
 import {escapeDoubleQuotes} from 'sentry/utils';
-import {
-  FieldValueType,
-  getFieldDefinition,
-  type FieldDefinition,
-} from 'sentry/utils/fields';
+import {FieldValueType, type FieldDefinition} from 'sentry/utils/fields';
 
 const SHOULD_ESCAPE_REGEX = /[\s"(),]/;
 
@@ -69,12 +65,15 @@ export function isAggregateFilterToken(
   }
 }
 
-export function getValidOpsForFilter(
-  filterToken: TokenResult<Token.FILTER>,
-  hasWildcardOperators: boolean
-): readonly TermOperator[] {
-  const fieldDefinition = getFieldDefinition(filterToken.key.text);
-
+export function getValidOpsForFilter({
+  filterToken,
+  hasWildcardOperators,
+  fieldDefinition,
+}: {
+  fieldDefinition: FieldDefinition | null;
+  filterToken: TokenResult<Token.FILTER>;
+  hasWildcardOperators: boolean;
+}): readonly TermOperator[] {
   // If the token is invalid we want to use the possible expected types as our filter type
   const validTypes = filterToken.invalid?.expectedType ?? [filterToken.filter];
 


### PR DESCRIPTION
Was noticing that my passed field definition was not affecting whether or not the new "contains" operators showed up. This is because the operator was using the imported `getFieldDefinition` instead of the one on context.

