### PR TITLE
chore(dashboards): Remove `router` usage from "Add to Dashboard" modal

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -13,7 +13,6 @@ import {
   DisplayType,
   WidgetType,
 } from 'sentry/views/dashboards/types';
-import {convertWidgetToBuilderStateParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 
 const stubEl = (props: {children?: React.ReactNode}) => <div>{props.children}</div>;
 
@@ -364,13 +363,13 @@ describe('add to dashboard modal', () => {
     expect(router.location.query).toEqual({
       title: 'Test title',
       description: 'Test description',
-      field: [],
-      query: [''],
-      yAxis: ['count()'],
-      sort: [''],
+      query: '',
+      yAxis: 'count()',
+      sort: '',
       displayType: DisplayType.LINE,
       dataset: WidgetType.ERRORS,
-      project: [1],
+      project: '1',
+      legendAlias: '',
       statsPeriod: '1h',
       source: DashboardWidgetSource.DISCOVERV2,
     });

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -138,7 +138,6 @@ describe('add to dashboard modal', () => {
         organization={initialData.organization}
         widget={widget}
         selection={defaultSelection}
-        router={initialData.router}
         location={LocationFixture()}
       />
     );
@@ -169,7 +168,6 @@ describe('add to dashboard modal', () => {
         organization={initialData.organization}
         widget={widget}
         selection={defaultSelection}
-        router={initialData.router}
         location={LocationFixture()}
       />
     );
@@ -198,7 +196,6 @@ describe('add to dashboard modal', () => {
         organization={initialData.organization}
         widget={widget}
         selection={defaultSelection}
-        router={initialData.router}
         location={LocationFixture()}
       />
     );
@@ -223,7 +220,6 @@ describe('add to dashboard modal', () => {
         organization={initialData.organization}
         widget={widget}
         selection={defaultSelection}
-        router={initialData.router}
         location={LocationFixture()}
       />
     );
@@ -276,7 +272,6 @@ describe('add to dashboard modal', () => {
         organization={initialData.organization}
         widget={widget}
         selection={defaultSelection}
-        router={initialData.router}
         location={LocationFixture()}
       />
     );
@@ -311,7 +306,6 @@ describe('add to dashboard modal', () => {
         organization={initialData.organization}
         widget={widget}
         selection={defaultSelection}
-        router={initialData.router}
         source={DashboardWidgetSource.DISCOVERV2}
         location={LocationFixture()}
       />
@@ -350,7 +344,6 @@ describe('add to dashboard modal', () => {
         organization={initialData.organization}
         widget={widget}
         selection={defaultSelection}
-        router={initialData.router}
         source={DashboardWidgetSource.DISCOVERV2}
         location={LocationFixture()}
       />
@@ -400,7 +393,6 @@ describe('add to dashboard modal', () => {
         organization={initialData.organization}
         widget={{...widget, widgetType: WidgetType.ERRORS}}
         selection={defaultSelection}
-        router={initialData.router}
         location={LocationFixture()}
       />
     );
@@ -461,7 +453,6 @@ describe('add to dashboard modal', () => {
         organization={initialData.organization}
         widget={widget}
         selection={defaultSelection}
-        router={initialData.router}
         location={LocationFixture()}
       />
     );
@@ -541,7 +532,6 @@ describe('add to dashboard modal', () => {
         organization={initialData.organization}
         widget={widget}
         selection={defaultSelection}
-        router={initialData.router}
         location={LocationFixture()}
       />
     );
@@ -598,7 +588,6 @@ describe('add to dashboard modal', () => {
         organization={initialData.organization}
         widget={widget}
         selection={defaultSelection}
-        router={initialData.router}
         location={LocationFixture()}
       />
     );
@@ -626,7 +615,6 @@ describe('add to dashboard modal', () => {
         organization={initialData.organization}
         widget={widget}
         selection={defaultSelection}
-        router={initialData.router}
         location={LocationFixture({pathname: '/organizations/org-slug/dashboard/1/'})}
       />,
       {
@@ -672,7 +660,6 @@ describe('add to dashboard modal', () => {
         organization={initialData.organization}
         widget={widget}
         selection={defaultSelection}
-        router={initialData.router}
         location={LocationFixture()}
       />
     );

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -296,7 +296,7 @@ describe('add to dashboard modal', () => {
   });
 
   it('navigates to the widget builder when clicking Open in Widget Builder', async () => {
-    render(
+    const {router} = render(
       <AddToDashboardModal
         Header={stubEl}
         Footer={stubEl as ModalRenderProps['Footer']}
@@ -317,24 +317,26 @@ describe('add to dashboard modal', () => {
     await selectEvent.select(screen.getByText('Select Dashboard'), 'Test Dashboard');
 
     await userEvent.click(screen.getByText('Open in Widget Builder'));
-    expect(initialData.router.push).toHaveBeenCalledWith({
-      pathname: '/organizations/org-slug/dashboard/1/widget-builder/widget/new/',
-      query: {
-        ...convertWidgetToBuilderStateParams(widget),
-        environment: [],
-        end: undefined,
-        start: undefined,
-        utc: undefined,
-        project: [1],
-        source: DashboardWidgetSource.DISCOVERV2,
-        statsPeriod: '1h',
-        title: 'Test title',
-      },
+    expect(router.location.pathname).toBe(
+      '/organizations/org-slug/dashboard/1/widget-builder/widget/new/'
+    );
+    expect(router.location.query).toEqual({
+      title: 'Test title',
+      description: 'Test description',
+      dataset: 'error-events',
+      source: DashboardWidgetSource.DISCOVERV2,
+      project: '1',
+      statsPeriod: '1h',
+      displayType: 'line',
+      legendAlias: '',
+      query: '',
+      sort: '',
+      yAxis: 'count()',
     });
   });
 
   it('navigates to the widget builder with saved filters', async () => {
-    render(
+    const {router} = render(
       <AddToDashboardModal
         Header={stubEl}
         Footer={stubEl as ModalRenderProps['Footer']}
@@ -355,21 +357,22 @@ describe('add to dashboard modal', () => {
     await selectEvent.select(screen.getByText('Select Dashboard'), 'Test Dashboard');
 
     await userEvent.click(screen.getByText('Open in Widget Builder'));
-    expect(initialData.router.push).toHaveBeenCalledWith({
-      pathname: '/organizations/org-slug/dashboard/1/widget-builder/widget/new/',
-      query: expect.objectContaining({
-        title: 'Test title',
-        description: 'Test description',
-        field: [],
-        query: [''],
-        yAxis: ['count()'],
-        sort: [''],
-        displayType: DisplayType.LINE,
-        dataset: WidgetType.ERRORS,
-        project: [1],
-        statsPeriod: '1h',
-        source: DashboardWidgetSource.DISCOVERV2,
-      }),
+
+    expect(router.location.pathname).toBe(
+      '/organizations/org-slug/dashboard/1/widget-builder/widget/new/'
+    );
+    expect(router.location.query).toEqual({
+      title: 'Test title',
+      description: 'Test description',
+      field: [],
+      query: [''],
+      yAxis: ['count()'],
+      sort: [''],
+      displayType: DisplayType.LINE,
+      dataset: WidgetType.ERRORS,
+      project: [1],
+      statsPeriod: '1h',
+      source: DashboardWidgetSource.DISCOVERV2,
     });
   });
 

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -18,12 +18,10 @@ import {Select} from 'sentry/components/core/select';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters, SelectValue} from 'sentry/types/core';
-import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useApi from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
@@ -65,7 +63,6 @@ type AddToDashboardModalActions =
 export type AddToDashboardModalProps = {
   location: Location;
   organization: Organization;
-  router: InjectedRouter;
   selection: PageFilters;
   widget: Widget;
   actions?: AddToDashboardModalActions[];
@@ -97,7 +94,6 @@ function AddToDashboardModal({
   closeModal,
   location,
   organization,
-  router,
   selection,
   widget,
   actions = DEFAULT_ACTIONS,
@@ -190,18 +186,16 @@ function AddToDashboardModal({
 
     const widgetAsQueryParams = convertWidgetToBuilderStateParams(widget);
 
-    router.push(
-      normalizeUrl({
-        pathname,
-        query: {
-          ...widgetAsQueryParams,
-          title: newWidgetTitle,
-          sort: orderBy ?? widgetAsQueryParams.sort,
-          source,
-          ...(selectedDashboard ? getSavedPageFilters(selectedDashboard) : {}),
-        },
-      })
-    );
+    navigate({
+      pathname,
+      query: {
+        ...widgetAsQueryParams,
+        title: newWidgetTitle,
+        sort: orderBy ?? widgetAsQueryParams.sort,
+        source,
+        ...(selectedDashboard ? getSavedPageFilters(selectedDashboard) : {}),
+      },
+    });
     closeModal();
   }
 

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -160,7 +160,6 @@ function WidgetCard(props: Props) {
     minTableColumnWidth,
     disableZoom,
     showLoadingText,
-    router,
     onWidgetTableSort,
     onWidgetTableResizeColumn,
     disableTableActions,
@@ -273,7 +272,6 @@ function WidgetCard(props: Props) {
         props.widgetLimitReached,
         props.hasEditAccess,
         location,
-        router,
         props.onDelete,
         props.onDuplicate,
         props.onEdit

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -8,7 +8,6 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
-import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
@@ -56,7 +55,6 @@ export function getMenuOptions(
   widgetLimitReached: boolean,
   hasEditAccess = true,
   location: Location,
-  router: InjectedRouter,
   onDelete?: () => void,
   onDuplicate?: () => void,
   onEdit?: () => void
@@ -179,7 +177,6 @@ export function getMenuOptions(
         openAddToDashboardModal({
           organization,
           location,
-          router,
           selection,
           widget: {
             ...widget,

--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -24,7 +24,6 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import useRouter from 'sentry/utils/useRouter';
 import {makeDiscoverPathname} from 'sentry/views/discover/pathnames';
 import {getSavedQueryWithDataset} from 'sentry/views/discover/savedQuery/utils';
 
@@ -129,7 +128,6 @@ const RENDER_PREBUILT_KEY = 'discover-render-prebuilt';
 function DiscoverLanding() {
   const organization = useOrganization();
   const location = useLocation();
-  const router = useRouter();
   const activeSort = useActiveSort();
   const savedSearchQuery = useSavedSearchQuery();
 
@@ -254,7 +252,6 @@ function DiscoverLanding() {
                   renderPrebuilt={renderPrebuilt}
                   location={location}
                   organization={organization}
-                  router={router}
                   refetchSavedQueries={refreshSavedQueries}
                 />
               )}

--- a/static/app/views/discover/queryList.spec.tsx
+++ b/static/app/views/discover/queryList.spec.tsx
@@ -1,7 +1,6 @@
 import {DiscoverSavedQueryFixture} from 'sentry-fixture/discover';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -86,7 +85,6 @@ describe('Discover > QueryList', () => {
   it('renders an empty list', () => {
     render(
       <QueryList
-        router={RouterFixture()}
         organization={organization}
         savedQueries={[]}
         savedQuerySearchQuery="no matches"
@@ -107,7 +105,6 @@ describe('Discover > QueryList', () => {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={RouterFixture()}
         organization={organization}
         savedQueries={savedQueries}
         renderPrebuilt
@@ -149,7 +146,6 @@ describe('Discover > QueryList', () => {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={RouterFixture()}
         organization={organization}
         savedQueries={[]}
         renderPrebuilt
@@ -209,7 +205,6 @@ describe('Discover > QueryList', () => {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={RouterFixture()}
         organization={org}
         savedQueries={savedQueries}
         renderPrebuilt
@@ -248,7 +243,6 @@ describe('Discover > QueryList', () => {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={RouterFixture()}
         organization={organization}
         savedQueries={savedQueries}
         pageLinks=""
@@ -284,7 +278,6 @@ describe('Discover > QueryList', () => {
       <QueryList
         savedQuerySearchQuery=""
         renderPrebuilt={false}
-        router={RouterFixture()}
         organization={organization}
         savedQueries={savedQueries}
         pageLinks=""
@@ -310,7 +303,6 @@ describe('Discover > QueryList', () => {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={RouterFixture()}
         organization={organization}
         savedQueries={savedQueries}
         pageLinks=""
@@ -335,7 +327,6 @@ describe('Discover > QueryList', () => {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={RouterFixture()}
         organization={organization}
         savedQueries={savedQueries.slice(1)}
         renderPrebuilt={false}
@@ -373,7 +364,6 @@ describe('Discover > QueryList', () => {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={RouterFixture()}
         organization={featuredOrganization}
         savedQueries={savedQueries.slice(1)}
         pageLinks=""
@@ -407,7 +397,6 @@ describe('Discover > QueryList', () => {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={RouterFixture()}
         organization={organization}
         savedQueries={savedQueries.slice(1)}
         pageLinks=""
@@ -450,7 +439,6 @@ describe('Discover > QueryList', () => {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={RouterFixture()}
         organization={featuredOrganization}
         savedQueries={[savedQueryWithMultiYAxis]}
         pageLinks=""
@@ -479,7 +467,6 @@ describe('Discover > QueryList', () => {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={RouterFixture()}
         organization={organization}
         savedQueries={savedQueries.slice(1)}
         renderPrebuilt={false}
@@ -510,7 +497,6 @@ describe('Discover > QueryList', () => {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={RouterFixture()}
         organization={featuredOrganization}
         savedQueries={[
           DiscoverSavedQueryFixture({
@@ -547,7 +533,6 @@ describe('Discover > QueryList', () => {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={RouterFixture()}
         organization={featuredOrganization}
         savedQueries={[
           DiscoverSavedQueryFixture({
@@ -584,7 +569,6 @@ describe('Discover > QueryList', () => {
       render(
         <QueryList
           savedQuerySearchQuery=""
-          router={RouterFixture()}
           organization={featuredOrganization}
           renderPrebuilt={false}
           savedQueries={[
@@ -651,7 +635,6 @@ describe('Discover > QueryList', () => {
       render(
         <QueryList
           savedQuerySearchQuery=""
-          router={RouterFixture()}
           renderPrebuilt={false}
           organization={featuredOrganization}
           savedQueries={[
@@ -719,7 +702,6 @@ describe('Discover > QueryList', () => {
       render(
         <QueryList
           savedQuerySearchQuery=""
-          router={RouterFixture()}
           organization={featuredOrganization}
           renderPrebuilt={false}
           savedQueries={[
@@ -756,7 +738,6 @@ describe('Discover > QueryList', () => {
       render(
         <QueryList
           savedQuerySearchQuery=""
-          router={RouterFixture()}
           organization={featuredOrganization}
           renderPrebuilt={false}
           savedQueries={[
@@ -794,7 +775,6 @@ describe('Discover > QueryList', () => {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={RouterFixture()}
         renderPrebuilt={false}
         organization={featuredOrganization}
         savedQueries={[

--- a/static/app/views/discover/queryList.tsx
+++ b/static/app/views/discover/queryList.tsx
@@ -15,7 +15,6 @@ import TimeSince from 'sentry/components/timeSince';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {NewQuery, Organization, SavedQuery} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
@@ -49,7 +48,6 @@ type Props = {
   pageLinks: string;
   refetchSavedQueries: () => void;
   renderPrebuilt: boolean;
-  router: InjectedRouter;
   savedQueries: SavedQuery[];
   savedQuerySearchQuery: string;
 };
@@ -142,7 +140,7 @@ class QueryList extends Component<Props> {
   }
 
   renderPrebuiltQueries() {
-    const {api, location, organization, savedQuerySearchQuery, router} = this.props;
+    const {api, location, organization, savedQuerySearchQuery} = this.props;
     const views = getPrebuiltQueries(organization);
 
     const hasSearchQuery =
@@ -190,7 +188,6 @@ class QueryList extends Component<Props> {
               query: view,
               organization,
               yAxis: view?.yAxis,
-              router,
               widgetType: hasDatasetSelector(organization)
                 ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
                   SAVED_QUERY_DATASET_TO_WIDGET_TYPE[
@@ -252,7 +249,7 @@ class QueryList extends Component<Props> {
   }
 
   renderSavedQueries() {
-    const {api, savedQueries, location, organization, router} = this.props;
+    const {api, savedQueries, location, organization} = this.props;
 
     if (!savedQueries || !Array.isArray(savedQueries) || savedQueries.length === 0) {
       return [];
@@ -288,7 +285,6 @@ class QueryList extends Component<Props> {
                     query: savedQuery,
                     organization,
                     yAxis: savedQuery?.yAxis ?? eventView.yAxis,
-                    router,
                     widgetType: hasDatasetSelector(organization)
                       ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
                         SAVED_QUERY_DATASET_TO_WIDGET_TYPE[

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -763,7 +763,7 @@ export class Results extends Component<Props, State> {
   }
 
   render() {
-    const {organization, location, router, selection, api, setSavedQuery, isHomepage} =
+    const {organization, location, selection, api, setSavedQuery, isHomepage} =
       this.props;
     const {
       eventView,
@@ -796,7 +796,6 @@ export class Results extends Component<Props, State> {
             location={location}
             eventView={eventView}
             yAxis={yAxisArray}
-            router={router}
             isHomepage={isHomepage}
             splitDecision={splitDecision}
           />

--- a/static/app/views/discover/results/resultsHeader.tsx
+++ b/static/app/views/discover/results/resultsHeader.tsx
@@ -11,7 +11,6 @@ import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionT
 import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization, SavedQuery} from 'sentry/types/organization';
 import type EventView from 'sentry/utils/discover/eventView';
 import type {SavedQueryDatasets} from 'sentry/utils/discover/types';
@@ -28,7 +27,6 @@ type Props = {
   eventView: EventView;
   location: Location;
   organization: Organization;
-  router: InjectedRouter;
   setSavedQuery: (savedQuery?: SavedQuery) => void;
   yAxis: string[];
   isHomepage?: boolean;
@@ -123,7 +121,6 @@ class ResultsHeader extends Component<Props, State> {
       errorCode,
       eventView,
       yAxis,
-      router,
       setSavedQuery,
       isHomepage,
       splitDecision,
@@ -188,7 +185,6 @@ class ResultsHeader extends Component<Props, State> {
             disabled={errorCode >= 400 && errorCode < 500}
             updateCallback={() => this.fetchData()}
             yAxis={yAxis}
-            router={router}
             isHomepage={isHomepage}
             setHomepageQuery={updatedHomepageQuery => {
               this.setState({

--- a/static/app/views/discover/savedQuery/index.spec.tsx
+++ b/static/app/views/discover/savedQuery/index.spec.tsx
@@ -1,6 +1,5 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -17,7 +16,6 @@ jest.mock('sentry/actionCreators/modal');
 function mount(
   location: ReturnType<typeof LocationFixture>,
   organization: Organization,
-  router: ReturnType<typeof RouterFixture>,
   eventView: EventView,
   savedQuery: SavedQuery | NewQuery | undefined,
   yAxis: string[],
@@ -33,7 +31,6 @@ function mount(
       disabled={disabled}
       updateCallback={() => {}}
       yAxis={yAxis}
-      router={router}
       queryDataLoading={false}
       setSavedQuery={setSavedQuery}
       setHomepageQuery={jest.fn()}
@@ -51,9 +48,6 @@ describe('Discover > SaveQueryButtonGroup', () => {
   const location = LocationFixture({
     pathname: '/organization/eventsv2/',
     query: {},
-  });
-  const router = RouterFixture({
-    location: {query: {}},
   });
   const yAxis = ['count()', 'failure_count()'];
 
@@ -102,13 +96,13 @@ describe('Discover > SaveQueryButtonGroup', () => {
     });
 
     it('renders disabled buttons when disabled prop is used', () => {
-      mount(location, organization, router, errorsView, undefined, yAxis, true);
+      mount(location, organization, errorsView, undefined, yAxis, true);
 
       expect(screen.getByRole('button', {name: /save as/i})).toBeDisabled();
     });
 
     it('renders the correct set of buttons', async () => {
-      mount(location, organization, router, errorsView, undefined, yAxis);
+      mount(location, organization, errorsView, undefined, yAxis);
 
       expect(screen.getByRole('button', {name: /save as/i})).toBeInTheDocument();
       expect(
@@ -124,7 +118,7 @@ describe('Discover > SaveQueryButtonGroup', () => {
       organization = OrganizationFixture({
         features: ['discover-query', 'dashboards-edit'],
       });
-      mount(location, organization, router, errorsView, undefined, yAxis);
+      mount(location, organization, errorsView, undefined, yAxis);
 
       expect(screen.getByRole('button', {name: /save as/i})).toBeInTheDocument();
       expect(screen.getByRole('button', {name: /set as default/i})).toBeInTheDocument();
@@ -150,7 +144,6 @@ describe('Discover > SaveQueryButtonGroup', () => {
       mount(
         location,
         organization,
-        router,
         errorsView,
         {...savedQuery, queryDataset: SavedQueryDatasets.ERRORS},
         yAxis
@@ -192,7 +185,7 @@ describe('Discover > SaveQueryButtonGroup', () => {
     });
 
     it('saves a well-formed query', async () => {
-      mount(location, organization, router, errorsView, undefined, yAxis);
+      mount(location, organization, errorsView, undefined, yAxis);
 
       // Click on ButtonSaveAs to open dropdown
       await userEvent.click(screen.getByRole('button', {name: 'Save as'}));
@@ -219,7 +212,7 @@ describe('Discover > SaveQueryButtonGroup', () => {
     });
 
     it('saves on enter', async () => {
-      mount(location, organization, router, errorsView, undefined, yAxis);
+      mount(location, organization, errorsView, undefined, yAxis);
 
       // Click on ButtonSaveAs to open dropdown
       await userEvent.click(screen.getByRole('button', {name: 'Save as'}));
@@ -244,7 +237,7 @@ describe('Discover > SaveQueryButtonGroup', () => {
     });
 
     it('rejects if query.name is empty', async () => {
-      mount(location, organization, router, errorsView, undefined, yAxis);
+      mount(location, organization, errorsView, undefined, yAxis);
 
       // Click on ButtonSaveAs to open dropdown
       await userEvent.click(screen.getByRole('button', {name: 'Save as'}));
@@ -278,7 +271,6 @@ describe('Discover > SaveQueryButtonGroup', () => {
       mount(
         location,
         organization,
-        router,
         EventView.fromSavedQuery({...errorsQuery, yAxis}),
         savedQuery,
         yAxis
@@ -296,14 +288,9 @@ describe('Discover > SaveQueryButtonGroup', () => {
     });
 
     it('treats undefined yAxis the same as count() when checking for changes', async () => {
-      mount(
-        location,
-        organization,
-        router,
-        errorsViewSaved,
-        {...savedQuery, yAxis: undefined},
-        ['count()']
-      );
+      mount(location, organization, errorsViewSaved, {...savedQuery, yAxis: undefined}, [
+        'count()',
+      ]);
 
       expect(screen.queryByRole('button', {name: /save as/i})).not.toBeInTheDocument();
       expect(
@@ -319,7 +306,6 @@ describe('Discover > SaveQueryButtonGroup', () => {
       mount(
         location,
         organization,
-        router,
         errorsViewSaved,
         {...savedQuery, yAxis: ['count()']},
         ['count()']
@@ -336,7 +322,7 @@ describe('Discover > SaveQueryButtonGroup', () => {
     });
 
     it('deletes the saved query', async () => {
-      mount(location, organization, router, errorsViewSaved, savedQuery, yAxis);
+      mount(location, organization, errorsViewSaved, savedQuery, yAxis);
 
       await userEvent.click(screen.getByRole('button', {name: /discover context menu/i}));
       await userEvent.click(
@@ -358,7 +344,6 @@ describe('Discover > SaveQueryButtonGroup', () => {
       mount(
         location,
         organization,
-        router,
         errorsViewModified,
         errorsViewSaved.toNewQuery(),
         yAxis
@@ -389,7 +374,6 @@ describe('Discover > SaveQueryButtonGroup', () => {
         mount(
           location,
           organization,
-          router,
           errorsViewModified,
           savedQuery,
           yAxis,
@@ -426,7 +410,7 @@ describe('Discover > SaveQueryButtonGroup', () => {
       });
 
       it('checks that it is forked from a saved query', async () => {
-        mount(location, organization, router, errorsViewModified, savedQuery, yAxis);
+        mount(location, organization, errorsViewModified, savedQuery, yAxis);
 
         // Click on ButtonSaveAs to open dropdown
         await userEvent.click(screen.getByRole('button', {name: 'Save as'}));
@@ -458,12 +442,12 @@ describe('Discover > SaveQueryButtonGroup', () => {
         ...organization,
         features: ['incidents'],
       };
-      mount(location, metricAlertOrg, router, errorsViewModified, savedQuery, yAxis);
+      mount(location, metricAlertOrg, errorsViewModified, savedQuery, yAxis);
 
       expect(screen.getByRole('button', {name: /create alert/i})).toBeInTheDocument();
     });
     it('does not render create alert button without metric alerts', () => {
-      mount(location, organization, router, errorsViewModified, savedQuery, yAxis);
+      mount(location, organization, errorsViewModified, savedQuery, yAxis);
 
       expect(
         screen.queryByRole('button', {name: /create alert/i})
@@ -480,14 +464,7 @@ describe('Discover > SaveQueryButtonGroup', () => {
         query: 'foo:bar',
       };
       const transactionView = EventView.fromSavedQuery(transactionSavedQuery);
-      mount(
-        location,
-        metricAlertOrg,
-        router,
-        transactionView,
-        transactionSavedQuery,
-        yAxis
-      );
+      mount(location, metricAlertOrg, transactionView, transactionSavedQuery, yAxis);
 
       const createAlertButton = screen.getByRole('button', {name: /create alert/i});
       const href = createAlertButton.getAttribute('href')!;
@@ -508,7 +485,7 @@ describe('Discover > SaveQueryButtonGroup', () => {
         query: 'foo:bar',
       };
       const transactionView = EventView.fromSavedQuery(errorSavedQuery);
-      mount(location, metricAlertOrg, router, transactionView, errorSavedQuery, yAxis);
+      mount(location, metricAlertOrg, transactionView, errorSavedQuery, yAxis);
 
       const createAlertButton = screen.getByRole('button', {name: /create alert/i});
       const href = createAlertButton.getAttribute('href')!;

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -25,7 +25,6 @@ import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import {IconBookmark, IconDelete, IconEllipsis, IconStar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization, SavedQuery} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
@@ -158,7 +157,6 @@ type Props = DefaultProps & {
   organization: Organization;
   projects: Project[];
   queryDataLoading: boolean;
-  router: InjectedRouter;
   savedQuery: SavedQuery | undefined;
   setHomepageQuery: (homepageQuery?: SavedQuery) => void;
   setSavedQuery: (savedQuery: SavedQuery) => void;
@@ -510,7 +508,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
   }
 
   renderButtonAddToDashboard() {
-    const {organization, eventView, savedQuery, yAxis, router, location} = this.props;
+    const {organization, eventView, savedQuery, yAxis, location} = this.props;
     return (
       <Button
         key="add-dashboard-widget-from-discover"
@@ -523,7 +521,6 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
             eventView,
             query: savedQuery,
             yAxis,
-            router,
             widgetType: hasDatasetSelector(organization)
               ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
                 SAVED_QUERY_DATASET_TO_WIDGET_TYPE[
@@ -633,8 +630,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
   }
 
   render() {
-    const {organization, eventView, savedQuery, yAxis, router, location, isHomepage} =
-      this.props;
+    const {organization, eventView, savedQuery, yAxis, location, isHomepage} = this.props;
 
     const currentDataset = getDatasetFromLocationOrSavedQueryDataset(
       location,
@@ -667,7 +663,6 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
             eventView,
             query: savedQuery,
             yAxis,
-            router,
             widgetType: hasDatasetSelector(organization)
               ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
                 SAVED_QUERY_DATASET_TO_WIDGET_TYPE[

--- a/static/app/views/discover/utils.spec.tsx
+++ b/static/app/views/discover/utils.spec.tsx
@@ -2,13 +2,11 @@ import type {Location} from 'history';
 import {EventFixture} from 'sentry-fixture/event';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import {openAddToDashboardModal} from 'sentry/actionCreators/modal';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/tables/gridEditable';
-import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import type {EventViewOptions} from 'sentry/utils/discover/eventView';
 import EventView from 'sentry/utils/discover/eventView';
@@ -946,12 +944,10 @@ describe('constructAddQueryToDashboardLink', () => {
 describe('handleAddQueryToDashboard', () => {
   let organization: Organization;
   let location: Location;
-  let router: InjectedRouter;
   let mockedOpenAddToDashboardModal: jest.Mock;
   beforeEach(() => {
     organization = OrganizationFixture();
     location = LocationFixture();
-    router = RouterFixture();
     mockedOpenAddToDashboardModal = jest.mocked(openAddToDashboardModal);
   });
 
@@ -965,7 +961,6 @@ describe('handleAddQueryToDashboard', () => {
       eventView,
       organization,
       location,
-      router,
       widgetType: WidgetType.TRANSACTIONS,
       yAxis: ['count()'],
       source: DashboardWidgetSource.DISCOVERV2,
@@ -1004,7 +999,6 @@ describe('handleAddQueryToDashboard', () => {
       eventView,
       organization,
       location,
-      router,
       source: DashboardWidgetSource.DISCOVERV2,
       widgetType: WidgetType.TRANSACTIONS,
       yAxis: ['count()'],
@@ -1042,7 +1036,6 @@ describe('handleAddQueryToDashboard', () => {
       eventView,
       organization,
       location,
-      router,
       source: DashboardWidgetSource.DISCOVERV2,
       widgetType: WidgetType.TRANSACTIONS,
       yAxis: ['count()', 'count_unique(user)'],
@@ -1087,7 +1080,6 @@ describe('handleAddQueryToDashboard', () => {
         eventView,
         organization,
         location,
-        router,
         source: DashboardWidgetSource.DISCOVERV2,
         widgetType: WidgetType.TRANSACTIONS,
         yAxis: ['count()'],
@@ -1127,7 +1119,6 @@ describe('handleAddQueryToDashboard', () => {
         eventView,
         organization,
         location,
-        router,
         source: DashboardWidgetSource.DISCOVERV2,
         widgetType: WidgetType.TRANSACTIONS,
         yAxis: ['count()'],
@@ -1166,7 +1157,6 @@ describe('handleAddQueryToDashboard', () => {
         eventView,
         organization,
         location,
-        router,
         source: DashboardWidgetSource.DISCOVERV2,
         widgetType: WidgetType.TRANSACTIONS,
         yAxis: ['count()', 'count_unique(user)'],

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -7,7 +7,6 @@ import {URL_PARAM} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
 import type {SelectValue} from 'sentry/types/core';
 import type {Event} from 'sentry/types/event';
-import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {
   NewQuery,
   Organization,
@@ -638,7 +637,6 @@ export function handleAddQueryToDashboard({
   location,
   query,
   organization,
-  router,
   yAxis,
   widgetType,
   source,
@@ -646,7 +644,6 @@ export function handleAddQueryToDashboard({
   eventView: EventView;
   location: Location;
   organization: Organization;
-  router: InjectedRouter;
   source: DashboardWidgetSource;
   widgetType: WidgetType | undefined;
   query?: NewQuery;
@@ -709,7 +706,6 @@ export function handleAddQueryToDashboard({
       widgetType,
     },
     source,
-    router,
     location,
   });
   return;

--- a/static/app/views/explore/hooks/useAddToDashboard.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.tsx
@@ -6,7 +6,6 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useRouter from 'sentry/utils/useRouter';
 import {
   DashboardWidgetSource,
   DEFAULT_WIDGET_NAME,
@@ -36,7 +35,6 @@ export const CHART_TYPE_TO_DISPLAY_TYPE = {
 
 export function useAddToDashboard() {
   const location = useLocation();
-  const router = useRouter();
   const {selection} = usePageFilters();
   const organization = useOrganization();
 
@@ -92,13 +90,12 @@ export function useAddToDashboard() {
         organization,
         location,
         eventView,
-        router,
         yAxis: eventView.yAxis,
         widgetType: WidgetType.SPANS,
         source: DashboardWidgetSource.TRACE_EXPLORER,
       });
     },
-    [organization, location, getEventView, router]
+    [organization, location, getEventView]
   );
 
   return {

--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -16,7 +16,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import useRouter from 'sentry/utils/useRouter';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {
@@ -221,7 +220,6 @@ function ContextMenu({
   visualize: Visualize;
 }) {
   const location = useLocation();
-  const router = useRouter();
   const organization = useOrganization();
   const {projects} = useProjects();
   const pageFilters = usePageFilters();
@@ -323,7 +321,6 @@ function ContextMenu({
           organization,
           location,
           eventView,
-          router,
           yAxis: visualize.yAxis,
           widgetType: WidgetType.LOGS,
           source: DashboardWidgetSource.LOGS,
@@ -357,7 +354,6 @@ function ContextMenu({
     organization,
     pageFilters,
     projects,
-    router,
     search,
     setVisible,
     visible,

--- a/static/app/views/explore/logs/useSaveAsItems.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.tsx
@@ -22,7 +22,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import useRouter from 'sentry/utils/useRouter';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {
   DashboardWidgetSource,
@@ -60,7 +59,6 @@ export function useSaveAsItems({
   visualizes,
 }: UseSaveAsItemsOptions) {
   const location = useLocation();
-  const router = useRouter();
   const organization = useOrganization();
   const {projects} = useProjects();
   const pageFilters = usePageFilters();
@@ -208,7 +206,6 @@ export function useSaveAsItems({
             organization,
             location,
             eventView,
-            router,
             yAxis: eventView.yAxis,
             widgetType: WidgetType.LOGS,
             source: DashboardWidgetSource.LOGS,
@@ -233,17 +230,7 @@ export function useSaveAsItems({
       disabled: !dashboardsUrls || dashboardsUrls.length === 0,
       isSubmenu: true,
     };
-  }, [
-    aggregates,
-    groupBys,
-    mode,
-    organization,
-    pageFilters,
-    search,
-    sortBys,
-    location,
-    router,
-  ]);
+  }, [aggregates, groupBys, mode, organization, pageFilters, search, sortBys, location]);
 
   return useMemo(() => {
     const saveAs = [];

--- a/static/app/views/explore/multiQueryMode/hooks/useAddCompareQueryToDashboard.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useAddCompareQueryToDashboard.tsx
@@ -7,7 +7,6 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useRouter from 'sentry/utils/useRouter';
 import {
   DashboardWidgetSource,
   DEFAULT_WIDGET_NAME,
@@ -28,7 +27,6 @@ export function useAddCompareQueryToDashboard(query: ReadableExploreQueryParts) 
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const location = useLocation();
-  const router = useRouter(); // required for handleAddQueryToDashboard
 
   const yAxes = query.yAxes.slice(0, MAX_NUM_Y_AXES);
   const groupBys = query.groupBys;
@@ -72,12 +70,11 @@ export function useAddCompareQueryToDashboard(query: ReadableExploreQueryParts) 
       organization,
       location,
       eventView,
-      router,
       yAxis: eventView.yAxis,
       widgetType: WidgetType.SPANS,
       source: DashboardWidgetSource.TRACE_EXPLORER,
     });
-  }, [organization, location, getEventView, router]);
+  }, [organization, location, getEventView]);
 
   return {
     addToDashboard,

--- a/static/app/views/insights/common/utils/useAddToSpanDashboard.ts
+++ b/static/app/views/insights/common/utils/useAddToSpanDashboard.ts
@@ -9,7 +9,6 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useRouter from 'sentry/utils/useRouter';
 import {
   DashboardWidgetSource,
   DEFAULT_WIDGET_NAME,
@@ -35,7 +34,6 @@ export const useAddToSpanDashboard = () => {
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const location = useLocation();
-  const router = useRouter();
 
   const addToSpanDashboard = useCallback(
     ({
@@ -78,12 +76,11 @@ export const useAddToSpanDashboard = () => {
         yAxis: yAxes,
         query: discoverQuery,
         location,
-        router,
         source: DashboardWidgetSource.INSIGHTS,
         widgetType: WidgetType.SPANS,
       });
     },
-    [organization, selection, location, router]
+    [organization, selection, location]
   );
 
   return {


### PR DESCRIPTION
That modal already _has_ `useNavigate` in it, but doesn't use it for the navigation. I spotted this and wanted to fix it. Turns out, a _lot_ of code is only there to pass around a `router` for this modal, so I threw out a lot of that.
