### PR TITLE
fix(project-creation): Disable submit button if platform is not selected

### DIFF
--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -376,6 +376,11 @@ describe('CreateProject', () => {
     });
 
     it('should enabled the submit button if and only if all the required information has been filled', async () => {
+      const {projectCreationMockRequest} = renderFrameworkModalMockRequests({
+        organization,
+        teamSlug: teamWithAccess.slug,
+      });
+
       render(<CreateProject />, {organization});
 
       // We need to query for the submit button every time we want to access it
@@ -384,7 +389,16 @@ describe('CreateProject', () => {
 
       expect(getSubmitButton()).toBeDisabled();
 
-      // Selecting the platform pre-fills the project name
+      // Fills the project name
+      await userEvent.type(screen.getByPlaceholderText('project-name'), 'my-project');
+
+      // Enforce users to select a platform
+      await userEvent.hover(getSubmitButton());
+      expect(await screen.findByText('Please select a platform')).toBeInTheDocument();
+
+      await userEvent.click(getSubmitButton());
+      expect(projectCreationMockRequest).not.toHaveBeenCalled();
+
       await userEvent.click(screen.getByTestId('platform-apple-ios'));
       expect(getSubmitButton()).toBeEnabled();
 
@@ -409,6 +423,9 @@ describe('CreateProject', () => {
 
       await userEvent.click(screen.getByText("I'll create my own alerts later"));
       expect(getSubmitButton()).toBeEnabled();
+
+      await userEvent.click(getSubmitButton());
+      expect(projectCreationMockRequest).toHaveBeenCalled();
     });
 
     it('should create an issue alert rule by default', async () => {

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -86,7 +86,7 @@ function getMissingValues({
   };
   projectName: string;
   team: string | undefined;
-  platform?: Partial<OnboardingSelectedSDK>;
+  platform?: OnboardingSelectedSDK;
 } & Partial<
   Pick<RequestDataFragment, 'conditions' | 'shouldCreateCustomRule' | 'shouldCreateRule'>
 >) {

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -58,7 +58,7 @@ import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 type FormData = {
   projectName: string;
   alertRule?: Partial<AlertRuleOptions>;
-  platform?: Partial<OnboardingSelectedSDK>;
+  platform?: OnboardingSelectedSDK;
   team?: string;
 };
 
@@ -69,12 +69,6 @@ type CreatedProject = Pick<Project, 'name' | 'id'> & {
   team?: string;
 };
 
-function isNotPartialPlatform(
-  platform: Partial<OnboardingSelectedSDK> | undefined
-): platform is OnboardingSelectedSDK {
-  return !!platform?.key;
-}
-
 function getMissingValues({
   team,
   projectName,
@@ -83,6 +77,7 @@ function getMissingValues({
   shouldCreateRule,
   shouldCreateCustomRule,
   isOrgMemberWithNoAccess,
+  platform,
 }: {
   isOrgMemberWithNoAccess: boolean;
   notificationProps: {
@@ -91,6 +86,7 @@ function getMissingValues({
   };
   projectName: string;
   team: string | undefined;
+  platform?: Partial<OnboardingSelectedSDK>;
 } & Partial<
   Pick<RequestDataFragment, 'conditions' | 'shouldCreateCustomRule' | 'shouldCreateRule'>
 >) {
@@ -106,6 +102,7 @@ function getMissingValues({
       shouldCreateRule &&
       notificationProps.actions?.includes(MultipleCheckboxOptions.INTEGRATION) &&
       !notificationProps.channel,
+    isMissingPlatform: !platform,
   };
 }
 
@@ -113,6 +110,7 @@ function getSubmitTooltipText({
   isMissingProjectName,
   isMissingAlertThreshold,
   isMissingMessagingIntegrationChannel,
+  isMissingPlatform,
   formErrorCount,
 }: ReturnType<typeof getMissingValues> & {
   formErrorCount: number;
@@ -129,7 +127,9 @@ function getSubmitTooltipText({
   if (isMissingMessagingIntegrationChannel) {
     return t('Please provide an integration channel for alert notifications');
   }
-
+  if (isMissingPlatform) {
+    return t('Please select a platform');
+  }
   return t('Please select a team');
 }
 
@@ -207,9 +207,11 @@ export function CreateProject() {
     shouldCreateCustomRule: alertRuleConfig.shouldCreateCustomRule,
     shouldCreateRule: alertRuleConfig.shouldCreateRule,
     conditions: alertRuleConfig.conditions,
+    platform: formData.platform,
   });
 
   const formErrorCount = [
+    missingValues.isMissingPlatform,
     missingValues.isMissingTeam,
     missingValues.isMissingProjectName,
     missingValues.isMissingAlertThreshold,
@@ -253,11 +255,6 @@ export function CreateProject() {
         platform: OnboardingSelectedSDK;
       }) => {
       const selectedPlatform = selectedFramework ?? platform;
-
-      if (!selectedPlatform) {
-        addErrorMessage(t('Please select a platform in Step 1'));
-        return;
-      }
 
       let projectToRollback: Project | undefined;
 
@@ -372,21 +369,14 @@ export function CreateProject() {
   );
 
   const handleProjectCreation = useCallback(
-    async (data: FormData) => {
-      const selectedPlatform = data.platform;
-
-      if (!isNotPartialPlatform(selectedPlatform)) {
-        addErrorMessage(t('Please select a platform in Step 1'));
-        return;
-      }
-
+    async ({platform, ...data}: Required<FormData>) => {
       if (
-        selectedPlatform.type !== 'language' ||
+        platform.type !== 'language' ||
         !Object.values(SupportedLanguages).includes(
-          selectedPlatform.language as SupportedLanguages
+          platform.language as SupportedLanguages
         )
       ) {
-        configurePlatform({...data, platform: selectedPlatform});
+        configurePlatform({...data, platform});
         return;
       }
 
@@ -399,11 +389,11 @@ export function CreateProject() {
           <FrameworkSuggestionModal
             {...deps}
             organization={organization}
-            selectedPlatform={selectedPlatform}
+            selectedPlatform={platform}
             onConfigure={selectedFramework => {
-              configurePlatform({...data, platform: selectedPlatform, selectedFramework});
+              configurePlatform({...data, platform, selectedFramework});
             }}
-            onSkip={() => configurePlatform({...data, platform: selectedPlatform})}
+            onSkip={() => configurePlatform({...data, platform})}
           />
         ),
         {
@@ -412,7 +402,7 @@ export function CreateProject() {
             trackAnalytics(
               'project_creation.select_framework_modal_close_button_clicked',
               {
-                platform: selectedPlatform.key,
+                platform: platform.key,
                 organization,
               }
             );
@@ -577,7 +567,9 @@ export function CreateProject() {
                   priority="primary"
                   disabled={!(canUserCreateProject && formErrorCount === 0)}
                   busy={createProjectAndRules.isPending}
-                  onClick={() => debounceHandleProjectCreation(formData)}
+                  onClick={() =>
+                    debounceHandleProjectCreation(formData as Required<FormData>)
+                  }
                 >
                   {t('Create Project')}
                 </Button>

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -369,7 +369,13 @@ export function CreateProject() {
   );
 
   const handleProjectCreation = useCallback(
-    async ({platform, ...data}: Required<FormData>) => {
+    async ({platform, ...data}: FormData) => {
+      // At this point, platform should be defined
+      // otherwise the submit button would be disabled.
+      if (!platform) {
+        return;
+      }
+
       if (
         platform.type !== 'language' ||
         !Object.values(SupportedLanguages).includes(
@@ -567,9 +573,7 @@ export function CreateProject() {
                   priority="primary"
                   disabled={!(canUserCreateProject && formErrorCount === 0)}
                   busy={createProjectAndRules.isPending}
-                  onClick={() =>
-                    debounceHandleProjectCreation(formData as Required<FormData>)
-                  }
+                  onClick={() => debounceHandleProjectCreation(formData)}
                 >
                   {t('Create Project')}
                 </Button>


### PR DESCRIPTION
**Problem**
The submit button should be disabled when required fields are incomplete. However, it remains enabled even when no platform is selected. Previously, users could create a project without choosing a platform, but we now require them to explicitly select “Other” if their desired platform isn’t listed. They can find the 'other' platform by using the search bar and typing something we don't yet support or by directly typing 'other'


<img width="1343" height="389" alt="image" src="https://github.com/user-attachments/assets/3e44b05a-6bd7-4962-a595-2958fd385bda" />



**Solution**
This PR updates the code making the button disabled if a platform is not yet selected.



https://github.com/user-attachments/assets/3223f9e3-c57e-4994-a0b0-8972c47c95c4





closes https://linear.app/getsentry/issue/TET-1248/project-creation-make-sure-button-is-deactivated-when-platform-is