### PR TITLE
fix(agent-insights): Transparent loading overlay

### DIFF
--- a/static/app/views/insights/agents/views/overview.tsx
+++ b/static/app/views/insights/agents/views/overview.tsx
@@ -313,6 +313,7 @@ function LoadingPanel() {
 const LoadingPlaceholder = styled('div')`
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
+  position: relative;
   height: 100%;
 
   display: flex;


### PR DESCRIPTION
Loading overlay was leaking from widget into the whole page as of missing `position: relative` on the container.