### PR TITLE
fix(o11y): dont propagate traces for post process task

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -88,6 +88,7 @@ class EventStream(Service):
                     "project_id": project_id,
                     "eventstream_type": eventstream_type,
                 },
+                headers={"sentry-propagate-traces": False},
             )
 
     def _get_occurrence_data(self, event: Event | GroupEvent) -> MutableMapping[str, Any]:

--- a/src/sentry/eventstream/kafka/dispatch.py
+++ b/src/sentry/eventstream/kafka/dispatch.py
@@ -65,6 +65,7 @@ def dispatch_post_process_group_task(
                 "eventstream_type": eventstream_type,
             },
             queue=queue,
+            headers={"sentry-propagate-traces": False},
         )
 
 

--- a/tests/sentry/eventstream/kafka/test_dispatch.py
+++ b/tests/sentry/eventstream/kafka/test_dispatch.py
@@ -128,4 +128,5 @@ def test_dispatch_task_with_occurrence(mock_post_process_group: Mock) -> None:
             "project_id": 2,
         },
         "queue": "post_process_issue_platform",
+        "headers": {"sentry-propagate-traces": False},
     }


### PR DESCRIPTION
this is causing traces that are far too large to view, and doesn't really help for debugging. let's not propagate traces here