### PR TITLE
chore(dynamic-sampling): reduce size of query sets for dynamic sampling

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/constants.py
+++ b/src/sentry/dynamic_sampling/tasks/constants.py
@@ -6,8 +6,8 @@ DEFAULT_REDIS_CACHE_KEY_TTL = 24 * 60 * 60 * 1000  # 24 hours
 ADJUSTED_FACTOR_REDIS_CACHE_KEY_TTL = 10 * 60 * 1000  # 10 minutes
 
 # Parameters to bound the queries run in Snuba.
-MAX_ORGS_PER_QUERY = 100
-MAX_PROJECTS_PER_QUERY = 5000
+MAX_ORGS_PER_QUERY = 80
+MAX_PROJECTS_PER_QUERY = 4000
 MAX_TRANSACTIONS_PER_PROJECT = 20
 
 # MIN and MAX rebalance factor in order to make sure we don't go crazy when rebalancing orgs.


### PR DESCRIPTION
- Use 80 instead of 100 orgs, and 4000 projects intead of 5000 projects per query
- Intent is to reduce the size of the query, so snuba does not run into query timeouts as frequently when running these queries
Closes TET-1224