### PR TITLE
chore(chartcuterie): Add css file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ node_modules
 /src/sentry/static/sentry/rest_framework/
 /src/sentry/integration-docs
 /src/sentry/loader/_registry.json
-/config/chartcuterie/config.js*
+/config/chartcuterie/config.*
 /config/*.pem
 /tests/apidocs/openapi-derefed.json
 /tests/apidocs/openapi-deprecated.json


### PR DESCRIPTION
There's a `config.css` file that chartcuterie builds that we need to add to .gitignore