### PR TITLE
ref(agent-monitoring): Remove feature flag usage

### DIFF
--- a/static/app/views/insights/agents/settings.ts
+++ b/static/app/views/insights/agents/settings.ts
@@ -8,4 +8,4 @@ export const DATA_TYPE_PLURAL = t('Agents');
 
 export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/agents/';
 
-export const MODULE_FEATURES = ['agents-insights'];
+export const MODULE_FEATURES = [];

--- a/static/app/views/insights/agents/utils/features.tsx
+++ b/static/app/views/insights/agents/utils/features.tsx
@@ -7,23 +7,8 @@ type InsightsFeaturePropsWithoutFeatures = Omit<
   'features'
 >;
 
-export function hasAgentInsightsFeature(organization: Organization) {
-  return organization.features.includes('agents-insights');
-}
-
 export function hasMCPInsightsFeature(organization: Organization) {
   return organization.features.includes('mcp-insights');
-}
-
-export function AIInsightsFeature(props: InsightsFeaturePropsWithoutFeatures) {
-  return (
-    <Feature
-      features={['agents-insights']}
-      renderDisabled={props.renderDisabled ?? NoAccess}
-    >
-      {props.children}
-    </Feature>
-  );
 }
 
 export function McpInsightsFeature(props: InsightsFeaturePropsWithoutFeatures) {

--- a/static/app/views/insights/agents/views/overview.tsx
+++ b/static/app/views/insights/agents/views/overview.tsx
@@ -39,7 +39,6 @@ import {
   useActiveTable,
 } from 'sentry/views/insights/agents/hooks/useActiveTable';
 import {useLocationSyncedState} from 'sentry/views/insights/agents/hooks/useLocationSyncedState';
-import {AIInsightsFeature} from 'sentry/views/insights/agents/utils/features';
 import {Referrer} from 'sentry/views/insights/agents/utils/referrers';
 import {Onboarding} from 'sentry/views/insights/agents/views/onboarding';
 import {TwoColumnWidgetGrid, WidgetGrid} from 'sentry/views/insights/agents/views/styles';
@@ -295,16 +294,14 @@ function ToolsView() {
 
 function PageWithProviders() {
   return (
-    <AIInsightsFeature>
-      <ModulePageProviders
-        moduleName={ModuleName.AGENTS}
-        analyticEventName="insight.page_loads.agents"
-      >
-        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
-          <AgentsOverviewPage />
-        </TraceItemAttributeProvider>
-      </ModulePageProviders>
-    </AIInsightsFeature>
+    <ModulePageProviders
+      moduleName={ModuleName.AGENTS}
+      analyticEventName="insight.page_loads.agents"
+    >
+      <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
+        <AgentsOverviewPage />
+      </TraceItemAttributeProvider>
+    </ModulePageProviders>
   );
 }
 

--- a/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
@@ -6,7 +6,6 @@ import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import {AIInsightsFeature} from 'sentry/views/insights/agents/utils/features';
 import {
   AGENTS_LANDING_SUB_PATH,
   getAISidebarLabel,
@@ -70,15 +69,13 @@ export function InsightsSecondaryNav() {
             {MOBILE_SIDEBAR_LABEL}
           </SecondaryNav.Item>
 
-          <AIInsightsFeature organization={organization} renderDisabled={() => null}>
-            <SecondaryNav.Item
-              to={`${baseUrl}/${AGENTS_LANDING_SUB_PATH}/`}
-              analyticsItemName="insights_agents"
-              trailingItems={<FeatureBadge type="new" />}
-            >
-              {getAISidebarLabel(organization)}
-            </SecondaryNav.Item>
-          </AIInsightsFeature>
+          <SecondaryNav.Item
+            to={`${baseUrl}/${AGENTS_LANDING_SUB_PATH}/`}
+            analyticsItemName="insights_agents"
+            trailingItems={<FeatureBadge type="new" />}
+          >
+            {getAISidebarLabel(organization)}
+          </SecondaryNav.Item>
         </SecondaryNav.Section>
         <SecondaryNav.Section id="insights-monitors">
           <SecondaryNav.Item to={`${baseUrl}/crons/`} analyticsItemName="insights_crons">

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -10,10 +10,7 @@ import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAt
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {LLMCosts} from 'sentry/views/insights/agents/components/llmCosts';
 import {ModelName} from 'sentry/views/insights/agents/components/modelName';
-import {
-  hasAgentInsightsFeature,
-  hasMCPInsightsFeature,
-} from 'sentry/views/insights/agents/utils/features';
+import {hasMCPInsightsFeature} from 'sentry/views/insights/agents/utils/features';
 import {AI_CREATE_AGENT_OPS, getIsAiSpan} from 'sentry/views/insights/agents/utils/query';
 
 type HighlightedAttribute = {
@@ -40,7 +37,7 @@ export function getHighlightedSpanAttributes({
 }): HighlightedAttribute[] {
   const attributeObject = ensureAttributeObject(attributes);
 
-  if (hasAgentInsightsFeature(organization) && getIsAiSpan({op})) {
+  if (getIsAiSpan({op})) {
     return getAISpanAttributes(attributeObject, op);
   }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -144,11 +144,7 @@ export function AIInputSection({
   attributes?: TraceItemResponseAttribute[];
   event?: EventTransaction;
 }) {
-  if (getIsAiNode(node)) {
-    return null;
-  }
-
-  if (!hasAIInputAttribute(node, attributes, event)) {
+  if (!getIsAiNode(node) || !hasAIInputAttribute(node, attributes, event)) {
     return null;
   }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -7,14 +7,12 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {EventTransaction} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {
   getIsAiNode,
   getTraceNodeAttribute,
 } from 'sentry/views/insights/agents/utils/aiTraceNodes';
-import {hasAgentInsightsFeature} from 'sentry/views/insights/agents/utils/features';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
@@ -146,8 +144,7 @@ export function AIInputSection({
   attributes?: TraceItemResponseAttribute[];
   event?: EventTransaction;
 }) {
-  const organization = useOrganization();
-  if (!hasAgentInsightsFeature(organization) && getIsAiNode(node)) {
+  if (getIsAiNode(node)) {
     return null;
   }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -52,10 +52,7 @@ export function AIOutputSection({
   attributes?: TraceItemResponseAttribute[];
   event?: EventTransaction;
 }) {
-  if (getIsAiNode(node)) {
-    return null;
-  }
-  if (!hasAIOutputAttribute(node, attributes, event)) {
+  if (!getIsAiNode(node) || !hasAIOutputAttribute(node, attributes, event)) {
     return null;
   }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -2,13 +2,11 @@ import {Fragment} from 'react';
 
 import {t} from 'sentry/locale';
 import type {EventTransaction} from 'sentry/types/event';
-import useOrganization from 'sentry/utils/useOrganization';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {
   getIsAiNode,
   getTraceNodeAttribute,
 } from 'sentry/views/insights/agents/utils/aiTraceNodes';
-import {hasAgentInsightsFeature} from 'sentry/views/insights/agents/utils/features';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
@@ -54,8 +52,7 @@ export function AIOutputSection({
   attributes?: TraceItemResponseAttribute[];
   event?: EventTransaction;
 }) {
-  const organization = useOrganization();
-  if (!hasAgentInsightsFeature(organization) && getIsAiNode(node)) {
+  if (getIsAiNode(node)) {
     return null;
   }
   if (!hasAIOutputAttribute(node, attributes, event)) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -54,10 +54,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {getIsAiNode} from 'sentry/views/insights/agents/utils/aiTraceNodes';
-import {
-  hasAgentInsightsFeature,
-  hasMCPInsightsFeature,
-} from 'sentry/views/insights/agents/utils/features';
+import {hasMCPInsightsFeature} from 'sentry/views/insights/agents/utils/features';
 import {getIsMCPNode} from 'sentry/views/insights/mcp/utils/mcpTraceNodes';
 import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
 import {useTransaction} from 'sentry/views/performance/newTraceDetails/traceApi/useTransaction';
@@ -448,7 +445,7 @@ function Highlights({
     return null;
   }
 
-  const isAiNode = hasAgentInsightsFeature(organization) && getIsAiNode(node);
+  const isAiNode = getIsAiNode(node);
   const isMCPNode = hasMCPInsightsFeature(organization) && getIsMCPNode(node);
 
   const hidePanelAndBreakdown = isAiNode || isMCPNode;

--- a/static/app/views/performance/newTraceDetails/useTraceContextSections.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceContextSections.tsx
@@ -4,7 +4,6 @@ import {VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import {getIsAiNode} from 'sentry/views/insights/agents/utils/aiTraceNodes';
-import {hasAgentInsightsFeature} from 'sentry/views/insights/agents/utils/features';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 
 export function useTraceContextSections({
@@ -27,8 +26,7 @@ export function useTraceContextSections({
   );
 
   const hasSummary: boolean = organization.features.includes('single-trace-summary');
-  const hasAiSpans: boolean =
-    hasAgentInsightsFeature(organization) && !!TraceTree.Find(tree.root, getIsAiNode);
+  const hasAiSpans = !!TraceTree.Find(tree.root, getIsAiNode);
 
   return useMemo(
     () => ({


### PR DESCRIPTION
Remove usage of `agents-insights` feature flag.

- part of [TET-1228: Remove agent and mcp monitoring feature flags](https://linear.app/getsentry/issue/TET-1228/remove-agent-and-mcp-monitoring-feature-flags)