### PR TITLE
fix(crons): Fix race where we can create duplicate `DataSource` rows

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -176,8 +176,8 @@ def _ensure_monitor_with_config(
                 "is_upserting": True,
             },
         )
-        ensure_cron_detector(monitor)
         if created:
+            ensure_cron_detector(monitor)
             signal_monitor_created(project, None, True, monitor, None)
 
     # Update existing monitor


### PR DESCRIPTION
Since we ingest cron checkins at a high rate, we can end up in a race condition where we create duplicate `DataSource` rows. There's no unique constraint here currently, so we end up with duplicate rows.

We'll need to clean up the duplicates as well.

<!-- Describe your PR here. -->