### PR TITLE
feat(tracemetrics): Allow deleting metrics

### DIFF
--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -36,7 +36,7 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
   }
 
   const metric = json.metric;
-  if (typeof metric !== 'object' || !metric.name || !metric.type) {
+  if (typeof metric !== 'object') {
     return null;
   }
 

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -23,6 +23,7 @@ export interface BaseMetricQuery {
 }
 
 export interface MetricQuery extends BaseMetricQuery {
+  removeMetric: () => void;
   setQueryParams: (queryParams: ReadableQueryParams) => void;
   setTraceMetric: (traceMetric: TraceMetric) => void;
 }

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -1,3 +1,4 @@
+import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
@@ -37,7 +38,7 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
   }
 
   const metric = json.metric;
-  if (typeof metric !== 'object') {
+  if (defined(metric) && typeof metric !== 'object') {
     return null;
   }
 

--- a/static/app/views/explore/metrics/metricRow/deleteMetricButton.tsx
+++ b/static/app/views/explore/metrics/metricRow/deleteMetricButton.tsx
@@ -1,0 +1,25 @@
+import {Button} from '@sentry/scraps/button';
+
+import {IconDelete} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useRemoveMetric} from 'sentry/views/explore/metrics/metricsQueryParams';
+import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+
+export function DeleteMetricButton() {
+  const removeMetric = useRemoveMetric();
+  const metricQueries = useMultiMetricsQueryParams();
+
+  // Don't show delete button if there's only one metric
+  if (metricQueries.length <= 1) {
+    return null;
+  }
+
+  return (
+    <Button
+      size="sm"
+      icon={<IconDelete />}
+      aria-label={t('Delete metric')}
+      onClick={removeMetric}
+    />
+  );
+}

--- a/static/app/views/explore/metrics/metricRow/index.tsx
+++ b/static/app/views/explore/metrics/metricRow/index.tsx
@@ -12,6 +12,7 @@ import {
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {AggregateDropdown} from 'sentry/views/explore/metrics/metricRow/aggregateDropdown';
+import {DeleteMetricButton} from 'sentry/views/explore/metrics/metricRow/deleteMetricButton';
 import {GroupBySelector} from 'sentry/views/explore/metrics/metricRow/groupBySelector';
 import {MetricSelector} from 'sentry/views/explore/metrics/metricRow/metricSelector';
 import {
@@ -91,6 +92,7 @@ function MetricToolbar({
         <GroupBySelector metricName={traceMetric.name} />
         {t('where')}
         <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />
+        <DeleteMetricButton />
       </Flex>
     </div>
   );

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -20,6 +20,7 @@ import {
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 
 interface TraceMetricContextValue {
+  removeMetric: () => void;
   setTraceMetric: (traceMetric: TraceMetric) => void;
 }
 
@@ -31,6 +32,7 @@ const [_MetricMetadataContextProvider, useTraceMetricContext, TraceMetricContext
 interface MetricsQueryParamsProviderProps {
   children: ReactNode;
   queryParams: ReadableQueryParams;
+  removeMetric: () => void;
   setQueryParams: (queryParams: ReadableQueryParams) => void;
   setTraceMetric: (traceMetric: TraceMetric) => void;
 }
@@ -40,6 +42,7 @@ export function MetricsQueryParamsProvider({
   queryParams,
   setQueryParams,
   setTraceMetric,
+  removeMetric,
 }: MetricsQueryParamsProviderProps) {
   const setWritableQueryParams = useCallback(
     (writableQueryParams: WritableQueryParams) => {
@@ -56,8 +59,9 @@ export function MetricsQueryParamsProvider({
   const traceMetricContextValue = useMemo(
     () => ({
       setTraceMetric,
+      removeMetric,
     }),
-    [setTraceMetric]
+    [setTraceMetric, removeMetric]
   );
 
   return (
@@ -100,6 +104,11 @@ export function useMetricVisualize(): VisualizeFunction {
 export function useSetTraceMetric() {
   const {setTraceMetric} = useTraceMetricContext();
   return setTraceMetric;
+}
+
+export function useRemoveMetric() {
+  const {removeMetric} = useTraceMetricContext();
+  return removeMetric;
 }
 
 export function useSetMetricVisualize() {

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -82,6 +82,7 @@ function MetricsTabBodySection() {
               queryParams={metricQuery.queryParams}
               setQueryParams={metricQuery.setQueryParams}
               setTraceMetric={metricQuery.setTraceMetric}
+              removeMetric={metricQuery.removeMetric}
             >
               <MetricPanel traceMetric={metricQuery.metric} />
             </MetricsQueryParamsProvider>

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -82,12 +82,33 @@ export function MultiMetricsQueryParamsProvider({
       };
     }
 
+    function removeMetricQueryForIndex(i: number) {
+      return function () {
+        // Don't allow removing the last metric query
+        if (metricQueries.length <= 1) {
+          return;
+        }
+
+        const target = {...location, query: {...location.query}};
+
+        const newMetricQueries: string[] = metricQueries
+          .filter((_, j) => i !== j)
+          .map((metricQuery: BaseMetricQuery) => encodeMetricQueryParams(metricQuery))
+          .filter(defined)
+          .filter(Boolean);
+        target.query.metric = newMetricQueries;
+
+        navigate(target);
+      };
+    }
+
     return {
       metricQueries: metricQueries.map((metric: BaseMetricQuery, index: number) => {
         return {
           ...metric,
           setQueryParams: setQueryParamsForIndex(index),
           setTraceMetric: setTraceMetricForIndex(index),
+          removeMetric: removeMetricQueryForIndex(index),
         };
       }),
     };


### PR DESCRIPTION
Adds a hook that manages deleting a metric and a button that can trigger deleting.

Also fixes a bug where new metrics weren't being added because the validation was unnecessarily restrictive and ignoring the new additions.