### PR TITLE
Increase test timeout for GitHub job

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -76,7 +76,7 @@ jobs:
     needs: files-changed
     name: backend test
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -158,7 +158,7 @@ jobs:
     # If you change the runs-on image, you must also change the runner in jest-balance.yml
     # so that the balancer runs in the same environment as the tests.
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 90
     strategy:
       # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
       # and reducing the risk that one of many runs would turn red again (read: intermittent tests)

--- a/.github/workflows/jest-balance.yml
+++ b/.github/workflows/jest-balance.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   jest-balance:
     # Buckle up, this may take a while
-    timeout-minutes: 60
+    timeout-minutes: 90
     # Make sure this matches the runner that runs frontend tests
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
<!-- Describe your PR here. -->
Bumps GitHub Actions job `timeout-minutes` from 60 (or 30) to 90 minutes for `backend-test`, `frontend-jest-tests`, and `jest-balance` jobs. This addresses instances where tests were prematurely timing out after 60 seconds at the workflow level.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/D09259VQFAP/p1759927574474669?thread_ts=1759927574.474669&cid=D09259VQFAP)

<a href="https://cursor.com/background-agent?bcId=bc-11c4dcf9-140e-4232-89c6-b5a365063711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-11c4dcf9-140e-4232-89c6-b5a365063711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

