### PR TITLE
fix(ui2): make NavigationTourReminder wrap the trigger

### DIFF
--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -45,6 +45,7 @@ interface SidebarItemDropdownProps {
   children?: React.ReactNode;
   disableTooltip?: boolean;
   onOpen?: MouseEventHandler<HTMLButtonElement>;
+  triggerWrap?: React.ComponentType<{children: React.ReactNode}>;
 }
 
 interface SidebarButtonProps {
@@ -114,6 +115,7 @@ export function SidebarMenu({
   label,
   onOpen,
   disableTooltip,
+  triggerWrap: TriggerWrap = Fragment,
 }: SidebarItemDropdownProps) {
   const theme = useTheme();
   // This component can be rendered without an organization in some cases
@@ -134,28 +136,30 @@ export function SidebarMenu({
             showLabel={showLabel}
             disableTooltip={disableTooltip}
           >
-            <NavButton
-              {...props}
-              aria-label={showLabel ? undefined : label}
-              onClick={event => {
-                if (organization) {
-                  recordPrimaryItemClick(analyticsKey, organization);
+            <TriggerWrap>
+              <NavButton
+                {...props}
+                aria-label={showLabel ? undefined : label}
+                onClick={event => {
+                  if (organization) {
+                    recordPrimaryItemClick(analyticsKey, organization);
+                  }
+                  props.onClick?.(event);
+                  onOpen?.(event);
+                }}
+                isMobile={layout === NavLayout.MOBILE}
+                icon={
+                  showLabel ? (
+                    <SidebarItemIcon layout={layout}>{children}</SidebarItemIcon>
+                  ) : null
                 }
-                props.onClick?.(event);
-                onOpen?.(event);
-              }}
-              isMobile={layout === NavLayout.MOBILE}
-              icon={
-                showLabel ? (
-                  <SidebarItemIcon layout={layout}>{children}</SidebarItemIcon>
-                ) : null
-              }
-            >
-              {theme.isChonk ? null : (
-                <InteractionStateLayer hasSelectedBackground={isOpen} />
-              )}
-              {showLabel ? label : children}
-            </NavButton>
+              >
+                {theme.isChonk ? null : (
+                  <InteractionStateLayer hasSelectedBackground={isOpen} />
+                )}
+                {showLabel ? label : children}
+              </NavButton>
+            </TriggerWrap>
           </SidebarItem>
         );
       }}

--- a/static/app/views/nav/primary/help.tsx
+++ b/static/app/views/nav/primary/help.tsx
@@ -62,111 +62,110 @@ export function PrimaryNavigationHelp() {
   const chonkPrompt = useChonkPrompt();
 
   return (
-    <StackedNavigationTourReminder>
-      <SidebarMenu
-        onOpen={() => {
-          chonkPrompt.dismissDotIndicatorPrompt();
-          chonkPrompt.dismissBannerPrompt();
-        }}
-        items={[
-          {
-            key: 'search',
-            label: t('Search support, docs and more'),
-            onAction() {
-              openHelpSearchModal({organization});
+    <SidebarMenu
+      triggerWrap={StackedNavigationTourReminder}
+      onOpen={() => {
+        chonkPrompt.dismissDotIndicatorPrompt();
+        chonkPrompt.dismissBannerPrompt();
+      }}
+      items={[
+        {
+          key: 'search',
+          label: t('Search support, docs and more'),
+          onAction() {
+            openHelpSearchModal({organization});
+          },
+        },
+        {
+          key: 'resources',
+          label: t('Resources'),
+          children: [
+            {
+              key: 'help-center',
+              label: t('Help Center'),
+              externalHref: 'https://sentry.zendesk.com/hc/en-us',
             },
-          },
-          {
-            key: 'resources',
-            label: t('Resources'),
-            children: [
-              {
-                key: 'help-center',
-                label: t('Help Center'),
-                externalHref: 'https://sentry.zendesk.com/hc/en-us',
+            {
+              key: 'docs',
+              label: t('Documentation'),
+              externalHref: 'https://docs.sentry.io',
+            },
+          ],
+        },
+        {
+          key: 'help',
+          label: t('Get Help'),
+          children: [
+            ...(contactSupportItem ? [contactSupportItem] : []),
+            {
+              key: 'github',
+              label: t('Sentry on GitHub'),
+              externalHref: 'https://github.com/getsentry/sentry/issues',
+            },
+            {
+              key: 'discord',
+              label: t('Join our Discord'),
+              externalHref: 'https://discord.com/invite/sentry',
+            },
+          ],
+        },
+        {
+          key: 'actions',
+          children: [
+            {
+              key: 'give-feedback',
+              label: t('Give feedback'),
+              onAction() {
+                openForm?.({
+                  tags: {
+                    ['feedback.source']: 'navigation_sidebar',
+                  },
+                });
               },
-              {
-                key: 'docs',
-                label: t('Documentation'),
-                externalHref: 'https://docs.sentry.io',
+              hidden: !openForm,
+            },
+            {
+              key: 'tour',
+              label: t('Tour the new navigation'),
+              onAction() {
+                startTour();
               },
-            ],
-          },
-          {
-            key: 'help',
-            label: t('Get Help'),
-            children: [
-              ...(contactSupportItem ? [contactSupportItem] : []),
-              {
-                key: 'github',
-                label: t('Sentry on GitHub'),
-                externalHref: 'https://github.com/getsentry/sentry/issues',
-              },
-              {
-                key: 'discord',
-                label: t('Join our Discord'),
-                externalHref: 'https://discord.com/invite/sentry',
-              },
-            ],
-          },
-          {
-            key: 'actions',
-            children: [
-              {
-                key: 'give-feedback',
-                label: t('Give feedback'),
-                onAction() {
-                  openForm?.({
-                    tags: {
-                      ['feedback.source']: 'navigation_sidebar',
+            },
+            organization?.features?.includes('chonk-ui')
+              ? user.options.prefersChonkUI
+                ? {
+                    key: 'new-chonk-ui',
+                    label: t('Switch back to our old look'),
+                    onAction() {
+                      mutateUserOptions({prefersChonkUI: false});
+                      trackAnalytics('navigation.help_menu_opt_out_chonk_ui_clicked', {
+                        organization,
+                      });
                     },
-                  });
-                },
-                hidden: !openForm,
-              },
-              {
-                key: 'tour',
-                label: t('Tour the new navigation'),
-                onAction() {
-                  startTour();
-                },
-              },
-              organization?.features?.includes('chonk-ui')
-                ? user.options.prefersChonkUI
-                  ? {
-                      key: 'new-chonk-ui',
-                      label: t('Switch back to our old look'),
-                      onAction() {
-                        mutateUserOptions({prefersChonkUI: false});
-                        trackAnalytics('navigation.help_menu_opt_out_chonk_ui_clicked', {
-                          organization,
-                        });
-                      },
-                    }
-                  : {
-                      key: 'new-chonk-ui',
-                      label: (
-                        <Fragment>
-                          {t('Try our new look')} <FeatureBadge type="beta" />
-                        </Fragment>
-                      ),
-                      textValue: 'Try our new look',
-                      onAction() {
-                        mutateUserOptions({prefersChonkUI: true});
-                        trackAnalytics('navigation.help_menu_opt_in_chonk_ui_clicked', {
-                          organization,
-                        });
-                      },
-                    }
-                : null,
-            ].filter(n => !!n),
-          },
-        ]}
-        analyticsKey="help"
-        label={t('Help')}
-      >
-        <IconQuestion />
-      </SidebarMenu>
-    </StackedNavigationTourReminder>
+                  }
+                : {
+                    key: 'new-chonk-ui',
+                    label: (
+                      <Fragment>
+                        {t('Try our new look')} <FeatureBadge type="beta" />
+                      </Fragment>
+                    ),
+                    textValue: 'Try our new look',
+                    onAction() {
+                      mutateUserOptions({prefersChonkUI: true});
+                      trackAnalytics('navigation.help_menu_opt_in_chonk_ui_clicked', {
+                        organization,
+                      });
+                    },
+                  }
+              : null,
+          ].filter(n => !!n),
+        },
+      ]}
+      analyticsKey="help"
+      label={t('Help')}
+    >
+      <IconQuestion />
+    </SidebarMenu>
   );
 }


### PR DESCRIPTION
instead of wrapping the whole Menu, as that doesn't look good in UI2. It makes no difference in UI1

note: the diff looks huge but it’s all just whitespace changes 😅 . View with:

https://github.com/getsentry/sentry/pull/101405/files?w=1

| before | after |
|--------|--------|
| <img width="784" height="485" alt="Screenshot 2025-10-13 at 13 50 14" src="https://github.com/user-attachments/assets/6083ab86-b14a-402c-8d79-6eb1f9533c9d" /> | <img width="641" height="485" alt="Screenshot 2025-10-13 at 13 47 14" src="https://github.com/user-attachments/assets/4222bc54-ca2b-47d1-89eb-3ecb9cc7fd5f" /> |
| <img width="784" height="485" alt="Screenshot 2025-10-13 at 13 50 06" src="https://github.com/user-attachments/assets/e1a66480-46c3-494d-8dad-6a47cc116071" /> | <img width="641" height="485" alt="Screenshot 2025-10-13 at 13 47 07" src="https://github.com/user-attachments/assets/09cc915c-3a79-4a4a-a091-e70ce0e7bf28" /> | 