### PR TITLE
fix(ci): Update external API calls in our build action to use exponential backoff

### DIFF
--- a/src/sentry/build/_download.py
+++ b/src/sentry/build/_download.py
@@ -5,13 +5,19 @@ import urllib.request
 from typing import IO
 
 
-def urlopen_with_retries(url: str, timeout: int = 5, retries: int = 10) -> IO[bytes]:
+def urlopen_with_retries(url: str, timeout: int = 5, retries: int = 6) -> IO[bytes]:
+    """
+    Retries with exponential backoff.
+    Assuming default parameters (5s timeout, 6 retries), waits for a maximum of
+    (5 + 2^0) + (5 + 2^1) + ... + (5 + 2^4) + (5) = 61s.
+            raises on the last one so no sleep ^
+    """
     for i in range(retries):
         try:
             return urllib.request.urlopen(url, timeout=timeout)
         except Exception:
             if i == retries - 1:
                 raise
-            time.sleep(i * 0.01)
+            time.sleep(2**i)  # 1, 2, 4, ..., 16
     else:
         raise AssertionError("unreachable")


### PR DESCRIPTION
We've been getting a lot of SSL EOF errors in CI lately, and as far as I know they are just transient.

Previously this function used a linear backoff that was really small, hopefully the longer exponential waits reduce the amount of transient hard faults.

As calculated in the docstring, this function takes a maximum of 61s so CI won't be slowed down significantly.