### PR TITLE
fix(insights): add extra check for meta field in `updateMetaIfExists`

### DIFF
--- a/static/app/views/insights/pages/frontend/queries/useFrontendTableData.tsx
+++ b/static/app/views/insights/pages/frontend/queries/useFrontendTableData.tsx
@@ -69,7 +69,7 @@ export const useFrontendTableData = (
   });
 
   const updateMetaIfExists = (oldField: string, newField: string) => {
-    if (response?.meta?.fields[oldField]) {
+    if (response?.meta?.fields?.[oldField]) {
       response.meta.fields[newField] = response?.meta?.fields[oldField];
     }
   };


### PR DESCRIPTION
fixes JAVASCRIPT-3361

We shouldn't try to update the meta, if the `fields` object doesn't exist.