### PR TITLE
feat(eap): Add cross trace queries to the table endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -29,7 +29,7 @@ from sentry.exceptions import InvalidParams
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.search.eap.types import FieldsACL, SearchResolverConfig
+from sentry.search.eap.types import AdditionalQueries, FieldsACL, SearchResolverConfig
 from sentry.snuba import (
     discover,
     errors,
@@ -498,8 +498,11 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             scoped_query = request.GET.get("query")
             dashboard_widget_id = request.GET.get("dashboardWidgetId", None)
             discover_saved_query_id = request.GET.get("discoverSavedQueryId", None)
-            span_queries = request.GET.getlist("spanQueries")
-            ourlog_queries = request.GET.getlist("logQueries")
+            additional_queries = AdditionalQueries(
+                span=request.GET.getlist("spanQueries"),
+                log=request.GET.getlist("logQueries"),
+                metric=request.GET.getlist("metricQueries"),
+            )
 
             def get_rpc_config():
                 if scoped_dataset not in RPC_DATASETS:
@@ -550,8 +553,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                         config=config,
                         sampling_mode=snuba_params.sampling_mode,
                         page_token=page_token,
-                        span_queries=span_queries,
-                        ourlog_queries=ourlog_queries,
+                        additional_queries=additional_queries,
                     )
 
                 return EAPPageTokenPaginator(data_fn=flex_time_data_fn), EAPPageTokenCursor
@@ -571,8 +573,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                         referrer=referrer,
                         config=config,
                         sampling_mode=snuba_params.sampling_mode,
-                        span_queries=span_queries,
-                        ourlog_queries=ourlog_queries,
+                        additional_queries=additional_queries,
                     )
 
                 if save_discover_dataset_decision and discover_saved_query_id:

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -498,6 +498,8 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             scoped_query = request.GET.get("query")
             dashboard_widget_id = request.GET.get("dashboardWidgetId", None)
             discover_saved_query_id = request.GET.get("discoverSavedQueryId", None)
+            span_queries = request.GET.getlist("spanQueries")
+            ourlog_queries = request.GET.getlist("logQueries")
 
             def get_rpc_config():
                 if scoped_dataset not in RPC_DATASETS:
@@ -548,6 +550,8 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                         config=config,
                         sampling_mode=snuba_params.sampling_mode,
                         page_token=page_token,
+                        span_queries=span_queries,
+                        ourlog_queries=ourlog_queries,
                     )
 
                 return EAPPageTokenPaginator(data_fn=flex_time_data_fn), EAPPageTokenCursor
@@ -567,6 +571,8 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                         referrer=referrer,
                         config=config,
                         sampling_mode=snuba_params.sampling_mode,
+                        span_queries=span_queries,
+                        ourlog_queries=ourlog_queries,
                     )
 
                 if save_discover_dataset_decision and discover_saved_query_id:

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -66,3 +66,10 @@ class TraceItemAttribute(TypedDict):
 class EAPResponse(EventsResponse):
     confidence: ConfidenceData
     page_token: NotRequired[PageToken]
+
+
+@dataclass()
+class AdditionalQueries:
+    span: list[str] | None
+    log: list[str] | None
+    metric: list[str] | None

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -39,6 +39,8 @@ class OurLogs(rpc_dataset_common.RPCBase):
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
         debug: bool = False,
+        ourlog_queries: list[str] | None = None,
+        span_queries: list[str] | None = None,
     ) -> EAPResponse:
         """timestamp_precise is always displayed in the UI in lieu of timestamp but since the TraceItem table isn't a DateTime64
         so we need to always order by it regardless of what is actually passed to the orderby.
@@ -76,6 +78,8 @@ class OurLogs(rpc_dataset_common.RPCBase):
                     config=config,
                 ),
                 page_token=page_token,
+                ourlog_queries=ourlog_queries,
+                span_queries=span_queries,
             ),
             debug=debug,
         )

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -8,7 +8,7 @@ from sentry.search.eap import constants
 from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.sampling import handle_downsample_meta
-from sentry.search.eap.types import EAPResponse, SearchResolverConfig
+from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolverConfig
 from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
 from sentry.snuba import rpc_dataset_common
 from sentry.snuba.discover import zerofill
@@ -39,8 +39,7 @@ class OurLogs(rpc_dataset_common.RPCBase):
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
         debug: bool = False,
-        ourlog_queries: list[str] | None = None,
-        span_queries: list[str] | None = None,
+        additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         """timestamp_precise is always displayed in the UI in lieu of timestamp but since the TraceItem table isn't a DateTime64
         so we need to always order by it regardless of what is actually passed to the orderby.
