### PR TITLE
ref(uptime): Read uptime status from detector state

### DIFF
--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -458,13 +458,14 @@ def disable_uptime_detector(detector: Detector, skip_quotas: bool = False):
         if not detector.enabled:
             return
 
-        if uptime_subscription.uptime_status == UptimeStatus.FAILED:
+        detector_state = detector.detectorstate_set.first()
+        if detector_state and detector_state.is_triggered:
             # Resolve the issue so that we don't see it in the ui anymore
             resolve_uptime_issue(detector)
 
-        # We set the status back to ok here so that if we re-enable we'll start
-        # from a good state
-        uptime_subscription.update(uptime_status=UptimeStatus.OK)
+            # We set the status back to ok here so that if we re-enable we'll
+            # start from a good state
+            detector_state.update(state=DetectorPriorityLevel.OK, is_triggered=False)
 
         detector.update(enabled=False)
 

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -44,13 +44,14 @@ from sentry.uptime.detectors.result_handler import (
 )
 from sentry.uptime.detectors.tasks import is_failed_url
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
-from sentry.uptime.models import UptimeStatus, UptimeSubscription, UptimeSubscriptionRegion
+from sentry.uptime.models import UptimeSubscription, UptimeSubscriptionRegion
 from sentry.uptime.subscriptions.subscriptions import (
     UptimeMonitorNoSeatAvailable,
     build_detector_fingerprint_component,
 )
 from sentry.uptime.types import IncidentStatus, UptimeMonitorMode
 from sentry.utils import json
+from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.uptime.subscriptions.test_tasks import ConfigPusherTestMixin
 
 
@@ -164,8 +165,11 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         assert group.issue_type == UptimeDomainCheckFailure
         assignee = group.get_assignee()
         assert assignee and (assignee.id == self.user.id)
-        self.subscription.refresh_from_db()
-        assert self.subscription.uptime_status == UptimeStatus.FAILED
+        self.detector.refresh_from_db()
+        detector_state = self.detector.detectorstate_set.first()
+        assert detector_state is not None
+        assert detector_state.priority_level == DetectorPriorityLevel.HIGH
+        assert detector_state.is_triggered
 
         # Issue is resolved
         with (self.feature(features),):
@@ -246,8 +250,11 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         hashed_fingerprint = md5(fingerprint).hexdigest()
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
-        self.subscription.refresh_from_db()
-        assert self.subscription.uptime_status == UptimeStatus.FAILED
+        self.detector.refresh_from_db()
+        detector_state = self.detector.detectorstate_set.first()
+        assert detector_state is not None
+        assert detector_state.priority_level == DetectorPriorityLevel.HIGH
+        assert detector_state.is_triggered
 
     def test_no_subscription(self) -> None:
         features = [


### PR DESCRIPTION
This is the first step in removing the redundant uptime_status field from UptimeSubscription. The uptime status information is already stored in the DetectorState model, so we can read from there instead.

Changes:
- Updated results_consumer.py, eap_producer.py to check is_triggered field
- Updated subscriptions.py to check is_triggered and reset it when disabling
- Updated all tests to use is_triggered and create_detector_state helper
- Added test for triggered detector state in eap_producer tests