### PR TITLE
chore(integrations): remove `jira-paginated-projects` flag usage

### DIFF
--- a/fixtures/integrations/jira/stub_client.py
+++ b/fixtures/integrations/jira/stub_client.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fixtures.integrations.stub_service import StubService
 from sentry.shared_integrations.exceptions import ApiError
 
@@ -22,6 +24,9 @@ class StubJiraApiClient(StubService):
 
     def get_versions(self, project_id):
         return self._get_stub_data("versions_response.json")
+
+    def get_projects_paginated(self, params: dict[str, Any] | None = None):
+        return self._get_stub_data("project_list_response.json")
 
     def get_projects_list(self, cached: bool = True):
         return self._get_stub_data("project_list_response.json")

--- a/fixtures/integrations/jira/stub_client.py
+++ b/fixtures/integrations/jira/stub_client.py
@@ -26,7 +26,7 @@ class StubJiraApiClient(StubService):
         return self._get_stub_data("versions_response.json")
 
     def get_projects_paginated(self, params: dict[str, Any] | None = None):
-        return self._get_stub_data("project_list_response.json")
+        return self._get_stub_data("projects_paginated.json")
 
     def get_projects_list(self, cached: bool = True):
         return self._get_stub_data("project_list_response.json")

--- a/fixtures/integrations/jira/stubs/projects_paginated.json
+++ b/fixtures/integrations/jira/stubs/projects_paginated.json
@@ -1,0 +1,58 @@
+{
+  "isLast": false,
+  "maxResults": 2,
+  "nextPage": "https://your-domain.atlassian.net/rest/api/3/project/search?startAt=2&maxResults=2",
+  "self": "https://your-domain.atlassian.net/rest/api/3/project/search?startAt=0&maxResults=2",
+  "startAt": 0,
+  "total": 7,
+  "values": [
+    {
+      "avatarUrls": {
+        "16x16": "https://your-domain.atlassian.net/secure/projectavatar?size=xsmall&pid=10000",
+        "24x24": "https://your-domain.atlassian.net/secure/projectavatar?size=small&pid=10000",
+        "32x32": "https://your-domain.atlassian.net/secure/projectavatar?size=medium&pid=10000",
+        "48x48": "https://your-domain.atlassian.net/secure/projectavatar?size=large&pid=10000"
+      },
+      "id": "10000",
+      "insight": {
+        "lastIssueUpdateTime": "2021-04-22T05:37:05.000+0000",
+        "totalIssueCount": 100
+      },
+      "key": "EX",
+      "name": "Example",
+      "projectCategory": {
+        "description": "First Project Category",
+        "id": "10000",
+        "name": "FIRST",
+        "self": "https://your-domain.atlassian.net/rest/api/3/projectCategory/10000"
+      },
+      "self": "https://your-domain.atlassian.net/rest/api/3/project/EX",
+      "simplified": false,
+      "style": "classic"
+    },
+    {
+      "avatarUrls": {
+        "16x16": "https://your-domain.atlassian.net/secure/projectavatar?size=xsmall&pid=10001",
+        "24x24": "https://your-domain.atlassian.net/secure/projectavatar?size=small&pid=10001",
+        "32x32": "https://your-domain.atlassian.net/secure/projectavatar?size=medium&pid=10001",
+        "48x48": "https://your-domain.atlassian.net/secure/projectavatar?size=large&pid=10001"
+      },
+      "id": "10001",
+      "insight": {
+        "lastIssueUpdateTime": "2021-04-22T05:37:05.000+0000",
+        "totalIssueCount": 100
+      },
+      "key": "ABC",
+      "name": "Alphabetical",
+      "projectCategory": {
+        "description": "First Project Category",
+        "id": "10000",
+        "name": "FIRST",
+        "self": "https://your-domain.atlassian.net/rest/api/3/projectCategory/10000"
+      },
+      "self": "https://your-domain.atlassian.net/rest/api/3/project/ABC",
+      "simplified": false,
+      "style": "classic"
+    }
+  ]
+}

--- a/src/sentry/integrations/jira/endpoints/search.py
+++ b/src/sentry/integrations/jira/endpoints/search.py
@@ -5,7 +5,6 @@ from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
@@ -87,9 +86,7 @@ class JiraSearchEndpoint(IntegrationEndpoint):
             users = [{"value": user_id, "label": display} for user_id, display in user_tuples]
             return Response(users)
 
-        if field == "project" and features.has(
-            "organizations:jira-paginated-projects", organization, actor=request.user
-        ):
+        if field == "project":
             try:
                 response = jira_client.get_projects_paginated(params={"query": query})
             except (ApiUnauthorized, ApiError):

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -793,13 +793,9 @@ class JiraIntegration(IssueSyncIntegration):
         project_id = params.get("project", defaults.get("project"))
         client = self.get_client()
         try:
