### PR TITLE
fix(aci): Don't require AlertRule to process workflows-only metrics detectors

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -136,6 +136,7 @@ class SubscriptionProcessor:
 
         self._alert_rule: AlertRule | None = None
         self.detector: Detector | None = None
+        self.last_update = to_datetime(0)  # should be overwritten on all success paths.
         if self._has_workflow_engine_processing_only or self._has_workflow_engine_processing:
             # If we're doing workflow engine processing, we need the Detector.
             try:

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -91,6 +91,7 @@ class MetricIssueDetectorConfig(TypedDict):
     """
     Schema for Metric Issue Detector.config.
     """
+
     comparison_delta: int | None
     detection_type: Literal["static", "percent", "dynamic"]
 
@@ -130,38 +131,40 @@ class SubscriptionProcessor:
                 or self._has_workflow_engine_processing_only
             )
         except Project.DoesNotExist:
-            # No processing to be done, project is gone.
-            self._has_workflow_engine_processing_only = False
-            self._has_workflow_engine_processing = False
+            # No more init needed; process_update knows to log and return early in this case.
+            return
 
         self._alert_rule: AlertRule | None = None
         self.detector: Detector | None = None
+        if self._has_workflow_engine_processing_only or self._has_workflow_engine_processing:
+            # If we're doing workflow engine processing, we need the Detector.
+            try:
+                self.detector = Detector.objects.get(
+                    data_sources__source_id=str(self.subscription.id),
+                    data_sources__type=DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
+                )
+                if self._has_workflow_engine_processing_only:
+                    # Single processing mode; we only need self.detector and self.last_update,
+                    # so we can return.
+                    self.last_update = get_detector_last_update(self.detector, project.id)
+                    return
+            except Detector.DoesNotExist:
+                logger.info("Detector not found", extra={"subscription_id": self.subscription.id})
+
+        if self._has_workflow_engine_processing_only and self.detector is None:
+            # Nothing more we can do.
+            return
+
+        # If we got here, we're trying to do legacy processing.
         try:
             self._alert_rule = AlertRule.objects.get_for_subscription(subscription)
         except AlertRule.DoesNotExist:
-            if self._has_workflow_engine_processing_only:
-                # Single processing with no AlertRule, so we use new conventions for
-                # last_update storage.
-                try:
-                    self.detector = Detector.objects.get(
-                        data_sources__source_id=str(self.subscription.id),
-                        data_sources__type=DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
-                    )
-                    self.last_update = get_detector_last_update(self.detector, project.id)
-                except Detector.DoesNotExist:
-                    logger.warning(
-                        "Detector not found for subscription",
-                        extra={"subscription_id": self.subscription.id},
-                    )
-                    # This is a bug; if we're single processing, there should always be a detector.
-                    raise
-            else:
-                # This is a bug; if we aren't workflow engine only, there should always be an AlertRule.
-                # Should be handled cleanly in process_update.
-                logger.info(
-                    "No AlertRule found for subscription",
-                    extra={"subscription_id": self.subscription.id},
-                )
+            # This is a bug; if we aren't workflow engine only, there should always be an AlertRule.
+            # process_update looks for this case and cleans up, so we can exit early.
+            logger.info(
+                "No AlertRule found for subscription",
+                extra={"subscription_id": self.subscription.id},
+            )
             return
 
         self.triggers = AlertRuleTrigger.objects.get_for_alert_rule(self._alert_rule)
@@ -388,18 +391,6 @@ class SubscriptionProcessor:
             comparison_delta = self._alert_rule.comparison_delta
 
         return comparison_delta
-
-    def get_detector(self, has_metric_alert_processing: bool) -> Detector | None:
-        detector = None
-        if has_metric_alert_processing:
-            try:
-                detector = self.detector or Detector.objects.get(
-                    data_sources__source_id=str(self.subscription.id),
-                    data_sources__type=DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
-                )
-            except Detector.DoesNotExist:
-                logger.info("Detector not found", extra={"subscription_id": self.subscription.id})
-        return detector
 
     def handle_logging_metrics_dual_processing(
         self,
@@ -764,7 +755,6 @@ class SubscriptionProcessor:
             )
 
         comparison_delta = None
-        detector = None
         with (
             metrics.timer(
                 "incidents.alert_rules.process_update",
@@ -776,8 +766,17 @@ class SubscriptionProcessor:
             ),
         ):
             metrics.incr("incidents.alert_rules.process_update.start")
-            detector = self.get_detector(self._has_workflow_engine_processing)
-            comparison_delta = self.get_comparison_delta(detector)
+            if self.detector is None and self._alert_rule is None:
+                logger.error(
+                    "No detector or alert rule found for subscription, skipping subscription processing",
+                    extra={
+                        "subscription_id": self.subscription.id,
+                        "project_id": self.subscription.project.id,
+                    },
+                )
+                return
+
+            comparison_delta = self.get_comparison_delta(self.detector)
             aggregation_value = self.get_aggregation_value(subscription_update, comparison_delta)
 
             if aggregation_value is None:
@@ -790,7 +789,7 @@ class SubscriptionProcessor:
                 legacy_results = None
 
                 if self._has_workflow_engine_processing:
-                    if detector is None:
+                    if not (detector := self.detector):
                         logger.error(
                             "Detector not found for subscription, skipping workflow engine processing",
                             extra={
@@ -828,7 +827,7 @@ class SubscriptionProcessor:
                     """
                     legacy_results = self.process_legacy_metric_alerts(
                         aggregation_value,
-                        detector,
+                        self.detector,
                         workflow_engine_results,
                     )
 
@@ -838,7 +837,7 @@ class SubscriptionProcessor:
                     logger.info(
                         metric_prefix,
                         extra={
-                            "detector": detector,
+                            "detector": self.detector,
                             "workflow_engine_triggered": bool(workflow_engine_results),
                             "metric_alert_triggered": bool(legacy_results),
                         },
@@ -1124,16 +1123,13 @@ def build_alert_rule_stat_keys(alert_rule: AlertRule, subscription: QuerySubscri
     return [ALERT_RULE_BASE_STAT_KEY % (key_base, stat_key) for stat_key in ALERT_RULE_STAT_KEYS]
 
 
-type DetectorLastUpdateKey = str
-
-
-def build_detector_last_update_key(detector: Detector, project_id: int) -> DetectorLastUpdateKey:
+def build_detector_last_update_key(detector: Detector, project_id: int) -> str:
     return f"detector:{detector.id}:project:{project_id}:last_update"
 
 
 def get_detector_last_update(detector: Detector, project_id: int) -> datetime:
     return to_datetime(
-        get_redis_client().get(build_detector_last_update_key(detector, project_id)) or 0
+        int(get_redis_client().get(build_detector_last_update_key(detector, project_id)) or "0")
     )
 
 

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -91,7 +91,6 @@ class MetricIssueDetectorConfig(TypedDict):
     """
     Schema for Metric Issue Detector.config.
     """
-
     comparison_delta: int | None
     detection_type: Literal["static", "percent", "dynamic"]
 

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -395,8 +395,8 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         data_source.detectors.set([detector])
 
         processor = self.send_update(rule, trigger.alert_threshold + 1)
-        self.assert_trigger_counts(processor, self.trigger, 0, 0)
-        self.assert_no_active_incident(rule)
+        # We're single processing; 'triggers' should not be set.
+        assert not hasattr(processor, "triggers")
 
         assert mock_process_data_packet.call_count == 1
         assert (


### PR DESCRIPTION
Rework SubscriptionProcessor so that we have no reliance on AlertRule for workflows processing.


Fixes ACI-476.
Fixes SENTRY-57J1.