### PR TITLE
fix(spans-migration): handle incomplete fields array in dashboards translation

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -125,6 +125,8 @@ class DashboardWidgetSerializer(Serializer):
                 q_index,
                 transaction_query["name"],
                 transaction_query["fields"],
+                transaction_query["columns"],
+                transaction_query["aggregates"],
                 transaction_query["orderby"],
                 transaction_query["conditions"],
                 transaction_query["fieldAliases"],
@@ -230,7 +232,6 @@ class DashboardWidgetSerializer(Serializer):
                 sort = spans_query.orderby
 
             # making the visualize as json strings because urlencode does not format this properly
-            # also JSON.stringify doesn't have spaces so we need to remove them
             if len(y_axes) > 0:
                 visualize = [
                     json.dumps(

--- a/src/sentry/explore/translation/dashboards_translation.py
+++ b/src/sentry/explore/translation/dashboards_translation.py
@@ -33,16 +33,26 @@ def translate_dashboard_widget_queries(
     q_index,
     name,
     original_fields,
+    original_columns,
+    original_aggregates,
     orderby,
     conditions,
     field_aliases,
     is_hidden,
     selected_aggregate,
 ):
-    equations = [field for field in original_fields if is_equation(field)]
-    other_fields = [field for field in original_fields if not is_equation(field)]
+    # some widgets have fields that are not columns + aggregates.
+    # we want to combine all of these into a single list but still preserve order the way we would in the frontend.
+    all_fields = (
+        original_fields
+        + [col for col in original_columns if col not in original_fields]
+        + [agg for agg in original_aggregates if agg not in original_fields]
+    )
 
-    fields_with_orderby = original_fields[:]
+    equations = [field for field in all_fields if is_equation(field)]
+    other_fields = [field for field in all_fields if not is_equation(field)]
+
+    fields_with_orderby = all_fields[:]
     if orderby and is_equation_alias(orderby):
         fields_with_orderby.append(orderby)
 
@@ -72,9 +82,9 @@ def translate_dashboard_widget_queries(
         original_fields[selected_aggregate] if selected_aggregate is not None else None
     )
 
-    col_index = 0
+    field_index = 0
     equation_index = 0
-    for old_index, field in enumerate(original_fields):
+    for old_index, field in enumerate(all_fields):
         is_selected_aggregate = selected_aggregate_field == field
         if field in dropped_cols or field in dropped_equations:
             if is_selected_aggregate:
@@ -90,14 +100,14 @@ def translate_dashboard_widget_queries(
             equation_index += 1
 
         elif is_function_field:
-            new_fields.append(eap_query_parts["selected_columns"][col_index])
-            new_aggregates.append(eap_query_parts["selected_columns"][col_index])
-            col_index += 1
+            new_fields.append(eap_query_parts["selected_columns"][field_index])
+            new_aggregates.append(eap_query_parts["selected_columns"][field_index])
+            field_index += 1
 
         else:
-            new_fields.append(eap_query_parts["selected_columns"][col_index])
-            new_columns.append(eap_query_parts["selected_columns"][col_index])
-            col_index += 1
+            new_fields.append(eap_query_parts["selected_columns"][field_index])
+            new_columns.append(eap_query_parts["selected_columns"][field_index])
+            field_index += 1
 
         if is_selected_aggregate:
             new_selected_aggregate = len(new_fields) - 1
@@ -135,6 +145,8 @@ def translate_dashboard_widget(widget: DashboardWidget) -> DashboardWidget:
     for q_index, query in enumerate(transaction_widget["queries"]):
         name = query.get("name", "")
         original_fields = query.get("fields", [])
+        original_columns = query.get("columns", [])
+        original_aggregates = query.get("aggregates", [])
         orderby = query.get("orderby", "")
         conditions = query.get("conditions", "")
         field_aliases = query.get("fieldAliases", [])
@@ -146,6 +158,8 @@ def translate_dashboard_widget(widget: DashboardWidget) -> DashboardWidget:
             q_index,
             name,
             original_fields,
+            original_columns,
+            original_aggregates,
             orderby,
             conditions,
             field_aliases,

--- a/src/sentry/explore/translation/dashboards_translation.py
+++ b/src/sentry/explore/translation/dashboards_translation.py
@@ -41,6 +41,7 @@ def translate_dashboard_widget_queries(
     is_hidden,
     selected_aggregate,
 ):
+    original_fields_length = len(original_fields)
     # some widgets have fields that are not columns + aggregates.
     # we want to combine all of these into a single list but still preserve order the way we would in the frontend.
     all_fields = (
@@ -100,12 +101,14 @@ def translate_dashboard_widget_queries(
             equation_index += 1
 
         elif is_function_field:
-            new_fields.append(eap_query_parts["selected_columns"][field_index])
+            if old_index < original_fields_length:
+                new_fields.append(eap_query_parts["selected_columns"][field_index])
             new_aggregates.append(eap_query_parts["selected_columns"][field_index])
             field_index += 1
 
         else:
-            new_fields.append(eap_query_parts["selected_columns"][field_index])
+            if old_index < original_fields_length:
+                new_fields.append(eap_query_parts["selected_columns"][field_index])
             new_columns.append(eap_query_parts["selected_columns"][field_index])
             field_index += 1
 

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -570,7 +570,7 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
             ]
             assert params["sort"] == ["-p95(span.duration)"]
             assert params["mode"] == ["aggregate"]
-            assert params["field"] == ["query.dataset"]
+            assert params["field"].sort() == ["query.dataset", "span.duration"].sort()
             assert params["aggregateField"] == [
                 '{"groupBy":"query.dataset"}',
                 '{"yAxes":["p95(span.duration)"],"chartType":1}',

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -533,6 +533,49 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
             assert params["field"].sort() == ["id", "transaction"].sort()
             assert "aggregateField" not in params
 
+    def test_explore_url_for_deformed_widget(self) -> None:
+        with self.feature("organizations:transaction-widget-deprecation-explore-view"):
+            dashboard_deprecation = Dashboard.objects.create(
+                title="Dashboard With Transaction Widget",
+                created_by_id=self.user.id,
+                organization=self.organization,
+            )
+            widget_deprecation = DashboardWidget.objects.create(
+                dashboard=dashboard_deprecation,
+                title="line widget",
+                display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+                widget_type=DashboardWidgetTypes.TRANSACTION_LIKE,
+                interval="1d",
+                detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+            )
+
+            DashboardWidgetQuery.objects.create(
+                widget=widget_deprecation,
+                fields=["query.dataset"],
+                columns=["query.dataset"],
+                aggregates=["p95(transaction.duration)"],
+                orderby="-p95(transaction.duration)",
+                conditions="transaction:/api/0/organizations/{organization_id_or_slug}/events/",
+                order=0,
+            )
+
+            response = self.do_request("get", self.url(dashboard_deprecation.id))
+            assert response.status_code == 200
+            explore_url = response.data["widgets"][0]["exploreUrls"][0]
+            assert "http://testserver/explore/traces/" in explore_url
+
+            params = dict(parse_qs(urlsplit(response.data["widgets"][0]["exploreUrls"][0]).query))
+            assert params["query"] == [
+                "(transaction:/api/0/organizations/{organization_id_or_slug}/events/) AND is_transaction:1"
+            ]
+            assert params["sort"] == ["-p95(span.duration)"]
+            assert params["mode"] == ["aggregate"]
+            assert params["field"] == ["query.dataset"]
+            assert params["aggregateField"] == [
+                '{"groupBy":"query.dataset"}',
+                '{"yAxes":["p95(span.duration)"],"chartType":1}',
+            ]
+
 
 class OrganizationDashboardDetailsDeleteTest(OrganizationDashboardDetailsTestCase):
     def test_delete(self) -> None:

--- a/tests/sentry/explore/translation/test_dashboards_translation.py
+++ b/tests/sentry/explore/translation/test_dashboards_translation.py
@@ -696,7 +696,7 @@ class DashboardRestoreTransactionWidgetTestCase(TestCase):
         assert new_query.widget_id == transaction_widget.id
         assert new_query.order == 0
 
-        assert new_query.fields == ["release", "count(span.duration)", "count_unique(user)"]
+        assert new_query.fields == ["release"]
         assert new_query.conditions == "(transaction:foo) AND is_transaction:1"
         assert new_query.aggregates == ["count(span.duration)", "count_unique(user)"]
         assert new_query.columns == ["release"]


### PR DESCRIPTION
Some widgets don't have all the fields in the `fields` param (sigh). In order to ensure that we have a correctly formatted fields array i've appended the missing columns/aggregates that are in the `columns` or `aggregates` param. This way we can ensure that all of the widgets are correctly translated and aren't missing any fields. 
