### PR TITLE
feat(dashboards): Add global filters to dashboard details

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -612,7 +612,7 @@ class DashboardDetailsModelSerializer(Serializer, DashboardFiltersMixin):
 
         if not features.has(
             "organizations:dashboards-global-filters",
-            organization=obj.dashboard.organization,
+            organization=obj.organization,
             actor=user,
         ):
             tag_filters["globalFilter"] = []

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -609,6 +609,14 @@ class DashboardDetailsModelSerializer(Serializer, DashboardFiltersMixin):
 
     def serialize(self, obj, attrs, user, **kwargs) -> DashboardDetailsResponse:
         page_filters, tag_filters = self.get_filters(obj)
+
+        if not features.has(
+            "organizations:dashboards-global-filters",
+            organization=obj.dashboard.organization,
+            actor=user,
+        ):
+            tag_filters["globalFilter"] = []
+
         data: DashboardDetailsResponse = {
             "id": str(obj.id),
             "title": obj.title,

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -446,7 +446,7 @@ class DashboardFiltersMixin:
             page_filters["utc"] = dashboard_filters["utc"]
 
         tag_filters: DashboardFilters = {}
-        for filter_key in ("release", "releaseId"):
+        for filter_key in ("release", "releaseId", "globalFilter"):
             if dashboard_filters.get(camel_to_snake_case(filter_key)):
                 tag_filters[filter_key] = dashboard_filters[camel_to_snake_case(filter_key)]
 
@@ -563,6 +563,7 @@ class DashboardListSerializer(Serializer, DashboardFiltersMixin):
 class DashboardFilters(TypedDict, total=False):
     release: list[str]
     releaseId: list[str]
+    globalFilter: list[dict[str, Any]]
 
 
 class DashboardDetailsResponseOptional(TypedDict, total=False):

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -610,7 +610,7 @@ class DashboardDetailsModelSerializer(Serializer, DashboardFiltersMixin):
     def serialize(self, obj, attrs, user, **kwargs) -> DashboardDetailsResponse:
         page_filters, tag_filters = self.get_filters(obj)
 
-        if not features.has(
+        if "globalFilter" in tag_filters and not features.has(
             "organizations:dashboards-global-filters",
             organization=obj.organization,
             actor=user,

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -694,7 +694,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
 
     def update_dashboard_filters(self, instance, validated_data):
         page_filter_keys = ["environment", "period", "start", "end", "utc"]
-        dashboard_filter_keys = ["release", "release_id"]
+        dashboard_filter_keys = ["release", "release_id", "global_filter"]
 
         filters = {}
 

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -694,7 +694,14 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
 
     def update_dashboard_filters(self, instance, validated_data):
         page_filter_keys = ["environment", "period", "start", "end", "utc"]
-        dashboard_filter_keys = ["release", "release_id", "global_filter"]
+        dashboard_filter_keys = ["release", "release_id"]
+
+        if features.has(
+            "organizations:dashboards-global-filters",
+            organization=self.context["organization"],
+            actor=self.context["request"].user,
+        ):
+            dashboard_filter_keys.append("global_filter")
 
         filters = {}
 


### PR DESCRIPTION
- Adds global filters to the expected dashboard filter keys
- This allows storing and retrieving global filters from dashboard details

Fixes [DAIN-990](https://linear.app/getsentry/issue/DAIN-990/add-global-filters-to-dashboard-details)