### PR TITLE
feat: Add `wordBreak` prop to `Text` element

### DIFF
--- a/static/app/components/core/text/text.mdx
+++ b/static/app/components/core/text/text.mdx
@@ -202,6 +202,40 @@ Handle text overflow with the `ellipsis` prop to truncate long text with an elli
 </Container>
 ```
 
+## Wrapping
+
+Use the `textWrap` prop to control how the text wraps, and the `wordBreak` prop to control where the text is split during wrapping.
+
+<Storybook.Demo>
+  <Stack gap="md">
+    <Container width="200px" padding="md" border="primary">
+      <Text wordBreak="break-word">
+        A URL string that breaks on word boundaries:
+        https://example.com/path/?marketingParam1=value1&amp;marketingParam2=some-awkward-long-value
+      </Text>
+    </Container>
+    <Container width="200px" padding="md" border="primary">
+      <Text textWrap="balance">
+        Balanced text wrapping for a string of words of varying lengths
+      </Text>
+    </Container>
+  </Stack>
+</Storybook.Demo>
+```jsx
+<Container width="200px" padding="md" border="primary">
+  <Text wordBreak="break-word">
+    A URL string that breaks on word boundaries:
+    https://example.com/path/?marketingParam1=value1&amp;marketingParam2=some-awkward-long-value
+  </Text>
+</Container>
+
+<Container width="200px" padding="md" border="primary">
+  <Text textWrap="balance">
+    Balanced text wrapping for a string of words of varying lengths
+  </Text>
+</Container>
+```
+
 ## Monospace
 
 Use `monospace` for fixed-width text.

--- a/static/app/components/core/text/text.tsx
+++ b/static/app/components/core/text/text.tsx
@@ -85,6 +85,12 @@ export interface BaseTextProps {
   variant?: keyof Theme['tokens']['content'];
 
   /**
+   * Determines where line breaks appear when wrapping the text.
+   * @default undefined
+   */
+  wordBreak?: 'normal' | 'break-all' | 'keep-all' | 'break-word';
+
+  /**
    * Determines text wrapping.
    */
   wrap?: 'nowrap' | 'normal' | 'pre' | 'pre-line' | 'pre-wrap';
@@ -132,6 +138,7 @@ export const Text = styled(
   text-overflow: ${p => (p.ellipsis ? 'ellipsis' : undefined)};
   white-space: ${p => (p.wrap ? p.wrap : p.ellipsis ? 'nowrap' : undefined)};
   text-wrap: ${p => p.textWrap ?? undefined};
+  word-break: ${p => p.wordBreak ?? undefined};
   width: ${p => (p.ellipsis ? '100%' : undefined)};
   display: ${p =>
     p.as === 'div'


### PR DESCRIPTION
Useful for controlling where wrapping lines are split. Added some docs while I was there.

**e.g.,**
<img width="844" height="571" alt="Screenshot 2025-10-10 at 11 05 02 AM" src="https://github.com/user-attachments/assets/94a458f3-4080-4e67-8485-e50f3842acc4" />
