### PR TITLE
fix(issues): Adjust line height of issue location

### DIFF
--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -226,6 +226,7 @@ const Location = styled('div')`
   font-size: ${p => p.theme.fontSize.sm};
   color: ${p => p.theme.subText};
   min-width: 10px;
+  line-height: 1.1;
   ${p => p.theme.overflowEllipsis};
 `;
 


### PR DESCRIPTION
Text slightly cut off. Seems like a half pixel issue.

see g in trigger

<img width="451" height="73" alt="image" src="https://github.com/user-attachments/assets/59c832d6-e054-4917-8f7f-e634cfb063d1" />

after

<img width="464" height="78" alt="image" src="https://github.com/user-attachments/assets/d8f15834-9542-4683-a059-68d1ff08abc5" />
