### PR TITLE
fix(widget-builder): Ignore limit when making request for tables

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -196,4 +196,35 @@ describe('convertBuilderStateToWidget', () => {
 
     expect(widget.queries[0]!.orderby).toBe('');
   });
+
+  it('sets limit to undefined for table widgets', () => {
+    const mockState: WidgetBuilderState = {
+      displayType: DisplayType.TABLE,
+      fields: [
+        {field: 'geo.country', kind: FieldValueKind.FIELD},
+        {function: ['count', '', undefined, undefined], kind: FieldValueKind.FUNCTION},
+      ],
+      dataset: WidgetType.ERRORS,
+      limit: 10,
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.limit).toBeUndefined();
+  });
+
+  it('sets limit to undefined for big number widgets', () => {
+    const mockState: WidgetBuilderState = {
+      displayType: DisplayType.BIG_NUMBER,
+      fields: [
+        {function: ['count', '', undefined, undefined], kind: FieldValueKind.FUNCTION},
+      ],
+      dataset: WidgetType.TRANSACTIONS,
+      limit: 5,
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.limit).toBeUndefined();
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -69,6 +69,12 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
     };
   });
 
+  const limit =
+    state.displayType &&
+    [DisplayType.BIG_NUMBER, DisplayType.TABLE].includes(state.displayType)
+      ? undefined
+      : state.limit;
+
   return {
     title: state.title ?? '',
     description: state.description,
@@ -76,7 +82,7 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
     interval: '1h', // TODO: Not sure what to put here yet
     queries: widgetQueries,
     widgetType: state.dataset,
-    limit: state.limit,
+    limit,
     thresholds: state.thresholds,
   };
 }

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -69,11 +69,11 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
     };
   });
 
-  const limit =
-    state.displayType &&
-    [DisplayType.BIG_NUMBER, DisplayType.TABLE].includes(state.displayType)
-      ? undefined
-      : state.limit;
+  const limit = [DisplayType.BIG_NUMBER, DisplayType.TABLE].includes(
+    state.displayType ?? DisplayType.TABLE
+  )
+    ? undefined
+    : state.limit;
 
   return {
     title: state.title ?? '',


### PR DESCRIPTION
Quick fix for now. Not entirely sure why we saw a table widget store a limit, but this should tell dashboards to ignore that field when serializing the state for the backend request.