### PR TITLE
chore(integrations): Silence 404s from GitHubs when firing alert handlers

### DIFF
--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -24,6 +24,7 @@ from sentry.shared_integrations.exceptions import (
     ApiUnauthorized,
     IntegrationConfigurationError,
     IntegrationFormError,
+    IntegrationResourceNotFoundError,
 )
 from sentry.silo.base import region_silo_function
 from sentry.types.rules import RuleFuture
@@ -183,6 +184,7 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
                 IntegrationFormError,
                 InvalidIdentity,
                 ApiUnauthorized,
+                IntegrationResourceNotFoundError,
             ) as e:
                 # Most of the time, these aren't explicit failures, they're
                 # some misconfiguration of an issue field - typically Jira.


### PR DESCRIPTION
This is like any other configuration error and handling the uninstall behaviour shouldn't be done in the alert receiver.
Ideally we'd remove this handler when we get a delete webhook, but either way this shouldn't be alerting here.