### PR TITLE
feat(timeseries): Add extrapolation param to `useFetchEventsTimeSeries`

### DIFF
--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -25,10 +25,6 @@ interface UseFetchEventsTimeSeriesOptions<YAxis, Attribute> {
    */
   yAxis: YAxis | YAxis[];
   /**
-   * Whether the request should disable aggregate extrapolation. Extrapolation is on by default.
-   */
-  disableAggregateExtrapolation?: boolean;
-  /**
    * Boolean. If missing, the query is enabled. If supplied, the query will obey the prop as specified.
    */
   enabled?: boolean;
@@ -36,6 +32,10 @@ interface UseFetchEventsTimeSeriesOptions<YAxis, Attribute> {
    * If true, the query will exclude the "other" group.
    */
   excludeOther?: boolean;
+  /**
+   * Whether the request should disable aggregate extrapolation. Extrapolation is on by default.
+   */
+  extrapolate?: boolean;
   /**
    * An array of tags by which to group the results. e.g., passing `["transaction"]` will group the results by the `"transaction"` tag. `["env", "transaction"]` will group by both the `"env"` and `"transaction"` tags.
    */
@@ -87,7 +87,7 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
     excludeOther,
     enabled,
     groupBy,
-    disableAggregateExtrapolation,
+    extrapolate = true,
     interval,
     query,
     sampling,
@@ -133,7 +133,7 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
           topEvents,
           groupBy,
           sort: sort ? encodeSort(sort) : undefined,
-          disableAggregateExtrapolation,
+          disableAggregateExtrapolation: extrapolate ? '0' : '1',
         },
       },
     ],

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -1,5 +1,6 @@
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
+import {defined} from 'sentry/utils';
 import {encodeSort} from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -94,7 +95,7 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
     excludeOther,
     enabled,
     groupBy,
-    extrapolate = true,
+    extrapolate,
     query,
     sampling,
     pageFilters,
@@ -141,7 +142,11 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
           topEvents,
           groupBy,
           sort: sort ? encodeSort(sort) : undefined,
-          disableAggregateExtrapolation: extrapolate ? '0' : '1',
+          disableAggregateExtrapolation: defined(extrapolate)
+            ? extrapolate
+              ? '0'
+              : '1'
+            : undefined,
         },
       },
     ],

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -25,6 +25,10 @@ interface UseFetchEventsTimeSeriesOptions<YAxis, Attribute> {
    */
   yAxis: YAxis | YAxis[];
   /**
+   * Whether the request should disable aggregate extrapolation. Extrapolation is on by default.
+   */
+  disableAggregateExtrapolation?: boolean;
+  /**
    * Boolean. If missing, the query is enabled. If supplied, the query will obey the prop as specified.
    */
   enabled?: boolean;
@@ -83,6 +87,7 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
     excludeOther,
     enabled,
     groupBy,
+    disableAggregateExtrapolation,
     interval,
     query,
     sampling,
@@ -128,6 +133,7 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
           topEvents,
           groupBy,
           sort: sort ? encodeSort(sort) : undefined,
+          disableAggregateExtrapolation,
         },
       },
     ],

--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -33,7 +33,7 @@ interface UseFetchEventsTimeSeriesOptions<YAxis, Attribute> {
    */
   excludeOther?: boolean;
   /**
-   * Whether the request should disable aggregate extrapolation. Extrapolation is on by default.
+   * Whether the request should enable aggregate extrapolation. Extrapolation is on by default.
    */
   extrapolate?: boolean;
   /**


### PR DESCRIPTION
This is in use in Explore, where it's possible to turn off aggregate extrapolation. I hate to rename a prop, but it's not even a boolean!
