### PR TITLE
chore(aci milestone 3): remove dual/single processing feature flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -495,7 +495,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable dual writing for issue alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-issue-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable workflow processing for metric issues
-    manager.add("organizations:workflow-engine-process-metric-issue-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:workflow-engine-process-metric-issue-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable single processing through workflow engine for issue alerts
     manager.add("organizations:workflow-engine-single-process-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable logging to debug workflow engine process workflows
@@ -507,7 +507,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable dual writing for metric alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-metric-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Processing for Metric Alerts in the workflow_engine
-    manager.add("organizations:workflow-engine-metric-alert-processing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:workflow-engine-metric-alert-processing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable Creation of Metric Alerts that use the `group_by` field in the workflow_engine
     manager.add("organizations:workflow-engine-metric-alert-group-by-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable ingestion through trusted relays only
@@ -519,7 +519,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Use workflow engine serializers to return data for old rule / incident endpoints
     manager.add("organizations:workflow-engine-rule-serializers", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable single processing of metric issues
-    manager.add("organizations:workflow-engine-single-process-metric-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:workflow-engine-single-process-metric-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable metric detector limits by plan type
     manager.add("organizations:workflow-engine-metric-detector-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable EventUniqueUserFrequencyConditionWithConditions special alert condition

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -505,7 +505,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable logs to debug metric alert dual processing
     manager.add("organizations:workflow-engine-metric-alert-dual-processing-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable dual writing for metric alert issues (see: alerts create issues)
-    manager.add("organizations:workflow-engine-metric-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:workflow-engine-metric-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable Processing for Metric Alerts in the workflow_engine
     manager.add("organizations:workflow-engine-metric-alert-processing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable Creation of Metric Alerts that use the `group_by` field in the workflow_engine

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -135,17 +135,13 @@ def fetch_metric_issue_open_periods(
     user: User | RpcUser | None = None,
 ) -> list[Any]:
     try:
-        if features.has(
-            "organizations:workflow-engine-single-process-metric-issues",
-            organization,  # Metric issue single processing
-        ):
-            # temporarily fetch the alert rule ID from the detector ID
-            alert_rule_detector = AlertRuleDetector.objects.filter(
-                detector_id=open_period_identifier, alert_rule_id__isnull=False
-            ).first()
-            if alert_rule_detector is not None:
-                # open_period_identifier is a metric detector ID -> get the alert rule ID
-                open_period_identifier = alert_rule_detector.alert_rule_id
+        # temporarily fetch the alert rule ID from the detector ID
+        alert_rule_detector = AlertRuleDetector.objects.filter(
+            detector_id=open_period_identifier, alert_rule_id__isnull=False
+        ).first()
+        if alert_rule_detector is not None:
+            # open_period_identifier is a metric detector ID -> get the alert rule ID
+            open_period_identifier = alert_rule_detector.alert_rule_id
 
         resp = client.get(
             auth=ApiKey(organization_id=organization.id, scope_list=["org:read"]),

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -10,7 +10,6 @@ from parsimonious.exceptions import ParseError
 from rest_framework import serializers
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
-from sentry import features
 from sentry.api.exceptions import BadRequest, RequestTimeout
 from sentry.api.fields.actor import ActorField
 from sentry.api.helpers.error_upsampling import are_any_projects_error_upsampled
@@ -298,15 +297,11 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
 
             self._handle_triggers(alert_rule, triggers)
 
-            should_dual_write = features.has(
-                "organizations:workflow-engine-metric-alert-dual-write", alert_rule.organization
-            )
-            if should_dual_write:
-                try:
-                    dual_write_alert_rule(alert_rule, user)
-                except Exception:
-                    sentry_sdk.capture_exception()
-                    raise BadRequest(message="Error when creating alert rule")
+            try:
+                dual_write_alert_rule(alert_rule, user)
+            except Exception:
+                sentry_sdk.capture_exception()
+                raise BadRequest(message="Error when creating alert rule")
             return alert_rule
 
     def _apply_error_upsampling_if_needed(self, validated_data):

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -133,17 +133,8 @@ class SubscriptionProcessor:
         self.orig_trigger_alert_counts = deepcopy(self.trigger_alert_counts)
         self.orig_trigger_resolve_counts = deepcopy(self.trigger_resolve_counts)
 
-        self._has_workflow_engine_processing_only = features.has(
-            "organizations:workflow-engine-single-process-metric-issues",
-            self.subscription.project.organization,
-        )
-        self._has_workflow_engine_processing = (
-            features.has(
-                "organizations:workflow-engine-metric-alert-processing",
-                self.subscription.project.organization,
-            )
-            or self._has_workflow_engine_processing_only
-        )
+        self._has_workflow_engine_processing_only = True
+        self._has_workflow_engine_processing = True
 
     @property
     def alert_rule(self) -> AlertRule:

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -10,7 +10,7 @@ import sentry_sdk
 from django.conf import settings
 from django.db import router, transaction
 
-from sentry import eventstream, features
+from sentry import eventstream
 from sentry.constants import LOG_LEVELS_MAP, MAX_CULPRIT_LENGTH
 from sentry.event_manager import (
     GroupInfo,
@@ -74,9 +74,7 @@ def save_issue_occurrence(
         _get_or_create_group_release(environment, release, event, [group_info])
 
         # Create IncidentGroupOpenPeriod relationship for metric issues
-        if occurrence.type == MetricIssue and features.has(
-            "organizations:workflow-engine-single-process-metric-issues", event.organization
-        ):
+        if occurrence.type == MetricIssue:
             open_period = get_latest_open_period(group_info.group)
             if open_period:
                 IncidentGroupOpenPeriod.create_from_occurrence(

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -486,13 +486,6 @@ class BaseMetricAlertHandler(ABC):
         if isinstance(event, GroupEvent):
             evidence_data, priority = cls._extract_from_group_event(event)
         elif isinstance(event, Activity):
-            # we only want to fire resolution activities if we are single processing
-            if not features.has(
-                "organizations:workflow-engine-single-process-metric-issues",
-                event_data.group.organization,
-            ):
-                return
-
             evidence_data, priority = cls._extract_from_activity(event)
         else:
             raise ValueError(

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -28,13 +28,7 @@ def should_fire_workflow_actions(org: Organization, type_id: int) -> bool:
             in rollout_type_ids  # While we are rolling out these groups & we are single  processing
             and features.has("organizations:workflow-engine-single-process-workflows", org)
         )
-        or (
-            type_id == MetricIssue.type_id
-            and features.has(
-                "organizations:workflow-engine-single-process-metric-issues",
-                org,  # Metric issue single processing
-            )
-        )
+        or (type_id == MetricIssue.type_id)
         or features.has(
             "organizations:workflow-engine-trigger-actions",
             org,  # Other action testing

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1046,13 +1046,6 @@ def process_workflow_engine_metric_issues(job: PostProcessJob) -> None:
     if job["is_reprocessed"]:
         return
 
-    org = job["event"].project.organization
-    if not (
-        features.has("organizations:workflow-engine-process-metric-issue-workflows", org)
-        or features.has("organizations:workflow-engine-single-process-metric-issues", org)
-    ):
-        return
-
     process_workflow_engine(job)
 
 

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
@@ -1,6 +1,5 @@
 import logging
 
-from sentry import features
 from sentry.issues.status_change_consumer import group_status_update_registry
 from sentry.issues.status_change_message import StatusChangeMessageData
 from sentry.models.activity import Activity
@@ -43,26 +42,8 @@ def workflow_status_update_handler(
         metrics.incr("workflow_engine.tasks.error.no_detector_id")
         return
 
-    # We should only fire actions for activity updates if we should be firing actions
-    # if dual proccessing or single proccessing is enabled
-    if features.has(  # Metric issue single processing
-        "organizations:workflow-engine-single-process-metric-issues",
-        group.organization,
-    ) or features.has(  # Metric dual processing
-        "organizations:workflow-engine-metric-alert-processing",
-        group.organization,
-    ):
-        process_workflow_activity.delay(
-            activity_id=activity.id,
-            group_id=group.id,
-            detector_id=detector_id,
-        )
-    else:
-        logger.info(
-            "workflow_engine.tasks.process_workflows.activity_update.skipped",
-            extra={
-                "activity_id": activity.id,
-                "group_id": group.id,
-                "detector_id": detector_id,
-            },
-        )
+    process_workflow_activity.delay(
+        activity_id=activity.id,
+        group_id=group.id,
+        detector_id=detector_id,
+    )

--- a/src/sentry/workflow_engine/models/incident_groupopenperiod.py
+++ b/src/sentry/workflow_engine/models/incident_groupopenperiod.py
@@ -3,7 +3,6 @@ import logging
 from django.db import models
 from django.db.models import Q
 
-from sentry import features
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
@@ -229,11 +228,6 @@ def update_incident_activity_based_on_group_activity(
         logger.warning("No open period found for group", extra={"group_id": group.id})
         return
 
-    if not features.has(
-        "organizations:workflow-engine-single-process-metric-issues", group.project.organization
-    ):
-        return
-
     # get the incident for the open period
     try:
         incident_id = IncidentGroupOpenPeriod.objects.get(group_open_period=open_period).incident_id
@@ -277,11 +271,6 @@ def update_incident_based_on_open_period_status_change(
     open_period = get_latest_open_period(group)
     if open_period is None:
         logger.warning("No open period found for group", extra={"group_id": group.id})
-        return
-
-    if not features.has(
-        "organizations:workflow-engine-single-process-metric-issues", group.project.organization
-    ):
         return
 
     # get the incident for the open period

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -825,7 +825,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         with (
             self.feature("organizations:incidents"),
-            self.feature("organizations:workflow-engine-metric-alert-dual-write"),
             self.feature("organizations:workflow-engine-rule-serializers"),
             outbox_runner(),
         ):
@@ -996,7 +995,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         # we test the logic for this method elsewhere, so just test that it's correctly called
         assert mock_dual_delete.call_count == 1
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_delete_trigger_dual_update_resolve(self) -> None:
         """
         If there is no explicit resolve threshold on an alert rule, then we need to dual update the
@@ -1027,7 +1025,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         assert len(resp.data["triggers"]) == 1
         assert_dual_written_resolution_threshold_equals(alert_rule, new_threshold)
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_update_trigger_threshold_dual_update_resolve(self) -> None:
         """
         If there is no explicit resolve threshold on an alert rule, then we need to dual update the
@@ -1066,7 +1063,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             )
         assert_dual_written_resolution_threshold_equals(alert_rule, new_threshold)
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_update_trigger_threshold_dual_update_resolve_noop(self) -> None:
         """
         If there is an explicit resolve threshold on an alert rule, then updating triggers should
@@ -1092,7 +1088,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         # remains unchanged
         assert_dual_written_resolution_threshold_equals(alert_rule, resolve_threshold)
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_remove_resolve_threshold_dual_update_resolve(self) -> None:
         """
         If we set the remove the resolve threshold from an alert rule, then we need to update the
@@ -1118,7 +1113,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         # resolve threshold changes to the warning threshold
         assert_dual_written_resolution_threshold_equals(alert_rule, new_threshold)
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_dual_update_resolve_all_triggers_removed_and_recreated(self) -> None:
         """
         If a PUT request is made via the API and the trigger IDs are not specified in the

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -384,7 +384,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 [
                     "organizations:incidents",
                     "organizations:performance-view",
-                    "organizations:workflow-engine-metric-alert-dual-write",
                     "organizations:workflow-engine-rule-serializers",
                 ]
             ),
@@ -398,7 +397,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         detector = Detector.objects.get(alertruledetector__alert_rule_id=int(resp.data.get("id")))
         assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_create_alert_rule_aci(self) -> None:
         with (
             outbox_runner(),

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_base.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_base.py
@@ -16,7 +16,6 @@ from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventTy
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import SnubaTestCase, SpanTestCase, TestCase
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.workflow_engine.models import DataSource, DataSourceDetector, DetectorState
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.detector import Detector
@@ -26,7 +25,6 @@ EMPTY = object()
 
 
 @freeze_time()
-@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class ProcessUpdateBaseClass(TestCase, SpanTestCase, SnubaTestCase):
     @pytest.fixture(autouse=True)
     def _setup_metrics_patch(self):

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -50,7 +50,6 @@ from tests.sentry.incidents.subscription_processor.test_subscription_processor i
 @freeze_time()
 class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.metrics")
     @patch("sentry.incidents.subscription_processor.logger")
     def test_alert_metrics_logging(self, mock_logger: MagicMock, mock_metrics: MagicMock) -> None:
@@ -111,7 +110,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         )
 
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.metrics")
     @patch("sentry.incidents.subscription_processor.logger")
     def test_snoozed_alert_metrics_logging(
@@ -155,7 +153,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         )
 
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.metrics")
     @patch("sentry.incidents.subscription_processor.logger")
     def test_resolve_metrics_logging(self, mock_logger: MagicMock, mock_metrics: MagicMock) -> None:
@@ -207,7 +204,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         )
 
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.metrics")
     @patch("sentry.incidents.subscription_processor.logger")
     def test_snoozed_resolve_metrics_logging(
@@ -343,7 +339,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
             ]
         )
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.process_data_packet")
     def test_process_data_packet_called(self, mock_process_data_packet: MagicMock) -> None:
         rule = self.rule
@@ -359,7 +354,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         assert data_packet.source_id == str(self.sub.id)
         assert data_packet.packet.values == {"value": 10}
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.process_data_packet")
     @patch("sentry.incidents.subscription_processor.get_comparison_aggregation_value")
     def test_process_data_packet_not_called(
@@ -378,7 +372,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         )
         assert mock_process_data_packet.call_count == 0
 
-    @with_feature("organizations:workflow-engine-single-process-metric-issues")
     @patch("sentry.incidents.subscription_processor.process_data_packet")
     def test_single_processing_no_trigger(self, mock_process_data_packet: MagicMock) -> None:
         """
@@ -404,7 +397,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         assert data_packet.source_id == str(self.sub.id)
         assert data_packet.packet.values == {"value": trigger.alert_threshold + 1}
 
-    @with_feature("organizations:workflow-engine-single-process-metric-issues")
     @patch("sentry.incidents.subscription_processor.metrics")
     def test_process_update__single_processing__sends_metrics(self, mock_metric):
         # Replicate the rule to a detector
@@ -428,7 +420,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         # Ensure that single processing metric is sent
         mock_metric.incr.assert_any_call("incidents.workflow_engine.processing.single")
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.logger")
     def test_process_update__dual_processing__result_log(self, mock_logger):
         self.detector = self.create_detector(type=MetricIssue.slug)
@@ -457,7 +448,6 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
             },
         )
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.logger")
     def test_process_update__dual_processing__missing_detector(self, mock_logger: MagicMock):
         """
@@ -548,7 +538,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
     )
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_seer_call_dual_processing__warning(self, mock_seer_request: MagicMock) -> None:
         rule = self.dynamic_rule
         trigger = self.trigger
@@ -577,7 +566,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
     )
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_seer_call_dual_processing__critical(self, mock_seer_request: MagicMock) -> None:
         rule = self.dynamic_rule
         trigger = self.trigger
@@ -623,7 +611,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
     )
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_seer_call_dual_processing__resolution(self, mock_seer_request: MagicMock) -> None:
         rule = self.dynamic_rule
         trigger = self.trigger
@@ -678,7 +665,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
 
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
     @patch(
         "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
@@ -751,7 +737,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
 
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
     @patch(
         "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
@@ -810,7 +795,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
 
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
     @patch(
         "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
@@ -896,7 +880,6 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
 
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
     @patch(
         "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"

--- a/tests/sentry/incidents/test_charts.py
+++ b/tests/sentry/incidents/test_charts.py
@@ -129,7 +129,6 @@ class BuildMetricAlertChartTest(TestCase):
 class FetchOpenPeriodsTest(TestCase):
     @freeze_time(frozen_time)
     @with_feature("organizations:incidents")
-    @with_feature("organizations:workflow-engine-single-process-metric-issues")
     def test_get_incidents_from_detector(self) -> None:
         self.create_detector()  # dummy so detector ID != alert rule ID
         detector = self.create_detector(project=self.project)

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -2200,7 +2200,6 @@ class EnableDisableAlertRuleTest(TestCase, BaseIncidentsTest):
     def setUp(self) -> None:
         self.alert_rule = self.create_alert_rule()
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_enable(self) -> None:
         with self.tasks():
             disable_alert_rule(self.alert_rule)
@@ -2215,7 +2214,6 @@ class EnableDisableAlertRuleTest(TestCase, BaseIncidentsTest):
             for subscription in alert_rule.snuba_query.subscriptions.all():
                 assert subscription.status == QuerySubscription.Status.ACTIVE.value
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_disable(self) -> None:
         with self.tasks():
             disable_alert_rule(self.alert_rule)
@@ -2268,7 +2266,6 @@ class EnableDisableDetectorTest(TestCase, BaseIncidentsTest):
         for qs in query_subscriptions:
             assert qs.status == query_subscription_status
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_enable(self) -> None:
         with self.tasks():
             update_detector(detector=self.detector, enabled=False)
@@ -2280,14 +2277,12 @@ class EnableDisableDetectorTest(TestCase, BaseIncidentsTest):
 
         self.assert_detector_enabled_disabled(detector=self.detector, enabled=True)
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_disable(self) -> None:
         with self.tasks():
             update_detector(detector=self.detector, enabled=False)
 
         self.assert_detector_enabled_disabled(detector=self.detector, enabled=False)
 
-    @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_multiple_data_sources_enable_disable(self) -> None:
         with self.tasks():
             self.snuba_query = create_snuba_query(

--- a/tests/sentry/incidents/test_metric_issue_post_process.py
+++ b/tests/sentry/incidents/test_metric_issue_post_process.py
@@ -10,7 +10,6 @@ from sentry.models.group import Group
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.services import eventstore
 from sentry.tasks.post_process import post_process_group
-from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.features import Feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Detector
@@ -32,7 +31,6 @@ class MetricIssueIntegrationTest(BaseWorkflowTest, BaseMetricIssueTest):
             {
                 "organizations:issue-metric-issue-ingest": True,
                 "organizations:issue-metric-issue-post-process-group": True,
-                "organizations:workflow-engine-single-process-metric-issues": True,
             }
         ):
             yield
@@ -201,7 +199,6 @@ class MetricIssueIntegrationTest(BaseWorkflowTest, BaseMetricIssueTest):
         self.call_post_process_group(occurrence)
         assert mock_trigger.call_count == 2  # both actions
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_resolution_from_critical(self, mock_trigger: MagicMock) -> None:
         value = self.critical_detector_trigger.comparison + 1
         data_packet = self.create_subscription_packet(value)
@@ -232,7 +229,6 @@ class MetricIssueIntegrationTest(BaseWorkflowTest, BaseMetricIssueTest):
                 sample_rate=1.0,
             )
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_resolution_from_warning(self, mock_trigger: MagicMock) -> None:
         value = self.warning_detector_trigger.comparison + 1
         data_packet = self.create_subscription_packet(value)

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -15,7 +15,6 @@ from sentry.incidents.models.incident import IncidentActivityType, IncidentStatu
 from sentry.incidents.tasks import handle_trigger_action
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.alert_rule import TemporaryAlertRuleTriggerActionRegistry
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_kafka, requires_snuba
 
 pytestmark = [pytest.mark.sentry_metrics, requires_snuba, requires_kafka]
@@ -101,7 +100,6 @@ class HandleTriggerActionTest(TestCase):
                 notification_uuid=str(activity.notification_uuid),
             )
 
-    @with_feature("organizations:workflow-engine-single-process-metric-issues")
     def test_when_workflow_engine_is_enabled(self) -> None:
         with TemporaryAlertRuleTriggerActionRegistry.registry_patched():
             mock_handler = Mock()

--- a/tests/sentry/issues/test_ingest_incident_integration.py
+++ b/tests/sentry/issues/test_ingest_incident_integration.py
@@ -22,14 +22,12 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import with_feature
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 from sentry.workflow_engine.models import IncidentGroupOpenPeriod
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
 
-@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class IncidentGroupOpenPeriodIntegrationTest(TestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -18,7 +18,6 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
@@ -27,7 +26,6 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 )
 
 
-@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:
         self.create_models()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -18,7 +18,6 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
@@ -27,7 +26,6 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 )
 
 
-@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:
         self.create_models()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
@@ -18,7 +18,6 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
@@ -27,7 +26,6 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 )
 
 
-@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:
         self.create_models()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
@@ -15,7 +15,6 @@ from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import (
     OpsgenieMetricAlertHandler,
 )
-from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
@@ -24,7 +23,6 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 )
 
 
-@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:
         self.create_models()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
@@ -15,7 +15,6 @@ from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import (
     PagerDutyMetricAlertHandler,
 )
-from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
@@ -24,7 +23,6 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 )
 
 
-@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:
         self.create_models()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -19,7 +19,6 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
@@ -29,7 +28,6 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 )
 
 
-@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -18,7 +18,6 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import DetectorPriorityLevel, WorkflowEventData
@@ -27,7 +26,6 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 )
 
 
-@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
     def setUp(self) -> None:
         self.create_models()

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -37,7 +37,6 @@ from sentry.seer.anomaly_detection.types import (
 )
 from sentry.services.eventstore.models import GroupEvent
 from sentry.snuba.models import QuerySubscription, SnubaQuery
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 from sentry.types.group import PriorityLevel
@@ -498,7 +497,6 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         assert mock_send_alert.call_count == 0
 
     @mock.patch.object(TestHandler, "send_alert")
-    @with_feature("organizations:workflow-engine-single-process-metric-issues")
     def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
         # Create an Activity instance with evidence data and priority
         activity_data = asdict(self.evidence_data)
@@ -564,7 +562,6 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         assert isinstance(notification_uuid, str)
 
     @mock.patch.object(TestHandler, "send_alert")
-    @with_feature("organizations:workflow-engine-single-process-metric-issues")
     def test_invoke_legacy_registry_with_activity_anomaly_detection(
         self, mock_send_alert: mock.MagicMock
     ) -> None:
@@ -632,7 +629,6 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         assert organization == self.detector.project.organization
         assert isinstance(notification_uuid, str)
 
-    @with_feature("organizations:workflow-engine-single-process-metric-issues")
     def test_invoke_legacy_registry_activity_missing_data(self) -> None:
         # Test with Activity that has no data field
         activity = Activity.objects.create(
@@ -653,7 +649,6 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
                 event_data_with_activity, self.action, self.detector
             )
 
-    @with_feature("organizations:workflow-engine-single-process-metric-issues")
     def test_invoke_legacy_registry_activity_empty_data(self) -> None:
         # Test with Activity that has non-empty but insufficient data for MetricIssueEvidenceData
         activity = Activity(

--- a/tests/sentry/workflow_engine/models/test_incident_groupopenperiod.py
+++ b/tests/sentry/workflow_engine/models/test_incident_groupopenperiod.py
@@ -15,12 +15,10 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.workflow_engine.models import IncidentGroupOpenPeriod
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
 
-@with_feature("organizations:workflow-engine-single-process-metric-issues")
 class IncidentGroupOpenPeriodTest(TestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -95,7 +95,6 @@ class BaseWorkflowIntegrationTest(BaseWorkflowTest):
 
 
 class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_workflow_engine__data_source__to_metric_issue_workflow(self) -> None:
         """
         This test ensures that a data_source can create the correct event in Issue Platform
@@ -112,7 +111,6 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
 
             mock_producer.assert_called_once()
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_workflow_engine__data_source__different_type(self) -> None:
         with mock.patch(
             "sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka"
@@ -124,7 +122,6 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
             assert detectors == []
             mock_producer.assert_not_called()
 
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
     def test_workflow_engine__data_source__no_detectors(self) -> None:
         self.detector.delete()
 
@@ -142,7 +139,6 @@ class TestWorkflowEngineIntegrationToIssuePlatform(BaseWorkflowIntegrationTest):
 
 class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest):
     @with_feature("organizations:issue-metric-issue-post-process-group")
-    @with_feature("organizations:workflow-engine-process-metric-issue-workflows")
     def test_workflow_engine__workflows(self) -> None:
         """
         This test ensures that the workflow engine is correctly hooked up to tasks/post_process.py.

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -9,7 +9,6 @@ from sentry.issues.status_change_message import StatusChangeMessageData
 from sentry.models.activity import Activity
 from sentry.models.group import GroupStatus
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.handlers.workflow import workflow_status_update_handler
@@ -92,38 +91,7 @@ class WorkflowStatusUpdateHandlerTests(TestCase):
             workflow_status_update_handler(group, message, activity)
             mock_delay.assert_not_called()
 
-    @with_feature("organizations:workflow-engine-single-process-metric-issues")
-    def test_single_processing(self) -> None:
-        detector = self.create_detector(project=self.project)
-        group = self.create_group(project=self.project, type=MetricIssue.type_id)
-        activity = Activity(
-            project=self.project,
-            group=group,
-            type=ActivityType.SET_RESOLVED.value,
-            data={"fingerprint": ["test_fingerprint"]},
-        )
-        message = StatusChangeMessageData(
-            id="test_message_id",
-            project_id=self.project.id,
-            new_status=GroupStatus.RESOLVED,
-            new_substatus=None,
-            fingerprint=["test_fingerprint"],
-            detector_id=detector.id,
-            activity_data={"test": "test"},
-        )
-
-        with mock.patch(
-            "sentry.workflow_engine.tasks.workflows.process_workflow_activity.delay"
-        ) as mock_delay:
-            workflow_status_update_handler(group, message, activity)
-            mock_delay.assert_called_once_with(
-                activity_id=activity.id,
-                group_id=group.id,
-                detector_id=detector.id,
-            )
-
-    @with_feature("organizations:workflow-engine-metric-alert-processing")
-    def test_dual_processing(self) -> None:
+    def test_processing(self) -> None:
         detector = self.create_detector(project=self.project)
         group = self.create_group(project=self.project, type=MetricIssue.type_id)
         activity = Activity(
@@ -239,7 +207,6 @@ class TestProcessWorkflowActivity(TestCase):
 
         mock_filter_actions.assert_called_once_with({self.action_group}, expected_event_data)
 
-    @with_feature("organizations:workflow-engine-single-process-metric-issues")
     @mock.patch(
         "sentry.workflow_engine.models.incident_groupopenperiod.update_incident_based_on_open_period_status_change"
     )  # rollout code that is independently tested
@@ -284,8 +251,6 @@ class TestProcessWorkflowActivity(TestCase):
                 sample_rate=1.0,
             )
 
-    @with_feature("organizations:workflow-engine-single-process-metric-issues")
-    @with_feature("organizations:workflow-engine-process-metric-issue-workflows")
     @mock.patch("sentry.issues.status_change_consumer.get_group_from_fingerprint")
     @mock.patch(
         "sentry.workflow_engine.models.incident_groupopenperiod.update_incident_based_on_open_period_status_change"


### PR DESCRIPTION
Remove references in the code to the following flags:
- organizations:workflow-engine-single-process-metric-issues
- organizations:workflow-engine-metric-alert-processing
- organizations:workflow-engine-process-metric-issue-workflows
- organizations:workflow-engine-metric-alert-dual-write

Also set their default values to True in `temporary.py`.