### PR TITLE
fix(crons): Fix bug where we send invalid assignee for cron monitor

### DIFF
--- a/src/sentry/types/actor.py
+++ b/src/sentry/types/actor.py
@@ -297,8 +297,6 @@ class ActorOwned(Protocol):
 
 
 def parse_and_validate_actor(actor_identifier: str | None, organization_id: int) -> Actor | None:
-    from sentry.models.organizationmember import OrganizationMember
-    from sentry.models.team import Team
 
     if not actor_identifier:
         return None
@@ -309,6 +307,15 @@ def parse_and_validate_actor(actor_identifier: str | None, organization_id: int)
         raise serializers.ValidationError(
             "Could not parse actor. Format should be `type:id` where type is `team` or `user`."
         )
+
+    validate_actor(actor, organization_id)
+    return actor
+
+
+def validate_actor(actor: Actor, organization_id: int) -> None:
+    from sentry.models.organizationmember import OrganizationMember
+    from sentry.models.team import Team
+
     try:
         obj = actor.resolve()
     except Actor.InvalidActor:
@@ -322,5 +329,3 @@ def parse_and_validate_actor(actor_identifier: str | None, organization_id: int)
             organization_id=organization_id, user_id=obj.id
         ).exists():
             raise serializers.ValidationError("User is not a member of this organization")
-
-    return actor


### PR DESCRIPTION
If the owner for a cron leaves the org, we still send it across with the occurrence. This change detects the problem and repairs the monitor.

Fixes SENTRY-3VZ0
<!-- Describe your PR here. -->