### PR TITLE
fix(aci): Use correct value for match condition to allow saving action filters

### DIFF
--- a/static/app/views/automations/components/actionFilters/subfiltersList.tsx
+++ b/static/app/views/automations/components/actionFilters/subfiltersList.tsx
@@ -153,7 +153,7 @@ function ComparisonTypeField() {
       <AutomationBuilderSelect
         name={`${subfilter_id}.type`}
         aria-label={t('Comparison type')}
-        value={subfilter.type}
+        value={subfilter.type ?? ''}
         placeholder={t('Select value type')}
         options={[
           {
@@ -200,7 +200,7 @@ function AttributeField() {
       name={`${subfilter_id}.attribute`}
       aria-label={t('Attribute')}
       placeholder={t('Select attribute')}
-      value={subfilter.attribute}
+      value={subfilter.attribute ?? ''}
       options={Object.values(Attributes).map(attribute => ({
         value: attribute,
         label: attribute,
@@ -219,7 +219,7 @@ function KeyField() {
       name={`${subfilter_id}.key`}
       aria-label={t('Tag')}
       placeholder={t('tag')}
-      value={subfilter.key}
+      value={subfilter.key ?? ''}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({...subfilter, key: e.target.value});
         removeError();
@@ -234,7 +234,7 @@ function MatchField() {
     <AutomationBuilderSelect
       name={`${subfilter_id}.match`}
       aria-label={t('Match type')}
-      value={subfilter.match}
+      value={subfilter.match ?? ''}
       options={[
         {
           label: 'is',
@@ -259,7 +259,7 @@ function ValueField() {
       name={`${subfilter_id}.value`}
       aria-label={t('Value')}
       placeholder={t('value')}
-      value={`${subfilter.value}`}
+      value={`${subfilter.value ?? ''}`}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({...subfilter, value: e.target.value});
         removeError();

--- a/static/app/views/automations/components/actionFilters/taggedEvent.tsx
+++ b/static/app/views/automations/components/actionFilters/taggedEvent.tsx
@@ -37,7 +37,7 @@ function KeyField() {
     <AutomationBuilderInput
       name={`${condition_id}.comparison.key`}
       placeholder={t('tag')}
-      value={condition.comparison.key}
+      value={condition.comparison.key ?? ''}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({comparison: {...condition.comparison, key: e.target.value}});
         removeError(condition.id);
@@ -53,7 +53,7 @@ function MatchField() {
     <AutomationBuilderSelect
       name={`${condition_id}.comparison.match`}
       aria-label={t('Match type')}
-      value={condition.comparison.match}
+      value={condition.comparison.match ?? ''}
       options={MATCH_CHOICES}
       onChange={(value: SelectValue<MatchType>) => {
         onUpdate({comparison: {...condition.comparison, match: value.value}});
@@ -71,7 +71,7 @@ function ValueField() {
       name={`${condition_id}.comparison.value`}
       aria-label={t('Value')}
       placeholder={t('value')}
-      value={condition.comparison.value}
+      value={condition.comparison.value ?? ''}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({comparison: {...condition.comparison, value: e.target.value}});
         removeError(condition.id);

--- a/static/app/views/automations/components/actionFilters/taggedEvent.tsx
+++ b/static/app/views/automations/components/actionFilters/taggedEvent.tsx
@@ -56,7 +56,7 @@ function MatchField() {
       value={condition.comparison.match}
       options={MATCH_CHOICES}
       onChange={(value: SelectValue<MatchType>) => {
-        onUpdate({comparison: {...condition.comparison, match: value}});
+        onUpdate({comparison: {...condition.comparison, match: value.value}});
       }}
     />
   );

--- a/static/app/views/automations/components/actions/integrationField.tsx
+++ b/static/app/views/automations/components/actions/integrationField.tsx
@@ -11,7 +11,7 @@ export function IntegrationField() {
     <AutomationBuilderSelect
       name={`${actionId}.integrationId`}
       aria-label={t('Integration')}
-      value={action.integrationId}
+      value={action.integrationId ?? ''}
       options={integrations?.map(team => ({
         label: team.name,
         value: team.id,

--- a/static/app/views/automations/components/actions/slack.tsx
+++ b/static/app/views/automations/components/actions/slack.tsx
@@ -96,7 +96,7 @@ function NotesField() {
       name={`${actionId}.data.notes`}
       aria-label={t('Notes')}
       placeholder={t('example notes')}
-      value={action.data.notes}
+      value={action.data.notes ?? ''}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({
           data: {...action.data, notes: e.target.value},

--- a/static/app/views/automations/components/actions/tagsField.tsx
+++ b/static/app/views/automations/components/actions/tagsField.tsx
@@ -9,7 +9,7 @@ export function TagsField() {
       name={`${actionId}.data.tags`}
       aria-label={t('Tags')}
       placeholder={t('e.g., environment,my_tag')}
-      value={action.data.tags}
+      value={action.data.tags ?? ''}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({
           data: {...action.data, tags: e.target.value},

--- a/static/app/views/automations/components/actions/targetDisplayField.tsx
+++ b/static/app/views/automations/components/actions/targetDisplayField.tsx
@@ -12,7 +12,7 @@ export function TargetDisplayField({placeholder}: {placeholder?: string}) {
       name={`${actionId}.config.targetDisplay`}
       aria-label={t('Target')}
       placeholder={placeholder ? placeholder : t('channel name or ID')}
-      value={action.config.targetDisplay}
+      value={action.config.targetDisplay ?? ''}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({
           config: {
@@ -35,7 +35,7 @@ export function TargetIdentifierField({placeholder}: {placeholder?: string}) {
       name={`${actionId}.config.targetIdentifier`}
       aria-label={t('Target ID')}
       placeholder={placeholder}
-      value={action.config.targetIdentifier}
+      value={action.config.targetIdentifier ?? ''}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({
           config: {

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -82,6 +82,7 @@ export default function AutomationBuilder() {
         </Step>
         <DataConditionNodeList
           handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
+          label={t('Add trigger')}
           placeholder={t('Select a trigger...')}
           conditions={state.triggers.conditions}
           groupId={state.triggers.id}
@@ -192,6 +193,7 @@ function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
           )}
           <DataConditionNodeList
             handlerGroup={DataConditionHandlerGroupType.ACTION_FILTER}
+            label={t('Add filter')}
             placeholder={t('Any event')}
             groupId={actionFilter.id}
             conditions={actionFilter?.conditions || []}

--- a/static/app/views/automations/components/dataConditionNodeList.spec.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.spec.tsx
@@ -47,6 +47,7 @@ describe('DataConditionNodeList', () => {
     onDeleteRow: mockOnDeleteRow,
     placeholder: 'Any event',
     updateCondition: mockUpdateCondition,
+    label: 'Add condition',
   };
   const defaultConflictContextProps = {
     conflictingConditionGroups: {},

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -26,6 +26,7 @@ interface DataConditionNodeListProps {
   conditions: DataCondition[];
   groupId: string;
   handlerGroup: DataConditionHandlerGroupType;
+  label: string;
   onAddRow: (type: DataConditionType) => void;
   onDeleteRow: (id: string) => void;
   placeholder: string;
@@ -41,6 +42,7 @@ export default function DataConditionNodeList({
   handlerGroup,
   groupId,
   placeholder,
+  label,
   conditions,
   onAddRow,
   onDeleteRow,
@@ -166,7 +168,7 @@ export default function DataConditionNodeList({
         }}
         placeholder={placeholder}
         value={null}
-        aria-label={t('Add condition')}
+        aria-label={label}
       />
     </Fragment>
   );

--- a/static/app/views/automations/new-settings.spec.tsx
+++ b/static/app/views/automations/new-settings.spec.tsx
@@ -1,0 +1,169 @@
+import {AutomationFixture} from 'sentry-fixture/automations';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {
+  ActionHandlerFixture,
+  DataConditionHandlerFixture,
+} from 'sentry-fixture/workflowEngine';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import selectEvent from 'sentry-test/selectEvent';
+
+import {ActionGroup, ActionType} from 'sentry/types/workflowEngine/actions';
+import {
+  DataConditionHandlerGroupType,
+  DataConditionHandlerSubgroupType,
+  DataConditionType,
+} from 'sentry/types/workflowEngine/dataConditions';
+import AutomationNewSettings from 'sentry/views/automations/new-settings';
+
+describe('AutomationNewSettings', () => {
+  const organization = OrganizationFixture({features: ['workflow-engine-ui']});
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
+    // Available actions (include Slack with a default integration)
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/available-actions/`,
+      method: 'GET',
+      body: [
+        ActionHandlerFixture({
+          type: ActionType.SLACK,
+          handlerGroup: ActionGroup.NOTIFICATION,
+          integrations: [{id: '1', name: 'My Slack Workspace'}],
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/data-conditions/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({group: DataConditionHandlerGroupType.ACTION_FILTER}),
+      ],
+      body: [
+        DataConditionHandlerFixture({
+          handlerGroup: DataConditionHandlerGroupType.ACTION_FILTER,
+          handlerSubgroup: DataConditionHandlerSubgroupType.ISSUE_ATTRIBUTES,
+          type: DataConditionType.TAGGED_EVENT,
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/data-conditions/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({group: DataConditionHandlerGroupType.WORKFLOW_TRIGGER}),
+      ],
+      body: [
+        DataConditionHandlerFixture({
+          handlerGroup: DataConditionHandlerGroupType.WORKFLOW_TRIGGER,
+        }),
+      ],
+    });
+
+    // Users endpoint fetched by AutomationBuilder for member selectors
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      method: 'GET',
+      body: [],
+    });
+
+    // Detectors list used by EditConnectedMonitors inside the form
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/detectors/`,
+      method: 'GET',
+      body: [],
+    });
+
+    // Projects for EnvironmentSelector
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      method: 'GET',
+      body: [],
+    });
+  });
+
+  it('creates an automation from scratch and submits successfully', async () => {
+    const created = AutomationFixture({id: '123', name: 'New Automation'});
+    const post = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/`,
+      method: 'POST',
+      body: created,
+    });
+
+    const {router} = render(<AutomationNewSettings />, {organization});
+
+    // Add an action filter (tagged event)
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Add filter'}),
+      /tagged event/i
+    );
+    await userEvent.type(screen.getByRole('textbox', {name: 'Tag'}), 'env');
+    await userEvent.type(screen.getByRole('textbox', {name: 'Value'}), 'prod');
+
+    // Add an action to the block (Slack)
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Add action'}), 'Slack');
+    await userEvent.type(screen.getByRole('textbox', {name: 'Target'}), '#alerts');
+
+    // Submit the form
+    await userEvent.click(screen.getByRole('button', {name: 'Create Automation'}));
+
+    await waitFor(() =>
+      expect(post).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: {
+            name: 'New Automation',
+            triggers: {
+              logicType: 'any-short',
+              conditions: [
+                {type: 'first_seen_event', comparison: true, conditionResult: true},
+                {type: 'reappeared_event', comparison: true, conditionResult: true},
+                {type: 'regression_event', comparison: true, conditionResult: true},
+              ],
+              actions: [],
+            },
+            environment: null,
+            actionFilters: [
+              {
+                logicType: 'any-short',
+                conditions: [
+                  {
+                    type: 'tagged_event',
+                    comparison: {match: 'co', key: 'env', value: 'prod'},
+                    conditionResult: true,
+                  },
+                ],
+                actions: [
+                  {
+                    type: 'slack',
+                    config: {
+                      targetType: 'specific',
+                      targetIdentifier: '',
+                      targetDisplay: '#alerts',
+                    },
+                    integrationId: '1',
+                    data: {},
+                    status: 'active',
+                  },
+                ],
+              },
+            ],
+            config: {frequency: 1440},
+            detectorIds: [],
+            enabled: true,
+          },
+        })
+      )
+    );
+
+    // Assert navigation to details page
+    await waitFor(() =>
+      expect(router.location.pathname).toBe(
+        `/organizations/${organization.slug}/issues/automations/${created.id}/`
+      )
+    );
+  });
+});


### PR DESCRIPTION
This is the main fix, which allows the form to be saved:

<img width="1340" height="130" alt="CleanShot 2025-10-10 at 12 08 14@2x" src="https://github.com/user-attachments/assets/b8e10dd7-4074-4660-a288-110be4a9a537" />

I also added a test for saving a new automation, which required adding some default values to inputs in order to avoid the "switching from uncontrolled to controlled input" console errors.