### PR TITLE
fix(sdk): Disable react rouer tracing integration in dev mode

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -8,7 +8,7 @@ import {
 import type {Event} from '@sentry/core';
 import * as Sentry from '@sentry/react';
 
-import {SENTRY_RELEASE_VERSION, SPA_DSN} from 'sentry/constants';
+import {NODE_ENV, SENTRY_RELEASE_VERSION, SPA_DSN} from 'sentry/constants';
 import type {Config} from 'sentry/types/system';
 import {addExtraMeasurements, addUIElementTag} from 'sentry/utils/performanceForSentry';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
@@ -57,18 +57,21 @@ function getSentryIntegrations() {
       // 6 is arbitrary, seems like a nice number
       depth: 6,
     }),
-    Sentry.reactRouterV6BrowserTracingIntegration({
-      useEffect,
-      useLocation,
-      useNavigationType,
-      createRoutesFromChildren,
-      matchRoutes,
-      _experiments: {
-        enableStandaloneClsSpans: true,
-        enableStandaloneLcpSpans: true,
-      },
-      linkPreviousTrace: 'session-storage',
-    }),
+    // Blocks main thread for long periods with react 19.2 in dev mode
+    NODE_ENV === 'production'
+      ? Sentry.reactRouterV6BrowserTracingIntegration({
+          useEffect,
+          useLocation,
+          useNavigationType,
+          createRoutesFromChildren,
+          matchRoutes,
+          _experiments: {
+            enableStandaloneClsSpans: true,
+            enableStandaloneLcpSpans: true,
+          },
+          linkPreviousTrace: 'session-storage',
+        })
+      : null,
     Sentry.browserProfilingIntegration(),
     Sentry.thirdPartyErrorFilterIntegration({
       filterKeys: ['sentry-spa'],
@@ -76,7 +79,7 @@ function getSentryIntegrations() {
     }),
     Sentry.featureFlagsIntegration(),
     Sentry.consoleLoggingIntegration(),
-  ];
+  ].filter(Boolean);
 
   return integrations;
 }

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -79,7 +79,7 @@ function getSentryIntegrations() {
     }),
     Sentry.featureFlagsIntegration(),
     Sentry.consoleLoggingIntegration(),
-  ].filter(x => x !== null);
+  ].filter(integration => integration !== null);
 
   return integrations;
 }

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -79,7 +79,7 @@ function getSentryIntegrations() {
     }),
     Sentry.featureFlagsIntegration(),
     Sentry.consoleLoggingIntegration(),
-  ].filter(Boolean);
+  ].filter(x => x !== null);
 
   return integrations;
 }


### PR DESCRIPTION
Seems to block main thread for long periods with react 19.2 in dev mode

related #100834
sdk issue https://github.com/getsentry/sentry-javascript/issues/17888