### PR TITLE
feat(tracemetrics): Render aggregates tab content

### DIFF
--- a/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
@@ -1,0 +1,100 @@
+import {useMemo} from 'react';
+
+import type {NewQuery} from 'sentry/types/organization';
+import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
+import {useMetricVisualize} from 'sentry/views/explore/metrics/metricsQueryParams';
+import {
+  useQueryParamsAggregateSortBys,
+  useQueryParamsGroupBys,
+  useQueryParamsSearch,
+} from 'sentry/views/explore/queryParams/context';
+import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
+
+interface UseMetricAggregatesTableOptions {
+  enabled: boolean;
+  limit: number;
+  metricName: string;
+}
+
+export interface MetricAggregatesTableResult {
+  eventView: EventView;
+  fields: string[];
+  result: ReturnType<typeof useSpansQuery<any[]>>;
+}
+
+export function useMetricAggregatesTable({
+  enabled,
+  limit,
+  metricName,
+}: UseMetricAggregatesTableOptions) {
+  return useMetricAggregatesTableImp({enabled, limit, metricName});
+}
+
+function useMetricAggregatesTableImp({
+  enabled,
+  limit,
+  metricName,
+}: UseMetricAggregatesTableOptions): MetricAggregatesTableResult {
+  const {selection} = usePageFilters();
+  const visualize = useMetricVisualize();
+  const groupBys = useQueryParamsGroupBys();
+  const searchQuery = useQueryParamsSearch();
+  const sortBys = useQueryParamsAggregateSortBys();
+
+  const fields = useMemo(() => {
+    const allFields: string[] = [];
+
+    // Add group by fields first
+    for (const groupBy of groupBys) {
+      if (groupBy && !allFields.includes(groupBy)) {
+        allFields.push(groupBy);
+      }
+    }
+
+    // Add the yAxis aggregate
+    if (visualize.yAxis && !allFields.includes(visualize.yAxis)) {
+      allFields.push(visualize.yAxis);
+    }
+
+    return allFields.filter(Boolean);
+  }, [groupBys, visualize.yAxis]);
+
+  const query = useMemo(() => {
+    const currentSearch = new MutableSearch(`metric.name:${metricName}`);
+    if (!searchQuery.isEmpty()) {
+      currentSearch.addStringFilter(searchQuery.formatString());
+    }
+    return currentSearch.formatString();
+  }, [metricName, searchQuery]);
+
+  const eventView = useMemo(() => {
+    const discoverQuery: NewQuery = {
+      id: undefined,
+      name: 'Explore - Metric Aggregates',
+      fields,
+      orderby: sortBys.map(formatSort),
+      query,
+      version: 2,
+      dataset: DiscoverDatasets.TRACEMETRICS,
+    };
+
+    return EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
+  }, [fields, query, selection, sortBys]);
+
+  const result = useSpansQuery({
+    enabled: enabled && Boolean(metricName) && fields.length > 0,
+    eventView,
+    initialData: [],
+    limit,
+    referrer: 'api.explore.metric-aggregates-table',
+    trackResponseAnalytics: false,
+  });
+
+  return useMemo(() => {
+    return {eventView, fields, result};
+  }, [eventView, fields, result]);
+}

--- a/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
@@ -20,7 +20,7 @@ interface UseMetricAggregatesTableOptions {
   metricName: string;
 }
 
