### PR TITLE
chore(timeseries): More improvements to comparison logic

### DIFF
--- a/static/app/utils/timeSeries/parseGroupBy.spec.tsx
+++ b/static/app/utils/timeSeries/parseGroupBy.spec.tsx
@@ -20,12 +20,30 @@ describe('parseGroupBy', () => {
     ]);
   });
 
-  it('handles more values than fields by using empty strings for extra values', () => {
-    const result = parseGroupBy('value1,value2', ['field1']);
+  it('handles empty fields with some values', () => {
+    const result = parseGroupBy('value1,value2,value3', []);
+    expect(result).toBeNull();
+  });
+
+  it('handles some fields but empty value', () => {
+    const result = parseGroupBy('', ['field1', 'field2']);
     expect(result).toEqual([
-      {key: 'field1', value: 'value1'},
-      {key: '', value: 'value2'},
+      {key: 'field1', value: ''},
+      {key: 'field2', value: ''},
     ]);
+  });
+
+  it('handles one more value than field by concatenating', () => {
+    const result = parseGroupBy('value1,value2,value3', ['field1', 'field2']);
+    expect(result).toEqual([
+      {key: 'field1', value: 'value1,value2'},
+      {key: 'field2', value: 'value3'},
+    ]);
+  });
+
+  it('handles many more values than fields by concatenating', () => {
+    const result = parseGroupBy('value1,value2,value3', ['field1']);
+    expect(result).toEqual([{key: 'field1', value: 'value1,value2,value3'}]);
   });
 
   it('handles more fields than values by using empty strings for missing values', () => {

--- a/static/app/utils/timeSeries/parseGroupBy.tsx
+++ b/static/app/utils/timeSeries/parseGroupBy.tsx
@@ -10,7 +10,7 @@ export function parseGroupBy(
     return null;
   }
 
-  if (fields.length < 1) {
+  if (fields.length === 0) {
     return null;
   }
 

--- a/static/app/utils/timeSeries/parseGroupBy.tsx
+++ b/static/app/utils/timeSeries/parseGroupBy.tsx
@@ -10,8 +10,21 @@ export function parseGroupBy(
     return null;
   }
 
+  if (fields.length < 1) {
+    return null;
+  }
+
   const groupKeys = fields;
-  const groupValues = groupName.split(',');
+  const groupValues = groupName.split(DELIMITER);
+
+  // If the `groupName` contains commas, that will result in more values than
+  // keys. In this case, concatenate the values back together until the number
+  // of keys and values matches. Do this greedily, which is not always accurate,
+  // but in practice this doesn't make a UI difference since all values are
+  // eventually concatenated with commas.
+  while (groupValues.length > groupKeys.length) {
+    groupValues.splice(0, 2, `${groupValues[0]!}${DELIMITER}${groupValues[1]!}`);
+  }
 
   const groupBys = zipWith(groupKeys, groupValues, (key, value) => {
     return {
@@ -24,3 +37,5 @@ export function parseGroupBy(
 
   return groupBys.length > 0 ? groupBys : null;
 }
+
+const DELIMITER = ',';

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -119,7 +119,7 @@ export const useSortedTimeSeries = <
   // compare the result and spot-check that there aren't any differences.
 
   // Re-roll the random value whenever the filters change
-  const key = `${yAxis.join(',')}-${typeof search === 'string' ? search : search?.formatString()}-${(fields ?? []).join(',')}-${pageFilters.selection.datetime.period}`;
+  const key = `${yAxis.join(',')}-${typeof search === 'string' ? search : search?.formatString()}-${topEvents}-${(fields ?? []).join(',')}-${pageFilters.selection.datetime.period}-${pageFilters.selection.datetime.start}-${pageFilters.selection.datetime.end}-${disableAggregateExtrapolation}`;
 
   const isTimeSeriesEndpointComparisonEnabled =
     useIsSampled(0.1, key) &&

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -136,6 +136,7 @@ export const useSortedTimeSeries = <
       sort: decodeSorts(orderby)[0],
       interval,
       sampling: samplingMode,
+      extrapolate: !disableAggregateExtrapolation,
       enabled: isTimeSeriesEndpointComparisonEnabled,
     },
     `${referrer}-time-series`

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -385,15 +385,24 @@ function comparator(
   objA: Record<PropertyKey, unknown>,
   objB: Record<PropertyKey, unknown>
 ) {
-  // Compare numbers by near equality, which makes the comparison less sensitive to small natural variations in value caused by request sequencing
   if (
     key &&
     NUMERIC_KEYS.includes(key) &&
     typeof valueA === 'number' &&
     typeof valueB === 'number' &&
-    !objA?.incomplete &&
-    !objB?.incomplete
+    (objA?.incomplete || objB?.incomplete)
   ) {
+    // Treat numerical values in incomplete buckets as equal, we don't care about the differences there
+    return true;
+  }
+
+  if (
+    key &&
+    NUMERIC_KEYS.includes(key) &&
+    typeof valueA === 'number' &&
+    typeof valueB === 'number'
+  ) {
+    // Compare numbers by near equality, which makes the comparison less sensitive to small natural variations in value caused by request sequencing
     return areNumbersAlmostEqual(valueA, valueB, 5);
   }
 


### PR DESCRIPTION
1. Improve parsing of groups. If the group name has commas in it, concatenate the values back until they match the number of fields.
2. Improve comparator. Fix a bug from a previous PR where the loose numeric comparison only applied to incomplete buckets
3. Pass through the extrapolation configuration
4. Re-run fetches slightly more often
