### PR TITLE
feat(tracemetrics): Clean up group by loading state

### DIFF
--- a/static/app/views/explore/metrics/metricGraph.tsx
+++ b/static/app/views/explore/metrics/metricGraph.tsx
@@ -127,7 +127,6 @@ function Graph({onChartTypeChange, timeseriesResult, visualize}: GraphProps) {
       Title={Title}
       Actions={Actions}
       Visualization={visualize.visible && <ChartVisualization chartInfo={chartInfo} />}
-      height={visualize.visible ? 200 : 50}
       revealActions="always"
       borderless
     />

--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -1,6 +1,5 @@
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import type {SelectOption} from 'sentry/components/core/compactSelect/types';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
@@ -54,7 +53,6 @@ export function GroupBySelector({metricName}: GroupBySelectorProps) {
   });
 
   const isLoading = numberTagsLoading || stringTagsLoading;
-  const triggerLabel = isLoading ? <LoadingIndicator size={16} /> : undefined;
 
   return (
     <CompactSelect<string>
@@ -62,8 +60,8 @@ export function GroupBySelector({metricName}: GroupBySelectorProps) {
       searchable
       options={enabledOptions}
       value={[...groupBys]}
-      disabled={isLoading || enabledOptions.length === 0}
-      triggerProps={triggerLabel ? {children: triggerLabel} : undefined}
+      loading={isLoading}
+      disabled={enabledOptions.length === 0}
       onChange={selectedOptions => {
         setGroupBys(selectedOptions.map(option => option.value));
       }}


### PR DESCRIPTION
- Cleans up some jank around the loading indicator that appears when a new metric is added
- Removes `height` from the chart so it's always the height of its container