### PR TITLE
fix(search-bar): Manually control combobox open state

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1130,8 +1130,6 @@ describe('SearchQueryBuilder', () => {
       const lastInput = (await screen.findAllByTestId('query-builder-input')).at(-1);
       expect(lastInput).toHaveFocus();
 
-      await userEvent.click(getLastInput());
-
       // Should have three tokens: a, or, b
       await screen.findByRole('row', {name: /a/});
       await screen.findByRole('row', {name: /or/});

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -41,6 +41,7 @@ import {
 import type {Token, TokenResult} from 'sentry/components/searchSyntax/parser';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
 import useOverlay from 'sentry/utils/useOverlay';
 import usePrevious from 'sentry/utils/usePrevious';
 
@@ -413,6 +414,8 @@ export function SearchQueryBuilderCombobox<
     // We handle closing on blur ourselves to prevent the combobox from closing
     // when the user clicks inside the custom menu
     shouldCloseOnBlur: false,
+    // We handle opening and closing ourselves to prevent the combobox from opening unexpectedly
+    menuTrigger: 'manual',
     ...comboBoxProps,
   });
 
@@ -451,8 +454,11 @@ export function SearchQueryBuilderCombobox<
             state.close();
             onCustomValueCommitted(inputValue);
             return;
-          default:
+          default: {
+            if (isOpen || isCtrlKeyPressed(e)) return;
+            state.open();
             return;
+          }
         }
       },
       onKeyUp,

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -455,7 +455,7 @@ export function SearchQueryBuilderCombobox<
             onCustomValueCommitted(inputValue);
             return;
           default: {
-            if (isOpen || isCtrlKeyPressed(e)) return;
+            if (isCtrlKeyPressed(e)) return;
             state.open();
             return;
           }

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -458,13 +458,12 @@ export function SearchQueryBuilderCombobox<
           return;
         }
 
-        // we need to force this open for aggregate filters e.g. count_if()
-        if (e.key === ',') {
-          state.open();
-          return;
-        }
-
-        if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || /^[a-z0-9]$/i.test(e.key)) {
+        if (
+          e.key === 'ArrowDown' ||
+          e.key === 'ArrowUp' ||
+          /^\w$/i.test(e.key) ||
+          e.key === ','
+        ) {
           if (isOpen || isCtrlKeyPressed(e)) return;
           state.open();
           return;

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -442,23 +442,32 @@ export function SearchQueryBuilderCombobox<
       },
       onKeyDown: e => {
         onKeyDown?.(e, {state});
-        switch (e.key) {
-          case 'Escape':
-            state.close();
-            onExit?.();
-            return;
-          case 'Enter':
-            if (isOpen && state.selectionManager.focusedKey) {
-              return;
-            }
-            state.close();
-            onCustomValueCommitted(inputValue);
-            return;
-          default: {
-            if (isCtrlKeyPressed(e)) return;
-            state.open();
+
+        if (e.key === 'Escape') {
+          state.close();
+          onExit?.();
+          return;
+        }
+
+        if (e.key === 'Enter') {
+          if (isOpen && state.selectionManager.focusedKey) {
             return;
           }
+          state.close();
+          onCustomValueCommitted(inputValue);
+          return;
+        }
+
+        // we need to force this open for aggregate filters e.g. count_if()
+        if (e.key === ',') {
+          state.open();
+          return;
+        }
+
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || /^[a-z0-9]$/i.test(e.key)) {
+          if (isOpen || isCtrlKeyPressed(e)) return;
+          state.open();
+          return;
         }
       },
       onKeyUp,

--- a/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
@@ -102,6 +102,13 @@ export function AggregateKey({
                 );
               }
             }}
+            onKeyDown={(e, {state: passedState}) => {
+              // we need to force this open for aggregate filters e.g. count_if()
+              if (e.key === ',') {
+                passedState.open();
+                return;
+              }
+            }}
           />
         </Parameters>
         <UnfocusedText>{')'}</UnfocusedText>

--- a/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useEffect, useMemo, useRef, useState, type ReactNode} from 'react';
 import {Item} from '@react-stately/collections';
+import type {ComboBoxState} from '@react-stately/combobox';
 import type {ListState} from '@react-stately/list';
 import type {KeyboardEvent} from '@react-types/shared';
 
@@ -26,6 +27,10 @@ type ParametersComboboxProps = {
   onDelete: () => void;
   state: ListState<ParseResultToken>;
   token: AggregateFilter;
+  onKeyDown?: (
+    e: KeyboardEvent,
+    extra: {state: ComboBoxState<SelectOptionWithKey<string>>}
+  ) => void;
 };
 
 type SuggestionItem = {
@@ -233,6 +238,7 @@ export function SearchQueryBuilderParametersCombobox({
   token,
   onCommit,
   onDelete,
+  onKeyDown: passedOnKeyDown,
 }: ParametersComboboxProps) {
   const {getFieldDefinition, getSuggestedFilterKey} = useSearchQueryBuilder();
 
@@ -262,13 +268,19 @@ export function SearchQueryBuilderParametersCombobox({
   const items = useParameterSuggestions({token, parameterIndex});
 
   const onKeyDown = useCallback(
-    (e: KeyboardEvent) => {
+    (
+      e: KeyboardEvent,
+      {state: passedState}: {state: ComboBoxState<SelectOptionWithKey<string>>}
+    ) => {
+      if (passedOnKeyDown) {
+        passedOnKeyDown(e, {state: passedState});
+      }
       // If there's nothing in the input and we hit a delete key, we should focus the filter
       if ((e.key === 'Backspace' || e.key === 'Delete') && !inputRef.current?.value) {
         onDelete();
       }
     },
-    [onDelete]
+    [onDelete, passedOnKeyDown]
   );
 
   const handleInputValueConfirmed = useCallback(


### PR DESCRIPTION
This PR moves control of the combobox opening out of the hands of React-Aria, and into ours. By default React-Aria opens the combobox input has changed (even if it's just being cleared), this causes extra combobox's to be opened.

Before:

https://github.com/user-attachments/assets/79174b73-2175-4635-8642-58b609b9e6f0

After:

https://github.com/user-attachments/assets/ba696bd6-bf0c-4365-bcc7-5bf24cc0c5cd