### PR TITLE
fix: skip acceptance test in test_organization_global_selection_header

### DIFF
--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -82,7 +82,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
 
         self.browser.click('[data-test-id="page-filter-timerange-selector"]')
 
-    @pytest.mark.xfail(reason="Failed in CI consistently in unrelated PRs")
+    @pytest.mark.skip(reason="Failed in CI consistently in unrelated PRs")
     def test_global_selection_header_navigates_with_browser_back_button(self) -> None:
         """
         Global Selection Header should:

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.utils import timezone as django_timezone
 
 from fixtures.page_objects.issue_details import IssueDetailsPage
@@ -81,6 +82,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
 
         self.browser.click('[data-test-id="page-filter-timerange-selector"]')
 
+    @pytest.mark.xfail(reason="Failed in CI consistently in unrelated PRs")
     def test_global_selection_header_navigates_with_browser_back_button(self) -> None:
         """
         Global Selection Header should:


### PR DESCRIPTION
- Test fails consistently in https://github.com/getsentry/sentry/actions/runs/18458345915/job/52583964269

- It was previously skipped for flakiness, but un-skipped 3 weeks ago: https://github.com/getsentry/sentry/pull/99847