### PR TITLE
fix(dashboards): Check for widget builder path on dashboard component update

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -217,6 +217,10 @@ class DashboardDetail extends Component<Props, State> {
   componentDidUpdate(prevProps: Props) {
     this.checkIfShouldMountWidgetViewerModal();
 
+    if (!this.state.isWidgetBuilderOpen && this.isWidgetBuilder()) {
+      this.setState({isWidgetBuilderOpen: true});
+    }
+
     if (prevProps.initialState !== this.props.initialState) {
       // Widget builder can toggle Edit state when saving
       this.setState({dashboardState: this.props.initialState});


### PR DESCRIPTION
This contributes to DAIN-976. The issue we're seeing (we think) is that users are causing navigation events by some means other than the UI (e.g., trackpad swipes, keyboard shortcuts, etc.) and triggering URL changes that don't open the Widget Builder. They get into a state where the Widget Builder is not open, but the URL has been updated. They are able to click the "Full Screen" button on a widget, which then mangles the URL because it's using a relative path.

This is Step 1 of the fix, which is to ensure that the Widget Builder opens on navigation. The better overall solution here would be to use `<Outlet />` from React Router instead of this manual routing, but one thing at a time.
