### PR TITLE
chore(feedback): remove unused llm options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2922,26 +2922,6 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Options for setting LLM providers and usecases
-register("llm.provider.options", default={}, flags=FLAG_NOSTORE)
-# Example provider:
-#     "openai": {
-#         "options": {
-#             "api_key": "",
-#         },
-#         "models": ["gpt-4-turbo", "gpt-3.5-turbo"],
-#     }
-
-register("llm.usecases.options", default={}, flags=FLAG_NOSTORE, type=Dict)
-# Example usecase:
-#     "suggestedfix": {
-#         "provider": "openai",
-#         "options": {
-#             "model": "gpt-3.5-turbo",
-#         },
-#     }
-# }
-
 register(
     "feedback.filter_garbage_messages",
     type=Bool,


### PR DESCRIPTION
relates to REPLAY-651

depends on https://github.com/getsentry/sentry/pull/101297 (merged & deployed ✅ )

Seer spam detection is now at 100% GA and the old unused LLM module for spam detection has been removed. Let's remove the unused options: `llm.provider.options` and `llm.usecases.options`.