### PR TITLE
ref(grouping): Remove frontend built-in fingerprint handling

### DIFF
--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -106,9 +106,6 @@ function GroupingVariant({event, variant, showNonContributing}: GroupingVariantP
       case EventGroupVariantType.CUSTOM_FINGERPRINT:
         addFingerprintInfo(data, variant, showNonContributing);
         break;
-      case EventGroupVariantType.BUILT_IN_FINGERPRINT:
-        addFingerprintInfo(data, variant, showNonContributing);
-        break;
       case EventGroupVariantType.SALTED_COMPONENT:
         component = variant.component;
         addFingerprintInfo(data, variant, showNonContributing);

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -51,7 +51,6 @@ export const enum EventGroupVariantType {
   CHECKSUM = 'checksum',
   FALLBACK = 'fallback',
   CUSTOM_FINGERPRINT = 'custom_fingerprint',
-  BUILT_IN_FINGERPRINT = 'built_in_fingerprint',
   COMPONENT = 'component',
   SALTED_COMPONENT = 'salted_component',
   PERFORMANCE_PROBLEM = 'performance_problem',
@@ -91,10 +90,6 @@ interface CustomFingerprintVariant extends BaseVariant, HasComponentGrouping {
   type: EventGroupVariantType.CUSTOM_FINGERPRINT;
 }
 
-interface BuiltInFingerprintVariant extends BaseVariant, HasComponentGrouping {
-  type: EventGroupVariantType.BUILT_IN_FINGERPRINT;
-}
-
 interface SaltedComponentVariant extends BaseVariant, HasComponentGrouping {
   type: EventGroupVariantType.SALTED_COMPONENT;
 }
@@ -110,7 +105,6 @@ export type EventGroupVariant =
   | ComponentVariant
   | SaltedComponentVariant
   | CustomFingerprintVariant
-  | BuiltInFingerprintVariant
   | PerformanceProblemVariant;
 
 /**


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry/pull/101094, which removed the separate `BuiltInFingerprintVariant` class in favor of adding a boolean `is_built_in` to the `CustomFingerprintVariant` class. Since grouping variants with the type `built_in_fingerprint` are no longer being sent to the front end, we can now remove the code handling that case. There's no behavior change because custom and built-in fingerprints have always been handled the exact same way, so this really is just consolidating two identical code paths.