### PR TITLE
feat(tracemetrics): Add basic samples tab

### DIFF
--- a/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
@@ -1,0 +1,81 @@
+import {useMemo} from 'react';
+
+import type {NewQuery} from 'sentry/types/organization';
+import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
+import {
+  useQueryParamsSearch,
+  useQueryParamsSortBys,
+} from 'sentry/views/explore/queryParams/context';
+import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
+
+interface UseMetricSamplesTableOptions {
+  enabled: boolean;
+  fields: string[];
+  limit: number;
+  metricName: string;
+}
+
+interface MetricSamplesTableResult {
+  eventView: EventView;
+  fields: string[];
+  result: ReturnType<typeof useSpansQuery<any[]>>;
+}
+
+export function useMetricSamplesTable({
+  enabled,
+  limit,
+  metricName,
+  fields,
+}: UseMetricSamplesTableOptions) {
+  return useMetricSamplesTableImp({enabled, limit, metricName, fields});
+}
+
+function useMetricSamplesTableImp({
+  enabled,
+  limit,
+  metricName,
+  fields,
+}: UseMetricSamplesTableOptions): MetricSamplesTableResult {
+  const {selection} = usePageFilters();
+  const searchQuery = useQueryParamsSearch();
+  const sortBys = useQueryParamsSortBys();
+
+  const query = useMemo(() => {
+    const currentSearch = new MutableSearch(`metric.name:${metricName}`);
+    if (!searchQuery.isEmpty()) {
+      currentSearch.addStringFilter(searchQuery.formatString());
+    }
+    return currentSearch.formatString();
+  }, [metricName, searchQuery]);
+
+  const eventView = useMemo(() => {
+    const discoverQuery: NewQuery = {
+      id: undefined,
+      name: 'Explore - Metric Samples',
+      fields,
+      orderby: sortBys.map(formatSort),
+      query,
+      version: 2,
+      dataset: DiscoverDatasets.TRACEMETRICS,
+    };
+
+    return EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
+  }, [fields, query, selection, sortBys]);
+
+  const result = useSpansQuery({
+    enabled: enabled && Boolean(metricName),
+    eventView,
+    initialData: [],
+    limit,
+    referrer: 'api.explore.metric-samples-table',
+    trackResponseAnalytics: false,
+  });
+
+  return useMemo(() => {
+    return {eventView, fields, result};
+  }, [eventView, fields, result]);
+}

--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -1,39 +1,44 @@
 import styled from '@emotion/styled';
 
 import {TabList, TabPanels, TabStateProvider} from 'sentry/components/core/tabs';
-import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {t} from 'sentry/locale';
 import {AggregatesTab} from 'sentry/views/explore/metrics/metricInfoTabs/aggregatesTab';
