### PR TITLE
fix(TimeRangeSelector): Don't use custom date filter if not applied

### DIFF
--- a/static/app/components/timeRangeSelector/index.tsx
+++ b/static/app/components/timeRangeSelector/index.tsx
@@ -350,7 +350,6 @@ export function TimeRangeSelector({
             setHasChanges(false);
             setSearch('');
           }}
-          onInteractOutside={commitChanges}
           onKeyDown={e => e.key === 'Escape' && commitChanges()}
           trigger={
             trigger ??


### PR DESCRIPTION
Fix for #59814: Filter should be applied when clicked in Apply button in case of Custom date filter.

`TimeRangeSelector` was set to apply `onInteractOutside`, removed that
