### PR TITLE
fix(agent-insights): Remove ai modules from module routes

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1994,26 +1994,6 @@ function buildRoutes(): RouteObject[] {
         },
       ],
     },
-    {
-      path: `${MODULE_BASE_URLS[ModuleName.AGENTS]}/`,
-      children: [
-        {
-          index: true,
-          handle: {module: ModuleName.AGENTS},
-          component: make(() => import('sentry/views/insights/agents/views/overview')),
-        },
-      ],
-    },
-    {
-      path: `${MODULE_BASE_URLS[ModuleName.MCP]}/`,
-      children: [
-        {
-          index: true,
-          handle: {module: ModuleName.MCP},
-          component: make(() => import('sentry/views/insights/mcp/views/overview')),
-        },
-      ],
-    },
   ];
 
   const domainViewChildRoutes: SentryRouteObject[] = [
@@ -2093,7 +2073,28 @@ function buildRoutes(): RouteObject[] {
           children: transactionSummaryChildren,
         },
         traceView,
-        ...moduleRoutes,
+        {
+          path: `${MODULE_BASE_URLS[ModuleName.AGENTS]}/`,
+          children: [
+            {
+              index: true,
+              handle: {module: ModuleName.AGENTS},
+              component: make(
+                () => import('sentry/views/insights/agents/views/overview')
+              ),
+            },
+          ],
+        },
+        {
+          path: `${MODULE_BASE_URLS[ModuleName.MCP]}/`,
+          children: [
+            {
+              index: true,
+              handle: {module: ModuleName.MCP},
+              component: make(() => import('sentry/views/insights/mcp/views/overview')),
+            },
+          ],
+        },
       ],
     },
     {


### PR DESCRIPTION
### Problem
Routes placed in `moduleRoutes` leak into all insights pages.
This allows to open agents insights e.g. via the unexpected URL `/insights/frontend/agents/`, resulting in the frontend item being selecting in the secondary nav while the AI page is rendered.
<img width="412" height="124" alt="Screenshot 2025-10-08 at 14 58 12" src="https://github.com/user-attachments/assets/642c380e-0d2f-440c-995d-bf2f241f65cc" />

### Solution
Remove the agent modules from the moduleRoutes variable.