### PR TITLE
chore(spans-migration): pass in datasets/sources to change on save in backend

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
@@ -7,10 +7,11 @@ import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
+import {DatasetSource} from 'sentry/utils/discover/types';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import type {Widget} from 'sentry/views/dashboards/types';
+import {WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import {flattenErrors} from 'sentry/views/dashboards/utils';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {useDisableTransactionWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useDisableTransactionWidget';
@@ -38,6 +39,9 @@ function SaveButton({isEditing, onSave, setError}: SaveButtonProps) {
       organization,
     });
     const widget = convertBuilderStateToWidget(state);
+    if (widget.widgetType === WidgetType.SPANS) {
+      widget.datasetSource = DatasetSource.USER;
+    }
     setIsSaving(true);
     try {
       await validateWidget(api, organization.slug, widget);

--- a/static/app/views/explore/hooks/useSaveQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.tsx
@@ -124,7 +124,10 @@ function useCreateOrUpdateSavedQuery(id?: string) {
         `/organizations/${organization.slug}/explore/saved/${id}/`,
         {
           method: 'PUT',
-          data,
+          data: {
+            ...data,
+            dataset: data.dataset === 'segment_spans' ? 'spans' : data.dataset,
+          },
         }
       );
       invalidateSavedQueries();
@@ -153,6 +156,9 @@ export function useFromSavedQuery() {
           method: 'POST',
           data: {
             ...savedQuery,
+            // we want to make sure no new queries are saved with the segment_spans dataset
+            dataset:
+              savedQuery.dataset === 'segment_spans' ? 'spans' : savedQuery.dataset,
           },
         }
       );
@@ -170,6 +176,9 @@ export function useFromSavedQuery() {
           method: 'PUT',
           data: {
             ...savedQuery,
+            // we want to make sure queries are locked in as spans once they're updated
+            dataset:
+              savedQuery.dataset === 'segment_spans' ? 'spans' : savedQuery.dataset,
           },
         }
       );


### PR DESCRIPTION
two things in this pr: 
1. we're making sure that all updated migrated saved queries in explore have the `spans` dataset instead of saving with the `segment_spans` dataset
2. we're passing in `USER` as the dataset source for spans widgets so that when they're updated we can set the dropped fields to null (backend change to follow)