### PR TITLE
ref(grouping): Include variant hint in snapshots

### DIFF
--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -379,13 +379,13 @@ def dump_variant(
         lines.append(
             "{}contributing component: {}".format("  " * indent, contributing_component_id)
         )
+        lines.append("{}hint: {}".format("  " * indent, variant.hint))
 
     # Note that this prints `__dict__`, not `as_dict()`, so if something seems missing, that's
     # probably why
     for key, value in sorted(variant.__dict__.items()):
-        if key in ["config", "hash", "contributing_component", "variant_name"]:
-            # We do not want to dump the config, and we've already dumped the hash and the
-            # contributing component
+        if key in ["config", "hash", "contributing_component", "variant_name", "hint"]:
+            # We do not want to dump the config, and we've already dumped the others
             continue
 
         if isinstance(value, BaseGroupingComponent):

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:33.803099+00:00'
+created: '2025-10-07T20:42:03.137989+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "738e7d2503464bc264b4f791286f5122"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -273,6 +274,7 @@ contributing variants:
   system*
     hash: "19a96e0438d28e48355653def82f887a"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:33.866785+00:00'
+created: '2025-10-07T20:42:03.163901+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "2552498cfe69a6ddf1dcdde5440ce9c3"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:33.893515+00:00'
+created: '2025-10-07T20:42:03.182509+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "228c649a3aa0901622c0a0e66ab0522c"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -45,6 +46,7 @@ contributing variants:
   system*
     hash: "4ccd0f1953483581ba360c7518f90332"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:33.915264+00:00'
+created: '2025-10-07T20:42:03.199389+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
     contributing component: threads
+    hint: None
     root_component:
       app*
         threads*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:33.933450+00:00'
+created: '2025-10-07T20:42:03.216355+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "d9c9b0f9ba46e32fddd7cd1512fad235"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:33.999226+00:00'
+created: '2025-10-07T20:42:03.270713+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "4ef1fb44d656c3be2a146971f2a222dc"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -49,6 +50,7 @@ contributing variants:
   system*
     hash: "47481871aa8d5ab5729cf2db78ce3032"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.052475+00:00'
+created: '2025-10-07T20:42:03.319800+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "7c8a196d16b94be382add324be2605ee"
     contributing component: threads
+    hint: None
     root_component:
       app*
         threads*
@@ -45,6 +46,7 @@ contributing variants:
   system*
     hash: "cd7f51d716fd57adc1a5ce1c112e538f"
     contributing component: threads
+    hint: None
     root_component:
       system*
         threads*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.070744+00:00'
+created: '2025-10-07T20:42:03.338017+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "6b059b9febc815ac18ac4d2082e38a9b"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -70,6 +71,7 @@ contributing variants:
   system*
     hash: "013d3477a774fe20c468dc8accd516f1"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.092367+00:00'
+created: '2025-10-07T20:42:03.355536+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "161ce02ecc5d6685a72e8e520ab726b3"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -42,6 +43,7 @@ contributing variants:
   system*
     hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.113882+00:00'
+created: '2025-10-07T20:42:03.373784+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.269006+00:00'
+created: '2025-10-07T20:42:03.506785+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   default*
     hash: "666766514295bb52812324097cdaf53e"
     contributing component: csp
+    hint: None
     root_component:
       default*
         csp*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_img_src.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_img_src.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.135583+00:00'
+created: '2025-10-07T20:42:03.390035+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   default*
     hash: "1742101e08eb1608f569751dfedd0062"
     contributing component: csp
+    hint: None
     root_component:
       default*
         csp*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.154815+00:00'
+created: '2025-10-07T20:42:03.406756+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   default*
     hash: "efddf1cde918097259aa7d4904fb1942"
     contributing component: csp
+    hint: None
     root_component:
       default*
         csp*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_data_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_data_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.176273+00:00'
+created: '2025-10-07T20:42:03.424086+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   default*
     hash: "4e6f2bce9d121aa89f4dc5e5da08afb5"
     contributing component: csp
+    hint: None
     root_component:
       default*
         csp*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.199596+00:00'
+created: '2025-10-07T20:42:03.441295+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -25,6 +25,7 @@ contributing variants:
   default*
     hash: "56c6520f35bce2f89ed2c4e725ccef65"
     contributing component: csp
+    hint: None
     root_component:
       default*
         csp*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.218236+00:00'
+created: '2025-10-07T20:42:03.457829+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -25,6 +25,7 @@ contributing variants:
   default*
     hash: "d346ee37d19a2be6587e609075ca2d57"
     contributing component: csp
+    hint: None
     root_component:
       default*
         csp*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.235616+00:00'
+created: '2025-10-07T20:42:03.474066+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   default*
     hash: "223cdacfe5b4b830dc700b5c18cc21b4"
     contributing component: csp
+    hint: None
     root_component:
       default*
         csp*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_style_src_elem.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_style_src_elem.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.252686+00:00'
+created: '2025-10-07T20:42:03.490265+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   default*
     hash: "537a973f594c364842893e9a72af62a5"
     contributing component: csp
+    hint: None
     root_component:
       default*
         csp*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.361728+00:00'
+created: '2025-10-07T20:42:03.593282+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "029f3b967068b1539f96957b7c0451d7"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.414962+00:00'
+created: '2025-10-07T20:42:03.649678+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "b23ee1963904c2ca87b145febf94b66c"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.378793+00:00'
+created: '2025-10-07T20:42:03.612765+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "9509e122c6175606d52862fa4f64853c"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.396686+00:00'
+created: '2025-10-07T20:42:03.632414+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "669cb6664e0f5fed38665da04e464f7e"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.434023+00:00'
+created: '2025-10-07T20:42:03.667990+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "e2bf1e0628b7b1824a9b63dec7a079a3"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.472715+00:00'
+created: '2025-10-07T20:42:03.701606+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "93b26686d00504b4e5aa1cb0244d8b37"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.450358+00:00'
+created: '2025-10-07T20:42:03.684647+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "93b26686d00504b4e5aa1cb0244d8b37"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.492943+00:00'
+created: '2025-10-07T20:42:03.717969+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "a4f16891fa438620699cb2d9af5cc827"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.509709+00:00'
+created: '2025-10-07T20:42:03.733850+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "028157fe357e4592e39eacb32eafa2db"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.543791+00:00'
+created: '2025-10-07T20:42:03.750484+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "f0078a82f351095ba595daa7d493aa3c"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.560700+00:00'
+created: '2025-10-07T20:42:03.766874+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "93b26686d00504b4e5aa1cb0244d8b37"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.584084+00:00'
+created: '2025-10-07T20:42:03.782342+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "0809098f9f613b63467605dd1739cc9b"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.603776+00:00'
+created: '2025-10-07T20:42:03.799022+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "0809098f9f613b63467605dd1739cc9b"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_exception.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_exception.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.621967+00:00'
+created: '2025-10-07T20:42:03.815399+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "a4f16891fa438620699cb2d9af5cc827"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.639391+00:00'
+created: '2025-10-07T20:42:03.831866+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "a4f16891fa438620699cb2d9af5cc827"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.656595+00:00'
+created: '2025-10-07T20:42:03.848228+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "17022e0561e9b6e6351723a08aa81b18"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.691063+00:00'
+created: '2025-10-07T20:42:03.881240+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "a4f16891fa438620699cb2d9af5cc827"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.673808+00:00'
+created: '2025-10-07T20:42:03.864992+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "f0078a82f351095ba595daa7d493aa3c"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.709389+00:00'
+created: '2025-10-07T20:42:03.898799+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "d505dfb9059ac63c11955233323a9100"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*
@@ -60,6 +61,7 @@ contributing variants:
   system*
     hash: "4f9cc6a81f4eb34f9e917374f281b9dc"
     contributing component: chained_exception
+    hint: None
     root_component:
       system*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_types.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_types.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.744863+00:00'
+created: '2025-10-07T20:42:03.936751+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "bca604b98cb4637167eb6190a92e8933"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.727422+00:00'
+created: '2025-10-07T20:42:03.917870+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "fca0fd23f09e8da4481304ef2a531100"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.762529+00:00'
+created: '2025-10-07T20:42:03.956611+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "26552f86ca2368e708afa1df6effc1c5"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_without_type.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_without_type.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.785230+00:00'
+created: '2025-10-07T20:42:03.974911+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "5eb63bbbe01eeed093cb22bb8f5acdc3"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_without_value.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_without_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.807479+00:00'
+created: '2025-10-07T20:42:03.993191+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "5a2cfd89b7b171fd7b4794b08023d04f"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/expectct.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/expectct.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.894316+00:00'
+created: '2025-10-07T20:42:04.094722+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,6 +23,7 @@ contributing variants:
   default*
     hash: "3d2933f4b5ec459ec8d569a398fd328c"
     contributing component: expect_ct
+    hint: None
     root_component:
       default*
         expect_ct*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.930109+00:00'
+created: '2025-10-07T20:42:04.112388+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "87497299851e09febfecf4e84e0d45ba"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:34.955671+00:00'
+created: '2025-10-07T20:42:04.132685+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "526b64456c48836a46ec1a89544fd412"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.001380+00:00'
+created: '2025-10-07T20:42:04.168347+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "7d2cc7acbf90328200d960bf78a26234"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.024616+00:00'
+created: '2025-10-07T20:42:04.185183+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "465d672b2d322bf6a1b44499f6dabc1f"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.044835+00:00'
+created: '2025-10-07T20:42:04.203711+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "45c0b0a8c777e7a7040d7c39233a08a5"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.087744+00:00'
+created: '2025-10-07T20:42:04.236743+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "353e05904b48bd3ae4fa9623934a70d0"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.104473+00:00'
+created: '2025-10-07T20:42:04.253846+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "0094f39fc617031afb6c655419f4a9f2"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.121696+00:00'
+created: '2025-10-07T20:42:04.272950+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "be15ca3d511b96918e087c4f42503ca2"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.143424+00:00'
+created: '2025-10-07T20:42:04.290874+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "e04dce7550635e05dbd7f656102cf304"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.162742+00:00'
+created: '2025-10-07T20:42:04.314237+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "098f6bcd4621d373cade4e832627b4f6"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.203923+00:00'
+created: '2025-10-07T20:42:04.349571+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "64a0e0a34d99dce03a8c5a4c237a4b5a"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.223164+00:00'
+created: '2025-10-07T20:42:04.366837+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "64a0e0a34d99dce03a8c5a4c237a4b5a"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.246212+00:00'
+created: '2025-10-07T20:42:04.383587+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "e0e7c4713e9092dc77635d5a0d5db31d"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.267025+00:00'
+created: '2025-10-07T20:42:04.399826+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "c32a94349d9e9b72d31a46610c6c9589"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.293812+00:00'
+created: '2025-10-07T20:42:04.415959+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "be7f1b8b4014de623c533a8218dba5bd"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.314547+00:00'
+created: '2025-10-07T20:42:04.431672+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "53b9e9679a8ea25880376080b76f98ad"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_javassist.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.373054+00:00'
+created: '2025-10-07T20:42:04.483514+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "538bdfd8d7bb2495d0d6429c3689a420"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.331627+00:00'
+created: '2025-10-07T20:42:04.449247+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "538bdfd8d7bb2495d0d6429c3689a420"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.351906+00:00'
+created: '2025-10-07T20:42:04.466488+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "dc3d511120ce04996b1eef3496516e5c"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.392974+00:00'
+created: '2025-10-07T20:42:04.499349+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "0cc175b9c0f1b6a831c399e269772661"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.433267+00:00'
+created: '2025-10-07T20:42:04.530917+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "30eb5001914d29dd8461898b5b8094fe"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.525977+00:00'
+created: '2025-10-07T20:42:04.608560+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "07d1a8e5728b3c4c7aa8b8273fd0e753"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.507441+00:00'
+created: '2025-10-07T20:42:04.593105+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "09e0efcab18f545166318118ed4e0292"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.547821+00:00'
+created: '2025-10-07T20:42:04.624320+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "9bc326575875422d0d4ced3c35d9f916"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.565695+00:00'
+created: '2025-10-07T20:42:04.640060+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "27eed4125fc13d42163ddb0b8f357b48"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.584416+00:00'
+created: '2025-10-07T20:42:04.655491+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "4067a71d7098866f87c746a57a77b2bb"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.623327+00:00'
+created: '2025-10-07T20:42:04.687282+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "2f908c015ad77a50595512fcf65d344c"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.602641+00:00'
+created: '2025-10-07T20:42:04.670876+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "2f908c015ad77a50595512fcf65d344c"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.643838+00:00'
+created: '2025-10-07T20:42:04.704731+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "60e0a667027bef0d0b7c4882891df7e8"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.661191+00:00'
+created: '2025-10-07T20:42:04.721609+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "acbd18db4cc2f85cedef654fccc4a4d8"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.678382+00:00'
+created: '2025-10-07T20:42:04.737919+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "1effb24729ae4c43efa36b460511136a"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.695692+00:00'
+created: '2025-10-07T20:42:04.754890+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "4b8bbc500bd2cabfcadc1f1be867e0bb"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -40,6 +41,7 @@ contributing variants:
   system*
     hash: "348fc4026c9fa11ffba8fbfa80a134c9"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.716252+00:00'
+created: '2025-10-07T20:42:04.775528+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "3da34e8c72dbcd4a490ac36eb7130638"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.742332+00:00'
+created: '2025-10-07T20:42:04.793749+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "ca733a48a19d237df8577d09449095d9"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.762816+00:00'
+created: '2025-10-07T20:42:04.812879+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "2c1bbd635b64d5adccdb64a620044075"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.781916+00:00'
+created: '2025-10-07T20:42:04.831675+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "9c336f632f6764c0f082a6a66edbf22d"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.802998+00:00'
+created: '2025-10-07T20:42:04.850369+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "49b6f72b6635cb43190c57ee56b026b0"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.823678+00:00'
+created: '2025-10-07T20:42:04.868714+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "49b6f72b6635cb43190c57ee56b026b0"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.842651+00:00'
+created: '2025-10-07T20:42:04.886537+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "aeed765d29d1a60cb094f66d2cd8efb2"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.861486+00:00'
+created: '2025-10-07T20:42:04.908658+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "aeed765d29d1a60cb094f66d2cd8efb2"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.882174+00:00'
+created: '2025-10-07T20:42:04.929112+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "8be5979a334287a1b47457228f1d4612"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.903630+00:00'
+created: '2025-10-07T20:42:04.949528+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "8be5979a334287a1b47457228f1d4612"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.924593+00:00'
+created: '2025-10-07T20:42:04.970682+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "7e64037e487c78ce0439f750a2ef503f"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.942908+00:00'
+created: '2025-10-07T20:42:04.988871+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "aeed765d29d1a60cb094f66d2cd8efb2"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.962923+00:00'
+created: '2025-10-07T20:42:05.010895+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "6148c73af04344a8597354711f5951ea"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:35.982325+00:00'
+created: '2025-10-07T20:42:05.030755+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "1056f62d72ff8b4d0c3842d696dbb10a"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.002465+00:00'
+created: '2025-10-07T20:42:05.050959+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "15526a7b64e9b5dc6d89e7ebec864260"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hpkp.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hpkp.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.020202+00:00'
+created: '2025-10-07T20:42:05.067363+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -23,6 +23,7 @@ contributing variants:
   default*
     hash: "1e37a374cb33572622d02ff7a6237c44"
     contributing component: hpkp
+    hint: None
     root_component:
       default*
         hpkp*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.037911+00:00'
+created: '2025-10-07T20:42:05.082967+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -28,6 +28,7 @@ contributing variants:
   app*
     hash: "e3d593b4335190212ca7c18b8e967fb1"
     contributing component: exception
+    hint: None
     fingerprint_info: {"client_fingerprint":["{{ default }}","dogs are great"]}
     root_component:
       app*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.056103+00:00'
+created: '2025-10-07T20:42:05.100262+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -31,6 +31,7 @@ contributing variants:
   app*
     hash: "19163f3ca34f5995c69d85351ce3d697"
     contributing component: exception
+    hint: None
     fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
     root_component:
       app*
@@ -126,6 +127,7 @@ contributing variants:
   system*
     hash: "847950eb44d280e6758d136c763d6ddc"
     contributing component: exception
+    hint: None
     fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
     root_component:
       system*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.091930+00:00'
+created: '2025-10-07T20:42:05.134757+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -28,6 +28,7 @@ contributing variants:
   app*
     hash: "5b5ad5a0fbb4deb5e3fc631ce42681ae"
     contributing component: exception
+    hint: None
     fingerprint_info: {"client_fingerprint":["{{ default }}","adopt don't shop"]}
     root_component:
       app*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.109779+00:00'
+created: '2025-10-07T20:42:05.152279+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -28,6 +28,7 @@ contributing variants:
   app*
     hash: "c5578778212497f1ff3435405e2a4a98"
     contributing component: exception
+    hint: None
     fingerprint_info: {"client_fingerprint":["{{ default }}","dogs are great"]}
     root_component:
       app*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.130571+00:00'
+created: '2025-10-07T20:42:05.173437+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "5b032559156688c9eabe4e4bd5ae6bd4"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -93,6 +94,7 @@ contributing variants:
   system*
     hash: "1921b991270e24c19ea1ed6863892d71"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.152116+00:00'
+created: '2025-10-07T20:42:05.196891+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "1959b227a7cf6acf7f3fd401b5d9f09b"
     contributing component: chained_exception
+    hint: None
     root_component:
       system*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.173079+00:00'
+created: '2025-10-07T20:42:05.218443+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "ef2555bf7958ada8eefafbfdaed1c409"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.210428+00:00'
+created: '2025-10-07T20:42:05.252273+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "10dfd81e2df31e96fae451b9e205ad81"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.189136+00:00'
+created: '2025-10-07T20:42:05.236099+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "b8e2a347e75266ca7bb565e2b3c0722e"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.227579+00:00'
+created: '2025-10-07T20:42:05.268483+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "c0f3f7d6deb17aec9d07259ac684fad0"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.266002+00:00'
+created: '2025-10-07T20:42:05.298574+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   default*
     hash: "4119639092e62c55ea8be348e4d9260d"
     contributing component: message
+    hint: None
     root_component:
       default*
         message*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_message_parameterization.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.245112+00:00'
+created: '2025-10-07T20:42:05.284038+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   default*
     hash: "f9e47f16e3b9770b440157179c47bf7a"
     contributing component: message
+    hint: None
     root_component:
       default*
         message* (stripped event-specific values)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.283947+00:00'
+created: '2025-10-07T20:42:05.315129+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "be36642f41f047346396f018f62375d3"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.304845+00:00'
+created: '2025-10-07T20:42:05.331621+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "6ab78545e13144405fb21dadb9045b91"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.324721+00:00'
+created: '2025-10-07T20:42:05.349375+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "c63e8727af1a8fe75872b6a762797113"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.344638+00:00'
+created: '2025-10-07T20:42:05.367466+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "c63e8727af1a8fe75872b6a762797113"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.367676+00:00'
+created: '2025-10-07T20:42:05.383896+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "c63e8727af1a8fe75872b6a762797113"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.389924+00:00'
+created: '2025-10-07T20:42:05.400117+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "b2602ad455472dede8e4c340d8a7eaba"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.413818+00:00'
+created: '2025-10-07T20:42:05.416506+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "b2602ad455472dede8e4c340d8a7eaba"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.437098+00:00'
+created: '2025-10-07T20:42:05.432536+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "b2602ad455472dede8e4c340d8a7eaba"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.457925+00:00'
+created: '2025-10-07T20:42:05.449612+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "b2602ad455472dede8e4c340d8a7eaba"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.478168+00:00'
+created: '2025-10-07T20:42:05.466538+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "c63e8727af1a8fe75872b6a762797113"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.501830+00:00'
+created: '2025-10-07T20:42:05.486218+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "4a3cf3893b6485428dd02da116c8370e"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -55,6 +56,7 @@ contributing variants:
   system*
     hash: "d5456487ea8dccfe96c1968b19870978"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.523919+00:00'
+created: '2025-10-07T20:42:05.504096+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "4a3cf3893b6485428dd02da116c8370e"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -55,6 +56,7 @@ contributing variants:
   system*
     hash: "0b81da6ea3d7cc82b1d4825b7aac0b8d"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.567826+00:00'
+created: '2025-10-07T20:42:05.542878+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "4665d486184740231357ab63f4543a8d"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -54,6 +55,7 @@ contributing variants:
   system*
     hash: "107ed03036d901157372f260bc3df446"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.543481+00:00'
+created: '2025-10-07T20:42:05.520897+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "a728cdf5d62c8e017c35c3fe04051b6e"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -40,6 +41,7 @@ contributing variants:
   system*
     hash: "63c67781779781d9b0a442a5b2bdb976"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/logentry_prefers_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/logentry_prefers_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.585809+00:00'
+created: '2025-10-07T20:42:05.558925+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   default*
     hash: "8ec8bbc71eb6e2af7fbe5076a8534f96"
     contributing component: message
+    hint: None
     root_component:
       default*
         message*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/logentry_uses_formatted.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/logentry_uses_formatted.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.606428+00:00'
+created: '2025-10-07T20:42:05.575171+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   default*
     hash: "329b29efcf1f77067a063e34f56e7791"
     contributing component: message
+    hint: None
     root_component:
       default*
         message*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.630101+00:00'
+created: '2025-10-07T20:42:05.594051+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "b8baf791d22ac902d5f59a7eedd844fd"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.655154+00:00'
+created: '2025-10-07T20:42:05.613956+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "36be6e0b6123ef6ecfbef62f5cb88406"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.678821+00:00'
+created: '2025-10-07T20:42:05.632951+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "70b7b816193e06eb5d6649989fbaf605"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/message_prefers_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/message_prefers_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.699098+00:00'
+created: '2025-10-07T20:42:05.648924+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   default*
     hash: "8ec8bbc71eb6e2af7fbe5076a8534f96"
     contributing component: message
+    hint: None
     root_component:
       default*
         message*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/message_uses_formatted.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/message_uses_formatted.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.719381+00:00'
+created: '2025-10-07T20:42:05.664943+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   default*
     hash: "d3f5e52d24e9c1eae5abe6c866cced63"
     contributing component: message
+    hint: None
     root_component:
       default*
         message*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/message_with_key_pair_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.741054+00:00'
+created: '2025-10-07T20:42:05.681265+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   default*
     hash: "d2ab1028e9cb44352a824e878951f412"
     contributing component: message
+    hint: None
     root_component:
       default*
         message* (stripped event-specific values)

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.767035+00:00'
+created: '2025-10-07T20:42:05.699473+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "dcfcd48a02c100bbe4023cbc783054f0"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.786550+00:00'
+created: '2025-10-07T20:42:05.715828+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.808653+00:00'
+created: '2025-10-07T20:42:05.733306+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "2e0d26cae5986fcda5edf66612a78268"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.827681+00:00'
+created: '2025-10-07T20:42:05.750784+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "c85e23e804b52ea4b9f290ba838e77a0"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.847843+00:00'
+created: '2025-10-07T20:42:05.768346+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "784442a33bd16c15013bb8f69f68e7d6"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.867771+00:00'
+created: '2025-10-07T20:42:05.785005+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "8f4c7709e4af98d3c47ce3519690e6d9"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.889774+00:00'
+created: '2025-10-07T20:42:05.802477+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "3ff01ce959249abecc6bc8a8f1432b0b"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.912883+00:00'
+created: '2025-10-07T20:42:05.820624+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "418120a66f7031923031f5c52aca0724"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -45,6 +46,7 @@ contributing variants:
   system*
     hash: "bbcdb2e1d8df09ffe0fffd30fb361d4b"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.933204+00:00'
+created: '2025-10-07T20:42:05.838470+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.952368+00:00'
+created: '2025-10-07T20:42:05.855196+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "46b84e4da51648cc9f9741abd2bdad51"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:36.984710+00:00'
+created: '2025-10-07T20:42:05.872688+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "c29439027eafcf7642f641554ab0f0ef"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.009912+00:00'
+created: '2025-10-07T20:42:05.889705+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "a20509269752c9a1bea6078851e4d39c"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -71,6 +72,7 @@ contributing variants:
   system*
     hash: "252dc79eb5653bf822e2684d90734cb8"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.028808+00:00'
+created: '2025-10-07T20:42:05.906315+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "be36642f41f047346396f018f62375d3"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.048764+00:00'
+created: '2025-10-07T20:42:05.924637+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "c52ebcc2d9d0780a23c7d99831678830"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*
@@ -44,6 +45,7 @@ contributing variants:
   system*
     hash: "669cb6664e0f5fed38665da04e464f7e"
     contributing component: chained_exception
+    hint: None
     root_component:
       system*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.067180+00:00'
+created: '2025-10-07T20:42:05.944591+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "121caa876de75ec51bf72ed4c852cd75"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -49,6 +50,7 @@ contributing variants:
   system*
     hash: "a5af2577d4caca8f983657c5d1919e14"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.086546+00:00'
+created: '2025-10-07T20:42:06.005342+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "90888e813b09fa25061af2883c0fb9bd"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.104527+00:00'
+created: '2025-10-07T20:42:06.047792+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "d59239f5aad3304d60beb1fde3369b78"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -49,6 +50,7 @@ contributing variants:
   system*
     hash: "133db3f366b1327dab4e661f66dfb961"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.158390+00:00'
+created: '2025-10-07T20:42:06.100534+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "11e6467c8358a9366c6538f95dcd7bd4"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.122468+00:00'
+created: '2025-10-07T20:42:06.064208+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "70dd09f56349dcce62a74137b00bb571"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.140286+00:00'
+created: '2025-10-07T20:42:06.082067+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -24,6 +24,7 @@ contributing variants:
   app*
     hash: "5f209162115f576bedbaf6f0ad30e5aa"
     contributing component: chained_exception
+    hint: None
     root_component:
       app*
         chained_exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.179419+00:00'
+created: '2025-10-07T20:42:06.122735+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "73470e545e51eea9cff8a6c006f68f57"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -45,6 +46,7 @@ contributing variants:
   system*
     hash: "ecd413627f0d90a5a25cb28d1ba9c39f"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_cocoa.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.196696+00:00'
+created: '2025-10-07T20:42:06.140740+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "eb416f98479efa56a77c524602dc9979"
     contributing component: stacktrace
+    hint: None
     root_component:
       app*
         stacktrace*
@@ -35,6 +36,7 @@ contributing variants:
   system*
     hash: "1df786c8c266506e1acb6669c8df5154"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.214875+00:00'
+created: '2025-10-07T20:42:06.158320+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "9bdadae4fa003cef6cf460ff1325e54b"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.231994+00:00'
+created: '2025-10-07T20:42:06.177080+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "1effb24729ae4c43efa36b460511136a"
     contributing component: stacktrace
+    hint: None
     root_component:
       app*
         stacktrace*
@@ -35,6 +36,7 @@ contributing variants:
   system*
     hash: "659ad79e2e70c822d30a53d7d889529e"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.266001+00:00'
+created: '2025-10-07T20:42:06.220845+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "acbd18db4cc2f85cedef654fccc4a4d8"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.302589+00:00'
+created: '2025-10-07T20:42:06.258321+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.319630+00:00'
+created: '2025-10-07T20:42:06.274958+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "cd2a9fd0cdaa8cd55ed22b101fc65882"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.337256+00:00'
+created: '2025-10-07T20:42:06.291675+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "659ad79e2e70c822d30a53d7d889529e"
     contributing component: stacktrace
+    hint: None
     root_component:
       app*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.354908+00:00'
+created: '2025-10-07T20:42:06.307228+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "c5da56c71b31f34c5880d734cbc8f5bb"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.373563+00:00'
+created: '2025-10-07T20:42:06.323935+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   system*
     hash: "eb87c1031dba55b67df86fb9fff59dc6"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.391805+00:00'
+created: '2025-10-07T20:42:06.340982+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "eb87c1031dba55b67df86fb9fff59dc6"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -38,6 +39,7 @@ contributing variants:
   system*
     hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.410565+00:00'
+created: '2025-10-07T20:42:06.357773+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "eb87c1031dba55b67df86fb9fff59dc6"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -38,6 +39,7 @@ contributing variants:
   system*
     hash: "0817e4e604fbe88c4534eff166df1db9"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.428074+00:00'
+created: '2025-10-07T20:42:06.374360+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "1effb24729ae4c43efa36b460511136a"
     contributing component: stacktrace
+    hint: None
     root_component:
       app*
         stacktrace*
@@ -35,6 +36,7 @@ contributing variants:
   system*
     hash: "659ad79e2e70c822d30a53d7d889529e"
     contributing component: stacktrace
+    hint: None
     root_component:
       system*
         stacktrace*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/template_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/template_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.446112+00:00'
+created: '2025-10-07T20:42:06.390675+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -20,6 +20,7 @@ contributing variants:
   default*
     hash: "1f5bdebe3c9f414c7dbb4296a8353245"
     contributing component: template
+    hint: None
     root_component:
       default*
         template*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.463442+00:00'
+created: '2025-10-07T20:42:06.408469+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "1a11687556cf74559f0ae90b1c87e2fd"
     contributing component: threads
+    hint: None
     root_component:
       app*
         threads*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unity.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.498286+00:00'
+created: '2025-10-07T20:42:06.441554+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "a12d579fed7636c2a5d2fae110c95ce5"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -40,6 +41,7 @@ contributing variants:
   system*
     hash: "c0dbeebf0430b3310ad1f7ceb48553a6"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unknown_variant.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unknown_variant.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-01T17:46:41.159876+00:00'
+created: '2025-10-07T20:42:08.965993+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -16,5 +16,6 @@ contributing variants:
   dogs*
     hash: "d41d8cd98f00b204e9800998ecf8427e"
     contributing component: null
+    hint: None
     root_component:
       not_a_known_variant_name*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.517909+00:00'
+created: '2025-10-07T20:42:06.460361+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "ecb890e5cd60dec2b626d500cc866de4"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -110,6 +111,7 @@ contributing variants:
   system*
     hash: "57493ac3e558feffb778cf170a7fd986"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.536183+00:00'
+created: '2025-10-07T20:42:06.478900+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "8c134ce2a43a0b2c55654902491307c2"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -78,6 +79,7 @@ contributing variants:
   system*
     hash: "f203e9bc12df86bb01fbd92a45643f86"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.556638+00:00'
+created: '2025-10-07T20:42:06.499920+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "c246c95d4a435b3d601044aebae72a38"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -124,6 +125,7 @@ contributing variants:
   system*
     hash: "d0669f63f03ddaec66ac8b9f4e3e449d"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.578915+00:00'
+created: '2025-10-07T20:42:06.522048+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "e7a1be23aff9a117598bb893ed4bedb4"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -104,6 +105,7 @@ contributing variants:
   system*
     hash: "1bba3ace796a07d167af26959c6039c9"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.599698+00:00'
+created: '2025-10-07T20:42:06.543310+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "4717aeb08ff642726ef6ea8f1ce55cdf"
     contributing component: exception
+    hint: None
     root_component:
       app*
         exception*
@@ -126,6 +127,7 @@ contributing variants:
   system*
     hash: "65244b22630821cacd0be603ebcef671"
     contributing component: exception
+    hint: None
     root_component:
       system*
         exception*

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-09-24T20:28:37.620023+00:00'
+created: '2025-10-07T20:42:06.563029+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -26,6 +26,7 @@ contributing variants:
   app*
     hash: "54e8028fb2526cf31b12dd66c01ad9e2"
     contributing component: threads
+    hint: None
     root_component:
       app*
         threads*
@@ -111,6 +112,7 @@ contributing variants:
   system*
     hash: "9e04decaf79ecba9dc0314dc0edd3993"
     contributing component: threads
+    hint: None
     root_component:
       system*
         threads*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/actix.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.406039+00:00'
+created: '2025-10-07T20:41:46.363849+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "738e7d2503464bc264b4f791286f5122"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -399,6 +400,7 @@ app:
 system:
   hash: "19a96e0438d28e48355653def82f887a"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/android_anr.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.460952+00:00'
+created: '2025-10-07T20:41:46.396283+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -790,6 +791,7 @@ app:
 system:
   hash: "2552498cfe69a6ddf1dcdde5440ce9c3"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/aspnetcore.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.489841+00:00'
+created: '2025-10-07T20:41:46.419572+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "228c649a3aa0901622c0a0e66ab0522c"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -175,6 +176,7 @@ app:
 default:
   hash: null
   contributing component: null
+  hint: ignored because app/system exception takes precedence
   root_component:
     default (ignored because app/system exception takes precedence)
       message (ignored because app/system exception takes precedence)
@@ -183,6 +185,7 @@ default:
 system:
   hash: "4ccd0f1953483581ba360c7518f90332"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.512364+00:00'
+created: '2025-10-07T20:41:46.444994+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
   contributing component: threads
+  hint: None
   root_component:
     app*
       threads*
@@ -23,6 +24,7 @@ app:
 default:
   hash: null
   contributing component: null
+  hint: ignored because app threads take precedence
   root_component:
     default (ignored because app threads take precedence)
       message (ignored because app threads take precedence)
@@ -31,6 +33,7 @@ default:
 system:
   hash: null
   contributing component: null
+  hint: ignored because app threads take precedence
   root_component:
     system (ignored because app threads take precedence)
       threads (ignored because hash matches app variant)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/bugly.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.537722+00:00'
+created: '2025-10-07T20:41:46.470701+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -32,6 +33,7 @@ app:
 system:
   hash: "d9c9b0f9ba46e32fddd7cd1512fad235"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.583626+00:00'
+created: '2025-10-07T20:41:46.525299+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because built-in fingerprint takes precedence
   root_component:
     app (ignored because built-in fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -30,6 +31,7 @@ built_in_fingerprint:
 system:
   hash: null
   contributing component: exception
+  hint: ignored because built-in fingerprint takes precedence
   root_component:
     system (ignored because built-in fingerprint takes precedence)
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.561124+00:00'
+created: '2025-10-07T20:41:46.502137+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because built-in fingerprint takes precedence
   root_component:
     app (ignored because built-in fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -30,6 +31,7 @@ built_in_fingerprint:
 system:
   hash: null
   contributing component: exception
+  hint: ignored because built-in fingerprint takes precedence
   root_component:
     system (ignored because built-in fingerprint takes precedence)
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.607190+00:00'
+created: '2025-10-07T20:41:46.547574+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "4ef1fb44d656c3be2a146971f2a222dc"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -132,6 +133,7 @@ app:
 system:
   hash: "47481871aa8d5ab5729cf2db78ce3032"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.667696+00:00'
+created: '2025-10-07T20:41:46.599633+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "7c8a196d16b94be382add324be2605ee"
   contributing component: threads
+  hint: None
   root_component:
     app*
       threads*
@@ -59,6 +60,7 @@ app:
 default:
   hash: null
   contributing component: null
+  hint: ignored because app/system threads take precedence
   root_component:
     default (ignored because app/system threads take precedence)
       message (ignored because app/system threads take precedence)
@@ -67,6 +69,7 @@ default:
 system:
   hash: "cd7f51d716fd57adc1a5ce1c112e538f"
   contributing component: threads
+  hint: None
   root_component:
     system*
       threads*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/connection_error.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.692871+00:00'
+created: '2025-10-07T20:41:46.618597+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "6b059b9febc815ac18ac4d2082e38a9b"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -117,6 +118,7 @@ app:
 default:
   hash: null
   contributing component: null
+  hint: ignored because app/system exception takes precedence
   root_component:
     default (ignored because app/system exception takes precedence)
       message (ignored because app/system exception takes precedence)
@@ -125,6 +127,7 @@ default:
 system:
   hash: "013d3477a774fe20c468dc8accd516f1"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.715124+00:00'
+created: '2025-10-07T20:41:46.637094+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "161ce02ecc5d6685a72e8e520ab726b3"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -46,6 +47,7 @@ app:
 system:
   hash: "c5e4b4a9ad1803c4d4ca7feee5e430ae"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.733302+00:00'
+created: '2025-10-07T20:41:46.655360+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -39,6 +40,7 @@ app:
 system:
   hash: "fe92cff6711f8a0a30cabb8b9245b1d6"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.899791+00:00'
+created: '2025-10-07T20:41:46.789176+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "666766514295bb52812324097cdaf53e"
   contributing component: csp
+  hint: None
   root_component:
     default*
       csp*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_img_src.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_img_src.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.753938+00:00'
+created: '2025-10-07T20:41:46.672507+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "1742101e08eb1608f569751dfedd0062"
   contributing component: csp
+  hint: None
   root_component:
     default*
       csp*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.775893+00:00'
+created: '2025-10-07T20:41:46.688761+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "efddf1cde918097259aa7d4904fb1942"
   contributing component: csp
+  hint: None
   root_component:
     default*
       csp*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_data_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_data_uri.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.796578+00:00'
+created: '2025-10-07T20:41:46.705185+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "4e6f2bce9d121aa89f4dc5e5da08afb5"
   contributing component: csp
+  hint: None
   root_component:
     default*
       csp*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.818199+00:00'
+created: '2025-10-07T20:41:46.721919+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "56c6520f35bce2f89ed2c4e725ccef65"
   contributing component: csp
+  hint: None
   root_component:
     default*
       csp*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.840011+00:00'
+created: '2025-10-07T20:41:46.738587+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "d346ee37d19a2be6587e609075ca2d57"
   contributing component: csp
+  hint: None
   root_component:
     default*
       csp*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_script_src_uri.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.860538+00:00'
+created: '2025-10-07T20:41:46.755879+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "223cdacfe5b4b830dc700b5c18cc21b4"
   contributing component: csp
+  hint: None
   root_component:
     default*
       csp*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_style_src_elem.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/csp_style_src_elem.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.880589+00:00'
+created: '2025-10-07T20:41:46.772952+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "537a973f594c364842893e9a72af62a5"
   contributing component: csp
+  hint: None
   root_component:
     default*
       csp*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.943655+00:00'
+created: '2025-10-07T20:41:46.824362+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: exception
+  hint: ignored because custom client fingerprint takes precedence
   root_component:
     app (ignored because custom client fingerprint takes precedence)
       exception*
@@ -176,6 +177,7 @@ custom_fingerprint:
 system:
   hash: null
   contributing component: exception
+  hint: ignored because custom client fingerprint takes precedence
   root_component:
     system (ignored because custom client fingerprint takes precedence)
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.922502+00:00'
+created: '2025-10-07T20:41:46.806785+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: exception
+  hint: ignored because custom server fingerprint takes precedence
   root_component:
     app (ignored because custom server fingerprint takes precedence)
       exception*
@@ -176,6 +177,7 @@ custom_fingerprint:
 system:
   hash: null
   contributing component: exception
+  hint: ignored because custom server fingerprint takes precedence
   root_component:
     system (ignored because custom server fingerprint takes precedence)
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:05.963002+00:00'
+created: '2025-10-07T20:41:46.841928+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: exception
+  hint: ignored because custom server fingerprint takes precedence
   root_component:
     app (ignored because custom server fingerprint takes precedence)
       exception*
@@ -176,6 +177,7 @@ custom_fingerprint:
 system:
   hash: null
   contributing component: exception
+  hint: ignored because custom server fingerprint takes precedence
   root_component:
     system (ignored because custom server fingerprint takes precedence)
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.000378+00:00'
+created: '2025-10-07T20:41:46.876591+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "029f3b967068b1539f96957b7c0451d7"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -93,6 +94,7 @@ app:
 system:
   hash: null
   contributing component: null
+  hint: ignored because app exception takes precedence
   root_component:
     system (ignored because app exception takes precedence)
       threads (ignored because app exception takes precedence)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.053202+00:00'
+created: '2025-10-07T20:41:46.928691+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "b23ee1963904c2ca87b145febf94b66c"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.018498+00:00'
+created: '2025-10-07T20:41:46.892769+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "9509e122c6175606d52862fa4f64853c"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -21,6 +22,7 @@ app:
 system:
   hash: null
   contributing component: null
+  hint: ignored because app exception takes precedence
   root_component:
     system (ignored because app exception takes precedence)
       exception (ignored because hash matches app variant)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.036292+00:00'
+created: '2025-10-07T20:41:46.912393+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "669cb6664e0f5fed38665da04e464f7e"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*
@@ -31,6 +32,7 @@ app:
 system:
   hash: null
   contributing component: null
+  hint: ignored because app exception takes precedence
   root_component:
     system (ignored because app exception takes precedence)
       chained_exception (ignored because hash matches app variant)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.069350+00:00'
+created: '2025-10-07T20:41:46.945756+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "e2bf1e0628b7b1824a9b63dec7a079a3"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.102607+00:00'
+created: '2025-10-07T20:41:46.979944+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "93b26686d00504b4e5aa1cb0244d8b37"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.085815+00:00'
+created: '2025-10-07T20:41:46.962890+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "93b26686d00504b4e5aa1cb0244d8b37"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.119275+00:00'
+created: '2025-10-07T20:41:46.996731+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "a4f16891fa438620699cb2d9af5cc827"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.136326+00:00'
+created: '2025-10-07T20:41:47.014964+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "028157fe357e4592e39eacb32eafa2db"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.155706+00:00'
+created: '2025-10-07T20:41:47.032187+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "f0078a82f351095ba595daa7d493aa3c"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.173794+00:00'
+created: '2025-10-07T20:41:47.049228+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "93b26686d00504b4e5aa1cb0244d8b37"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.190688+00:00'
+created: '2025-10-07T20:41:47.066640+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "0809098f9f613b63467605dd1739cc9b"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.208119+00:00'
+created: '2025-10-07T20:41:47.085365+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "0809098f9f613b63467605dd1739cc9b"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_exception.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_exception.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.225091+00:00'
+created: '2025-10-07T20:41:47.101689+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "a4f16891fa438620699cb2d9af5cc827"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.248379+00:00'
+created: '2025-10-07T20:41:47.120843+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "a4f16891fa438620699cb2d9af5cc827"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.269469+00:00'
+created: '2025-10-07T20:41:47.138588+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "17022e0561e9b6e6351723a08aa81b18"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.310766+00:00'
+created: '2025-10-07T20:41:47.172083+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "a4f16891fa438620699cb2d9af5cc827"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.290283+00:00'
+created: '2025-10-07T20:41:47.154824+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "f0078a82f351095ba595daa7d493aa3c"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.335316+00:00'
+created: '2025-10-07T20:41:47.190678+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "d505dfb9059ac63c11955233323a9100"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*
@@ -50,6 +51,7 @@ app:
 system:
   hash: "4f9cc6a81f4eb34f9e917374f281b9dc"
   contributing component: chained_exception
+  hint: None
   root_component:
     system*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_types.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_types.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.373150+00:00'
+created: '2025-10-07T20:41:47.225482+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "bca604b98cb4637167eb6190a92e8933"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.355156+00:00'
+created: '2025-10-07T20:41:47.208339+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "fca0fd23f09e8da4481304ef2a531100"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.390623+00:00'
+created: '2025-10-07T20:41:47.243019+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -34,6 +35,7 @@ app:
 system:
   hash: "26552f86ca2368e708afa1df6effc1c5"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_without_type.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_without_type.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.413857+00:00'
+created: '2025-10-07T20:41:47.261154+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "5eb63bbbe01eeed093cb22bb8f5acdc3"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_without_value.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/exception_without_value.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.434197+00:00'
+created: '2025-10-07T20:41:47.278269+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "5a2cfd89b7b171fd7b4794b08023d04f"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/expectct.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/expectct.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.521328+00:00'
+created: '2025-10-07T20:41:47.386458+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "3d2933f4b5ec459ec8d569a398fd328c"
   contributing component: expect_ct
+  hint: None
   root_component:
     default*
       expect_ct*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.552254+00:00'
+created: '2025-10-07T20:41:47.406917+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -34,6 +35,7 @@ app:
 system:
   hash: "87497299851e09febfecf4e84e0d45ba"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.592455+00:00'
+created: '2025-10-07T20:41:47.425487+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "526b64456c48836a46ec1a89544fd412"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_empty_list.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.610346+00:00'
+created: '2025-10-07T20:41:47.441655+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     app
       stacktrace (ignored because it contains no frames)
@@ -16,6 +17,7 @@ fallback:
 system:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     system
       stacktrace (ignored because it contains no frames)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.627584+00:00'
+created: '2025-10-07T20:41:47.459866+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "7d2cc7acbf90328200d960bf78a26234"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.648158+00:00'
+created: '2025-10-07T20:41:47.477339+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "465d672b2d322bf6a1b44499f6dabc1f"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.664430+00:00'
+created: '2025-10-07T20:41:47.495902+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "45c0b0a8c777e7a7040d7c39233a08a5"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.685492+00:00'
+created: '2025-10-07T20:41:47.511536+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
@@ -21,6 +22,7 @@ fallback:
 system:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.705075+00:00'
+created: '2025-10-07T20:41:47.527819+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "353e05904b48bd3ae4fa9623934a70d0"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.729318+00:00'
+created: '2025-10-07T20:41:47.544602+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "0094f39fc617031afb6c655419f4a9f2"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.751252+00:00'
+created: '2025-10-07T20:41:47.562135+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "be15ca3d511b96918e087c4f42503ca2"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.767792+00:00'
+created: '2025-10-07T20:41:47.579452+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -32,6 +33,7 @@ app:
 system:
   hash: "e04dce7550635e05dbd7f656102cf304"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.785006+00:00'
+created: '2025-10-07T20:41:47.595547+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "098f6bcd4621d373cade4e832627b4f6"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.805423+00:00'
+created: '2025-10-07T20:41:47.611047+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
@@ -19,6 +20,7 @@ fallback:
 system:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.826274+00:00'
+created: '2025-10-07T20:41:47.627157+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -20,6 +21,7 @@ app:
 system:
   hash: "64a0e0a34d99dce03a8c5a4c237a4b5a"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.843189+00:00'
+created: '2025-10-07T20:41:47.645348+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -20,6 +21,7 @@ app:
 system:
   hash: "64a0e0a34d99dce03a8c5a4c237a4b5a"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.860895+00:00'
+created: '2025-10-07T20:41:47.661959+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -20,6 +21,7 @@ app:
 system:
   hash: "e0e7c4713e9092dc77635d5a0d5db31d"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.882868+00:00'
+created: '2025-10-07T20:41:47.678519+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "c32a94349d9e9b72d31a46610c6c9589"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.901174+00:00'
+created: '2025-10-07T20:41:47.693975+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "be7f1b8b4014de623c533a8218dba5bd"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.918683+00:00'
+created: '2025-10-07T20:41:47.709625+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "53b9e9679a8ea25880376080b76f98ad"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.976927+00:00'
+created: '2025-10-07T20:41:47.762308+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "538bdfd8d7bb2495d0d6429c3689a420"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.938113+00:00'
+created: '2025-10-07T20:41:47.726811+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "538bdfd8d7bb2495d0d6429c3689a420"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.957645+00:00'
+created: '2025-10-07T20:41:47.744882+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "dc3d511120ce04996b1eef3496516e5c"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_module_if_page_url.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.015528+00:00'
+created: '2025-10-07T20:41:47.795165+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
@@ -21,6 +22,7 @@ fallback:
 system:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:06.995494+00:00'
+created: '2025-10-07T20:41:47.779039+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -20,6 +21,7 @@ app:
 system:
   hash: "0cc175b9c0f1b6a831c399e269772661"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.032008+00:00'
+created: '2025-10-07T20:41:47.812326+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "30eb5001914d29dd8461898b5b8094fe"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.048882+00:00'
+created: '2025-10-07T20:41:47.829462+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
@@ -51,6 +52,7 @@ fallback:
 system:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.065031+00:00'
+created: '2025-10-07T20:41:47.849363+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
@@ -21,6 +22,7 @@ fallback:
 system:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.080863+00:00'
+created: '2025-10-07T20:41:47.867485+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
@@ -21,6 +22,7 @@ fallback:
 system:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.115228+00:00'
+created: '2025-10-07T20:41:47.904553+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "07d1a8e5728b3c4c7aa8b8273fd0e753"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.097832+00:00'
+created: '2025-10-07T20:41:47.885739+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "09e0efcab18f545166318118ed4e0292"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.132295+00:00'
+created: '2025-10-07T20:41:47.923766+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -23,6 +24,7 @@ app:
 system:
   hash: "9bc326575875422d0d4ced3c35d9f916"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.149247+00:00'
+created: '2025-10-07T20:41:47.950154+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "27eed4125fc13d42163ddb0b8f357b48"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.165847+00:00'
+created: '2025-10-07T20:41:47.967030+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "4067a71d7098866f87c746a57a77b2bb"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.199282+00:00'
+created: '2025-10-07T20:41:48.003602+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -16,6 +17,7 @@ app:
 system:
   hash: "2f908c015ad77a50595512fcf65d344c"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.182818+00:00'
+created: '2025-10-07T20:41:47.985796+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -16,6 +17,7 @@ app:
 system:
   hash: "2f908c015ad77a50595512fcf65d344c"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.216058+00:00'
+created: '2025-10-07T20:41:48.021614+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -20,6 +21,7 @@ app:
 system:
   hash: "60e0a667027bef0d0b7c4882891df7e8"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.231937+00:00'
+created: '2025-10-07T20:41:48.039258+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "acbd18db4cc2f85cedef654fccc4a4d8"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.248318+00:00'
+created: '2025-10-07T20:41:48.058855+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -16,6 +17,7 @@ app:
 system:
   hash: "1effb24729ae4c43efa36b460511136a"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.264460+00:00'
+created: '2025-10-07T20:41:48.078959+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "4b8bbc500bd2cabfcadc1f1be867e0bb"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -32,6 +33,7 @@ app:
 system:
   hash: "348fc4026c9fa11ffba8fbfa80a134c9"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.284456+00:00'
+created: '2025-10-07T20:41:48.101169+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -146,6 +147,7 @@ app:
 system:
   hash: "3da34e8c72dbcd4a490ac36eb7130638"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.304065+00:00'
+created: '2025-10-07T20:41:48.121255+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -90,6 +91,7 @@ app:
 system:
   hash: "ca733a48a19d237df8577d09449095d9"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.324543+00:00'
+created: '2025-10-07T20:41:48.141211+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -106,6 +107,7 @@ app:
 system:
   hash: "2c1bbd635b64d5adccdb64a620044075"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.345396+00:00'
+created: '2025-10-07T20:41:48.161633+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -98,6 +99,7 @@ app:
 system:
   hash: "9c336f632f6764c0f082a6a66edbf22d"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.368496+00:00'
+created: '2025-10-07T20:41:48.181406+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -147,6 +148,7 @@ app:
 system:
   hash: "49b6f72b6635cb43190c57ee56b026b0"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.390428+00:00'
+created: '2025-10-07T20:41:48.201974+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -162,6 +163,7 @@ app:
 system:
   hash: "49b6f72b6635cb43190c57ee56b026b0"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.408995+00:00'
+created: '2025-10-07T20:41:48.222109+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -66,6 +67,7 @@ app:
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.427715+00:00'
+created: '2025-10-07T20:41:48.241316+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -61,6 +62,7 @@ app:
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.448942+00:00'
+created: '2025-10-07T20:41:48.264399+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -195,6 +196,7 @@ app:
 system:
   hash: "8be5979a334287a1b47457228f1d4612"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.469860+00:00'
+created: '2025-10-07T20:41:48.286010+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -200,6 +201,7 @@ app:
 system:
   hash: "8be5979a334287a1b47457228f1d4612"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.490925+00:00'
+created: '2025-10-07T20:41:48.307984+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -198,6 +199,7 @@ app:
 system:
   hash: "7e64037e487c78ce0439f750a2ef503f"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.508401+00:00'
+created: '2025-10-07T20:41:48.326705+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -48,6 +49,7 @@ app:
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.528322+00:00'
+created: '2025-10-07T20:41:48.348529+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -132,6 +133,7 @@ app:
 system:
   hash: "6148c73af04344a8597354711f5951ea"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.549224+00:00'
+created: '2025-10-07T20:41:48.370798+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -132,6 +133,7 @@ app:
 system:
   hash: "1056f62d72ff8b4d0c3842d696dbb10a"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.570190+00:00'
+created: '2025-10-07T20:41:48.395850+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -153,6 +154,7 @@ app:
 system:
   hash: "15526a7b64e9b5dc6d89e7ebec864260"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hpkp.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hpkp.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.587556+00:00'
+created: '2025-10-07T20:41:48.416475+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "1e37a374cb33572622d02ff7a6237c44"
   contributing component: hpkp
+  hint: None
   root_component:
     default*
       hpkp*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.604966+00:00'
+created: '2025-10-07T20:41:48.437466+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "e3d593b4335190212ca7c18b8e967fb1"
   contributing component: exception
+  hint: None
   fingerprint_info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   root_component:
     app*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.624541+00:00'
+created: '2025-10-07T20:41:48.456372+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "19163f3ca34f5995c69d85351ce3d697"
   contributing component: exception
+  hint: None
   fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
   root_component:
     app*
@@ -173,6 +174,7 @@ app:
 system:
   hash: "847950eb44d280e6758d136c763d6ddc"
   contributing component: exception
+  hint: None
   fingerprint_info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
   root_component:
     system*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.649154+00:00'
+created: '2025-10-07T20:41:48.475725+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: exception
+  hint: ignored because custom server fingerprint takes precedence
   root_component:
     app (ignored because custom server fingerprint takes precedence)
       exception*
@@ -176,6 +177,7 @@ custom_fingerprint:
 system:
   hash: null
   contributing component: exception
+  hint: ignored because custom server fingerprint takes precedence
   root_component:
     system (ignored because custom server fingerprint takes precedence)
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.665248+00:00'
+created: '2025-10-07T20:41:48.493730+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "5b5ad5a0fbb4deb5e3fc631ce42681ae"
   contributing component: exception
+  hint: None
   fingerprint_info: {"client_fingerprint":["{{ default }}","adopt don't shop"]}
   root_component:
     app*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.686450+00:00'
+created: '2025-10-07T20:41:48.510680+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "c5578778212497f1ff3435405e2a4a98"
   contributing component: exception
+  hint: None
   fingerprint_info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   root_component:
     app*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.714893+00:00'
+created: '2025-10-07T20:41:48.531284+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "5b032559156688c9eabe4e4bd5ae6bd4"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -152,6 +153,7 @@ app:
 system:
   hash: "1921b991270e24c19ea1ed6863892d71"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_chained.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.740635+00:00'
+created: '2025-10-07T20:41:48.553957+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       chained_exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -395,6 +396,7 @@ app:
 default:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     default (ignored because system exception takes precedence)
       message (ignored because system exception takes precedence)
@@ -403,6 +405,7 @@ default:
 system:
   hash: "1959b227a7cf6acf7f3fd401b5d9f09b"
   contributing component: chained_exception
+  hint: None
   root_component:
     system*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.764920+00:00'
+created: '2025-10-07T20:41:48.575854+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -403,6 +404,7 @@ app:
 default:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     default (ignored because system exception takes precedence)
       message (ignored because system exception takes precedence)
@@ -411,6 +413,7 @@ default:
 system:
   hash: "ef2555bf7958ada8eefafbfdaed1c409"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.802891+00:00'
+created: '2025-10-07T20:41:48.610480+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "10dfd81e2df31e96fae451b9e205ad81"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.786157+00:00'
+created: '2025-10-07T20:41:48.592473+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "b8e2a347e75266ca7bb565e2b3c0722e"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.824693+00:00'
+created: '2025-10-07T20:41:48.631253+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -78,6 +79,7 @@ app:
 system:
   hash: "c0f3f7d6deb17aec9d07259ac684fad0"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_message.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_message.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.862236+00:00'
+created: '2025-10-07T20:41:48.663361+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "4119639092e62c55ea8be348e4d9260d"
   contributing component: message
+  hint: None
   root_component:
     default*
       message*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_message_parameterization.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.841279+00:00'
+created: '2025-10-07T20:41:48.648031+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "f9e47f16e3b9770b440157179c47bf7a"
   contributing component: message
+  hint: None
   root_component:
     default*
       message* (stripped event-specific values)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.888908+00:00'
+created: '2025-10-07T20:41:48.680544+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "be36642f41f047346396f018f62375d3"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -33,6 +34,7 @@ app:
 system:
   hash: null
   contributing component: null
+  hint: ignored because app exception takes precedence
   root_component:
     system (ignored because app exception takes precedence)
       exception (ignored because hash matches app variant)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.911115+00:00'
+created: '2025-10-07T20:41:48.696787+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -40,6 +41,7 @@ app:
 system:
   hash: "6ab78545e13144405fb21dadb9045b91"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.929567+00:00'
+created: '2025-10-07T20:41:48.715889+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -64,6 +65,7 @@ app:
 system:
   hash: "c63e8727af1a8fe75872b6a762797113"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.952726+00:00'
+created: '2025-10-07T20:41:48.734629+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -68,6 +69,7 @@ app:
 system:
   hash: "c63e8727af1a8fe75872b6a762797113"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.977468+00:00'
+created: '2025-10-07T20:41:48.752795+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -61,6 +62,7 @@ app:
 system:
   hash: "c63e8727af1a8fe75872b6a762797113"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:07.998179+00:00'
+created: '2025-10-07T20:41:48.771993+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -82,6 +83,7 @@ app:
 system:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.018602+00:00'
+created: '2025-10-07T20:41:48.791419+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -86,6 +87,7 @@ app:
 system:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.035641+00:00'
+created: '2025-10-07T20:41:48.807584+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -79,6 +80,7 @@ app:
 system:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.053353+00:00'
+created: '2025-10-07T20:41:48.824721+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -85,6 +86,7 @@ app:
 system:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.070832+00:00'
+created: '2025-10-07T20:41:48.841486+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -69,6 +70,7 @@ app:
 system:
   hash: "c63e8727af1a8fe75872b6a762797113"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.090526+00:00'
+created: '2025-10-07T20:41:48.860616+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "4a3cf3893b6485428dd02da116c8370e"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -180,6 +181,7 @@ app:
 system:
   hash: "d5456487ea8dccfe96c1968b19870978"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.110241+00:00'
+created: '2025-10-07T20:41:48.878511+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "4a3cf3893b6485428dd02da116c8370e"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -149,6 +150,7 @@ app:
 system:
   hash: "0b81da6ea3d7cc82b1d4825b7aac0b8d"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/laravel.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.153145+00:00'
+created: '2025-10-07T20:41:48.916422+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "4665d486184740231357ab63f4543a8d"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -366,6 +367,7 @@ app:
 system:
   hash: "107ed03036d901157372f260bc3df446"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/laravel_anonymous.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.128878+00:00'
+created: '2025-10-07T20:41:48.896258+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "a728cdf5d62c8e017c35c3fe04051b6e"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -37,6 +38,7 @@ app:
 system:
   hash: "63c67781779781d9b0a442a5b2bdb976"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/logentry_prefers_message.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/logentry_prefers_message.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.174876+00:00'
+created: '2025-10-07T20:41:48.932665+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "8ec8bbc71eb6e2af7fbe5076a8534f96"
   contributing component: message
+  hint: None
   root_component:
     default*
       message*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/logentry_uses_formatted.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/logentry_uses_formatted.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.196405+00:00'
+created: '2025-10-07T20:41:48.948306+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "329b29efcf1f77067a063e34f56e7791"
   contributing component: message
+  hint: None
   root_component:
     default*
       message*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.217008+00:00'
+created: '2025-10-07T20:41:48.967688+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -161,6 +162,7 @@ app:
 system:
   hash: "b8baf791d22ac902d5f59a7eedd844fd"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.243615+00:00'
+created: '2025-10-07T20:41:48.988713+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -189,6 +190,7 @@ app:
 system:
   hash: "36be6e0b6123ef6ecfbef62f5cb88406"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.269029+00:00'
+created: '2025-10-07T20:41:49.008392+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -102,6 +103,7 @@ app:
 system:
   hash: "70b7b816193e06eb5d6649989fbaf605"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/message_prefers_message.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/message_prefers_message.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.295222+00:00'
+created: '2025-10-07T20:41:49.024164+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "8ec8bbc71eb6e2af7fbe5076a8534f96"
   contributing component: message
+  hint: None
   root_component:
     default*
       message*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/message_uses_formatted.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/message_uses_formatted.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.332190+00:00'
+created: '2025-10-07T20:41:49.040098+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "d3f5e52d24e9c1eae5abe6c866cced63"
   contributing component: message
+  hint: None
   root_component:
     default*
       message*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/message_with_key_pair_values.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/message_with_key_pair_values.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.352257+00:00'
+created: '2025-10-07T20:41:49.057706+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "d2ab1028e9cb44352a824e878951f412"
   contributing component: message
+  hint: None
   root_component:
     default*
       message* (stripped event-specific values)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.375908+00:00'
+created: '2025-10-07T20:41:49.075835+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -214,6 +215,7 @@ app:
 system:
   hash: "dcfcd48a02c100bbe4023cbc783054f0"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.397848+00:00'
+created: '2025-10-07T20:41:49.092366+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -27,6 +28,7 @@ app:
 system:
   hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.425438+00:00'
+created: '2025-10-07T20:41:49.111570+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -37,6 +38,7 @@ app:
 system:
   hash: "2e0d26cae5986fcda5edf66612a78268"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.452178+00:00'
+created: '2025-10-07T20:41:49.128980+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -32,6 +33,7 @@ app:
 system:
   hash: "c85e23e804b52ea4b9f290ba838e77a0"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.483625+00:00'
+created: '2025-10-07T20:41:49.146361+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -38,6 +39,7 @@ app:
 system:
   hash: "784442a33bd16c15013bb8f69f68e7d6"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.506714+00:00'
+created: '2025-10-07T20:41:49.162991+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -27,6 +28,7 @@ app:
 system:
   hash: "8f4c7709e4af98d3c47ce3519690e6d9"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.531031+00:00'
+created: '2025-10-07T20:41:49.180905+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -36,6 +37,7 @@ app:
 system:
   hash: "3ff01ce959249abecc6bc8a8f1432b0b"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_no_filenames.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.549425+00:00'
+created: '2025-10-07T20:41:49.199595+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "418120a66f7031923031f5c52aca0724"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -60,6 +61,7 @@ app:
 system:
   hash: "bbcdb2e1d8df09ffe0fffd30fb361d4b"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.575464+00:00'
+created: '2025-10-07T20:41:49.216202+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -27,6 +28,7 @@ app:
 system:
   hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.596751+00:00'
+created: '2025-10-07T20:41:49.234253+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -43,6 +44,7 @@ app:
 system:
   hash: "46b84e4da51648cc9f9741abd2bdad51"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/native_with_function_name.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.617701+00:00'
+created: '2025-10-07T20:41:49.253972+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -39,6 +40,7 @@ app:
 system:
   hash: "c29439027eafcf7642f641554ab0f0ef"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.637402+00:00'
+created: '2025-10-07T20:41:49.274815+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "a20509269752c9a1bea6078851e4d39c"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -104,6 +105,7 @@ app:
 system:
   hash: "252dc79eb5653bf822e2684d90734cb8"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.656302+00:00'
+created: '2025-10-07T20:41:49.293919+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "be36642f41f047346396f018f62375d3"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -30,6 +31,7 @@ app:
 system:
   hash: null
   contributing component: null
+  hint: ignored because app exception takes precedence
   root_component:
     system (ignored because app exception takes precedence)
       exception (ignored because hash matches app variant)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.674545+00:00'
+created: '2025-10-07T20:41:49.313725+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "c52ebcc2d9d0780a23c7d99831678830"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*
@@ -31,6 +32,7 @@ app:
 system:
   hash: "669cb6664e0f5fed38665da04e464f7e"
   contributing component: chained_exception
+  hint: None
   root_component:
     system*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.695052+00:00'
+created: '2025-10-07T20:41:49.333669+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "121caa876de75ec51bf72ed4c852cd75"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -108,6 +109,7 @@ app:
 system:
   hash: "a5af2577d4caca8f983657c5d1919e14"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.713939+00:00'
+created: '2025-10-07T20:41:49.355408+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -108,6 +109,7 @@ app:
 system:
   hash: "90888e813b09fa25061af2883c0fb9bd"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.732319+00:00'
+created: '2025-10-07T20:41:49.375099+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "d59239f5aad3304d60beb1fde3369b78"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -45,6 +46,7 @@ app:
 default:
   hash: null
   contributing component: null
+  hint: ignored because app/system exception takes precedence
   root_component:
     default (ignored because app/system exception takes precedence)
       message (ignored because app/system exception takes precedence)
@@ -53,6 +55,7 @@ default:
 system:
   hash: "133db3f366b1327dab4e661f66dfb961"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.785618+00:00'
+created: '2025-10-07T20:41:49.432915+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "11e6467c8358a9366c6538f95dcd7bd4"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.750026+00:00'
+created: '2025-10-07T20:41:49.393521+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "70dd09f56349dcce62a74137b00bb571"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.768376+00:00'
+created: '2025-10-07T20:41:49.413495+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "5f209162115f576bedbaf6f0ad30e5aa"
   contributing component: chained_exception
+  hint: None
   root_component:
     app*
       chained_exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/react_native.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.805605+00:00'
+created: '2025-10-07T20:41:49.460235+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "73470e545e51eea9cff8a6c006f68f57"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -210,6 +211,7 @@ app:
 system:
   hash: "ecd413627f0d90a5a25cb28d1ba9c39f"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_cocoa.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.823174+00:00'
+created: '2025-10-07T20:41:49.480835+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "eb416f98479efa56a77c524602dc9979"
   contributing component: stacktrace
+  hint: None
   root_component:
     app*
       stacktrace*
@@ -19,6 +20,7 @@ app:
 system:
   hash: "1df786c8c266506e1acb6669c8df5154"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.841287+00:00'
+created: '2025-10-07T20:41:49.500254+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -62,6 +63,7 @@ app:
 system:
   hash: "9bdadae4fa003cef6cf460ff1325e54b"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.858034+00:00'
+created: '2025-10-07T20:41:49.518817+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "1effb24729ae4c43efa36b460511136a"
   contributing component: stacktrace
+  hint: None
   root_component:
     app*
       stacktrace*
@@ -19,6 +20,7 @@ app:
 system:
   hash: "659ad79e2e70c822d30a53d7d889529e"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_discards_seemingly_useless_stack.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_discards_seemingly_useless_stack.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.875474+00:00'
+created: '2025-10-07T20:41:49.538744+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
@@ -19,6 +20,7 @@ fallback:
 system:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.892024+00:00'
+created: '2025-10-07T20:41:49.556653+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -16,6 +17,7 @@ app:
 system:
   hash: "acbd18db4cc2f85cedef654fccc4a4d8"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_does_not_group_different_js_errors.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_does_not_group_different_js_errors.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.909598+00:00'
+created: '2025-10-07T20:41:49.575483+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     app
       stacktrace (ignored because it contains no in-app frames)
@@ -19,6 +20,7 @@ fallback:
 system:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     system
       stacktrace (ignored because it contains no contributing frames)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.927379+00:00'
+created: '2025-10-07T20:41:49.594618+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -39,6 +40,7 @@ app:
 system:
   hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.944621+00:00'
+created: '2025-10-07T20:41:49.613216+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -18,6 +19,7 @@ app:
 system:
   hash: "cd2a9fd0cdaa8cd55ed22b101fc65882"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.960999+00:00'
+created: '2025-10-07T20:41:49.630301+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "659ad79e2e70c822d30a53d7d889529e"
   contributing component: stacktrace
+  hint: None
   root_component:
     app*
       stacktrace*
@@ -19,6 +20,7 @@ app:
 system:
   hash: null
   contributing component: null
+  hint: ignored because app stacktrace takes precedence
   root_component:
     system (ignored because app stacktrace takes precedence)
       stacktrace (ignored because hash matches app variant)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.978201+00:00'
+created: '2025-10-07T20:41:49.648114+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system stacktrace takes precedence
   root_component:
     app (ignored because system stacktrace takes precedence)
       stacktrace (ignored because it contains no in-app frames)
@@ -26,6 +27,7 @@ app:
 system:
   hash: "c5da56c71b31f34c5880d734cbc8f5bb"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:08.995932+00:00'
+created: '2025-10-07T20:41:49.665561+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: ignored because system exception takes precedence
   root_component:
     app (ignored because system exception takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
@@ -39,6 +40,7 @@ app:
 system:
   hash: "eb87c1031dba55b67df86fb9fff59dc6"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:09.016742+00:00'
+created: '2025-10-07T20:41:49.683810+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "eb87c1031dba55b67df86fb9fff59dc6"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -39,6 +40,7 @@ app:
 system:
   hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:09.036587+00:00'
+created: '2025-10-07T20:41:49.703051+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "eb87c1031dba55b67df86fb9fff59dc6"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -39,6 +40,7 @@ app:
 system:
   hash: "0817e4e604fbe88c4534eff166df1db9"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:09.054457+00:00'
+created: '2025-10-07T20:41:49.722001+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "1effb24729ae4c43efa36b460511136a"
   contributing component: stacktrace
+  hint: None
   root_component:
     app*
       stacktrace*
@@ -49,6 +50,7 @@ app:
 system:
   hash: "659ad79e2e70c822d30a53d7d889529e"
   contributing component: stacktrace
+  hint: None
   root_component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/template_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/template_compute_hashes.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:09.071278+00:00'
+created: '2025-10-07T20:41:49.741297+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 default:
   hash: "1f5bdebe3c9f414c7dbb4296a8353245"
   contributing component: template
+  hint: None
   root_component:
     default*
       template*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:09.089493+00:00'
+created: '2025-10-07T20:41:49.759791+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "1a11687556cf74559f0ae90b1c87e2fd"
   contributing component: threads
+  hint: None
   root_component:
     app*
       threads*
@@ -19,6 +20,7 @@ app:
 system:
   hash: null
   contributing component: null
+  hint: ignored because app threads take precedence
   root_component:
     system (ignored because app threads take precedence)
       threads (ignored because hash matches app variant)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/threads_no_hash.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/threads_no_hash.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:09.106846+00:00'
+created: '2025-10-07T20:41:49.776732+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   contributing component: null
+  hint: None
   root_component:
     app
       threads (ignored because it contains neither a single thread nor multiple threads with exactly one crashing or current thread; instead contains 0 crashing, 2 current, and 2 total threads)

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unity.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:09.126995+00:00'
+created: '2025-10-07T20:41:49.795501+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "a12d579fed7636c2a5d2fae110c95ce5"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -58,6 +59,7 @@ app:
 system:
   hash: "c0dbeebf0430b3310ad1f7ceb48553a6"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:09.146880+00:00'
+created: '2025-10-07T20:41:49.815790+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "ecb890e5cd60dec2b626d500cc866de4"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -114,6 +115,7 @@ app:
 system:
   hash: "57493ac3e558feffb778cf170a7fd986"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:09.166505+00:00'
+created: '2025-10-07T20:41:49.835632+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "8c134ce2a43a0b2c55654902491307c2"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -86,6 +87,7 @@ app:
 system:
   hash: "f203e9bc12df86bb01fbd92a45643f86"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:09.186630+00:00'
+created: '2025-10-07T20:41:49.858078+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "c246c95d4a435b3d601044aebae72a38"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -157,6 +158,7 @@ app:
 system:
   hash: "d0669f63f03ddaec66ac8b9f4e3e449d"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:09.208856+00:00'
+created: '2025-10-07T20:41:49.880036+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "e7a1be23aff9a117598bb893ed4bedb4"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -266,6 +267,7 @@ app:
 system:
   hash: "1bba3ace796a07d167af26959c6039c9"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:09.229616+00:00'
+created: '2025-10-07T20:41:49.901433+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "4717aeb08ff642726ef6ea8f1ce55cdf"
   contributing component: exception
+  hint: None
   root_component:
     app*
       exception*
@@ -186,6 +187,7 @@ app:
 system:
   hash: "65244b22630821cacd0be603ebcef671"
   contributing component: exception
+  hint: None
   root_component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,11 +1,12 @@
 ---
-created: '2025-09-24T20:27:09.251707+00:00'
+created: '2025-10-07T20:41:49.920891+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: "54e8028fb2526cf31b12dd66c01ad9e2"
   contributing component: threads
+  hint: None
   root_component:
     app*
       threads*
@@ -137,6 +138,7 @@ app:
 default:
   hash: null
   contributing component: null
+  hint: ignored because app/system threads take precedence
   root_component:
     default (ignored because app/system threads take precedence)
       message (ignored because app/system threads take precedence)
@@ -145,6 +147,7 @@ default:
 system:
   hash: "9e04decaf79ecba9dc0314dc0edd3993"
   contributing component: threads
+  hint: None
   root_component:
     system*
       threads*


### PR DESCRIPTION
Now that [variants have a `hint` property](https://github.com/getsentry/sentry/pull/100259), we should probably include it in our snapshots.  It's already in the grouping info snapshots, because it's included in the variant serialization, but this adds it to grouphash metadata and variant snapshots.