### PR TITLE
feat(metrics): Encode metric query into url

### DIFF
--- a/static/app/views/explore/metrics/metricPanel.tsx
+++ b/static/app/views/explore/metrics/metricPanel.tsx
@@ -10,9 +10,9 @@ import {useDimensions} from 'sentry/utils/useDimensions';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {MetricsGraph} from 'sentry/views/explore/metrics/metricGraph';
 import MetricInfoTabs from 'sentry/views/explore/metrics/metricInfoTabs';
+import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricRow} from 'sentry/views/explore/metrics/metricRow';
 import {useMetricVisualize} from 'sentry/views/explore/metrics/metricsQueryParams';
-import {type TraceMetric} from 'sentry/views/explore/metrics/traceMetric';
 import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 
 interface MetricPanelProps {

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -1,0 +1,101 @@
+import type {Sort} from 'sentry/utils/discover/fields';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+export interface TraceMetric {
+  name: string;
+}
+
+export interface BaseMetricQuery {
+  metric: TraceMetric;
+  queryParams: ReadableQueryParams;
+}
+
+export interface MetricQuery extends BaseMetricQuery {
+  setQueryParams: (queryParams: ReadableQueryParams) => void;
+}
+
+export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null {
+  let json: any;
+  try {
+    json = JSON.parse(value);
+  } catch {
+    return null;
+  }
+
+  const metric = json.metric;
+  if (typeof metric !== 'string') {
+    return null;
+  }
+
+  const query = json.query;
+  if (typeof query !== 'string') {
+    return null;
+  }
+
+  return {
+    metric: {name: metric},
+    queryParams: new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query,
+
+      cursor: '',
+      fields: defaultFields(),
+      sortBys: defaultSortBys(),
+
+      aggregateCursor: '',
+      aggregateFields: defaultAggregateFields(),
+      aggregateSortBys: defaultAggregateSortBys(),
+    }),
+  };
+}
+
+export function encodeMetricQueryParams(metricQuery: BaseMetricQuery): string {
+  return JSON.stringify({
+    metric: metricQuery.metric.name,
+    query: metricQuery.queryParams.query,
+  });
+}
+
+export function defaultMetricQuery(): BaseMetricQuery {
+  return {
+    metric: {name: 'myfirstmetric'},
+    queryParams: new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query: defaultQuery(),
+
+      cursor: '',
+      fields: defaultFields(),
+      sortBys: defaultSortBys(),
+
+      aggregateCursor: '',
+      aggregateFields: defaultAggregateFields(),
+      aggregateSortBys: defaultAggregateSortBys(),
+    }),
+  };
+}
+
+export function defaultQuery(): string {
+  return '';
+}
+
+function defaultFields(): string[] {
+  return ['id', 'timestamp'];
+}
+
+function defaultSortBys(): Sort[] {
+  return [{field: 'timestamp', kind: 'desc'}];
+}
+
+function defaultAggregateFields(): AggregateField[] {
+  return [new VisualizeFunction('count(span.duration)', {chartType: ChartType.BAR})];
+}
+
+function defaultAggregateSortBys(): Sort[] {
+  return [{field: 'count(span.duration)', kind: 'desc'}];
+}

--- a/static/app/views/explore/metrics/metricRow.tsx
+++ b/static/app/views/explore/metrics/metricRow.tsx
@@ -9,8 +9,8 @@ import {
   useSearchQueryBuilderProps,
   type TraceItemSearchQueryBuilderProps,
 } from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
