### PR TITLE
fix(aci): Display dataset on metric detectors

### DIFF
--- a/static/app/views/detectors/components/details/metric/detect.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
-import {Text} from 'sentry/components/core/text';
+import {Heading, Text} from 'sentry/components/core/text';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {
   FilterWrapper,
@@ -17,6 +17,7 @@ import type {
 import {getExactDuration} from 'sentry/utils/duration/getExactDuration';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
+import type {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 
 interface MetricDetectorDetectProps {
   detector: MetricDetector;
@@ -37,8 +38,12 @@ function SnubaQueryDetails({dataSource}: {dataSource: SnubaQueryDataSource}) {
 
   return (
     <Container>
+      <Flex gap="xs" align="center">
+        <Heading as="h4">{t('Dataset:')}</Heading>
+        <Value>{datasetConfig.name}</Value>
+      </Flex>
       <Flex direction="column" gap="xs">
-        <Heading>{t('Query:')}</Heading>
+        <Heading as="h4">{t('Query:')}</Heading>
         <Query>
           <Label>
             <Text variant="muted">{t('Visualize')}</Text>
@@ -67,10 +72,10 @@ function SnubaQueryDetails({dataSource}: {dataSource: SnubaQueryDataSource}) {
             </Fragment>
           )}
         </Query>
-      </Flex>
-      <Flex gap="xs" align="center">
-        <Heading>{t('Interval:')}</Heading>
-        <Value>{getExactDuration(dataSource.queryObj.snubaQuery.timeWindow)}</Value>
+        <Flex gap="xs" align="center">
+          <Heading as="h4">{t('Interval:')}</Heading>
+          <Value>{getExactDuration(dataSource.queryObj.snubaQuery.timeWindow)}</Value>
+        </Flex>
       </Flex>
     </Container>
   );
@@ -80,11 +85,6 @@ export function MetricDetectorDetailsDetect({detector}: MetricDetectorDetectProp
   const dataSource = detector.dataSources?.[0];
   return <SnubaQueryDetails dataSource={dataSource} />;
 }
-
-const Heading = styled('h4')`
-  font-size: ${p => p.theme.fontSize.md};
-  margin: 0;
-`;
 
 const Query = styled('dl')`
   display: grid;

--- a/static/app/views/detectors/components/details/metric/detect.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.tsx
@@ -38,11 +38,11 @@ function SnubaQueryDetails({dataSource}: {dataSource: SnubaQueryDataSource}) {
 
   return (
     <Container>
-      <Flex gap="xs" align="center">
-        <Heading as="h4">{t('Dataset:')}</Heading>
-        <Value>{datasetConfig.name}</Value>
-      </Flex>
-      <Flex direction="column" gap="xs">
+      <Flex direction="column" gap="md">
+        <Flex gap="xs" align="baseline">
+          <Heading as="h4">{t('Dataset:')}</Heading>
+          <Value>{datasetConfig.name}</Value>
+        </Flex>
         <Heading as="h4">{t('Query:')}</Heading>
         <Query>
           <Label>
@@ -72,7 +72,7 @@ function SnubaQueryDetails({dataSource}: {dataSource: SnubaQueryDataSource}) {
             </Fragment>
           )}
         </Query>
-        <Flex gap="xs" align="center">
+        <Flex gap="xs" align="baseline">
           <Heading as="h4">{t('Interval:')}</Heading>
           <Value>{getExactDuration(dataSource.queryObj.snubaQuery.timeWindow)}</Value>
         </Flex>
@@ -91,6 +91,7 @@ const Query = styled('dl')`
   grid-template-columns: auto minmax(0, 1fr);
   gap: ${p => p.theme.space.sm} ${p => p.theme.space.xs};
   margin: 0;
+  align-items: baseline;
 `;
 
 const Label = styled('dt')`

--- a/static/app/views/detectors/components/details/metric/detect.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.tsx
@@ -17,7 +17,6 @@ import type {
 import {getExactDuration} from 'sentry/utils/duration/getExactDuration';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
-import type {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 
 interface MetricDetectorDetectProps {
   detector: MetricDetector;

--- a/static/app/views/detectors/datasetConfig/base.tsx
+++ b/static/app/views/detectors/datasetConfig/base.tsx
@@ -107,6 +107,7 @@ export interface DetectorDatasetConfig<SeriesResponse> {
   getTimePeriods: (
     interval: MetricDetectorInterval
   ) => readonly MetricDetectorTimePeriod[];
+  name: string;
   /**
    * Extracts event types from the query string
    */

--- a/static/app/views/detectors/datasetConfig/errors.tsx
+++ b/static/app/views/detectors/datasetConfig/errors.tsx
@@ -1,3 +1,4 @@
+import {t} from 'sentry/locale';
 import type {SelectValue} from 'sentry/types/core';
 import type {EventsStats} from 'sentry/types/organization';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
@@ -74,6 +75,7 @@ const DEFAULT_FIELD: QueryFieldValue = {
 const DEFAULT_EVENT_TYPES = [EventTypes.ERROR, EventTypes.DEFAULT];
 
 export const DetectorErrorsConfig: DetectorDatasetConfig<ErrorsSeriesResponse> = {
+  name: t('Errors'),
   SearchBar: EventsSearchBar,
   defaultEventTypes: DEFAULT_EVENT_TYPES,
   defaultField: DEFAULT_FIELD,

--- a/static/app/views/detectors/datasetConfig/logs.tsx
+++ b/static/app/views/detectors/datasetConfig/logs.tsx
@@ -1,3 +1,4 @@
+import {t} from 'sentry/locale';
 import type {EventsStats} from 'sentry/types/organization';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {EventTypes} from 'sentry/views/alerts/rules/metric/types';
@@ -26,6 +27,7 @@ type LogsSeriesRepsonse = EventsStats;
 const DEFAULT_EVENT_TYPES = [EventTypes.TRACE_ITEM_LOG];
 
 export const DetectorLogsConfig: DetectorDatasetConfig<LogsSeriesRepsonse> = {
+  name: t('Logs'),
   SearchBar: TraceSearchBar,
   defaultEventTypes: DEFAULT_EVENT_TYPES,
   defaultField: LogsConfig.defaultField,

--- a/static/app/views/detectors/datasetConfig/releases.tsx
+++ b/static/app/views/detectors/datasetConfig/releases.tsx
@@ -1,3 +1,4 @@
+import {t} from 'sentry/locale';
 import type {SelectValue} from 'sentry/types/core';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {SessionField} from 'sentry/types/sessions';
@@ -100,6 +101,7 @@ const toApiAggregate = (aggregate: string) => {
 };
 
 export const DetectorReleasesConfig: DetectorDatasetConfig<ReleasesSeriesResponse> = {
+  name: t('Releases'),
   defaultField: DEFAULT_FIELD,
   defaultEventTypes: DEFAULT_EVENT_TYPES,
   getAggregateOptions: () => AGGREGATE_OPTIONS,

--- a/static/app/views/detectors/datasetConfig/spans.tsx
+++ b/static/app/views/detectors/datasetConfig/spans.tsx
@@ -1,3 +1,4 @@
+import {t} from 'sentry/locale';
 import type {EventsStats} from 'sentry/types/organization';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -27,6 +28,7 @@ type SpansSeriesResponse = EventsStats;
 const DEFAULT_EVENT_TYPES = [EventTypes.TRACE_ITEM_SPAN];
 
 export const DetectorSpansConfig: DetectorDatasetConfig<SpansSeriesResponse> = {
+  name: t('Spans'),
   SearchBar: TraceSearchBar,
   defaultEventTypes: DEFAULT_EVENT_TYPES,
   defaultField: SpansConfig.defaultField,

--- a/static/app/views/detectors/datasetConfig/transactions.tsx
+++ b/static/app/views/detectors/datasetConfig/transactions.tsx
@@ -1,3 +1,4 @@
+import {t} from 'sentry/locale';
 import type {SelectValue} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import type {EventsStats, Organization} from 'sentry/types/organization';
@@ -70,6 +71,7 @@ function getAggregateOptions(
 
 export const DetectorTransactionsConfig: DetectorDatasetConfig<TransactionsSeriesResponse> =
   {
+    name: t('Transactions'),
     SearchBar: TraceSearchBar,
     defaultEventTypes: DEFAULT_EVENT_TYPES,
     defaultField: TransactionsConfig.defaultField,


### PR DESCRIPTION
adds dataset above query, adjust line alignment

before

<img width="377" height="232" alt="image" src="https://github.com/user-attachments/assets/02f4cde9-fa53-40cd-970c-d99d292d6eb9" />


after

<img width="397" height="277" alt="image" src="https://github.com/user-attachments/assets/cd0cf204-ccd8-4298-a96e-5531bddf34f2" />
