### PR TITLE
feat(aci): Seed new automations with all trigger conditions

### DIFF
--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -13,8 +13,9 @@ import {
 } from 'sentry/types/workflowEngine/actions';
 import {
   DataConditionGroupLogicType,
+  DataConditionType,
+  type DataCondition,
   type DataConditionGroup,
-  type DataConditionType,
 } from 'sentry/types/workflowEngine/dataConditions';
 import {actionNodesMap} from 'sentry/views/automations/components/actionNodes';
 import {dataConditionNodesMap} from 'sentry/views/automations/components/dataConditionNodes';
@@ -186,7 +187,11 @@ export const initialAutomationBuilderState: AutomationBuilderState = {
   triggers: {
     id: 'when',
     logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
-    conditions: [],
+    conditions: [
+      createWhenCondition(DataConditionType.FIRST_SEEN_EVENT),
+      createWhenCondition(DataConditionType.REAPPEARED_EVENT),
+      createWhenCondition(DataConditionType.REGRESSION_EVENT),
+    ],
   },
   actionFilters: [
     {
@@ -293,6 +298,15 @@ type AutomationBuilderAction =
   | UpdateIfActionAction
   | UpdateIfLogicTypeAction;
 
+function createWhenCondition(conditionType: DataConditionType): DataCondition {
+  return {
+    id: uuid4(),
+    type: conditionType,
+    comparison: true,
+    conditionResult: true,
+  };
+}
+
 function addWhenCondition(
   state: AutomationBuilderState,
   action: AddWhenConditionAction
@@ -303,12 +317,7 @@ function addWhenCondition(
       ...state.triggers,
       conditions: [
         ...state.triggers.conditions,
-        {
-          id: uuid4(),
-          type: action.conditionType,
-          comparison: true,
-          conditionResult: true,
-        },
+        createWhenCondition(action.conditionType),
       ],
     },
   };


### PR DESCRIPTION
This should be a more explicit starting state and probably what most users want when creating a new automation.

<img width="863" height="276" alt="CleanShot 2025-10-09 at 16 18 39" src="https://github.com/user-attachments/assets/58111406-fa42-4fad-b3ba-21868815de80" />
