### PR TITLE
chore(timeseries): Improve comparison logic

### DIFF
--- a/static/app/utils/timeSeries/parseGroupBy.spec.tsx
+++ b/static/app/utils/timeSeries/parseGroupBy.spec.tsx
@@ -1,9 +1,9 @@
 import {parseGroupBy} from './parseGroupBy';
 
 describe('parseGroupBy', () => {
-  it('returns undefined for "Other" group name', () => {
+  it('returns null for "Other" group name', () => {
     const result = parseGroupBy('Other', ['field1', 'field2']);
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
   });
 
   it('parses single field and value correctly', () => {
@@ -47,6 +47,6 @@ describe('parseGroupBy', () => {
 
   it('handles empty fields array', () => {
     const result = parseGroupBy('', []);
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
   });
 });

--- a/static/app/utils/timeSeries/parseGroupBy.tsx
+++ b/static/app/utils/timeSeries/parseGroupBy.tsx
@@ -5,9 +5,9 @@ import type {TimeSeriesGroupBy} from 'sentry/views/dashboards/widgets/common/typ
 export function parseGroupBy(
   groupName: string,
   fields: string[]
-): TimeSeriesGroupBy[] | undefined {
+): TimeSeriesGroupBy[] | null {
   if (groupName === 'Other') {
-    return undefined;
+    return null;
   }
 
   const groupKeys = fields;
@@ -22,5 +22,5 @@ export function parseGroupBy(
     return groupBy.key || groupBy.value;
   });
 
-  return groupBys.length > 0 ? groupBys : undefined;
+  return groupBys.length > 0 ? groupBys : null;
 }

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -90,9 +90,9 @@ export type TimeSeries = {
    * Represents the grouping information for the time series, if applicable.
    * e.g., if the initial request supplied a `groupBy` query param of `"span.op"`, the
    * `groupBy` of the `TimeSeries` could be `[{key: 'span.op': value: 'db' }]`
-   * If the `excludeOther` query param is `true`, an "other" time series will be part of the response. `TimeSeries.meta.isOther` specifies the "other" time series.
+   * If the `excludeOther` query param is `true`, an "other" time series will be part of the response. `TimeSeries.meta.isOther` specifies the "other" time series, and `groupBy` is `null` in that case
    */
-  groupBy?: TimeSeriesGroupBy[];
+  groupBy?: TimeSeriesGroupBy[] | null;
 };
 
 export type TabularValueType = AttributeValueType | null;

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -361,13 +361,24 @@ export function convertEventsStatsToTimeSeriesData(
   return [delayedTimeSeries.meta.order ?? 0, delayedTimeSeries];
 }
 
+const NUMERIC_KEYS: Array<symbol | string | number> = [
+  'value',
+  'sampleCount',
+  'sampleRate',
+];
+
 function comparator(
   valueA: unknown,
   valueB: unknown,
   key: symbol | string | number | undefined
 ) {
   // Compare numbers by near equality, which makes the comparison less sensitive to small natural variations in value caused by request sequencing
-  if (key === 'value' && typeof valueA === 'number' && typeof valueB === 'number') {
+  if (
+    key &&
+    NUMERIC_KEYS.includes(key) &&
+    typeof valueA === 'number' &&
+    typeof valueB === 'number'
+  ) {
     return areNumbersAlmostEqual(valueA, valueB, 5);
   }
 

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -23,7 +23,7 @@ import {decodeSorts} from 'sentry/utils/queryString';
 import {getTimeSeriesInterval} from 'sentry/utils/timeSeries/getTimeSeriesInterval';
 import {markDelayedData} from 'sentry/utils/timeSeries/markDelayedData';
 import {parseGroupBy} from 'sentry/utils/timeSeries/parseGroupBy';
-import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
+import {useFetchEventsTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -121,7 +121,8 @@ export const useSortedTimeSeries = <
     useIsSampled(0.1, key) &&
     organization.features.includes('explore-events-time-series-spot-check');
 
-  const timeSeriesResult = useFetchSpanTimeSeries(
+  const timeSeriesResult = useFetchEventsTimeSeries(
+    dataset ?? DiscoverDatasets.SPANS,
     {
       yAxis: yAxis as unknown as any,
       query: search,

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -371,6 +371,11 @@ function comparator(
     return areNumbersAlmostEqual(valueA, valueB, 5);
   }
 
+  // This can be removed when ENG-5677 is resolved. There's a known bug here.
+  if (key === 'dataScanned') {
+    return true;
+  }
+
   // Otherwise use default deep comparison
   return undefined;
 }


### PR DESCRIPTION
A few more improvements to the comparison algorith. This loosens the comparison criteria somewhat, and improves some of the behaviour.

- Improve `groupBy` type and docs
- Improve `groupBy` parsing
- Add support for logs
- Ignore `dataScanned` in comparator
- Apply loose comparison to all numeric keys
