### PR TITLE
fix(cleanup): Fix commit cleanup to order by `id`

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -471,7 +471,7 @@ def models_which_use_deletions_code_path() -> list[tuple[type[Model], str, str]]
         (RuleFireHistory, "date_added", "date_added"),
         (Release, "date_added", "date_added"),
         (File, "timestamp", "timestamp"),
-        (Commit, "date_added", "date_added"),
+        (Commit, "date_added", "id"),
     ]
 
 


### PR DESCRIPTION
We have no index on date_added. For now, order by id so that we can delete rows - this should allow us to use the PK index here, and we can consider adding a proper index later.

<!-- Describe your PR here. -->