### PR TITLE
ref(overwatch): include organization slug and name in response data

### DIFF
--- a/src/sentry/overwatch/endpoints/overwatch_rpc.py
+++ b/src/sentry/overwatch/endpoints/overwatch_rpc.py
@@ -161,7 +161,12 @@ class PreventPrReviewSentryOrgEndpoint(Endpoint):
         return Response(
             data={
                 "organizations": [
-                    {"org_id": org.id, "has_consent": _can_use_prevent_ai_features(org)}
+                    {
+                        "org_id": org.id,
+                        "org_slug": org.slug,
+                        "org_name": org.name,
+                        "has_consent": _can_use_prevent_ai_features(org),
+                    }
                     for org in organizations
                 ]
             }

--- a/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
+++ b/tests/sentry/overwatch/endpoints/test_overwatch_rpc.py
@@ -126,8 +126,18 @@ class TestPreventPrReviewSentryOrgEndpoint(APITestCase):
         assert resp.status_code == 200
         # Should return both orgs with their consent status
         expected_orgs = [
-            {"org_id": org_with_consent.id, "has_consent": True},
-            {"org_id": org_without_consent.id, "has_consent": False},
+            {
+                "org_id": org_with_consent.id,
+                "org_slug": org_with_consent.slug,
+                "org_name": org_with_consent.name,
+                "has_consent": True,
+            },
+            {
+                "org_id": org_without_consent.id,
+                "org_slug": org_without_consent.slug,
+                "org_name": org_without_consent.name,
+                "has_consent": False,
+            },
         ]
         # Sort both lists by org_id to ensure consistent comparison
         expected_orgs = sorted(expected_orgs, key=lambda x: x["org_id"])


### PR DESCRIPTION
Updated the PreventPrReviewSentryOrgEndpoint to return additional organization details (slug and name) in the response. Corresponding test cases have been adjusted to reflect these changes.
