### PR TITLE
fix(devinfra): Stop artifacts action if run was cancelled (II)

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -144,7 +144,7 @@ jobs:
       # it reduces large coverage fluctuations
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
-        if: ${{ always() && needs.files-changed.outputs.backend_all == 'true' }}
+        if: ${{ !cancelled() && needs.files-changed.outputs.backend_all == 'true' }}
         continue-on-error: true
         timeout-minutes: 5
         with:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -130,7 +130,7 @@ jobs:
       # Upload coverage data even if running the tests step fails since
       # it reduces large coverage fluctuations
       - name: Handle artifacts
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         continue-on-error: true
         timeout-minutes: 5
         uses: ./.github/actions/artifacts
@@ -317,7 +317,7 @@ jobs:
       # Upload coverage data even if running the tests step fails since
       # it reduces large coverage fluctuations
       - name: Handle artifacts
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         continue-on-error: true
         timeout-minutes: 5
         uses: ./.github/actions/artifacts

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -232,7 +232,7 @@ jobs:
       # it reduces large coverage fluctuations.
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
-        if: always()
+        if: ${{ !cancelled() }}
         continue-on-error: true
         timeout-minutes: 5
         with:


### PR DESCRIPTION
This is the same as https://github.com/getsentry/sentry/commit/e1d28fd73a72add4565a2788a522a07c3c1299f2

There were other workflows in which that situation is still happening. This change adjusts the behavior in all "handle artifacts" calls to not fire if the workflow was cancelled.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
