### PR TITLE
feat(spans-migration): return dropped fields from dashboards/explore endpoints

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -57,6 +57,12 @@ class ThresholdType(TypedDict):
     unit: str
 
 
+class WidgetChangedReasonType(TypedDict):
+    orderby: list[dict[str, str]] | None
+    equations: list[dict[str, str | list[str]]] | None
+    selected_columns: list[str]
+
+
 class DashboardWidgetResponse(TypedDict):
     id: str
     title: str
@@ -72,6 +78,7 @@ class DashboardWidgetResponse(TypedDict):
     layout: dict[str, int] | None
     datasetSource: str | None
     exploreUrls: NotRequired[list[str] | None]
+    changedReason: list[WidgetChangedReasonType] | None
 
 
 class DashboardPermissionsResponse(TypedDict):
@@ -304,6 +311,7 @@ class DashboardWidgetSerializer(Serializer):
             "widgetType": widget_type,
             "layout": obj.detail.get("layout") if obj.detail else None,
             "datasetSource": DATASET_SOURCES[obj.dataset_source],
+            "changedReason": obj.changed_reason,
         }
 
         if explore_urls:

--- a/src/sentry/api/serializers/models/exploresavedquery.py
+++ b/src/sentry/api/serializers/models/exploresavedquery.py
@@ -24,6 +24,12 @@ class ExploreSavedQueryResponseOptional(TypedDict, total=False):
     mode: str
 
 
+class ExploreSavedQueryChangedReasonType(TypedDict):
+    orderby: list[dict[str, str]] | None
+    equations: list[dict[str, str | list[str]]] | None
+    columns: list[str]
+
+
 class ExploreSavedQueryResponse(ExploreSavedQueryResponseOptional):
     id: str
     name: str
@@ -37,6 +43,7 @@ class ExploreSavedQueryResponse(ExploreSavedQueryResponseOptional):
     starred: bool
     position: int | None
     isPrebuilt: bool
+    changedReason: ExploreSavedQueryChangedReasonType | None
 
 
 @register(ExploreSavedQuery)
@@ -111,6 +118,7 @@ class ExploreSavedQueryModelSerializer(Serializer):
             "starred": attrs.get("starred"),
             "position": attrs.get("position"),
             "isPrebuilt": obj.prebuilt_id is not None,
+            "changedReason": obj.changed_reason,
         }
 
         for key in query_keys:

--- a/src/sentry/apidocs/examples/dashboard_examples.py
+++ b/src/sentry/apidocs/examples/dashboard_examples.py
@@ -64,6 +64,7 @@ DASHBOARD_OBJECT = {
             "widgetType": "transaction-like",
             "layout": {"w": 2, "y": 0, "h": 2, "minH": 2, "x": 0},
             "exploreUrls": None,
+            "changedReason": None,
         }
     ],
     "projects": [1],

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -622,6 +622,55 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
                 '{"yAxes":["p95(span.duration)"],"chartType":1}',
             ]
 
