### PR TITLE
fix(logs): Only persist explicitly set fields

### DIFF
--- a/static/app/views/explore/logs/logsLocationQueryParamsProvider.tsx
+++ b/static/app/views/explore/logs/logsLocationQueryParamsProvider.tsx
@@ -48,11 +48,6 @@ export function LogsLocationQueryParamsProvider({
     (writableQueryParams: WritableQueryParams) => {
       const toPersist: Partial<PersistedLogsPageParams> = {};
 
-      const fields = writableQueryParams.fields;
-      if (defined(fields)) {
-        toPersist.fields = fields;
-      }
-
       const sortBys = writableQueryParams.sortBys;
       if (defined(sortBys)) {
         toPersist.sortBys = sortBys;


### PR DESCRIPTION
This only persists fields when the user explicitly updates fields through the edit table modal. Meaning auto managed fields do not get persisted.