### PR TITLE
chore: move and update alert deprecation message

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -91,6 +91,14 @@ def create_metric_alert(
         raise ResourceDoesNotExist
 
     data = deepcopy(request.data)
+
+    if features.has("organizations:discover-saved-queries-deprecation", organization) and data.get(
+        "dataset"
+    ) in ["generic_metrics", "transactions"]:
+        raise ValidationError(
+            "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. To expedite and re-enable edit functionality, use span-based alerts with the is_transaction:true filter instead."
+        )
+
     if project:
         data["projects"] = [project.slug]
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -96,7 +96,7 @@ def create_metric_alert(
         "dataset"
     ) in ["generic_metrics", "transactions"]:
         raise ValidationError(
-            "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. To expedite and re-enable edit functionality, use span-based alerts with the is_transaction:true filter instead."
+            "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. Create span-based alerts (`dataset=events_analytics_platform`) with the is_transaction:true filter instead."
         )
 
     if project:

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -96,7 +96,7 @@ def create_metric_alert(
         "dataset"
     ) in ["generic_metrics", "transactions"]:
         raise ValidationError(
-            "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. Create span-based alerts (`dataset=events_analytics_platform`) with the is_transaction:true filter instead."
+            "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. Create span-based alerts (dataset: events_analytics_platform) with the is_transaction:true filter instead."
         )
 
     if project:

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -352,13 +352,6 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
         return time_window_seconds
 
     def _validate_performance_dataset(self, dataset):
-        if features.has(
-            "organizations:discover-saved-queries-deprecation", self.context["organization"]
-        ):
-            raise serializers.ValidationError(
-                f"The {dataset.value} dataset is being deprecated. Please use the 'events_analytics_platform' dataset with the `is_transaction:true` filter instead."
-            )
-
         if dataset != Dataset.Transactions:
             return dataset
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -1716,7 +1716,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             resp = self.get_error_response(self.organization.slug, status_code=400, **data)
         assert (
             resp.data[0]
-            == "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. Create span-based alerts (`dataset=events_analytics_platform`) with the is_transaction:true filter instead."
+            == "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. Create span-based alerts (dataset: events_analytics_platform) with the is_transaction:true filter instead."
         )
 
     def test_generic_metrics_dataset_deprecation_validation(self) -> None:
@@ -1735,7 +1735,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             resp = self.get_error_response(self.organization.slug, status_code=400, **data)
         assert (
             resp.data[0]
-            == "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. Create span-based alerts (`dataset=events_analytics_platform`) with the is_transaction:true filter instead."
+            == "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. Create span-based alerts (dataset: events_analytics_platform) with the is_transaction:true filter instead."
         )
 
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -1715,7 +1715,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         ):
             resp = self.get_error_response(self.organization.slug, status_code=400, **data)
         assert (
-            resp.data["dataset"][0]
+            resp.data[0]
             == "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. Create span-based alerts (`dataset=events_analytics_platform`) with the is_transaction:true filter instead."
         )
 
@@ -1726,11 +1726,15 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         data["aggregate"] = "p95(transaction.duration)"
 
         with self.feature(
-            ["organizations:incidents", "organizations:discover-saved-queries-deprecation"]
+            [
+                "organizations:incidents",
+                "organizations:discover-saved-queries-deprecation",
+                "organizations:performance-view",
+            ]
         ):
             resp = self.get_error_response(self.organization.slug, status_code=400, **data)
         assert (
-            resp.data["dataset"][0]
+            resp.data[0]
             == "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. Create span-based alerts (`dataset=events_analytics_platform`) with the is_transaction:true filter instead."
         )
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -1716,7 +1716,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             resp = self.get_error_response(self.organization.slug, status_code=400, **data)
         assert (
             resp.data["dataset"][0]
-            == "The transactions dataset is being deprecated. Please use the 'events_analytics_platform' dataset with the `is_transaction:true` filter instead."
+            == "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. Create span-based alerts (`dataset=events_analytics_platform`) with the is_transaction:true filter instead."
         )
 
     def test_generic_metrics_dataset_deprecation_validation(self) -> None:
@@ -1731,7 +1731,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             resp = self.get_error_response(self.organization.slug, status_code=400, **data)
         assert (
             resp.data["dataset"][0]
-            == "The generic_metrics dataset is being deprecated. Please use the 'events_analytics_platform' dataset with the `is_transaction:true` filter instead."
+            == "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. Create span-based alerts (`dataset=events_analytics_platform`) with the is_transaction:true filter instead."
         )
 
 

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -196,7 +196,7 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
                 params,
                 {
                     "dataset": [
-                        "The transactions dataset is being deprecated. Please use the 'events_analytics_platform' dataset with the `is_transaction:true` filter instead."
+                        "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. To expedite and re-enable edit functionality, use span-based alerts with the is_transaction:true filter instead."
                     ]
                 },
             )
@@ -213,7 +213,7 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
                 params,
                 {
                     "dataset": [
-                        "The generic_metrics dataset is being deprecated. Please use the 'events_analytics_platform' dataset with the `is_transaction:true` filter instead."
+                        "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. To expedite and re-enable edit functionality, use span-based alerts with the is_transaction:true filter instead."
                     ]
                 },
             )

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -187,37 +187,6 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
             },
         )
 
-    def test_transactions_dataset_deprecation_validation(self) -> None:
-        """Test that transactions dataset is rejected when discover-saved-queries-deprecation flag is enabled"""
-        params = self.valid_transaction_params.copy()
-
-        with self.feature("organizations:discover-saved-queries-deprecation"):
-            self.run_fail_validation_test(
-                params,
-                {
-                    "dataset": [
-                        "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. To expedite and re-enable edit functionality, use span-based alerts with the is_transaction:true filter instead."
-                    ]
-                },
-            )
-
-    def test_generic_metrics_dataset_deprecation_validation(self) -> None:
-        """Test that generic_metrics dataset is rejected when discover-saved-queries-deprecation flag is enabled"""
-        params = self.valid_params.copy()
-        params["dataset"] = Dataset.PerformanceMetrics.value
-        params["event_types"] = [SnubaQueryEventType.EventType.TRANSACTION.name.lower()]
-        params["aggregate"] = "p95(transaction.duration)"
-
-        with self.feature("organizations:discover-saved-queries-deprecation"):
-            self.run_fail_validation_test(
-                params,
-                {
-                    "dataset": [
-                        "Creation of transaction-based alerts is disabled, as we migrate to the span dataset. To expedite and re-enable edit functionality, use span-based alerts with the is_transaction:true filter instead."
-                    ]
-                },
-            )
-
     def test_dataset(self) -> None:
         invalid_values = ["Invalid dataset, valid values are %s" % [item.value for item in Dataset]]
         self.run_fail_validation_test({"dataset": "events_wrong"}, {"dataset": invalid_values})


### PR DESCRIPTION
We still want to allow updating alert thresholds and assignments, so I'm pulling this out of the validator and into the create endpoint