### PR TITLE
ref(disclosure): Remove flex styling

### DIFF
--- a/static/app/components/core/disclosure/disclosure.tsx
+++ b/static/app/components/core/disclosure/disclosure.tsx
@@ -68,14 +68,7 @@ function DisclosureComponent({
     <DisclosureContext.Provider
       value={{buttonProps, panelProps, panelRef, state, context: {size}}}
     >
-      <Flex
-        data-disclosure
-        direction="column"
-        align="start"
-        flex="1 1 100%"
-        ref={ref}
-        {...props}
-      >
+      <Flex data-disclosure direction="column" align="start" ref={ref} {...props}>
         {children}
       </Flex>
     </DisclosureContext.Provider>

--- a/static/app/debug/notifications/components/debugNotificationsPreview.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsPreview.tsx
@@ -27,7 +27,6 @@ export function DebugNotificationsPreview({
 }
 
 const PreviewDisclosure = styled(Disclosure)`
-  flex: 0;
   pre,
   code {
     white-space: pre-wrap;


### PR DESCRIPTION
### Problem
The disclosure component is growing per default in a flex layout.

https://github.com/user-attachments/assets/0d644b6e-1b13-4dea-8136-05315251dc84


### Solution
Remove default flex styles from Disclosure.

- closes [TET-1212: UI Jumping when filtering span attributes](https://linear.app/getsentry/issue/TET-1212/ui-jumping-when-filtering-span-attributes)