### PR TITLE
fix(dashboards): Calculate bucket size from known good data

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -265,7 +265,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
   const durationUnit = isDurationChart
     ? timeseriesResults && getDurationUnit(timeseriesResults, legendOptions)
     : undefined;
-  const bucketSize = getBucketSize(timeseriesResults);
+  const bucketSize = getBucketSize(series);
 
   const valueFormatter = (value: number, seriesName?: string) => {
     const decodedSeriesName = seriesName


### PR DESCRIPTION
Gross one! `timeseriesResults` is a sparse array. In cases where the _first_ element in the array is missing, the bucket size calculation failed, crashing the chart. Instead, run the bucket size calculation on `series` which is a filtered list of `Series` that are defined.
