### PR TITLE
chore(preprod): Slightly improve error UI for size upload failure case

### DIFF
--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -71,8 +71,9 @@ export default function BuildDetails() {
           <BuildError
             title="Build details unavailable"
             message={
-              buildDetailsQuery.error?.message ||
-              'Unable to load build details for this artifact' // TODO(preprod): translate once we have a final design
+              typeof buildDetailsQuery.error?.responseJSON?.error === 'string'
+                ? buildDetailsQuery.error?.responseJSON.error
+                : 'Unable to load build details for this artifact' // TODO(preprod): translate once we have a final design
             }
           />
         </Layout.Page>


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/EME-395/improve-error-handling-for-failed-upload-case-not-size-error-but

We should show the message related to the error for the user's improved comprehension

Before:
<img width="1395" height="1198" alt="Screenshot 2025-10-07 at 9 26 10 AM" src="https://github.com/user-attachments/assets/9c12f1a5-4166-4539-a203-995785da8716" />

After:
<img width="1276" height="1116" alt="image" src="https://github.com/user-attachments/assets/7025d74a-9e34-47f6-bb41-3754cbb03ca0" />
