### PR TITLE
fix(issues): Make integration keys unique, silence warning

### DIFF
--- a/static/app/components/group/externalIssuesList/hooks/useIntegrationExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/useIntegrationExternalIssues.tsx
@@ -73,7 +73,7 @@ export function useIntegrationExternalIssues({
       // Roll up all configurations into a single integration item
       results.integrations.push({
         displayName: getIntegrationDisplayName(providerKey),
-        key: providerKey,
+        key: `integration-${providerKey}`,
         displayIcon,
         actions,
       });
@@ -84,7 +84,7 @@ export function useIntegrationExternalIssues({
       ...configurations
         .filter(config => config.externalIssues.length > 0)
         .map<GroupIntegrationIssueResult['linkedIssues'][number]>(config => ({
-          key: config.externalIssues[0]!.id,
+          key: `integration-linked-${config.externalIssues[0]!.id}`,
           displayName: config.externalIssues[0]!.key,
           displayIcon,
           url: config.externalIssues[0]!.url,

--- a/static/app/components/group/externalIssuesList/hooks/usePluginExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/usePluginExternalIssues.tsx
@@ -40,7 +40,7 @@ export function usePluginExternalIssues({
     const displayName = plugin.name || plugin.title;
     if (plugin.issue) {
       result.linkedIssues.push({
-        key: plugin.id,
+        key: `plugin-linked-${plugin.id}`,
         displayName: `${displayName} Issue`,
         displayIcon,
         title: plugin.issue.issue_id,
@@ -72,7 +72,7 @@ export function usePluginExternalIssues({
       });
     } else {
       result.integrations.push({
-        key: plugin.id,
+        key: `plugin-${plugin.id}`,
         displayName,
         displayIcon,
         actions: [
@@ -120,7 +120,7 @@ export function usePluginExternalIssues({
 
   for (const [title, action] of group.pluginActions) {
     result.integrations.push({
-      key: `${title}-${action}`,
+      key: `plugin-action-${title}-${action}`,
       displayName: title,
       displayIcon: getIntegrationIcon(title, 'sm'),
       actions: [

--- a/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
@@ -57,7 +57,7 @@ export function useSentryAppExternalIssues({
     );
     if (externalIssue) {
       result.linkedIssues.push({
-        key: externalIssue.id,
+        key: `sentryapp-linked-${externalIssue.id}`,
         displayName: externalIssue.displayName,
         url: externalIssue.webUrl,
         // Some display names look like PROJ#1234
@@ -80,7 +80,7 @@ export function useSentryAppExternalIssues({
       });
     } else {
       result.integrations.push({
-        key: component.sentryApp.slug,
+        key: `sentryapp-${component.sentryApp.slug}`,
         displayName: appDisplayName,
         displayIcon,
         disabled: Boolean(component.error),


### PR DESCRIPTION
React was throwing a warning since the keys for plugin jira and integration jira were both "jira"
