### PR TITLE
fix(proj-transfer): delete codeowners when transferring projects

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -639,7 +639,7 @@ class Project(Model):
             "linked_id", flat=True
         )
 
-        # Delete code mappings to prevent them from being stuck on the old org
+        # Delete issue ownership objects to prevent them from being stuck on the old org
         ProjectCodeOwners.objects.filter(project_id=self.id).delete()
         RepositoryProjectPathConfig.objects.filter(project_id=self.id).delete()
 

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -641,7 +641,6 @@ class Project(Model):
 
         # Delete code mappings to prevent them from being stuck on the old org
         ProjectCodeOwners.objects.filter(project_id=self.id).delete()
-        # Delete code mappings to prevent them from being stuck on the old org
         RepositoryProjectPathConfig.objects.filter(project_id=self.id).delete()
 
         for external_issues in chunked(

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -504,6 +504,7 @@ class Project(Model):
             RepositoryProjectPathConfig,
         )
         from sentry.models.environment import Environment, EnvironmentProject
+        from sentry.models.projectcodeowners import ProjectCodeOwners
         from sentry.models.projectteam import ProjectTeam
         from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
         from sentry.models.releases.release_project import ReleaseProject
@@ -638,6 +639,8 @@ class Project(Model):
             "linked_id", flat=True
         )
 
+        # Delete code mappings to prevent them from being stuck on the old org
+        ProjectCodeOwners.objects.filter(project_id=self.id).delete()
         # Delete code mappings to prevent them from being stuck on the old org
         RepositoryProjectPathConfig.objects.filter(project_id=self.id).delete()
 


### PR DESCRIPTION
Fixes SENTRY-5ABP

When deleting code mappings during project transfer (see #100565), we also need to delete any tied codeowner files.

https://github.com/getsentry/sentry/pull/101416 first attempt