### PR TITLE
fix(ui): adapt NoProjectMessage on mobile to add padding and change direction

### DIFF
--- a/static/app/components/illustrations/NoProjectEmptyState.tsx
+++ b/static/app/components/illustrations/NoProjectEmptyState.tsx
@@ -202,7 +202,7 @@ const Smoke = styled('g')`
   )}
 `;
 
-function NoProjectEmptyState() {
+function NoProjectEmptyState({className}: {className?: string}) {
   return (
     <svg
       width="683"
@@ -210,6 +210,7 @@ function NoProjectEmptyState() {
       viewBox="0 0 683 600"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      className={className}
     >
       <Background {...backgroundAnimationProps}>
         <path d="M425.89 15.49v118.33h128c.38 0 0-118 0-118l-128-.33z" fill="#E7E1EC" />

--- a/static/app/components/noProjectMessage.tsx
+++ b/static/app/components/noProjectMessage.tsx
@@ -72,10 +72,24 @@ function NoProjectMessage({
   );
 
   return (
-    <Flex flex="1" align="center" justify="center">
-      <NoProjectEmptyState />
+    <Flex
+      flex="1"
+      align="center"
+      justify="center"
+      gap="3xl"
+      padding="lg"
+      direction={{xs: 'column', sm: 'row'}}
+    >
+      <Flex
+        align="center"
+        justify="center"
+        height="auto"
+        width={{xs: '300px', sm: 'auto'}}
+      >
+        <StyledNoProjectEmptyState />
+      </Flex>
 
-      <Content>
+      <Flex direction="column" justify="center">
         <Layout.Title>{t('Remain Calm')}</Layout.Title>
         <HelpMessage>{t('You need at least one project to use this view')}</HelpMessage>
         <Actions>
@@ -88,22 +102,20 @@ function NoProjectMessage({
             createProjectAction
           )}
         </Actions>
-      </Content>
+      </Flex>
     </Flex>
   );
 }
 
 export default NoProjectMessage;
 
-const HelpMessage = styled('div')`
-  margin-bottom: ${space(2)};
+const StyledNoProjectEmptyState = styled(NoProjectEmptyState)`
+  width: 100%;
+  height: auto;
 `;
 
-const Content = styled('div')`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  margin-left: 40px;
+const HelpMessage = styled('div')`
+  margin-bottom: ${space(2)};
 `;
 
 const Actions = styled(ButtonBar)`


### PR DESCRIPTION
This changes the way how the "NoProjectMessage" is shown on mobile and tablet. A little padding is always added, so that the corners are not touching the browser borders.

<details>
<summary>
Before on various mobile devices:
</summary>
<img width="300" height="940" alt="iPhonePro12_b" src="https://github.com/user-attachments/assets/556db191-0162-4ea2-8a70-c77c75f3c36a" />

<img width="300" height="1119" alt="iPadMini_b" src="https://github.com/user-attachments/assets/b1ce2569-52de-49cf-9304-9d99223257cf" />

<img width="300" height="1145" alt="iPadAir_b" src="https://github.com/user-attachments/assets/5e331af2-f417-48ab-8f59-c7c407d97edf" />

</details>

<details>
<summary>
After on various mobile devices:
</summary>

<img width="300" height="928" alt="iPhonePro12" src="https://github.com/user-attachments/assets/1714fbbf-9599-4a6c-a595-e39de992d87e" />

<img width="300" height="1114" alt="iPadMini" src="https://github.com/user-attachments/assets/2e1ef4ea-c43c-42f3-be49-68d9f609ce2f" />

<img width="300" height="1142" alt="iPadAir" src="https://github.com/user-attachments/assets/50e775cc-bfd6-458c-b294-1d1f0e3fcdee" />

</details>