### PR TITLE
feat(aci): Improve metric monitor detect details

### DIFF
--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -168,7 +168,7 @@ const QueryWrapper = styled('div')`
   column-gap: ${space(1)};
 `;
 
-const FilterWrapper = styled('div')`
+export const FilterWrapper = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(0.5)};

--- a/static/app/views/detectors/components/details/metric/detect.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.tsx
@@ -6,12 +6,10 @@ import {Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {
   FilterWrapper,
-  FormattedQuery,
   ProvidedFormattedQuery,
 } from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {
   MetricDetector,
   SnubaQueryDataSource,

--- a/static/app/views/detectors/components/details/metric/detect.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.tsx
@@ -2,6 +2,13 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {
+  FilterWrapper,
+  FormattedQuery,
+  ProvidedFormattedQuery,
+} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -35,21 +42,37 @@ function SnubaQueryDetails({dataSource}: {dataSource: SnubaQueryDataSource}) {
       <Flex direction="column" gap="xs">
         <Heading>{t('Query:')}</Heading>
         <Query>
-          <Label>{t('visualize:')}</Label>
+          <Label>
+            <Text variant="muted">{t('Visualize')}</Text>
+          </Label>
           <Value>
-            {datasetConfig.fromApiAggregate(dataSource.queryObj.snubaQuery.aggregate)}
+            <Flex>
+              <FilterWrapper>
+                {datasetConfig.fromApiAggregate(dataSource.queryObj.snubaQuery.aggregate)}
+              </FilterWrapper>
+            </Flex>
           </Value>
           {query && (
             <Fragment>
-              <Label>{t('where:')}</Label>
-              <Value>{query}</Value>
+              <Label>
+                <Text variant="muted">{t('Where')}</Text>
+              </Label>
+              <Value>
+                <Tooltip
+                  showOnlyOnOverflow
+                  title={<ProvidedFormattedQuery query={query} />}
+                  maxWidth={400}
+                >
+                  <ProvidedFormattedQuery query={query} />
+                </Tooltip>
+              </Value>
             </Fragment>
           )}
         </Query>
       </Flex>
       <Flex gap="xs" align="center">
-        <Heading>{t('Threshold:')}</Heading>
-        <Value>{getExactDuration(dataSource.queryObj.snubaQuery.timeWindow, true)}</Value>
+        <Heading>{t('Interval:')}</Heading>
+        <Value>{getExactDuration(dataSource.queryObj.snubaQuery.timeWindow)}</Value>
       </Flex>
     </Container>
   );
@@ -67,9 +90,8 @@ const Heading = styled('h4')`
 
 const Query = styled('dl')`
   display: grid;
-  grid-template-columns: auto auto;
-  width: fit-content;
-  gap: ${space(0.25)} ${space(0.5)};
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: ${p => p.theme.space.sm} ${p => p.theme.space.xs};
   margin: 0;
 `;
 
@@ -77,6 +99,7 @@ const Label = styled('dt')`
   color: ${p => p.theme.subText};
   justify-self: flex-end;
   margin: 0;
+  font-weight: ${p => p.theme.fontWeight.normal};
 `;
 
 const Value = styled('dl')`

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -118,7 +118,7 @@ describe('DetectorDetails', () => {
         await screen.findByRole('heading', {name: snubaQueryDetector.name})
       ).toBeInTheDocument();
       // Displays the snuba query
-      expect(screen.getByText('event.type:error test')).toBeInTheDocument();
+      expect(screen.getByLabelText('event.type:error test')).toBeInTheDocument();
       // Displays the environment
       expect(
         screen.getByText(dataSource.queryObj!.snubaQuery.environment!)

--- a/static/app/views/detectors/utils/useDetectorFilterKeys.tsx
+++ b/static/app/views/detectors/utils/useDetectorFilterKeys.tsx
@@ -17,7 +17,6 @@ const DETECTOR_FILTER_KEYS: Record<
       desc: 'Name of the monitor',
       kind: FieldKind.FIELD,
       valueType: FieldValueType.STRING,
-      allowWildcard: false,
       keywords: ['title'],
     },
   },


### PR DESCRIPTION
- Use FormattedQuery to format aggregate/query
- Formatted the visualize/where labels more similarly to how it shows up in saved trace queries
- Fixed threshold -> interval and removed the unnecessary abbreviation of time

Before:

<img width="361" height="198" alt="CleanShot 2025-10-06 at 14 43 03" src="https://github.com/user-attachments/assets/c5c7844e-095c-4ddb-874e-d019620c6c4b" />

After:

<img width="364" height="246" alt="CleanShot 2025-10-06 at 14 39 44" src="https://github.com/user-attachments/assets/90acb233-d155-40ea-a2da-861e24b0e803" />

Also added a tooltip when the query cannot be shown due to space issues:

<img width="422" height="225" alt="CleanShot 2025-10-06 at 14 40 01" src="https://github.com/user-attachments/assets/eac16648-ecd6-4bb1-aa09-9d924a173f4d" />
