### PR TITLE
fix(ai-insights): token types separator

### DIFF
--- a/static/app/views/insights/agents/components/tokenTypesWidget.tsx
+++ b/static/app/views/insights/agents/components/tokenTypesWidget.tsx
@@ -198,7 +198,7 @@ export default function TokenTypesWidget() {
           }}
         />
       </div>
-      <FooterText>{t('Input Tokens (Cached)')}</FooterText>
+      <FooterText>{t('Input Tokens / Cached')}</FooterText>
       <span>
         <TokenTypeCount
           value={Number(sums['sum(gen_ai.usage.input_tokens)'] || 0)}
@@ -213,7 +213,7 @@ export default function TokenTypesWidget() {
           }}
         />
       </div>
-      <FooterText>{t('Output Tokens (Reasoning)')}</FooterText>
+      <FooterText>{t('Output Tokens / Reasoning')}</FooterText>
       <span>
         <TokenTypeCount
           value={Number(sums['sum(gen_ai.usage.output_tokens)'] || 0)}
@@ -280,9 +280,8 @@ function TokenTypeCount({
   return (
     <TokenTypeCountWrapper>
       <Count value={value} />
-      <span>
-        (<Count value={secondaryValue} />)
-      </span>
+      /
+      <Count value={secondaryValue} />
     </TokenTypeCountWrapper>
   );
 }


### PR DESCRIPTION
Before:
<img width="543" height="281" alt="image" src="https://github.com/user-attachments/assets/e6fab465-de67-4500-89f8-3bd3e6318d6e" />

After:
<img width="543" height="281" alt="image" src="https://github.com/user-attachments/assets/79e9e514-eb24-47bd-8a9b-e2cefd43d462" />

