### PR TITLE
feat(tracemetrics): Update metric selector

### DIFF
--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -36,7 +36,7 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
   }
 
   const metric = json.metric;
-  if (typeof metric !== 'object') {
+  if (typeof metric !== 'object' || !metric.name || !metric.type) {
     return null;
   }
 

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -14,6 +14,7 @@ import {ChartType} from 'sentry/views/insights/common/components/chart';
 
 export interface TraceMetric {
   name: string;
+  type: string;
 }
 
 export interface BaseMetricQuery {
@@ -22,8 +23,8 @@ export interface BaseMetricQuery {
 }
 
 export interface MetricQuery extends BaseMetricQuery {
-  setMetricName: (metricName: string) => void;
   setQueryParams: (queryParams: ReadableQueryParams) => void;
+  setTraceMetric: (traceMetric: TraceMetric) => void;
 }
 
 export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null {
@@ -35,7 +36,7 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
   }
 
   const metric = json.metric;
-  if (typeof metric !== 'string') {
+  if (typeof metric !== 'object') {
     return null;
   }
 
@@ -62,7 +63,7 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
   const aggregateFields = [...visualizes, ...groupBys];
 
   return {
-    metric: {name: metric},
+    metric,
     queryParams: new ReadableQueryParams({
       extrapolate: true,
       mode: Mode.AGGREGATE,
@@ -81,7 +82,7 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
 
 export function encodeMetricQueryParams(metricQuery: BaseMetricQuery): string {
   return JSON.stringify({
-    metric: metricQuery.metric.name,
+    metric: metricQuery.metric,
     query: metricQuery.queryParams.query,
     aggregateFields: metricQuery.queryParams.aggregateFields.map(field => {
       if (isVisualize(field)) {
@@ -96,7 +97,7 @@ export function encodeMetricQueryParams(metricQuery: BaseMetricQuery): string {
 
 export function defaultMetricQuery(): BaseMetricQuery {
   return {
-    metric: {name: ''},
+    metric: {name: '', type: ''},
     queryParams: new ReadableQueryParams({
       extrapolate: true,
       mode: Mode.AGGREGATE,

--- a/static/app/views/explore/metrics/metricRow/index.tsx
+++ b/static/app/views/explore/metrics/metricRow/index.tsx
@@ -1,6 +1,5 @@
 import {useMemo} from 'react';
 
-import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {Flex} from 'sentry/components/core/layout';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
 import {t} from 'sentry/locale';
@@ -9,11 +8,10 @@ import {
   useSearchQueryBuilderProps,
   type TraceItemSearchQueryBuilderProps,
 } from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
-import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {AggregateDropdown} from 'sentry/views/explore/metrics/metricRow/aggregateDropdown';
 import {GroupBySelector} from 'sentry/views/explore/metrics/metricRow/groupBySelector';
-import {useSetMetricName} from 'sentry/views/explore/metrics/metricsQueryParams';
+import {MetricSelector} from 'sentry/views/explore/metrics/metricRow/metricSelector';
 import {
   useQueryParamsQuery,
   useSetQueryParamsQuery,
@@ -64,37 +62,12 @@ function MetricToolbar({
   tracesItemSearchQueryBuilderProps,
   traceMetric,
 }: MetricToolbarProps) {
-  const {data: metricOptionsData} = useMetricOptions();
-  const setMetricName = useSetMetricName();
-
-  const metricOptions = useMemo(() => {
-    return [
-      ...(metricOptionsData?.data?.map(option => ({
-        label: `${option['metric.name']} (${option['metric.type']})`,
-        value: option['metric.name'],
-        type: option['metric.type'],
-      })) ?? []),
-    ];
-  }, [metricOptionsData]);
-
-  // TODO(nar): This should come from the metric data context
-  // so we can display different types with conflicting names
-  const currentMetricType = useMemo(() => {
-    return metricOptions?.find(metricData => metricData.value === traceMetric.name)?.type;
-  }, [metricOptions, traceMetric.name]);
-
   return (
     <div style={{width: '100%'}}>
       <Flex direction="row" gap="md" align="center">
         {t('Query')}
-        <CompactSelect
-          options={metricOptions ?? []}
-          value={traceMetric.name}
-          onChange={option => {
-            setMetricName(option.value);
-          }}
-        />
-        <AggregateDropdown type={currentMetricType} />
+        <MetricSelector traceMetric={traceMetric} />
+        <AggregateDropdown type={traceMetric.type} />
         {t('by')}
         <GroupBySelector metricName={traceMetric.name} />
         {t('where')}

--- a/static/app/views/explore/metrics/metricRow/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricRow/metricSelector.tsx
@@ -35,7 +35,7 @@ export function MetricSelector({traceMetric}: {traceMetric: TraceMetric}) {
   }, [metricOptionsData]);
 
   useEffect(() => {
-    if (!traceMetric.name) {
+    if (metricOptions.length && !traceMetric.name) {
       setTraceMetric({
         name: metricOptions[0]?.value ?? '',
         type: metricOptions[0]?.type ?? '',

--- a/static/app/views/explore/metrics/metricRow/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricRow/metricSelector.tsx
@@ -1,0 +1,50 @@
+import {useMemo} from 'react';
+
+import {Tag} from '@sentry/scraps/badge/tag';
+import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
+
+import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
+import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {useSetTraceMetric} from 'sentry/views/explore/metrics/metricsQueryParams';
+
+interface MetricSelectOption extends SelectOption<string> {
+  type: string;
+}
+
+function TypeBadge({kind}: {kind: string}) {
+  if (!kind) {
+    return null;
+  }
+
+  return <Tag>{kind}</Tag>;
+}
+
+export function MetricSelector({traceMetric}: {traceMetric: TraceMetric}) {
+  const {data: metricOptionsData} = useMetricOptions();
+  const setTraceMetric = useSetTraceMetric();
+
+  const metricOptions = useMemo((): MetricSelectOption[] => {
+    return [
+      ...(metricOptionsData?.data?.map(option => ({
+        label: `${option['metric.name']}`,
+        value: option['metric.name'],
+        type: option['metric.type'],
+        trailingItems: <TypeBadge kind={option['metric.type']} />,
+      })) ?? []),
+    ];
+  }, [metricOptionsData]);
+
+  return (
+    <CompactSelect
+      searchable
+      options={metricOptions ?? []}
+      value={traceMetric.name}
+      onChange={option => {
+        if ('type' in option) {
+          const typedOption = option as MetricSelectOption;
+          setTraceMetric({name: typedOption.value, type: typedOption.type});
+        }
+      }}
+    />
+  );
+}

--- a/static/app/views/explore/metrics/metricRow/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricRow/metricSelector.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 
 import {Tag} from '@sentry/scraps/badge/tag';
 import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
@@ -33,6 +33,15 @@ export function MetricSelector({traceMetric}: {traceMetric: TraceMetric}) {
       })) ?? []),
     ];
   }, [metricOptionsData]);
+
+  useEffect(() => {
+    if (!traceMetric.name) {
+      setTraceMetric({
+        name: metricOptions[0]?.value ?? '',
+        type: metricOptions[0]?.type ?? '',
+      });
+    }
+  }, [metricOptions, setTraceMetric, traceMetric.name]);
 
   return (
     <CompactSelect

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -3,7 +3,7 @@ import {useCallback, useMemo} from 'react';
 
 import {defined} from 'sentry/utils';
 import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
-import {defaultQuery} from 'sentry/views/explore/metrics/metricQuery';
+import {defaultQuery, type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {
   QueryParamsContextProvider,
@@ -19,27 +19,27 @@ import {
 } from 'sentry/views/explore/queryParams/visualize';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 
-interface MetricNameContextValue {
-  setMetricName: (metricName: string) => void;
+interface TraceMetricContextValue {
+  setTraceMetric: (traceMetric: TraceMetric) => void;
 }
 
-const [_MetricNameContextProvider, useMetricNameContext, MetricNameContext] =
-  createDefinedContext<MetricNameContextValue>({
-    name: 'MetricNameContext',
+const [_MetricMetadataContextProvider, useTraceMetricContext, TraceMetricContext] =
+  createDefinedContext<TraceMetricContextValue>({
+    name: 'TraceMetricContext',
   });
 
 interface MetricsQueryParamsProviderProps {
   children: ReactNode;
   queryParams: ReadableQueryParams;
-  setMetricName: (metricName: string) => void;
   setQueryParams: (queryParams: ReadableQueryParams) => void;
+  setTraceMetric: (traceMetric: TraceMetric) => void;
 }
 
 export function MetricsQueryParamsProvider({
   children,
   queryParams,
   setQueryParams,
-  setMetricName,
+  setTraceMetric,
 }: MetricsQueryParamsProviderProps) {
   const setWritableQueryParams = useCallback(
     (writableQueryParams: WritableQueryParams) => {
@@ -53,15 +53,15 @@ export function MetricsQueryParamsProvider({
     [queryParams, setQueryParams]
   );
 
-  const metricNameContextValue = useMemo(
+  const traceMetricContextValue = useMemo(
     () => ({
-      setMetricName,
+      setTraceMetric,
     }),
-    [setMetricName]
+    [setTraceMetric]
   );
 
   return (
-    <MetricNameContext value={metricNameContextValue}>
+    <TraceMetricContext value={traceMetricContextValue}>
       <QueryParamsContextProvider
         queryParams={queryParams}
         setQueryParams={setWritableQueryParams}
@@ -70,7 +70,7 @@ export function MetricsQueryParamsProvider({
       >
         {children}
       </QueryParamsContextProvider>
-    </MetricNameContext>
+    </TraceMetricContext>
   );
 }
 
@@ -97,9 +97,9 @@ export function useMetricVisualize(): VisualizeFunction {
   throw new Error('Only 1 visualize per metric allowed');
 }
 
-export function useSetMetricName() {
-  const {setMetricName} = useMetricNameContext();
-  return setMetricName;
+export function useSetTraceMetric() {
+  const {setTraceMetric} = useTraceMetricContext();
+  return setTraceMetric;
 }
 
 export function useSetMetricVisualize() {

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -81,7 +81,7 @@ function MetricsTabBodySection() {
               key={index}
               queryParams={metricQuery.queryParams}
               setQueryParams={metricQuery.setQueryParams}
-              setMetricName={metricQuery.setMetricName}
+              setTraceMetric={metricQuery.setTraceMetric}
             >
               <MetricPanel traceMetric={metricQuery.metric} />
             </MetricsQueryParamsProvider>

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -12,6 +12,7 @@ import {
   encodeMetricQueryParams,
   type BaseMetricQuery,
   type MetricQuery,
+  type TraceMetric,
 } from 'sentry/views/explore/metrics/metricQuery';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 
@@ -63,18 +64,15 @@ export function MultiMetricsQueryParamsProvider({
       };
     }
 
-    function setMetricNameForIndex(i: number) {
-      return function (newMetricName: string) {
+    function setTraceMetricForIndex(i: number) {
+      return function (newTraceMetric: TraceMetric) {
         const target = {...location, query: {...location.query}};
         target.query.metric = metricQueries
-          .map((metric: BaseMetricQuery, j: number) => {
+          .map((metricQuery: BaseMetricQuery, j: number) => {
             if (i !== j) {
-              return metric;
+              return metricQuery;
             }
-            return {
-              ...metric,
-              metric: {name: newMetricName},
-            };
+            return {...metricQuery, metric: newTraceMetric};
           })
           .map((metric: BaseMetricQuery) => encodeMetricQueryParams(metric))
           .filter(defined)
@@ -89,7 +87,7 @@ export function MultiMetricsQueryParamsProvider({
         return {
           ...metric,
           setQueryParams: setQueryParamsForIndex(index),
-          setMetricName: setMetricNameForIndex(index),
+          setTraceMetric: setTraceMetricForIndex(index),
         };
       }),
     };


### PR DESCRIPTION
- Add type to the metric interface to store it in the URL
- Extracts the metric selector into its own component
- Sets the first metric automatically on page open when the request for data completes
- Improves the rendering UI with the type chips

<img width="485" height="186" alt="Screenshot 2025-10-09 at 4 17 56 PM" src="https://github.com/user-attachments/assets/45fcd861-71db-4217-ac66-b7a037a65c34" />
