### PR TITLE
fix(replay): Set opaque background color of unmask banner in replays

### DIFF
--- a/static/app/components/replays/unmaskAlert.tsx
+++ b/static/app/components/replays/unmaskAlert.tsx
@@ -51,4 +51,7 @@ export default UnmaskAlert;
 const UnmaskAlertContainer = styled('div')`
   position: absolute;
   bottom: ${space(1)};
+  & > div {
+    background-color: ${p => p.theme.backgroundSecondary};
+  }
 `;


### PR DESCRIPTION
It can sometimes be hard to read the unmask banner when viewing a replay due to the semi-transparent background color (theme.blue100). Adding a blur won't work on dark mode due to the contrast between the light video and the dark background. Let's instead use the secondary background color.

Before:
<img width="596" height="63" alt="Screenshot 2025-10-10 at 11 26 21 AM" src="https://github.com/user-attachments/assets/35de85ef-06e7-458e-920d-06cba5c7cf7e" />
<img width="596" height="63" alt="Screenshot 2025-10-10 at 11 28 10 AM" src="https://github.com/user-attachments/assets/ece0057f-67ff-4179-abe0-8f2fe7e260a1" />

After:
<img width="596" height="63" alt="Screenshot 2025-10-10 at 11 26 09 AM" src="https://github.com/user-attachments/assets/e0a0aac9-0ded-45bd-a519-47177f22aba7" />
<img width="596" height="63" alt="Screenshot 2025-10-10 at 11 28 32 AM" src="https://github.com/user-attachments/assets/92861505-d598-42fb-9171-8cec8cacf31d" />

Before (chonk UI):
<img width="596" height="63" alt="Screenshot 2025-10-10 at 11 26 48 AM" src="https://github.com/user-attachments/assets/e448ecbf-0346-4d26-913f-caf669c139bd" />
<img width="596" height="63" alt="Screenshot 2025-10-10 at 11 27 41 AM" src="https://github.com/user-attachments/assets/3bc94e41-8677-475e-bb81-f6fd7be53e3f" />

After (chonk UI):
<img width="596" height="63" alt="Screenshot 2025-10-10 at 11 27 00 AM" src="https://github.com/user-attachments/assets/35469ab0-d185-4e38-b3d2-0b8f8577be29" />
<img width="596" height="63" alt="Screenshot 2025-10-10 at 11 27 30 AM" src="https://github.com/user-attachments/assets/e57ac125-c5b2-4360-bd91-5a1b14b7703c" />
