### PR TITLE
chore(timeseries): Improve conversion of confidence data

### DIFF
--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -56,8 +56,14 @@ export type TimeSeriesItem = {
    */
   incomplete?: boolean;
   incompleteReason?: IncompleteReason;
-  sampleCount?: number;
-  sampleRate?: number;
+  /**
+   * Indicates the sample count that's associated with the data point. Might be `undefined` if the data set doesn't support extrapolation, or `null` if the extrapolation data was not known.
+   */
+  sampleCount?: number | null;
+  /**
+   * Indicates the sampling rate that's associated with the data point. Might be `undefined` if the data set doesn't support extrapolation, or `null` if the extrapolation data was not known.
+   */
+  sampleRate?: number | null;
 };
 
 /**

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -319,18 +319,21 @@ export function convertEventsStatsToTimeSeriesData(
         value: countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
       };
 
-      if (seriesData.meta?.accuracy?.confidence) {
-        item.confidence = seriesData.meta?.accuracy?.confidence?.[index]?.value ?? null;
-      }
+      if (seriesData.meta?.accuracy) {
+        const confidenceItem = seriesData.meta.accuracy.confidence?.[index];
+        if (defined(confidenceItem) && Object.hasOwn(confidenceItem, 'value')) {
+          item.confidence = confidenceItem.value;
+        }
 
-      if (seriesData.meta?.accuracy?.sampleCount) {
-        item.sampleCount =
-          seriesData.meta?.accuracy?.sampleCount?.[index]?.value ?? undefined;
-      }
+        const sampleCountItem = seriesData.meta.accuracy.sampleCount?.[index];
+        if (defined(sampleCountItem) && Object.hasOwn(sampleCountItem, 'value')) {
+          item.sampleCount = sampleCountItem.value;
+        }
 
-      if (seriesData.meta?.accuracy?.samplingRate) {
-        item.sampleRate =
-          seriesData.meta?.accuracy?.samplingRate?.[index]?.value ?? undefined;
+        const sampleRateItem = seriesData.meta.accuracy.samplingRate?.[index];
+        if (defined(sampleRateItem) && Object.hasOwn(sampleRateItem, 'value')) {
+          item.sampleRate = sampleRateItem.value;
+        }
       }
 
       return item;


### PR DESCRIPTION
A few small improvements to match the backend behaviour.

1. Update types to match the real output (there were some recent updates)
2. Update frontend logic to make sure that `null` and `undefined` are attached or omitted appropriately
