### PR TITLE
feat(tracemetrics): Add tracemetrics column definitions to trace-items

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -354,12 +354,7 @@ class OrganizationTraceItemAttributeValuesEndpoint(OrganizationTraceItemAttribut
 
         max_attribute_values = options.get("explore.trace-items.values.max")
 
-        if item_type == SupportedTraceItemType.SPANS.value:
-            definitions = SPAN_DEFINITIONS
-        elif item_type == SupportedTraceItemType.TRACEMETRICS.value:
-            definitions = TRACE_METRICS_DEFINITIONS
-        else:
-            definitions = OURLOG_DEFINITIONS
+        definitions = get_column_definitions(SupportedTraceItemType(item_type))
 
         def data_fn(offset: int, limit: int):
             executor = TraceItemAttributeValuesAutocompletionExecutor(

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -354,11 +354,12 @@ class OrganizationTraceItemAttributeValuesEndpoint(OrganizationTraceItemAttribut
 
         max_attribute_values = options.get("explore.trace-items.values.max")
 
-        definitions = (
-            SPAN_DEFINITIONS
-            if item_type == SupportedTraceItemType.SPANS.value
-            else OURLOG_DEFINITIONS
-        )
+        if item_type == SupportedTraceItemType.SPANS.value:
+            definitions = SPAN_DEFINITIONS
+        elif item_type == SupportedTraceItemType.TRACEMETRICS.value:
+            definitions = TRACE_METRICS_DEFINITIONS
+        else:
+            definitions = OURLOG_DEFINITIONS
 
         def data_fn(offset: int, limit: int):
             executor = TraceItemAttributeValuesAutocompletionExecutor(

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -37,6 +37,7 @@ from sentry.search.eap.columns import ColumnDefinitions
 from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
+from sentry.search.eap.trace_metrics.definitions import TRACE_METRICS_DEFINITIONS
 from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
 from sentry.search.eap.utils import (
     can_expose_attribute,
@@ -107,6 +108,7 @@ class OrganizationTraceItemAttributesEndpointBase(OrganizationEventsV2EndpointBa
     feature_flags = [
         "organizations:ourlogs-enabled",
         "organizations:visibility-explore-view",
+        "organizations:tracemetrics-enabled",
     ]
 
     def has_feature(self, organization: Organization, request: Request) -> bool:
@@ -139,7 +141,14 @@ def is_valid_item_type(item_type: str) -> bool:
 
 
 def get_column_definitions(item_type: SupportedTraceItemType) -> ColumnDefinitions:
-    return SPAN_DEFINITIONS if item_type == SupportedTraceItemType.SPANS else OURLOG_DEFINITIONS
+    if item_type == SupportedTraceItemType.SPANS:
+        return SPAN_DEFINITIONS
+    elif item_type == SupportedTraceItemType.LOGS:
+        return OURLOG_DEFINITIONS
+    elif item_type == SupportedTraceItemType.TRACEMETRICS:
+        return TRACE_METRICS_DEFINITIONS
+
+    raise ValueError(f"Invalid item type: {item_type}")
 
 
 def resolve_attribute_referrer(item_type: str, attribute_type: str) -> Referrer:

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -152,19 +152,25 @@ def get_column_definitions(item_type: SupportedTraceItemType) -> ColumnDefinitio
 
 
 def resolve_attribute_referrer(item_type: str, attribute_type: str) -> Referrer:
-    return (
-        Referrer.API_SPANS_TAG_KEYS_RPC
-        if item_type == SupportedTraceItemType.SPANS.value
-        else Referrer.API_LOGS_TAG_KEYS_RPC
-    )
+    if item_type == SupportedTraceItemType.SPANS.value:
+        return Referrer.API_SPANS_TAG_KEYS_RPC
+    elif item_type == SupportedTraceItemType.LOGS.value:
+        return Referrer.API_LOGS_TAG_KEYS_RPC
+    elif item_type == SupportedTraceItemType.TRACEMETRICS.value:
+        return Referrer.API_TRACE_METRICS_TAG_KEYS_RPC
+    else:
+        raise ValueError(f"Invalid item type: {item_type}")
 
 
 def resolve_attribute_values_referrer(item_type: str) -> Referrer:
-    return (
-        Referrer.API_SPANS_TAG_VALUES_RPC
-        if item_type == SupportedTraceItemType.SPANS.value
-        else Referrer.API_LOGS_TAG_VALUES_RPC
-    )
+    if item_type == SupportedTraceItemType.SPANS.value:
+        return Referrer.API_SPANS_TAG_VALUES_RPC
+    elif item_type == SupportedTraceItemType.LOGS.value:
+        return Referrer.API_LOGS_TAG_VALUES_RPC
+    elif item_type == SupportedTraceItemType.TRACEMETRICS.value:
+        return Referrer.API_TRACE_METRICS_TAG_VALUES_RPC
+    else:
+        raise ValueError(f"Invalid item type: {item_type}")
 
 
 def as_attribute_key(

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -548,6 +548,8 @@ class Referrer(StrEnum):
     API_SPANS_FREQUENCY_STATS_RPC = "api.spans.fields-stats.rpc"
     API_SPANS_TAG_VALUES_RPC = "api.spans.tags-values.rpc"
     API_SPANS_TRACE_VIEW = "api.spans.trace-view"
+    API_TRACE_METRICS_TAG_KEYS_RPC = "api.tracemetrics.tags-keys.rpc"
+    API_TRACE_METRICS_TAG_VALUES_RPC = "api.tracemetrics.tags-values.rpc"
 
     API_SPAN_SAMPLE_GET_BOUNDS = "api.spans.sample-get-bounds"
     API_SPAN_SAMPLE_GET_SPAN_IDS = "api.spans.sample-get-span-ids"

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3483,6 +3483,7 @@ class TraceMetricsTestCase(BaseTestCase, TraceItemTestCase):
         project: Project | None = None,
         timestamp: datetime | None = None,
         trace_id: str | None = None,
+        attributes: dict[str, Any] | None = None,
     ) -> TraceItem:
         if organization is None:
             organization = self.organization
@@ -3505,6 +3506,10 @@ class TraceMetricsTestCase(BaseTestCase, TraceItemTestCase):
             "sentry.metric_name": AnyValue(string_value=metric_name),
             "sentry.value": AnyValue(double_value=metric_value),
         }
+
+        if attributes:
+            for k, v in attributes.items():
+                attributes_proto[k] = scalar_to_any_value(v)
 
         return TraceItem(
             organization_id=organization.id,


### PR DESCRIPTION
The `trace-items` endpoint wasn't using the `TRACE_METRICS_DEFINITIONS` instance to resolve columns, so a number of options did not appear when using the endpoint. Added the item type to the definitions and tests to check that we can get the keys, as well as values for tracemetrics.