### PR TITLE
feat(insights): initial dashboards platform version of session health module

### DIFF
--- a/static/app/views/insights/sessions/utils/useHasDashboardsPlatformizedSessionHealth.tsx
+++ b/static/app/views/insights/sessions/utils/useHasDashboardsPlatformizedSessionHealth.tsx
@@ -3,7 +3,5 @@ import useOrganization from 'sentry/utils/useOrganization';
 export default function useHasDashboardsPlatformizedSessionHealth() {
   const organization = useOrganization();
 
-  return organization.features.includes(
-    'organizations:performance-session-health-dashboard-migration'
-  );
+  return organization.features.includes('performance-session-health-dashboard-migration');
 }

--- a/static/app/views/insights/sessions/utils/useHasDashboardsPlatformizedSessionHealth.tsx
+++ b/static/app/views/insights/sessions/utils/useHasDashboardsPlatformizedSessionHealth.tsx
@@ -1,0 +1,9 @@
+import useOrganization from 'sentry/utils/useOrganization';
+
+export default function useHasDashboardsPlatformizedSessionHealth() {
+  const organization = useOrganization();
+
+  return organization.features.includes(
+    'organizations:performance-session-health-dashboard-migration'
+  );
+}

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -23,6 +23,8 @@ import FilterReleaseDropdown from 'sentry/views/insights/sessions/components/fil
 import ReleaseTableSearch from 'sentry/views/insights/sessions/components/releaseTableSearch';
 import ReleaseHealth from 'sentry/views/insights/sessions/components/tables/releaseHealth';
 import useProjectHasSessions from 'sentry/views/insights/sessions/queries/useProjectHasSessions';
