### PR TITLE
feat(features): add batch_has_for_organizations to feature manager

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -60,6 +60,7 @@ entity_features = default_manager.entity_features
 get = default_manager.get
 has = default_manager.has
 batch_has = default_manager.batch_has
+batch_has_for_organizations = default_manager.batch_has_for_organizations
 all = default_manager.all
 add_handler = default_manager.add_handler
 add_entity_handler = default_manager.add_entity_handler

--- a/src/sentry/features/handler.py
+++ b/src/sentry/features/handler.py
@@ -70,31 +70,7 @@ class FeatureHandler:
         actor: User | RpcUser | AnonymousUser | None,
         organizations: Sequence[Organization],
     ) -> dict[str, dict[str, bool | None]] | None:
-        """
-        Check the same set of feature flags for multiple organizations at once.
-
-        Default implementation iterates through organizations individually.
-        Subclasses in getsentry can override this for optimized batch checking.
-
-        Args:
-            feature_names: List of feature names to check
-            actor: Optional actor for feature checks
-            organizations: List of organizations to check the features for
-
-        Returns:
-            Mapping from organization keys (format: "organization:{id}") to
-            feature name to result mapping
-        """
-        from sentry.features.base import OrganizationFeature
-
-        results: dict[str, dict[str, bool | None]] = {}
-        for organization in organizations:
-            org_key = f"organization:{organization.id}"
-            org_results = results[org_key] = {}
-            for feature_name in feature_names:
-                feature = OrganizationFeature(feature_name, organization)
-                org_results[feature_name] = self.has(feature, actor)
-        return results
+        raise NotImplementedError
 
 
 class BatchFeatureHandler(FeatureHandler):

--- a/src/sentry/features/handler.py
+++ b/src/sentry/features/handler.py
@@ -67,8 +67,8 @@ class FeatureHandler:
     def batch_has_for_organizations(
         self,
         feature_name: str,
-        actor: User | RpcUser | AnonymousUser | None,
         organizations: Sequence[Organization],
+        actor: User | RpcUser | AnonymousUser | None = None,
     ) -> dict[str, bool] | None:
         raise NotImplementedError
 

--- a/src/sentry/features/handler.py
+++ b/src/sentry/features/handler.py
@@ -69,7 +69,7 @@ class FeatureHandler:
         feature_name: str,
         actor: User | RpcUser | AnonymousUser | None,
         organizations: Sequence[Organization],
-    ) -> dict[str, bool]:
+    ) -> dict[str, bool] | None:
         raise NotImplementedError
 
 

--- a/src/sentry/features/handler.py
+++ b/src/sentry/features/handler.py
@@ -64,12 +64,12 @@ class FeatureHandler:
     ) -> dict[str, dict[str, bool | None]] | None:
         raise NotImplementedError
 
-    def has_batch_for_organizations(
+    def batch_has_for_organizations(
         self,
-        feature_names: Sequence[str],
+        feature_name: str,
         actor: User | RpcUser | AnonymousUser | None,
         organizations: Sequence[Organization],
-    ) -> dict[str, dict[str, bool | None]] | None:
+    ) -> dict[str, bool]:
         raise NotImplementedError
 
 

--- a/src/sentry/features/handler.py
+++ b/src/sentry/features/handler.py
@@ -68,7 +68,6 @@ class FeatureHandler:
         self,
         feature_name: str,
         organizations: Sequence[Organization],
-        actor: User | RpcUser | AnonymousUser | None = None,
     ) -> dict[str, bool] | None:
         raise NotImplementedError
 

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -406,11 +406,12 @@ class FeatureManager(RegisteredFeatureManager):
                         feature_name, actor, organizations
                     )
             else:
-                results: dict[str, dict[str, bool | None]] = {}
+                results: dict[str, bool | None] = {}
                 for organization in organizations:
                     org_key = f"organization:{organization.id}"
                     results[org_key] = self.has(feature_name, organization, actor=actor)
                 return results
+
         except Exception as e:
             if in_random_rollout("features.error.capture_rate"):
                 sentry_sdk.capture_exception(e)

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -402,7 +402,7 @@ class FeatureManager(RegisteredFeatureManager):
             ):
                 with metrics.timer("features.batch_has_for_organizations", sample_rate=0.01):
                     return self._entity_handler.batch_has_for_organizations(
-                        feature_name, actor, organizations
+                        feature_name, organizations, actor
                     )
             else:
                 results: dict[str, bool] = {}

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -379,7 +379,7 @@ class FeatureManager(RegisteredFeatureManager):
         feature_name: str,
         organizations: Sequence[Organization],
         actor: User | RpcUser | AnonymousUser | None = None,
