### PR TITLE
fix(aci): Add OK to the list of supported metric detector conditions

### DIFF
--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -74,7 +74,7 @@ class MetricIssueComparisonConditionValidator(BaseDataConditionValidator):
         (Condition.GREATER, Condition.LESS, Condition.ANOMALY_DETECTION)
     )
     supported_condition_results = frozenset(
-        (DetectorPriorityLevel.HIGH, DetectorPriorityLevel.MEDIUM)
+        (DetectorPriorityLevel.HIGH, DetectorPriorityLevel.MEDIUM, DetectorPriorityLevel.OK)
     )
 
     def validate_type(self, value: str) -> Condition:


### PR DESCRIPTION
The missing OK prevented the form from saving a resolution threshold.