### PR TITLE
ref(grouping): Remove separate built-in fingerprint class

### DIFF
--- a/src/sentry/grouping/__init__.py
+++ b/src/sentry/grouping/__init__.py
@@ -60,10 +60,6 @@ Variants
     by the SDK.  If the special `{{ default }}` value is used then this
     variant is not used.
 
-`BuiltInFingerprintVariant`:
-    Same as the custom fingerprint variant but produced by pre-defined
-    built-in rules.  This is used for server-side fingerprinting.
-
 `SaltedComponentVariant`:
     This variant is used when the server or client produces a fingerprint
     that refers (with the special `{{ default }}` value) to the default

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -464,7 +464,7 @@ def _get_fingerprint_hashing_metadata(
             if not matched_rule
             else (
                 "server_builtin_rule"
-                if contributing_variant.type == "built_in_fingerprint"
+                if contributing_variant.key == "built_in_fingerprint"
                 else "server_custom_rule"
             )
         ),

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -196,7 +196,11 @@ class CustomFingerprintVariant(BaseVariant):
 
     @property
     def description(self) -> str:
-        return "custom fingerprint"
+        return "Sentry defined fingerprint" if self.is_built_in else "custom fingerprint"
+
+    @property
+    def key(self) -> str:
+        return "built_in_fingerprint" if self.is_built_in else "custom_fingerprint"
 
     def get_hash(self) -> str | None:
         return hash_from_values(self.values)

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -209,16 +209,6 @@ class CustomFingerprintVariant(BaseVariant):
         return expose_fingerprint_dict(self.values, self.fingerprint_info)
 
 
-class BuiltInFingerprintVariant(CustomFingerprintVariant):
-    """A built-in, Sentry-defined fingerprint."""
-
-    type = "built_in_fingerprint"
-
-    @property
-    def description(self) -> str:
-        return "Sentry defined fingerprint"
-
-
 class SaltedComponentVariant(ComponentVariant):
     """A salted version of a component."""
 

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -192,6 +192,7 @@ class CustomFingerprintVariant(BaseVariant):
     def __init__(self, fingerprint: list[str], fingerprint_info: FingerprintInfo):
         self.values = fingerprint
         self.fingerprint_info = fingerprint_info
+        self.is_built_in = fingerprint_info.get("matched_rule", {}).get("is_builtin", False)
 
     @property
     def description(self) -> str:

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -287,7 +287,7 @@ class VariantsByDescriptor(TypedDict, total=False):
     system: ComponentVariant
     app: ComponentVariant
     custom_fingerprint: CustomFingerprintVariant
-    built_in_fingerprint: BuiltInFingerprintVariant
+    built_in_fingerprint: CustomFingerprintVariant
     checksum: ChecksumVariant
     hashed_checksum: HashedChecksumVariant
     default: ComponentVariant

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -384,8 +384,16 @@ def dump_variant(
     # Note that this prints `__dict__`, not `as_dict()`, so if something seems missing, that's
     # probably why
     for key, value in sorted(variant.__dict__.items()):
-        if key in ["config", "hash", "contributing_component", "variant_name", "hint"]:
-            # We do not want to dump the config, and we've already dumped the others
+        if key in [
+            "config",
+            "is_built_in",
+            "hash",
+            "contributing_component",
+            "variant_name",
+            "hint",
+        ]:
+            # We do not want to dump the config, the built-in-ness is included elsewhere, and we've
+            # already dumped the others
             continue
 
         if isinstance(value, BaseGroupingComponent):

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.833830+00:00'
+created: '2025-10-06T22:48:50.594615+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -116,7 +116,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "hint": null,
     "key": "built_in_fingerprint",
     "matched_rule": "family:\"javascript\" type:\"ChunkLoadError\" -> \"chunkloaderror\"",
-    "type": "built_in_fingerprint",
+    "type": "custom_fingerprint",
     "values": [
       "chunkloaderror"
     ]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.815912+00:00'
+created: '2025-10-06T22:48:50.578017+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -120,7 +120,7 @@ source: tests/sentry/grouping/test_grouping_info.py
     "hint": null,
     "key": "built_in_fingerprint",
     "matched_rule": "family:\"javascript\" type:\"ChunkLoadError\" -> \"chunkloaderror\"",
-    "type": "built_in_fingerprint",
+    "type": "custom_fingerprint",
     "values": [
       "chunkloaderror"
     ]

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-06T17:30:32.851483+00:00'
+created: '2025-10-06T22:48:22.626811+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,7 +23,7 @@ variants:
     hint: null
     key: built_in_fingerprint
     matched_rule: family:"javascript" type:"ChunkLoadError" -> "chunkloaderror"
-    type: built_in_fingerprint
+    type: custom_fingerprint
     values:
     - chunkloaderror
   system:

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -569,7 +569,7 @@ class BuiltInFingerprintingTest(TestCase):
 
         assert variants["built_in_fingerprint"].as_dict() == {
             "hash": mock.ANY,  # ignore hash as it can change for unrelated reasons
-            "type": "built_in_fingerprint",
+            "type": "custom_fingerprint",
             "key": "built_in_fingerprint",
             "contributes": True,
             "description": "Sentry defined fingerprint",


### PR DESCRIPTION
This is a small simplification of the grouping code, eliminating the separate `BuiltInFingerprint` class since it exists purely to automatically set a single value (the variant's `description` property, which we're in the process of moving away from). While it's true that this will change the grouping info data we send to the front end (it will switch the `type` from `built_in_fingerprint` to `custom_fingerprint`), this won't actually change anything, because the two types are handled identically:

https://github.com/getsentry/sentry/blob/1253037954abbe40d4cfd2969de36068980275fe/static/app/components/events/groupingInfo/groupingVariant.tsx#L106-L111

Once this PR is deployed, a follow-up will remove the built-in fingerprint handling there.