### PR TITLE
fix(detectors): Uptime failure threshold Automations not issues

### DIFF
--- a/static/app/views/detectors/components/forms/uptime/detect/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/detect/index.tsx
@@ -141,7 +141,7 @@ export function UptimeDetectorFormDetectSection() {
               const downDuration = intervalSeconds * threshold;
 
               return tct(
-                'Issue created after [threshold] consecutive failures (after [downtime] of downtime).',
+                'Automations Triggered after [threshold] consecutive failures (after [downtime] of downtime).',
                 {
                   threshold: <strong>{threshold}</strong>,
                   downtime: <strong>{getDuration(downDuration)}</strong>,


### PR DESCRIPTION
Fixes [NEW-557: Detector form probably should say "Automation triggered" after in Failure Threshold help text](https://linear.app/getsentry/issue/NEW-557/detector-form-probably-should-say-automation-triggered-after-in)