### PR TITLE
ref(uptime): Remove all writes to uptime_status field

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -156,7 +156,6 @@ from sentry.types.region import Region, get_local_region, get_region_by_name
 from sentry.types.token import AuthTokenType
 from sentry.uptime.models import (
     IntervalSecondsLiteral,
-    UptimeStatus,
     UptimeSubscription,
     UptimeSubscriptionRegion,
 )
@@ -2091,8 +2090,6 @@ class Factories:
         headers,
         body,
         date_updated: datetime,
-        uptime_status: UptimeStatus,
-        uptime_status_update_date: datetime,
         trace_sampling: bool = False,
     ):
         if url is None:
@@ -2115,8 +2112,6 @@ class Factories:
             headers=headers,
             body=body,
             trace_sampling=trace_sampling,
-            uptime_status=uptime_status,
-            uptime_status_update_date=uptime_status_update_date,
         )
 
     @staticmethod

--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -14,7 +14,6 @@ from sentry.auth.superuser import is_active_superuser
 from sentry.constants import ObjectStatus
 from sentry.models.environment import Environment
 from sentry.uptime.models import (
-    UptimeStatus,
     UptimeSubscription,
     UptimeSubscriptionDataSourceHandler,
     get_audit_log_data,
@@ -453,7 +452,6 @@ class UptimeMonitorDataSourceValidator(BaseDataSourceValidator[UptimeSubscriptio
                 interval_seconds=validated_data["interval_seconds"],
                 timeout_ms=validated_data["timeout_ms"],
                 trace_sampling=validated_data.get("trace_sampling", False),
-                uptime_status=UptimeStatus.OK,
                 method=validated_data.get("method", "GET"),
                 headers=validated_data.get("headers", None),
                 body=validated_data.get("body", None),

--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import override
 
-from django.utils import timezone as django_timezone
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import CheckResult, CheckStatus
 
 from sentry import options
@@ -15,7 +14,7 @@ from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
 from sentry.uptime.endpoints.validators import UptimeDomainCheckFailureValidator
-from sentry.uptime.models import UptimeStatus, UptimeSubscription
+from sentry.uptime.models import UptimeSubscription
 from sentry.uptime.subscriptions.subscriptions import build_fingerprint
 from sentry.uptime.types import GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE, UptimeMonitorMode
 from sentry.utils import metrics
@@ -151,19 +150,6 @@ class UptimeDetectorHandler(StatefulDetectorHandler[UptimePacketValue, CheckStat
         host_provider_enabled = host_provider_id not in restricted_host_provider_ids
 
         issue_creation_allowed = issue_creation_enabled and host_provider_enabled
-
-        # XXX(epurkhiser): We currently are duplicating the detector state onto
-        # the uptime_subscription when the detector changes state. Once we stop
-        # using this field we can drop this update logic.
-        if evaluation.priority == DetectorPriorityLevel.OK:
-            uptime_status = UptimeStatus.OK
-        elif evaluation.priority != DetectorPriorityLevel.OK:
-            uptime_status = UptimeStatus.FAILED
-
-        uptime_subscription.update(
-            uptime_status=uptime_status,
-            uptime_status_update_date=django_timezone.now(),
-        )
 
         if not host_provider_enabled:
             metrics.incr(

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -19,7 +19,6 @@ from sentry.quotas.base import SeatAssignmentResult
 from sentry.types.actor import Actor
 from sentry.uptime.detectors.url_extraction import extract_domain_parts
 from sentry.uptime.models import (
-    UptimeStatus,
     UptimeSubscription,
     UptimeSubscriptionRegion,
     get_uptime_subscription,
@@ -128,7 +127,6 @@ def create_uptime_subscription(
     headers: Sequence[tuple[str, str]] | None = None,
     body: str | None = None,
     trace_sampling: bool = False,
-    uptime_status: UptimeStatus = UptimeStatus.OK,
 ) -> UptimeSubscription:
     """
     Creates a new uptime subscription. This creates the row in postgres, and fires a task that will send the config
@@ -152,7 +150,6 @@ def create_uptime_subscription(
         headers=headers,  # type: ignore[misc]
         body=body,
         trace_sampling=trace_sampling,
-        uptime_status=uptime_status,
     )
 
     # Associate active regions with this subscription
@@ -280,7 +277,6 @@ def create_uptime_detector(
             headers=headers,
             body=body,
             trace_sampling=trace_sampling,
-            uptime_status=UptimeStatus.OK,
         )
         owner_user_id = None
         owner_team_id = None

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -12,8 +12,8 @@ from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.types.actor import Actor
-from sentry.uptime.models import UptimeStatus
 from sentry.uptime.types import UptimeMonitorMode
+from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.incidents.endpoints.serializers.test_alert_rule import BaseAlertRuleSerializerTest
 
 
@@ -998,9 +998,10 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             alert_rule_trigger=trigger3,
             status=TriggerStatus.ACTIVE.value,
         )
+
         uptime_detector = self.create_uptime_detector()
         failed_uptime_detector = self.create_uptime_detector(
-            uptime_status=UptimeStatus.FAILED,
+            detector_state=DetectorPriorityLevel.HIGH,
         )
         ok_cron_monitor = self.create_monitor(
             name="OK Monitor",

--- a/tests/sentry/uptime/endpoints/test_detector.py
+++ b/tests/sentry/uptime/endpoints/test_detector.py
@@ -3,7 +3,7 @@ from rest_framework import status
 
 from sentry.testutils.cases import APITestCase
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
-from sentry.uptime.models import UptimeStatus, UptimeSubscription, get_uptime_subscription
+from sentry.uptime.models import UptimeSubscription, get_uptime_subscription
 from sentry.uptime.types import UptimeMonitorMode
 from sentry.workflow_engine.models import Detector
 
@@ -54,7 +54,6 @@ class UptimeDetectorBaseTest(APITestCase):
             headers=[],
             body=None,
             trace_sampling=False,
-            uptime_status=UptimeStatus.OK,
         )
 
         self.detector = self.create_uptime_detector(


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/101034

This is the second step in removing the redundant uptime_status field from
UptimeSubscription. All writes to this field have been removed.

Changes:
- Removed uptime_status parameter from create_uptime_subscription
- Removed duplicate state update logic in UptimeDetectorHandler
- Updated test fixtures to accept detector_state parameter instead
- Updated broken_monitor_checker to query DetectorState instead
- All tests updated to use detector_state parameter