### PR TITLE
fix(aci milestone 3): check for alert rule ID existing when rendering chart

### DIFF
--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -140,10 +140,12 @@ def fetch_metric_issue_open_periods(
             organization,  # Metric issue single processing
         ):
             # temporarily fetch the alert rule ID from the detector ID
-            alert_rule_id = AlertRuleDetector.objects.get(
-                detector_id=open_period_identifier
-            ).alert_rule_id
-            open_period_identifier = alert_rule_id
+            alert_rule_detector = AlertRuleDetector.objects.filter(
+                detector_id=open_period_identifier, alert_rule_id__isnull=False
+            ).first()
+            if alert_rule_detector is not None:
+                # open_period_identifier is a metric detector ID -> get the alert rule ID
+                open_period_identifier = alert_rule_detector.alert_rule_id
 
         resp = client.get(
             auth=ApiKey(organization_id=organization.id, scope_list=["org:read"]),


### PR DESCRIPTION
Single processing organizations could still enter the unfurling chart-building flow via a legacy alert ID. Do a check to make sure the open period ID is a metric detector.