### PR TITLE
feat(ui): Reset lazy load error state on hot reload

### DIFF
--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -78,6 +78,9 @@ class ErrorBoundary extends Component<{children: React.ReactNode}, ErrorBoundary
     if (process.env.NODE_ENV === 'development') {
       if (typeof module !== 'undefined' && module.hot) {
         module.hot.accept(this.handleRetry);
+
+        // Reset lazyload state itself on mount / hot replacement
+        this.handleRetry();
       }
     }
   }


### PR DESCRIPTION
Seeing lazy load itself sometimes hot reloads and preserves the error state, missing the component updates. Should always allow you to hot reload out of the error state.
