### PR TITLE
fix(aci/anomaly detection): pass source ID and source type in store data request

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -643,10 +643,6 @@ def create_alert_rule(
             **_owner_kwargs_from_actor(owner),
         )
 
-        if alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC.value:
-            # NOTE: if adding a new metric alert type, take care to check that it's handled here
-            send_new_rule_data(alert_rule, projects[0], snuba_query)
-
         if user:
             create_audit_entry_from_user(
                 user,
@@ -663,6 +659,10 @@ def create_alert_rule(
 
         # NOTE: This constructs the query in snuba
         subscribe_projects_to_alert_rule(alert_rule, projects)
+
+        if alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC.value:
+            # NOTE: if adding a new metric alert type, take care to check that it's handled here
+            send_new_rule_data(alert_rule, projects[0], snuba_query)
 
         # Activity is an audit log of what's happened with this alert rule
         AlertRuleActivity.objects.create(

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -192,8 +192,8 @@ def send_historical_data_to_seer(
         # this won't happen because we've already gone through the serializer, but mypy insists
         raise ValidationError("Missing expected configuration for a dynamic alert.")
 
-    source_id = QuerySubscription.objects.filter(snuba_query_id=snuba_query.id).first()
-    if source_id is None:
+    query_subscription = QuerySubscription.objects.filter(snuba_query_id=snuba_query.id).first()
+    if query_subscription is None:
         raise ValidationError("No QuerySubscription found for snuba query ID")
 
     anomaly_detection_config = AnomalyDetectionConfig(
@@ -203,7 +203,9 @@ def send_historical_data_to_seer(
         expected_seasonality=alert_rule.seasonality,
     )
     alert = AlertInSeer(
-        id=alert_rule.id, source_id=source_id, source_type=DataSourceType.SNUBA_QUERY_SUBSCRIPTION
+        id=alert_rule.id,
+        source_id=query_subscription.id,
+        source_type=DataSourceType.SNUBA_QUERY_SUBSCRIPTION,
     )
     body = StoreDataRequest(
         organization_id=alert_rule.organization.id,

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -30,7 +30,7 @@ from sentry.seer.anomaly_detection.utils import (
     translate_direction,
 )
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
-from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
+from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.utils import json, metrics
 from sentry.utils.json import JSONDecodeError
 
@@ -192,7 +192,7 @@ def send_historical_data_to_seer(
         # this won't happen because we've already gone through the serializer, but mypy insists
         raise ValidationError("Missing expected configuration for a dynamic alert.")
 
-    query_subscription = QuerySubscription.objects.filter(snuba_query_id=snuba_query.id).first()
+    query_subscription = snuba_query.subscriptions.first()
     if query_subscription is None:
         raise ValidationError("No QuerySubscription found for snuba query ID")
 

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -97,6 +97,7 @@ from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of
 from sentry.types.actor import Actor
+from sentry.utils import json
 from sentry.workflow_engine.models.detector import Detector
 
 pytestmark = [pytest.mark.sentry_metrics]
@@ -663,6 +664,12 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         )
 
         assert mock_seer_request.call_count == 1
+        call_args_str = mock_seer_request.call_args_list[0].kwargs["body"].decode("utf-8")
+        assert json.loads(call_args_str)["alert"] == {
+            "id": alert_rule.id,
+            "source_id": alert_rule.snuba_query.subscriptions.get().id,
+            "source_type": 1,
+        }
         assert alert_rule.name == self.dynamic_metric_alert_settings["name"]
         assert alert_rule.user_id is None
         assert alert_rule.team_id is None


### PR DESCRIPTION
We're seeing some errors with the detect anomalies request when a dynamic alert has been edited. Send these so that the data is keyed according to the IDs that are passed.

The problem: alerts created since July will not fire because their stored data is keyed using alert rule ID, which is not sent anywhere in the processing request. Alerts updated since then will have their source ID overwritten, so the same problem applies.

The solution: pass source ID in the store data request.