-export interface MetricAggregatesTableResult {
+interface MetricAggregatesTableResult {
   eventView: EventView;
   fields: string[];
   result: ReturnType<typeof useSpansQuery<any[]>>;

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -1,0 +1,207 @@
+import {useMemo, useRef} from 'react';
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
+
+import {Tooltip} from 'sentry/components/core/tooltip';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import LoadingMask from 'sentry/components/loadingMask';
+import type {Alignments} from 'sentry/components/tables/gridEditable/sortLink';
+import {GridBodyCell, GridHeadCell} from 'sentry/components/tables/gridEditable/styles';
+import {IconArrow} from 'sentry/icons/iconArrow';
+import {IconWarning} from 'sentry/icons/iconWarning';
+import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
+import {
+  fieldAlignment,
+  parseFunction,
+  prettifyParsedFunction,
+} from 'sentry/utils/discover/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {TopResultsIndicator} from 'sentry/views/discover/table/topResultsIndicator';
+import {
+  TableBody,
+  TableHead,
+  TableRow,
+  TableStatus,
+  useTableStyles,
+} from 'sentry/views/explore/components/table';
+import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
+import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
+import {useMetricAggregatesTable} from 'sentry/views/explore/metrics/hooks/useMetricAggregatesTable';
+import {Table} from 'sentry/views/explore/multiQueryMode/components/miniTable';
+import {
+  useQueryParamsAggregateSortBys,
+  useSetQueryParamsAggregateSortBys,
+} from 'sentry/views/explore/queryParams/context';
+import {FieldRenderer} from 'sentry/views/explore/tables/fieldRenderer';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+
+const TABLE_HEIGHT = 230;
+const RESULT_LIMIT = 50;
+
+interface AggregatesTabProps {
+  metricName: string;
+}
+
+export function AggregatesTab({metricName}: AggregatesTabProps) {
+  const topEvents = useTopEvents();
+
+  const {result, eventView, fields} = useMetricAggregatesTable({
+    enabled: Boolean(metricName),
+    limit: RESULT_LIMIT,
+    metricName,
+  });
+
+  const columns = useMemo(() => eventView.getColumns(), [eventView]);
+  const sorts = useQueryParamsAggregateSortBys();
+  const setSorts = useSetQueryParamsAggregateSortBys();
+
+  const metricNameFilter = metricName
+    ? MutableSearch.fromQueryObject({['metric.name']: [metricName]}).formatString()
+    : undefined;
+
+  const {attributes: numberTags} = useTraceItemAttributeKeys({
+    traceItemType: TraceItemDataset.TRACEMETRICS,
+    type: 'number',
+    enabled: Boolean(metricNameFilter),
+    query: metricNameFilter,
+  });
+  const {attributes: stringTags} = useTraceItemAttributeKeys({
+    traceItemType: TraceItemDataset.TRACEMETRICS,
+    type: 'string',
+    enabled: Boolean(metricNameFilter),
+    query: metricNameFilter,
+  });
+
+  const tableRef = useRef<HTMLTableElement>(null);
+  const {initialTableStyles} = useTableStyles(fields, tableRef, {
+    minimumColumnWidth: 50,
+  });
+
+  const meta = result.meta ?? {};
+
+  return (
+    <TableContainer>
+      {result.isPending && <TransparentLoadingMask />}
+      <Table ref={tableRef} style={initialTableStyles} scrollable height={TABLE_HEIGHT}>
+        <TableHead>
+          <TableRow>
+            {fields.map((field, i) => {
+              let label = field;
+              const fieldType = meta.fields?.[field];
+              const align = fieldAlignment(field, fieldType);
+              const tag = stringTags?.[field] ?? numberTags?.[field] ?? null;
+              if (tag) {
+                label = tag.name;
+              }
+
+              const func = parseFunction(field);
+              if (func) {
+                label = prettifyParsedFunction(func);
+              }
+
+              const direction = sorts.find(s => s.field === field)?.kind;
+
+              function updateSort() {
+                const kind = direction === 'desc' ? 'asc' : 'desc';
+                setSorts([{field, kind}]);
+              }
+
+              return (
+                <TableHeadCell align={align} key={i} isFirst={i === 0}>
+                  <TableHeadCellContent align="center" gap="sm" onClick={updateSort}>
+                    <Tooltip showOnlyOnOverflow title={label}>
+                      {label}
+                    </Tooltip>
+                    {defined(direction) && (
+                      <IconArrow
+                        size="xs"
+                        direction={
+                          direction === 'desc'
+                            ? 'down'
+                            : direction === 'asc'
+                              ? 'up'
+                              : undefined
+                        }
+                      />
+                    )}
+                  </TableHeadCellContent>
+                </TableHeadCell>
+              );
+            })}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {result.isError ? (
+            <TableStatus>
+              <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
+            </TableStatus>
+          ) : result.data?.length ? (
+            result.data.map((row, i) => {
+              return (
+                <TableRow key={i}>
+                  {topEvents && i < topEvents && (
+                    <StyledTopResultsIndicator count={topEvents} index={i} />
+                  )}
+                  {fields.map((field, j) => {
+                    return (
+                      <StyledTableBodyCell key={j}>
+                        <FieldRenderer
+                          column={columns[j]}
+                          data={row}
+                          unit={meta?.units?.[field]}
+                          meta={meta}
+                        />
+                      </StyledTableBodyCell>
+                    );
+                  })}
+                </TableRow>
+              );
+            })
+          ) : result.isPending ? (
+            <TableStatus>
+              <LoadingIndicator />
+            </TableStatus>
+          ) : (
+            <TableStatus>
+              <EmptyStateWarning>
+                <p>{t('No aggregates found')}</p>
+              </EmptyStateWarning>
+            </TableStatus>
+          )}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+const TableContainer = styled('div')`
+  position: relative;
+`;
+
+const StyledTableBodyCell = styled(GridBodyCell)`
+  font-size: ${p => p.theme.fontSize.sm};
+  min-height: 12px;
+`;
+
+const TableHeadCell = styled(GridHeadCell)<{align?: Alignments}>`
+  ${p => p.align && `justify-content: ${p.align};`}
+  font-size: ${p => p.theme.fontSize.sm};
+  height: 33px;
+`;
+
+const TableHeadCellContent = styled(Flex)`
+  cursor: pointer;
+  user-select: none;
+`;
+
+const TransparentLoadingMask = styled(LoadingMask)`
+  opacity: 0.4;
+  z-index: 1;
+`;
+
+const StyledTopResultsIndicator = styled(TopResultsIndicator)`
+  margin-top: 9.5px;
+`;

--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -1,8 +1,10 @@
-import {Fragment} from 'react';
+import styled from '@emotion/styled';
 
 import {TabList, TabPanels, TabStateProvider} from 'sentry/components/core/tabs';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {t} from 'sentry/locale';
+import {AggregatesTab} from 'sentry/views/explore/metrics/metricInfoTabs/aggregatesTab';
+import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 
 enum MetricsInfoTab {
   AGGREGATES = 'aggregates',
@@ -11,22 +13,26 @@ enum MetricsInfoTab {
   TRACES = 'traces',
 }
 
-export default function MetricInfoTabs() {
+interface MetricInfoTabsProps {
+  traceMetric: TraceMetric;
+}
+
+export default function MetricInfoTabs({traceMetric}: MetricInfoTabsProps) {
   return (
-    <Fragment>
-      <TabStateProvider<MetricsInfoTab> defaultValue={MetricsInfoTab.AGGREGATES}>
+    <TabStateProvider<MetricsInfoTab> defaultValue={MetricsInfoTab.AGGREGATES}>
+      <HeaderWrapper>
         <TabList>
           <TabList.Item key={MetricsInfoTab.AGGREGATES}>{t('Aggregates')}</TabList.Item>
           <TabList.Item key={MetricsInfoTab.ERRORS}>{t('Errors')}</TabList.Item>
           <TabList.Item key={MetricsInfoTab.LOGS}>{t('Logs')}</TabList.Item>
           <TabList.Item key={MetricsInfoTab.TRACES}>{t('Traces')}</TabList.Item>
         </TabList>
+      </HeaderWrapper>
 
+      <BodyContainer>
         <TabPanels>
           <TabPanels.Item key={MetricsInfoTab.AGGREGATES}>
-            <EmptyStateWarning>
-              <p>{t('No aggregates data available')}</p>
-            </EmptyStateWarning>
+            <AggregatesTab metricName={traceMetric.name} />
           </TabPanels.Item>
           <TabPanels.Item key={MetricsInfoTab.ERRORS}>
             <EmptyStateWarning>
@@ -44,7 +50,17 @@ export default function MetricInfoTabs() {
             </EmptyStateWarning>
           </TabPanels.Item>
         </TabPanels>
-      </TabStateProvider>
-    </Fragment>
+      </BodyContainer>
+    </TabStateProvider>
   );
 }
+
+const HeaderWrapper = styled('div')`
+  padding-bottom: ${p => p.theme.space.sm};
+`;
+
+const BodyContainer = styled('div')`
+  padding: ${p => p.theme.space.md};
+  padding-top: 0;
+  height: 250px;
+`;

--- a/static/app/views/explore/metrics/metricPanel.tsx
+++ b/static/app/views/explore/metrics/metricPanel.tsx
@@ -7,6 +7,7 @@ import SplitPanel from 'sentry/components/splitPanel';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useDimensions} from 'sentry/utils/useDimensions';
+import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
 import {MetricsGraph} from 'sentry/views/explore/metrics/metricGraph';
@@ -15,6 +16,7 @@ import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {useMetricVisualize} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {MetricToolbar} from 'sentry/views/explore/metrics/metricToolbar';
 import {
+  useQueryParamsAggregateSortBys,
   useQueryParamsGroupBys,
   useQueryParamsSearch,
 } from 'sentry/views/explore/queryParams/context';
@@ -35,6 +37,7 @@ export function MetricPanel({traceMetric}: MetricPanelProps) {
   const [interval] = useChartInterval();
   const topEvents = useTopEvents();
   const searchQuery = useQueryParamsSearch();
+  const sortBys = useQueryParamsAggregateSortBys();
 
   const search = useMemo(() => {
     const currentSearch = new MutableSearch(`metric.name:${traceMetric.name}`);
@@ -52,6 +55,7 @@ export function MetricPanel({traceMetric}: MetricPanelProps) {
       fields: [...groupBys],
       enabled: Boolean(traceMetric.name),
       topEvents,
+      orderby: sortBys.map(formatSort),
     },
     'api.explore.metrics-stats',
     DiscoverDatasets.TRACEMETRICS
@@ -75,7 +79,7 @@ export function MetricPanel({traceMetric}: MetricPanelProps) {
                 min: MIN_LEFT_WIDTH,
                 max: width - MIN_RIGHT_WIDTH,
               }}
-              right={<MetricInfoTabs />}
+              right={<MetricInfoTabs traceMetric={traceMetric} />}
             />
           ) : null}
         </div>

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -64,6 +64,11 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
 
   const aggregateFields = [...visualizes, ...groupBys];
 
+  const aggregateSortBys = json.aggregateSortBys;
+  if (!Array.isArray(aggregateSortBys)) {
+    return null;
+  }
+
   return {
     metric,
     queryParams: new ReadableQueryParams({
@@ -77,7 +82,7 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
 
       aggregateCursor: '',
       aggregateFields,
-      aggregateSortBys: defaultAggregateSortBys(),
+      aggregateSortBys,
     }),
   };
 }
@@ -94,6 +99,7 @@ export function encodeMetricQueryParams(metricQuery: BaseMetricQuery): string {
       // Keep Group By as-is
       return field;
     }),
+    aggregateSortBys: metricQuery.queryParams.aggregateSortBys,
   });
 }
 

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -49,6 +49,7 @@ export function MetricsQueryParamsProvider({
       const newQueryParams = updateQueryParams(queryParams, {
         query: getUpdatedValue(writableQueryParams.query, defaultQuery),
         aggregateFields: writableQueryParams.aggregateFields,
+        aggregateSortBys: writableQueryParams.aggregateSortBys,
       });
 
       setQueryParams(newQueryParams);


### PR DESCRIPTION
Render content for the aggregates tab. It heavily uses a similar implementation to the Multi Query Mode tables with specifics for the aggregates. In the future we may circle back and make that table more reusable.


https://github.com/user-attachments/assets/7831dcb2-7952-4a94-8e5d-5896cfdd55a5



