### PR TITLE
fix(issues): include assigned issues in suggested owner search

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -189,7 +189,6 @@ def assigned_or_suggested_filter(
         query |= Q(
             **{
                 f"{field_filter}__in": GroupOwner.objects.filter(
-                    Q(group__assignee_set__isnull=True),
                     team__in=teams,
                     project_id__in=project_ids,
                     organization_id=organization_id,
@@ -207,7 +206,6 @@ def assigned_or_suggested_filter(
             **{
                 f"{field_filter}__in": GroupOwner.objects.filter(
                     query_ids,
-                    group__assignee_set__isnull=True,
                     project_id__in=[p.id for p in projects],
                     organization_id=organization_id,
                 )

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -280,13 +280,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         inbox_4 = add_group_to_inbox(owned_me_assigned_to_other, GroupInboxReason.NEW)
         inbox_4.update(date_added=inbox_1.date_added - timedelta(hours=1))
         GroupAssignee.objects.assign(owned_me_assigned_to_other, other_user)
-        GroupOwner.objects.create(
-            group=owned_me_assigned_to_other,
-            project=self.project,
-            organization=self.organization,
-            type=GroupOwnerType.OWNERSHIP_RULE.value,
-            user_id=self.user.id,
-        )
 
         unowned_assigned_to_other = self.store_event(
             data={

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -1371,7 +1371,8 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert int(response.data[2]["id"]) == event2.group.id
         assert int(response.data[3]["id"]) == assigned_event.group.id
 
-        # Assign group to another user and now it shouldn't show up in owner search for this team.
+        # Assign group to another user
+        # Since the old owner is still a suggested owner, it should show up in assigned_or_suggested search for this team.
         GroupAssignee.objects.create(
             group=event.group,
             project=event.group.project,
@@ -1381,7 +1382,8 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             sort_by="date", limit=10, query=f"assigned_or_suggested:#{self.team.slug}"
         )
         assert response.status_code == 200
-        assert len(response.data) == 0
+        assert len(response.data) == 1
+        assert int(response.data[0]["id"]) == event.group.id
 
     def test_semver(self) -> None:
         release_1 = self.create_release(version="test@1.2.3")

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1306,7 +1306,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             [group, group1, group2, assigned_group, assigned_to_other_group],
         )
 
-        GroupOwner.objects.create(
+        other_group_suggested_owner = GroupOwner.objects.create(
             group=assigned_to_other_group,
             project=self.project,
             organization=self.organization,
@@ -1328,7 +1328,8 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             [group1, group2, assigned_group],
         )
 
-        # Because assigned_to_other_event is assigned to self.other_user, it should not show up in assigned_or_suggested search for anyone but self.other_user. (aka. they are now the only owner)
+        # Issue is assigned to another user
+        # Since the original owner is still a suggested owner, issue should show up in assigned_or_suggested search for the original user.
         other_user = self.create_user("other@user.com", is_superuser=False)
         GroupAssignee.objects.create(
             group=assigned_to_other_group,
@@ -1337,7 +1338,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         self.run_test_query(
             "assigned_or_suggested:[me]",
-            [group],
+            [group, assigned_to_other_group],
             [group1, group2, assigned_group, assigned_to_other_group],
         )
 
@@ -1352,8 +1353,10 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         self.run_test_query(
             f"assigned_or_suggested:[{self.user.email}]",
-            [assigned_group, group],
+            [assigned_group, group, assigned_to_other_group],
         )
+
+        other_group_suggested_owner.delete()
 
         GroupOwner.objects.create(
             group=group,

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1470,7 +1470,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             user=self.user,
         )
 
-        GroupOwner.objects.create(
+        other_group_suggested_owner = GroupOwner.objects.create(
             group=assigned_to_other_group,
             project=self.project,
             organization=self.organization,
@@ -1503,7 +1503,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             user=self.user,
         )
 
-        # Because assigned_to_other_event is assigned to self.other_user, it should not show up in assigned_or_suggested search for anyone but self.other_user. (aka. they are now the only owner)
+        # Since the original owner is still a suggested owner, issue should show up in assigned_or_suggested search for the original user.
         other_user = self.create_user("other@user.com", is_superuser=False)
         GroupAssignee.objects.create(
             group=assigned_to_other_group,
@@ -1513,8 +1513,8 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
 
         self.run_test_query(
             "assigned_or_suggested:me",
-            [group],
-            [group1, group2, assigned_group, my_team_group, assigned_to_other_group],
+            [group, assigned_to_other_group],
+            [group1, group2, assigned_group, my_team_group],
             user=self.user,
         )
         self.run_test_query(
@@ -1529,6 +1529,8 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             [group, group1, group2, assigned_group, my_team_group],
             user=self.user,
         )
+
+        other_group_suggested_owner.delete()
 
         GroupAssignee.objects.create(
             group=assigned_group, project=self.project, user_id=self.user.id

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1630,7 +1630,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             user=self.user,
         )
 
-        GroupOwner.objects.create(
+        other_group_suggested_owner = GroupOwner.objects.create(
             group=assigned_to_other_group,
             project=self.project,
             organization=self.organization,
@@ -1669,7 +1669,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             user=self.user,
         )
 
-        # Because assigned_to_other_event is assigned to self.other_user, it should not show up in assigned_or_suggested search for anyone but self.other_user. (aka. they are now the only owner)
+        # Since the original owner is still a suggested owner, issue should show up in assigned_or_suggested search for the original user.
         other_user = self.create_user("other@user.com", is_superuser=False)
         GroupAssignee.objects.create(
             group=assigned_to_other_group,
@@ -1679,8 +1679,8 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
 
         self.run_test_query(
             "assigned_or_suggested:[me]",
-            [group],
-            [group1, group2, assigned_group, my_team_group, assigned_to_other_group],
+            [group, assigned_to_other_group],
+            [group1, group2, assigned_group, my_team_group],
             user=self.user,
         )
         self.run_test_query(
@@ -1691,8 +1691,8 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         self.run_test_query(
             "assigned_or_suggested:[me, my_teams]",
-            [group, my_team_group],
-            [group1, group2, assigned_group, assigned_to_other_group],
+            [group, my_team_group, assigned_to_other_group],
+            [group1, group2, assigned_group],
             user=self.user,
         )
         self.run_test_query(
@@ -1708,8 +1708,8 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
 
         self.run_test_query(
             f"assigned_or_suggested:[{self.user.email}]",
-            [assigned_group, group],
-            [group1, group2, my_team_group, assigned_to_other_group],
+            [assigned_group, group, assigned_to_other_group],
+            [group1, group2, my_team_group],
             user=self.user,
         )
 
@@ -1730,8 +1730,8 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         self.run_test_query(
             "assigned_or_suggested:[me, none]",
-            [group, group1, group2, assigned_group],
-            [my_team_group, assigned_to_other_group],
+            [group, group1, group2, assigned_group, assigned_to_other_group],
+            [my_team_group],
             user=self.user,
         )
         self.run_test_query(
@@ -1742,10 +1742,12 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         self.run_test_query(
             "assigned_or_suggested:[me, my_teams, none]",
-            [group, group1, group2, my_team_group, assigned_group],
-            [assigned_to_other_group],
+            [group, group1, group2, my_team_group, assigned_group, assigned_to_other_group],
+            [],
             user=self.user,
         )
+
+        other_group_suggested_owner.delete()
 
         not_me = self.create_user(email="notme@sentry.io")
         GroupOwner.objects.create(

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1339,7 +1339,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         self.run_test_query(
             "assigned_or_suggested:[me]",
             [group, assigned_to_other_group],
-            [group1, group2, assigned_group, assigned_to_other_group],
+            [group1, group2, assigned_group],
         )
 
         self.run_test_query(


### PR DESCRIPTION
Issues with a user/team as a suggested assignee should show up in `assigned_or_suggested` searches, even if they have already been assigned to a different user/team.

See https://github.com/getsentry/sentry/issues/40485

Fixes https://linear.app/getsentry/issue/RTC-1172/assigned-or-suggestedteam-doesnt-match-assigned-issues