### PR TITLE
fix(grouping): Add chained `NSError` to grouping info description options

### DIFF
--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -78,6 +78,7 @@ def _get_new_description(variant: BaseVariant) -> str:
         "chained_exception_message": "chained exception messages",
         "chained_exception_stacktrace": "chained exception stacktraces",
         "chained_exception_type": "chained exception types",
+        "chained_ns_error": "chained NSErrors",
         "checksum": "checksum",
         "csp_local_script_violation": "directive",
         "csp_url": "directive and URL",


### PR DESCRIPTION
This is another hotfix for https://github.com/getsentry/sentry/pull/101042, adding a missing key to the grouping info description dictionary.