### PR TITLE
fix(aci): Consistently display document title with suffix

### DIFF
--- a/static/app/components/sentryDocumentTitle.tsx
+++ b/static/app/components/sentryDocumentTitle.tsx
@@ -25,10 +25,6 @@ const DEFAULT_PAGE_TITLE = 'Sentry';
 
 const DocumentTitleContext = createContext(DEFAULT_PAGE_TITLE);
 
-export function useDocumentTitle() {
-  return useContext(DocumentTitleContext);
-}
-
 /**
  * Assigns the document title. The deepest nested version of this title will be
  * the one which is assigned.

--- a/static/app/components/workflowEngine/layout/list.tsx
+++ b/static/app/components/workflowEngine/layout/list.tsx
@@ -1,19 +1,22 @@
 import {Flex} from 'sentry/components/core/layout';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {useDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 
 interface WorkflowEngineListLayoutProps {
   actions: React.ReactNode;
   /** The main content for this page */
   children: React.ReactNode;
+  title: string;
 }
 
 /**
  * Precomposed full-width layout for Automations / Monitors index pages.
  * The `children` are rendered as the main body content.
  */
-function WorkflowEngineListLayout({children, actions}: WorkflowEngineListLayoutProps) {
-  const title = useDocumentTitle();
+function WorkflowEngineListLayout({
+  children,
+  actions,
+  title,
+}: WorkflowEngineListLayoutProps) {
   return (
     <Layout.Page>
       <Layout.Header unified>

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -73,7 +73,7 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
   const warning = getAutomationActionsWarning(automation);
 
   return (
-    <SentryDocumentTitle title={automation.name} noSuffix>
+    <SentryDocumentTitle title={automation.name}>
       <DetailLayout>
         <DetailLayout.Header>
           <DetailLayout.HeaderContent>

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -78,9 +78,9 @@ export default function AutomationsList() {
   }, [pageLinks]);
 
   return (
-    <SentryDocumentTitle title={t('Automations')} noSuffix>
+    <SentryDocumentTitle title={t('Automations')}>
       <PageFiltersContainer>
-        <ListLayout actions={<Actions />}>
+        <ListLayout actions={<Actions />} title={t('Automations')}>
           <TableHeader />
           <div>
             <AutomationListTable

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -53,7 +53,7 @@ export default function AutomationNew() {
   });
 
   return (
-    <SentryDocumentTitle title={t('New Automation')} noSuffix>
+    <SentryDocumentTitle title={t('New Automation')}>
       <Layout.Page>
         <StyledLayoutHeader>
           <Layout.HeaderContent>

--- a/static/app/views/detectors/detail.tsx
+++ b/static/app/views/detectors/detail.tsx
@@ -41,7 +41,7 @@ export default function DetectorDetails() {
   }
 
   return (
-    <SentryDocumentTitle title={detector.name} noSuffix>
+    <SentryDocumentTitle title={detector.name}>
       <DetectorDetailsContent detector={detector} project={project} />
     </SentryDocumentTitle>
   );

--- a/static/app/views/detectors/list.tsx
+++ b/static/app/views/detectors/list.tsx
@@ -81,7 +81,7 @@ export default function DetectorsList() {
   return (
     <SentryDocumentTitle title={t('Monitors')}>
       <PageFiltersContainer>
-        <ListLayout actions={<Actions />}>
+        <ListLayout actions={<Actions />} title={t('Monitors')}>
           <TableHeader />
           <div>
             <DetectorListTable


### PR DESCRIPTION
We were passing `noSuffix` for many of the pages, but I'm not sure why. Went through and removed all the ones I could find.