### PR TITLE
fix(aci): More specific logging on inconsistency-triggered subscription deletion

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -681,8 +681,8 @@ class SubscriptionProcessor:
             # QuerySubscriptions must _always_ have an associated AlertRule
             # If the alert rule has been removed then clean up associated tables and return
             metrics.incr("incidents.alert_rules.no_alert_rule_for_subscription", sample_rate=1.0)
-            logger.info(
-                "Deleting snuba subscription because no alert rule for subscription",
+            logger.error(
+                "Deleting QuerySubscription due to lack of matching AlertRule",
                 extra={
                     "subscription_id": self.subscription.id,
                 },

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -680,7 +680,13 @@ class SubscriptionProcessor:
         if not hasattr(self, "alert_rule"):
             # QuerySubscriptions must _always_ have an associated AlertRule
             # If the alert rule has been removed then clean up associated tables and return
-            metrics.incr("incidents.alert_rules.no_alert_rule_for_subscription")
+            metrics.incr("incidents.alert_rules.no_alert_rule_for_subscription", sample_rate=1.0)
+            logger.info(
+                "Deleting snuba subscription because no alert rule for subscription",
+                extra={
+                    "subscription_id": self.subscription.id,
+                },
+            )
             delete_snuba_subscription(self.subscription)
             return
 

--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -239,7 +239,7 @@ def update_snuba_subscription(subscription, old_query_type, old_dataset, old_agg
     return subscription
 
 
-def bulk_delete_snuba_subscriptions(subscriptions):
+def bulk_delete_snuba_subscriptions(subscriptions: Iterable[QuerySubscription]) -> None:
     """
     Deletes a list of snuba query subscriptions.
     :param subscriptions: The subscriptions to delete
@@ -250,7 +250,7 @@ def bulk_delete_snuba_subscriptions(subscriptions):
         delete_snuba_subscription(subscription)
 
 
-def delete_snuba_subscription(subscription):
+def delete_snuba_subscription(subscription: QuerySubscription) -> None:
     """
     Deletes a subscription to a snuba query.
     :param subscription: The subscription to delete

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
@@ -299,7 +299,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         ):
             SubscriptionProcessor(self.sub).process_update(message)
         self.metrics.incr.assert_called_once_with(
-            "incidents.alert_rules.no_alert_rule_for_subscription"
+            "incidents.alert_rules.no_alert_rule_for_subscription", sample_rate=1.0
         )
         assert not QuerySubscription.objects.filter(id=subscription_id).exists()
         assert SnubaQuery.objects.filter(id=snuba_query.id).exists()
@@ -324,7 +324,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         ):
             SubscriptionProcessor(subscription).process_update(message)
         self.metrics.incr.assert_called_once_with(
-            "incidents.alert_rules.no_alert_rule_for_subscription"
+            "incidents.alert_rules.no_alert_rule_for_subscription", sample_rate=1.0
         )
         assert not QuerySubscription.objects.filter(id=subscription_id).exists()
         assert not SnubaQuery.objects.filter(id=snuba_query.id).exists()


### PR DESCRIPTION
This sort of inconsistency is rare and consequential; we want to know exactly how often it happens,
and have a clear error message for each case.