### PR TITLE
fix(ui): Use configured timezone in TimeSince tooltip

### DIFF
--- a/static/app/components/timeSince.spec.tsx
+++ b/static/app/components/timeSince.spec.tsx
@@ -1,6 +1,7 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import TimeSince from 'sentry/components/timeSince';
+import {TimezoneProvider} from 'sentry/components/timezoneProvider';
 
 describe('TimeSince', () => {
   const now = new Date();
@@ -55,5 +56,19 @@ describe('TimeSince', () => {
   it('renders a custom suffix with shortened', () => {
     render(<TimeSince unitStyle="extraShort" date={pastTenMin} suffix="atrás" />);
     expect(screen.getByText('10m atrás')).toBeInTheDocument();
+  });
+
+  it('respects timezone in tooltip', async () => {
+    const date = new Date('2024-01-15T12:00:00Z');
+    render(
+      <TimezoneProvider timezone="America/New_York">
+        <TimeSince date={date} />
+      </TimezoneProvider>
+    );
+    const timeElement = screen.getByRole('time');
+    await userEvent.hover(timeElement);
+    await waitFor(() => {
+      expect(screen.getByText(/EST/)).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -9,6 +9,8 @@ import getDuration from 'sentry/utils/duration/getDuration';
 import type {ColorOrAlias} from 'sentry/utils/theme';
 import {useUser} from 'sentry/utils/useUser';
 
+import {useTimezone} from './timezoneProvider';
+
 function getDateObj(date: RelaxedDateType): Date {
   return typeof date === 'string' || isNumber(date) ? new Date(date) : date;
 }
@@ -120,6 +122,7 @@ function TimeSince({
   ...props
 }: Props) {
   const user = useUser();
+  const tz = useTimezone();
 
   // Counter to trigger periodic re-computation of relative time
   const [tick, setTick] = useState(0);
@@ -153,7 +156,7 @@ function TimeSince({
     : 'MMMM D, YYYY h:mm A z';
   const format = options?.clock24Hours ? 'MMMM D, YYYY HH:mm z' : tooltipFormat;
 
-  const tooltip = moment(dateObj).format(format);
+  const tooltip = moment.tz(dateObj, tz).format(format);
 
   return (
     <Tooltip


### PR DESCRIPTION
The TimeSince component now uses the timezone from useTimezone() hook to format the tooltip, ensuring it displays the correct timezone abbreviation based on the `TimezoneProvider`.