### PR TITLE
fix(ai-insights): tool call link

### DIFF
--- a/static/app/views/insights/agents/components/modelsTable.tsx
+++ b/static/app/views/insights/agents/components/modelsTable.tsx
@@ -58,7 +58,7 @@ const EMPTY_ARRAY: never[] = [];
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
   {key: 'model', name: t('Model'), width: COL_WIDTH_UNDEFINED},
   {key: 'count()', name: t('Requests'), width: 120},
-  {key: 'count_if(span.status,equals,unknown)', name: t('Errors'), width: 120},
+  {key: 'count_if(span.status,equals,internal_error)', name: t('Errors'), width: 120},
   {key: 'avg(span.duration)', name: t('Avg'), width: 100},
   {key: 'p95(span.duration)', name: t('P95'), width: 100},
   {key: 'sum(gen_ai.usage.total_cost)', name: t('Cost'), width: 100},
@@ -81,7 +81,7 @@ const rightAlignColumns = new Set([
   'sum(gen_ai.usage.output_tokens.reasoning)',
   'sum(gen_ai.usage.input_tokens.cached)',
   'sum(gen_ai.usage.total_cost)',
-  'count_if(span.status,equals,unknown)',
+  'count_if(span.status,equals,internal_error)',
   'avg(span.duration)',
   'p95(span.duration)',
 ]);
