### PR TITLE
feat(timeSince): Remove duplicate `TimeSince` render

### DIFF
--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -124,7 +124,6 @@ function TimeSince({
   // Counter to trigger periodic re-computation of relative time
   const [tick, setTick] = useState(0);
 
-  // Memoized relative date calculation - recalculates when props or tick changes
   const relative = useMemo(() => {
     void tick; // Ensure recomputation when tick changes
     return getRelativeDate(date, suffix, prefix, unitStyle);

--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
+import {Fragment, useEffect, useMemo, useState} from 'react';
 import isNumber from 'lodash/isNumber';
 import moment from 'moment-timezone';
 
@@ -120,19 +120,17 @@ function TimeSince({
   ...props
 }: Props) {
   const user = useUser();
-  const tickerRef = useRef<number | undefined>(undefined);
 
-  const computeRelativeDate = useCallback(
-    () => getRelativeDate(date, suffix, prefix, unitStyle),
-    [date, suffix, prefix, unitStyle]
-  );
+  // Counter to trigger periodic re-computation of relative time
+  const [tick, setTick] = useState(0);
 
-  const [relative, setRelative] = useState<string>(computeRelativeDate());
+  // Memoized relative date calculation - recalculates when props or tick changes
+  const relative = useMemo(() => {
+    void tick; // Ensure recomputation when tick changes
+    return getRelativeDate(date, suffix, prefix, unitStyle);
+  }, [date, suffix, prefix, unitStyle, tick]);
 
   useEffect(() => {
-    // Immediately update if props change
-    setRelative(computeRelativeDate());
-
     const interval =
       liveUpdateInterval === 'minute'
         ? 60 * 1000
@@ -141,13 +139,10 @@ function TimeSince({
           : liveUpdateInterval;
 
     // Start a ticker to update the relative time
-    tickerRef.current = window.setInterval(
-      () => setRelative(computeRelativeDate()),
-      interval
-    );
+    const ticker = window.setInterval(() => setTick(prev => prev + 1), interval);
 
-    return () => window.clearInterval(tickerRef.current);
-  }, [liveUpdateInterval, computeRelativeDate]);
+    return () => window.clearInterval(ticker);
+  }, [liveUpdateInterval]);
 
   const dateObj = getDateObj(date);
   const options = user ? user.options : null;


### PR DESCRIPTION
Previously, the useEffect ran on first render triggering a rerender via the setState.

this would force rendering twice
```
  useEffect(() => {
    // Immediately update if props change
    setRelative(computeRelativeDate());
```

Now, it will not rerender until the first tick.
Replaces ref with local variable.
