### PR TITLE
fix(ui): remove vertical scrollbar

### DIFF
--- a/static/app/components/events/interfaces/message.tsx
+++ b/static/app/components/events/interfaces/message.tsx
@@ -75,5 +75,6 @@ const PlainPre = styled('pre')`
   border: 0;
   margin-bottom: 0;
   white-space: pre-wrap;
+  overflow-x: unset;
   word-break: break-all;
 `;


### PR DESCRIPTION
the message gets rendered as a `pre` tag that has global styles applied with:

```
overflow-x: auto
```

I think the browser reserves space for the horizontal scrollbar (which will never show up because the Message text is wrapping...) and that's why the vertical one shows up.

Fix is to disallow horizontal overflowing, which will also remove the unnecessary vertical scrollbar placeholder

before:
<img width="1085" height="114" alt="Screenshot 2025-10-09 at 15 09 34" src="https://github.com/user-attachments/assets/41d2f5e2-d3ed-4b2e-9804-dd5d79b93d3e" />

after:
<img width="1069" height="110" alt="Screenshot 2025-10-09 at 15 09 27" src="https://github.com/user-attachments/assets/67bd63d5-32f2-4eba-a4ee-402625aed7f0" />
