### PR TITLE
feat(onboarding): Add Pydantic AI integration steps and links

### DIFF
--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -730,6 +730,8 @@ export const agentMonitoringOnboarding: OnboardingConfig = {
       packageName = 'sentry-sdk[litellm]';
     } else if (selected === 'google_genai') {
       packageName = 'sentry-sdk[google_genai]';
+    } else if (selected === 'pydantic_ai') {
+      packageName = 'sentry-sdk[pydantic_ai]';
     }
 
     return [
@@ -1016,11 +1018,53 @@ sentry_sdk.init(
         {
           type: 'code',
           language: 'python',
+          code: `import sentry_sdk
+
+sentry_sdk.init(dsn="${params.dsn.public}", traces_sample_rate=1.0)`,
+        },
+      ],
+    };
+
+    const pydanticAiStep: OnboardingStep = {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Import and initialize the Sentry SDK for [pydantic_ai:Pydantic AI] monitoring:',
+            {
+              pydantic_ai: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/integrations/pydantic-ai/" />
+              ),
+            }
+          ),
+        },
+        {
+          type: 'code',
+          language: 'python',
           code: `
 import sentry_sdk
+from sentry_sdk.integrations.pydantic_ai import PydanticAiIntegration
 
-sentry_sdk.init(dsn="${params.dsn.public}", traces_sample_rate=1.0)
-`,
+sentry_sdk.init(
+    dsn="${params.dsn.public}",
+    environment="local",
+    traces_sample_rate=1.0,
+    # Add data like inputs and responses to/from LLMs and tools;
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+    integrations=[
+        PydanticAiIntegration(),
+    ],
+    # Disable OpenAI integration for correct token accounting
+    disabled_integrations=[OpenAIIntegration()],
+)`,
+        },
+        {
+          type: 'text',
+          text: t(
+            'The Pydantic AI integration will automatically collect information about agents, tools, prompts, tokens, and models.'
+          ),
         },
       ],
     };
@@ -1043,6 +1087,9 @@ sentry_sdk.init(dsn="${params.dsn.public}", traces_sample_rate=1.0)
     }
     if (selected === 'google_genai') {
       return [googleGenAIStep];
+    }
+    if (selected === 'pydantic_ai') {
+      return [pydanticAiStep];
     }
     if (selected === 'manual') {
       return [manualStep];
@@ -1299,7 +1346,32 @@ response = client.models.generate_content(
 )
 
 print(response)
+`,
+        },
+      ],
+    };
 
+    const pydanticAiVerifyStep: OnboardingStep = {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Verify that agent monitoring is working correctly by creating a Pydantic AI agent:'
+          ),
+        },
+        {
+          type: 'code',
+          language: 'python',
+          code: `
+from pydantic_ai import Agent
+
+# Create an agent with OpenAI model
+agent = Agent('openai:gpt-4o-mini')
+
+# Run the agent
+result = agent.run_sync('Tell me a joke')
+print(result.data)
 `,
         },
       ],
@@ -1359,6 +1431,9 @@ with sentry_sdk.start_span(op="gen_ai.chat", name="chat o3-mini") as span:
     }
     if (selected === 'google_genai') {
       return [googleGenAIVerifyStep];
+    }
+    if (selected === 'pydantic_ai') {
+      return [pydanticAiVerifyStep];
     }
     if (selected === 'manual') {
       return [manualVerifyStep];

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -1045,6 +1045,8 @@ sentry_sdk.init(dsn="${params.dsn.public}", traces_sample_rate=1.0)`,
           code: `
 import sentry_sdk
 from sentry_sdk.integrations.pydantic_ai import PydanticAiIntegration
+from sentry_sdk.integrations.openai import OpenAIIntegration
+
 
 sentry_sdk.init(
     dsn="${params.dsn.public}",

--- a/static/app/views/insights/agents/views/onboarding.tsx
+++ b/static/app/views/insights/agents/views/onboarding.tsx
@@ -220,6 +220,7 @@ export function Onboarding() {
             {label: 'LangChain', value: 'langchain'},
             {label: 'LangGraph', value: 'langgraph'},
             {label: 'LiteLLM', value: 'litellm'},
+            {label: 'Pydantic AI', value: 'pydantic_ai'},
             {label: 'Manual', value: 'manual'},
           ]
         : [

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
@@ -33,6 +33,7 @@ const knownSpanOrigins = {
     'auto.ai.anthropic',
     'auto.ai.litellm',
     'auto.ai.google_genai',
+    'auto.ai.pydantic_ai',
   ],
   javascript: ['auto.ai.anthropic', 'auto.ai.openai', 'auto.vercelai.otel'],
 } as const;
@@ -139,6 +140,8 @@ const pythonIntegrationLinks: Record<PythonSpanOrigin, string> = {
   'auto.ai.litellm': 'https://docs.sentry.io/platforms/python/integrations/litellm/',
   'auto.ai.google_genai':
     'https://docs.sentry.io/platforms/python/integrations/google-genai/',
+  'auto.ai.pydantic_ai':
+    'https://docs.sentry.io/platforms/python/integrations/pydantic-ai/',
 };
 
 function PythonContent({


### PR DESCRIPTION
- Introduced onboarding steps for Pydantic AI, including configuration and verification instructions.
- Updated the onboarding dropdown to include Pydantic AI as an option.
- Added relevant links for Pydantic AI integration in the Python span origins.

Requires https://github.com/getsentry/sentry-python/pull/4906 to be merged

Contributes to https://linear.app/getsentry/issue/TET-1242/python-sdk-pydantic-ai-integration