### PR TITLE
chore(otlp): Remove usage of span links flag

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -504,7 +504,7 @@ function EAPSpanNodeDetailsContent({
 
         <LogDetails />
 
-        {organization.features.includes('trace-view-span-links') && links?.length ? (
+        {links?.length ? (
           <TraceSpanLinks
             tree={tree}
             node={node}


### PR DESCRIPTION
It's rolled out, no worries.
