### PR TITLE
fix(uptime): Disabled uptime detector should not prevent creating new uptime detectors.

### DIFF
--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -92,6 +92,7 @@ def check_uptime_subscription_limit(organization_id: int) -> None:
     """
     manual_subscription_count = Detector.objects.filter(
         status=ObjectStatus.ACTIVE,
+        enabled=True,
         type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
         project__organization_id=organization_id,
         config__mode=UptimeMonitorMode.MANUAL,

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -311,6 +311,154 @@ class CreateUptimeDetectorTest(UptimeTestCase):
                 override_manual_org_limit=True,
             )
 
+    def test_disabled_monitors_dont_count_toward_limit(self) -> None:
+        """
+        Verify that disabled monitors do not count towards the organization's manual monitor limit.
+
+        Disabled monitors (enabled=False, status=ACTIVE) should not prevent creating new monitors.
+        The limit check should only count enabled monitors, allowing users to create new monitors
+        up to MAX_MANUAL_SUBSCRIPTIONS_PER_ORG enabled monitors regardless of how many are disabled.
+        """
+        with mock.patch(
+            "sentry.uptime.subscriptions.subscriptions.MAX_MANUAL_SUBSCRIPTIONS_PER_ORG", new=2
+        ):
+            # Create and then disable a monitor
+            detector1 = create_uptime_detector(
+                self.project,
+                self.environment,
+                url="https://example1.com",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=UptimeMonitorMode.MANUAL,
+            )
+            disable_uptime_detector(detector1)
+
+            # Verify the detector is disabled but still ACTIVE status
+            detector1.refresh_from_db()
+            assert detector1.enabled is False
+            assert detector1.status == ObjectStatus.ACTIVE
+
+            # Should be able to create 2 more monitors (disabled one shouldn't count)
+            detector2 = create_uptime_detector(
+                self.project,
+                self.environment,
+                url="https://example2.com",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=UptimeMonitorMode.MANUAL,
+            )
+            assert detector2.enabled is True
+
+            detector3 = create_uptime_detector(
+                self.project,
+                self.environment,
+                url="https://example3.com",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=UptimeMonitorMode.MANUAL,
+            )
+            assert detector3.enabled is True
+
+            # Verify we have 2 enabled and 1 disabled
+            enabled_count = Detector.objects.filter(
+                project__organization_id=self.organization.id,
+                status=ObjectStatus.ACTIVE,
+                enabled=True,
+                type=UptimeDomainCheckFailure.slug,
+                config__mode=UptimeMonitorMode.MANUAL.value,
+            ).count()
+            assert enabled_count == 2
+
+            total_active_count = Detector.objects.filter(
+                project__organization_id=self.organization.id,
+                status=ObjectStatus.ACTIVE,
+                type=UptimeDomainCheckFailure.slug,
+                config__mode=UptimeMonitorMode.MANUAL.value,
+            ).count()
+            assert total_active_count == 3  # 2 enabled + 1 disabled
+
+            # Creating a 3rd enabled monitor should fail (at limit of enabled)
+            with pytest.raises(MaxManualUptimeSubscriptionsReached):
+                create_uptime_detector(
+                    self.project,
+                    self.environment,
+                    url="https://example4.com",
+                    interval_seconds=3600,
+                    timeout_ms=1000,
+                    mode=UptimeMonitorMode.MANUAL,
+                )
+
+    def test_deleted_monitor_frees_slot_immediately(self) -> None:
+        """
+        Verify that deleting a monitor immediately frees up a slot for creating a new one.
+
+        Deleted monitors have status=PENDING_DELETION rather than status=ACTIVE, so they
+        should not be counted by check_uptime_subscription_limit(), allowing immediate
+        reuse of their quota slot.
+        """
+        with mock.patch(
+            "sentry.uptime.subscriptions.subscriptions.MAX_MANUAL_SUBSCRIPTIONS_PER_ORG", new=2
+        ):
+            # Create 2 monitors (at limit)
+            detector1 = create_uptime_detector(
+                self.project,
+                self.environment,
+                url="https://example1.com",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=UptimeMonitorMode.MANUAL,
+            )
+            create_uptime_detector(
+                self.project,
+                self.environment,
+                url="https://example2.com",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=UptimeMonitorMode.MANUAL,
+            )
+
+            # Verify at limit
+            with pytest.raises(MaxManualUptimeSubscriptionsReached):
+                create_uptime_detector(
+                    self.project,
+                    self.environment,
+                    url="https://should-fail.com",
+                    interval_seconds=3600,
+                    timeout_ms=1000,
+                    mode=UptimeMonitorMode.MANUAL,
+                )
+
+            # Delete one monitor
+            with self.tasks():
+                delete_uptime_detector(detector1)
+                run_scheduled_deletions()
+
+            # Verify detector is deleted
+            with pytest.raises(Detector.DoesNotExist):
+                detector1.refresh_from_db()
+
+            # Should be able to create a new monitor immediately
+            detector3 = create_uptime_detector(
+                self.project,
+                self.environment,
+                url="https://example3.com",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=UptimeMonitorMode.MANUAL,
+            )
+            assert detector3.enabled is True
+
+            # Verify we're at limit again (2 enabled monitors)
+            with pytest.raises(MaxManualUptimeSubscriptionsReached):
+                create_uptime_detector(
+                    self.project,
+                    self.environment,
+                    url="https://should-fail-again.com",
+                    interval_seconds=3600,
+                    timeout_ms=1000,
+                    mode=UptimeMonitorMode.MANUAL,
+                )
+
     def test_auto_associates_active_regions(self) -> None:
         regions = [
             UptimeRegionConfig(
@@ -1033,6 +1181,88 @@ class EnableUptimeDetectorTest(UptimeTestCase):
 
         detector.refresh_from_db()
         assert detector.enabled
+
+    @mock.patch(
+        "sentry.quotas.backend.assign_seat",
+        return_value=Outcome.ACCEPTED,
+    )
+    @mock.patch(
+        "sentry.quotas.backend.check_assign_seat",
+        return_value=SeatAssignmentResult(assignable=True),
+    )
+    def test_enable_with_other_disabled_monitors_present(
+        self, mock_assign_seat: mock.MagicMock, mock_check_assign_seat: mock.MagicMock
+    ) -> None:
+        """
+        Verify that enabling a monitor works regardless of disabled monitors in the organization.
+
+        The ENABLE path (via update_uptime_detector) uses billing seat quota checks only,
+        not the organization-level monitor count limit. This allows enabling monitors even
+        when other disabled monitors exist, as long as billing quota is available.
+        """
+        with mock.patch(
+            "sentry.uptime.subscriptions.subscriptions.MAX_MANUAL_SUBSCRIPTIONS_PER_ORG", new=2
+        ):
+            # Create two monitors
+            with mock.patch("sentry.uptime.subscriptions.subscriptions.enable_uptime_detector"):
+                detector1 = create_uptime_detector(
+                    self.project,
+                    self.environment,
+                    url="https://example1.com",
+                    interval_seconds=3600,
+                    timeout_ms=1000,
+                    mode=UptimeMonitorMode.MANUAL,
+                )
+                detector2 = create_uptime_detector(
+                    self.project,
+                    self.environment,
+                    url="https://example2.com",
+                    interval_seconds=3600,
+                    timeout_ms=1000,
+                    mode=UptimeMonitorMode.MANUAL,
+                )
+
+            # Disable first monitor
+            disable_uptime_detector(detector1)
+            detector1.refresh_from_db()
+            assert detector1.enabled is False
+            assert detector1.status == ObjectStatus.ACTIVE
+
+            # Mark second monitor as disabled
+            detector2.update(enabled=False)
+            uptime_sub2 = get_uptime_subscription(detector2)
+            uptime_sub2.update(status=UptimeSubscription.Status.DISABLED.value)
+
+            # Should be able to enable the second monitor even though first is disabled
+            # This bypasses check_uptime_subscription_limit() and only checks billing quota
+            with self.tasks():
+                enable_uptime_detector(detector2)
+
+            detector2.refresh_from_db()
+            assert detector2.enabled is True
+
+            # Verify quota backend was called for seat assignment
+            mock_check_assign_seat.assert_called_with(DataCategory.UPTIME, detector2)
+            mock_assign_seat.assert_called_with(DataCategory.UPTIME, detector2)
+
+            # Verify we still have 1 enabled and 1 disabled
+            enabled_count = Detector.objects.filter(
+                project__organization_id=self.organization.id,
+                status=ObjectStatus.ACTIVE,
+                enabled=True,
+                type=UptimeDomainCheckFailure.slug,
+                config__mode=UptimeMonitorMode.MANUAL.value,
+            ).count()
+            assert enabled_count == 1
+
+            disabled_count = Detector.objects.filter(
+                project__organization_id=self.organization.id,
+                status=ObjectStatus.ACTIVE,
+                enabled=False,
+                type=UptimeDomainCheckFailure.slug,
+                config__mode=UptimeMonitorMode.MANUAL.value,
+            ).count()
+            assert disabled_count == 1
 
 
 class CheckAndUpdateRegionsTest(UptimeTestCase):


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1661/disabled-uptime-detector-should-not-prevent-creating-new-uptime

Disabled uptime detectors `(enabled=False, status=ACTIVE)` should not prevent creating new uptime detectors.
The limit check (i.e. `check_uptime_subscription_limit()`) should only count enabled uptime detectors, allowing users to create new uptime detectors
up to `MAX_MANUAL_SUBSCRIPTIONS_PER_ORG` enabled uptime detectors regardless of how many are disabled.