### PR TITLE
fix(ui): remove highlight from inline code

### DIFF
--- a/static/app/components/core/code/inlineCode.tsx
+++ b/static/app/components/core/code/inlineCode.tsx
@@ -17,7 +17,6 @@ export const inlineCodeStyles = (theme: Theme) => css`
 
   color: ${theme.tokens.content.promotion};
   background: color-mix(in oklab, currentColor, transparent 92%);
-  border-top: 2px solid transparent;
 
   padding-inline: 0.3ch;
   margin-inline: -0.15ch;

--- a/static/app/components/core/code/inlineCode.tsx
+++ b/static/app/components/core/code/inlineCode.tsx
@@ -17,12 +17,7 @@ export const inlineCodeStyles = (theme: Theme) => css`
 
   color: ${theme.tokens.content.promotion};
   background: color-mix(in oklab, currentColor, transparent 92%);
-  border-top: 1px solid transparent;
-  border-image: radial-gradient(
-      color-mix(in oklab, currentColor, transparent 50%),
-      transparent
-    )
-    1;
+  border-top: 2px solid transparent;
 
   padding-inline: 0.3ch;
   margin-inline: -0.15ch;


### PR DESCRIPTION
Accidentally merged #100646 with a non-standard highlight on the `InlineCode` component. Removing that!

See [Deploy Preview](https://sentry-ojojrrmxm.sentry.dev/stories/core/inline-code)

**Before**
<img width="932" height="442" alt="inline-code-before" src="https://github.com/user-attachments/assets/827c4db1-5d15-4bc0-80aa-43a43892a1b3" />

**After**
<img width="855" height="425" alt="inline-code-after" src="https://github.com/user-attachments/assets/3dec4f9c-ce67-4c6d-9915-e32541ba64ca" />
