### PR TITLE
feat(search-bar): Add tooltip to case sensitivity toggle

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4147,9 +4147,7 @@ describe('SearchQueryBuilder', () => {
         {organization: {features: ['search-query-builder-case-insensitivity']}}
       );
 
-      expect(
-        await screen.findByRole('button', {name: 'Toggle case sensitivity'})
-      ).toBeInTheDocument();
+      expect(await screen.findByRole('button', {name: 'Match case'})).toBeInTheDocument();
     });
   });
 

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -198,19 +198,21 @@ function ActionButtons({
     return null;
   }
 
+  const isCaseInsensitive = caseInsensitive === 1;
+
   return (
     <ButtonsWrapper ref={ref}>
       {trailingItems}
       {defined(onCaseInsensitiveClick) && hasCaseSensitiveSearch ? (
         <ActionButton
           aria-label={t('Toggle case sensitivity')}
-          aria-pressed={caseInsensitive === 1}
+          aria-pressed={isCaseInsensitive}
           size="zero"
-          icon={<IconCase color={caseInsensitive ? 'active' : 'subText'} />}
+          icon={<IconCase color={isCaseInsensitive ? 'subText' : 'active'} />}
           borderless
-          active={caseInsensitive === 1}
+          active={!isCaseInsensitive}
           onClick={() => {
-            onCaseInsensitiveClick?.(caseInsensitive === 1 ? null : 1);
+            onCaseInsensitiveClick?.(isCaseInsensitive ? null : 1);
           }}
         />
       ) : null}

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -201,7 +201,7 @@ function ActionButtons({
   }
 
   const isCaseInsensitive = caseInsensitive === 1;
-  const caseInsensitiveLabel = isCaseInsensitive ? t('Ignore case') : t('Match case');
+  const caseInsensitiveLabel = isCaseInsensitive ? t('Match case') : t('Ignore case');
 
   return (
     <ButtonsWrapper ref={ref}>

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -2,8 +2,10 @@ import {useContext, useLayoutEffect} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/core/button';
-import {Input} from 'sentry/components/core/input';
+import {Button} from '@sentry/scraps/button';
+import {Input} from '@sentry/scraps/input';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
 import {
   SearchQueryBuilderContext,
   SearchQueryBuilderProvider,
@@ -199,22 +201,25 @@ function ActionButtons({
   }
 
   const isCaseInsensitive = caseInsensitive === 1;
+  const caseInsensitiveLabel = isCaseInsensitive ? t('Ignore case') : t('Match case');
 
   return (
     <ButtonsWrapper ref={ref}>
       {trailingItems}
       {defined(onCaseInsensitiveClick) && hasCaseSensitiveSearch ? (
-        <ActionButton
-          aria-label={t('Toggle case sensitivity')}
-          aria-pressed={isCaseInsensitive}
-          size="zero"
-          icon={<IconCase color={isCaseInsensitive ? 'subText' : 'active'} />}
-          borderless
-          active={!isCaseInsensitive}
-          onClick={() => {
-            onCaseInsensitiveClick?.(isCaseInsensitive ? null : 1);
-          }}
-        />
+        <Tooltip title={caseInsensitiveLabel}>
+          <ActionButton
+            aria-label={caseInsensitiveLabel}
+            aria-pressed={isCaseInsensitive}
+            size="zero"
+            icon={<IconCase color={isCaseInsensitive ? 'subText' : 'active'} />}
+            borderless
+            active={!isCaseInsensitive}
+            onClick={() => {
+              onCaseInsensitiveClick?.(isCaseInsensitive ? null : 1);
+            }}
+          />
+        </Tooltip>
       ) : null}
       {query === '' ? null : (
         <ActionButton

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -259,7 +259,7 @@ describe('LogsTabContent', () => {
     expect(eventTableMock).toHaveBeenCalled();
 
     const caseInsensitiveBtn = await screen.findByRole('button', {
-      name: 'Toggle case sensitivity',
+      name: 'Ignore case',
     });
     await userEvent.click(caseInsensitiveBtn);
 

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -261,7 +261,7 @@ describe('SpansTabContent', () => {
       );
 
       const caseSensitivityToggle = screen.getByRole('button', {
-        name: 'Toggle case sensitivity',
+        name: 'Ignore case',
       });
       expect(caseSensitivityToggle).toBeInTheDocument();
     });
@@ -275,7 +275,7 @@ describe('SpansTabContent', () => {
       );
 
       const caseSensitivityToggle = screen.getByRole('button', {
-        name: 'Toggle case sensitivity',
+        name: 'Ignore case',
       });
       expect(caseSensitivityToggle).toBeInTheDocument();
       await userEvent.click(caseSensitivityToggle);
@@ -304,7 +304,7 @@ describe('SpansTabContent', () => {
       );
 
       const caseSensitivityToggle = screen.getByRole('button', {
-        name: 'Toggle case sensitivity',
+        name: 'Ignore case',
       });
       expect(caseSensitivityToggle).toBeInTheDocument();
       await userEvent.click(caseSensitivityToggle);


### PR DESCRIPTION
Quickly adding in a tooltip (and fixing backwards color states), to help inform users what will result when clicking on the button.


https://github.com/user-attachments/assets/25943e1f-2daf-4ba7-a0fc-8ab6be297ef8