### PR TITLE
fix(ui): cell alignment of manage monitors table

### DIFF
--- a/static/app/components/modals/bulkEditMonitorsModal.tsx
+++ b/static/app/components/modals/bulkEditMonitorsModal.tsx
@@ -193,9 +193,17 @@ export function BulkEditMonitorsModal({Header, Body, Footer, closeModal}: Props)
                     />
                     <Text>{monitor.slug}</Text>
                   </MonitorSlug>
-                  <Text>{monitor.status === 'active' ? t('Active') : t('Disabled')}</Text>
-                  <Text>{monitor.isMuted ? t('Yes') : t('No')}</Text>
-                  <Text>{scheduleAsText(monitor.config)}</Text>
+                  <div>
+                    <Text>
+                      {monitor.status === 'active' ? t('Active') : t('Disabled')}
+                    </Text>
+                  </div>
+                  <div>
+                    <Text>{monitor.isMuted ? t('Yes') : t('No')}</Text>
+                  </div>
+                  <div>
+                    <Text>{scheduleAsText(monitor.config)}</Text>
+                  </div>
                 </Fragment>
               ))}
         </StyledPanelTable>


### PR DESCRIPTION
found this misalignment by accident. @JonasBa I think we might’ve broken this by changing the `Text` primitive, which was used here before.

The issue is that we are rendering `Text` directly inside the `PanelTable`, where `PanelTable` wants to apply padding with the direct child universal selector:

https://github.com/getsentry/sentry/blob/f11bf42341774cafe031e9f7c3ec76626cbf68c9/static/app/components/panels/panelTable.tsx#L160-L161

however, `Text` internally sets `padding:0` now, which I think has a higher specificty.

I opted for the minimal invasive fix, which is wrapping each Cell into an additional `div` so that the padding gets applied there.

before:
<img width="861" height="417" alt="Screenshot 2025-10-09 at 09 53 13" src="https://github.com/user-attachments/assets/164615d8-1975-485b-b901-139b4a2154a4" />

after:
<img width="860" height="483" alt="Screenshot 2025-10-09 at 09 58 11" src="https://github.com/user-attachments/assets/a020a68f-cc57-4c37-9641-8cee23e7fc75" />
