### PR TITLE
fix(issues): Set stats loading state on early exit

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -293,6 +293,7 @@ function IssueListOverview({
     async (newGroupIds: string[]) => {
       // If we have no groups to fetch, just skip stats
       if (!newGroupIds.length) {
+        setStatsLoading(false);
         return;
       }
 


### PR DESCRIPTION
fixes an issue with going from a query with results to a query with no results could get stuck on the loading skeleton https://github.com/getsentry/sentry/blob/34fe8fae7d54aaf3bae6f6f5b0737d1bd0f46c08/static/app/views/issueList/issueListTable.tsx#L118

To reproduce:
- Results load and we started fetching stats for multiple groups
- Query is changed before stats request finishes. New query has no results.
- We cancel the old stats request because we have a new query, and the new query never fetches stats because there are no groups to fetch stats for.

fixes https://linear.app/getsentry/issue/RTC-1227/submitting-search-on-issue-feed-gets-stuck-on-loading-skeleton
fixes #100859