### PR TITLE
feat(ui): wrap TabPanels in React's new Activity

### DIFF
--- a/static/app/components/activity/note/input.spec.tsx
+++ b/static/app/components/activity/note/input.spec.tsx
@@ -107,7 +107,7 @@ describe('NoteInput', () => {
       // Switch to preview
       await userEvent.click(screen.getByRole('tab', {name: 'Preview'}));
 
-      expect(screen.getByText('an existing item')).toBeInTheDocument();
+      expect(screen.getAllByText('an existing item')[0]).toBeInTheDocument();
 
       // Switch to edit
       await userEvent.click(screen.getByRole('tab', {name: 'Edit'}));

--- a/static/app/components/core/tabs/index.stories.tsx
+++ b/static/app/components/core/tabs/index.stories.tsx
@@ -1,10 +1,25 @@
 import {Fragment, useState} from 'react';
 import range from 'lodash/range';
 
+import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
+import {Flex} from 'sentry/components/core/layout';
+import {ExternalLink} from 'sentry/components/core/link';
+import {Text} from 'sentry/components/core/text';
 import * as Storybook from 'sentry/stories';
 
 import type {TabListProps, TabsProps} from '.';
 import {TabList, TabPanels, Tabs} from '.';
+
+function StatefulComponent(props: {children?: React.ReactNode}) {
+  const [count, setCount] = useState(0);
+  return (
+    <Flex gap="md" align="center">
+      <Text>{props.children}</Text>
+      <Button onClick={() => setCount(count + 1)}>Inc {count}</Button>
+    </Flex>
+  );
+}
 
 export default Storybook.story('Tabs', story => {
   const TABS = [
@@ -26,6 +41,16 @@ export default Storybook.story('Tabs', story => {
         This will give you all kinds of accessibility and state tracking out of the box.
         But you will have to render all tab content, including hooks, upfront.
       </p>
+      <p>
+        <Alert type="info">
+          Note: All <Storybook.JSXNode name="TabPanels" /> are wrapped in React's new{' '}
+          <ExternalLink href="https://react.dev/reference/react/Activity">
+            <Storybook.JSXNode name="Activity" />
+          </ExternalLink>{' '}
+          by default, which ensures that state is preserved when switching between tabs
+          without impacting render performance.
+        </Alert>
+      </p>
       <Tabs>
         <TabList>
           {TABS.map(tab => (
@@ -36,7 +61,9 @@ export default Storybook.story('Tabs', story => {
         </TabList>
         <TabPanels>
           {TABS.map(tab => (
-            <TabPanels.Item key={tab.key}>{tab.content}</TabPanels.Item>
+            <TabPanels.Item key={tab.key}>
+              <StatefulComponent>{tab.content}</StatefulComponent>
+            </TabPanels.Item>
           ))}
         </TabPanels>
       </Tabs>

--- a/static/app/components/core/tabs/tabPanels.tsx
+++ b/static/app/components/core/tabs/tabPanels.tsx
@@ -1,4 +1,4 @@
-import {useContext, useRef} from 'react';
+import {Activity, useContext, useRef} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {AriaTabPanelProps} from '@react-aria/tabs';
@@ -51,7 +51,11 @@ export function TabPanels(props: TabPanelsProps) {
       orientation={orientation}
       key={tabListState?.selectedKey}
     >
-      {selectedPanel?.props.children}
+      {[...collection].map(item => (
+        <Activity mode={item === selectedPanel ? 'visible' : 'hidden'} key={item.key}>
+          {item.props.children}
+        </Activity>
+      ))}
     </TabPanel>
   );
 }

--- a/static/app/components/core/tabs/tabPanels.tsx
+++ b/static/app/components/core/tabs/tabPanels.tsx
@@ -45,12 +45,7 @@ export function TabPanels(props: TabPanelsProps) {
     : null;
 
   return (
-    <TabPanel
-      {...props}
-      state={tabListState}
-      orientation={orientation}
-      key={tabListState?.selectedKey}
-    >
+    <TabPanel {...props} state={tabListState} orientation={orientation}>
       {[...collection].map(item => (
         <Activity mode={item === selectedPanel ? 'visible' : 'hidden'} key={item.key}>
           {item.props.children}


### PR DESCRIPTION
This PR wraps `TabPanels` children into `Activity` from `React`. Instead of only rendering the active child, thus unmounting and re-mounting between every tab switch, we can now leverage the new `Activity` component to render the active child with `mode=“visible”` and all other ones as `mode=“hidden”`.

This will render all tabs at the same time, but the hidden ones have a lower priority so it shouldn’t affect perf in a negative way. In fact, it should make things faster because switching between tabs doesn’t need to re-mount the component. Effects and Queries will still unmount and remount, so there shouldn’t be any overfetching.

Note: I’ve tested this in two situations I could find in the product, and they both still worked fine. There aren’t that many usages of `TabPanels`. Most of the time, we use `<TabList>` to render the tabs, but the tabs content is then rendered _without_ `TabPanels` - we just do manual conditional rendering without it, like e.g. here:

https://github.com/getsentry/sentry/blob/a1a13c6f1b9b76634f31aa2e056769aa21f95e8c/static/app/views/performance/newTraceDetails/index.tsx#L175-L186

So this change doesn’t affect many places even though it’s quite central.