### PR TITLE
fix(spans-migration): add selection params to explore url in frontend

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -191,7 +191,10 @@ function WidgetCard(props: Props) {
   const extractionStatus = useExtractionStatus({queryKey: widget});
   const indexedEventsWarning = useIndexedEventsWarning();
   const onDemandWarning = useOnDemandWarning({widget});
-  const transactionsDeprecationWarning = useTransactionsDeprecationWarning({widget});
+  const transactionsDeprecationWarning = useTransactionsDeprecationWarning({
+    widget,
+    selection,
+  });
   const sessionDurationWarning = hasSessionDuration ? SESSION_DURATION_ALERT_TEXT : null;
   const spanTimeRangeWarning = useTimeRangeWarning({widget});
 


### PR DESCRIPTION
add the page params to the transaction widget warning urls on the frontend so they can see the  same thing if they haven't submitted their dashboard filters. NOTE: i noticed that now the entire dashboard reloads when changing dashboard filters because the urls have to be re-rendered. This kinda sucks but it will be temporary
