### PR TITLE
feat(auto_source): Use consistent stack trace granularity

### DIFF
--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -9,10 +9,6 @@ METRIC_PREFIX = "auto_source_code_config"
 DERIVED_ENHANCEMENTS_OPTION_KEY = "sentry:derived_grouping_enhancements"
 SUPPORTED_INTEGRATIONS = [IntegrationProviderSlug.GITHUB.value]
 STACK_ROOT_MAX_LEVEL = 4
-# Stacktrace roots that match one of these will have an extra level of granularity
-# com.au, co.uk, org.uk, gov.uk, net.uk, edu.uk, ct.uk
-# This list does not have to be exhaustive as the fallback is two levels of granularity
-SECOND_LEVEL_TLDS = ("com", "co", "org", "gov", "net", "edu")
 
 # Any new languages should also require updating the stacktraceLink.tsx
 # The extensions do not need to be exhaustive but only include the ones that show up in stacktraces

--- a/src/sentry/issues/auto_source_code_config/frame_info.py
+++ b/src/sentry/issues/auto_source_code_config/frame_info.py
@@ -5,10 +5,9 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from sentry import options
 from sentry.integrations.source_code_management.repo_trees import get_extension
 
-from .constants import SECOND_LEVEL_TLDS, STACK_ROOT_MAX_LEVEL
+from .constants import STACK_ROOT_MAX_LEVEL
 from .errors import (
     DoesNotFollowJavaPackageNamingConvention,
     MissingModuleOrAbsPath,
@@ -157,25 +156,19 @@ def get_path_from_module(module: str, abs_path: str) -> tuple[str, str]:
 
 
 def get_granularity(parts: Sequence[str]) -> int:
-    # a.Bar, Bar.kt -> stack_root: a/, file_path:  a/Bar.kt
+    # a.Bar, Bar.kt -> stack_root: a/, file_path: a/Bar.kt
     granularity = 1
 
     if len(parts) > 1:
         # com.example.foo.bar.Baz$InnerClass, Baz.kt ->
-        #    stack_root: com/example/foo/
+        #    stack_root: com/example/foo/bar/
         #    file_path:  com/example/foo/bar/Baz.kt
-        granularity = STACK_ROOT_MAX_LEVEL - 1
-
-        if parts[1] in SECOND_LEVEL_TLDS:
-            # uk.co.example.foo.bar.Baz$InnerClass, Baz.kt ->
-            #    stack_root: uk/co/example/foo/
-            #    file_path:  uk/co/example/foo/bar/Baz.kt
-            granularity = STACK_ROOT_MAX_LEVEL
-
-        elif options.get("auto_source_code_config.multi_module_java"):
-            # com.example.multi.foo.bar.Baz$InnerClass, Baz.kt ->
-            #    stack_root: com/example/multi/foo/
-            #    file_path:  com/example/multi/foo/bar/Baz.kt
-            granularity = STACK_ROOT_MAX_LEVEL
+        # uk.co.example.foo.bar.Baz$InnerClass, Baz.kt ->
+        #    stack_root: uk/co/example/foo/
+        #    file_path:  uk/co/example/foo/bar/Baz.kt
+        # com.example.multi.foo.bar.Baz$InnerClass, Baz.kt ->
+        #    stack_root: com/example/multi/foo/
+        #    file_path:  com/example/multi/foo/bar/Baz.kt
+        granularity = STACK_ROOT_MAX_LEVEL
 
     return granularity

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -904,13 +904,6 @@ register(
 )
 
 register(
-    "auto_source_code_config.multi_module_java",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
     "issues.severity.first-event-severity-calculation-projects-allowlist",
     type=Sequence,
     default=[],

--- a/tests/sentry/issues/auto_source_code_config/test_frame_info.py
+++ b/tests/sentry/issues/auto_source_code_config/test_frame_info.py
@@ -90,8 +90,6 @@ class TestFrameInfo:
         with pytest.raises(expected_exception):
             create_frame_info(frame, "java")
 
-    # Only necessary while auto_source_code_config.multi_module_java is used
-    @pytest.mark.django_db
     @pytest.mark.parametrize(
         "frame, expected_stack_root, expected_normalized_path",
         [

--- a/tests/sentry/issues/auto_source_code_config/test_frame_info.py
+++ b/tests/sentry/issues/auto_source_code_config/test_frame_info.py
@@ -117,6 +117,12 @@ class TestFrameInfo:
                 "foo/bar/Baz",  # The path does not use the abs_path
                 id="invalid_abs_path_dollar_sign",
             ),
+            pytest.param(
+                {"module": "foo.Baz", "abs_path": "foo"},
+                "foo/",  # Single-depth stack root
+                "foo/Baz",
+                id="granularity_1",
+            ),
         ],
     )
     def test_java_valid_frames(

--- a/tests/sentry/issues/ownership/test_grammar.py
+++ b/tests/sentry/issues/ownership/test_grammar.py
@@ -230,8 +230,6 @@ def test_matcher_test_threads() -> None:
     assert not Matcher("url", "*.py").test(data, munged_data)
 
 
-# Only necessary while auto_source_code_config.multi_module_java is used
-@pytest.mark.django_db
 def test_matcher_test_platform_java_threads() -> None:
     data = {
         "platform": "java",

--- a/tests/sentry/utils/test_event_frames.py
+++ b/tests/sentry/utils/test_event_frames.py
@@ -1,7 +1,5 @@
 import unittest
 
-import pytest
-
 from sentry.testutils.cases import TestCase
 from sentry.utils.event_frames import (
     EventFrame,
@@ -78,8 +76,6 @@ class FilenameMungingTestCase(unittest.TestCase):
     def test_platform_sdk_name_not_supported(self) -> None:
         assert not munged_filename_and_frames("javascript", [], "munged", "sdk.other")
 
-    # Only necessary while auto_source_code_config.multi_module_java is used
-    @pytest.mark.django_db
     def test_supported_platform_sdk_name_not_required(self) -> None:
         frames = [
             {
@@ -92,8 +88,6 @@ class FilenameMungingTestCase(unittest.TestCase):
 
 
 class JavaFilenameMungingTestCase(unittest.TestCase):
-    # Only necessary while auto_source_code_config.multi_module_java is used
-    @pytest.mark.django_db
     def test_platform_java(self) -> None:
         frames = [
             {
@@ -146,8 +140,6 @@ class JavaFilenameMungingTestCase(unittest.TestCase):
         munged = munged_filename_and_frames("java", [frame])
         assert munged is None
 
-    # Only necessary while auto_source_code_config.multi_module_java is used
-    @pytest.mark.django_db
     def test_platform_android_kotlin(self) -> None:
         exception_frames = [
             {


### PR DESCRIPTION
This makes the granularity of the stack root consistent rather than trying to optimize number of created code mappings.

This also removes the option and old code path from #101288.