### PR TITLE
fix(explore): bypass feature flag on explore export

### DIFF
--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -295,10 +295,11 @@ class DataExportEndpoint(OrganizationEndpoint):
         }
         logger.info("API Request started", extra=extra)
 
-        # The data export feature is only available alongside `discover-query`.
+        # The data export feature is only available alongside `discover-query` (except for explore).
         # So to export issue tags, they must have have `discover-query`
         if not features.has("organizations:discover-query", organization):
-            return Response(status=404)
+            if request.data.get("query_type") != ExportQueryType.EXPLORE_STR:
+                return Response(status=404)
 
         # Get environment_id and limit if available
         try:

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -58,9 +58,14 @@ class DataExportTest(APITestCase):
     def test_authorization(self) -> None:
         payload = self.make_payload("issue")
 
+        payload_explore = self.make_payload("explore")
+
         # Without the discover-query feature, the endpoint should 404
         with self.feature({"organizations:discover-query": False}):
             self.get_error_response(self.org.slug, status_code=404, **payload)
+
+        with self.feature({"organizations:discover-query": False}):
+            self.get_success_response(self.org.slug, status_code=201, **payload_explore)
 
         # With the right permissions, the endpoint should 201
         with self.feature("organizations:discover-query"):


### PR DESCRIPTION
backend change for https://github.com/getsentry/sentry/pull/101106

explore export shouldn't require the `discover-query` flag as teams don't have this but should still be able to export on logs/tracing
