### PR TITLE
fix(dashboards): handle index and nonetype errors

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -595,7 +595,7 @@ class DashboardDetailsModelSerializer(Serializer, DashboardFiltersMixin):
         )
 
         for dashboard in item_list:
-            dashboard_widgets = [w for w in widgets if w["dashboardId"] == str(dashboard.id)]
+            dashboard_widgets = [w for w in widgets if w and w["dashboardId"] == str(dashboard.id)]
             result[dashboard] = {"widgets": dashboard_widgets}
 
         return result

--- a/src/sentry/explore/translation/dashboards_translation.py
+++ b/src/sentry/explore/translation/dashboards_translation.py
@@ -96,7 +96,8 @@ def translate_dashboard_widget_queries(
         is_function_field = is_function(field)
 
         if is_equation_field:
-            new_fields.append(eap_query_parts["equations"][equation_index])
+            if old_index < original_fields_length:
+                new_fields.append(eap_query_parts["equations"][equation_index])
             new_aggregates.append(eap_query_parts["equations"][equation_index])
             equation_index += 1
 

--- a/src/sentry/explore/translation/dashboards_translation.py
+++ b/src/sentry/explore/translation/dashboards_translation.py
@@ -116,7 +116,8 @@ def translate_dashboard_widget_queries(
             new_selected_aggregate = len(new_fields) - 1
 
         if len(field_aliases) == len(original_fields):
-            new_aliases.append(field_aliases[old_index])
+            if old_index < original_fields_length:
+                new_aliases.append(field_aliases[old_index])
 
     return (
         DashboardWidgetQuery(


### PR DESCRIPTION
the export urls logic was causing the following errors:
[SENTRY-5ACK](https://sentry.sentry.io/issues/6931242362/)
[SENTRY-5ACM](https://sentry.sentry.io/issues/6931242390/)
this fixes them (hopefully)
