### PR TITLE
ci: tag latest version only for calver release

### DIFF
--- a/.github/workflows/release-ghcr-version-tag.yml
+++ b/.github/workflows/release-ghcr-version-tag.yml
@@ -20,3 +20,9 @@ jobs:
           docker buildx imagetools create --tag \
            ghcr.io/getsentry/sentry:${{ github.ref_name }} \
            ghcr.io/getsentry/sentry:${{ github.sha }}
+
+      - name: Tag latest version
+        run: |
+          docker buildx imagetools create --tag \
+           ghcr.io/getsentry/sentry:latest \
+           ghcr.io/getsentry/sentry:${{ github.sha }}

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -115,6 +115,5 @@ jobs:
           docker buildx imagetools create \
             --tag ghcr.io/getsentry/sentry:${{ github.sha }} \
             --tag ghcr.io/getsentry/sentry:nightly \
-            --tag ghcr.io/getsentry/sentry:latest \
             ghcr.io/getsentry/sentry:${{ github.sha }}-amd64 \
             ghcr.io/getsentry/sentry:${{ github.sha }}-arm64


### PR DESCRIPTION
`latest` should point at CalVer release, and `nightly` should point at master/main branch. We're cleaning things up for self-hosted users.
