### PR TITLE
feat(notif-platform): Implement discord notification CLI

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -607,10 +607,9 @@ register("slack.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 # signing-secret is preferred, but need to keep verification-token for apps that use it
 register("slack.verification-token", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("slack.signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
-register(
-    "slack.default-workspace", default="example-workspace-name", flags=FLAG_AUTOMATOR_MODIFIABLE
-)
-register("slack.default-channel", default="general", flags=FLAG_AUTOMATOR_MODIFIABLE)
+# Debug values are used for the Notification Debug CLI
+register("slack.debug-workspace", flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("slack.debug-channel", flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Issue Summary on Alerts (timeout in seconds)
 register("alerts.issue_summary_timeout", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
@@ -741,6 +740,9 @@ register("discord.application-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_M
 register("discord.public-key", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 register("discord.bot-token", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("discord.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
+# Debug values are used for the Notification Debug CLI
+register("discord.debug-server", flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("discord.debug-channel", flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # AWS Lambda Integration
 register("aws-lambda.access-key-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/runner/commands/notifications.py
+++ b/src/sentry/runner/commands/notifications.py
@@ -188,6 +188,7 @@ def send_discord(
 
     configure()
 
+    from sentry.constants import ObjectStatus
     from sentry.integrations.models.integration import Integration
     from sentry.integrations.types import IntegrationProviderSlug
     from sentry.models.organizationmapping import OrganizationMapping
@@ -216,7 +217,9 @@ def send_discord(
 
     try:
         integration = Integration.objects.get(
-            provider=IntegrationProviderSlug.DISCORD.value, name=integration_name
+            provider=IntegrationProviderSlug.DISCORD.value,
+            name=integration_name,
+            status=ObjectStatus.ACTIVE,
         )
     except Integration.DoesNotExist:
         click.echo(f"Discord integration '{integration_name}' not found!")

--- a/src/sentry/runner/commands/notifications.py
+++ b/src/sentry/runner/commands/notifications.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-
-from __future__ import annotations
-
 from typing import Any
 
 import click
@@ -28,7 +25,7 @@ def send_cmd() -> None:
     help="Registered template source (see `sentry notifications list registry`)",
     default="error-alert-service",
 )
-@click.option("-t", "--target", help="Recipient email address", default="user@example.com")
+@click.option("-e", "--email", help="Recipient email address", default="user@example.com")
 def send_email(source: str, target: str) -> None:
     """
     Send an email notification.
@@ -78,7 +75,7 @@ def send_email(source: str, target: str) -> None:
 )
 @click.option("-o", "--organization_slug", help="Organization slug")
 @click.option("-i", "--integration_name", help="Slack integration name", default=None)
-@click.option("-t", "--channel_name", help="Slack channel name", default=None)
+@click.option("-c", "--channel_name", help="Slack channel name", default=None)
 def send_slack(
     source: str, organization_slug: str, integration_name: str | None, channel_name: str | None
 ) -> None:
@@ -109,11 +106,11 @@ def send_slack(
         click.echo(f"Organization '{organization_slug}' not found!")
         return
 
-    integration_name = integration_name or options.get("slack.default-workspace")
+    integration_name = integration_name or options.get("slack.debug-workspace")
     if integration_name is None or integration_name == "":
         click.echo(
             "\nThis command requires a slack integration name."
-            "\nProvide it with the `-i` flag or by setting `slack.default-workspace` in .sentry/config.yml."
+            "\nProvide it with the `-i` flag or by setting `slack.debug-workspace` in .sentry/config.yml."
             f"\nBrowse the local integrations with `sentry notifications list integrations -o {organization_slug}`."
         )
         return
@@ -128,11 +125,11 @@ def send_slack(
         click.echo(f"Slack integration '{integration_name}' not found!")
         return
 
-    channel_name = channel_name or options.get("slack.default-channel")
+    channel_name = channel_name or options.get("slack.debug-channel")
     if channel_name is None or channel_name == "":
         click.echo(
             "\nThis command requires a slack channel name."
-            "\nProvide it with the `-t` flag or by setting `slack.default-channel` in .sentry/config.yml."
+            "\nProvide it with the `-c` flag or by setting `slack.debug-channel` in .sentry/config.yml."
         )
         return
 
@@ -176,7 +173,7 @@ def send_msteams() -> None:
 )
 @click.option("-o", "--organization_slug", help="Organization slug", required=True)
 @click.option("-i", "--integration_name", help="Discord integration name", default=None)
-@click.option("-t", "--channel_id", help="Discord channel ID", default=None)
+@click.option("-c", "--channel_id", help="Discord channel ID", default=None)
 def send_discord(
     source: str,
     organization_slug: str,
@@ -229,7 +226,7 @@ def send_discord(
     if channel_id is None or channel_id == "":
         click.echo(
             "\nThis command requires a discord channel ID."
-            "\nProvide it with the `-t` flag or by setting `discord.debug-channel` in .sentry/config.yml."
+            "\nProvide it with the `-c` flag or by setting `discord.debug-channel` in .sentry/config.yml."
         )
         return
 

--- a/src/sentry/runner/commands/notifications.py
+++ b/src/sentry/runner/commands/notifications.py
@@ -26,7 +26,7 @@ def send_cmd() -> None:
     default="error-alert-service",
 )
 @click.option("-e", "--email", help="Recipient email address", default="user@example.com")
-def send_email(source: str, target: str) -> None:
+def send_email(source: str, email: str) -> None:
     """
     Send an email notification.
     Note: Requires configuring SMTP settings in .sentry/config.yml.
@@ -59,11 +59,11 @@ def send_email(source: str, target: str) -> None:
     email_target = GenericNotificationTarget(
         provider_key=NotificationProviderKey.EMAIL,
         resource_type=NotificationTargetResourceType.EMAIL,
-        resource_id=target,
+        resource_id=email,
     )
     template_cls = template_registry.get(source)
     NotificationService(data=template_cls.example_data).notify(targets=[email_target])
-    click.echo(f"Example '{source}' email sent to {target}.")
+    click.echo(f"Example '{source}' email sent to {email}.")
 
 
 @send_cmd.command("slack")


### PR DESCRIPTION
Implements the discord CLI for the notification platform, and makes some other changes:
- Removes the defaults for slack, changing the options to explicitly call out they are for debugging
- Changes the list-integrations command to a subcommand of list, putting the previous one on `sentry notifications list registry` instead.