### PR TITLE
fix(grouping): Add `exception` to description dictionary

### DIFF
--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -82,6 +82,7 @@ def _get_new_description(variant: BaseVariant) -> str:
         "csp_local_script_violation": "directive",
         "csp_url": "directive and URL",
         "custom_fingerprint": "custom fingerprint",
+        "exception": "exception",  # TODO: hotfix for case in which nothing in the exception contributes
         "exception_message": "exception message",
         "exception_stacktrace": "exception stacktrace",
         "exception_type": "exception type",


### PR DESCRIPTION
This is a hotfix for the case in which the app variant of an exception component has no contributing child components (for example if all frames are out of app and the type is ignored because the exception is synthetic), and so therefore the variant has nothing to put in the `exception_SOMETHING` blank in its `key` value.

This fix will keep grouping info from crashing, but in the longer term we need to handle this case more gracefully.