### PR TITLE
feat(autofix): Allow user to select stopping point in flyout

### DIFF
--- a/static/app/components/events/autofix/autofixStartBox.tsx
+++ b/static/app/components/events/autofix/autofixStartBox.tsx
@@ -1,26 +1,78 @@
-import {useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import starImage from 'sentry-images/spot/banner-star.svg';
 
 import {Button} from 'sentry/components/core/button';
+import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {TextArea} from 'sentry/components/core/textarea';
-import {IconArrow, IconSeer} from 'sentry/icons';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {AutofixStoppingPoint} from 'sentry/components/events/autofix/types';
+import {IconArrow, IconChevron, IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 
 interface AutofixStartBoxProps {
   groupId: string;
-  onSend: (message: string) => void;
+  onSend: (message: string, stoppingPoint?: AutofixStoppingPoint) => void;
 }
+
+const STOPPING_POINT_OPTIONS = [
+  {
+    key: AutofixStoppingPoint.ROOT_CAUSE,
+    label: t('Start Root Cause Analysis'),
+    value: AutofixStoppingPoint.ROOT_CAUSE,
+  },
+  {
+    key: AutofixStoppingPoint.SOLUTION,
+    label: t('Plan a Solution'),
+    value: AutofixStoppingPoint.SOLUTION,
+  },
+  {
+    key: AutofixStoppingPoint.CODE_CHANGES,
+    label: t('Write Code Changes'),
+    value: AutofixStoppingPoint.CODE_CHANGES,
+  },
+  {
+    key: AutofixStoppingPoint.OPEN_PR,
+    label: t('Draft a Pull Request'),
+    value: AutofixStoppingPoint.OPEN_PR,
+  },
+] as const;
 
 export function AutofixStartBox({onSend, groupId}: AutofixStartBoxProps) {
   const [message, setMessage] = useState('');
+  const [selectedStoppingPoint, setSelectedStoppingPoint] =
+    useLocalStorageState<AutofixStoppingPoint>(
+      'autofix:selected-stopping-point',
+      AutofixStoppingPoint.ROOT_CAUSE
+    );
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    onSend(message);
-  };
+  const handleSubmit = useCallback(
+    (e: React.FormEvent, stoppingPoint?: AutofixStoppingPoint) => {
+      e.preventDefault();
+      const finalStoppingPoint = stoppingPoint ?? selectedStoppingPoint;
+      setSelectedStoppingPoint(finalStoppingPoint);
+      onSend(message, finalStoppingPoint);
+    },
+    [message, selectedStoppingPoint, onSend, setSelectedStoppingPoint]
+  );
+
+  const {primaryOption, dropdownOptions} = useMemo(() => {
+    const primary =
+      STOPPING_POINT_OPTIONS.find(opt => opt.value === selectedStoppingPoint) ??
+      STOPPING_POINT_OPTIONS[0];
+    const dropdown = STOPPING_POINT_OPTIONS.filter(
+      opt => opt.value !== selectedStoppingPoint
+    ).map(opt => ({
+      key: opt.key,
+      label: opt.label,
+      onAction: () =>
+        handleSubmit({preventDefault: () => {}} as React.FormEvent, opt.value),
+    }));
+    return {primaryOption: primary, dropdownOptions: dropdown};
+  }, [selectedStoppingPoint, handleSubmit]);
 
   return (
     <Wrapper>
@@ -78,23 +130,36 @@ export function AutofixStartBox({onSend, groupId}: AutofixStartBoxProps) {
               maxRows={10}
               size="sm"
             />
-            <StyledButton
-              type="submit"
-              priority="primary"
-              analyticsEventKey={
-                message
-                  ? 'autofix.give_instructions_clicked'
-                  : 'autofix.start_fix_clicked'
-              }
-              analyticsEventName={
-                message
-                  ? 'Autofix: Give Instructions Clicked'
-                  : 'Autofix: Start Fix Clicked'
-              }
-              analyticsParams={{group_id: groupId}}
-            >
-              {t('Start Root Cause Analysis')}
-            </StyledButton>
+            <ButtonBar merged gap="0">
+              <StyledButton
+                type="submit"
+                priority="primary"
+                analyticsEventKey={
+                  message
+                    ? 'autofix.give_instructions_clicked'
+                    : 'autofix.start_fix_clicked'
+                }
+                analyticsEventName={
+                  message
+                    ? 'Autofix: Give Instructions Clicked'
+                    : 'Autofix: Start Fix Clicked'
+                }
+                analyticsParams={{group_id: groupId}}
+              >
+                {primaryOption.label}
+              </StyledButton>
+              <DropdownMenu
+                items={dropdownOptions}
+                trigger={(triggerProps, isOpen) => (
+                  <DropdownTrigger
+                    {...triggerProps}
+                    priority="primary"
+                    aria-label={t('Choose stopping point')}
+                    icon={<IconChevron direction={isOpen ? 'up' : 'down'} size="xs" />}
+                  />
+                )}
+              />
+            </ButtonBar>
           </InputWrapper>
         </Container>
       </ScaleContainer>
@@ -116,6 +181,7 @@ const ScaleContainer = styled('div')`
   flex-direction: column;
   align-items: center;
   gap: ${space(1)};
+  margin-bottom: 100px;
 `;
 
 const Container = styled('div')`
@@ -124,7 +190,7 @@ const Container = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
   background: ${p => p.theme.background}
     linear-gradient(135deg, ${p => p.theme.pink400}08, ${p => p.theme.pink400}20);
-  overflow: hidden;
+  overflow: visible;
   padding: ${space(0.5)};
   border: 1px solid ${p => p.theme.border};
 `;
@@ -136,6 +202,7 @@ const AutofixStartText = styled('div')`
   word-break: break-word;
   font-size: ${p => p.theme.fontSize.lg};
   position: relative;
+  overflow: hidden;
 `;
 
 const StartTextRow = styled('div')`
@@ -177,4 +244,10 @@ const StyledInput = styled(TextArea)`
 
 const StyledButton = styled(Button)`
   flex-shrink: 0;
+`;
+
+const DropdownTrigger = styled(Button)`
+  box-shadow: none;
+  border-radius: 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0;
+  border-left: none;
 `;

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -30,6 +30,13 @@ export enum AutofixStatus {
   WAITING_FOR_USER_RESPONSE = 'WAITING_FOR_USER_RESPONSE',
 }
 
+export enum AutofixStoppingPoint {
+  ROOT_CAUSE = 'root_cause',
+  SOLUTION = 'solution',
+  CODE_CHANGES = 'code_changes',
+  OPEN_PR = 'open_pr',
+}
+
 type AutofixPullRequestDetails = {
   pr_number: number;
   pr_url: string;

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -4,6 +4,7 @@ import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicato
 import {
   AutofixStatus,
   AutofixStepType,
+  AutofixStoppingPoint,
   CodingAgentStatus,
   type AutofixData,
   type GroupWithAutofix,
@@ -236,7 +237,7 @@ export const useAiAutofix = (
   );
 
   const triggerAutofix = useCallback(
-    async (instruction: string) => {
+    async (instruction: string, stoppingPoint?: AutofixStoppingPoint) => {
       setIsReset(false);
       setCurrentRunId(null);
       setWaitingForNextRun(true);
@@ -254,6 +255,7 @@ export const useAiAutofix = (
             data: {
               event_id: event.id,
               instruction,
+              ...(stoppingPoint && {stopping_point: stoppingPoint}),
             },
           }
         );


### PR DESCRIPTION
Adds a dropdown on the start screen that let's a user select how far they want that run to go. Defaults to RCA, but remembers your last selection with local storage.

<img width="789" height="399" alt="Screenshot 2025-10-09 at 1 21 59 PM" src="https://github.com/user-attachments/assets/cdbf6b21-a869-48f4-8a9e-ae54b0def3c1" />
<img width="823" height="437" alt="Screenshot 2025-10-09 at 1 22 07 PM" src="https://github.com/user-attachments/assets/3ddd8f56-5ad3-4f5d-840e-0d72a894a73f" />
