### PR TITLE
feat(dashboards): update /dashboards endpoint to accept linked_dashboards

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta
 from enum import Enum
 from math import floor
-from typing import Any, TypedDict
+from typing import TypedDict
 
 import sentry_sdk
 from django.db.models import Max
@@ -58,6 +58,11 @@ DATASET_SOURCE_MAP = {source[1]: source[0] for source in DatasetSourcesTypes.as_
 class QueryWarning(TypedDict):
     queries: list[str | None]
     columns: dict[str, str]
+
+
+class LinkedDashboard(TypedDict):
+    field: str
+    dashboard_id: int
 
 
 def is_equation(field: str) -> bool:
@@ -914,7 +919,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
     def _update_or_create_field_links(
         self,
         query: DashboardWidgetQuery,
-        linked_dashboards: list[dict[str, Any]],
+        linked_dashboards: list[LinkedDashboard],
         widget: DashboardWidget,
     ):
         """

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -1043,7 +1043,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             if "linked_dashboards" in query_data["query_data"]:
                 self._update_or_create_field_links(
                     query_data["query_obj"],
-                    query_data["query_data"].get("linked_dashboards"),
+                    query_data["query_data"].get("linked_dashboards", []),
                     widget,
                 )
 
@@ -1072,7 +1072,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         DashboardWidgetQuery.objects.filter(widget_id=widget_id).exclude(id__in=keep_ids).delete()
 
 
-class DashboardSerializer(DashboardDetailsSerializer):
+class DashboardSerializer:
     title = serializers.CharField(
         required=True, max_length=255, help_text="The user defined title for this dashboard."
     )

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -1072,7 +1072,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         DashboardWidgetQuery.objects.filter(widget_id=widget_id).exclude(id__in=keep_ids).delete()
 
 
-class DashboardSerializer:
+class DashboardSerializer(DashboardDetailsSerializer):
     title = serializers.CharField(
         required=True, max_length=255, help_text="The user defined title for this dashboard."
     )

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -70,6 +70,11 @@ interface WidgetQueryOnDemand {
   extractionState: OnDemandExtractionState;
 }
 
+export type LinkedDashboard = {
+  dashboardId: string;
+  field: string;
+};
+
 /**
  * A widget query is one or more aggregates and a single filter string (conditions.)
  * Widgets can have multiple widget queries, and they all combine into a unified timeseries view (for example)
@@ -88,6 +93,7 @@ export type WidgetQuery = {
   // widgets.
   fields?: string[];
   isHidden?: boolean | null;
+  linkedDashboards?: string[];
   // Contains the on-demand entries for the widget query.
   onDemand?: WidgetQueryOnDemand[];
   // Aggregate selected for the Big Number widget builder

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -70,11 +70,6 @@ interface WidgetQueryOnDemand {
   extractionState: OnDemandExtractionState;
 }
 
-export type LinkedDashboard = {
-  dashboardId: string;
-  field: string;
-};
-
 /**
  * A widget query is one or more aggregates and a single filter string (conditions.)
  * Widgets can have multiple widget queries, and they all combine into a unified timeseries view (for example)
@@ -93,7 +88,6 @@ export type WidgetQuery = {
   // widgets.
   fields?: string[];
   isHidden?: boolean | null;
-  linkedDashboards?: string[];
   // Contains the on-demand entries for the widget query.
   onDemand?: WidgetQueryOnDemand[];
   // Aggregate selected for the Big Number widget builder


### PR DESCRIPTION
This PR allows the /dashboards endpoint to create, update and delete linked dashboards (when the flag is enabled).
The endpoint will only allow this for `Table` widgets, and all dashboard links are updated after widget queries are made as they are a foreign key to the links. This gets us closer to developing a full POC of this feature.