### PR TITLE
fix(search-bar): Retain position in value combobox when multi-selecting

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2344,6 +2344,38 @@ describe('SearchQueryBuilder', () => {
         });
       });
 
+      it('sorts multi-selected values after re-opening the combobox', async () => {
+        const user = userEvent.setup();
+        render(<SearchQueryBuilder {...defaultProps} initialQuery='browser.name:""' />);
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+
+        const checkboxOptions = await screen.findAllByRole('checkbox');
+        expect(checkboxOptions).toHaveLength(4);
+        expect(checkboxOptions[0]).toHaveAccessibleName('Toggle Chrome');
+        expect(checkboxOptions[1]).toHaveAccessibleName('Toggle Firefox');
+
+        await user.keyboard('{Control>}');
+        await user.click(checkboxOptions[1]!);
+
+        expect(checkboxOptions[1]).toHaveAccessibleName('Toggle Firefox');
+        expect(checkboxOptions[1]).toBeChecked();
+
+        await user.keyboard('{Escape}');
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+
+        const updatedCheckboxOptions = await screen.findAllByRole('checkbox');
+        expect(updatedCheckboxOptions).toHaveLength(4);
+        expect(updatedCheckboxOptions[0]).toHaveAccessibleName('Toggle Firefox');
+        expect(updatedCheckboxOptions[0]).toBeChecked();
+        expect(updatedCheckboxOptions[1]).toHaveAccessibleName('Toggle Chrome');
+        expect(updatedCheckboxOptions[1]).not.toBeChecked();
+      });
+
       it('collapses many selected options', async () => {
         render(
           <SearchQueryBuilder

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -97,10 +97,11 @@ type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<stri
     extra: {state: ComboBoxState<T>}
   ) => void;
   onKeyUp?: (e: KeyboardEvent) => void;
-  onOpenChange?: (newOpenState: boolean) => void;
+  onOpenChange?: (newOpenState: boolean, state?: any) => void;
   onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void;
   openOnFocus?: boolean;
   placeholder?: string;
+  preserveFocusOnInputChange?: boolean;
   ref?: React.Ref<HTMLInputElement>;
   /**
    * Function to determine whether the menu should close when interacting with
@@ -372,6 +373,7 @@ export function SearchQueryBuilderCombobox<
   onClick,
   customMenu,
   isOpen: incomingIsOpen,
+  preserveFocusOnInputChange = false,
   ['data-test-id']: dataTestId,
   ref,
 }: SearchQueryBuilderComboboxProps<T>) {
@@ -482,10 +484,15 @@ export function SearchQueryBuilderCombobox<
 
   const previousInputValue = usePrevious(inputValue);
   useEffect(() => {
-    if (inputValue !== previousInputValue) {
+    if (!preserveFocusOnInputChange && inputValue !== previousInputValue) {
       state.selectionManager.setFocusedKey(null);
     }
-  }, [inputValue, previousInputValue, state.selectionManager]);
+  }, [
+    inputValue,
+    previousInputValue,
+    state.selectionManager,
+    preserveFocusOnInputChange,
+  ]);
 
   const totalOptions = items.reduce(
     (acc, item) => acc + (itemIsSection(item) ? item.options.length : 1),
@@ -502,9 +509,10 @@ export function SearchQueryBuilderCombobox<
     isOpen: incomingIsOpen,
   });
 
+  // Always notify parent of state so they can maintain up-to-date references
   useEffect(() => {
-    onOpenChange?.(isOpen);
-  }, [onOpenChange, isOpen]);
+    onOpenChange?.(isOpen, state);
+  }, [onOpenChange, isOpen, state]);
 
   const {
     overlayProps,

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -509,7 +509,6 @@ export function SearchQueryBuilderCombobox<
     isOpen: incomingIsOpen,
   });
 
-  // Always notify parent of state so they can maintain up-to-date references
   useEffect(() => {
     onOpenChange?.(isOpen, state);
   }, [onOpenChange, isOpen, state]);

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -502,7 +502,6 @@ function useFilterSuggestions({
       })),
     ];
     // selectedValues is needed to trigger re-renders when checkboxes are toggled
-    // initialSelectedValues is a ref so it won't trigger re-renders, but we list it for correctness
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     createItem,

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -144,10 +144,9 @@ function getSelectedValuesFromText(
 
       // Check if this value is selected by looking at the character after the value in
       // the text. If there's a comma after the value, it means this value is selected.
-      // We need to check the text content to ensure that we account for any quotes the
-      // user may have added.
-      const valueText = item.value?.text ?? '';
-      const selected = text.charAt(text.indexOf(valueText) + valueText.length) === ',';
+      // Use the actual token location from the parser instead of indexOf to avoid
+      // matching substrings (e.g., "artifact_bundle.assemble" inside "artifact_bundle.assemble.find_projects")
+      const selected = text.charAt(item.value?.location.end.offset ?? 0) === ',';
 
       return {value, selected};
     });

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -146,7 +146,8 @@ function getSelectedValuesFromText(
       // the text. If there's a comma after the value, it means this value is selected.
       // Use the actual token location from the parser instead of indexOf to avoid
       // matching substrings (e.g., "cool.property" inside "cool.property.thing")
-      const selected = text.charAt(item.value?.location.end.offset ?? 0) === ',';
+      const selected =
+        text.charAt(item.value?.location.end.offset ?? text.length - 1) === ',';
 
       return {value, selected};
     });

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -1014,9 +1014,7 @@ export function SearchQueryBuilderValueCombobox({
         token={token}
         inputLabel={t('Edit filter value')}
         onInputChange={e => setInputValue(e.target.value)}
-        onKeyDown={e => {
-          onKeyDown(e);
-        }}
+        onKeyDown={onKeyDown}
         onKeyUp={updateSelectionIndex}
         onClick={() => {
           updateSelectionIndex();

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -589,7 +589,6 @@ export function SearchQueryBuilderValueCombobox({
 }: SearchQueryValueBuilderProps) {
   const ref = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const comboboxStateRef = useRef<any>(null);
   const organization = useOrganization();
   const {
     getFieldDefinition,
@@ -1015,8 +1014,7 @@ export function SearchQueryBuilderValueCombobox({
         token={token}
         inputLabel={t('Edit filter value')}
         onInputChange={e => setInputValue(e.target.value)}
-        onKeyDown={(e, {state}) => {
-          comboboxStateRef.current = state;
+        onKeyDown={e => {
           onKeyDown(e);
         }}
         onKeyUp={updateSelectionIndex}
@@ -1025,12 +1023,6 @@ export function SearchQueryBuilderValueCombobox({
           // Also capture state on click to ensure it's available for mouse selections
           if (inputRef.current) {
             inputRef.current.focus();
-          }
-        }}
-        onOpenChange={(_isOpen, state) => {
-          // Capture the combobox state so we can restore focus after selections
-          if (state) {
-            comboboxStateRef.current = state;
           }
         }}
         autoFocus

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -145,7 +145,7 @@ function getSelectedValuesFromText(
       // Check if this value is selected by looking at the character after the value in
       // the text. If there's a comma after the value, it means this value is selected.
       // Use the actual token location from the parser instead of indexOf to avoid
-      // matching substrings (e.g., "artifact_bundle.assemble" inside "artifact_bundle.assemble.find_projects")
+      // matching substrings (e.g., "cool.property" inside "cool.property.thing")
       const selected = text.charAt(item.value?.location.end.offset ?? 0) === ',';
 
       return {value, selected};

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -157,8 +157,7 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
     ) {
       const keyToRestore = lastFocusedKeyRef.current;
       state.selectionManager.setFocusedKey(keyToRestore);
-      // Center the restored option on next tick
-      setTimeout(() => centerKeyInView(keyToRestore), 0);
+      centerKeyInView(keyToRestore);
     }
   }, [isOpen, state, centerKeyInView]);
   const totalOptions = items.reduce(

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -220,11 +220,11 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
               size="sm"
               style={{maxWidth: overlayProps.style!.maxWidth}}
             />
-            {/* {isLoading && anyItemsShowing ? (
+            {isLoading && anyItemsShowing ? (
               <LoadingWrapper height="32px" width="100%">
                 <LoadingIndicator size={24} />
               </LoadingWrapper>
-            ) : null} */}
+            ) : null}
             <Footer
               isMultiSelect={isMultiSelect}
               canUseWildcard={canUseWildcard}

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -125,22 +125,23 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
 
   const centerKeyInView = useCallback(
     (key: Key | null) => {
-      if (key === null) return;
-      const container = listBoxRef.current;
-      if (!container) return;
-      const elId = getItemId(state as any, key as any);
-      if (!elId) return;
-      const el = document.getElementById(elId);
+      if (key === null || !listBoxRef.current) return;
+
+      const el = document.getElementById(getItemId(state as any, key as any));
       if (!el) return;
 
-      const containerRect = container.getBoundingClientRect();
       const elRect = el.getBoundingClientRect();
-      const offsetTopWithinContainer =
-        container.scrollTop + (elRect.top - containerRect.top);
-      const targetScrollTop =
-        offsetTopWithinContainer - container.clientHeight / 2 + elRect.height / 2;
+      const containerRect = listBoxRef.current.getBoundingClientRect();
 
-      container.scrollTop = Math.max(0, targetScrollTop);
+      const offsetTopWithinContainer =
+        listBoxRef.current.scrollTop + (elRect.top - containerRect.top);
+
+      const targetScrollTop =
+        offsetTopWithinContainer -
+        listBoxRef.current.clientHeight / 2 +
+        elRect.height / 2;
+
+      listBoxRef.current.scrollTop = Math.max(0, targetScrollTop);
     },
     [listBoxRef, state]
   );
