### PR TITLE
fix(trace-view): Pass thread id through for span profile details

### DIFF
--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -71,9 +71,12 @@ export function useSpanProfileDetails(
 
   // TODO: Pick another thread if it's more relevant.
   const threadId = useMemo(() => {
-    const maybeThreadId = Number(span.thread_id);
-    if (!isNaN(maybeThreadId)) {
-      return maybeThreadId;
+    const rawThreadId = span.thread_id?.trim();
+    if (rawThreadId) {
+      const maybeThreadId = Number(rawThreadId);
+      if (!isNaN(maybeThreadId)) {
+        return maybeThreadId;
+      }
     }
     return profileGroup.profiles[profileGroup.activeProfileIndex]?.threadId;
   }, [span.thread_id, profileGroup]);

--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -41,6 +41,7 @@ export interface SpanProfileDetailsProps {
     end_timestamp: number;
     span_id: string;
     start_timestamp: number;
+    thread_id?: string;
   }>;
   onNoProfileFound?: () => void;
 }
@@ -69,10 +70,13 @@ export function useSpanProfileDetails(
   }, [event, profileGroup]);
 
   // TODO: Pick another thread if it's more relevant.
-  const threadId = useMemo(
-    () => profileGroup.profiles[profileGroup.activeProfileIndex]?.threadId,
-    [profileGroup]
-  );
+  const threadId = useMemo(() => {
+    const maybeThreadId = Number(span.thread_id);
+    if (!isNaN(maybeThreadId)) {
+      return maybeThreadId;
+    }
+    return profileGroup.profiles[profileGroup.activeProfileIndex]?.threadId;
+  }, [span.thread_id, profileGroup]);
 
   const profile = useMemo(() => {
     if (!defined(threadId)) {
@@ -173,13 +177,14 @@ export function useSpanProfileDetails(
           query: {
             eventId: event.id,
             spanId: span.span_id,
+            tid: threadId ? String(threadId) : undefined,
           },
         });
       }
     }
 
     return undefined;
-  }, [organization, project, event, span]);
+  }, [organization, project, event, span, threadId]);
 
   return {
     processedEvent,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -26,6 +26,7 @@ import {useExploreDataset} from 'sentry/views/explore/contexts/pageParamsContext
 import {
   useTraceItemDetails,
   type TraceItemDetailsResponse,
+  type TraceItemResponseAttribute,
 } from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -429,13 +430,20 @@ function EAPSpanNodeDetailsContent({
   const links = traceItemData.links;
   const isTransaction = isEAPTransactionNode(node) && !!eventTransaction;
 
+  const threadIdAttribute: TraceItemResponseAttribute | undefined = attributes.find(
+    attribute => attribute.name === 'thread.id'
+  );
+  const threadId: string | undefined =
+    typeof threadIdAttribute?.value === 'string' ? threadIdAttribute.value : undefined;
+
   const span = useMemo(() => {
     return {
       span_id: node.value.event_id,
       start_timestamp: node.value.start_timestamp,
       end_timestamp: node.value.end_timestamp,
+      thread_id: threadId,
     };
-  }, [node]);
+  }, [node, threadId]);
 
   const {profile, frames} = useSpanProfileDetails(
     organization,
@@ -514,11 +522,7 @@ function EAPSpanNodeDetailsContent({
             organization={organization}
             project={project}
             event={eventTransaction}
-            span={{
-              span_id: node.value.event_id,
-              start_timestamp: node.value.start_timestamp,
-              end_timestamp: node.value.end_timestamp,
-            }}
+            span={span}
           />
         ) : null}
 


### PR DESCRIPTION
Make sure to check the profile for the thread matching the spans. Without this, it often looks at a random profile that doesn't have any relevant frames.