### PR TITLE
fix(autofix): Invalidate setup query on consent

### DIFF
--- a/static/app/components/events/autofix/useSeerAcknowledgeMutation.tsx
+++ b/static/app/components/events/autofix/useSeerAcknowledgeMutation.tsx
@@ -21,8 +21,20 @@ export function useSeerAcknowledgeMutation() {
       });
     },
     onSuccess: () => {
+      // Invalidate organization-level setup check
       queryClient.invalidateQueries({
         queryKey: [setupCheckQueryKey(organization.slug)],
+      });
+      // Invalidate all group-level autofix setup queries
+      queryClient.invalidateQueries({
+        predicate: query => {
+          const key = query.queryKey[0];
+          return (
+            typeof key === 'string' &&
+            key.includes(`/organizations/${organization.slug}/issues/`) &&
+            key.includes('/autofix/setup/')
+          );
+        },
       });
     },
   });


### PR DESCRIPTION
Fixes customer complaints where clicking the consent button in the flyout didn't do anything until you refreshed the page