### PR TITLE
fix(uptime): Recompute uptime timeWindowConfig on interval

### DIFF
--- a/static/app/views/alerts/rules/uptime/detailsTimeline.tsx
+++ b/static/app/views/alerts/rules/uptime/detailsTimeline.tsx
@@ -29,18 +29,16 @@ export function DetailsTimeline({uptimeDetector, onStatsLoaded}: Props) {
   const {width: containerWidth} = useDimensions<HTMLDivElement>({elementRef});
   const timelineWidth = useDebouncedValue(containerWidth, 500);
 
-  const timeWindowConfig = useTimeWindowConfig({timelineWidth});
+  const timeWindowConfig = useTimeWindowConfig({
+    timelineWidth,
+    recomputeInterval: 60_000,
+    recomputeOnWindowFocus: true,
+  });
 
-  const {data: uptimeStats} = useUptimeMonitorStats(
-    {
-      detectorIds: [String(uptimeDetector.id)],
-      timeWindowConfig,
-    },
-    {
-      refetchOnWindowFocus: true,
-      refetchInterval: 60_000,
-    }
-  );
+  const {data: uptimeStats} = useUptimeMonitorStats({
+    detectorIds: [String(uptimeDetector.id)],
+    timeWindowConfig,
+  });
 
   useEffect(
     () => uptimeStats?.[id] && onStatsLoaded?.(uptimeStats[id]),


### PR DESCRIPTION
Just refetching the monitor stats won't work, since we compute the stats
from the time the timeWindowConfig was instantiated.