### PR TITLE
fix(sub v3): Correct sub settings layout

### DIFF
--- a/static/gsApp/components/subscriptionSettingsLayout.tsx
+++ b/static/gsApp/components/subscriptionSettingsLayout.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Container, Flex} from 'sentry/components/core/layout';
+import {Flex} from 'sentry/components/core/layout';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -50,10 +50,8 @@ function SubscriptionSettingsLayout(props: Props) {
         </Flex>
       </StyledSettingsHeader>
 
-      <Flex flex="1">
-        <Container minWidth={0} flex={1}>
-          {children}
-        </Container>
+      <Flex minWidth={0} flex="1" direction="column">
+        {children}
       </Flex>
     </SettingsColumn>
   );

--- a/static/gsApp/views/subscriptionPage/components/subscriptionPageContainer.tsx
+++ b/static/gsApp/views/subscriptionPage/components/subscriptionPageContainer.tsx
@@ -31,7 +31,7 @@ function SubscriptionPageContainer({
       <Container
         padding={{xs: 'xl', md: '3xl'}}
         background={background}
-        height="100%"
+        flexGrow={1}
         data-test-id={dataTestId}
         borderTop={background === 'secondary' ? 'primary' : undefined}
       >


### PR DESCRIPTION
`height=100%` can create unnecessarily long pages on large screens; use `flexGrow=1` instead

### before
<img width="1222" height="289" alt="Screenshot 2025-10-08 at 12 09 24 PM" src="https://github.com/user-attachments/assets/27441844-d1fe-4bb7-b11a-807dbceee6dd" />


### after 

<img width="1222" height="240" alt="Screenshot 2025-10-08 at 12 10 03 PM" src="https://github.com/user-attachments/assets/083b2262-2a9b-4086-9a31-72d7a973b2ec" />