+    def test_changed_reason_response(self) -> None:
+        response = self.do_request("get", self.url(self.dashboard.id))
+        assert response.status_code == 200
+        widget = response.data["widgets"][0]
+        assert widget["changedReason"] is None
+
+    def test_changed_reason_response_with_data(self) -> None:
+        dashboard_deprecation = Dashboard.objects.create(
+            title="Dashboard With Transaction Widget",
+            created_by_id=self.user.id,
+            organization=self.organization,
+        )
+
+        widget_deprecation = DashboardWidget.objects.create(
+            dashboard=dashboard_deprecation,
+            title="line widget",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=DashboardWidgetTypes.TRANSACTION_LIKE,
+            interval="1d",
+            detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+            changed_reason=[
+                {
+                    "orderby": ["total.count"],
+                    "equations": [],
+                    "columns": ["total.count"],
+                }
+            ],
+        )
+
+        DashboardWidgetQuery.objects.create(
+            widget=widget_deprecation,
+            fields=["query.dataset"],
+            columns=["query.dataset"],
+            aggregates=["p95(transaction.duration)"],
+            orderby="-p95(transaction.duration)",
+            conditions="transaction:/api/0/organizations/{organization_id_or_slug}/events/",
+            order=0,
+        )
+
+        response = self.do_request("get", self.url(dashboard_deprecation.id))
+        assert response.status_code == 200
+        widget = response.data["widgets"][0]
+        assert widget["changedReason"] is not None
+        assert isinstance(widget["changedReason"], list)
+        assert len(widget["changedReason"]) == 1
+        assert widget["changedReason"][0]["orderby"] == ["total.count"]
+        assert widget["changedReason"][0]["equations"] == []
+        assert widget["changedReason"][0]["columns"] == ["total.count"]
+
 
 class OrganizationDashboardDetailsDeleteTest(OrganizationDashboardDetailsTestCase):
     def test_delete(self) -> None:

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -644,7 +644,9 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
             detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
             changed_reason=[
                 {
-                    "orderby": ["total.count"],
+                    "orderby": [
+                        {"orderby": "total.count", "reason": "fields were dropped: total.count"}
+                    ],
                     "equations": [],
                     "columns": ["total.count"],
                 }
@@ -667,7 +669,9 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         assert widget["changedReason"] is not None
         assert isinstance(widget["changedReason"], list)
         assert len(widget["changedReason"]) == 1
-        assert widget["changedReason"][0]["orderby"] == ["total.count"]
+        assert widget["changedReason"][0]["orderby"] == [
+            {"orderby": "total.count", "reason": "fields were dropped: total.count"}
+        ]
         assert widget["changedReason"][0]["equations"] == []
         assert widget["changedReason"][0]["columns"] == ["total.count"]
 

--- a/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
@@ -102,7 +102,9 @@ class ExploreSavedQueryDetailTest(APITestCase, SnubaTestCase):
             name="Test query",
             query={"fields": ["span.op"], "mode": "samples"},
             changed_reason={
-                "orderby": ["total.count"],
+                "orderby": [
+                    {"orderby": "total.count", "reason": "fields were dropped: total.count"}
+                ],
                 "equations": [],
                 "columns": ["total.count"],
             },
@@ -121,7 +123,9 @@ class ExploreSavedQueryDetailTest(APITestCase, SnubaTestCase):
 
         assert response_1.status_code == 200, response_1.content
         assert response_1.data["changedReason"] is not None
-        assert response_1.data["changedReason"]["orderby"] == ["total.count"]
+        assert response_1.data["changedReason"]["orderby"] == [
+            {"orderby": "total.count", "reason": "fields were dropped: total.count"}
+        ]
         assert response_1.data["changedReason"]["equations"] == []
         assert response_1.data["changedReason"]["columns"] == ["total.count"]
 

--- a/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
@@ -95,6 +95,39 @@ class ExploreSavedQueryDetailTest(APITestCase, SnubaTestCase):
         assert response.data["starred"] is True
         assert response.data["position"] == 1
 
+    def test_get_changed_reason(self) -> None:
+        migrated_query = ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Test query",
+            query={"fields": ["span.op"], "mode": "samples"},
+            changed_reason={
+                "orderby": ["total.count"],
+                "equations": [],
+                "columns": ["total.count"],
+            },
+        )
+
+        migrated_query.set_projects(self.project_ids)
+        with self.feature(self.feature_name):
+            url = reverse(
+                "sentry-api-0-explore-saved-query-detail", args=[self.org.slug, migrated_query.id]
+            )
+            url_2 = reverse(
+                "sentry-api-0-explore-saved-query-detail", args=[self.org.slug, self.model.id]
+            )
+            response_1 = self.client.get(url)
+            response_2 = self.client.get(url_2)
+
+        assert response_1.status_code == 200, response_1.content
+        assert response_1.data["changedReason"] is not None
+        assert response_1.data["changedReason"]["orderby"] == ["total.count"]
+        assert response_1.data["changedReason"]["equations"] == []
+        assert response_1.data["changedReason"]["columns"] == ["total.count"]
+
+        assert response_2.status_code == 200, response_2.content
+        assert response_2.data["changedReason"] is None
+
     def test_put(self) -> None:
         with self.feature(self.feature_name):
             url = reverse(


### PR DESCRIPTION
I forgot to return the dropped fields from the endpoints.... i need them for the dropped fields warnings 🤦‍♀️ 