### PR TITLE
feat(ui): Stabilize page titles, remove layout props

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2965,7 +2965,6 @@ function buildRoutes(): RouteObject[] {
       legacyOrganizationRootRoutes,
       legacyOrgRedirects,
     ],
-    deprecatedRouteProps: true,
   };
 
   const legacyRedirectRoutes: SentryRouteObject = {

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -3138,7 +3138,16 @@ function buildRoutes(): RouteObject[] {
           authV2Routes,
           organizationRoutes,
           legacyRedirectRoutes,
-          {path: '*', component: errorHandler(RouteNotFound), deprecatedRouteProps: true},
+          {
+            path: '*',
+            component: errorHandler(OrganizationLayout),
+            children: [
+              {
+                path: '*',
+                component: errorHandler(RouteNotFound),
+              },
+            ],
+          },
         ],
       },
     ],

--- a/static/app/views/organizationLayout/index.spec.tsx
+++ b/static/app/views/organizationLayout/index.spec.tsx
@@ -47,14 +47,9 @@ describe('OrganizationLayout', () => {
       });
       OrganizationStore.onUpdate(organization);
 
-      render(
-        <OrganizationLayout>
-          <div />
-        </OrganizationLayout>,
-        {
-          organization,
-        }
-      );
+      render(<OrganizationLayout />, {
+        organization,
+      });
 
       expect(await screen.findByText('Deletion Scheduled')).toBeInTheDocument();
       expect(screen.getByLabelText('Restore Organization')).toBeInTheDocument();
@@ -75,14 +70,9 @@ describe('OrganizationLayout', () => {
       });
       OrganizationStore.onUpdate(organization);
 
-      render(
-        <OrganizationLayout>
-          <div />
-        </OrganizationLayout>,
-        {
-          organization,
-        }
-      );
+      render(<OrganizationLayout />, {
+        organization,
+      });
 
       expect(await screen.findByText('Deletion Scheduled')).toBeInTheDocument();
 
@@ -104,14 +94,9 @@ describe('OrganizationLayout', () => {
     });
     OrganizationStore.onUpdate(organization);
 
-    render(
-      <OrganizationLayout>
-        <div />
-      </OrganizationLayout>,
-      {
-        organization,
-      }
-    );
+    render(<OrganizationLayout />, {
+      organization,
+    });
 
     const inProgress = await screen.findByText(
       'currently in the process of being deleted from Sentry.',
@@ -132,11 +117,7 @@ describe('OrganizationLayout', () => {
       url: '/internal/health/',
     });
 
-    render(
-      <OrganizationLayout>
-        <div />
-      </OrganizationLayout>
-    );
+    render(<OrganizationLayout />);
 
     expect(
       await screen.findByText(/Celery workers have not checked in/)
@@ -160,9 +141,7 @@ describe('OrganizationLayout', () => {
 
       render(
         <OrganizationContext.Provider value={null}>
-          <OrganizationLayout>
-            <div />
-          </OrganizationLayout>
+          <OrganizationLayout />
         </OrganizationContext.Provider>
       );
 

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -1,4 +1,4 @@
-import {ScrollRestoration} from 'react-router-dom';
+import {Outlet, ScrollRestoration} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import DemoHeader from 'sentry/components/demo/demoHeader';
@@ -24,18 +24,11 @@ import {useReleasesDrawer} from 'sentry/views/releases/drawer/useReleasesDrawer'
 
 import OrganizationDetailsBody from './body';
 
-interface Props {
-  children: React.ReactNode;
-}
-
 const OrganizationHeader = HookOrDefault({
   hookName: 'component:organization-header',
 });
 
-function OrganizationLayout({children}: Props) {
-  useRouteAnalyticsHookSetup();
-  useRegisterDomainViewUsage();
-
+function OrganizationLayout() {
   // XXX(epurkhiser): The OrganizationContainer is responsible for ensuring the
   // oganization is loaded before rendering children. Organization may not be
   // loaded yet when this first renders.
@@ -45,9 +38,10 @@ function OrganizationLayout({children}: Props) {
 
   return (
     <SentryDocumentTitle noSuffix title={organization?.name ?? 'Sentry'}>
+      <GlobalAnalytics />
       <OrganizationContainer>
         <GlobalDrawer>
-          <AppLayout organization={organization}>{children}</AppLayout>
+          <AppLayout organization={organization} />
         </GlobalDrawer>
       </OrganizationContainer>
       <ScrollRestoration getKey={location => location.pathname} />
@@ -55,7 +49,7 @@ function OrganizationLayout({children}: Props) {
   );
 }
 
-interface LayoutProps extends Props {
+interface LayoutProps {
   organization: Organization | null;
 }
 
@@ -70,7 +64,7 @@ function AppDrawers() {
   return null;
 }
 
-function AppLayout({children, organization}: LayoutProps) {
+function AppLayout({organization}: LayoutProps) {
   return (
     <NavContextProvider>
       <AppContainer>
@@ -80,7 +74,9 @@ function AppLayout({children, organization}: LayoutProps) {
           <DemoHeader />
           <AppBodyContent>
             {organization && <OrganizationHeader organization={organization} />}
-            <OrganizationDetailsBody>{children}</OrganizationDetailsBody>
+            <OrganizationDetailsBody>
+              <Outlet />
+            </OrganizationDetailsBody>
           </AppBodyContent>
           <Footer />
         </BodyContainer>
@@ -88,6 +84,17 @@ function AppLayout({children, organization}: LayoutProps) {
       {organization ? <AppDrawers /> : null}
     </NavContextProvider>
   );
+}
+
+/**
+ * Pulled into its own component to avoid re-rendering the OrganizationLayout
+ * TODO: figure out why these analytics hooks trigger rerenders
+ */
+function GlobalAnalytics() {
+  useRouteAnalyticsHookSetup();
+  useRegisterDomainViewUsage();
+
+  return null;
 }
 
 const AppContainer = styled('div')`

--- a/static/app/views/routeNotFound.tsx
+++ b/static/app/views/routeNotFound.tsx
@@ -5,16 +5,13 @@ import NotFound from 'sentry/components/errors/notFound';
 import * as Layout from 'sentry/components/layouts/thirds';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useLastKnownRoute} from 'sentry/views/lastKnownRouteContextProvider';
-import OrganizationLayout from 'sentry/views/organizationLayout';
 
-type Props = RouteComponentProps;
-
-function RouteNotFound({location}: Props) {
+function RouteNotFound() {
   const navigate = useNavigate();
-  const {pathname, search, hash} = location;
+  const {pathname, search, hash} = useLocation();
   const lastKnownRoute = useLastKnownRoute();
   const isMissingSlash = pathname[pathname.length - 1] !== '/';
 
@@ -40,11 +37,9 @@ function RouteNotFound({location}: Props) {
 
   return (
     <SentryDocumentTitle title={t('Page Not Found')}>
-      <OrganizationLayout>
-        <Layout.Page withPadding>
-          <NotFound />
-        </Layout.Page>
-      </OrganizationLayout>
+      <Layout.Page withPadding>
+        <NotFound />
+      </Layout.Page>
     </SentryDocumentTitle>
   );
 }


### PR DESCRIPTION
When OrganizationLayout rerenders it was causing the document title to reset to "Sentry" sometimes overwriting the more accurate page title that was already rendered. Remove all rerendering by removing deprecated router props and moving global analytics into its own component
