### PR TITLE
fix(relocations) Ignore str/int deltas for useroptions

### DIFF
--- a/src/sentry/backup/comparators.py
+++ b/src/sentry/backup/comparators.py
@@ -592,6 +592,42 @@ class EqualOrRemovedComparator(JSONScrubbingComparator):
         return findings
 
 
+class OptionValueComparator(JSONScrubbingComparator):
+    """
+    Some exports from earlier sentry versions encode simple option values
+    as string integers, while newer versions of sentry encode those values as string.
+
+    If either side is a string, cast both to strings and compare.
+    """
+
+    def compare(self, on: InstanceID, left: Any, right: Any) -> list[ComparatorFinding]:
+        findings = []
+        fields = sorted(self.fields)
+        for f in fields:
+            left_field = left["fields"].get(f)
+            right_field = right["fields"].get(f)
+
+            if left_field == right_field:
+                continue
+
+            if isinstance(left_field, str):
+                right_field = str(right_field)
+            elif isinstance(right_field, str):
+                left_field = str(left_field)
+
+            if left_field != right_field:
+                findings.append(
+                    ComparatorFinding(
+                        kind=self.get_kind(),
+                        on=on,
+                        left_pk=left["pk"],
+                        right_pk=right["pk"],
+                        reason=f"""the left value ({left_field}) of `{f}` was not equal to the right value ({right_field})""",
+                    )
+                )
+        return findings
+
+
 class SecretHexComparator(RegexComparator):
     """Certain 16-byte hexadecimal API keys are regenerated during an import operation."""
 
@@ -881,6 +917,7 @@ def get_default_comparators() -> dict[str, list[JSONScrubbingComparator]]:
                 # we only really want to compare the IP address itself.
                 IgnoredComparator("country_code", "region_code"),
             ],
+            "sentry.useroption": [OptionValueComparator("value")],
             "sentry.userrole": [DateUpdatedComparator("date_updated")],
             "sentry.userroleuser": [DateUpdatedComparator("date_updated")],
             "workflow_engine.action": [DateUpdatedComparator("date_updated", "date_added")],

--- a/src/sentry/backup/findings.py
+++ b/src/sentry/backup/findings.py
@@ -133,6 +133,9 @@ class ComparatorFindingKind(FindingKind):
     # present or `None`.
     UserPasswordObfuscatingComparatorExistenceCheck = auto()
 
+    # Option values
+    OptionValueComparator = auto()
+
 
 @dataclass(frozen=True)
 class Finding(ABC):

--- a/tests/sentry/backup/test_comparators.py
+++ b/tests/sentry/backup/test_comparators.py
@@ -12,6 +12,7 @@ from sentry.backup.comparators import (
     ForeignKeyComparator,
     HashObfuscatingComparator,
     IgnoredComparator,
+    OptionValueComparator,
     ScrubbedData,
     SecretHexComparator,
     SubscriptionIDComparator,
@@ -2165,3 +2166,94 @@ def test_good_user_password_obfuscating_comparator_scrubbed_short() -> None:
 
     assert right["scrubbed"]
     assert right["scrubbed"]["UserPasswordObfuscatingComparator::password"] == ["..."]
+
+
+def test_good_option_value_comparator() -> None:
+    cmp = OptionValueComparator("value")
+    id = InstanceID("sentry.test", 0)
+
+    # Ensure that int and str-int are reasonably equivalent.
+    left: Any = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "value": 1,
+        },
+    }
+    right: Any = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "value": "1",
+        },
+    }
+    assert not cmp.compare(id, left, right)
+
+    # Ensure that int and int are equivalent.
+    left: Any = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "value": 1,
+        },
+    }
+    right: Any = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "value": 1,
+        },
+    }
+    assert not cmp.compare(id, left, right)
+
+    # Ensure that str and str are equivalent.
+    left: Any = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "value": "1",
+        },
+    }
+    right: Any = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "value": "1",
+        },
+    }
+    assert not cmp.compare(id, left, right)
+
+
+def test_bad_option_value_comparator() -> None:
+    cmp = OptionValueComparator("value")
+    id = InstanceID("sentry.test", 0)
+    # Ensure that str + bool are not the same
+    left: Any = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "value": True,
+        },
+    }
+    right: Any = {
+        "model": "test",
+        "ordinal": 1,
+        "pk": 1,
+        "fields": {
+            "value": "1",
+        },
+    }
+    findings = cmp.compare(id, left, right)
+    assert len(findings) == 1
+    assert findings[0]
+    assert findings[0].kind == ComparatorFindingKind.OptionValueComparator
+    assert findings[0].left_pk
+    assert findings[0].right_pk
+    assert "(True) of `value` was not equal to the right value (1)" in findings[0].reason

--- a/tests/sentry/backup/test_comparators.py
+++ b/tests/sentry/backup/test_comparators.py
@@ -2192,7 +2192,7 @@ def test_good_option_value_comparator() -> None:
     assert not cmp.compare(id, left, right)
 
     # Ensure that int and int are equivalent.
-    left: Any = {
+    left = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -2200,7 +2200,7 @@ def test_good_option_value_comparator() -> None:
             "value": 1,
         },
     }
-    right: Any = {
+    right = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -2211,7 +2211,7 @@ def test_good_option_value_comparator() -> None:
     assert not cmp.compare(id, left, right)
 
     # Ensure that str and str are equivalent.
-    left: Any = {
+    left = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,
@@ -2219,7 +2219,7 @@ def test_good_option_value_comparator() -> None:
             "value": "1",
         },
     }
-    right: Any = {
+    right = {
         "model": "test",
         "ordinal": 1,
         "pk": 1,


### PR DESCRIPTION
I think the recent changes to JSONField have led to imports failing from previous versions of sentry as option values are `int` on one side but `str` on the other. By relaxing the comparision between option values we should be able to process imports.
