### PR TITLE
fix(sub v3): Adjust header cards

### DIFF
--- a/static/gsApp/components/subscriptionSettingsLayout.tsx
+++ b/static/gsApp/components/subscriptionSettingsLayout.tsx
@@ -50,7 +50,7 @@ function SubscriptionSettingsLayout(props: Props) {
         </Flex>
       </StyledSettingsHeader>
 
-      <Flex maxWidth="1440px" flex="1">
+      <Flex flex="1">
         <Container minWidth={0} flex={1}>
           {children}
         </Container>

--- a/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.spec.tsx
@@ -27,7 +27,7 @@ describe('BillingInfoCard', () => {
     render(<BillingInfoCard organization={organization} subscription={subscription} />);
 
     expect(screen.getByText('Billing information')).toBeInTheDocument();
-    await screen.findByText('Test company');
+    await screen.findByText('Test company, Display Address');
     expect(screen.getByText('Card ending in 4242')).toBeInTheDocument();
   });
 

--- a/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.spec.tsx
@@ -28,6 +28,26 @@ describe('BillingInfoCard', () => {
 
     expect(screen.getByText('Billing information')).toBeInTheDocument();
     await screen.findByText('Test company, Display Address');
+    expect(screen.getByText('Billing email: test@gmail.com')).toBeInTheDocument();
+    expect(screen.getByText('Card ending in 4242')).toBeInTheDocument();
+  });
+
+  it('renders with some pre-existing info', async () => {
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-details/`,
+      method: 'GET',
+      body: BillingDetailsFixture({billingEmail: null, companyName: null}),
+    });
+    const subscription = SubscriptionFixture({organization});
+    render(<BillingInfoCard organization={organization} subscription={subscription} />);
+
+    expect(screen.getByText('Billing information')).toBeInTheDocument();
+    await screen.findByText('Display Address');
+    expect(screen.queryByText('Test company')).not.toBeInTheDocument();
+    expect(screen.queryByText('Billing email: test@gmail.com')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('No billing email or tax number on file')
+    ).toBeInTheDocument();
     expect(screen.getByText('Card ending in 4242')).toBeInTheDocument();
   });
 

--- a/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.tsx
@@ -78,7 +78,8 @@ function BillingDetailsInfo() {
   }
 
   const taxFieldInfo = getTaxFieldInfo(billingDetails.countryCode);
-  const showTaxNumber = countryHasSalesTax(billingDetails.countryCode);
+  const showTaxNumber =
+    countryHasSalesTax(billingDetails.countryCode) && !!billingDetails.taxNumber;
 
   const primaryDetails = [
     billingDetails.companyName,

--- a/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.tsx
@@ -1,9 +1,7 @@
-import moment from 'moment-timezone';
-
+import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Container, Flex} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import Placeholder from 'sentry/components/placeholder';
-import {IconSettings, IconUser} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 
@@ -29,18 +27,23 @@ function BillingInfoCard({
   return (
     <SubscriptionHeaderCard
       title={t('Billing information')}
-      icon={<IconUser />}
       sections={[
-        <BillingDetailsInfo key="billing-details-info" />,
-        <PaymentSourceInfo key="payment-source-info" subscription={subscription} />,
+        <Flex key="billing-info" direction="column" gap="md" align="start">
+          <BillingDetailsInfo />
+          <PaymentSourceInfo subscription={subscription} />
+        </Flex>,
+        <LinkButton
+          key="edit-billing-information"
+          aria-label={t('Edit billing information')}
+          to={`/settings/${organization.slug}/billing/details/`}
+          priority="link"
+          size="sm"
+        >
+          <Text size="sm" variant="accent">
+            {t('Edit billing information')}
+          </Text>
+        </LinkButton>,
       ]}
-      button={{
-        ariaLabel: t('Edit billing information'),
-        label: t('Edit billing information'),
-        linkTo: `/settings/${organization.slug}/billing/details/`,
-        icon: <IconSettings />,
-        priority: 'default',
-      }}
     />
   );
 }
@@ -49,14 +52,7 @@ function BillingDetailsInfo() {
   const {data: billingDetails, isLoading} = useBillingDetails();
 
   if (isLoading) {
-    return (
-      <Flex direction="column" gap="xs">
-        <Placeholder height="16px" />
-        <Placeholder height="16px" />
-        <Placeholder height="16px" />
-        <Placeholder height="16px" />
-      </Flex>
-    );
+    return <Placeholder height="14px" />;
   }
 
   if (!billingDetails || !hasSomeBillingDetails(billingDetails)) {
@@ -68,46 +64,25 @@ function BillingDetailsInfo() {
   }
 
   return (
-    <Flex direction="column" gap="xs">
-      {billingDetails.companyName && (
-        <Text variant="muted" size="sm">
-          {billingDetails.companyName}
-        </Text>
-      )}
-      {billingDetails.billingEmail && (
-        <Text variant="muted" size="sm">
-          {billingDetails.billingEmail}
-        </Text>
-      )}
-      {billingDetails.displayAddress && (
-        <Text variant="muted" size="sm">
-          {billingDetails.displayAddress}
-        </Text>
-      )}
-    </Flex>
+    <Text ellipsis size="sm" variant="muted">
+      {`${billingDetails.companyName ? `${billingDetails.companyName}, ` : ''}${billingDetails.displayAddress}`}
+    </Text>
   );
 }
 
 function PaymentSourceInfo({subscription}: {subscription: Subscription}) {
   const {paymentSource} = subscription;
-  const paymentSourceExpiryDate = paymentSource
-    ? moment(new Date(paymentSource.expYear, paymentSource.expMonth - 1))
-    : null;
 
   if (!paymentSource) {
     return <Text variant="muted">{t('No payment method on file')}</Text>;
   }
 
   return (
-    <Flex direction="column" gap="xs">
-      <Text>{tct('Card ending in [last4]', {last4: paymentSource.last4})}</Text>
-      <Text variant="muted" size="sm">
-        {tct('Expires [expMonth]/[expYear]', {
-          expMonth: paymentSourceExpiryDate?.format('MM'),
-          expYear: paymentSourceExpiryDate?.format('YY'),
-        })}
-      </Text>
-    </Flex>
+    <Text ellipsis size="sm" variant="muted">
+      {tct('Card ending in [last4]', {
+        last4: paymentSource.last4,
+      })}
+    </Text>
   );
 }
 

--- a/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
@@ -52,7 +52,7 @@ function HeaderCards({organization, subscription}: HeaderCardsProps) {
         <Grid
           columns={{
             xs: '1fr',
-            md: `repeat(${cards.length}, 1fr)`,
+            md: `repeat(${cards.length}, minmax(0, 1fr))`,
           }}
           gap="xl"
         >

--- a/static/gsApp/views/subscriptionPage/headerCards/linksCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/linksCard.tsx
@@ -1,5 +1,6 @@
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import {IconList, IconSubscribed, IconTimer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
@@ -16,21 +17,27 @@ function LinksCard() {
             icon={<IconList />}
             to="/settings/billing/receipts/"
           >
-            {t('View all receipts')}
+            <Text size="sm" variant="accent">
+              {t('View all receipts')}
+            </Text>
           </LinkButton>
           <LinkButton
             priority="link"
             icon={<IconTimer />}
             to="/settings/billing/usage-log/"
           >
-            {t('View activity')}
+            <Text size="sm" variant="accent">
+              {t('View activity')}
+            </Text>
           </LinkButton>
           <LinkButton
             priority="link"
             icon={<IconSubscribed />}
             to="/settings/billing/notifications/"
           >
-            {t('Manage spend notifications')}
+            <Text size="sm" variant="accent">
+              {t('Manage spend notifications')}
+            </Text>
           </LinkButton>
         </Flex>,
       ]}

--- a/static/gsApp/views/subscriptionPage/headerCards/subscriptionHeaderCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/subscriptionHeaderCard.tsx
@@ -1,53 +1,21 @@
-import React, {cloneElement, Fragment, isValidElement} from 'react';
+import React, {Fragment} from 'react';
 
-import {Button} from 'sentry/components/core/button';
-import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
-import {Separator} from 'sentry/components/core/separator';
 import {Heading, Text} from 'sentry/components/core/text';
-import type {SVGIconProps} from 'sentry/icons/svgIcon';
-
-interface ButtonInfo {
-  ariaLabel: string;
-  label: React.ReactNode;
-  priority: 'primary' | 'default';
-  icon?: React.ReactNode;
-  linkTo?: string;
-  onClick?: () => void;
-}
 
 interface SubscriptionHeaderCardProps {
   sections: React.ReactNode[];
-  button?: ButtonInfo;
-  icon?: React.ReactNode;
+  title: React.ReactNode;
   isMainCard?: boolean;
   subtitle?: React.ReactNode;
-  title?: React.ReactNode;
 }
 
 function SubscriptionHeaderCard({
   title,
-  icon,
   sections,
-  button,
   isMainCard = false,
   subtitle,
 }: SubscriptionHeaderCardProps) {
-  const hasCustomTitle = icon || title;
-  const getButtonContent = () => {
-    if (!button) {
-      return null;
-    }
-    return (
-      <Flex align="center" gap="sm">
-        {isValidElement(button.icon)
-          ? cloneElement(button.icon, {size: 'sm'} as SVGIconProps)
-          : null}
-        {button.label}
-      </Flex>
-    );
-  };
-
   return (
     <Flex
       direction="column"
@@ -55,47 +23,20 @@ function SubscriptionHeaderCard({
       background={isMainCard ? 'secondary' : 'primary'}
       border="primary"
       radius="md"
-      gap="xs"
+      gap="lg"
     >
-      {hasCustomTitle && (
-        <Flex align="center" gap="sm">
-          {isValidElement(icon) &&
-            cloneElement(icon, {size: 'sm', color: 'subText'} as SVGIconProps)}
-          <Heading as="h2" size="lg">
-            {title}
-          </Heading>
-        </Flex>
-      )}
+      <Flex align="center" gap="sm">
+        <Heading as="h2" size="lg">
+          {title}
+        </Heading>
+      </Flex>
+
       {subtitle && <Text variant="muted">{subtitle}</Text>}
-      <Flex direction="column" gap="md" padding={button ? 'xl 0' : 'xl 0 0'}>
+      <Flex direction="column" gap="lg" align="start">
         {sections.map((section, index) => {
-          const isLast = index === sections.length - 1;
-          return (
-            <Fragment key={index}>
-              {section}
-              {!isLast && <Separator orientation="horizontal" border="primary" />}
-            </Fragment>
-          );
+          return <Fragment key={index}>{section}</Fragment>;
         })}
       </Flex>
-      {button &&
-        (button.linkTo ? (
-          <LinkButton
-            priority={button.priority}
-            aria-label={button.ariaLabel}
-            to={button.linkTo}
-          >
-            {getButtonContent()}
-          </LinkButton>
-        ) : (
-          <Button
-            onClick={button.onClick}
-            aria-label={button.ariaLabel}
-            priority={button.priority}
-          >
-            {getButtonContent()}
-          </Button>
-        ))}
     </Flex>
   );
 }


### PR DESCRIPTION
Adjust header cards to reflect latest design (billing info card, links card).
<img width="1220" height="175" alt="Screenshot 2025-10-07 at 11 16 04 AM" src="https://github.com/user-attachments/assets/506ba9e5-7475-4a14-9e6d-2b3a50afda19" />


Also removes max width for subscription settings pages when `subscriptions-v3` is enabled.