### PR TITLE
fix(uptime): Use detector config for detection/recovery thresholds in details

### DIFF
--- a/static/app/views/detectors/components/details/uptime/index.tsx
+++ b/static/app/views/detectors/components/details/uptime/index.tsx
@@ -4,7 +4,7 @@ import {KeyValueTableRow} from 'sentry/components/keyValueTable';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
 import Section from 'sentry/components/workflowEngine/ui/section';
-import {t} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {UptimeDetector} from 'sentry/types/workflowEngine/detectors';
 import getDuration from 'sentry/utils/duration/getDuration';
@@ -58,9 +58,19 @@ export function UptimeDetectorDetails({detector, project}: UptimeDetectorDetails
           <DetectorDetailsAutomations detector={detector} />
         </DetailLayout.Main>
         <DetailLayout.Sidebar>
-          <Section title={t('Detect')}>{t('Three consecutive failed checks.')}</Section>
+          <Section title={t('Detect')}>
+            {tn(
+              '%s consecutive failed check.',
+              '%s consecutive failed checks.',
+              detector.config.downtimeThreshold
+            )}
+          </Section>
           <Section title={t('Resolve')}>
-            {t('Three consecutive successful checks.')}
+            {tn(
+              '%s consecutive successful check.',
+              '%s consecutive successful checks.',
+              detector.config.recoveryThreshold
+            )}
           </Section>
           <Section title={t('Legend')}>
             <DetailsTimelineLegend showMissedLegend={showMissedLegend} />

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -269,10 +269,8 @@ describe('DetectorDetails', () => {
         await screen.findByRole('heading', {name: uptimeDetector.name})
       ).toBeInTheDocument();
 
-      expect(screen.getByText('Three consecutive failed checks.')).toBeInTheDocument();
-      expect(
-        screen.getByText('Three consecutive successful checks.')
-      ).toBeInTheDocument();
+      expect(screen.getByText('3 consecutive failed checks.')).toBeInTheDocument();
+      expect(screen.getByText('1 consecutive successful check.')).toBeInTheDocument();
 
       // Interval
       expect(screen.getByText('Every 1 minute')).toBeInTheDocument();


### PR DESCRIPTION
Replaces hardcoded "Three consecutive" text with actual threshold values
from detector config using tn() for proper pluralization.

Fixes [NEW-573: Detect and Resolve are hardcoded to 3, this should use uptime config](https://linear.app/getsentry/issue/NEW-573/detect-and-resolve-are-hardcoded-to-3-this-should-use-uptime-config)