### PR TITLE
fix(insights): am1 customers should not see laravel and nextjs pages

### DIFF
--- a/static/app/views/insights/pages/platform/laravel/features.tsx
+++ b/static/app/views/insights/pages/platform/laravel/features.tsx
@@ -1,6 +1,7 @@
 import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 
@@ -10,6 +11,7 @@ export function useIsLaravelInsightsAvailable() {
   const {projects} = useProjects();
   const {selection} = usePageFilters();
   const {view, isInOverviewPage} = useDomainViewFilters();
+  const hasEap = useInsightsEap();
 
   const selectedProjects = getSelectedProjectList(selection.projects, projects);
 
@@ -17,5 +19,11 @@ export function useIsLaravelInsightsAvailable() {
     project => project.platform === 'php-laravel'
   );
 
-  return isOnlyLaravelSelected && view && laravelViews.includes(view) && isInOverviewPage;
+  return (
+    hasEap &&
+    isOnlyLaravelSelected &&
+    view &&
+    laravelViews.includes(view) &&
+    isInOverviewPage
+  );
 }

--- a/static/app/views/insights/pages/platform/nextjs/features.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/features.tsx
@@ -1,12 +1,14 @@
 import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 
 export function useIsNextJsInsightsAvailable() {
   const {projects} = useProjects();
   const {selection} = usePageFilters();
   const {view} = useDomainViewFilters();
+  const hasEap = useInsightsEap();
 
   const selectedProjects = getSelectedProjectList(selection.projects, projects);
 
@@ -14,5 +16,5 @@ export function useIsNextJsInsightsAvailable() {
     project => project.platform === 'javascript-nextjs'
   );
 
-  return isOnlyNextJsSelected && (view === 'frontend' || view === 'backend');
+  return hasEap && isOnlyNextJsSelected && (view === 'frontend' || view === 'backend');
 }


### PR DESCRIPTION
Am1 customers should not see laravel/nextjs pages, I believe any customers that doesn't have eap (which is only am1), should not see laravel/nextjs.