### PR TITLE
feat(eco): Adds credentials service integration interface, implements it for Github

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -516,6 +516,20 @@ class IntegrationInstallation(abc.ABC):
     def metadata(self) -> dict[str, Any]:
         return self.model.metadata
 
+    def _update_integration_model(self) -> None:
+        from sentry.integrations.services.integration.service import integration_service
+
+        updated_model: RpcIntegration | Integration | None = None
+        if isinstance(self.model, Integration):
+            updated_model = Integration.objects.get(id=self.model.id)
+        else:
+            updated_model = integration_service.get_integration(self.model.id)
+
+        if updated_model is None:
+            raise IntegrationError("Integration model not found")
+
+        self.model = updated_model
+
     def uninstall(self) -> None:
         """
         For integrations that need additional steps for uninstalling

--- a/src/sentry/integrations/credentials_service/types.py
+++ b/src/sentry/integrations/credentials_service/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 
@@ -18,13 +19,13 @@ class CredentialLeasable(ABC):
     @abstractmethod
     def refresh_access_token_with_minimum_validity_time(
         self, token_minimum_validity_time: timedelta
-    ) -> str: ...
+    ) -> CredentialLease: ...
 
     @abstractmethod
-    def force_refresh_access_token(self) -> str: ...
+    def force_refresh_access_token(self) -> CredentialLease: ...
 
     @abstractmethod
-    def get_active_access_token(self) -> str: ...
+    def get_active_access_token(self) -> CredentialLease: ...
 
     @abstractmethod
     def get_current_access_token_expiration(self) -> datetime | None: ...
@@ -39,6 +40,13 @@ class CredentialLeasable(ABC):
 
         minimum_expiry_time = datetime.now(UTC) + token_minimum_validity_time
         return expires_at < minimum_expiry_time
+
+
+@dataclass
+class CredentialLease:
+    access_token: str
+    permissions: dict[str, str] | None
+    expires_at: datetime
 
 
 class InvalidCredentialLeaseTarget(Exception):

--- a/src/sentry/integrations/credentials_service/types.py
+++ b/src/sentry/integrations/credentials_service/types.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from datetime import timedelta
+
+
+class CredentialLeasableMixin(ABC):
+    """
+    Interface for integrations that can lease credentials to other services.
+
+    This is largely abstract, but is mainly used to flag which integration
+    providers support this functionality.
+    """
+
+    @abstractmethod
+    def get_maximum_lease_duration_seconds(self) -> int: ...
+
+    @abstractmethod
+    def refresh_access_token_with_minimum_validity_time(
+        self, token_minimum_validity_time: timedelta
+    ) -> str: ...
+
+    @abstractmethod
+    def force_refresh_access_token(self) -> str: ...
+
+    @abstractmethod
+    def get_active_access_token(self) -> str: ...
+
+    @abstractmethod
+    def does_access_token_expire_within(self, token_minimum_validity_time: timedelta) -> bool: ...
+
+
+class InvalidCredentialLeaseTarget(Exception):
+    pass

--- a/src/sentry/integrations/credentials_service/types.py
+++ b/src/sentry/integrations/credentials_service/types.py
@@ -46,7 +46,7 @@ class CredentialLeasable(ABC):
 class CredentialLease:
     access_token: str
     permissions: dict[str, str] | None
-    expires_at: datetime
+    expires_at: datetime | None
 
 
 class InvalidCredentialLeaseTarget(Exception):

--- a/src/sentry/integrations/credentials_service/types.py
+++ b/src/sentry/integrations/credentials_service/types.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from datetime import UTC, datetime, timedelta
 
 
-class CredentialLeasableMixin(ABC):
+class CredentialLeasable(ABC):
     """
     Interface for integrations that can lease credentials to other services.
 

--- a/src/sentry/integrations/credentials_service/types.py
+++ b/src/sentry/integrations/credentials_service/types.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
+from sentry.silo.base import control_silo_function
+
 
 class CredentialLeasable(ABC):
     """
@@ -11,26 +13,74 @@ class CredentialLeasable(ABC):
 
     This is largely abstract, but is mainly used to flag which integration
     providers support this functionality.
+
+    NOTE: Every this implementation is currently coupled to our integration
+    installations. This implementation does _not_ guarantee concurrency safety,
+    so make sure that the provider implementation is thread/process safe.
     """
 
     @abstractmethod
     def get_maximum_lease_duration_seconds(self) -> int: ...
 
