### PR TITLE
ref(tsc): remove deprecatedRouteProps and HoCs from transactionSummary

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1823,7 +1823,6 @@ function buildRoutes(): RouteObject[] {
       component: make(
         () => import('sentry/views/performance/transactionSummary/transactionOverview')
       ),
-      deprecatedRouteProps: true,
     },
     traceView,
     {
@@ -1837,21 +1836,18 @@ function buildRoutes(): RouteObject[] {
       component: make(
         () => import('sentry/views/performance/transactionSummary/transactionVitals')
       ),
-      deprecatedRouteProps: true,
     },
     {
       path: 'tags/',
       component: make(
         () => import('sentry/views/performance/transactionSummary/transactionTags')
       ),
-      deprecatedRouteProps: true,
     },
     {
       path: 'events/',
       component: make(
         () => import('sentry/views/performance/transactionSummary/transactionEvents')
       ),
-      deprecatedRouteProps: true,
     },
     {
       path: 'profiles/',

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -30,6 +30,9 @@ import {
 import {PerformanceEventViewProvider} from 'sentry/utils/performance/contexts/performanceEventViewContext';
 import {decodeScalar} from 'sentry/utils/queryString';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {useOTelFriendlyUI} from 'sentry/views/performance/otlp/useOTelFriendlyUI';
@@ -84,9 +87,6 @@ type Props = {
     transactionName: string;
   }) => EventView;
   getDocumentTitle: (name: string) => string;
-  location: Location;
-  organization: Organization;
-  projects: Project[];
   tab: Tab;
   features?: string[];
   fillSpace?: boolean;
@@ -94,15 +94,15 @@ type Props = {
 
 function PageLayout(props: Props) {
   const {
-    location,
-    organization,
-    projects,
     tab,
     getDocumentTitle,
     generateEventView,
     childComponent: ChildComponent,
     features = [],
   } = props;
+  const location = useLocation();
+  const {projects} = useProjects();
+  const organization = useOrganization();
 
   let projectId: string | undefined;
   const filterProjects = location.query.project;

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
@@ -4,7 +4,6 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
@@ -18,8 +17,6 @@ import {removeHistogramQueryStrings} from 'sentry/utils/performance/histogram';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import withOrganization from 'sentry/utils/withOrganization';
-import withProjects from 'sentry/utils/withProjects';
 import {
   decodeFilterFromLocation,
   filterToLocationQuery,
@@ -45,20 +42,9 @@ import {
 
 type PercentileValues = Record<EventsDisplayFilterName, number>;
 
-type Props = {
-  location: Location;
-  organization: Organization;
-  projects: Project[];
-};
-
-function TransactionEvents(props: Props) {
-  const {location, organization, projects} = props;
-
+function TransactionEvents() {
   return (
     <PageLayout
-      location={location}
-      organization={organization}
-      projects={projects}
       tab={Tab.EVENTS}
       getDocumentTitle={getDocumentTitle}
       generateEventView={generateEventView}
@@ -277,4 +263,4 @@ function generateEventView({
   );
 }
 
-export default withProjects(withOrganization(TransactionEvents));
+export default TransactionEvents;

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -5,7 +5,6 @@ import type {Location} from 'history';
 import {loadOrganizationTags} from 'sentry/actionCreators/tags';
 import LoadingContainer from 'sentry/components/loading/loadingContainer';
 import {t} from 'sentry/locale';
-import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
@@ -28,8 +27,8 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import withOrganization from 'sentry/utils/withOrganization';
-import withPageFilters from 'sentry/utils/withPageFilters';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {useTransactionSummaryEAP} from 'sentry/views/performance/otlp/useTransactionSummaryEAP';
 import {
   decodeFilterFromLocation,
@@ -53,15 +52,10 @@ import SummaryContent, {OTelSummaryContent} from './content';
 // as string | number
 type TotalValues = Record<string, number>;
 
-type Props = {
-  organization: Organization;
-  selection: PageFilters;
-};
-
-function TransactionOverview(props: Props) {
+function TransactionOverview() {
   const api = useApi();
-
-  const {selection, organization} = props;
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
 
   useEffect(() => {
     loadOrganizationTags(api, organization.slug, selection);
@@ -472,4 +466,4 @@ function getEAPTotalsEventView(
   return eventView.withColumns([...totalsColumns]);
 }
 
-export default withPageFilters(withOrganization(TransactionOverview));
+export default TransactionOverview;

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -7,7 +7,6 @@ import LoadingContainer from 'sentry/components/loading/loadingContainer';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
@@ -31,7 +30,6 @@ import useApi from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
-import withProjects from 'sentry/utils/withProjects';
 import {useTransactionSummaryEAP} from 'sentry/views/performance/otlp/useTransactionSummaryEAP';
 import {
   decodeFilterFromLocation,
@@ -56,16 +54,14 @@ import SummaryContent, {OTelSummaryContent} from './content';
 type TotalValues = Record<string, number>;
 
 type Props = {
-  location: Location;
   organization: Organization;
-  projects: Project[];
   selection: PageFilters;
 };
 
 function TransactionOverview(props: Props) {
   const api = useApi();
 
-  const {location, selection, organization, projects} = props;
+  const {selection, organization} = props;
 
   useEffect(() => {
     loadOrganizationTags(api, organization.slug, selection);
@@ -80,9 +76,6 @@ function TransactionOverview(props: Props) {
   return (
     <MEPSettingProvider>
       <PageLayout
-        location={location}
-        organization={organization}
-        projects={projects}
         tab={Tab.TRANSACTION_SUMMARY}
         getDocumentTitle={getDocumentTitle}
         generateEventView={generateEventView}
@@ -479,4 +472,4 @@ function getEAPTotalsEventView(
   return eventView.withColumns([...totalsColumns]);
 }
 
-export default withPageFilters(withProjects(withOrganization(TransactionOverview)));
+export default withPageFilters(withOrganization(TransactionOverview));

--- a/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
@@ -8,7 +8,6 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {TransactionSearchQueryBuilder} from 'sentry/components/performance/transactionSearchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Organization} from 'sentry/types/organization';
 import EventView from 'sentry/utils/discover/eventView';
 import {isAggregateField} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -25,11 +24,10 @@ import Tab from 'sentry/views/performance/transactionSummary/tabs';
 import {TransactionProfilesContent} from './content';
 
 interface ProfilesProps {
-  organization: Organization;
   transaction: string;
 }
 
-function Profiles({organization, transaction}: ProfilesProps) {
+function Profiles({transaction}: ProfilesProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const {projects} = useProjects();
@@ -76,9 +74,6 @@ function Profiles({organization, transaction}: ProfilesProps) {
 
   return (
     <PageLayout
-      location={location}
-      organization={organization}
-      projects={projects}
       tab={Tab.PROFILING}
       generateEventView={() => EventView.fromLocation(location)}
       getDocumentTitle={() => t(`Profile: %s`, transaction)}
@@ -129,7 +124,7 @@ function ProfilesIndex() {
     return null;
   }
 
-  return <Profiles organization={organization} transaction={transaction} />;
+  return <Profiles transaction={transaction} />;
 }
 
 export default ProfilesIndex;

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -24,8 +24,6 @@ import {
 import useReplayList from 'sentry/utils/replays/hooks/useReplayList';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
-import useOrganization from 'sentry/utils/useOrganization';
-import useProjects from 'sentry/utils/useProjects';
 import type {ChildProps} from 'sentry/views/performance/transactionSummary/pageLayout';
 import PageLayout from 'sentry/views/performance/transactionSummary/pageLayout';
 import Tab from 'sentry/views/performance/transactionSummary/tabs';
@@ -37,15 +35,8 @@ import useReplaysFromTransaction from './useReplaysFromTransaction';
 import useReplaysWithTxData from './useReplaysWithTxData';
 
 function TransactionReplays() {
-  const location = useLocation<ReplayListLocationQuery>();
-  const organization = useOrganization();
-  const {projects} = useProjects();
-
   return (
     <PageLayout
-      location={location}
-      organization={organization}
-      projects={projects}
       tab={Tab.REPLAYS}
       getDocumentTitle={getDocumentTitle}
       generateEventView={generateEventView}

--- a/static/app/views/performance/transactionSummary/transactionTags/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.tsx
@@ -1,32 +1,17 @@
 import type {Location} from 'history';
 
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
 import EventView from 'sentry/utils/discover/eventView';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import withOrganization from 'sentry/utils/withOrganization';
-import withProjects from 'sentry/utils/withProjects';
 import PageLayout from 'sentry/views/performance/transactionSummary/pageLayout';
 import Tab from 'sentry/views/performance/transactionSummary/tabs';
 
 import TagsPageContent from './content';
 
-type Props = {
-  location: Location;
-  organization: Organization;
-  projects: Project[];
-};
-
-function TransactionTags(props: Props) {
-  const {location, organization, projects} = props;
-
+function TransactionTags() {
   return (
     <PageLayout
-      location={location}
-      organization={organization}
-      projects={projects}
       tab={Tab.TAGS}
       getDocumentTitle={getDocumentTitle}
       generateEventView={generateEventView}
@@ -74,4 +59,4 @@ function generateEventView({
   return eventView;
 }
 
-export default withProjects(withOrganization(TransactionTags));
+export default TransactionTags;

--- a/static/app/views/performance/transactionSummary/transactionVitals/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/index.tsx
@@ -2,36 +2,22 @@ import {useTheme, type Theme} from '@emotion/react';
 import type {Location} from 'history';
 
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
 import EventView from 'sentry/utils/discover/eventView';
 import {isAggregateField} from 'sentry/utils/discover/fields';
 import type {WebVital} from 'sentry/utils/fields';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import withOrganization from 'sentry/utils/withOrganization';
-import withProjects from 'sentry/utils/withProjects';
 import PageLayout from 'sentry/views/performance/transactionSummary/pageLayout';
 import Tab from 'sentry/views/performance/transactionSummary/tabs';
 
 import {makeVitalGroups, PERCENTILE} from './constants';
 import VitalsContent from './content';
 
-type Props = {
-  location: Location;
-  organization: Organization;
-  projects: Project[];
-};
-
-function TransactionVitals(props: Props) {
-  const {location, organization, projects} = props;
+function TransactionVitals() {
   const theme = useTheme();
   return (
     <PageLayout
-      location={location}
-      organization={organization}
-      projects={projects}
       tab={Tab.WEB_VITALS}
       getDocumentTitle={getDocumentTitle}
       generateEventView={({location: locationArg, transactionName}) =>
@@ -97,4 +83,4 @@ function generateEventView({
   );
 }
 
-export default withProjects(withOrganization(TransactionVitals));
+export default TransactionVitals;


### PR DESCRIPTION
There’s no need to use higher order components on functional components, as they can just use hooks directly.