@@ -78,8 +77,7 @@ class OurLogs(rpc_dataset_common.RPCBase):
                     config=config,
                 ),
                 page_token=page_token,
-                ourlog_queries=ourlog_queries,
-                span_queries=span_queries,
+                additional_queries=additional_queries,
             ),
             debug=debug,
         )

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -48,7 +48,13 @@ from sentry.search.eap.columns import (
 from sentry.search.eap.constants import DOUBLE, MAX_ROLLUP_POINTS, VALID_GRANULARITIES
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.sampling import handle_downsample_meta
-from sentry.search.eap.types import CONFIDENCES, ConfidenceData, EAPResponse, SearchResolverConfig
+from sentry.search.eap.types import (
+    CONFIDENCES,
+    AdditionalQueries,
+    ConfidenceData,
+    EAPResponse,
+    SearchResolverConfig,
+)
 from sentry.search.events.fields import get_function_alias, is_function
 from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaData, SnubaParams
 from sentry.snuba.discover import OTHER_KEY, create_groupby_dict, create_result_key
@@ -79,8 +85,7 @@ class TableQuery:
     equations: list[str] | None = None
     name: str | None = None
     page_token: PageToken | None = None
-    ourlog_queries: list[str] | None = None
-    span_queries: list[str] | None = None
+    additional_queries: AdditionalQueries | None = None
 
 
 @dataclass
@@ -145,6 +150,52 @@ class RPCBase:
         else:
             raise Exception(f"Unknown column type {type(column)}")
 
+    @classmethod
+    def get_cross_trace_queries(cls, query: TableQuery) -> list[TraceItemFilterWithType]:
+        from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
+        from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
+        from sentry.search.eap.trace_metrics.definitions import TRACE_METRICS_DEFINITIONS
+
+        if query.additional_queries is None:
+            return []
+
+        # resolve cross trace queries
+        # Copy the existing resolver, but we don't allow aggregate conditions for cross trace filters
+        cross_trace_config = replace(query.resolver.config, use_aggregate_conditions=False)
+
+        cross_trace_queries = []
+        for queries, definitions, item_type in [
+            (
+                query.additional_queries.log,
+                OURLOG_DEFINITIONS,
+                TraceItemType.TRACE_ITEM_TYPE_LOG,
+            ),
+            (query.additional_queries.span, SPAN_DEFINITIONS, TraceItemType.TRACE_ITEM_TYPE_SPAN),
+            (
+                query.additional_queries.metric,
+                TRACE_METRICS_DEFINITIONS,
+                TraceItemType.TRACE_ITEM_TYPE_METRIC,
+            ),
+        ]:
+            if queries is not None:
+                # Create a resolver for the subqueries
+                cross_resolver = SearchResolver(
+                    params=query.resolver.params,
+                    config=cross_trace_config,
+                    definitions=definitions,
+                )
+                for query_string in queries:
+                    # Having and VCCs aren't relevant from these queries
+                    cross_query_where, _, _ = cross_resolver.resolve_query(query_string)
+                    if cross_query_where is not None:
+                        cross_trace_queries.append(
+                            TraceItemFilterWithType(
+                                filter=cross_query_where,
+                                item_type=item_type,
+                            )
+                        )
+        return cross_trace_queries
+
     """ Table Methods """
 
     @classmethod
@@ -155,33 +206,7 @@ class RPCBase:
         meta = resolver.resolve_meta(referrer=query.referrer, sampling_mode=query.sampling_mode)
         where, having, query_contexts = resolver.resolve_query(query.query_string)
 
-        # resolve cross trace queries
-        # Copy the existing resolver, but we don't allow aggregate conditions for cross trace filters
-        cross_trace_config = replace(resolver.config, use_aggregate_conditions=False)
-        cross_trace_queries = []
-
-        from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
-        from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
-
-        for queries, definitions, item_type in [
-            (query.ourlog_queries, OURLOG_DEFINITIONS, TraceItemType.TRACE_ITEM_TYPE_LOG),
-            (query.span_queries, SPAN_DEFINITIONS, TraceItemType.TRACE_ITEM_TYPE_SPAN),
-        ]:
-            if queries is not None:
-                cross_resolver = SearchResolver(
-                    params=resolver.params,
-                    config=cross_trace_config,
-                    definitions=definitions,
-                )
-                for query_string in queries:
-                    cross_query_where, _, _ = cross_resolver.resolve_query(query_string)
-                    if cross_query_where is not None:
-                        cross_trace_queries.append(
-                            TraceItemFilterWithType(
-                                filter=cross_query_where,
-                                item_type=item_type,
-                            )
-                        )
+        cross_trace_queries = cls.get_cross_trace_queries(query)
 
         trace_column, _ = resolver.resolve_column("trace")
         if isinstance(trace_column, ResolvedAttribute) and has_top_level_trace_condition(
@@ -296,8 +321,7 @@ class RPCBase:
         equations: list[str] | None = None,
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
-        ourlog_queries: list[str] | None = None,
-        span_queries: list[str] | None = None,
+        additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         raise NotImplementedError()
 

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -42,6 +42,8 @@ class Spans(rpc_dataset_common.RPCBase):
         equations: list[str] | None = None,
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
+        ourlog_queries: list[str] | None = None,
+        span_queries: list[str] | None = None,
     ) -> EAPResponse:
         return cls._run_table_query(
             rpc_dataset_common.TableQuery(
@@ -55,6 +57,8 @@ class Spans(rpc_dataset_common.RPCBase):
                 sampling_mode=sampling_mode,
                 page_token=page_token,
                 resolver=search_resolver or cls.get_resolver(params, config),
+                ourlog_queries=ourlog_queries,
+                span_queries=span_queries,
             ),
             params.debug,
         )

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -11,7 +11,7 @@ from sentry.search.eap.constants import DOUBLE, INT, STRING
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.sampling import handle_downsample_meta
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
-from sentry.search.eap.types import EAPResponse, SearchResolverConfig
+from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolverConfig
 from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
 from sentry.snuba import rpc_dataset_common
 from sentry.snuba.discover import zerofill
@@ -42,8 +42,7 @@ class Spans(rpc_dataset_common.RPCBase):
         equations: list[str] | None = None,
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
-        ourlog_queries: list[str] | None = None,
-        span_queries: list[str] | None = None,
+        additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         return cls._run_table_query(
             rpc_dataset_common.TableQuery(
@@ -57,8 +56,7 @@ class Spans(rpc_dataset_common.RPCBase):
                 sampling_mode=sampling_mode,
                 page_token=page_token,
                 resolver=search_resolver or cls.get_resolver(params, config),
-                ourlog_queries=ourlog_queries,
-                span_queries=span_queries,
+                additional_queries=additional_queries,
             ),
             params.debug,
         )

--- a/src/sentry/snuba/trace_metrics.py
+++ b/src/sentry/snuba/trace_metrics.py
@@ -8,7 +8,7 @@ from sentry.search.eap import constants
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.sampling import handle_downsample_meta
 from sentry.search.eap.trace_metrics.definitions import TRACE_METRICS_DEFINITIONS
-from sentry.search.eap.types import EAPResponse, SearchResolverConfig
+from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolverConfig
 from sentry.search.events.types import SAMPLING_MODES, EventsMeta, SnubaParams
 from sentry.snuba import rpc_dataset_common
 from sentry.snuba.discover import zerofill
@@ -40,6 +40,8 @@ class TraceMetrics(rpc_dataset_common.RPCBase):
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
         debug: bool = False,
+        ourlog_queries: list[str] | None = None,
+        additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         """timestamp_precise is always displayed in the UI in lieu of timestamp but since the TraceItem table isn't a DateTime64
         so we need to always order by it regardless of what is actually passed to the orderby."""
@@ -68,6 +70,7 @@ class TraceMetrics(rpc_dataset_common.RPCBase):
                     config=config,
                 ),
                 page_token=page_token,