-            jira_projects = (
-                client.get_projects_paginated({"maxResults": MAX_PER_PROJECT_QUERIES})["values"]
-                if features.has(
-                    "organizations:jira-paginated-projects", self.organization, actor=user
-                )
-                else client.get_projects_list()
-            )
+            jira_projects = client.get_projects_paginated({"maxResults": MAX_PER_PROJECT_QUERIES})[
+                "values"
+            ]
         except ApiError as e:
             logger.info(
                 "jira.get-create-issue-config.no-projects",
@@ -841,11 +837,10 @@ class JiraIntegration(IssueSyncIntegration):
             "updatesForm": True,
             "required": True,
         }
-        if features.has("organizations:jira-paginated-projects", self.organization, actor=user):
-            paginated_projects_url = reverse(
-                "sentry-extensions-jira-search", args=[self.organization.slug, self.model.id]
-            )
-            projects_form_field["url"] = paginated_projects_url
+        paginated_projects_url = reverse(
+            "sentry-extensions-jira-search", args=[self.organization.slug, self.model.id]
+        )
+        projects_form_field["url"] = paginated_projects_url
 
         fields = [
             projects_form_field,

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
@@ -13,7 +13,6 @@ from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.users.models.identity import Identity
 
@@ -134,7 +133,6 @@ class IssueOrganizationIntegrationDetailsGetTest(APITestCase):
         self.integration.add_organization(self.organization, self.user)
 
     @responses.activate
-    @with_feature("organizations:jira-paginated-projects")
     def test_serialize_organizationintegration_with_create_issue_config_for_jira(self) -> None:
         """Test the flow of choosing ticket creation on alert rule fire action
         then serializes the issue config correctly for Jira"""

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -28,7 +28,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, IntegrationTestCase
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.users.services.user.serial import serialize_rpc_user
@@ -215,7 +214,6 @@ class RegionJiraIntegrationTest(APITestCase):
             ]
 
     @responses.activate
-    @with_feature("organizations:jira-paginated-projects")
     def test_get_create_issue_config_with_none_issue(self) -> None:
         # Mock the paginated projects response
         responses.add(
@@ -277,7 +275,6 @@ class RegionJiraIntegrationTest(APITestCase):
         assert project_field["type"] == "select"
 
     @responses.activate
-    @with_feature("organizations:jira-paginated-projects")
     def test_get_create_issue_config_paginated_projects(self) -> None:
         """Test that projects are fetched using pagination when the feature flag is enabled"""
         event = self.store_event(

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -119,6 +119,7 @@ class RegionJiraIntegrationTest(APITestCase):
                     "choices": [("10000", "EX - Example"), ("10001", "ABC - Alphabetical")],
                     "label": "Jira Project",
                     "type": "select",
+                    "url": search_url,
                     "required": True,
                 },
                 {
@@ -509,6 +510,10 @@ class RegionJiraIntegrationTest(APITestCase):
                 "type": "select",
                 "name": "project",
                 "label": "Jira Project",
+                "url": reverse(
+                    "sentry-extensions-jira-search",
+                    args=[self.organization.slug, self.integration.id],
+                ),
                 "updatesForm": True,
                 "required": True,
             }
@@ -543,6 +548,10 @@ class RegionJiraIntegrationTest(APITestCase):
                 "type": "select",
                 "name": "project",
                 "label": "Jira Project",
+                "url": reverse(
+                    "sentry-extensions-jira-search",
+                    args=[self.organization.slug, self.integration.id],
+                ),
                 "updatesForm": True,
                 "required": True,
             }
@@ -593,6 +602,10 @@ class RegionJiraIntegrationTest(APITestCase):
                 "type": "select",
                 "name": "project",
                 "label": "Jira Project",
+                "url": reverse(
+                    "sentry-extensions-jira-search",
+                    args=[self.organization.slug, self.integration.id],
+                ),
                 "updatesForm": True,
                 "required": True,
             }

--- a/tests/sentry/integrations/jira/test_search_endpoint.py
+++ b/tests/sentry/integrations/jira/test_search_endpoint.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 
 from fixtures.integrations.stub_service import StubService
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test
 
 
@@ -184,7 +183,6 @@ class JiraSearchEndpointTest(APITestCase):
         }
 
     @responses.activate
-    @with_feature("organizations:jira-paginated-projects")
     def test_project_search_with_pagination(self) -> None:
         responses.add(
             responses.GET,
@@ -210,7 +208,6 @@ class JiraSearchEndpointTest(APITestCase):
         ]
 
     @responses.activate
-    @with_feature("organizations:jira-paginated-projects")
     def test_project_search_error_with_pagination(self) -> None:
         responses.add(
             responses.GET,


### PR DESCRIPTION
`jira-paginated-projects` has been fully rolled out for a few months, so we can clean it up. Had to add a new mock for the jira paginated project endpoint found [here](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/#api-rest-api-3-project-search-get).