### PR TITLE
fix(tracemetrics): Add yAxis to fields array

### DIFF
--- a/static/app/views/explore/metrics/metricPanel.tsx
+++ b/static/app/views/explore/metrics/metricPanel.tsx
@@ -52,7 +52,7 @@ export function MetricPanel({traceMetric}: MetricPanelProps) {
       search,
       yAxis: [visualize.yAxis],
       interval,
-      fields: [...groupBys],
+      fields: [...groupBys, visualize.yAxis],
       enabled: Boolean(traceMetric.name),
       topEvents,
       orderby: sortBys.map(formatSort),


### PR DESCRIPTION
Without it, the order by gets ignored and we don't update the timeseries request properly.