### PR TITLE
ref(billing): remove references to expired transaction discount promotion

### DIFF
--- a/static/gsApp/views/subscriptionPage/overview.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.tsx
@@ -117,21 +117,6 @@ function Overview({location, subscription, promotionData}: Props) {
         openPerformanceQuotaCreditsPromoModal({api, promotionData, organization});
         return;
       }
-
-      promotion = promotionData.availablePromotions?.find(
-        promo => promo.promptActivityTrigger === 'performance_reserved_txns_discount'
-      );
-
-      if (promotion) {
-        openPerformanceReservedTransactionsDiscountModal({
-          api,
-          promotionData,
-          organization,
-          promptFeature: 'performance_reserved_txns_discount',
-          navigate,
-        });
-        return;
-      }
     }
 
     // open the codecov modal if the query param is present

--- a/static/gsApp/views/subscriptionPage/promotions/performanceReservedTransactionsPromo.tsx
+++ b/static/gsApp/views/subscriptionPage/promotions/performanceReservedTransactionsPromo.tsx
@@ -16,9 +16,7 @@ type Props = {
   navigate: ReturnType<typeof useNavigate>;
   organization: Organization;
   promotionData: PromotionData;
-  promptFeature:
-    | 'performance_reserved_txns_discount'
-    | 'performance_reserved_txns_discount_v1';
+  promptFeature: 'performance_reserved_txns_discount_v1';
 };
 
 function PromotionModalBody() {


### PR DESCRIPTION
Removes references to `performance_reserved_txns_discount` since the promotion expired. See https://github.com/getsentry/getsentry/pull/18554