### PR TITLE
ref(uptime): Convert uptime-create-issues to a option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3166,7 +3166,6 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-
 register(
     "uptime.date_cutoff_epoch_seconds",
     type=Int,
@@ -3176,6 +3175,14 @@ register(
 
 register(
     "uptime.snuba_uptime_results.enabled",
+    type=Bool,
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# Controls whether uptime monitoring creates issues via the issue platform.
+register(
+    "uptime.create-issues",
     type=Bool,
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,


### PR DESCRIPTION
Instead of using a temporary feature flag for this let's control this
via an option.

I don't think we've ever used this to disable issue creation for a
specific organization