### PR TITLE
fix(timeseries): Handle sampleRates same as stats

### DIFF
--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -60,7 +60,7 @@ class Row(TypedDict):
     incomplete: bool
     comparisonValue: NotRequired[float]
     sampleCount: NotRequired[float]
-    sampleRate: NotRequired[float]
+    sampleRate: NotRequired[float | None]
     confidence: NotRequired[Literal["low", "high"] | None]
     incompleteReason: NotRequired[str]
 
@@ -89,6 +89,13 @@ class TimeSeries(TypedDict):
 class StatsResponse(TypedDict):
     meta: StatsMeta
     timeSeries: list[TimeSeries]
+
+
+def null_zero(value: float) -> float | None:
+    if value == 0:
+        return None
+    else:
+        return value
 
 
 @region_silo_endpoint
@@ -391,7 +398,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                 processed_timeseries.confidence,
             ):
                 value["sampleCount"] = count[axis]
-                value["sampleRate"] = rate[axis]
+                # We want to null sample rates that are 0 since that means we received no data during this bucket
+                value["sampleRate"] = null_zero(rate[axis])
                 value["confidence"] = confidence[axis]
 
         timeseries["values"] = timeseries_values

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
@@ -77,7 +77,7 @@ class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpoi
             3_600_000,
             event_counts,
             sample_count=event_counts,
-            sample_rate=[1 if val else 0 for val in event_counts],
+            sample_rate=[1 if val else None for val in event_counts],
             confidence=[any_confidence if val else None for val in event_counts],
         )
         assert timeseries["meta"] == {

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -126,7 +126,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             3_600_000,
             event_counts,
             sample_count=event_counts,
-            sample_rate=[1 if val else 0 for val in event_counts],
+            sample_rate=[1 if val else None for val in event_counts],
             confidence=[any_confidence if val else None for val in event_counts],
         )
         assert timeseries["meta"] == {
@@ -1059,7 +1059,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             3_600_000,
             [val * 10 for val in event_counts],
             sample_count=event_counts,
-            sample_rate=[pytest.approx(0.1) if val else 0 for val in event_counts],
+            sample_rate=[pytest.approx(0.1) if val else None for val in event_counts],
             confidence=["low" if val else None for val in event_counts],
         )
         assert timeseries["meta"] == {
@@ -1133,7 +1133,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                 3_600_000,
                 expected_values,
                 sample_count=event_counts,
-                sample_rate=[pytest.approx(0.1) if val else 0 for val in event_counts],
+                sample_rate=[pytest.approx(0.1) if val else None for val in event_counts],
                 confidence=[any_confidence if val else None for val in event_counts],
             ), y_axis
 
@@ -1184,7 +1184,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                 3_600_000,
                 [val * 10 if y_axis == "count()" else val for val in event_counts],
                 sample_count=event_counts,
-                sample_rate=[pytest.approx(0.1) if val else 0 for val in event_counts],
+                sample_rate=[pytest.approx(0.1) if val else None for val in event_counts],
                 confidence=[any_confidence if val else None for val in event_counts],
             )
 
@@ -1257,7 +1257,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                 60_000,
                 [val * 10 for val in event_counts],
                 sample_count=event_counts,
-                sample_rate=[pytest.approx(0.1) if val else 0 for val in event_counts],
+                sample_rate=[pytest.approx(0.1) if val else None for val in event_counts],
                 confidence=[any_confidence if val else None for val in event_counts],
             )
 


### PR DESCRIPTION
- events-stats Nulls non existent sample rates instead of leaving the 0, this updates the timeseries endpoint to do the same
- ENG-5672