### PR TITLE
fix(aci): Allow alerts:write to use test-fire-actions endpoint

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -18,6 +18,9 @@ from sentry.constants import ObjectStatus
 from sentry.models.project import Project
 from sentry.notifications.notification_action.grouptype import get_test_notification_event_data
 from sentry.notifications.types import TEST_NOTIFICATION_ID
+from sentry.workflow_engine.endpoints.organization_workflow_index import (
+    OrganizationWorkflowPermission,
+)
 from sentry.workflow_engine.endpoints.utils.test_fire_action import test_fire_action
 from sentry.workflow_engine.endpoints.validators.base.action import BaseActionValidator
 from sentry.workflow_engine.models import Action, Detector
@@ -45,6 +48,7 @@ class OrganizationTestFireActionsEndpoint(OrganizationEndpoint):
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ECOSYSTEM
+    permission_classes = (OrganizationWorkflowPermission,)
 
     @extend_schema(
         operation_id="Test Fire Actions",


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/101179

This was giving me a 403 since I don't have org:write, but that shouldn't be necessary. Using the same permissions as the workflow endpoints, which I think makes sense because that should be the only place it's being used.