+import useHasDashboardsPlatformizedSessionHealth from 'sentry/views/insights/sessions/utils/useHasDashboardsPlatformizedSessionHealth';
+import {PlatformizedSessionsOverview} from 'sentry/views/insights/sessions/views/platformizedOverview';
 import {ModuleName} from 'sentry/views/insights/types';
 
 function SessionsOverview() {
@@ -139,6 +141,11 @@ function ViewSpecificCharts({
 }
 
 function PageWithProviders() {
+  const hasDashboardsPlatformizedSessionHealth =
+    useHasDashboardsPlatformizedSessionHealth();
+  if (hasDashboardsPlatformizedSessionHealth) {
+    return <PlatformizedSessionsOverview />;
+  }
   return (
     <ModulePageProviders moduleName="sessions">
       <SessionsOverview />

--- a/static/app/views/insights/sessions/views/platformizedOverview.tsx
+++ b/static/app/views/insights/sessions/views/platformizedOverview.tsx
@@ -9,7 +9,6 @@ const RELEASE_HEALTH_WIDGETS: Widget[] = [
   {
     id: 'unhealthy-sessions',
     title: t('Unhealthy Sessions'),
-    description: t('Percentage of sessions that did not crash.'),
     displayType: DisplayType.LINE,
     widgetType: WidgetType.RELEASE,
     interval: '',
@@ -28,7 +27,6 @@ const RELEASE_HEALTH_WIDGETS: Widget[] = [
   {
     id: 'user-health',
     title: t('User Health'),
-    description: t('Number of users by status.'),
     displayType: DisplayType.AREA,
     widgetType: WidgetType.RELEASE,
     interval: '',
@@ -47,7 +45,6 @@ const RELEASE_HEALTH_WIDGETS: Widget[] = [
   {
     id: 'session-health',
     title: t('Session Health'),
-    description: t('Number of sessions by status.'),
     displayType: DisplayType.LINE,
     widgetType: WidgetType.RELEASE,
     interval: '',
@@ -66,7 +63,6 @@ const RELEASE_HEALTH_WIDGETS: Widget[] = [
   {
     id: 'session-counts',
     title: t('Session Counts'),
-    description: t('Number of sessions by status.'),
     displayType: DisplayType.LINE,
     widgetType: WidgetType.RELEASE,
     interval: '',
@@ -85,7 +81,6 @@ const RELEASE_HEALTH_WIDGETS: Widget[] = [
   {
     id: 'user-counts',
     title: t('User Counts'),
-    description: t('Number of users by status.'),
     displayType: DisplayType.LINE,
     widgetType: WidgetType.RELEASE,
     interval: '',

--- a/static/app/views/insights/sessions/views/platformizedOverview.tsx
+++ b/static/app/views/insights/sessions/views/platformizedOverview.tsx
@@ -1,0 +1,137 @@
+import {t} from 'sentry/locale';
+import {useLocation} from 'sentry/utils/useLocation';
+import useRouter from 'sentry/utils/useRouter';
+import DashboardDetail from 'sentry/views/dashboards/detail';
+import type {DashboardDetails, Widget} from 'sentry/views/dashboards/types';
+import {DashboardState, DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+
+const RELEASE_HEALTH_WIDGETS: Widget[] = [
+  {
+    id: 'unhealthy-sessions',
+    title: t('Unhealthy Sessions'),
+    description: t('Percentage of sessions that did not crash.'),
+    displayType: DisplayType.LINE,
+    widgetType: WidgetType.RELEASE,
+    interval: '',
+    queries: [
+      {
+        name: '',
+        conditions: '',
+        fields: ['session.status', 'sum(session)'],
+        aggregates: ['sum(session)'],
+        columns: ['session.status'],
+        orderby: '',
+      },
+    ],
+    layout: {x: 0, y: 0, w: 3, h: 2, minH: 2},
+  },
+  {
+    id: 'user-health',
+    title: t('User Health'),
+    description: t('Number of users by status.'),
+    displayType: DisplayType.AREA,
+    widgetType: WidgetType.RELEASE,
+    interval: '',
+    queries: [
+      {
+        name: '',
+        conditions: '',
+        fields: ['session.status', 'count_unique(user)'],
+        aggregates: ['count_unique(user)'],
+        columns: ['session.status'],
+        orderby: '',
+      },
+    ],
+    layout: {x: 3, y: 0, w: 3, h: 2, minH: 2},
+  },
+  {
+    id: 'session-health',
+    title: t('Session Health'),
+    description: t('Number of sessions by status.'),
+    displayType: DisplayType.LINE,
+    widgetType: WidgetType.RELEASE,
+    interval: '',
+    queries: [
+      {
+        name: '',
+        conditions: '',
+        fields: ['session.status', 'sum(session)'],
+        aggregates: ['sum(session)'],
+        columns: ['session.status'],
+        orderby: '',
+      },
+    ],
+    layout: {x: 0, y: 2, w: 2, h: 2, minH: 2},
+  },
+  {
+    id: 'session-counts',
+    title: t('Session Counts'),
+    description: t('Number of sessions by status.'),
+    displayType: DisplayType.LINE,
+    widgetType: WidgetType.RELEASE,
+    interval: '',
+    queries: [
+      {
+        name: '',
+        conditions: '',
+        fields: ['session.status', 'sum(session)'],
+        aggregates: ['sum(session)'],
+        columns: ['session.status'],
+        orderby: '',
+      },
+    ],
+    layout: {x: 2, y: 2, w: 2, h: 2, minH: 2},
+  },
+  {
+    id: 'user-counts',
+    title: t('User Counts'),
+    description: t('Number of users by status.'),
+    displayType: DisplayType.LINE,
+    widgetType: WidgetType.RELEASE,
+    interval: '',
+    queries: [
+      {
+        name: '',
+        conditions: '',
+        fields: ['session.status', 'count_unique(user)'],
+        aggregates: ['count_unique(user)'],
+        columns: ['session.status'],
+        orderby: '',
+      },
+    ],
+    layout: {x: 4, y: 2, w: 2, h: 2, minH: 2},
+  },
+];
+
+const DASHBOARD: DashboardDetails = {
+  id: 'session-health-overview',
+  title: t('Session Health'),
+  widgets: RELEASE_HEALTH_WIDGETS,
+  dateCreated: '',
+  filters: {},
+  projects: undefined,
+};
+
+export function PlatformizedSessionsOverview() {
+  const location = useLocation();
+  const router = useRouter();
+
+  return (
+    <DashboardDetail
+      dashboard={DASHBOARD}
+      location={location}
+      params={{
+        dashboardId: undefined,
+        templateId: undefined,
+        widgetId: undefined,
+        widgetIndex: undefined,
+      }}
+      route={{}}
+      routeParams={{}}
+      router={router}
+      routes={[]}
+      dashboards={[]}
+      initialState={DashboardState.VIEW}
+    />
+  );
+}


### PR DESCRIPTION
Adds an alternate session health overview component using the dashboards platform. This UI is work in progress and mostly serves as an initial testing ground to determine feasibility of migrating insights modules to the dashboards platform.

- the `DashboardDetail` component is directly rendered on the module overview component. We'll likely come up with a more formal pattern to embed dashboard content later on.
- Session Health charts are recreated as close as possible in hardcoded dashboard `Widget` objects/json. Due to api limitations and post-query series transformations on some charts, we can't recreate certain charts 1:1 in dashboards.
- TODO: Missing Issue Widget and Widget Viewer functionality.
<img width="972" height="722" alt="image" src="https://github.com/user-attachments/assets/331aed47-617a-4fb6-b5a3-884d4dab8706" />
