### PR TITLE
fix(sub v3): Don't show add-on sub-categories if not enabled

### DIFF
--- a/static/gsApp/views/subscriptionPage/usageOverview.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview.spec.tsx
@@ -172,8 +172,9 @@ describe('UsageOverview', () => {
     expect(
       screen.queryByRole('button', {name: 'Collapse Prevent details'})
     ).not.toBeInTheDocument();
-    expect(screen.queryByRole('cell', {name: 'Prevent Users'})).not.toBeInTheDocument();
-    expect(screen.queryByRole('cell', {name: 'Prevent Reviews'})).not.toBeInTheDocument();
+    // We test it this way to ensure we don't show the cell with the proper display name or the raw DataCategory
+    expect(screen.queryByRole('cell', {name: /Prevent*Users/})).not.toBeInTheDocument();
+    expect(screen.queryByRole('cell', {name: /Prevent*Reviews/})).not.toBeInTheDocument();
   });
 
   it('can open drawer for data categories but not add ons', async () => {


### PR DESCRIPTION
We want to show add-ons regardless of whether the customer has bought them, but we only wanna show the sub-categories if they've bought the add-on.