### PR TITLE
fix(logs): Indicate no results in direction for flex time

### DIFF
--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -343,7 +343,11 @@ function getPageParam(
       // the flex time sampling strategy has no previous page cursor and only
       // a next page cursor because it only works in timestamp desc order
       const link = isGetPreviousPage ? links.previous : links.next;
-      cursor = link?.results ? (link.cursor ?? undefined) : undefined;
+      // return `undefined` to indicate that there are no results in this direction
+      if (!link?.results) {
+        return undefined;
+      }
+      cursor = link.cursor ?? undefined;
     }
 
     const pageParamResult: LogPageParam = {


### PR DESCRIPTION
By returning `undefined` in the `getNextPageParams` and `getPreviousPageParams` functions, we can indicate to react query that we've finished paginating the results so we can stop.