### PR TITLE
feat(tracemetrics): Use metric type to expose applicable aggregates

### DIFF
--- a/static/app/views/explore/hooks/useMetricOptions.tsx
+++ b/static/app/views/explore/hooks/useMetricOptions.tsx
@@ -10,7 +10,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 interface EventsMetricResult {
   data: Array<{
     ['metric.name']: string;
-    ['metric.type']: 'counter' | 'distribution' | 'gauge';
+    ['metric.type']: string;
   }>;
   meta?: {
     fields?: Record<string, string>;

--- a/static/app/views/explore/hooks/useMetricOptions.tsx
+++ b/static/app/views/explore/hooks/useMetricOptions.tsx
@@ -10,7 +10,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 interface EventsMetricResult {
   data: Array<{
     ['metric.name']: string;
-    ['metric.type']: string;
+    ['metric.type']: 'counter' | 'distribution' | 'gauge';
   }>;
   meta?: {
     fields?: Record<string, string>;

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -37,6 +37,11 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
     return null;
   }
 
+  const aggregateFields = json.aggregateFields;
+  if (!Array.isArray(aggregateFields)) {
+    return null;
+  }
+
   return {
     metric: {name: metric},
     queryParams: new ReadableQueryParams({
@@ -49,7 +54,14 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
       sortBys: defaultSortBys(),
 
       aggregateCursor: '',
-      aggregateFields: defaultAggregateFields(),
+      aggregateFields: aggregateFields
+        .filter(field => field && typeof field.yAxis === 'string')
+        .map(
+          aggregateField =>
+            new VisualizeFunction(aggregateField.yAxis, {
+              chartType: aggregateField.chartType,
+            })
+        ),
       aggregateSortBys: defaultAggregateSortBys(),
     }),
   };
@@ -59,6 +71,7 @@ export function encodeMetricQueryParams(metricQuery: BaseMetricQuery): string {
   return JSON.stringify({
     metric: metricQuery.metric.name,
     query: metricQuery.queryParams.query,
+    aggregateFields: metricQuery.queryParams.aggregateFields,
   });
 }
 

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -1,8 +1,15 @@
 import type {Sort} from 'sentry/utils/discover/fields';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import {isGroupBy, type GroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
-import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {
+  isBaseVisualize,
+  isVisualize,
+  Visualize,
+  VisualizeFunction,
+  type BaseVisualize,
+} from 'sentry/views/explore/queryParams/visualize';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 
 export interface TraceMetric {
@@ -37,10 +44,22 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
     return null;
   }
 
-  const aggregateFields = json.aggregateFields;
-  if (!Array.isArray(aggregateFields)) {
+  const rawAggregateFields = json.aggregateFields;
+  if (!Array.isArray(rawAggregateFields)) {
     return null;
   }
+
+  const visualizes = rawAggregateFields
+    .filter<BaseVisualize>(isBaseVisualize)
+    .flatMap(vis => Visualize.fromJSON(vis));
+
+  if (!visualizes.length) {
+    return null;
+  }
+
+  const groupBys = rawAggregateFields.filter<GroupBy>(isGroupBy);
+
+  const aggregateFields = [...visualizes, ...groupBys];
 
   return {
     metric: {name: metric},
@@ -54,14 +73,7 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
       sortBys: defaultSortBys(),
 
       aggregateCursor: '',
-      aggregateFields: aggregateFields
-        .filter(field => field && typeof field.yAxis === 'string')
-        .map(
-          aggregateField =>
-            new VisualizeFunction(aggregateField.yAxis, {
-              chartType: aggregateField.chartType,
-            })
-        ),
+      aggregateFields,
       aggregateSortBys: defaultAggregateSortBys(),
     }),
   };
@@ -71,7 +83,14 @@ export function encodeMetricQueryParams(metricQuery: BaseMetricQuery): string {
   return JSON.stringify({
     metric: metricQuery.metric.name,
     query: metricQuery.queryParams.query,
-    aggregateFields: metricQuery.queryParams.aggregateFields,
+    aggregateFields: metricQuery.queryParams.aggregateFields.map(field => {
+      if (isVisualize(field)) {
+        return field.serialize();
+      }
+
+      // Keep Group By as-is
+      return field;
+    }),
   });
 }
 

--- a/static/app/views/explore/metrics/metricRow/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricRow/aggregateDropdown.tsx
@@ -1,0 +1,82 @@
+import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {defined} from 'sentry/utils';
+import {
+  useMetricVisualize,
+  useSetMetricVisualize,
+} from 'sentry/views/explore/metrics/metricsQueryParams';
+
+const OPTIONS_BY_TYPE = {
+  counter: [
+    {
+      label: 'sum',
+      value: 'sum',
+    },
+  ],
+  distribution: [
+    {
+      label: 'percentile',
+      value: 'percentile',
+    },
+    {
+      label: 'avg',
+      value: 'avg',
+    },
+    {
+      label: 'min',
+      value: 'min',
+    },
+    {
+      label: 'max',
+      value: 'max',
+    },
+    {
+      label: 'sum',
+      value: 'sum',
+    },
+    {
+      label: 'count',
+      value: 'count',
+    },
+  ],
+  gauge: [
+    {
+      label: 'min',
+      value: 'min',
+    },
+    {
+      label: 'max',
+      value: 'max',
+    },
+    {
+      label: 'avg',
+      value: 'avg',
+    },
+    {
+      label: 'last',
+      value: 'last',
+    },
+  ],
+};
+
+export function AggregateDropdown({
+  type,
+}: {
+  type: 'counter' | 'distribution' | 'gauge' | undefined;
+}) {
+  const visualize = useMetricVisualize();
+  const setVisualize = useSetMetricVisualize();
+
+  return (
+    <CompactSelect
+      options={defined(type) ? OPTIONS_BY_TYPE[type] : []}
+      value={visualize.parsedFunction?.name ?? ''}
+      onChange={option => {
+        setVisualize(
+          visualize.replace({
+            yAxis: `${option.value}(${visualize.parsedFunction?.arguments?.[0] ?? ''})`,
+          })
+        );
+      }}
+    />
+  );
+}

--- a/static/app/views/explore/metrics/metricRow/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricRow/aggregateDropdown.tsx
@@ -5,7 +5,7 @@ import {
   useSetMetricVisualize,
 } from 'sentry/views/explore/metrics/metricsQueryParams';
 
-const OPTIONS_BY_TYPE = {
+const OPTIONS_BY_TYPE: Record<string, Array<{label: string; value: string}>> = {
   counter: [
     {
       label: 'sum',
@@ -74,17 +74,15 @@ const OPTIONS_BY_TYPE = {
   ],
 };
 
-export function AggregateDropdown({
-  type,
-}: {
-  type: 'counter' | 'distribution' | 'gauge' | undefined;
-}) {
+export function AggregateDropdown({type}: {type: string | undefined}) {
   const visualize = useMetricVisualize();
   const setVisualize = useSetMetricVisualize();
 
   return (
     <CompactSelect
-      options={defined(type) ? OPTIONS_BY_TYPE[type] : []}
+      options={
+        defined(type) && defined(OPTIONS_BY_TYPE[type]) ? OPTIONS_BY_TYPE[type] : []
+      }
       value={visualize.parsedFunction?.name ?? ''}
       onChange={option => {
         setVisualize(

--- a/static/app/views/explore/metrics/metricRow/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricRow/aggregateDropdown.tsx
@@ -14,8 +14,24 @@ const OPTIONS_BY_TYPE = {
   ],
   distribution: [
     {
-      label: 'percentile',
-      value: 'percentile',
+      label: 'p50',
+      value: 'p50',
+    },
+    {
+      label: 'p75',
+      value: 'p75',
+    },
+    {
+      label: 'p90',
+      value: 'p90',
+    },
+    {
+      label: 'p95',
+      value: 'p95',
+    },
+    {
+      label: 'p99',
+      value: 'p99',
     },
     {
       label: 'avg',

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -13,6 +13,7 @@ import {
 import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {
+  isVisualizeFunction,
   parseVisualize,
   VisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
@@ -90,8 +91,8 @@ function getUpdatedValue<T>(
 
 export function useMetricVisualize(): VisualizeFunction {
   const visualizes = useQueryParamsVisualizes();
-  if (visualizes.length === 1) {
-    return visualizes[0] as VisualizeFunction;
+  if (visualizes.length === 1 && isVisualizeFunction(visualizes[0]!)) {
+    return visualizes[0];
   }
   throw new Error('Only 1 visualize per metric allowed');
 }

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -8,10 +8,14 @@ import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateFie
 import {
   QueryParamsContextProvider,
   useQueryParamsVisualizes,
+  useSetQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
 import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
-import {parseVisualize} from 'sentry/views/explore/queryParams/visualize';
+import {
+  parseVisualize,
+  VisualizeFunction,
+} from 'sentry/views/explore/queryParams/visualize';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 
 interface MetricNameContextValue {
@@ -40,6 +44,7 @@ export function MetricsQueryParamsProvider({
     (writableQueryParams: WritableQueryParams) => {
       const newQueryParams = updateQueryParams(queryParams, {
         query: getUpdatedValue(writableQueryParams.query, defaultQuery),
+        aggregateFields: writableQueryParams.aggregateFields,
       });
 
       setQueryParams(newQueryParams);
@@ -83,10 +88,10 @@ function getUpdatedValue<T>(
   return undefined;
 }
 
-export function useMetricVisualize() {
+export function useMetricVisualize(): VisualizeFunction {
   const visualizes = useQueryParamsVisualizes();
   if (visualizes.length === 1) {
-    return visualizes[0]!;
+    return visualizes[0] as VisualizeFunction;
   }
   throw new Error('Only 1 visualize per metric allowed');
 }
@@ -94,6 +99,17 @@ export function useMetricVisualize() {
 export function useSetMetricName() {
   const {setMetricName} = useMetricNameContext();
   return setMetricName;
+}
+
+export function useSetMetricVisualize() {
+  const setVisualizes = useSetQueryParamsVisualizes();
+  const setVisualize = useCallback(
+    (newVisualize: VisualizeFunction) => {
+      setVisualizes([newVisualize.serialize()]);
+    },
+    [setVisualizes]
+  );
+  return setVisualize;
 }
 
 function updateQueryParams(

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -1,5 +1,4 @@
-import type {ReactNode} from 'react';
-import {useMemo} from 'react';
+import {useMemo, type ReactNode} from 'react';
 import type {Location} from 'history';
 
 import {defined} from 'sentry/utils';

--- a/static/app/views/explore/queryParams/visualize.ts
+++ b/static/app/views/explore/queryParams/visualize.ts
@@ -85,7 +85,7 @@ export class VisualizeFunction extends Visualize {
     this.parsedFunction = parseFunction(yAxis);
   }
 
-  clone(): Visualize {
+  clone(): VisualizeFunction {
     return new VisualizeFunction(this.yAxis, {
       chartType: this.selectedChartType,
       visible: this.visible,
@@ -100,7 +100,7 @@ export class VisualizeFunction extends Visualize {
     chartType?: ChartType;
     visible?: boolean;
     yAxis?: string;
-  }): Visualize {
+  }): VisualizeFunction {
     return new VisualizeFunction(yAxis ?? this.yAxis, {
       chartType: chartType ?? this.selectedChartType,
       visible: visible ?? this.visible,


### PR DESCRIPTION
The metric types we support are currently counter, distribution, and gauge. When the metric is selected, the applicable options are presented for aggregates.

Updates the context to serialize the `aggregateFields` to the URL and adds a new component that renders a static list of options for the user to select. When a selection is made, we update the yAxis for that visualize context.

Notes:
- I haven't implemented default behaviour if the selected aggregate isn't compatible (i.e. going from a distribution looking at the percentile -> a counter, since counters don't have percentile). I will follow up at a later time
- In a future PR, I will update the metric context we use to store the name to also store the type so it can handle metrics with conflicting names but different types. At the moment it simply uses a `.find` to get the type

Demo:


https://github.com/user-attachments/assets/f45e0596-aff2-4e6e-accd-4605ba7ab9b7


