### PR TITLE
fix(dashboards): Remove widget hover effect

### DIFF
--- a/static/app/views/dashboards/widgets/widget/widget.stories.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.stories.tsx
@@ -143,12 +143,6 @@ import {Widget} from './widget';
             <code>noVisualizationPadding</code>
           </li>
           <li>
-            The <code>revealActions</code> prop also controls the hover behavior. If you
-            set it to <code>"hover"</code>, the widget will have a grey hover state, to
-            create some contrast against the controls. If you set it to{' '}
-            <code>"always"</code>, the hover effect will be turned off
-          </li>
-          <li>
             Avoid the <code>height</code> prop if you can. It's much easier and more
             robust to place <code>Widget</code> components within a CSS grid or another
             kind of layout, and size them that way

--- a/static/app/views/dashboards/widgets/widget/widget.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.tsx
@@ -154,14 +154,6 @@ const Frame = styled('div')<{
   ${p =>
     p.revealActions === 'hover' &&
     css`
-      :hover {
-        background-color: ${p.theme.surface200};
-        transition:
-          background-color 100ms linear,
-          box-shadow 100ms linear;
-        box-shadow: ${p.theme.dropShadowLight};
-      }
-
       &:not(:hover):not(:focus-within) {
         ${TitleHoverItems} {
           opacity: 0;


### PR DESCRIPTION
By request from Design.

**Before:**

<img width="427" height="322" alt="Screenshot 2025-10-06 at 5 10 36 PM" src="https://github.com/user-attachments/assets/5886acee-c572-4a0a-8792-ce4d4a48b969" />

**After:**
<img width="429" height="328" alt="Screenshot 2025-10-06 at 5 11 29 PM" src="https://github.com/user-attachments/assets/905a576b-96d4-4ca4-85e2-a07a36525dce" />
