### PR TITLE
fix(aci): Hide resolution threshold when automatic

### DIFF
--- a/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.tsx
@@ -224,10 +224,13 @@ export function useMetricDetectorThresholdSeries({
           data: [],
         };
       });
-
       additional.push(...thresholdSeries);
-      // Add manual resolution line and safe area if present (green)
-      if (resolution) {
+
+      // Resolution is considered "automatic" when it equals any alert threshold value
+      const isResolutionManual = Boolean(
+        resolution && !thresholds.some(threshold => threshold.value === resolution.value)
+      );
+      if (resolution && isResolutionManual) {
         const resolutionSeries: LineSeriesOption = {
           type: 'line',
           markLine: createThresholdMarkLine(theme.green300, resolution.value),
@@ -243,7 +246,7 @@ export function useMetricDetectorThresholdSeries({
 
       const valuesForMax = [
         ...thresholds.map(threshold => threshold.value),
-        ...(resolution ? [resolution.value] : []),
+        ...(resolution && isResolutionManual ? [resolution.value] : []),
       ];
       const maxValue = valuesForMax.length > 0 ? Math.max(...valuesForMax) : undefined;
       return {maxValue, additionalSeries: additional};


### PR DESCRIPTION
Hides the resolution threshold shaded area on the chart if they're using automatic resolution.

with resolution threshold

<img width="852" height="225" alt="image" src="https://github.com/user-attachments/assets/f8de59a0-d01d-43e3-a0d7-4ff4b4837c75" />