+import {SamplesTab} from 'sentry/views/explore/metrics/metricInfoTabs/samplesTab';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
-
-enum MetricsInfoTab {
-  AGGREGATES = 'aggregates',
-  SAMPLES = 'samples',
-}
+import {
+  useQueryParamsMode,
+  useSetQueryParamsMode,
+} from 'sentry/views/explore/queryParams/context';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
 
 interface MetricInfoTabsProps {
   traceMetric: TraceMetric;
 }
 
 export default function MetricInfoTabs({traceMetric}: MetricInfoTabsProps) {
+  const queryParamsMode = useQueryParamsMode();
+  const setAggregatesMode = useSetQueryParamsMode();
   return (
-    <TabStateProvider<MetricsInfoTab> defaultValue={MetricsInfoTab.AGGREGATES}>
+    <TabStateProvider<Mode>
+      defaultValue={queryParamsMode}
+      onChange={mode => {
+        setAggregatesMode(mode);
+      }}
+    >
       <HeaderWrapper>
         <TabList>
-          <TabList.Item key={MetricsInfoTab.AGGREGATES}>{t('Aggregates')}</TabList.Item>
-          <TabList.Item key={MetricsInfoTab.SAMPLES}>{t('Samples')}</TabList.Item>
+          <TabList.Item key={Mode.AGGREGATE}>{t('Aggregates')}</TabList.Item>
+          <TabList.Item key={Mode.SAMPLES}>{t('Samples')}</TabList.Item>
         </TabList>
       </HeaderWrapper>
 
       <BodyContainer>
         <TabPanels>
-          <TabPanels.Item key={MetricsInfoTab.AGGREGATES}>
+          <TabPanels.Item key={Mode.AGGREGATE}>
             <AggregatesTab metricName={traceMetric.name} />
           </TabPanels.Item>
-          <TabPanels.Item key={MetricsInfoTab.SAMPLES}>
-            <EmptyStateWarning>
-              <p>{t('No samples data available')}</p>
-            </EmptyStateWarning>
+          <TabPanels.Item key={Mode.SAMPLES}>
+            <SamplesTab metricName={traceMetric.name} />
           </TabPanels.Item>
         </TabPanels>
       </BodyContainer>

--- a/static/app/views/explore/metrics/metricInfoTabs/samplesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/samplesTab.tsx
@@ -1,0 +1,205 @@
+import {useMemo, useRef} from 'react';
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
+
+import {Link} from 'sentry/components/core/link';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import LoadingMask from 'sentry/components/loadingMask';
+import type {Alignments} from 'sentry/components/tables/gridEditable/sortLink';
+import {GridBodyCell, GridHeadCell} from 'sentry/components/tables/gridEditable/styles';
+import {IconArrow} from 'sentry/icons/iconArrow';
+import {IconWarning} from 'sentry/icons/iconWarning';
+import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
+import {fieldAlignment} from 'sentry/utils/discover/fields';
+import {getShortEventId} from 'sentry/utils/events';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {
+  TableBody,
+  TableHead,
+  TableRow,
+  TableStatus,
+  useTableStyles,
+} from 'sentry/views/explore/components/table';
+import {useMetricSamplesTable} from 'sentry/views/explore/metrics/hooks/useMetricSamplesTable';
+import {Table} from 'sentry/views/explore/multiQueryMode/components/miniTable';
+import {
+  useQueryParamsSortBys,
+  useSetQueryParamsSortBys,
+} from 'sentry/views/explore/queryParams/context';
+import {FieldRenderer} from 'sentry/views/explore/tables/fieldRenderer';
+import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
+import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
+
+const TABLE_HEIGHT = 230;
+const RESULT_LIMIT = 50;
+
+interface SamplesTabProps {
+  metricName: string;
+}
+
+export function SamplesTab({metricName}: SamplesTabProps) {
+  const organization = useOrganization();
+  const location = useLocation();
+  const {selection} = usePageFilters();
+
+  const {result, eventView, fields} = useMetricSamplesTable({
+    enabled: Boolean(metricName),
+    limit: RESULT_LIMIT,
+    metricName,
+    fields: ['timestamp', 'trace', 'value'],
+  });
+
+  const columns = useMemo(() => eventView.getColumns(), [eventView]);
+  const sorts = useQueryParamsSortBys();
+  const setSorts = useSetQueryParamsSortBys();
+
+  const tableRef = useRef<HTMLTableElement>(null);
+  const {initialTableStyles} = useTableStyles(fields, tableRef, {
+    minimumColumnWidth: 50,
+  });
+
+  const meta = result.meta ?? {};
+
+  const fieldLabels: Record<string, string> = {
+    trace: t('Trace'),
+    value: t('Value'),
+    timestamp: t('Timestamp'),
+  };
+
+  return (
+    <TableContainer>
+      {result.isPending && <TransparentLoadingMask />}
+      <Table ref={tableRef} style={initialTableStyles} scrollable height={TABLE_HEIGHT}>
+        <TableHead>
+          <TableRow>
+            {fields.map((field, i) => {
+              const label = fieldLabels[field] ?? field;
+              const fieldType = meta.fields?.[field];
+              const align = fieldAlignment(field, fieldType);
+
+              const direction = sorts.find(s => s.field === field)?.kind;
+
+              function updateSort() {
+                const kind = direction === 'desc' ? 'asc' : 'desc';
+                setSorts([{field, kind}]);
+              }
+
+              return (
+                <TableHeadCell align={align} key={i} isFirst={i === 0}>
+                  <TableHeadCellContent align="center" gap="sm" onClick={updateSort}>
+                    <Tooltip showOnlyOnOverflow title={label}>
+                      {label}
+                    </Tooltip>
+                    {defined(direction) && (
+                      <IconArrow
+                        size="xs"
+                        direction={
+                          direction === 'desc'
+                            ? 'down'
+                            : direction === 'asc'
+                              ? 'up'
+                              : undefined
+                        }
+                      />
+                    )}
+                  </TableHeadCellContent>
+                </TableHeadCell>
+              );
+            })}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {result.isError ? (
+            <TableStatus>
+              <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
+            </TableStatus>
+          ) : result.data?.length ? (
+            result.data.map((row, i) => {
+              return (
+                <TableRow key={i}>
+                  {fields.map((field, j) => {
+                    if (field === 'trace') {
+                      const traceId = row.trace as string;
+                      const timestamp = row.timestamp as number;
+                      const target = getTraceDetailsUrl({
+                        organization,
+                        traceSlug: traceId,
+                        dateSelection: {
+                          start: selection.datetime.start,
+                          end: selection.datetime.end,
+                          statsPeriod: selection.datetime.period,
+                        },
+                        timestamp: timestamp / 1000,
+                        location,
+                        source: TraceViewSources.TRACES,
+                      });
+
+                      return (
+                        <StyledTableBodyCell key={j}>
+                          <Link to={target} style={{minWidth: '66px'}}>
+                            {getShortEventId(traceId)}
+                          </Link>
+                        </StyledTableBodyCell>
+                      );
+                    }
+                    return (
+                      <StyledTableBodyCell key={j}>
+                        <FieldRenderer
+                          column={columns[j]}
+                          data={row}
+                          unit={meta?.units?.[field]}
+                          meta={meta}
+                        />
+                      </StyledTableBodyCell>
+                    );
+                  })}
+                </TableRow>
+              );
+            })
+          ) : result.isPending ? (
+            <TableStatus>
+              <LoadingIndicator />
+            </TableStatus>
+          ) : (
+            <TableStatus>
+              <EmptyStateWarning>
+                <p>{t('No samples found')}</p>
+              </EmptyStateWarning>
+            </TableStatus>
+          )}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+const TableContainer = styled('div')`
+  position: relative;
+`;
+
+const StyledTableBodyCell = styled(GridBodyCell)`
+  font-size: ${p => p.theme.fontSize.sm};
+  min-height: 12px;
+`;
+
+const TableHeadCell = styled(GridHeadCell)<{align?: Alignments}>`
+  ${p => p.align && `justify-content: ${p.align};`}
+  font-size: ${p => p.theme.fontSize.sm};
+  height: 33px;
+`;
+
+const TableHeadCellContent = styled(Flex)`
+  cursor: pointer;
+  user-select: none;
+`;
+
+const TransparentLoadingMask = styled(LoadingMask)`
+  opacity: 0.4;
+  z-index: 1;
+`;

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -73,7 +73,7 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
     metric,
     queryParams: new ReadableQueryParams({
       extrapolate: true,
-      mode: Mode.AGGREGATE,
+      mode: json.mode,
       query,
 
       cursor: '',
@@ -100,6 +100,7 @@ export function encodeMetricQueryParams(metricQuery: BaseMetricQuery): string {
       return field;
     }),
     aggregateSortBys: metricQuery.queryParams.aggregateSortBys,
+    mode: metricQuery.queryParams.mode,
   });
 }
 

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -50,6 +50,7 @@ export function MetricsQueryParamsProvider({
         query: getUpdatedValue(writableQueryParams.query, defaultQuery),
         aggregateFields: writableQueryParams.aggregateFields,
         aggregateSortBys: writableQueryParams.aggregateSortBys,
+        mode: writableQueryParams.mode,
       });
 
       setQueryParams(newQueryParams);


### PR DESCRIPTION
It doesn't have any connected telemetry, but for now it just shows the latest traces along with timestamp, the trace ID, and value. It also persists the mode when you navigate to the tab.

<img width="548" height="396" alt="Screenshot 2025-10-10 at 4 18 48 PM" src="https://github.com/user-attachments/assets/d3f9e20c-fa28-4585-85fd-20d1e6234faf" />