-    @abstractmethod
+    """
+    Returns the maximum length a token can be leased for. Typically, this should
+    be the maximum token validity on the provider this is implemented for.
+    """
+
+    @control_silo_function
     def refresh_access_token_with_minimum_validity_time(
+        self, token_minimum_validity_time: timedelta
+    ) -> CredentialLease:
+        """
+        Conditionally refreshes the installation's access token if the current token
+        would expire within the given minimum validity time. Returns a new
+        credential lease.
+        """
+        return self._refresh_access_token_with_minimum_validity_time(token_minimum_validity_time)
+
+    @abstractmethod
+    def _refresh_access_token_with_minimum_validity_time(
         self, token_minimum_validity_time: timedelta
     ) -> CredentialLease: ...
 
-    @abstractmethod
-    def force_refresh_access_token(self) -> CredentialLease: ...
+    @control_silo_function
+    def force_refresh_access_token(self) -> CredentialLease:
+        """
+        Force rotates an access token, regardless of the remaining validity.
+        This can be useful for ensuring the maximum token validity, or if a token is
+        compromised for any reason.
+        """
+
+        return self._force_refresh_access_token()
 
     @abstractmethod
-    def get_active_access_token(self) -> CredentialLease: ...
+    def _force_refresh_access_token(self) -> CredentialLease: ...
+
+    @control_silo_function
+    def get_active_access_token(self) -> CredentialLease:
+        """
+        Returns the current active access token. This may refresh the token if it
+        has already expired, though this is up to the provider implementation. This
+        """
+        return self._get_active_access_token()
+
+    @abstractmethod
+    def _get_active_access_token(self) -> CredentialLease: ...
 
     @abstractmethod
     def get_current_access_token_expiration(self) -> datetime | None: ...
 
+    """
+    Returns the current expiration time of the active access token, if there is
+    one.
+    """
+
     def does_access_token_expire_within(self, token_minimum_validity_time: timedelta) -> bool:
+        """
+        Checks if the active access token will expire within the given minimum
+        validity time. This will largely be used by the credentials service to
+        determine which access token method to call.
+        """
         expires_at = self.get_current_access_token_expiration()
         if not expires_at:
             return True
@@ -44,6 +94,12 @@ class CredentialLeasable(ABC):
 
 @dataclass
 class CredentialLease:
+    """
+    Represents a leased access token, though makes no guarantee about the
+    validity of the token. It's entirely possible that the token has expired,
+    or was invalidated by the provider.
+    """
+
     access_token: str
     permissions: dict[str, str] | None
     expires_at: datetime | None

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -120,6 +120,7 @@ class GithubProxyClient(IntegrationProxyClient):
     class AccessTokenData(TypedDict):
         access_token: str
         permissions: dict[str, str] | None
+        expires_at: datetime
 
     def _get_installation_id(self) -> str:
         """
@@ -175,6 +176,7 @@ class GithubProxyClient(IntegrationProxyClient):
         return {
             "access_token": access_token,
             "permissions": permissions,
+            "expires_at": expires_at,
         }
 
     @control_silo_function

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -153,7 +153,8 @@ class GithubProxyClient(IntegrationProxyClient):
         )
         data = self.post(f"/app/installations/{self._get_installation_id()}/access_tokens")
         access_token = data["token"]
-        expires_at = datetime.strptime(data["expires_at"], "%Y-%m-%dT%H:%M:%SZ").isoformat()
+        expiration_time = datetime.strptime(data["expires_at"], "%Y-%m-%dT%H:%M:%SZ")
+        expires_at = expiration_time.isoformat()
         permissions = data.get("permissions")
         integration.metadata.update(
             {
@@ -176,7 +177,7 @@ class GithubProxyClient(IntegrationProxyClient):
         return {
             "access_token": access_token,
             "permissions": permissions,
-            "expires_at": expires_at,
+            "expires_at": expiration_time,
         }
 
     @control_silo_function

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -120,7 +120,7 @@ class GithubProxyClient(IntegrationProxyClient):
     class AccessTokenData(TypedDict):
         access_token: str
         permissions: dict[str, str] | None
-        expires_at: datetime
+        expires_at: datetime | None
 
     def _get_installation_id(self) -> str:
         """
