### PR TITLE
fix(aci): Add targetIdentifier to slack action

### DIFF
--- a/static/app/views/automations/components/actions/slack.tsx
+++ b/static/app/views/automations/components/actions/slack.tsx
@@ -13,7 +13,10 @@ import {ActionType} from 'sentry/types/workflowEngine/actions';
 import {useActionNodeContext} from 'sentry/views/automations/components/actionNodes';
 import {IntegrationField} from 'sentry/views/automations/components/actions/integrationField';
 import {TagsField} from 'sentry/views/automations/components/actions/tagsField';
-import {TargetDisplayField} from 'sentry/views/automations/components/actions/targetDisplayField';
+import {
+  TargetDisplayField,
+  TargetIdentifierField,
+} from 'sentry/views/automations/components/actions/targetDisplayField';
 
 export function SlackDetails({
   action,
@@ -56,11 +59,15 @@ export function SlackNode() {
   return (
     <Flex direction="column" gap="md" flex="1">
       <RowLine>
-        {tct('Send a [logo] Slack message to the [workspace] workspace, to [channel]', {
-          logo: ActionMetadata[ActionType.SLACK]?.icon,
-          workspace: <IntegrationField />,
-          channel: <TargetDisplayField placeholder={t('e.g., #critical, Jane')} />,
-        })}
+        {tct(
+          'Send a [logo] Slack message to the [workspace] workspace, to [channel] (optionally, an ID: [channel_id])',
+          {
+            logo: ActionMetadata[ActionType.SLACK]?.icon,
+            workspace: <IntegrationField />,
+            channel: <TargetDisplayField placeholder={t('e.g., #critical, Jane')} />,
+            channel_id: <TargetIdentifierField placeholder={t('e.g., CA2FRA079')} />,
+          }
+        )}
       </RowLine>
       <OptionalRowLine>
         {tct('Optional: in the message show tags [tags] and notes [notes]', {
@@ -103,7 +110,7 @@ export function validateSlackAction(action: Action): string | undefined {
   if (!action.integrationId) {
     return t('You must specify a Slack workspace.');
   }
-  if (!action.config.targetDisplay) {
+  if (!action.config.targetDisplay && !action.config.targetIdentifier) {
     return t('You must specify a channel name or ID.');
   }
   return undefined;

--- a/static/app/views/automations/components/actions/targetDisplayField.tsx
+++ b/static/app/views/automations/components/actions/targetDisplayField.tsx
@@ -16,8 +16,31 @@ export function TargetDisplayField({placeholder}: {placeholder?: string}) {
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({
           config: {
-            targetType: action.config.targetType,
+            ...action.config,
             targetDisplay: e.target.value,
+          },
+        });
+        removeError(action.id);
+      }}
+    />
+  );
+}
+
+export function TargetIdentifierField({placeholder}: {placeholder?: string}) {
+  const {action, actionId, onUpdate} = useActionNodeContext();
+  const {removeError} = useAutomationBuilderErrorContext();
+
+  return (
+    <AutomationBuilderInput
+      name={`${actionId}.config.targetIdentifier`}
+      aria-label={t('Target ID')}
+      placeholder={placeholder}
+      value={action.config.targetIdentifier}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+        onUpdate({
+          config: {
+            ...action.config,
+            targetIdentifier: e.target.value,
           },
         });
         removeError(action.id);

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -478,11 +478,11 @@ function getDefaultConfig(actionHandler: ActionHandler): ActionConfig {
     actionHandler.sentryApp?.id ??
     actionHandler.integrations?.[0]?.services?.[0]?.id ??
     actionHandler.services?.[0]?.slug ??
-    undefined;
+    '';
 
   return {
     targetType,
-    ...(targetIdentifier && {targetIdentifier}),
+    targetIdentifier,
     ...(actionHandler.sentryApp?.id && {
       sentryAppIdentifier: SentryAppIdentifier.SENTRY_APP_ID,
     }),


### PR DESCRIPTION
Add an input for the channel ID like we have in alerts:

<img width="1094" height="201" alt="CleanShot 2025-10-09 at 12 46 56" src="https://github.com/user-attachments/assets/3c0e0ea7-fe75-4a39-8533-24e5bf2919db" />
