### PR TITLE
chore(auto_source_config): Bump code mapping derivation timeout

### DIFF
--- a/src/sentry/tasks/auto_source_code_config.py
+++ b/src/sentry/tasks/auto_source_code_config.py
@@ -11,10 +11,6 @@ from sentry.taskworker.retry import Retry
 @instrumented_task(
     name="sentry.tasks.auto_source_code_config",
     namespace=issues_tasks,
-    # The auto source code configuration process can take longer for large projects
-    # or when interacting with external services. Increase the processing deadline
-    # from 5 minutes to 10 minutes to reduce the likelihood of premature task
-    # termination in these scenarios.
     processing_deadline_duration=10 * 60,
     retry=Retry(times=3, delay=60 * 10),
 )

--- a/src/sentry/tasks/auto_source_code_config.py
+++ b/src/sentry/tasks/auto_source_code_config.py
@@ -11,7 +11,11 @@ from sentry.taskworker.retry import Retry
 @instrumented_task(
     name="sentry.tasks.auto_source_code_config",
     namespace=issues_tasks,
-    processing_deadline_duration=5 * 60,
+    # The auto source code configuration process can take longer for large projects
+    # or when interacting with external services. Increase the processing deadline
+    # from 5 minutes to 10 minutes to reduce the likelihood of premature task
+    # termination in these scenarios.
+    processing_deadline_duration=10 * 60,
     retry=Retry(times=3, delay=60 * 10),
 )
 def auto_source_code_config(project_id: int, event_id: str, group_id: int, **kwargs: Any) -> None:


### PR DESCRIPTION
We see too many ProcessingDeadlineExceeded errors in the last few months.

To speed up this task we would need major changes, thus, this is the best way out.