### PR TITLE
fix(logs): Handle removing empty pages for flex time

### DIFF
--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -19,6 +19,7 @@ export const QUERY_PAGE_LIMIT_WITH_AUTO_REFRESH = 1000;
 export const LOG_ATTRIBUTE_LAZY_LOAD_HOVER_TIMEOUT = 150;
 export const DEFAULT_TRACE_ITEM_HOVER_TIMEOUT = 150;
 export const DEFAULT_TRACE_ITEM_HOVER_TIMEOUT_WITH_AUTO_REFRESH = 400; // With autorefresh on, a stationary mouse can prefetch multiple rows since virtual time moves rows constantly.
+export const MAX_LOGS_INFINITE_QUERY_PAGES = 30; // This number * the refresh interval must be more seconds than 2 * the smallest time interval in the chart for streaming to work.
 
 /**
  * These are required fields are always added to the query when fetching the log table.


### PR DESCRIPTION
React query removes the first/last page by default (depending on the direction) when max pages is reached. This clears out empty pages that are not the first or last page when possible to keep as much data around as possible.