### PR TITLE
feat(project-creation): Show failed proj. creation error in modal 

### DIFF
--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -13,7 +13,11 @@ import {Radio} from 'sentry/components/core/radio';
 import {RadioLineItem} from 'sentry/components/forms/controls/radioGroup';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
-import {useIsCreatingProjectAndRules} from 'sentry/components/onboarding/useCreateProjectAndRules';
+import {ProjectCreationErrorAlert} from 'sentry/components/onboarding/projectCreationErrorAlert';
+import {
+  useCreateProjectAndRulesError,
+  useIsCreatingProjectAndRules,
+} from 'sentry/components/onboarding/useCreateProjectAndRules';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {categoryList, createablePlatforms} from 'sentry/data/platformPickerCategories';
@@ -136,6 +140,7 @@ export function FrameworkSuggestionModal({
   newOrg,
 }: FrameworkSuggestionModalProps) {
   const isCreatingProjectAndRules = useIsCreatingProjectAndRules();
+  const createProjectAndRulesError = useCreateProjectAndRulesError();
 
   const [selectedFramework, setSelectedFramework] = useState<
     OnboardingSelectedSDK | undefined
@@ -280,6 +285,7 @@ export function FrameworkSuggestionModal({
         <TopFrameworksImage frameworks={listEntries} />
         <Heading>{t('Do you use a framework?')}</Heading>
         <Description>{languageDescriptions[selectedPlatform.key]}</Description>
+        <ProjectCreationErrorAlert error={createProjectAndRulesError} />
         <StyledPanel>
           <StyledPanelBody>
             <CollapsePanel

--- a/static/app/components/onboarding/projectCreationErrorAlert.tsx
+++ b/static/app/components/onboarding/projectCreationErrorAlert.tsx
@@ -1,0 +1,37 @@
+import startCase from 'lodash/startCase';
+
+import {Alert} from 'sentry/components/core/alert';
+import {t} from 'sentry/locale';
+import type RequestError from 'sentry/utils/requestError/requestError';
+
+type Props = {
+  error?: RequestError | null;
+};
+
+const keyToErrorText: Record<string, string> = {
+  actions: t('Notify via integration'),
+  conditions: t('Alert conditions'),
+  name: t('Alert name'),
+  detail: t('Project details'),
+};
+
+export function ProjectCreationErrorAlert({error}: Props) {
+  const response = error?.responseJSON;
+
+  if (!response) {
+    return null;
+  }
+
+  return (
+    <Alert.Container>
+      <Alert type="error" showIcon={false}>
+        {Object.keys(response).map(key => (
+          <div key={key}>
+            <strong>{keyToErrorText?.[key] ?? startCase(key)}</strong>:{' '}
+            {(response as any)[key]}
+          </div>
+        ))}
+      </Alert>
+    </Alert.Container>
+  );
+}

--- a/static/app/components/onboarding/useCreateProjectAndRules.ts
+++ b/static/app/components/onboarding/useCreateProjectAndRules.ts
@@ -84,10 +84,14 @@ export function useIsCreatingProjectAndRules() {
 }
 
 export function useCreateProjectAndRulesError(): RequestError | undefined {
-  const errors = useMutationState<RequestError | undefined>({
+  const mutations = useMutationState<RequestError | undefined>({
     filters: {mutationKey: [MUTATION_KEY]},
     select: mutation => mutation.state.error as RequestError | undefined,
   });
 
-  return errors.findLast((err): err is RequestError => Boolean(err));
+  if (mutations.length === 0) {
+    return undefined;
+  }
+
+  return mutations[mutations.length - 1] ?? undefined;
 }

--- a/static/app/components/onboarding/useCreateProjectAndRules.ts
+++ b/static/app/components/onboarding/useCreateProjectAndRules.ts
@@ -4,7 +4,7 @@ import type {IssueAlertRule} from 'sentry/types/alerts';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
-import {useIsMutating, useMutation} from 'sentry/utils/queryClient';
+import {useIsMutating, useMutation, useMutationState} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import type {useCreateNotificationAction} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import type {RequestDataFragment} from 'sentry/views/projectInstall/issueAlertOptions';
@@ -81,4 +81,13 @@ export function useCreateProjectAndRules() {
 
 export function useIsCreatingProjectAndRules() {
   return Boolean(useIsMutating({mutationKey: [MUTATION_KEY]}));
+}
+
+export function useCreateProjectAndRulesError(): RequestError | undefined {
+  const errors = useMutationState<RequestError | undefined>({
+    filters: {mutationKey: [MUTATION_KEY]},
+    select: mutation => mutation.state.error as RequestError | undefined,
+  });
+
+  return errors.findLast((err): err is RequestError => Boolean(err));
 }

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -3,22 +3,22 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import debounce from 'lodash/debounce';
 import omit from 'lodash/omit';
-import startCase from 'lodash/startCase';
 import {PlatformIcon} from 'platformicons';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openConsoleModal, openModal} from 'sentry/actionCreators/modal';
 import {removeProject} from 'sentry/actionCreators/projects';
 import Access from 'sentry/components/acl/access';
-import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {Input} from 'sentry/components/core/input';
 import {ExternalLink} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
+import {useGlobalModal} from 'sentry/components/globalModal/useGlobalModal';
 import * as Layout from 'sentry/components/layouts/thirds';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
+import {ProjectCreationErrorAlert} from 'sentry/components/onboarding/projectCreationErrorAlert';
 import {useCreateProjectAndRules} from 'sentry/components/onboarding/useCreateProjectAndRules';
 import PlatformPicker, {type Platform} from 'sentry/components/platformPicker';
 import TeamSelector from 'sentry/components/teamSelector';
@@ -133,14 +133,8 @@ function getSubmitTooltipText({
   return t('Please select a team');
 }
 
-const keyToErrorText: Record<string, string> = {
-  actions: t('Notify via integration'),
-  conditions: t('Alert conditions'),
-  name: t('Alert name'),
-  detail: t('Project details'),
-};
-
 export function CreateProject() {
+  const globalModal = useGlobalModal();
   const api = useApi();
   const navigate = useNavigate();
   const organization = useOrganization();
@@ -580,17 +574,8 @@ export function CreateProject() {
               </Tooltip>
             </div>
           </FormFieldGroup>
-          {createProjectAndRules.isError && createProjectAndRules.error.responseJSON && (
-            <Alert.Container>
-              <Alert type="error" showIcon={false}>
-                {Object.keys(createProjectAndRules.error.responseJSON).map(key => (
-                  <div key={key}>
-                    <strong>{keyToErrorText[key] ?? startCase(key)}</strong>:{' '}
-                    {(createProjectAndRules.error.responseJSON as any)[key]}
-                  </div>
-                ))}
-              </Alert>
-            </Alert.Container>
+          {!globalModal.visible && (
+            <ProjectCreationErrorAlert error={createProjectAndRules.error} />
           )}
         </List>
       </div>


### PR DESCRIPTION
**Problem**
When a user selects a vanilla platform, a modal appears suggesting a framework to configure. If the user clicks the “Configure SDK” button and project creation fails, the resulting error message appears beneath the modal, making it hard to notice.

**Solution**
Display the error directly inside the modal when project creation fails, ensuring it’s clearly visible. If the user closes the modal, the error will then appear on the main page as it already occurs.


https://github.com/user-attachments/assets/84a60633-2133-4d7c-aac4-b12706c187c5


closes https://linear.app/getsentry/issue/TET-1229/implement-dropdown-or-validation-for-slack-field