### PR TITLE
fix(explore): allow explore exporting for everyone

### DIFF
--- a/static/app/components/dataExport.spec.tsx
+++ b/static/app/components/dataExport.spec.tsx
@@ -21,6 +21,11 @@ const mockPayload = {
   queryInfo: {project_id: '1', group_id: '1027', key: 'user'},
 };
 
+const mockExplorePayload = {
+  queryType: ExportQueryType.EXPLORE,
+  queryInfo: {project_id: '1', group_id: '1027', key: 'user'},
+};
+
 const mockContext = (organization: Organization) => {
   return {organization};
 };
@@ -38,6 +43,13 @@ describe('DataExport', () => {
       ...mockContext(mockAuthorizedOrg),
     });
     expect(screen.getByText(/Export All to CSV/)).toBeInTheDocument();
+  });
+
+  it('should render the button for an unauthorized organization using explore', () => {
+    render(<DataExport payload={mockExplorePayload} />, {
+      ...mockContext(mockUnauthorizedOrg),
+    });
+    expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
   it('should render custom children if provided', () => {

--- a/static/app/components/dataExport.spec.tsx
+++ b/static/app/components/dataExport.spec.tsx
@@ -21,11 +21,6 @@ const mockPayload = {
   queryInfo: {project_id: '1', group_id: '1027', key: 'user'},
 };
 
-const mockExplorePayload = {
-  queryType: ExportQueryType.EXPLORE,
-  queryInfo: {project_id: '1', group_id: '1027', key: 'user'},
-};
-
 const mockContext = (organization: Organization) => {
   return {organization};
 };
@@ -45,8 +40,8 @@ describe('DataExport', () => {
     expect(screen.getByText(/Export All to CSV/)).toBeInTheDocument();
   });
 
-  it('should render the button for an unauthorized organization using explore', () => {
-    render(<DataExport payload={mockExplorePayload} />, {
+  it('should render the button for an unauthorized organization using flag override', () => {
+    render(<DataExport payload={mockPayload} overrideFeatureFlags />, {
       ...mockContext(mockUnauthorizedOrg),
     });
     expect(screen.getByRole('button')).toBeInTheDocument();

--- a/static/app/components/dataExport.tsx
+++ b/static/app/components/dataExport.tsx
@@ -134,7 +134,13 @@ function DataExport({
   };
 
   return (
-    <Feature features="organizations:discover-query">
+    <Feature
+      features={
+        payload.queryType === ExportQueryType.EXPLORE
+          ? []
+          : 'organizations:discover-query'
+      }
+    >
       {inProgress ? (
         <Button
           size={size}

--- a/static/app/components/dataExport.tsx
+++ b/static/app/components/dataExport.tsx
@@ -26,6 +26,7 @@ interface DataExportProps {
   disabled?: boolean;
   icon?: React.ReactNode;
   onClick?: () => void;
+  overrideFeatureFlags?: boolean;
   size?: 'xs' | 'sm' | 'md';
 }
 
@@ -98,6 +99,7 @@ function DataExport({
   payload,
   icon,
   size = 'sm',
+  overrideFeatureFlags,
   onClick,
 }: DataExportProps): React.ReactElement {
   const unmountedRef = useRef(false);
@@ -134,13 +136,7 @@ function DataExport({
   };
 
   return (
-    <Feature
-      features={
-        payload.queryType === ExportQueryType.EXPLORE
-          ? []
-          : 'organizations:discover-query'
-      }
-    >
+    <Feature features={overrideFeatureFlags ? [] : 'organizations:discover-query'}>
       {inProgress ? (
         <Button
           size={size}

--- a/static/app/views/explore/components/exploreExport.tsx
+++ b/static/app/views/explore/components/exploreExport.tsx
@@ -110,6 +110,7 @@ export function ExploreExport(props: ExploreExportProps) {
         },
       }}
       disabled={disabled}
+      overrideFeatureFlags
       icon={<IconDownload />}
       onClick={() => {
         trackAnalytics('explore.table_exported', {


### PR DESCRIPTION
[Thread for context](https://sentry.slack.com/archives/C081M1KEQ0L/p1759153749840799)

TLDR the logs/tracing export button is reusing the discover export button which meant organizations needed to have the `discover-query` flag on. Since logs/tracing is available to people who may not have access to that feature, we needed to remove that feature check so the export button wouldn't disappear for them.