@@ -279,7 +279,7 @@ const BodyCell = memo(function BodyCell({
       return <DurationCell milliseconds={dataRow.p95} />;
     case 'sum(gen_ai.usage.total_cost)':
       return <TextAlignRight>{formatLLMCosts(dataRow.cost)}</TextAlignRight>;
-    case 'count_if(span.status,equals,unknown)':
+    case 'count_if(span.status,equals,internal_error)':
       return (
         <ErrorCell
           value={dataRow.errors}

--- a/static/app/views/insights/agents/components/modelsTable.tsx
+++ b/static/app/views/insights/agents/components/modelsTable.tsx
@@ -125,7 +125,7 @@ export function ModelsTable() {
         'count()',
         'avg(span.duration)',
         'p95(span.duration)',
-        'count_if(span.status,equals,internal_error)', // spans with status unknown are errors
+        'count_if(span.status,equals,internal_error)',
       ],
       sorts: [{field: sortField, kind: sortOrder}],
       search: fullQuery,

--- a/static/app/views/insights/agents/components/modelsTable.tsx
+++ b/static/app/views/insights/agents/components/modelsTable.tsx
@@ -125,7 +125,7 @@ export function ModelsTable() {
         'count()',
         'avg(span.duration)',
         'p95(span.duration)',
-        'count_if(span.status,equals,unknown)', // spans with status unknown are errors
+        'count_if(span.status,equals,internal_error)', // spans with status unknown are errors
       ],
       sorts: [{field: sortField, kind: sortOrder}],
       search: fullQuery,
@@ -147,7 +147,7 @@ export function ModelsTable() {
       avg: span['avg(span.duration)'] ?? 0,
       p95: span['p95(span.duration)'] ?? 0,
       cost: span['sum(gen_ai.usage.total_cost)'],
-      errors: span['count_if(span.status,equals,unknown)'] ?? 0,
+      errors: span['count_if(span.status,equals,internal_error)'] ?? 0,
       inputTokens: Number(span['sum(gen_ai.usage.input_tokens)']),
       inputCachedTokens: Number(span['sum(gen_ai.usage.input_tokens.cached)']),
       outputTokens: Number(span['sum(gen_ai.usage.output_tokens)']),
@@ -284,7 +284,7 @@ const BodyCell = memo(function BodyCell({
         <ErrorCell
           value={dataRow.errors}
           target={getExploreUrl({
-            query: `${query} span.status:unknown gen_ai.request.model:${dataRow.model}`,
+            query: `${query} span.status:internal_error gen_ai.request.model:"${dataRow.model}"`,
             organization,
             selection,
             referrer: Referrer.MODELS_TABLE,

--- a/static/app/views/insights/agents/components/toolErrorsWidget.tsx
+++ b/static/app/views/insights/agents/components/toolErrorsWidget.tsx
@@ -36,7 +36,9 @@ export default function ToolErrorsWidget() {
 
   const theme = useTheme();
 
-  const fullQuery = useCombinedQuery('span.op:gen_ai.execute_tool span.status:unknown');
+  const fullQuery = useCombinedQuery(
+    'span.op:gen_ai.execute_tool span.status:internal_error'
+  );
 
   const toolsRequest = useSpans(
     {

--- a/static/app/views/insights/agents/components/toolsTable.tsx
+++ b/static/app/views/insights/agents/components/toolsTable.tsx
@@ -95,7 +95,7 @@ export function ToolsTable() {
         'avg(span.duration)',
         'p95(span.duration)',
         'failure_rate()',
-        'count_if(span.status,equals,internal_error)', // spans with status unknown are errors
+        'count_if(span.status,equals,internal_error)',
       ],
       sorts: [{field: sortField, kind: sortOrder}],
       search: fullQuery,

--- a/static/app/views/insights/agents/components/toolsTable.tsx
+++ b/static/app/views/insights/agents/components/toolsTable.tsx
@@ -47,14 +47,14 @@ const EMPTY_ARRAY: never[] = [];
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
   {key: 'tool', name: t('Tool Name'), width: COL_WIDTH_UNDEFINED},
   {key: 'count()', name: t('Requests'), width: 120},
-  {key: 'count_if(span.status,equals,unknown)', name: t('Errors'), width: 120},
+  {key: 'count_if(span.status,equals,internal_error)', name: t('Errors'), width: 120},
   {key: 'avg(span.duration)', name: t('Avg'), width: 100},
   {key: 'p95(span.duration)', name: t('P95'), width: 100},
 ];
 
 const rightAlignColumns = new Set([
   'count()',
-  'count_if(span.status,equals,unknown)',
+  'count_if(span.status,equals,internal_error)',
   'avg(span.duration)',
   'p95(span.duration)',
 ]);
@@ -95,7 +95,7 @@ export function ToolsTable() {
         'avg(span.duration)',
         'p95(span.duration)',
         'failure_rate()',
-        'count_if(span.status,equals,unknown)', // spans with status unknown are errors
+        'count_if(span.status,equals,internal_error)', // spans with status unknown are errors
       ],
       sorts: [{field: sortField, kind: sortOrder}],
       search: fullQuery,
@@ -116,7 +116,7 @@ export function ToolsTable() {
       requests: Number(span['count()']),
       avg: Number(span['avg(span.duration)']),
       p95: Number(span['p95(span.duration)']),
-      errors: Number(span['count_if(span.status,equals,unknown)']),
+      errors: Number(span['count_if(span.status,equals,internal_error)']),
     }));
   }, [toolsRequest.data]);
 
@@ -204,7 +204,7 @@ const BodyCell = memo(function BodyCell({
         yAxes: ['avg(span.duration)'],
       },
     ],
-    query: `gen_ai.tool.name:${dataRow.tool}`,
+    query: `gen_ai.tool.name:"${dataRow.tool}"`,
     field: ['span.description', 'gen_ai.tool.output', 'span.duration', 'timestamp'],
   });
 
@@ -217,12 +217,12 @@ const BodyCell = memo(function BodyCell({
       return <DurationCell milliseconds={dataRow.avg} />;
     case 'p95(span.duration)':
       return <DurationCell milliseconds={dataRow.p95} />;
-    case 'count_if(span.status,equals,unknown)':
+    case 'count_if(span.status,equals,internal_error)':
       return (
         <ErrorCell
           value={dataRow.errors}
           target={getExploreUrl({
-            query: `${query} span.status:unknown gen_ai.tool.name:${dataRow.tool}`,
+            query: `${query} span.status:internal_error gen_ai.tool.name:"${dataRow.tool}"`,
             organization,
             selection,
             referrer: Referrer.TOOLS_TABLE,

--- a/static/app/views/insights/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/agents/components/tracesTable.tsx
@@ -123,7 +123,7 @@ export function TracesTable() {
   const traceErrorRequest = useSpans(
     {
       // Get all spans with error status
-      search: `has:span.status span.status:*error trace:[${tracesRequest.data?.data.map(span => span.trace).join(',')}]`,
+      search: `span.status:internal_error trace:[${tracesRequest.data?.data.map(span => span.trace).join(',')}]`,
       fields: ['trace', 'count(span.duration)'],
       limit: tracesRequest.data?.data.length ?? 0,
       enabled: Boolean(tracesRequest.data && tracesRequest.data.data.length > 0),
@@ -288,7 +288,7 @@ const BodyCell = memo(function BodyCell({
         <ErrorCell
           value={dataRow.errors}
           target={getExploreUrl({
-            query: `${query} span.status:*error trace:[${dataRow.traceId}]`,
+            query: `${query} span.status:internal_error trace:[${dataRow.traceId}]`,
             organization,
             selection,
             referrer: Referrer.TRACES_TABLE,

--- a/static/app/views/insights/agents/views/styles.tsx
+++ b/static/app/views/insights/agents/views/styles.tsx
@@ -30,7 +30,7 @@ const StyledGrid = styled('div')<{rowHeight: number; paddingBottom?: number}>`
 const TwoColumnStyledGrid = styled('div')<{rowHeight: number; paddingBottom?: number}>`
   display: grid;
   gap: ${p => p.theme.space.xl};
-  padding-bottom: ${p => p.paddingBottom ?? p.theme.space.md};
+  padding-bottom: ${p => p.paddingBottom ?? p.theme.space.xl};
 
   grid-template-columns: minmax(0, 1fr);
   grid-template-rows: ${p => p.rowHeight}px ${p => p.rowHeight}px;


### PR DESCRIPTION
Fixes [TET-1273: Bug when following tool with space in its name](https://linear.app/getsentry/issue/TET-1273/bug-when-following-tool-with-space-in-its-name)

- Also makes sure all of the error querying is consistent
- Fixes padding