@@ -151,15 +152,13 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
 
   useLayoutEffect(() => {
     if (!isOpen) return;
-    if (
-      lastFocusedKeyRef.current !== null &&
-      state.selectionManager.focusedKey === null
-    ) {
-      const keyToRestore = lastFocusedKeyRef.current;
-      state.selectionManager.setFocusedKey(keyToRestore);
-      centerKeyInView(keyToRestore);
-    }
+    if (!lastFocusedKeyRef.current) return;
+    if (state.selectionManager.focusedKey !== null) return;
+
+    state.selectionManager.setFocusedKey(lastFocusedKeyRef.current);
+    centerKeyInView(lastFocusedKeyRef.current);
   }, [isOpen, state, centerKeyInView]);
+
   const totalOptions = items.reduce(
     (acc, item) => acc + (itemIsSection(item) ? item.options.length : 1),
     0
@@ -221,11 +220,11 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
               size="sm"
               style={{maxWidth: overlayProps.style!.maxWidth}}
             />
-            {isLoading && anyItemsShowing ? (
+            {/* {isLoading && anyItemsShowing ? (
               <LoadingWrapper height="32px" width="100%">
                 <LoadingIndicator size={24} />
               </LoadingWrapper>
-            ) : null}
+            ) : null} */}
             <Footer
               isMultiSelect={isMultiSelect}
               canUseWildcard={canUseWildcard}

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -3,7 +3,6 @@ import {createPortal} from 'react-dom';
 import styled from '@emotion/styled';
 import {getItemId} from '@react-aria/listbox';
 import {isMac} from '@react-aria/utils';
-import type {ComboBoxState} from '@react-stately/combobox';
 import type {Key} from '@react-types/shared';
 
 import {ListBox} from 'sentry/components/core/compactSelect/listBox';


### PR DESCRIPTION
This PR updates the combobox's so that they retain the users select position when multi-selecting items, and will sort the checked items to the top after they have closed and re-opened the combobox.

Ticket: EXP-357

Before:

https://github.com/user-attachments/assets/4d0ed0b6-86e1-4a25-83e5-f0b04537c445

After:

https://github.com/user-attachments/assets/c5e47f20-b356-43cb-9f0a-d559706eb7fc