### PR TITLE
fix(aci): Some minor table layout fixes for automations

### DIFF
--- a/static/app/views/automations/components/actions/tagsField.tsx
+++ b/static/app/views/automations/components/actions/tagsField.tsx
@@ -8,7 +8,7 @@ export function TagsField() {
     <AutomationBuilderInput
       name={`${actionId}.data.tags`}
       aria-label={t('Tags')}
-      placeholder={t('e.g. environment,my_tag')}
+      placeholder={t('e.g., environment,my_tag')}
       value={action.data.tags}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -216,7 +216,7 @@ const AutomationsSimpleTable = styled(SimpleTable)`
   }
 
   @media (min-width: ${p => p.theme.breakpoints.md}) {
-    grid-template-columns: 2.5fr 1fr 1fr 1fr;
+    grid-template-columns: 2.5fr minmax(160px, 1fr) 1fr 1fr;
 
     [data-column-name='last-triggered'] {
       display: flex;
@@ -224,7 +224,7 @@ const AutomationsSimpleTable = styled(SimpleTable)`
   }
 
   @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    grid-template-columns: minmax(0, 3fr) 1fr 1fr 1fr 1fr;
+    grid-template-columns: minmax(0, 3fr) minmax(160px, 1fr) 1fr 1fr 1fr;
 
     [data-column-name='connected-monitors'] {
       display: flex;

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -125,7 +125,7 @@ const Container = styled('div')`
 `;
 
 const SimpleTableWithColumns = styled(SimpleTable)`
-  grid-template-columns: 1fr 100px auto auto auto;
+  grid-template-columns: 1fr 100px minmax(0, 0.8fr) auto auto;
 
   /*
     The connected column can be added/removed depending on props, so in order to


### PR DESCRIPTION
Before:

<img width="560" height="124" alt="CleanShot 2025-10-09 at 13 00 34" src="https://github.com/user-attachments/assets/cae54739-362e-4ff1-a292-5e7e718cb7ce" />

<img width="450" height="130" alt="CleanShot 2025-10-09 at 13 00 11" src="https://github.com/user-attachments/assets/cf877403-370f-44ab-98a3-42f9ec3a6412" />


After:

<img width="579" height="102" alt="CleanShot 2025-10-09 at 12 59 16" src="https://github.com/user-attachments/assets/e70c7cb2-ffa5-4b89-946c-094ae7694fe7" />

<img width="1426" height="129" alt="CleanShot 2025-10-09 at 12 59 44" src="https://github.com/user-attachments/assets/5a345d1b-2d6f-4838-8ffc-f4c67e276165" />
