### PR TITLE
✨ feat(github): outbound assignment syncing

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -161,6 +161,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Project Management Integrations Feature Parity Flags
     # GitHub inbound assignee sync
     manager.add("organizations:integrations-github-inbound-assignee-sync", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:integrations-github-outbound-assignee-sync", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable inviting billing members to organizations at the member limit.
     manager.add("organizations:invite-billing", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=False, api_expose=False)
     # Enable inviting members to organizations.

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -536,6 +536,13 @@ class GitHubBaseClient(
         endpoint = f"/repos/{repo}/issues"
         return self.post(endpoint, data=data)
 
+    def update_issue(self, repo: str, issue_number: str, assignees: list[str]) -> Any:
+        """
+        https://docs.github.com/en/rest/issues/issues#update-an-issue
+        """
+        endpoint = f"/repos/{repo}/issues/{issue_number}"
+        return self.patch(endpoint, data={"assignees": assignees})
+
     def create_comment(self, repo: str, issue_id: str, data: dict[str, Any]) -> Any:
         """
         https://docs.github.com/en/rest/issues/comments#create-an-issue-comment


### PR DESCRIPTION
<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->
  - Implemented `sync_assignee_outbound()` method in GitHubIntegration class
  - Added logic to map Sentry users to GitHub usernames via ExternalActor records
  - Integrated with GitHub API to update issue assignments
  - Added configuration option `sync_forward_assignment` to control the feature
  - Gated behind `organizations:integrations-github-outbound-assignee-sync`


https://github.com/user-attachments/assets/b0f4484d-45c2-4986-9aea-cf1065f40e94



### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
