### PR TITLE
fix(deletions): Allow `Commit` to be deleted via cleanup.py

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -15,7 +15,6 @@ from django.conf import settings
 from django.db.models import Model, QuerySet
 from django.utils import timezone
 
-from sentry.models.commit import Commit
 from sentry.runner.decorators import log_options
 from sentry.silo.base import SiloLimit, SiloMode
 
@@ -450,6 +449,7 @@ def exported_data(
 
 def models_which_use_deletions_code_path() -> list[tuple[type[Model], str, str]]:
     from sentry.models.artifactbundle import ArtifactBundle
+    from sentry.models.commit import Commit
     from sentry.models.eventattachment import EventAttachment
     from sentry.models.files.file import File
     from sentry.models.grouprulestatus import GroupRuleStatus

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.db.models import Model, QuerySet
 from django.utils import timezone
 
+from sentry.models.commit import Commit
 from sentry.runner.decorators import log_options
 from sentry.silo.base import SiloLimit, SiloMode
 
@@ -470,6 +471,7 @@ def models_which_use_deletions_code_path() -> list[tuple[type[Model], str, str]]
         (RuleFireHistory, "date_added", "date_added"),
         (Release, "date_added", "date_added"),
         (File, "timestamp", "timestamp"),
+        (Commit, "date_added", "date_added"),
     ]
 
 


### PR DESCRIPTION
I missed this before attempting to start the job

<!-- Describe your PR here. -->