### PR TITLE
chore(eco): add pending deletion state for sentry app installs

### DIFF
--- a/static/app/actionCreators/sentryAppInstallations.tsx
+++ b/static/app/actionCreators/sentryAppInstallations.tsx
@@ -53,7 +53,7 @@ export function uninstallSentryApp(
     install.app.slug.charAt(0).toUpperCase() + install.app.slug.slice(1);
   promise.then(
     () => {
-      addSuccessMessage(t('%s successfully uninstalled.', capitalizedAppSlug));
+      addSuccessMessage(t('%s successfully queued for deletion.', capitalizedAppSlug));
     },
     () => clearIndicators()
   );

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -267,7 +267,7 @@ export type SentryAppInstallation = {
   organization: {
     slug: string;
   };
-  status: 'installed' | 'pending';
+  status: 'installed' | 'pending' | 'pending_deletion';
   uuid: string;
   code?: string;
 };

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -74,7 +74,7 @@ export const getIntegrationFeatureGate = () => {
 };
 
 export const getSentryAppInstallStatus = (install: SentryAppInstallation | undefined) => {
-  if (install?.status !== 'pending_deletion') {
+  if (install && install.status !== 'pending_deletion') {
     return capitalize(install.status) as IntegrationInstallationStatus;
   }
   if (install && install.status === 'pending_deletion') {

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -74,8 +74,11 @@ export const getIntegrationFeatureGate = () => {
 };
 
 export const getSentryAppInstallStatus = (install: SentryAppInstallation | undefined) => {
-  if (install) {
+  if (install && install.status !== 'pending_deletion') {
     return capitalize(install.status) as IntegrationInstallationStatus;
+  }
+  if (install && install.status === 'pending_deletion') {
+    return 'Pending Deletion';
   }
   return 'Not Installed';
 };

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -74,7 +74,7 @@ export const getIntegrationFeatureGate = () => {
 };
 
 export const getSentryAppInstallStatus = (install: SentryAppInstallation | undefined) => {
-  if (install && install.status !== 'pending_deletion') {
+  if (install?.status !== 'pending_deletion') {
     return capitalize(install.status) as IntegrationInstallationStatus;
   }
   if (install && install.status === 'pending_deletion') {

--- a/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.spec.tsx
@@ -140,6 +140,10 @@ describe('SentryAppDetailedView', () => {
       await userEvent.click(screen.getByRole('button', {name: 'Uninstall'}));
       await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
       expect(deleteRequest).toHaveBeenCalledTimes(1);
+
+      expect(
+        await screen.findByRole('button', {name: 'Pending Deletion'})
+      ).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.spec.tsx
@@ -141,6 +141,8 @@ describe('SentryAppDetailedView', () => {
       await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
       expect(deleteRequest).toHaveBeenCalledTimes(1);
 
+      expect(await screen.findAllByText('Pending Deletion')).toHaveLength(2);
+
       expect(
         await screen.findByRole('button', {name: 'Pending Deletion'})
       ).toBeInTheDocument();

--- a/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx
@@ -229,7 +229,10 @@ export default function SentryAppDetailedView() {
         setApiQueryData<SentryAppInstallation[]>(
           queryClient,
           makeSentryAppInstallationsQueryKey({orgSlug: organization.slug}),
-          (existingData = []) => existingData.filter(i => i.app.slug !== sentryApp.slug)
+          (existingData = []) =>
+            existingData.map(i =>
+              i.app.slug === sentryApp.slug ? {...i, status: 'pending_deletion'} : i
+            )
         );
       } catch (error) {
         addErrorMessage(t('Unable to uninstall %s', sentryApp.name));
@@ -306,6 +309,13 @@ export default function SentryAppDetailedView() {
     (disabledFromFeatures: boolean, userHasAccess: boolean) => {
       const capitalizedSlug =
         integrationSlug.charAt(0).toUpperCase() + integrationSlug.slice(1);
+      if (install?.status === 'pending_deletion') {
+        return (
+          <StyledButton size="sm" disabled>
+            {t('Pending Deletion')}
+          </StyledButton>
+        );
+      }
       if (install) {
         return (
           <Confirm
@@ -317,10 +327,10 @@ export default function SentryAppDetailedView() {
             onConfirming={recordUninstallClicked} // called when the confirm modal opens
             priority="danger"
           >
-            <StyledUninstallButton size="sm" data-test-id="sentry-app-uninstall">
+            <StyledButton size="sm" data-test-id="sentry-app-uninstall">
               <IconSubtract isCircled style={{marginRight: space(0.75)}} />
               {t('Uninstall')}
-            </StyledUninstallButton>
+            </StyledButton>
           </Confirm>
         );
       }
@@ -431,7 +441,7 @@ const InstallButton = styled(Button)`
   margin-left: ${space(1)};
 `;
 
-const StyledUninstallButton = styled(Button)`
+const StyledButton = styled(Button)`
   color: ${p => p.theme.subText};
   background: ${p => p.theme.background};
 


### PR DESCRIPTION
Merge after https://github.com/getsentry/sentry/pull/100930

When deleting a Sentry app install, we queue it for deletion in the above PR, so we should show this state to the FE.

After the DELETE call is successful, update the FE state of the current installation to `pending_deletion` and also update buttons and labels.