### PR TITLE
chore(eco): resolve by region rpc to update action status for sentry app installs

### DIFF
--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -41,6 +41,19 @@ class DatabaseBackedActionService(ActionService):
             config__target_identifier=sentry_app_install_uuid,
         ).update(status=status)
 
+    def update_action_status_for_sentry_app_via_uuid__region(
+        self,
+        *,
+        region_name: str,
+        status: int,
+        sentry_app_install_uuid: str,
+    ) -> None:
+        Action.objects.filter(
+            type=Action.Type.SENTRY_APP,
+            config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+            config__target_identifier=sentry_app_install_uuid,
+        ).update(status=status)
+
     def update_action_status_for_sentry_app_via_sentry_app_id(
         self,
         *,

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -47,6 +47,17 @@ class ActionService(RpcService):
 
     @regional_rpc_method(resolve=ByRegionName())
     @abc.abstractmethod
+    def update_action_status_for_sentry_app_via_uuid__region(
+        self,
+        *,
+        region_name: str,
+        status: int,
+        sentry_app_install_uuid: str,
+    ) -> None:
+        pass
+
+    @regional_rpc_method(resolve=ByRegionName())
+    @abc.abstractmethod
     def update_action_status_for_sentry_app_via_sentry_app_id(
         self,
         *,

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -274,6 +274,28 @@ class TestActionService(TestCase):
             action.refresh_from_db()
             assert action.status == ObjectStatus.DISABLED
 
+    def test_update_action_status_for_sentry_app__installation_uuid__region(self) -> None:
+        sentry_app_installation = self.create_sentry_app_installation(
+            slug=self.sentry_app.slug,
+            organization=self.organization,
+        )
+        action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": sentry_app_installation.uuid,
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+        action_service.update_action_status_for_sentry_app_via_uuid__region(
+            region_name="us",
+            sentry_app_install_uuid=sentry_app_installation.uuid,
+            status=ObjectStatus.DISABLED,
+        )
+        with assume_test_silo_mode(SiloMode.REGION):
+            action.refresh_from_db()
+            assert action.status == ObjectStatus.DISABLED
+
     def test_update_action_status_for_sentry_app__via_sentry_app_id(self) -> None:
         action = self.create_action(
             type=Action.Type.SENTRY_APP,


### PR DESCRIPTION
While writing the script to backfill the disabled status for deleted sentry apps / installs, I realized we need a resolve by region RPC function to update action status for sentry app installs.

The resolve by organization one works when deleting Sentry App installs via the deletion task because the install has an org id attached to it. But if the install is already deleted, we must resolve by region.