### PR TITLE
chore(integrations): remove github-multi-org registration

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -577,8 +577,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:jira-paginated-projects", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable single trace summary
     manager.add("organizations:single-trace-summary", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable users to connect many Sentry orgs to a single Github org
-    manager.add("organizations:github-multi-org", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable seeing upsell modal when clicking upgrade for multi-org
     manager.add("organizations:github-multi-org-upsell-modal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables new checkout UI


### PR DESCRIPTION
Remove `github-multi-org`, since it isn't used. Removed from automator in https://github.com/getsentry/sentry-options-automator/pull/5422