### PR TITLE
ref(grouping): Split getting grouping info into new and legacy functions

### DIFF
--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -116,6 +116,13 @@ def _get_new_description(variant: BaseVariant) -> str:
     return " ".join(description_parts)
 
 
+# TODO: Switch Seer stacktrace string to use variants directly, and then this can go away
+def get_grouping_info_from_variants_legacy(
+    variants: dict[str, BaseVariant],
+) -> dict[str, dict[str, Any]]:
+    return {key: {"key": key, **variant.as_dict()} for key, variant in variants.items()}
+
+
 def get_grouping_info_from_variants(
     variants: dict[str, BaseVariant],
     # Shim to keep the output (which we also use for getting the Seer stacktrace string) stable

--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -20,7 +20,7 @@ def get_grouping_info(
 
     variants = event.get_grouping_variants(grouping_config, normalize_stacktraces=True)
 
-    grouping_info = get_grouping_info_from_variants(variants, use_legacy_format=False)
+    grouping_info = get_grouping_info_from_variants(variants)
 
     # One place we use this info is in the grouping info section of the event details page, and for
     # that we recalculate hashes/variants on the fly since we don't store the variants as part of
@@ -125,18 +125,12 @@ def get_grouping_info_from_variants_legacy(
 
 def get_grouping_info_from_variants(
     variants: dict[str, BaseVariant],
-    # Shim to keep the output (which we also use for getting the Seer stacktrace string) stable
-    # until we can switch `get_stacktrace_string` to use variants directly
-    use_legacy_format: bool = True,
 ) -> dict[str, dict[str, Any]]:
     """
     Given a dictionary of variant objects, create and return a copy of the dictionary in which each
     variant object value has been transformed into an equivalent dictionary value, which knows the
     key under which it lives.
     """
-
-    if use_legacy_format:
-        return {key: {"key": key, **variant.as_dict()} for key, variant in variants.items()}
 
     return {
         # Overwrite the description with a new, improved version

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from sentry import options
 from sentry import ratelimits as ratelimiter
 from sentry.conf.server import SEER_SIMILARITY_MODEL_VERSION
-from sentry.grouping.grouping_info import get_grouping_info_from_variants
+from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
 from sentry.grouping.ingest.grouphash_metadata import (
     check_grouphashes_for_positive_fingerprint_match,
 )
@@ -240,7 +240,7 @@ def _circuit_breaker_broken(event: Event, project: Project) -> bool:
 
 
 def _has_empty_stacktrace_string(event: Event, variants: dict[str, BaseVariant]) -> bool:
-    stacktrace_string = get_stacktrace_string(get_grouping_info_from_variants(variants))
+    stacktrace_string = get_stacktrace_string(get_grouping_info_from_variants_legacy(variants))
     if not stacktrace_string:
         if stacktrace_string == "":
             record_did_call_seer_metric(event, call_made=False, blocker="empty-stacktrace-string")
@@ -268,7 +268,7 @@ def get_seer_similar_issues(
 
     stacktrace_string = event.data.get(
         "stacktrace_string",
-        get_stacktrace_string(get_grouping_info_from_variants(variants)),
+        get_stacktrace_string(get_grouping_info_from_variants_legacy(variants)),
     )
 
     request_data: SimilarIssuesEmbeddingsRequest = {

--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -12,7 +12,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.serializers import serialize
-from sentry.grouping.grouping_info import get_grouping_info_from_variants
+from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
@@ -91,7 +91,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
             if not has_too_many_contributing_frames(
                 latest_event, variants, ReferrerOptions.SIMILAR_ISSUES_TAB
             ):
-                grouping_info = get_grouping_info_from_variants(variants)
+                grouping_info = get_grouping_info_from_variants_legacy(variants)
                 try:
                     stacktrace_string = get_stacktrace_string(grouping_info)
                 except Exception:

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -13,7 +13,7 @@ from snuba_sdk import Column, Condition, Entity, Limit, Op, Query, Request
 
 from sentry import nodestore, options
 from sentry.conf.server import SEER_SIMILARITY_MODEL_VERSION
-from sentry.grouping.grouping_info import get_grouping_info_from_variants
+from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
@@ -418,7 +418,7 @@ def get_events_from_nodestore(
                 invalid_event_reasons["excess_frames"] += 1
                 continue
 
-            grouping_info = get_grouping_info_from_variants(variants)
+            grouping_info = get_grouping_info_from_variants_legacy(variants)
             stacktrace_string = get_stacktrace_string(grouping_info)
 
             if not stacktrace_string:

--- a/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
+++ b/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, call, patch
 
 from sentry import options
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
-from sentry.grouping.grouping_info import get_grouping_info_from_variants
+from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
 from sentry.grouping.ingest.grouphash_metadata import create_or_update_grouphash_metadata_if_needed
 from sentry.grouping.ingest.seer import get_seer_similar_issues
 from sentry.grouping.variants import BaseVariant
@@ -59,7 +59,7 @@ def create_new_event(
     )
 
     if stacktrace_string is None:
-        stacktrace_string = get_stacktrace_string(get_grouping_info_from_variants(variants))
+        stacktrace_string = get_stacktrace_string(get_grouping_info_from_variants_legacy(variants))
     event.data["stacktrace_string"] = stacktrace_string
 
     return (event, variants, grouphash, stacktrace_string)

--- a/tests/sentry/grouping/seer_similarity/test_seer_eligibility.py
+++ b/tests/sentry/grouping/seer_similarity/test_seer_eligibility.py
@@ -3,7 +3,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid1
 
-from sentry.grouping.grouping_info import get_grouping_info_from_variants
+from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
 from sentry.grouping.ingest.seer import (
     _event_content_is_seer_eligible,
     should_call_seer_for_grouping,
@@ -49,7 +49,7 @@ class ShouldCallSeerTest(TestCase):
         self.variants = self.event.get_grouping_variants()
         self.primary_hashes = self.event.get_hashes()
         self.stacktrace_string = get_stacktrace_string(
-            get_grouping_info_from_variants(self.variants)
+            get_grouping_info_from_variants_legacy(self.variants)
         )
         self.event_grouphash = GroupHash.objects.create(project_id=self.project.id, hash="908415")
 
@@ -233,7 +233,7 @@ class ShouldCallSeerTest(TestCase):
         empty_frame_variants = empty_frame_event.get_grouping_variants()
         empty_frame_grouphash = GroupHash(project_id=self.project.id, hash="415908")
         empty_frame_stacktrace_string = get_stacktrace_string(
-            get_grouping_info_from_variants(empty_frame_variants)
+            get_grouping_info_from_variants_legacy(empty_frame_variants)
         )
 
         assert self.stacktrace_string != ""

--- a/tests/sentry/grouping/test_grouping_info.py
+++ b/tests/sentry/grouping/test_grouping_info.py
@@ -16,7 +16,7 @@ from tests.sentry.grouping import run_as_grouping_inputs_snapshot_test, to_json
 def test_grouping_info(
     variants: dict[str, BaseVariant], create_snapshot: InstaSnapshotter, **kwargs: Any
 ) -> None:
-    grouping_info = get_grouping_info_from_variants(variants, use_legacy_format=False)
+    grouping_info = get_grouping_info_from_variants(variants)
     create_snapshot(to_json(grouping_info, pretty_print=True))
 
 


### PR DESCRIPTION
This is a small refactor to split the old and new behavior into two separate functions rather than relying on a `use_legacy_format` parameter. This should keep things a little simpler as we continue to make changes to the format of grouping info.