-    ) -> dict[str, dict[str, bool | None]] | None:
+    ) -> dict[str, bool | None]:
         """
         Check the same set of feature flags for multiple organizations at once.
 

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -375,10 +375,7 @@ class FeatureManager(RegisteredFeatureManager):
             return None
 
     def batch_has_for_organizations(
-        self,
-        feature_name: str,
-        organizations: Sequence[Organization],
-        actor: User | RpcUser | AnonymousUser | None = None,
+        self, feature_name: str, organizations: Sequence[Organization]
     ) -> dict[str, bool] | None:
         """
         Check the same set of feature flags for multiple organizations at once.
@@ -390,7 +387,6 @@ class FeatureManager(RegisteredFeatureManager):
         Args:
             feature_names: List of feature names to check
             organizations: List of organizations to check the features for
-            actor: Optional actor for feature checks
 
         Returns:
             Mapping from organization keys (format: "organization:{id}") to
@@ -402,13 +398,13 @@ class FeatureManager(RegisteredFeatureManager):
             ):
                 with metrics.timer("features.batch_has_for_organizations", sample_rate=0.01):
                     return self._entity_handler.batch_has_for_organizations(
-                        feature_name, organizations, actor
+                        feature_name, organizations
                     )
             else:
                 results: dict[str, bool] = {}
                 for organization in organizations:
                     org_key = f"organization:{organization.id}"
-                    results[org_key] = self.has(feature_name, organization, actor=actor)
+                    results[org_key] = self.has(feature_name, organization)
                 return results
 
         except Exception as e:

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -44,12 +44,6 @@ class MockBatchHandler(features.BatchFeatureHandler):
 
         return {"unscoped": feature_results}
 
-    def has_batch_for_organizations(self, feature_names, actor, organizations):
-        feature_results = {
-            feature_name: True for feature_name in feature_names if feature_name in self.features
-        }
-        return {f"organization:{org.id}": feature_results for org in organizations}
-
     def _check_for_batch(self, feature_name, organization, actor):
         raise NotImplementedError
 

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -414,7 +414,7 @@ class FeatureManagerTest(TestCase):
             override_options({"features.error.capture_rate": 1.0}),
         ):
             result = manager.batch_has_for_organizations(
-                ["organizations:feature"], organizations, actor=self.user
+                "organizations:feature", organizations, actor=self.user
             )
             assert result is None
             assert mock_capture.call_count == 1

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -387,6 +387,26 @@ class FeatureManagerTest(TestCase):
             def has(self, feature, actor, skip_entity: bool | None = False):
                 return feature.name in self.features
 
+            def batch_has(
+                self, feature_names, *args: Any, projects=None, organization=None, **kwargs: Any
+            ):
+                feature_results = {
+                    feature_name: True
+                    for feature_name in feature_names
+                    if feature_name in self.features
+                }
+
+                if projects:
+                    return {f"project:{project.id}": feature_results for project in projects}
+
+                if organization:
+                    return {f"organization:{organization.id}": feature_results}
+
+                return {"unscoped": feature_results}
+
+            def _check_for_batch(self, feature_name, organization, actor):
+                raise NotImplementedError
+
         manager = features.FeatureManager()
         manager.add("organizations:feature", OrganizationFeature)
         manager.add_handler(NoBatchOrgHandler())

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -394,11 +394,11 @@ class FeatureManagerTest(TestCase):
         organizations = [self.organization, self.create_organization()]
 
         result = manager.batch_has_for_organizations(
-            ["organizations:feature"], organizations, actor=self.user
+            "organizations:feature", organizations, actor=self.user
         )
         assert result is not None
         for org in organizations:
-            assert result[f"organization:{org.id}"]["organizations:feature"]
+            assert result[f"organization:{org.id}"] is True
 
     def test_batch_has_for_organizations_error(self) -> None:
         manager = features.FeatureManager()

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -47,6 +47,32 @@ class MockBatchHandler(features.BatchFeatureHandler):
     def _check_for_batch(self, feature_name, organization, actor):
         raise NotImplementedError
 
