### PR TITLE
fix(spans-migration): remove dashboard level filters in explore url

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -9,7 +9,6 @@ from django.db.models import prefetch_related_objects
 
 from sentry import features
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.constants import ALL_ACCESS_PROJECT_ID
 from sentry.discover.arithmetic import get_equation_alias_index, is_equation, is_equation_alias
 from sentry.models.dashboard import Dashboard, DashboardFavoriteUser
 from sentry.models.dashboard_permissions import DashboardPermissions
@@ -155,21 +154,9 @@ class DashboardWidgetSerializer(Serializer):
                     explore_mode = "samples"
 
             filters = obj.dashboard.filters
-            environment = []
             release = []
-            end = None
-            start = None
-            period = None
-            utc = None
-            all_projects = None
             if filters:
-                environment = filters.get("environment", [])
                 release = filters.get("release", [])
-                end = filters.get("end")
-                start = filters.get("start")
-                period = filters.get("period")
-                utc = filters.get("utc")
-                all_projects = filters.get("all_projects")
 
             non_aggregate_group_by_fields = [
                 field
@@ -249,18 +236,7 @@ class DashboardWidgetSerializer(Serializer):
                     for y_axis in y_axes
                 ]
 
-            if all_projects:
-                projects = [ALL_ACCESS_PROJECT_ID]
-            else:
-                projects = list(obj.dashboard.projects.all().values_list("id", flat=True))
-
             all_query_params = {
-                "project": projects,
-                "environment": environment,
-                "statsPeriod": period,
-                "start": start,
-                "end": end,
-                "utc": utc,
                 "mode": explore_mode,
                 # using aggregateField instead of visualize + groupBy because that format will be deprecated
                 "aggregateField": visualize,

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -498,10 +498,13 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
 
     def test_explore_url_for_table_widget(self) -> None:
         with self.feature("organizations:transaction-widget-deprecation-explore-view"):
+            start = before_now(days=2)
+            end = before_now(days=1)
             dashboard_deprecation = Dashboard.objects.create(
                 title="Dashboard With Transaction Widget",
                 created_by_id=self.user.id,
                 organization=self.organization,
+                filters={"all_projects": True, "start": start.isoformat(), "end": end.isoformat()},
             )
             widget_deprecation = DashboardWidget.objects.create(
                 dashboard=dashboard_deprecation,
@@ -532,6 +535,65 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
             # need to sort because fields order is not guaranteed
             assert params["field"].sort() == ["id", "transaction"].sort()
             assert "aggregateField" not in params
+            assert params["project"] == ["-1"]
+            assert params["start"] == [start.isoformat()]
+            assert params["end"] == [end.isoformat()]
+
+    def test_explore_url_for_widget_with_env_params(self) -> None:
+        with self.feature("organizations:transaction-widget-deprecation-explore-view"):
+            project = self.create_project()
+            project2 = self.create_project()
+            environment = self.create_environment(project=project)
+            environment2 = self.create_environment(project=project2)
+            dashboard_deprecation = Dashboard.objects.create(
+                title="Dashboard With Transaction Widget",
+                created_by_id=self.user.id,
+                organization=self.organization,
+                filters={
+                    "environment": [environment.name, environment2.name],
+                    "release": ["1.0.0"],
+                    "period": "14d",
+                },
+            )
+            dashboard_deprecation.projects.set([project, project2])
+            widget_deprecation = DashboardWidget.objects.create(
+                dashboard=dashboard_deprecation,
+                title="transaction widget",
+                display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+                widget_type=DashboardWidgetTypes.TRANSACTION_LIKE,
+                interval="1d",
+                detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+            )
+
+            DashboardWidgetQuery.objects.create(
+                widget=widget_deprecation,
+                fields=["count()", "transaction"],
+                columns=["transaction"],
+                aggregates=["count()"],
+                conditions="count():>50",
+                orderby="-count",
+                order=0,
+            )
+
+            response = self.do_request("get", self.url(dashboard_deprecation.id))
+            assert response.status_code == 200
+            explore_url = response.data["widgets"][0]["exploreUrls"][0]
+            assert "http://testserver/explore/traces/" in explore_url
+
+            params = dict(parse_qs(urlsplit(response.data["widgets"][0]["exploreUrls"][0]).query))
+            assert params["query"] == [
+                "(count(span.duration):>50) AND is_transaction:1 AND release:1.0.0"
+            ]
+            assert params["sort"] == ["-count(span.duration)"]
+            assert params["mode"] == ["aggregate"]
+            assert params["aggregateField"] == [
+                '{"groupBy":"transaction"}',
+                '{"yAxes":["count(span.duration)"],"chartType":1}',
+            ]
+
+            assert params["environment"] == [environment.name, environment2.name]
+            assert params["project"] == [str(project.id), str(project2.id)]
+            assert params["statsPeriod"] == ["14d"]
 
     def test_explore_url_for_deformed_widget(self) -> None:
         with self.feature("organizations:transaction-widget-deprecation-explore-view"):


### PR DESCRIPTION
project wasn't getting carried over in the explore link for cases like all projects. We're going to handle all of the global filters in the frontend now so we can handle unsaved params. So i'm removing them all except for releases because that needs to be added into the query.