### PR TITLE
fix(events): use numbers for param

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -172,7 +172,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 query_string=query,
                 sampling_mode=sampling_mode,
                 debug=request.user.is_superuser and "debug" in request.GET,
-                case_insensitive=request.GET.get("caseInsensitive", 0) == 1,
+                case_insensitive=request.GET.get("caseInsensitive", "0") == "1",
             )
             return params
 

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -172,7 +172,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 query_string=query,
                 sampling_mode=sampling_mode,
                 debug=request.user.is_superuser and "debug" in request.GET,
-                case_insensitive=request.GET.get("caseInsensitive", "false").lower() == "true",
+                case_insensitive=request.GET.get("caseInsensitive", 0) == 1,
             )
             return params
 

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -657,7 +657,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             "field": ["id", "parent_span", "span.duration"],
             "query": "",
             "maxSpansPerTrace": 3,
-            "caseInsensitive": True,
+            "caseInsensitive": 1,
         }
 
         response = self.do_request(query)

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -1241,7 +1241,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
                 "project": self.project.id,
                 "dataset": "spans",
                 "statsPeriod": "1h",
-                "caseInsensitive": True,
+                "caseInsensitive": 1,
             }
         )
         assert response.status_code == 200, response.content
@@ -1308,7 +1308,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
                 "project": self.project.id,
                 "dataset": "spans",
                 "statsPeriod": "1h",
-                "caseInsensitive": True,
+                "caseInsensitive": 1,
             }
         )
         assert response.status_code == 200, response.content


### PR DESCRIPTION
- Use numbers for the params instead of true/false strings