### PR TITLE
fix(releases): fix release per-project new issues count in UI

### DIFF
--- a/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
+++ b/static/app/views/insights/sessions/queries/useOrganizationReleases.tsx
@@ -97,7 +97,7 @@ export default function useOrganizationReleases({
               : '',
             crash_free_sessions: release.projects[0]?.healthData?.crashFreeSessions ?? 0,
             sessions: release.projects[0]?.healthData?.totalSessions ?? 0,
-            error_count: release.newGroups ?? 0,
+            error_count: release.projects[0]?.newGroups ?? 0,
             project_id: release.projects[0]?.id ?? 0,
             adoption: release.projects[0]?.healthData?.adoption ?? 0,
             status: release.status,

--- a/static/app/views/releases/drawer/releasesDrawerTable.tsx
+++ b/static/app/views/releases/drawer/releasesDrawerTable.tsx
@@ -94,7 +94,7 @@ export function ReleasesDrawerTable({
     project: d.projects[0]!,
     release: d.version,
     date: d.dateCreated,
-    error_count: d.newGroups ?? 0,
+    error_count: d.projects[0]?.newGroups ?? 0,
     project_id: d.projects[0]?.id ?? 0,
   }));
 

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -88,7 +88,6 @@ function ReleaseCard({
     dateCreated,
     versionInfo,
     adoptionStages,
-    newGroups,
     projects,
   } = release;
 
@@ -268,7 +267,6 @@ function ReleaseCard({
                   location={location}
                   organization={organization}
                   project={project}
-                  newGroups={newGroups}
                   releaseVersion={version}
                   showPlaceholders={showHealthPlaceholders}
                   showReleaseAdoptionStages={showReleaseAdoptionStages}

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -65,7 +65,6 @@ type Props = {
   index: number;
   isTopRelease: boolean;
   location: Location;
-  newGroups: number;
   organization: Organization;
   project: ReleaseProject;
   releaseVersion: string;
@@ -86,10 +85,9 @@ function ReleaseCardProjectRow({
   releaseVersion,
   showPlaceholders,
   showReleaseAdoptionStages,
-  newGroups,
 }: Props) {
   const theme = useTheme();
-  const {id} = project;
+  const {id, newGroups} = project;
 
   const crashCount = getHealthData.getCrashCount(
     releaseVersion,


### PR DESCRIPTION
Previously, we were using release.newGroups to populate the per-project new issues counts for releases. However, this count is the total number of new issues for this release. Here, we instead use release.projects[x].newGroups, which now contains the correct number of new issues for this release in the selected project. 

We switch to using release.projects[x].newGroups in the following places: releases index, releases drawer, session health

reverts https://github.com/getsentry/sentry/pull/99555, which switched from release.projects[x].newGroups to release.newGroups

followup to https://github.com/getsentry/sentry/pull/101003, which fixed the backend bug when calculating release.projects[x].newGroups

### Demo Setup 

RELEASE 1.0.0

Project A - **3** total new groups
- Development - **2** new groups (Error & TypeError)
- Production - **1** new group (SyntaxError)

Project B - **4** total new groups
- Development - **3** new groups (ReferenceError & EvalError & URIError
- Production - **1** new group (SyntaxError)

RELEASE 2.0.0

Project A - **1** total new group
- Development - **1** new group (RangeError)

### Demo

Before: the new issues counts for each project are all equal to the total number of new issues in that release (eg, 7 new groups for each project in Release 1.0.0 == 2+1+3+1)

https://github.com/user-attachments/assets/043ceed5-f0cb-4c6a-a954-837830d2c091


After: we get the correct per-project new issues counts, even when filtering by project or env or both

https://github.com/user-attachments/assets/df5c4057-235d-4b4f-a93f-3c7aea2af656

