### PR TITLE
feat(sub v3): route for activity-logs

### DIFF
--- a/static/gsApp/hooks/settingsRoutes.tsx
+++ b/static/gsApp/hooks/settingsRoutes.tsx
@@ -78,9 +78,16 @@ const settingsRoutes = (): SentryRouteObject => ({
           component: make(() => import('../views/subscriptionPage/billingInformation')),
           deprecatedRouteProps: true,
         },
+        // TODO(sub-v3): We're keeping both routes for now, but we should remove the usage-log route once we're confident in keeping the new name
         {
           path: 'usage-log/',
           name: 'Usage Log',
+          component: make(() => import('../views/subscriptionPage/usageLog')),
+          deprecatedRouteProps: true,
+        },
+        {
+          path: 'activity-logs/',
+          name: 'Activity Logs',
           component: make(() => import('../views/subscriptionPage/usageLog')),
           deprecatedRouteProps: true,
         },

--- a/static/gsApp/views/subscriptionPage/headerCards/linksCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/linksCard.tsx
@@ -31,7 +31,7 @@ function LinksCard({organization}: {organization: Organization}) {
               <LinkButton
                 priority="link"
                 icon={<IconTimer />}
-                to="/settings/billing/usage-log/"
+                to="/settings/billing/activity-logs/"
               >
                 <Text size="sm" variant="accent">
                   {t('View activity')}
@@ -51,7 +51,7 @@ function LinksCard({organization}: {organization: Organization}) {
             <LinkButton
               priority="link"
               icon={<IconTimer />}
-              to="/settings/billing/usage-log/"
+              to="/settings/billing/activity-logs/"
             >
               <Text size="sm" variant="accent">
                 {t('View activity')}


### PR DESCRIPTION
Adds a route for `/activity-logs`, which is the same as `/usage-log`, but allows us to render `Subscription > Activity Logs` instead of `Subscription > Usage Log` when that route is hit.

<img width="725" height="210" alt="Screenshot 2025-10-10 at 2 47 08 PM" src="https://github.com/user-attachments/assets/781a3120-fa2c-46c5-a96e-c389f118f77d" />
