### PR TITLE
chore(issues): Log warning instead of exception

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1222,7 +1222,7 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                         log_snuba_info("{}.err: {}".format(referrer, body["error"]))
             except ValueError:
                 if response.status != 200:
-                    logger.exception(
+                    logger.warning(
                         "snuba.query.invalid-json",
                         extra={"response.data": response.data},
                     )


### PR DESCRIPTION
We raise an exception when failing to parse a Snuba response, there is no need to also log an exception here since it otherwise results in 2 separate errors being logged for the same problem.

Fixes SENTRY-5AGR

See also SENTRY-5AGQ