+    def has_batch_for_organizations(self, feature_names, actor, organizations):
+        """
+        Check the same feature flag for multiple organizations at once.
+
+        This method optimizes the case where you need to check the same feature
+        for many different organizations by parsing the feature configuration once
+        and reusing it across all organization contexts.
+
+        Args:
+            feature_names: The names of the features to check
+            organizations: List of organizations to check the feature for
+
+        Returns:
+            Mapping from organization keys (format: "organization:{id}") to feature results
+        """
+        # This implementation assumes self.features contains the feature names this handler can evaluate.
+        # Returns a dict from org key to subdict {feature: bool}
+        results = {}
+        for org in organizations:
+            entity_key = f"organization:{org.id}"
+            feature_results = {}
+            for feature_name in feature_names:
+                feature_results[feature_name] = feature_name in self.features
+            results[entity_key] = feature_results
+        return results
+
 
 class MockUserBatchHandler(features.BatchFeatureHandler):
     features = {"users:feature"}

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -47,7 +47,7 @@ class MockBatchHandler(features.BatchFeatureHandler):
     def _check_for_batch(self, feature_name, organization, actor):
         raise NotImplementedError
 
-    def batch_has_for_organizations(self, feature_name, organizations, actor) -> dict[str, bool]:
+    def batch_has_for_organizations(self, feature_name, organizations) -> dict[str, bool]:
         results: dict[str, bool] = {}
         for org in organizations:
             entity_key = f"organization:{org.id}"
@@ -367,9 +367,7 @@ class FeatureManagerTest(TestCase):
 
         organizations = [self.organization, self.create_organization()]
 
-        result = manager.batch_has_for_organizations(
-            "organizations:feature", organizations, self.user
-        )
+        result = manager.batch_has_for_organizations("organizations:feature", organizations)
         assert result is not None
         for org in organizations:
             assert result[f"organization:{org.id}"]
@@ -408,9 +406,7 @@ class FeatureManagerTest(TestCase):
 
         organizations = [self.organization, self.create_organization()]
 
-        result = manager.batch_has_for_organizations(
-            "organizations:feature", organizations, actor=self.user
-        )
+        result = manager.batch_has_for_organizations("organizations:feature", organizations)
         assert result is not None
         for org in organizations:
             assert result[f"organization:{org.id}"] is True

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -47,7 +47,7 @@ class MockBatchHandler(features.BatchFeatureHandler):
     def _check_for_batch(self, feature_name, organization, actor):
         raise NotImplementedError
 
-    def batch_has_for_organizations(self, feature_name, actor, organizations) -> dict[str, bool]:
+    def batch_has_for_organizations(self, feature_name, organizations, actor) -> dict[str, bool]:
         results: dict[str, bool] = {}
         for org in organizations:
             entity_key = f"organization:{org.id}"
@@ -368,7 +368,7 @@ class FeatureManagerTest(TestCase):
         organizations = [self.organization, self.create_organization()]
 
         result = manager.batch_has_for_organizations(
-            "organizations:feature", organizations, actor=self.user
+            "organizations:feature", organizations, self.user
         )
         assert result is not None
         for org in organizations:

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -380,9 +380,16 @@ class FeatureManagerTest(TestCase):
             assert result[f"organization:{org.id}"]["organizations:feature"]
 
     def test_batch_has_for_organizations_no_entity_handler(self) -> None:
+        # Deliberately do NOT define has_batch_for_organizations
+        class NoBatchOrgHandler(features.BatchFeatureHandler):
+            features = {"organizations:feature"}
+
+            def has(self, feature, actor, skip_entity: bool | None = False):
+                return feature.name in self.features
+
         manager = features.FeatureManager()
         manager.add("organizations:feature", OrganizationFeature)
-        manager.add_handler(MockBatchHandler())
+        manager.add_handler(NoBatchOrgHandler())
 
         organizations = [self.organization, self.create_organization()]
 

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -48,20 +48,6 @@ class MockBatchHandler(features.BatchFeatureHandler):
         raise NotImplementedError
 
     def has_batch_for_organizations(self, feature_names, actor, organizations):
-        """
-        Check the same feature flag for multiple organizations at once.
-
-        This method optimizes the case where you need to check the same feature
-        for many different organizations by parsing the feature configuration once
-        and reusing it across all organization contexts.
-
-        Args:
-            feature_names: The names of the features to check
-            organizations: List of organizations to check the feature for
-
-        Returns:
-            Mapping from organization keys (format: "organization:{id}") to feature results
-        """
         # This implementation assumes self.features contains the feature names this handler can evaluate.
         # Returns a dict from org key to subdict {feature: bool}
         results = {}


### PR DESCRIPTION
- Add `batch_has_for_organizations` declaration to FeatureHandler without implementation
- Add `batch_has_for_organizations` definition with fallback to FeatureManager
- Export `batch_has_for_organizations` in the __init__.py

Contributes to TET-1151