### PR TITLE
metrics(auto_source): Track get_repo cache usage

### DIFF
--- a/src/sentry/integrations/source_code_management/repo_trees.py
+++ b/src/sentry/integrations/source_code_management/repo_trees.py
@@ -195,6 +195,13 @@ class RepoTreesIntegration(ABC):
         """
         key = f"{self.integration_name}:repo:{repo_full_name}:{'source-code' if only_source_code_files else 'all'}"
         repo_files: list[str] = cache.get(key, [])
+
+        # Track where the repo tree data is sourced from (cache or API) so that we can
+        # better understand the effectiveness of our caching strategy. This will help
+        # us tune the cache TTL and identify integrations that are making excessive
+        # API calls.
+        source: str = "cache" if repo_files else "api"
+
         if not repo_files and not only_use_cache:
             tree = self.get_client().get_tree(repo_full_name, tree_sha)
             if tree:
@@ -202,14 +209,23 @@ class RepoTreesIntegration(ABC):
                 repo_files = [x["path"] for x in tree if x["type"] == "blob"]
                 if only_source_code_files:
                     repo_files = filter_source_code_files(files=repo_files)
-                # The backend's caching will skip silently if the object size greater than 5MB
-                # The trees API does not return structures larger than 7MB
-                # As an example, all file paths in Sentry is about 1.3MB
-                # Larger customers may have larger repositories, however,
-                # the cost of not having cached the files cached for those
-                # repositories is a single API network request, thus,
-                # being acceptable to sometimes not having everything cached
+                # The backend's caching will skip silently if the object size is greater than 5 MB.
+                # The trees API does not return structures larger than 7 MB. As an example, all file
+                # paths in Sentry total about 1.3 MB. For larger customers this may be bigger, but
+                # the penalty for skipping the cache is just a single API request, which is acceptable.
                 cache.set(key, repo_files, self.CACHE_SECONDS + shifted_seconds)
+
+        # Emit Datadog metric once per invocation to capture source of truth.
+        # Examples:
+        #   integrations.source_code_management.get_tree_source{source:"cache"} 1
+        #   integrations.source_code_management.get_tree_source{source:"api"} 1
+        metrics.incr(
+            "integrations.source_code_management.get_tree_source",
+            tags={
+                "source": source,
+                "integration": self.integration_name,
+            },
+        )
 
         return repo_files
 

--- a/src/sentry/integrations/source_code_management/repo_trees.py
+++ b/src/sentry/integrations/source_code_management/repo_trees.py
@@ -195,13 +195,8 @@ class RepoTreesIntegration(ABC):
         """
         key = f"{self.integration_name}:repo:{repo_full_name}:{'source-code' if only_source_code_files else 'all'}"
 
-        # A value of None means cache miss; [] (empty list) means cached repo with no files.
-        repo_files_cached: list[str] | None = cache.get(key)
-
-        cache_hit: bool = repo_files_cached is not None
-
-        # When restricted to cache-only, treat a miss as an empty list.
-        repo_files: list[str] = repo_files_cached if repo_files_cached is not None else []
+        cache_hit: bool = cache.has_key(key)
+        repo_files: list[str] = cache.get(key, [])
 
         if not cache_hit and not only_use_cache:
             # Cache miss – fetch from API

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -337,13 +337,22 @@ class TestGenericBehaviour(BaseDeriveCodeMappings):
                 platform=platform,
             )
 
-            with patch(f"{REPO_TREES_CODE}.get_supported_extensions", return_value=["tbd"]):
-                self._process_and_assert_configuration_changes(
-                    repo_trees={REPO1: [file_in_repo]},
-                    frames=[self.frame(frame_filename, True)],
-                    platform=platform,
-                    expected_new_code_mappings=[self.code_mapping("foo/", "src/foo/")],
-                )
+    def test_extension_is_included(self) -> None:
+        frame_filename = "foo/bar.tbd"
+        file_in_repo = "src/foo/bar.tbd"
+        platform = "other"
+        self.event = self.create_event([{"filename": frame_filename, "in_app": True}], platform)
+
+        with (
+            patch(f"{CODE_ROOT}.utils.platform.get_platform_config", return_value={}),
+            patch(f"{REPO_TREES_CODE}.get_supported_extensions", return_value=["tbd"]),
+        ):
+            self._process_and_assert_configuration_changes(
+                repo_trees={REPO1: [file_in_repo]},
+                frames=[self.frame(frame_filename, True)],
+                platform=platform,
+                expected_new_code_mappings=[self.code_mapping("foo/", "src/foo/")],
+            )
 
     def test_multiple_calls(self) -> None:
         platform = "other"


### PR DESCRIPTION
Add a Datadog metric to track whether repo tree data is sourced from cache or API to evaluate caching effectiveness.

The task is taking very long and I want to determine what our cache hit ratio is.