### PR TITLE
fix(releases): Normalize both release values to equal one another

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -41,6 +41,7 @@ from sentry.models.grouphistory import record_group_history_from_activity_type
 from sentry.models.groupinbox import GroupInboxRemoveAction, remove_group_from_inbox
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupopenperiod import update_group_open_period
+from sentry.models.grouprelease import GroupRelease
 from sentry.models.groupresolution import GroupResolution
 from sentry.models.groupseen import GroupSeen
 from sentry.models.groupshare import GroupShare
@@ -154,7 +155,19 @@ def get_current_release_version_of_group(group: Group, follows_semver: bool = Fa
     """
     current_release_version = None
     if follows_semver:
-        release = greatest_semver_release(group.project)
+        # Fetch all the release-packages associated with the group. We'll find the largest semver
+        # version for one of these packages.
+        group_packages = list(
+            GroupRelease.objects.filter(
+                group_id=group.id,
+                project_id=group.project_id,
+                release__package__isnull=False,
+            )
+            .distinct()
+            .values_list("release__package", flat=True)
+        )
+
+        release = greatest_semver_release(group.project, packages=group_packages)
         if release is not None:
             current_release_version = release.version
     else:
@@ -537,6 +550,10 @@ def process_group_resolution(
                     # in release
                     resolution_params.update(
                         {
+                            "release": Release.objects.filter(
+                                organization_id=group.organization_id,
+                                version=current_release_version,
+                            ).get(),
                             "type": GroupResolution.Type.in_release,
                             "status": GroupResolution.Status.resolved,
                         }
@@ -841,14 +858,20 @@ def most_recent_release_matching_commit(
     )
 
 
-def greatest_semver_release(project: Project) -> Release | None:
-    return get_semver_releases(project).first()
+def greatest_semver_release(project: Project, packages: list[str]) -> Release | None:
+    return get_semver_releases(project, packages).first()
 
 
-def get_semver_releases(project: Project) -> QuerySet[Release]:
+def get_semver_releases(project: Project, packages: list[str]) -> QuerySet[Release]:
+    query = Release.objects.filter(projects=project, organization_id=project.organization_id)
+
+    # Multiple packages may exist for a single project. If we were able to infer the packages
+    # associated with an issue we'll include them.
+    if packages:
+        query = query.filter(package__in=packages)
+
     return (
-        Release.objects.filter(projects=project, organization_id=project.organization_id)
-        .filter_to_semver()  # type: ignore[attr-defined]
+        query.filter_to_semver()  # type: ignore[attr-defined]
         .annotate_prerelease_column()
         .order_by(*[f"-{col}" for col in Release.SEMVER_COLS])
     )

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -49,7 +49,7 @@ from sentry.models.grouptombstone import TOMBSTONE_FIELDS_FROM_GROUP, GroupTombs
 from sentry.models.project import Project
 from sentry.models.release import Release, follows_semver_versioning_scheme
 from sentry.notifications.types import SUBSCRIPTION_REASON_MAP, GroupSubscriptionReason
-from sentry.releases.use_cases.release import fetch_packages_for_group
+from sentry.releases.use_cases.release import fetch_semver_packages_for_group
 from sentry.signals import issue_resolved
 from sentry.types.activity import ActivityType
 from sentry.types.actor import Actor, ActorType
@@ -157,7 +157,7 @@ def get_current_release_version_of_group(group: Group, follows_semver: bool = Fa
     if follows_semver:
         # Fetch all the release-packages associated with the group. We'll find the largest semver
         # version for one of these packages.
-        group_packages = fetch_packages_for_group(
+        group_packages = fetch_semver_packages_for_group(
             organization_id=group.project.organization_id,
             project_id=group.project_id,
             group_id=group.id,

--- a/src/sentry/releases/use_cases/release.py
+++ b/src/sentry/releases/use_cases/release.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, cast
 
 import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
@@ -16,6 +16,7 @@ from sentry.api.serializers.types import ReleaseSerializerResponse
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.deploy import Deploy
+from sentry.models.grouprelease import GroupRelease
 from sentry.models.project import Project
 from sentry.models.projectplatform import ProjectPlatform
 from sentry.models.release import Release
@@ -434,4 +435,29 @@ def fetch_project_platforms(project_ids: Iterable[int]) -> list[tuple[int, str]]
         ProjectPlatform.objects.filter(project_id__in=project_ids).values_list(
             "project_id", "platform"
         )
+    )
+
+
+def fetch_packages_for_group(organization_id: int, project_id: int, group_id: int) -> list[str]:
+    """Fetch a unique list of release packages associated with the group."""
+    release_ids = list(
+        GroupRelease.objects.filter(
+            group_id=group_id,
+            project_id=project_id,
+        )
+        .distinct()
+        .values_list("release_id", flat=True)
+    )
+
+    return cast(
+        list[str],
+        list(
+            Release.objects.filter(
+                organization_id=organization_id,
+                id__in=release_ids,
+                package__isnull=False,
+            )
+            .distinct()
+            .values_list("package", flat=True)
+        ),
     )

--- a/src/sentry/releases/use_cases/release.py
+++ b/src/sentry/releases/use_cases/release.py
@@ -440,7 +440,7 @@ def fetch_project_platforms(project_ids: Iterable[int]) -> list[tuple[int, str]]
 
 def fetch_packages_for_group(organization_id: int, project_id: int, group_id: int) -> list[str]:
     """Fetch a unique list of release packages associated with the group."""
-    release_ids = list(
+    release_ids = (
         GroupRelease.objects.filter(
             group_id=group_id,
             project_id=project_id,

--- a/src/sentry/releases/use_cases/release.py
+++ b/src/sentry/releases/use_cases/release.py
@@ -438,8 +438,10 @@ def fetch_project_platforms(project_ids: Iterable[int]) -> list[tuple[int, str]]
     )
 
 
-def fetch_packages_for_group(organization_id: int, project_id: int, group_id: int) -> list[str]:
-    """Fetch a unique list of release packages associated with the group."""
+def fetch_semver_packages_for_group(
+    organization_id: int, project_id: int, group_id: int
+) -> list[str]:
+    """Fetch a unique list of semver release packages associated with the group."""
     release_ids = (
         GroupRelease.objects.filter(
             group_id=group_id,
@@ -452,7 +454,8 @@ def fetch_packages_for_group(organization_id: int, project_id: int, group_id: in
     return cast(
         list[str],
         list(
-            Release.objects.filter(
+            Release.objects.filter_to_semver()
+            .filter(
                 organization_id=organization_id,
                 id__in=release_ids,
                 package__isnull=False,

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -3588,6 +3588,66 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
         assert activity.data["version"] == ""
 
+    def test_set_resolved_in_next_semver_release(self) -> None:
+        release = Release.objects.create(
+            organization_id=self.project.organization_id, version="a@1.0.0"
+        )
+        release.add_project(self.project)
+
+        # Smaller than 1.0.0 but more recent.
+        release2 = Release.objects.create(
+            organization_id=self.project.organization_id, version="a@0.9.1"
+        )
+        release2.add_project(self.project)
+
+        # Bigger than 1.0.0 and more recent but different package.
+        release3 = Release.objects.create(
+            organization_id=self.project.organization_id, version="b@1.0.1"
+        )
+        release3.add_project(self.project)
+
+        # Smaller than 1.0.0, a different package, and associated to the group. This package's
+        # release should be in contention for largest semver but not selected.
+        release4 = Release.objects.create(
+            organization_id=self.project.organization_id, version="c@0.9.9"
+        )
+        release4.add_project(self.project)
+
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        # Record the release as a group release so the group is scoped to at least one package.
+        self.create_group_release(self.project, group=group, release=release)
+        self.create_group_release(self.project, group=group, release=release4)
+
+        self.login_as(user=self.user)
+
+        response = self.get_success_response(
+            qs_params={"id": group.id}, status="resolved", statusDetails={"inNextRelease": True}
+        )
+        assert response.data["status"] == "resolved"
+        assert response.data["statusDetails"]["inNextRelease"]
+        assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
+        assert "activity" in response.data
+
+        group = Group.objects.get(id=group.id)
+        assert group.status == GroupStatus.RESOLVED
+
+        resolution = GroupResolution.objects.get(group=group)
+        assert resolution.release == release
+        assert resolution.type == GroupResolution.Type.in_release
+        assert resolution.status == GroupResolution.Status.resolved
+        assert resolution.actor_id == self.user.id
+
+        assert GroupSubscription.objects.filter(
+            user_id=self.user.id, group=group, is_active=True
+        ).exists()
+
+        activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
+        )
+        assert activity.data["version"] == ""
+        assert activity.data["current_release_version"] == "a@1.0.0"
+
     def test_set_resolved_in_next_release_legacy(self) -> None:
         release = Release.objects.create(organization_id=self.project.organization_id, version="a")
         release.add_project(self.project)


### PR DESCRIPTION
Normalize resolve-in-next-release release values between activity data and group resolution params. Also, fetches the latest semver release scoped to the packages present on the group.

Previously when resolving in the next semver release the `release` stored on the group resolution was the most recent time-ordered release. This PR changes that so we're setting the latest semver release as the `release` value.

But some projects can have multiple packages. Either old packages no longer in use or concurrent packages with their own ordering characteristics. By filtering by the package we force the group resolution to only consider releases relevant to the problem being solved.