+import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {useMetricVisualize} from 'sentry/views/explore/metrics/metricsQueryParams';
-import {type TraceMetric} from 'sentry/views/explore/metrics/traceMetric';
 import {
   useQueryParamsGroupBys,
   useQueryParamsQuery,

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -92,7 +92,9 @@ function updateQueryParams(
 
     aggregateCursor:
       writableQueryParams.aggregateCursor ?? readableQueryParams.aggregateCursor,
-    aggregateFields: aggregateFields ?? readableQueryParams.aggregateFields,
+    aggregateFields: aggregateFields.length
+      ? aggregateFields
+      : readableQueryParams.aggregateFields,
     aggregateSortBys:
       writableQueryParams.aggregateSortBys ?? readableQueryParams.aggregateSortBys,
 

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -1,52 +1,43 @@
 import type {ReactNode} from 'react';
-import {useCallback, useMemo} from 'react';
+import {useCallback} from 'react';
 
-import {useResettableState} from 'sentry/utils/useResettableState';
-import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {defined} from 'sentry/utils';
+import {defaultQuery} from 'sentry/views/explore/metrics/metricQuery';
+import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {
   QueryParamsContextProvider,
   useQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
+import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
-import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {parseVisualize} from 'sentry/views/explore/queryParams/visualize';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
-import {ChartType} from 'sentry/views/insights/common/components/chart';
 
 interface MetricsQueryParamsProviderProps {
   children: ReactNode;
+  queryParams: ReadableQueryParams;
+  setQueryParams: (queryParams: ReadableQueryParams) => void;
 }
 
-export function MetricsQueryParamsProvider({children}: MetricsQueryParamsProviderProps) {
-  const [query, setQuery] = useResettableState(() => '');
-
-  const readableQueryParams = useMemo(() => {
-    return new ReadableQueryParams({
-      extrapolate: true,
-      mode: Mode.AGGREGATE,
-      query,
-
-      cursor: '',
-      fields: ['id', 'timestamp'],
-      sortBys: [{field: 'timestamp', kind: 'desc'}],
-
-      aggregateCursor: '',
-      aggregateFields: [
-        new VisualizeFunction('count(span.duration)', {chartType: ChartType.BAR}),
-      ],
-      aggregateSortBys: [{field: 'count(span.duration)', kind: 'desc'}],
-    });
-  }, [query]);
-
+export function MetricsQueryParamsProvider({
+  children,
+  queryParams,
+  setQueryParams,
+}: MetricsQueryParamsProviderProps) {
   const setWritableQueryParams = useCallback(
     (writableQueryParams: WritableQueryParams) => {
-      setQuery(writableQueryParams.query);
+      const newQueryParams = updateQueryParams(queryParams, {
+        query: getUpdatedValue(writableQueryParams.query, defaultQuery),
+      });
+
+      setQueryParams(newQueryParams);
     },
-    [setQuery]
+    [queryParams, setQueryParams]
   );
 
   return (
     <QueryParamsContextProvider
-      queryParams={readableQueryParams}
+      queryParams={queryParams}
       setQueryParams={setWritableQueryParams}
       isUsingDefaultFields
       shouldManageFields={false}
@@ -56,10 +47,56 @@ export function MetricsQueryParamsProvider({children}: MetricsQueryParamsProvide
   );
 }
 
+function getUpdatedValue<T>(
+  newValue: T | null | undefined,
+  defaultValue: () => T
+): T | undefined {
+  if (defined(newValue)) {
+    return newValue;
+  }
+
+  if (newValue === null) {
+    return defaultValue();
+  }
+
+  return undefined;
+}
+
 export function useMetricVisualize() {
   const visualizes = useQueryParamsVisualizes();
   if (visualizes.length === 1) {
     return visualizes[0]!;
   }
   throw new Error('Only 1 visualize per metric allowed');
+}
+
+function updateQueryParams(
+  readableQueryParams: ReadableQueryParams,
+  writableQueryParams: WritableQueryParams
+): ReadableQueryParams {
+  const aggregateFields: readonly AggregateField[] =
+    writableQueryParams.aggregateFields?.flatMap<AggregateField>(aggregateField => {
+      if (isGroupBy(aggregateField)) {
+        return [aggregateField];
+      }
+      return parseVisualize(aggregateField);
+    }) ?? [];
+  return new ReadableQueryParams({
+    extrapolate: writableQueryParams.extrapolate ?? readableQueryParams.extrapolate,
+    mode: writableQueryParams.mode ?? readableQueryParams.mode,
+    query: writableQueryParams.query ?? readableQueryParams.query,
+
+    cursor: writableQueryParams.cursor ?? readableQueryParams.cursor,
+    fields: writableQueryParams.fields ?? readableQueryParams.fields,
+    sortBys: writableQueryParams.sortBys ?? readableQueryParams.sortBys,
+
+    aggregateCursor:
+      writableQueryParams.aggregateCursor ?? readableQueryParams.aggregateCursor,
+    aggregateFields: aggregateFields ?? readableQueryParams.aggregateFields,
+    aggregateSortBys:
+      writableQueryParams.aggregateSortBys ?? readableQueryParams.aggregateSortBys,
+
+    id: readableQueryParams.id,
+    title: readableQueryParams.title,
+  });
 }

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -1,4 +1,3 @@
-import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
@@ -16,7 +15,6 @@ import {
   TopSectionBody,
 } from 'sentry/views/explore/logs/styles';
 import {MetricPanel} from 'sentry/views/explore/metrics/metricPanel';
-import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {
   MultiMetricsQueryParamsProvider,
@@ -72,11 +70,6 @@ function MetricsTabFilterSection({
 function MetricsTabBodySection() {
   const metricQueries = useMultiMetricsQueryParams();
   const addMetricQuery = useAddMetricQuery();
-
-  const [traceMetrics, setTraceMetrics] = useState<TraceMetric[]>([
-    {name: 'myfirstmetric'},
-    {name: 'mysecondmetric'},
-  ]);
 
   return (
     <BottomSectionBody>

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState} from 'react';
+import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
@@ -16,8 +16,13 @@ import {
   TopSectionBody,
 } from 'sentry/views/explore/logs/styles';
 import {MetricPanel} from 'sentry/views/explore/metrics/metricPanel';
+import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
-import {type TraceMetric} from 'sentry/views/explore/metrics/traceMetric';
+import {
+  MultiMetricsQueryParamsProvider,
+  useAddMetricQuery,
+  useMultiMetricsQueryParams,
+} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import type {PickableDays} from 'sentry/views/explore/utils';
 
 type LogsTabProps = PickableDays;
@@ -28,14 +33,14 @@ export function MetricsTabContent({
   relativeOptions,
 }: LogsTabProps) {
   return (
-    <Fragment>
+    <MultiMetricsQueryParamsProvider>
       <MetricsTabFilterSection
         defaultPeriod={defaultPeriod}
         maxPickableDays={maxPickableDays}
         relativeOptions={relativeOptions}
       />
       <MetricsTabBodySection />
-    </Fragment>
+    </MultiMetricsQueryParamsProvider>
   );
 }
 
@@ -65,6 +70,9 @@ function MetricsTabFilterSection({
 }
 
 function MetricsTabBodySection() {
+  const metricQueries = useMultiMetricsQueryParams();
+  const addMetricQuery = useAddMetricQuery();
+
   const [traceMetrics, setTraceMetrics] = useState<TraceMetric[]>([
     {name: 'myfirstmetric'},
     {name: 'mysecondmetric'},
@@ -73,11 +81,15 @@ function MetricsTabBodySection() {
   return (
     <BottomSectionBody>
       <Flex direction="column" gap="lg">
-        {traceMetrics.map((traceMetric, index) => {
+        {metricQueries.map((metricQuery, index) => {
           return (
             // TODO: figure out a better `key`
-            <MetricsQueryParamsProvider key={index}>
-              <MetricPanel traceMetric={traceMetric} />
+            <MetricsQueryParamsProvider
+              key={index}
+              queryParams={metricQuery.queryParams}
+              setQueryParams={metricQuery.setQueryParams}
+            >
+              <MetricPanel traceMetric={metricQuery.metric} />
             </MetricsQueryParamsProvider>
           );
         })}
@@ -86,12 +98,7 @@ function MetricsTabBodySection() {
             size="sm"
             priority="default"
             icon={<IconAdd />}
-            onClick={() => {
-              setTraceMetrics([
-                ...traceMetrics,
-                {name: `metric${traceMetrics.length + 1}`},
-              ]);
-            }}
+            onClick={addMetricQuery}
           >
             {t('Add Metric')}
           </Button>

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -1,0 +1,114 @@
+import type {ReactNode} from 'react';
+import {useMemo} from 'react';
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
+import {decodeList} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {
+  decodeMetricsQueryParams,
+  defaultMetricQuery,
+  encodeMetricQueryParams,
+  type BaseMetricQuery,
+  type MetricQuery,
+} from 'sentry/views/explore/metrics/metricQuery';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+
+interface MultiMetricsQueryParamsContextValue {
+  metricQueries: MetricQuery[];
+}
+
+const [
+  _MultiMetricsQueryParamsContextProvider,
+  useMultiMetricsQueryParamsContext,
+  MultiMetricsQueryParamsContext,
+] = createDefinedContext<MultiMetricsQueryParamsContextValue>({
+  name: 'QueryParamsContext',
+});
+
+interface MultiMetricsQueryParamsProviderProps {
+  children: ReactNode;
+}
+
+export function MultiMetricsQueryParamsProvider({
+  children,
+}: MultiMetricsQueryParamsProviderProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const value: MultiMetricsQueryParamsContextValue = useMemo(() => {
+    const metricQueries = getMultiMetricsQueryParamsFromLocation(location);
+
+    function setQueryParamsForIndex(i: number) {
+      return function (newQueryParams: ReadableQueryParams) {
+        const target = {...location, query: {...location.query}};
+
+        const newMetricQueries: string[] = metricQueries
+          .map((metricQuery: BaseMetricQuery, j: number) => {
+            if (i !== j) {
+              return metricQuery;
+            }
+            return {
+              metric: metricQuery.metric,
+              queryParams: newQueryParams,
+            };
+          })
+          .map((metricQuery: BaseMetricQuery) => encodeMetricQueryParams(metricQuery))
+          .filter(defined)
+          .filter(Boolean);
+        target.query.metric = newMetricQueries;
+
+        navigate(target);
+      };
+    }
+
+    return {
+      metricQueries: metricQueries.map((metric: BaseMetricQuery, index: number) => {
+        return {
+          ...metric,
+          setQueryParams: setQueryParamsForIndex(index),
+        };
+      }),
+    };
+  }, [location, navigate]);
+
+  return (
+    <MultiMetricsQueryParamsContext value={value}>
+      {children}
+    </MultiMetricsQueryParamsContext>
+  );
+}
+
+function getMultiMetricsQueryParamsFromLocation(location: Location): BaseMetricQuery[] {
+  const rawQueryParams = decodeList(location.query.metric);
+  if (!rawQueryParams.length) {
+    return [defaultMetricQuery()];
+  }
+
+  return rawQueryParams.map(decodeMetricsQueryParams).filter(defined);
+}
+
+export function useMultiMetricsQueryParams() {
+  const {metricQueries} = useMultiMetricsQueryParamsContext();
+  return metricQueries;
+}
+
+export function useAddMetricQuery() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const {metricQueries} = useMultiMetricsQueryParamsContext();
+
+  return function () {
+    const target = {...location, query: {...location.query}};
+
+    const newMetricQueries: string[] = [...metricQueries, defaultMetricQuery()]
+      .map((metricQuery: BaseMetricQuery) => encodeMetricQueryParams(metricQuery))
+      .filter(defined)
+      .filter(Boolean);
+    target.query.metric = newMetricQueries;
+
+    navigate(target);
+  };
+}

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -83,11 +83,12 @@ export function MultiMetricsQueryParamsProvider({
 
 function getMultiMetricsQueryParamsFromLocation(location: Location): BaseMetricQuery[] {
   const rawQueryParams = decodeList(location.query.metric);
-  if (!rawQueryParams.length) {
-    return [defaultMetricQuery()];
-  }
 
-  return rawQueryParams.map(decodeMetricsQueryParams).filter(defined);
+  const metricQueries = rawQueryParams.map(decodeMetricsQueryParams).filter(defined);
+  if (metricQueries.length) {
+    return metricQueries;
+  }
+  return [defaultMetricQuery()];
 }
 
 export function useMultiMetricsQueryParams() {

--- a/static/app/views/explore/metrics/traceMetric.tsx
+++ b/static/app/views/explore/metrics/traceMetric.tsx
@@ -1,3 +1,0 @@
-export interface TraceMetric {
-  name: string;
-}


### PR DESCRIPTION
Previously, the queries was stored via react state. This uses the url to persist the queries instead.

Closes LOGS-382