### PR TITLE
feat(checkout v3): Auto-open sliders for customers with reserved volumes

### DIFF
--- a/static/gsApp/views/amCheckout/reserveAdditionalVolume.spec.tsx
+++ b/static/gsApp/views/amCheckout/reserveAdditionalVolume.spec.tsx
@@ -299,8 +299,9 @@ describe('ReserveAdditionalVolume', () => {
     });
 
     it('auto-shows sliders if customer has reserved volume above platform', () => {
-      subscription.categories.errors!.reserved = 100_000;
-      render(<ReserveAdditionalVolume {...stepProps} />);
+      const paidSub = SubscriptionFixture({organization, plan: 'am3_business'});
+      paidSub.categories.errors!.reserved = 100_000;
+      render(<ReserveAdditionalVolume {...stepProps} subscription={paidSub} />);
       expect(screen.getByTestId('errors-volume-item')).toBeInTheDocument();
     });
   });

--- a/static/gsApp/views/amCheckout/reserveAdditionalVolume.tsx
+++ b/static/gsApp/views/amCheckout/reserveAdditionalVolume.tsx
@@ -38,7 +38,11 @@ function ReserveAdditionalVolume({
     isDeveloperPlan(subscription.planDetails)
       ? false
       : Object.values(subscription.categories ?? {})
-          .filter(({category}) => activePlan.checkoutCategories.includes(category))
+          .filter(
+            ({category}) =>
+              activePlan.checkoutCategories.includes(category) &&
+              category in activePlan.planCategories
+          )
           .some(
             ({category, reserved}) =>
               getBucket({

--- a/static/gsApp/views/amCheckout/reserveAdditionalVolume.tsx
+++ b/static/gsApp/views/amCheckout/reserveAdditionalVolume.tsx
@@ -11,7 +11,7 @@ import {t} from 'sentry/locale';
 import type {DataCategory} from 'sentry/types/core';
 
 import {PlanTier} from 'getsentry/types';
-import {isAmPlan} from 'getsentry/utils/billing';
+import {isAmPlan, isDeveloperPlan} from 'getsentry/utils/billing';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 import VolumeSliders from 'getsentry/views/amCheckout/steps/volumeSliders';
 import type {StepProps} from 'getsentry/views/amCheckout/types';
@@ -35,13 +35,17 @@ function ReserveAdditionalVolume({
 >) {
   // if the customer has any reserved volume above platform already, auto-show the sliders
   const [showSliders, setShowSliders] = useState<boolean>(
-    Object.values(subscription.categories)
-      .filter(({category}) => activePlan.checkoutCategories.includes(category))
-      .some(
-        ({category, reserved}) =>
-          getBucket({buckets: activePlan.planCategories[category], events: reserved ?? 0})
-            .price > 0
-      )
+    isDeveloperPlan(subscription.planDetails)
+      ? false
+      : Object.values(subscription.categories ?? {})
+          .filter(({category}) => activePlan.checkoutCategories.includes(category))
+          .some(
+            ({category, reserved}) =>
+              getBucket({
+                buckets: activePlan.planCategories[category],
+                events: reserved ?? 0,
+              }).price > 0
+          )
   );
   const reservedVolumeTotal = useMemo(() => {
     return Object.entries(formData.reserved).reduce((acc, [category, value]) => {


### PR DESCRIPTION
Auto-opens the `Reserve additional volume` substep for customers that already have at least one category reserved above platform volume.