+                additional_queries=additional_queries,
             ),
             debug=debug,
         )

--- a/src/sentry/snuba/trace_metrics.py
+++ b/src/sentry/snuba/trace_metrics.py
@@ -40,7 +40,6 @@ class TraceMetrics(rpc_dataset_common.RPCBase):
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
         debug: bool = False,
-        ourlog_queries: list[str] | None = None,
         additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         """timestamp_precise is always displayed in the UI in lieu of timestamp but since the TraceItem table isn't a DateTime64

--- a/src/sentry/snuba/uptime_checks.py
+++ b/src/sentry/snuba/uptime_checks.py
@@ -4,7 +4,7 @@ import sentry_sdk
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken
 
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.types import EAPResponse, SearchResolverConfig
+from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolverConfig
 from sentry.search.eap.uptime_checks.definitions import UPTIME_CHECK_DEFINITIONS
 from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import rpc_dataset_common
@@ -33,6 +33,7 @@ class UptimeChecks(rpc_dataset_common.RPCBase):
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
         debug: bool = False,
+        additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         return cls._run_table_query(
             rpc_dataset_common.TableQuery(

--- a/src/sentry/snuba/uptime_results.py
+++ b/src/sentry/snuba/uptime_results.py
@@ -4,7 +4,7 @@ import sentry_sdk
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken
 
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.types import EAPResponse, SearchResolverConfig
+from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolverConfig
 from sentry.search.eap.uptime_results.definitions import UPTIME_RESULT_DEFINITIONS
 from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import rpc_dataset_common
@@ -33,6 +33,7 @@ class UptimeResults(rpc_dataset_common.RPCBase):
         search_resolver: SearchResolver | None = None,
         page_token: PageToken | None = None,
         debug: bool = False,
+        additional_queries: AdditionalQueries | None = None,
     ) -> EAPResponse:
         return cls._run_table_query(
             rpc_dataset_common.TableQuery(

--- a/tests/snuba/api/endpoints/test_organization_events_cross_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_cross_trace.py
@@ -1,0 +1,297 @@
+import uuid
+
+from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
+
+
+class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
+    def test_cross_trace_query_with_logs(self) -> None:
+        trace_id = uuid.uuid4().hex
+        excluded_trace_id = uuid.uuid4().hex
+        logs = [
+            self.create_ourlog(
+                {"body": "foo", "trace_id": trace_id},
+                timestamp=self.ten_mins_ago,
+            ),
+            self.create_ourlog(
+                {"body": "bar", "trace_id": excluded_trace_id},
+                timestamp=self.nine_mins_ago,
+            ),
+        ]
+        self.store_ourlogs(logs)
+        self.store_spans(
+            [
+                # only this event should show up since we'll filtered to trace_id
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "five"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "six"},
+                        "trace_id": excluded_trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["tags[foo]", "count()"],
+                "query": "description:baz",
+                "orderby": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+                "logQueries": ["message:foo"],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        assert response.data["data"][0]["tags[foo]"] == "five"
+
+    def test_cross_trace_query_with_spans(self) -> None:
+        trace_id = uuid.uuid4().hex
+        excluded_trace_id = uuid.uuid4().hex
+        self.store_spans(
+            [
+                # only this event should show up since we'll filtered to trace_id
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "five"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "boo",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "six"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "seven"},
+                        "trace_id": excluded_trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["tags[foo]", "count()"],
+                "query": "description:baz",
+                "orderby": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+                "spanQueries": ["tags[foo]:six"],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        assert response.data["data"][0]["tags[foo]"] == "five"
+
+    def test_cross_trace_query_with_spans_and_logs(self) -> None:
+        trace_id = uuid.uuid4().hex
+        excluded_trace_id = uuid.uuid4().hex
+        # Both of these traces will be valid
+        logs = [
+            self.create_ourlog(
+                {"body": "foo", "trace_id": trace_id},
+                timestamp=self.ten_mins_ago,
+            ),
+            self.create_ourlog(
+                {"body": "foo", "trace_id": excluded_trace_id},
+                timestamp=self.nine_mins_ago,
+            ),
+        ]
+        self.store_ourlogs(logs)
+        self.store_spans(
+            [
+                # only this event should show up since we'll filtered to trace_id
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "five"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                # we should only get this trace
+                self.create_span(
+                    {
+                        "description": "boo",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "six"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "seven"},
+                        "trace_id": excluded_trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["tags[foo]", "count()"],
+                "query": "description:baz",
+                "orderby": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+                "spanQueries": ["tags[foo]:six"],
+                "logsQueries": ["message:foo"],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        assert response.data["data"][0]["tags[foo]"] == "five"
+
+    def test_cross_trace_query_with_multiple_spans(self) -> None:
+        trace_id = uuid.uuid4().hex
+        excluded_trace_id = uuid.uuid4().hex
+        self.store_spans(
+            [
+                # only this event should show up since we'll filtered to trace_id
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "five"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                # we should only get this trace
+                self.create_span(
+                    {
+                        "description": "boo",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "six"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "bam",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "seven"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "eight"},
+                        "trace_id": excluded_trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["tags[foo]", "count()"],
+                "query": "description:baz",
+                "orderby": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+                "spanQueries": ["tags[foo]:six", "tags[foo]:seven"],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        assert response.data["data"][0]["tags[foo]"] == "five"
+
+    def test_cross_trace_qurey_with_multiple_logs(self) -> None:
+        trace_id = uuid.uuid4().hex
+        excluded_trace_id = uuid.uuid4().hex
+        logs = [
+            self.create_ourlog(
+                {"body": "foo", "trace_id": trace_id},
+                timestamp=self.ten_mins_ago,
+            ),
+            self.create_ourlog(
+                {"body": "faa", "trace_id": trace_id},
+                timestamp=self.ten_mins_ago,
+            ),
+            self.create_ourlog(
+                {"body": "bar", "trace_id": excluded_trace_id},
+                timestamp=self.nine_mins_ago,
+            ),
+        ]
+        self.store_ourlogs(logs)
+        self.store_spans(
+            [
+                # only this event should show up since we'll filtered to trace_id
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "five"},
+                        "trace_id": trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "baz",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "eight"},
+                        "trace_id": excluded_trace_id,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["tags[foo]", "count()"],
+                "query": "description:baz",
+                "orderby": "count()",
+                "project": self.project.id,
+                "dataset": "spans",
+                "logQueries": ["message:faa", "message:foo"],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        assert response.data["data"][0]["tags[foo]"] == "five"

--- a/tests/snuba/api/endpoints/test_organization_events_cross_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_cross_trace.py
@@ -168,7 +168,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
                 "project": self.project.id,
                 "dataset": "spans",
                 "spanQueries": ["tags[foo]:six"],
-                "logsQueries": ["message:foo"],
+                "logQueries": ["message:foo"],
             }
         )
 


### PR DESCRIPTION
- This adds the ability to pass multiple span or log queries to the table endpoint
- Open to other suggestions for how the params should be passed down, trying to get something reasonable up before I leave for vacation to unblock Nick
- Depends on https://github.com/getsentry/snuba/pull/7450 because we can't pass a single additional query currently, the snuba backend is assuming there's at least two