### PR TITLE
Cobyeastwood/rtc 1208 issue stream does not support project search property

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1829,7 +1829,11 @@ const SHARED_FIELD_KEY: Record<SharedFieldKey, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [FieldKey.PROJECT]: {kind: FieldKind.FIELD, valueType: FieldValueType.STRING},
+  [FieldKey.PROJECT]: {
+    desc: t('The name of the project'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
   [FieldKey.HAS]: {
     desc: t('Determines if a tag or field exists in an event'),
     kind: FieldKind.FIELD,
@@ -2491,6 +2495,7 @@ export const ISSUE_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.DETECTOR,
   FieldKey.FIRST_RELEASE,
   FieldKey.FIRST_SEEN,
+  FieldKey.PROJECT,
   FieldKey.HAS,
   FieldKey.IS,
   FieldKey.ISSUE_CATEGORY,

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2495,7 +2495,6 @@ export const ISSUE_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.DETECTOR,
   FieldKey.FIRST_RELEASE,
   FieldKey.FIRST_SEEN,
-  FieldKey.PROJECT,
   FieldKey.HAS,
   FieldKey.IS,
   FieldKey.ISSUE_CATEGORY,
@@ -2571,6 +2570,9 @@ export const ISSUE_EVENT_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.OTA_UPDATES_CHANNEL,
   FieldKey.OTA_UPDATES_RUNTIME_VERSION,
   FieldKey.OTA_UPDATES_UPDATE_ID,
+
+  // Field aliases defined in src/sentry/api/event_search.py
+  FieldKey.PROJECT,
 ];
 
 export const ISSUE_FIELDS: FieldKey[] = [

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -165,6 +165,7 @@ export function useIssueListSearchBarDataProvider(
         return [
           ...(await fetchTagValues({
             ...fetchTagValuesPayload,
+            dataset: Dataset.ERRORS,
             // enabling this maps project ids to project slugs
             includeTransactions: true,
           })),

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -161,6 +161,16 @@ export function useIssueListSearchBarDataProvider(
         });
       }
 
+      if (key === FieldKey.PROJECT) {
+        return [
+          ...(await fetchTagValues({
+            ...fetchTagValuesPayload,
+            // enabling this maps project ids to project slugs
+            includeTransactions: true,
+          })),
+        ];
+      }
+
       if (key === FieldKey.FIRST_RELEASE) {
         const includeLatest = 'latest'.startsWith(search.toLowerCase());
         return [


### PR DESCRIPTION
Adds project tag to issue search, and fetches project tag values from src/sentry/tagstore/snuba/backend.py.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