@@ -236,6 +236,7 @@ class GithubProxyClient(IntegrationProxyClient):
             return {
                 "access_token": access_token,
                 "permissions": self.integration.metadata.get("permissions"),
+                "expires_at": datetime.fromisoformat(expires_at) if expires_at else None,
             }
 
         return None

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -269,11 +269,13 @@ class GitHubIntegration(
         raise NotImplementedError("Force refresh access token is not supported for GitHub")
 
     def get_active_access_token(self) -> CredentialLease:
+        self._update_integration_model()
         access_token_data = self.get_client().get_access_token()
         assert access_token_data is not None, "Expected Integration to have an access token"
         return self._credential_lease_from_model()
 
     def get_current_access_token_expiration(self) -> datetime | None:
+        self._update_integration_model()
         expiration = self.model.metadata.get("expires_at")
         if not expiration:
             return None

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -28,7 +28,7 @@ from sentry.integrations.base import (
     IntegrationMetadata,
     IntegrationProvider,
 )
-from sentry.integrations.credentials_service.types import CredentialLeasableMixin
+from sentry.integrations.credentials_service.types import CredentialLeasable
 from sentry.integrations.github.constants import ISSUE_LOCKED_ERROR_MESSAGE, RATE_LIMITED_MESSAGE
 from sentry.integrations.github.tasks.codecov_account_link import codecov_account_link
 from sentry.integrations.github.tasks.link_all_repos import link_all_repos
@@ -231,7 +231,7 @@ class GitHubIntegration(
     IssueSyncIntegration,
     CommitContextIntegration,
     RepoTreesIntegration,
-    CredentialLeasableMixin,
+    CredentialLeasable,
 ):
     integration_name = IntegrationProviderSlug.GITHUB
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -40,7 +40,6 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.referrer_ids import GITHUB_OPEN_PR_BOT_REFERRER, GITHUB_PR_BOT_REFERRER
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.repository import RpcRepository, repository_service
 from sentry.integrations.source_code_management.commit_context import (
     OPEN_PR_MAX_FILES_CHANGED,
@@ -298,18 +297,6 @@ class GitHubIntegration(
             permissions=self.model.metadata.get("permissions"),
             expires_at=expiration_time,
         )
-
-    def _update_integration_model(self) -> None:
-        updated_model: RpcIntegration | Integration | None = None
-        if isinstance(self.model, Integration):
-            updated_model = Integration.objects.get(id=self.model.id)
-        else:
-            updated_model = integration_service.get_integration(self.model.id)
-
-        if updated_model is None:
-            raise IntegrationError("Integration model not found")
-
-        self.model = updated_model
 
     # IntegrationInstallation methods
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import datetime
 import logging
 import re
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
-from datetime import timedelta
+from datetime import datetime, timedelta
 from enum import StrEnum
 from typing import Any, TypedDict
 from urllib.parse import parse_qsl
@@ -273,16 +272,11 @@ class GitHubIntegration(
         assert access_token_data is not None, "Expected Integration to have an access token"
         return access_token_data["access_token"]
 
-    def does_access_token_expire_within(self, token_minimum_validity_time: timedelta) -> bool:
-        if "access_token" not in self.model.metadata:
-            return True
-
-        expires_at = self.model.metadata.get("expires_at")
-        if not expires_at:
-            return True
-        expires_at = datetime.datetime.fromisoformat(expires_at).replace(tzinfo=datetime.UTC)
-        minimum_expiry_time = datetime.datetime.now(datetime.UTC) + token_minimum_validity_time
-        return expires_at < minimum_expiry_time
+    def get_current_access_token_expiration(self) -> datetime | None:
+        expiration = self.model.metadata.get("expires_at")
+        if not expiration:
+            return None
+        return datetime.fromisoformat(expiration)
 
     # IntegrationInstallation methods
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -286,13 +286,15 @@ class GitHubIntegration(
         # model, but the model reference on this class isn't updated.
         # self.model.refresh_from_db()
         self._update_integration_model()
-        if self.model.metadata.get("expires_at"):
-            expiration_time = datetime.fromisoformat(
-                self.model.metadata.get("expires_at")
-            ).astimezone(UTC)
+        model_expiration_str = self.model.metadata.get("expires_at")
+        if model_expiration_str:
+            expiration_time = datetime.fromisoformat(model_expiration_str).astimezone(UTC)
+
+        access_token = self.model.metadata.get("access_token")
+        assert access_token is not None, "Expected Integration to have an access token"
 
         return CredentialLease(
-            access_token=self.model.metadata.get("access_token"),
+            access_token=access_token,
             permissions=self.model.metadata.get("permissions"),
             expires_at=expiration_time,
         )

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -74,6 +74,7 @@ from sentry.organizations.services.organization.model import (
 from sentry.pipeline.views.base import PipelineView, render_react_view
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.shared_integrations.exceptions import ApiError, ApiInvalidRequestError, IntegrationError
+from sentry.silo.base import control_silo_function
 from sentry.snuba.referrer import Referrer
 from sentry.templatetags.sentry_helpers import small_count
 from sentry.users.models.user import User
@@ -265,15 +266,18 @@ class GitHubIntegration(
 
         return self._credential_lease_from_model()
 
+    @control_silo_function
     def force_refresh_access_token(self) -> CredentialLease:
         raise NotImplementedError("Force refresh access token is not supported for GitHub")
 
+    @control_silo_function
     def get_active_access_token(self) -> CredentialLease:
         self._update_integration_model()
         access_token_data = self.get_client().get_access_token()
         assert access_token_data is not None, "Expected Integration to have an access token"
         return self._credential_lease_from_model()
 
+    @control_silo_function
     def get_current_access_token_expiration(self) -> datetime | None:
         self._update_integration_model()
         expiration = self.model.metadata.get("expires_at")
@@ -281,6 +285,7 @@ class GitHubIntegration(
             return None
         return datetime.fromisoformat(expiration).astimezone(UTC)
 
+    @control_silo_function
     def _credential_lease_from_model(self) -> CredentialLease:
         expiration_time = None
         # Annoying quirk that the underlying client may update the integration

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -19,6 +19,7 @@ from sentry.integrations.base import (
     IntegrationFeatures,
     IntegrationMetadata,
 )
+from sentry.integrations.credentials_service.types import CredentialLeasable
 from sentry.integrations.github.constants import ISSUE_LOCKED_ERROR_MESSAGE, RATE_LIMITED_MESSAGE
 from sentry.integrations.github.integration import GitHubIntegrationProvider, build_repository_query
 from sentry.integrations.github.issues import GitHubIssuesSpec
@@ -153,7 +154,7 @@ API_ERRORS = {
 
 
 class GitHubEnterpriseIntegration(
-    RepositoryIntegration, GitHubIssuesSpec, CommitContextIntegration
+    RepositoryIntegration, GitHubIssuesSpec, CommitContextIntegration, CredentialLeasable
 ):
     codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
 

--- a/tests/sentry/integrations/credentials_service/test_credentials_leasable_abc.py
+++ b/tests/sentry/integrations/credentials_service/test_credentials_leasable_abc.py
@@ -9,7 +9,7 @@ class MockClass(CredentialLeasable):
     def get_maximum_lease_duration_seconds(self) -> int:
         return 3600
 
-    def refresh_access_token_with_minimum_validity_time(
+    def _refresh_access_token_with_minimum_validity_time(
         self, token_minimum_validity_time: timedelta
     ) -> CredentialLease:
         return CredentialLease(
@@ -18,14 +18,14 @@ class MockClass(CredentialLeasable):
             permissions=None,
         )
 
-    def force_refresh_access_token(self) -> CredentialLease:
+    def _force_refresh_access_token(self) -> CredentialLease:
         return CredentialLease(
             access_token="access_token",
             expires_at=datetime.now(UTC) + timedelta(hours=1),
             permissions=None,
         )
 
-    def get_active_access_token(self) -> CredentialLease:
+    def _get_active_access_token(self) -> CredentialLease:
         return CredentialLease(
             access_token="access_token",
             expires_at=datetime.now(UTC) + timedelta(hours=1),

--- a/tests/sentry/integrations/credentials_service/test_credentials_leasable_abc.py
+++ b/tests/sentry/integrations/credentials_service/test_credentials_leasable_abc.py
@@ -36,7 +36,7 @@ class MockClass(CredentialLeasable):
         raise NotImplementedError
 
 
-class CredentialsLeasableMixinTest(TestCase):
+class CredentialsLeasableTest(TestCase):
     def setUp(self) -> None:
         self.mock_class = MockClass()
         self.patcher = mock.patch.object(

--- a/tests/sentry/integrations/credentials_service/test_credentials_leasable_abc.py
+++ b/tests/sentry/integrations/credentials_service/test_credentials_leasable_abc.py
@@ -1,0 +1,68 @@
+from datetime import UTC, datetime, timedelta
+from unittest import TestCase, mock
+
+from sentry.integrations.credentials_service.types import CredentialLeasable, CredentialLease
+from sentry.testutils.helpers.datetime import freeze_time
+
+
+class MockClass(CredentialLeasable):
+    def get_maximum_lease_duration_seconds(self) -> int:
+        return 3600
+
+    def refresh_access_token_with_minimum_validity_time(
+        self, token_minimum_validity_time: timedelta
+    ) -> CredentialLease:
+        return CredentialLease(
+            access_token="access_token",
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+            permissions=None,
+        )
+
+    def force_refresh_access_token(self) -> CredentialLease:
+        return CredentialLease(
+            access_token="access_token",
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+            permissions=None,
+        )
+
+    def get_active_access_token(self) -> CredentialLease:
+        return CredentialLease(
+            access_token="access_token",
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+            permissions=None,
+        )
+
+    def get_current_access_token_expiration(self) -> datetime | None:
+        raise NotImplementedError
+
+
+class CredentialsLeasableMixinTest(TestCase):
+    def setUp(self) -> None:
+        self.mock_class = MockClass()
+        self.patcher = mock.patch.object(
+            self.mock_class, "get_current_access_token_expiration", return_value=None
+        )
+        self.mock_get_expiration = self.patcher.start()
+
+    def tearDown(self) -> None:
+        self.patcher.stop()
+
+    def test_does_access_token_expire_within__no_expiry(self) -> None:
+        self.mock_get_expiration.return_value = None
+        assert self.mock_class.does_access_token_expire_within(timedelta(hours=1)) is True
+
+    @freeze_time("2025-01-01T12:00:00Z")
+    def test_does_access_token_expire_within__already_expired(self) -> None:
+        # Token just expired, any positive timedelta should return True
+        self.mock_get_expiration.return_value = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+        assert self.mock_class.does_access_token_expire_within(timedelta(seconds=1)) is True
+
+        self.mock_get_expiration.return_value = datetime(2025, 1, 1, 11, 59, 0, tzinfo=UTC)
+        assert self.mock_class.does_access_token_expire_within(timedelta(seconds=2)) is True
+
+    @freeze_time("2025-01-01T12:00:00Z")
+    def test_does_access_token_expire_within__under_expiry(self) -> None:
+        # Token expires in 1 minute, check boundaries around this
+        self.mock_get_expiration.return_value = datetime(2025, 1, 1, 12, 0, 1, tzinfo=UTC)
+        assert self.mock_class.does_access_token_expire_within(timedelta(seconds=1)) is False
+        assert self.mock_class.does_access_token_expire_within(timedelta(seconds=2)) is True

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -568,6 +568,7 @@ class GithubProxyClientTest(TestCase):
                 "metadata": "read",
                 "pull_requests": "read",
             },
+            "expires_at": datetime.fromisoformat("3000-01-01T00:00:00Z"),
         }
 
     @responses.activate

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -16,6 +16,7 @@ from django.urls import reverse
 import sentry
 from fixtures.github import INSTALLATION_EVENT_EXAMPLE
 from sentry.constants import ObjectStatus
+from sentry.integrations.credentials_service.types import CredentialLease
 from sentry.integrations.github import client
 from sentry.integrations.github import integration as github_integration
 from sentry.integrations.github.client import MINIMUM_REQUESTS, GithubSetupApiClient
@@ -1957,7 +1958,17 @@ class GithubIntegrationCredentialLeasingTest(IntegrationTestCase):
         self._stub_github_credentials()
         installation = self.integration.get_installation(organization_id=self.organization.id)
         assert installation is not None
-        assert installation.get_active_access_token() == self.access_token
+        assert installation.get_active_access_token() == CredentialLease(
+            access_token=self.access_token,
+            permissions={
+                "administration": "read",
+                "contents": "read",
+                "issues": "write",
+                "metadata": "read",
+                "pull_requests": "read",
+            },
+            expires_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        )
 
     @responses.activate
     def test_get_maximum_lease_duration_seconds(self) -> None:
@@ -1970,7 +1981,16 @@ class GithubIntegrationCredentialLeasingTest(IntegrationTestCase):
         self._stub_github_credentials()
         installation = self.integration.get_installation(organization_id=self.organization.id)
         assert installation is not None
-        assert (
-            installation.refresh_access_token_with_minimum_validity_time(timedelta(minutes=1))
-            == self.access_token
+        assert installation.refresh_access_token_with_minimum_validity_time(
+            timedelta(minutes=1)
+        ) == CredentialLease(
+            access_token=self.access_token,
+            permissions={
+                "administration": "read",
+                "contents": "read",
+                "issues": "write",
+                "metadata": "read",
+                "pull_requests": "read",
+            },
+            expires_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
         )

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -50,7 +50,6 @@ from sentry.testutils.asserts import (
 )
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.helpers import with_feature
-from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.integrations import get_installation_of_type
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -1975,40 +1974,3 @@ class GithubIntegrationCredentialLeasingTest(IntegrationTestCase):
             installation.refresh_access_token_with_minimum_validity_time(timedelta(minutes=1))
             == self.access_token
         )
-
-    @responses.activate
-    def test_does_access_token_expire_within(self) -> None:
-        self._stub_github_credentials()
-        installation = self.integration.get_installation(organization_id=self.organization.id)
-        assert installation is not None
-
-        # Without token, with 1 hour to expiration
-        with freeze_time("2025-01-01T11:00:00Z"):
-            assert installation.does_access_token_expire_within(timedelta(minutes=1)) is True
-
-        assert installation.get_active_access_token() is not None
-        # Annoying quirk with our "installations", we have to refresh the model
-        # before calling `get_installation` for it to populate the metadata
-        # after the token is refreshed.
-        self.integration.refresh_from_db()
-        installation = self.integration.get_installation(organization_id=self.organization.id)
-
-        assert self.integration.metadata["access_token"] is not None
-
-        # With 0 time left to expiration
-        with freeze_time("2025-01-01T12:00:00Z"):
-            assert installation.does_access_token_expire_within(timedelta(minutes=1)) is True
-            assert installation.does_access_token_expire_within(timedelta(seconds=1)) is True
-
-        # with 1 second left
-        with freeze_time("2025-01-01T11:01:00Z"):
-            assert installation.does_access_token_expire_within(timedelta(seconds=1)) is False
-
-        with freeze_time("2025-01-01T11:59:01Z"):
-            assert installation.does_access_token_expire_within(timedelta(minutes=1)) is True
-            assert installation.does_access_token_expire_within(timedelta(minutes=2)) is True
-
-        # With 1 hour
-        with freeze_time("2025-01-01T11:00:01Z"):
-            assert installation.does_access_token_expire_within(timedelta(seconds=3599)) is False
-            assert installation.does_access_token_expire_within(timedelta(seconds=3600)) is True

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -1958,7 +1958,7 @@ class GithubIntegrationCredentialLeasingTest(IntegrationTestCase):
         self._stub_github_credentials()
         installation = self.integration.get_installation(organization_id=self.organization.id)
         assert installation is not None
-        assert installation.get_active_access_token() == CredentialLease(
+        assert installation._get_active_access_token() == CredentialLease(
             access_token=self.access_token,
             permissions={
                 "administration": "read",
@@ -1981,7 +1981,7 @@ class GithubIntegrationCredentialLeasingTest(IntegrationTestCase):
         self._stub_github_credentials()
         installation = self.integration.get_installation(organization_id=self.organization.id)
         assert installation is not None
-        assert installation.refresh_access_token_with_minimum_validity_time(
+        assert installation._refresh_access_token_with_minimum_validity_time(
             timedelta(minutes=1)
         ) == CredentialLease(
             access_token=self.access_token,


### PR DESCRIPTION
Adds a new `CredentialsLeasable` interface to be used on integration classes. This will be used to signal whether or not an integration supports leasing its credentials to other services.

The interface includes 4 new methods:
1. `get_maximum_lease_duration_seconds`, which allows the integration class to set bounds on the maximum "lease" of a set of credentials
2. `refresh_access_token_with_minimum_validity_time`, which conditionally refreshes an integration's token if the provided time is larger than its remaining validity time.
3. `force_refresh_access_token`, which, as the name implies, forces a token refresh and revocation of the old token.
4. `does_access_token_expire_within`, which checks the current token expiration date, and returns whether or not the token will expire within that given time window.

These 4 methods provide us the basis for our credentials lease service to manage and dole out tokens to downstream services.
