### PR TITLE
fix(ui): allow display:none on Container

### DIFF
--- a/static/app/components/core/alert/alert.tsx
+++ b/static/app/components/core/alert/alert.tsx
@@ -4,6 +4,8 @@ import styled from '@emotion/styled';
 import {useHover} from '@react-aria/interactions';
 import classNames from 'classnames';
 
+import type {DistributiveOmit} from '@sentry/scraps/types';
+
 import {Button, type ButtonProps} from 'sentry/components/core/button';
 import {IconCheckmark, IconChevron, IconInfo, IconNot, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -325,10 +327,6 @@ const Container = styled('div')`
 `;
 
 Alert.Container = Container;
-
-type DistributiveOmit<TObject, TKey extends keyof TObject> = TObject extends unknown
-  ? Omit<TObject, TKey>
-  : never;
 
 function AlertButton(props: DistributiveOmit<ButtonProps, 'size'>) {
   const theme = useTheme();

--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -22,7 +22,14 @@ import {
 interface ContainerLayoutProps {
   background?: Responsive<keyof Theme['tokens']['background']>;
   display?: Responsive<
-    'block' | 'inline' | 'inline-block' | 'flex' | 'inline-flex' | 'grid' | 'inline-grid'
+    | 'block'
+    | 'inline'
+    | 'inline-block'
+    | 'flex'
+    | 'inline-flex'
+    | 'grid'
+    | 'inline-grid'
+    | 'none'
   >;
 
   padding?: Responsive<Shorthand<SpacingSize, 4>>;

--- a/static/app/components/core/layout/flex.spec.tsx
+++ b/static/app/components/core/layout/flex.spec.tsx
@@ -1,8 +1,10 @@
 import React, {createRef} from 'react';
+import {expectTypeOf} from 'expect-type';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Flex} from 'sentry/components/core/layout/flex';
+import {Flex, type FlexProps} from 'sentry/components/core/layout/flex';
+import type {Responsive} from 'sentry/components/core/layout/styles';
 
 describe('Flex', () => {
   it('renders children', () => {
@@ -106,5 +108,14 @@ describe('Flex', () => {
     const paddingFirst = screen.getByText('Padding First').className;
     const paddingBottomFirst = screen.getByText('PaddingBottom First').className;
     expect(paddingFirst).toEqual(paddingBottomFirst);
+  });
+
+  describe('types', () => {
+    it('has a limited display prop', () => {
+      const props: FlexProps = {};
+      expectTypeOf(props.display).toEqualTypeOf<
+        Responsive<'flex' | 'inline-flex' | 'none'> | undefined
+      >();
+    });
   });
 });

--- a/static/app/components/core/layout/flex.tsx
+++ b/static/app/components/core/layout/flex.tsx
@@ -1,6 +1,8 @@
 import type {CSSProperties} from 'react';
 import styled from '@emotion/styled';
 
+import type {DistributiveOmit} from '@sentry/scraps/types';
+
 import {Container, type ContainerElement, type ContainerProps} from './container';
 import {getSpacing, rc, type Responsive, type SpacingSize} from './styles';
 
@@ -50,7 +52,10 @@ interface FlexLayoutProps {
   wrap?: Responsive<'nowrap' | 'wrap' | 'wrap-reverse'>;
 }
 
-export type FlexProps<T extends ContainerElement = 'div'> = ContainerProps<T> &
+export type FlexProps<T extends ContainerElement = 'div'> = DistributiveOmit<
+  ContainerProps<T>,
+  'display'
+> &
   FlexLayoutProps;
 
 export const Flex = styled(Container, {

--- a/static/app/components/core/types.ts
+++ b/static/app/components/core/types.ts
@@ -1,0 +1,4 @@
+export type DistributiveOmit<
+  TObject,
+  TKey extends keyof TObject,
+> = TObject extends unknown ? Omit<TObject, TKey> : never;


### PR DESCRIPTION
This also fixes a type issue for `Flex` because `display` on `Flex` has a type that is narrower than `Container` but the intersection merged the types. `DistributiveOmit` solves this.