### PR TITLE
fix(ai-insights): use span status to query for errors

### DIFF
--- a/static/app/views/insights/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/agents/components/aiSpanList.tsx
@@ -386,9 +386,12 @@ function hasError(node: AITraceSpanNode) {
     return true;
   }
 
-  // spans with status unknown are errors
   if (isEAPSpanNode(node)) {
-    return node.value.additional_attributes?.[SpanFields.SPAN_STATUS] === 'unknown';
+    const status = node.value.additional_attributes?.[SpanFields.SPAN_STATUS];
+    if (typeof status === 'string') {
+      return status.includes('error');
+    }
+    return false;
   }
 
   return false;

--- a/static/app/views/insights/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/agents/components/tracesTable.tsx
@@ -127,7 +127,7 @@ export function TracesTable() {
   const traceErrorRequest = useSpans(
     {
       // Get all generations and tool calls with status unknown
-      search: `has:span.status !span.status:ok trace:[${tracesRequest.data?.data.map(span => span.trace).join(',')}]`,
+      search: `has:span.status span.status:*error trace:[${tracesRequest.data?.data.map(span => span.trace).join(',')}]`,
       fields: ['trace', ...AI_AGENT_SUB_OPS],
       limit: tracesRequest.data?.data.length ?? 0,
       enabled: Boolean(tracesRequest.data && tracesRequest.data.data.length > 0),


### PR DESCRIPTION
Followup of https://github.com/getsentry/relay/pull/5202/