### PR TITLE
ref(projectSettings): Rename "Name" to "Slug" in project settings and create project

### DIFF
--- a/static/app/components/modals/projectCreationModal.spec.tsx
+++ b/static/app/components/modals/projectCreationModal.spec.tsx
@@ -115,7 +115,7 @@ describe('Project Creation Modal', () => {
       await screen.findByText('Name your project and assign it a team')
     ).toBeInTheDocument();
     await userEvent.type(
-      screen.getByPlaceholderText('project-name'),
+      screen.getByPlaceholderText('project-slug'),
       'test-react-project'
     );
 

--- a/static/app/components/modals/projectCreationModal.tsx
+++ b/static/app/components/modals/projectCreationModal.tsx
@@ -189,13 +189,13 @@ export default function ProjectCreationModal({
           <Subtitle>{t('Name your project and assign it a team')}</Subtitle>
           <ProjectNameTeamSection>
             <div>
-              <Label>{t('Project name')}</Label>
+              <Label>{t('Project slug')}</Label>
               <ProjectNameInputWrap>
                 <StyledPlatformIcon platform={platform?.key ?? 'other'} size={20} />
                 <ProjectNameInput
                   type="text"
                   name="project-name"
-                  placeholder={t('project-name')}
+                  placeholder={t('project-slug')}
                   autoComplete="off"
                   value={projectName}
                   onChange={e => setProjectName(slugify(e.target.value))}

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -56,7 +56,7 @@ export const fields = {
     required: true,
     label: t('Slug'),
     placeholder: t('my-awesome-project'),
-    help: t('A slug for this project'),
+    help: t('A unique ID used to identify this project'),
     transformInput: slugify,
     getData: (data: {name?: string}) => {
       return {

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -68,7 +68,7 @@ export const fields = {
     saveOnBlur: false,
     saveMessageAlertType: 'warning',
     saveMessage: t(
-      "Changing a project's name will also change the project slug. This can break your build scripts! Please proceed carefully."
+      "Changing a project's slug can break your build scripts! Please proceed carefully."
     ),
   },
 

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -54,9 +54,9 @@ export const fields = {
     name: 'name',
     type: 'string',
     required: true,
-    label: t('Name'),
+    label: t('Slug'),
     placeholder: t('my-awesome-project'),
-    help: t('A name for this project'),
+    help: t('A slug for this project'),
     transformInput: slugify,
     getData: (data: {name?: string}) => {
       return {

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -167,17 +167,17 @@ describe('CreateProject', () => {
     });
 
     await userEvent.click(screen.getByTestId('platform-apple-ios'));
-    expect(screen.getByPlaceholderText('project-name')).toHaveValue('apple-ios');
+    expect(screen.getByPlaceholderText('project-slug')).toHaveValue('apple-ios');
 
     await userEvent.click(screen.getByTestId('platform-ruby-rails'));
-    expect(screen.getByPlaceholderText('project-name')).toHaveValue('ruby-rails');
+    expect(screen.getByPlaceholderText('project-slug')).toHaveValue('ruby-rails');
 
-    // but not replace it when project name is something else:
-    await userEvent.clear(screen.getByPlaceholderText('project-name'));
-    await userEvent.type(screen.getByPlaceholderText('project-name'), 'another');
+    // but not replace it when project slug is something else:
+    await userEvent.clear(screen.getByPlaceholderText('project-slug'));
+    await userEvent.type(screen.getByPlaceholderText('project-slug'), 'another');
 
     await userEvent.click(screen.getByTestId('platform-apple-ios'));
-    expect(screen.getByPlaceholderText('project-name')).toHaveValue('another');
+    expect(screen.getByPlaceholderText('project-slug')).toHaveValue('another');
   });
 
   it('should display success message on proj creation', async () => {
@@ -389,8 +389,8 @@ describe('CreateProject', () => {
 
       expect(getSubmitButton()).toBeDisabled();
 
-      // Fills the project name
-      await userEvent.type(screen.getByPlaceholderText('project-name'), 'my-project');
+      // Fills the project slug
+      await userEvent.type(screen.getByPlaceholderText('project-slug'), 'my-project');
 
       // Enforce users to select a platform
       await userEvent.hover(getSubmitButton());

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -523,7 +523,7 @@ export function CreateProject() {
           </StyledListItem>
           <FormFieldGroup>
             <div>
-              <FormLabel>{t('Project name')}</FormLabel>
+              <FormLabel>{t('Project slug')}</FormLabel>
               <ProjectNameInputWrap>
                 <StyledPlatformIcon
                   platform={formData.platform?.key ?? 'other'}
@@ -532,7 +532,7 @@ export function CreateProject() {
                 <ProjectNameInput
                   type="text"
                   name="name"
-                  placeholder={t('project-name')}
+                  placeholder={t('project-slug')}
                   autoComplete="off"
                   value={formData.projectName}
                   onChange={e => updateFormData('projectName', slugify(e.target.value))}

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -119,7 +119,7 @@ function getSubmitTooltipText({
     return t('Please fill out all the required fields');
   }
   if (isMissingProjectName) {
-    return t('Please provide a project name');
+    return t('Please provide a project slug');
   }
   if (isMissingAlertThreshold) {
     return t('Please provide an alert threshold');

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -112,7 +112,7 @@ describe('ReleasesList', () => {
 
     expect(await within(items.at(1)!).findByText('0%')).toBeInTheDocument();
     expect(within(items.at(2)!).getByText('af4f231ec9a8')).toBeInTheDocument();
-    expect(within(items.at(2)!).getByText('Project Name')).toBeInTheDocument();
+    expect(within(items.at(2)!).getByText('Project Slug')).toBeInTheDocument();
   });
 
   it('displays quickstart when appropriate', async () => {

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -224,7 +224,7 @@ function ReleaseCard({
         {/* projects is the table */}
         <ReleaseProjectsHeader lightText>
           <ReleaseProjectsLayout showReleaseAdoptionStages={showReleaseAdoptionStages}>
-            <ReleaseProjectColumn>{t('Project Name')}</ReleaseProjectColumn>
+            <ReleaseProjectColumn>{t('Project Slug')}</ReleaseProjectColumn>
             {showReleaseAdoptionStages && (
               <AdoptionStageColumn>{t('Adoption Stage')}</AdoptionStageColumn>
             )}

--- a/static/app/views/settings/projectGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.spec.tsx
@@ -87,7 +87,7 @@ describe('projectGeneralSettings', () => {
       }
     );
 
-    expect(await screen.findByRole('textbox', {name: 'Name'})).toHaveValue(
+    expect(await screen.findByRole('textbox', {name: 'Slug'})).toHaveValue(
       'Project Name'
     );
     expect(screen.getByRole('textbox', {name: 'Subject Prefix'})).toHaveValue('[my-org]');
@@ -305,7 +305,7 @@ describe('projectGeneralSettings', () => {
     );
 
     await userEvent.type(
-      await screen.findByRole('textbox', {name: 'Name'}),
+      await screen.findByRole('textbox', {name: 'Slug'}),
       'New Project'
     );
 

--- a/static/app/views/setupWizard/wizardProjectSelection.tsx
+++ b/static/app/views/setupWizard/wizardProjectSelection.tsx
@@ -268,11 +268,11 @@ export function WizardProjectSelection({
 
   const projectNameField = (
     <FieldWrapper>
-      <label>{t('Project Name')}</label>
+      <label>{t('Project Slug')}</label>
       <Input
         value={newProjectName}
         onChange={event => setNewProjectName(event.target.value)}
-        placeholder={t('Enter a project name')}
+        placeholder={t('Enter a project slug')}
       />
     </FieldWrapper>
   );


### PR DESCRIPTION
[linear issue](https://linear.app/getsentry/issue/RTC-1233/rename-name-to-slug-in-project-settings) (#101140)

The "project name" has been deprecated and "project slug" is used instead. Changes project `name` fields to `slug` in project settings. Also where projects are created.

<img width="1215" height="199" alt="image" src="https://github.com/user-attachments/assets/107cc736-6378-4a38-ae3e-b20ff2035088" />

<img width="771" height="161" alt="image" src="https://github.com/user-attachments/assets/b30f73cd-8d7f-41ee-8bc1-c093709e89a0" />


Note: These changes are to the UI only