### PR TITLE
fix(sub v3): Consolidate trial info in Usage Overview

### DIFF
--- a/static/gsApp/views/subscriptionPage/usageOverview.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview.spec.tsx
@@ -135,7 +135,7 @@ describe('UsageOverview', () => {
         name: 'Start 14 day free Continuous Profile Hours trial',
       })
     ).toBeInTheDocument();
-    expect(screen.getByText('Trial available')).toBeInTheDocument();
+    expect(screen.queryByText('Trial available')).not.toBeInTheDocument();
 
     // Replays product trial active
     expect(screen.getByText('20 days left')).toBeInTheDocument();

--- a/static/gsApp/views/subscriptionPage/usageOverview.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview.tsx
@@ -194,7 +194,7 @@ function UsageOverviewTable({subscription, organization, usageData}: UsageOvervi
         width: 200,
       },
       {
-        key: 'cta',
+        key: 'trialInfo',
         name: '',
         width: 50,
       },
@@ -205,7 +205,7 @@ function UsageOverviewTable({subscription, organization, usageData}: UsageOvervi
           !column.key.endsWith('Spend') ||
           ((subscription.onDemandInvoiced || subscription.onDemandInvoicedManual) &&
             column.key === 'budgetSpend')) &&
-        (hasAnyPotentialProductTrial || column.key !== 'cta')
+        (hasAnyPotentialProductTrial || column.key !== 'trialInfo')
     );
   }, [
     hasBillingPerms,
@@ -459,13 +459,10 @@ function UsageOverviewTable({subscription, organization, usageData}: UsageOvervi
           switch (column.key) {
             case 'product': {
               const title = (
-                <Text as="div" textWrap="balance">
-                  <Text bold>
-                    {!hasAccess && <IconLock locked size="xs" />} {product}
-                    {softCapType &&
-                      ` (${toTitleCase(softCapType.replace(/_/g, ' ').toLocaleLowerCase())})`}{' '}
-                  </Text>{' '}
-                  {productTrial && <ProductTrialTag trial={productTrial} />}{' '}
+                <Text bold textWrap="balance">
+                  {!hasAccess && <IconLock locked size="xs" />} {product}
+                  {softCapType &&
+                    ` (${toTitleCase(softCapType.replace(/_/g, ' ').toLocaleLowerCase())})`}{' '}
                 </Text>
               );
 
@@ -597,49 +594,55 @@ function UsageOverviewTable({subscription, organization, usageData}: UsageOvervi
                 : '-';
               return <CurrencyCell>{formattedSpend}</CurrencyCell>;
             }
-            case 'cta': {
-              if (productTrial && !productTrial.isStarted) {
+            case 'trialInfo': {
+              if (productTrial) {
                 return (
-                  <Flex justify="center">
-                    <StartTrialButton
-                      organization={organization}
-                      source="usage-overview"
-                      requestData={{
-                        productTrial: {
-                          category: productTrial.category,
-                          reasonCode: productTrial.reasonCode,
-                        },
-                      }}
-                      aria-label={t('Start 14 day free %s trial', product)}
-                      priority="primary"
-                      handleClick={() => {
-                        setTrialButtonBusyState(prev => ({
-                          ...prev,
-                          [productTrial.category]: true,
-                        }));
-                      }}
-                      onTrialStarted={() => {
-                        setTrialButtonBusyState(prev => ({
-                          ...prev,
-                          [productTrial.category]: true,
-                        }));
-                      }}
-                      onTrialFailed={() => {
-                        setTrialButtonBusyState(prev => ({
-                          ...prev,
-                          [productTrial.category]: false,
-                        }));
-                      }}
-                      busy={trialButtonBusyState[productTrial.category]}
-                      disabled={trialButtonBusyState[productTrial.category]}
-                      size="xs"
-                    >
-                      <Flex align="center" gap="sm">
-                        <IconLightning size="xs" />
-                        <Container>{t('Start 14 day free trial')}</Container>
-                      </Flex>
-                    </StartTrialButton>
-                  </Flex>
+                  <Container>
+                    {productTrial.isStarted ? (
+                      <Container>
+                        <ProductTrialTag trial={productTrial} />
+                      </Container>
+                    ) : (
+                      <StartTrialButton
+                        organization={organization}
+                        source="usage-overview"
+                        requestData={{
+                          productTrial: {
+                            category: productTrial.category,
+                            reasonCode: productTrial.reasonCode,
+                          },
+                        }}
+                        aria-label={t('Start 14 day free %s trial', product)}
+                        priority="primary"
+                        handleClick={() => {
+                          setTrialButtonBusyState(prev => ({
+                            ...prev,
+                            [productTrial.category]: true,
+                          }));
+                        }}
+                        onTrialStarted={() => {
+                          setTrialButtonBusyState(prev => ({
+                            ...prev,
+                            [productTrial.category]: true,
+                          }));
+                        }}
+                        onTrialFailed={() => {
+                          setTrialButtonBusyState(prev => ({
+                            ...prev,
+                            [productTrial.category]: false,
+                          }));
+                        }}
+                        busy={trialButtonBusyState[productTrial.category]}
+                        disabled={trialButtonBusyState[productTrial.category]}
+                        size="xs"
+                      >
+                        <Flex align="center" gap="sm">
+                          <IconLightning size="xs" />
+                          <Container>{t('Start 14 day free trial')}</Container>
+                        </Flex>
+                      </StartTrialButton>
+                    )}
+                  </Container>
                 );
               }
               return <div />;

--- a/static/gsApp/views/subscriptionPage/usageOverview.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview.tsx
@@ -22,6 +22,7 @@ import {t, tct} from 'sentry/locale';
 import type {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
+import getDaysSinceDate from 'sentry/utils/getDaysSinceDate';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -180,8 +181,10 @@ function UsageOverviewTable({subscription, organization, usageData}: UsageOvervi
   ).flatMap(addOn => addOn.dataCategories);
 
   const columnOrder: GridColumnOrder[] = useMemo(() => {
-    const hasAnyPotentialProductTrial = subscription.productTrials?.some(
-      trial => !trial.isStarted
+    const hasAnyPotentialOrActiveProductTrial = subscription.productTrials?.some(
+      trial =>
+        !trial.isStarted ||
+        (trial.isStarted && getDaysSinceDate(trial.endDate ?? '') <= 0)
     );
     return [
       {key: 'product', name: t('Product'), width: 300},
@@ -205,7 +208,7 @@ function UsageOverviewTable({subscription, organization, usageData}: UsageOvervi
           !column.key.endsWith('Spend') ||
           ((subscription.onDemandInvoiced || subscription.onDemandInvoicedManual) &&
             column.key === 'budgetSpend')) &&
-        (hasAnyPotentialProductTrial || column.key !== 'trialInfo')
+        (hasAnyPotentialOrActiveProductTrial || column.key !== 'trialInfo')
     );
   }, [
     hasBillingPerms,

--- a/static/gsApp/views/subscriptionPage/usageOverview.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview.tsx
@@ -192,7 +192,7 @@ function UsageOverviewTable({subscription, organization, usageData}: UsageOvervi
     const hasAnyPotentialOrActiveProductTrial = subscription.productTrials?.some(
       trial =>
         !trial.isStarted ||
-        (trial.isStarted && getDaysSinceDate(trial.endDate ?? '') <= 0)
+        (trial.isStarted && trial.endDate && getDaysSinceDate(trial.endDate) <= 0)
     );
     return [
       {key: 'product', name: t('Product'), width: 300},


### PR DESCRIPTION
- Removed the `Trial available` tag as it was redundant with the trial starter button
- Moved the `x days left` tag to the same column as the trial starter button
- Renamed column key to be more accurate to column contents

<img width="1350" height="732" alt="Screenshot 2025-10-14 at 10 20 52 AM" src="https://github.com/user-attachments/assets/ba523f61-05b3-4217-85b7-ea4fa79a6a2f" />
