### PR TITLE
fix: Remove custom measurements from alerts wizard

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -297,8 +297,13 @@ class RuleConditionsForm extends PureComponent<Props, State> {
   }
 
   get transactionAlertDisabledMessage() {
-    return t(
-      'Transaction based alerts are no longer supported. Create span alerts instead.'
+    return tct(
+      'The transaction dataset is being deprecated. Please use Span alerts instead. Spans are a superset of transactions, you can isolate transactions by using the [code:is_transaction:true] filter. Please read these [FAQLink:FAQs] for more information.',
+      {
+        FAQLink: (
+          <ExternalLink href="https://sentry.zendesk.com/hc/en-us/articles/40366087871515-FAQ-Transactions-Spans-Migration" />
+        ),
+      }
     );
   }
 

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -297,7 +297,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
   }
 
   get transactionAlertDisabledMessage() {
-    return tct(
+    return tctCode(
       'The transaction dataset is being deprecated. Please use Span alerts instead. Spans are a superset of transactions, you can isolate transactions by using the [code:is_transaction:true] filter. Please read these [FAQLink:FAQs] for more information.',
       {
         FAQLink: (

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -663,16 +663,12 @@ describe('Incident Rules Form', () => {
 
       await userEvent.hover(screen.getAllByText('Throughput')[1]!);
       expect(
-        await screen.findByText(
-          'Transaction based alerts are no longer supported. Create span alerts instead.'
-        )
+        await screen.findByText(/The transaction dataset is being deprecated./)
       ).toBeInTheDocument();
 
       await userEvent.hover(screen.getByText('project-slug'));
       expect(
-        await screen.findByText(
-          'Transaction based alerts are no longer supported. Create span alerts instead.'
-        )
+        await screen.findByText(/The transaction dataset is being deprecated./)
       ).toBeInTheDocument();
 
       const radio = screen.getByRole('radio', {

--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -180,15 +180,19 @@ export default function WizardField({
           },
         ]
       : []),
-    {
-      label: t('CUSTOM'),
-      options: [
-        {
-          label: AlertWizardAlertNames.custom_transactions,
-          value: 'custom_transactions',
-        },
-      ],
-    },
+    ...((deprecateTransactionAlerts(organization)
+      ? []
+      : [
+          {
+            label: t('CUSTOM'),
+            options: [
+              {
+                label: AlertWizardAlertNames.custom_transactions,
+                value: 'custom_transactions',
+              },
+            ],
+          },
+        ]) as GroupedMenuOption[]),
   ];
 
   return (

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -182,10 +182,12 @@ export const getAlertWizardCategories = (org: Organization) => {
       options: ['crons_monitor'],
     });
 
-    result.push({
-      categoryHeading: t('Custom'),
-      options: ['custom_transactions'],
-    });
+    if (!deprecateTransactionAlerts(org)) {
+      result.push({
+        categoryHeading: t('Custom'),
+        options: ['custom_transactions'],
+      });
+    }
   }
   return result;
 };

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -71,6 +71,7 @@ export const DEPRECATED_TRANSACTION_ALERTS: AlertType[] = [
   'lcp',
   'fid',
   'cls',
+  'custom_transactions',
 ];
 
 export const DatasetMEPAlertQueryTypes: Record<

--- a/static/app/views/detectors/components/details/metric/transactionsDatasetWarning.tsx
+++ b/static/app/views/detectors/components/details/metric/transactionsDatasetWarning.tsx
@@ -1,6 +1,6 @@
 import {Alert} from 'sentry/components/core/alert';
 import {ExternalLink} from 'sentry/components/core/link';
-import {tct} from 'sentry/locale';
+import {tctCode} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 
 export function TransactionsDatasetWarning() {
@@ -14,10 +14,9 @@ export function TransactionsDatasetWarning() {
 
   return (
     <Alert type="warning">
-      {tct(
+      {tctCode(
         'The transaction dataset is being deprecated. Please use Span alerts instead. Spans are a superset of transactions, you can isolate transactions by using the [code:is_transaction:true] filter. Please read these [FAQLink:FAQs] for more information.',
         {
-          code: <code />,
           FAQLink: (
             <ExternalLink href="https://sentry.zendesk.com/hc/en-us/articles/40366087871515-FAQ-Transactions-Spans-Migration" />
           ),


### PR DESCRIPTION
These shouldn't be allowed if transaction deprecation is enabled