### PR TITLE
feat(ui): Support adding filter value lists to MutableSearch

### DIFF
--- a/static/app/components/searchSyntax/mutableSearch.spec.tsx
+++ b/static/app/components/searchSyntax/mutableSearch.spec.tsx
@@ -336,6 +336,28 @@ describe('MutableSearch', () => {
         `( a:a1 OR a:a2 ) ( b:${WildcardOperators.CONTAINS}b1 OR b:${WildcardOperators.CONTAINS}b2 ) ( c:${WildcardOperators.STARTS_WITH}c1 OR c:${WildcardOperators.STARTS_WITH}c2 ) ( d:${WildcardOperators.ENDS_WITH}d1 OR d:${WildcardOperators.ENDS_WITH}d2 )`
       );
     });
+
+    it('addFilterValueList', () => {
+      const results = new MutableSearch('');
+
+      results.addFilterValueList('a', ['a1', 'a2']);
+      expect(results.formatString()).toBe('a:[a1,a2]');
+
+      results.addContainsFilterValueList('b', ['b1', 'b2']);
+      expect(results.formatString()).toBe(
+        `a:[a1,a2] b:${WildcardOperators.CONTAINS}[b1,b2]`
+      );
+
+      results.addStartsWithFilterValueList('c', ['c1', 'c2']);
+      expect(results.formatString()).toBe(
+        `a:[a1,a2] b:${WildcardOperators.CONTAINS}[b1,b2] c:${WildcardOperators.STARTS_WITH}[c1,c2]`
+      );
+
+      results.addEndsWithFilterValueList('d', ['d1', 'd2']);
+      expect(results.formatString()).toBe(
+        `a:[a1,a2] b:${WildcardOperators.CONTAINS}[b1,b2] c:${WildcardOperators.STARTS_WITH}[c1,c2] d:${WildcardOperators.ENDS_WITH}[d1,d2]`
+      );
+    });
   });
 
   describe('formatString', () => {

--- a/static/app/components/searchSyntax/mutableSearch.tsx
+++ b/static/app/components/searchSyntax/mutableSearch.tsx
@@ -628,6 +628,63 @@ export class MutableSearch {
     return this;
   }
 
+  private _addFilterValueList(
+    key: string,
+    values: string[],
+    shouldEscape = true,
+    operator:
+      | ''
+      | WildcardOperators.CONTAINS
+      | WildcardOperators.STARTS_WITH
+      | WildcardOperators.ENDS_WITH
+  ): this {
+    const escapedValues = values.map(value => {
+      const escaped = shouldEscape ? escapeFilterValue(value) : value;
+      return quoteIfNeeded(escaped);
+    });
+
+    this.tokens.push({
+      type: TokenType.FILTER,
+      key,
+      value: `${operator}[${escapedValues.join(',')}]`,
+      listValues: escapedValues,
+      text: `${key}:${operator}[${escapedValues.join(',')}]`,
+      wildcard: operator || undefined,
+    });
+    return this;
+  }
+
+  addFilterValueList(key: string, values: string[], shouldEscape = true): this {
+    return this._addFilterValueList(key, values, shouldEscape, '');
+  }
+
+  addContainsFilterValueList(key: string, values: string[], shouldEscape = true): this {
+    return this._addFilterValueList(
+      key,
+      values,
+      shouldEscape,
+      WildcardOperators.CONTAINS
+    );
+  }
+
+  addStartsWithFilterValueList(key: string, values: string[], shouldEscape = true): this {
+    return this._addFilterValueList(
+      key,
+      values,
+      shouldEscape,
+      WildcardOperators.STARTS_WITH
+    );
+  }
+
+  addEndsWithFilterValueList(key: string, values: string[], shouldEscape = true): this {
+    return this._addFilterValueList(
+      key,
+      values,
+      shouldEscape,
+      WildcardOperators.ENDS_WITH
+    );
+  }
+
   getFilters(): Record<string, string[]> {
     return this.tokens.reduce<Record<string, string[]>>((acc, t) => {
       if (!isFilterToken(t)) {


### PR DESCRIPTION
- Adds a new method in MutableSearch for adding filter value lists
- Supports wildcard operators that can apply to the entire filter value list
