### PR TITLE
fix(aci): Add link to team in monitor details sidebar

### DIFF
--- a/static/app/views/detectors/components/details/common/assignee.tsx
+++ b/static/app/views/detectors/components/details/common/assignee.tsx
@@ -1,43 +1,55 @@
 import {Flex} from 'sentry/components/core/layout/flex';
-import {Tooltip} from 'sentry/components/core/tooltip';
+import {Link} from 'sentry/components/core/link';
 import Placeholder from 'sentry/components/placeholder';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {t} from 'sentry/locale';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useTeamsById} from 'sentry/utils/useTeamsById';
 import useUserFromId from 'sentry/utils/useUserFromId';
 
+function AssignToPlaceholder() {
+  return (
+    <Flex align="center" gap="xs">
+      {t('Assign to')} <Placeholder width="80px" height="16px" />
+    </Flex>
+  );
+}
+
 function AssignToTeam({teamId}: {teamId: string}) {
+  const organization = useOrganization();
   const {teams, isLoading} = useTeamsById({ids: [teamId]});
   const team = teams.find(tm => tm.id === teamId);
 
   if (isLoading) {
-    return (
-      <Flex align="center" gap="xs">
-        {t('Assign to')} <Placeholder width="80px" height="16px" />
-      </Flex>
-    );
+    return <AssignToPlaceholder />;
   }
 
-  return t('Assign to %s', `#${team?.slug ?? 'unknown'}`);
+  const teamName = `#${team?.slug ?? 'unknown'}`;
+  return (
+    <div>
+      {t('Assign to')}{' '}
+      {team?.slug ? (
+        <Link to={`/settings/${organization.slug}/teams/${team?.slug}/`}>{teamName}</Link>
+      ) : (
+        teamName
+      )}
+    </div>
+  );
 }
 
 function AssignToUser({userId}: {userId: string}) {
   const {isPending, data: user} = useUserFromId({id: parseInt(userId, 10)});
 
   if (isPending) {
-    return (
-      <Flex align="center" gap="xs">
-        {t('Assign to')} <Placeholder width="80px" height="16px" />
-      </Flex>
-    );
+    return <AssignToPlaceholder />;
   }
 
   const title = user?.name ?? user?.email ?? t('Unknown user');
   return (
-    <Tooltip title={title} showOnlyOnOverflow>
-      {t('Assign to %s', title)}
-    </Tooltip>
+    <div>
+      {t('Assign to')} {title}
+    </div>
   );
 }
 

--- a/static/app/views/detectors/components/details/common/assignee.tsx
+++ b/static/app/views/detectors/components/details/common/assignee.tsx
@@ -1,5 +1,6 @@
 import {Flex} from 'sentry/components/core/layout/flex';
 import {Link} from 'sentry/components/core/link';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import Placeholder from 'sentry/components/placeholder';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {t} from 'sentry/locale';
@@ -47,9 +48,9 @@ function AssignToUser({userId}: {userId: string}) {
 
   const title = user?.name ?? user?.email ?? t('Unknown user');
   return (
-    <div>
-      {t('Assign to')} {title}
-    </div>
+    <Tooltip title={title} showOnlyOnOverflow>
+      {t('Assign to %s', title)}
+    </Tooltip>
   );
 }
 

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -124,7 +124,10 @@ describe('DetectorDetails', () => {
         screen.getByText(dataSource.queryObj.snubaQuery.environment!)
       ).toBeInTheDocument();
       // Displays the owner team
-      expect(screen.getByText(`Assign to #${ownerTeam.slug}`)).toBeInTheDocument();
+      expect(screen.getByText('Assign to')).toBeInTheDocument();
+      expect(
+        await screen.findByRole('link', {name: `#${ownerTeam.slug}`})
+      ).toBeInTheDocument();
     });
 
     it('can edit the detector when the user has alerts:write access', async () => {


### PR DESCRIPTION
didn't do user because there isn't a great way to get member id without loading all members? Seems insane.

<img width="162" height="73" alt="image" src="https://github.com/user-attachments/assets/7634da78-f6a4-48d4-b5cd-8310461d00af" />
