### PR TITLE
fix(aci): Allow users with alerts:write to create/edit workflows

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -103,6 +103,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         "DELETE": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ISSUES
+    permission_classes = (OrganizationWorkflowPermission,)
 
     def filter_workflows(self, request: Request, organization: Organization) -> QuerySet[Workflow]:
         """

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -15,6 +15,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.event_search import SearchConfig, SearchFilter, SearchKey, default_config
 from sentry.api.event_search import parse_search_query as base_parse_search_query
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -69,7 +70,18 @@ workflow_search_config = SearchConfig.create_from(
 parse_workflow_query = partial(base_parse_search_query, config=workflow_search_config)
 
 
+class OrganizationWorkflowPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
+        "POST": ["org:write", "org:admin", "alerts:write"],
+        "PUT": ["org:write", "org:admin", "alerts:write"],
+        "DELETE": ["org:write", "org:admin", "alerts:write"],
+    }
+
+
 class OrganizationWorkflowEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationWorkflowPermission,)
+
     def convert_args(self, request: Request, workflow_id, *args, **kwargs):
         args, kwargs = super().convert_args(request, *args, **kwargs)
         try:


### PR DESCRIPTION
Right now the workflow endpoints require you to have org:write to create/edit workflows since it uses the default `OrganizationPermission`.

The new permission now checks `alerts:write` as well. This is slightly different than the detector permission class, which uses a more permissive scope_map but checks for project access as well. But because workflows are not attached to a project, that does not translate so we just look for the org-level `alerts:write`.