### PR TITLE
ref(settings): Remove usage of `deprecatedRouteProps` from `ProjectLoaderScript` settings view

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -771,7 +771,6 @@ function buildRoutes(): RouteObject[] {
       path: 'loader-script/',
       name: t('Loader Script'),
       component: make(() => import('sentry/views/settings/project/loaderScript')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'csp/',

--- a/static/app/views/settings/project/loaderScript.spec.tsx
+++ b/static/app/views/settings/project/loaderScript.spec.tsx
@@ -8,6 +8,7 @@ import {
   waitForElementToBeRemoved,
 } from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import type {Organization} from 'sentry/types/organization';
 import type {Project, ProjectKey} from 'sentry/types/project';
 import LoaderScript from 'sentry/views/settings/project/loaderScript';
@@ -30,8 +31,20 @@ function mockApi({
 }
 
 describe('LoaderScript', () => {
+  const initialRouterConfig = (project: Project, organization: Organization) => ({
+    location: {
+      pathname: `/settings/${organization.slug}/projects/${project.slug}/loader-script/`,
+    },
+    route: '/settings/:orgId/projects/:projectId/loader-script/',
+  });
+
+  beforeEach(() => {
+    ProjectsStore.reset();
+  });
+
   it('renders error', async () => {
     const {organization, project} = initializeOrg();
+    ProjectsStore.loadInitialData([project]);
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/keys/`,
@@ -39,7 +52,10 @@ describe('LoaderScript', () => {
       statusCode: 400,
     });
 
-    render(<LoaderScript project={project} />);
+    render(<LoaderScript />, {
+      organization,
+      initialRouterConfig: initialRouterConfig(project, organization),
+    });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -50,10 +66,14 @@ describe('LoaderScript', () => {
 
   it('renders empty', async () => {
     const {organization, project} = initializeOrg();
+    ProjectsStore.loadInitialData([project]);
 
     mockApi({organization, project, projectKeys: []});
 
-    render(<LoaderScript project={project} />);
+    render(<LoaderScript />, {
+      organization,
+      initialRouterConfig: initialRouterConfig(project, organization),
+    });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -64,12 +84,16 @@ describe('LoaderScript', () => {
 
   it('renders for single project', async () => {
     const {organization, project} = initializeOrg();
+    ProjectsStore.loadInitialData([project]);
     const projectKey = ProjectKeysFixture()[0]!;
     const projectKeys = [projectKey];
 
     mockApi({organization, project, projectKeys});
 
-    render(<LoaderScript project={project} />);
+    render(<LoaderScript />, {
+      organization,
+      initialRouterConfig: initialRouterConfig(project, organization),
+    });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -84,6 +108,7 @@ describe('LoaderScript', () => {
 
   it('renders multiple keys', async () => {
     const {organization, project} = initializeOrg();
+    ProjectsStore.loadInitialData([project]);
     const projectKeys = ProjectKeysFixture([
       {
         dsn: {
@@ -132,7 +157,10 @@ describe('LoaderScript', () => {
 
     mockApi({organization, project, projectKeys});
 
-    render(<LoaderScript project={project} />);
+    render(<LoaderScript />, {
+      organization,
+      initialRouterConfig: initialRouterConfig(project, organization),
+    });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -148,6 +176,7 @@ describe('LoaderScript', () => {
 
   it('allows to update key settings', async () => {
     const {organization, project} = initializeOrg();
+    ProjectsStore.loadInitialData([project]);
     const baseKey = ProjectKeysFixture()[0]!;
     const projectKey = {
       ...baseKey,
@@ -171,7 +200,10 @@ describe('LoaderScript', () => {
       },
     });
 
-    render(<LoaderScript project={project} />);
+    render(<LoaderScript />, {
+      organization,
+      initialRouterConfig: initialRouterConfig(project, organization),
+    });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -226,6 +258,7 @@ describe('LoaderScript', () => {
 
   it('allows to update one of multiple keys', async () => {
     const {organization, project} = initializeOrg();
+    ProjectsStore.loadInitialData([project]);
     const projectKeys = ProjectKeysFixture([
       {
         dsn: {
@@ -286,7 +319,10 @@ describe('LoaderScript', () => {
       },
     });
 
-    render(<LoaderScript project={project} />);
+    render(<LoaderScript />, {
+      organization,
+      initialRouterConfig: initialRouterConfig(project, organization),
+    });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 

--- a/static/app/views/settings/project/loaderScript.tsx
+++ b/static/app/views/settings/project/loaderScript.tsx
@@ -14,11 +14,17 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project, ProjectKey} from 'sentry/types/project';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import useProjects from 'sentry/utils/useProjects';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import {LoaderSettings} from 'sentry/views/settings/project/projectKeys/details/loaderSettings';
 
-function ProjectLoaderScript({project}: {project: Project}) {
+export default function ProjectLoaderScript() {
+  const {projectId} = useParams<{projectId: string}>();
+  const {projects} = useProjects({slugs: [projectId]});
+  const project = projects.find(p => p.slug === projectId)!;
+
   const organization = useOrganization();
   const apiEndpoint = `/projects/${organization.slug}/${project.slug}/keys/`;
   const [updatedProjectKeys, setUpdatedProjectKeys] = useState<ProjectKey[]>([]);
@@ -136,5 +142,3 @@ function LoaderItem({
     </Panel>
   );
 }
-
-export default ProjectLoaderScript;


### PR DESCRIPTION
Migrates usage of `deprecatedRouteProps` for `ProjectLoaderScript` - `sentry/views/settings/project/loaderScript`.

https://www.notion.so/sentry/Frontend-TSC-Project-Remove-all-uses-of-deprecatedRouteProps-true-26a8b10e4b5d8015a6a2dd14f9d41dd7