### PR TITLE
fix(timseeries): Consistent response

### DIFF
--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -12,7 +12,14 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.endpoints.organization_events_stats import SENTRY_BACKEND_REFERRERS
-from sentry.api.endpoints.timeseries import Row, SeriesMeta, StatsMeta, StatsResponse, TimeSeries
+from sentry.api.endpoints.timeseries import (
+    EMPTY_STATS_RESPONSE,
+    Row,
+    SeriesMeta,
+    StatsMeta,
+    StatsResponse,
+    TimeSeries,
+)
 from sentry.api.utils import handle_query_errors
 from sentry.constants import MAX_TOP_EVENTS
 from sentry.models.organization import Organization
@@ -139,7 +146,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                     organization,
                 )
             except NoProjects:
-                return Response([], status=200)
+                return Response(EMPTY_STATS_RESPONSE, status=200)
 
         with handle_query_errors():
             self.validate_comparison_delta(comparison_delta, snuba_params, organization)

--- a/src/sentry/api/endpoints/timeseries.py
+++ b/src/sentry/api/endpoints/timeseries.py
@@ -40,11 +40,10 @@ class TimeSeries(TypedDict):
 
 
 class StatsResponse(TypedDict):
-    meta: StatsMeta
+    meta: NotRequired[StatsMeta]
     timeSeries: list[TimeSeries]
 
 
 EMPTY_STATS_RESPONSE: dict[str, Any] = {
-    "meta": {},
     "timeSeries": [],
 }

--- a/src/sentry/api/endpoints/timeseries.py
+++ b/src/sentry/api/endpoints/timeseries.py
@@ -1,4 +1,4 @@
-from typing import Literal, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 
 class StatsMeta(TypedDict):
@@ -42,3 +42,9 @@ class TimeSeries(TypedDict):
 class StatsResponse(TypedDict):
     meta: StatsMeta
     timeSeries: list[TimeSeries]
+
+
+EMPTY_STATS_RESPONSE: dict[str, Any] = {
+    "meta": {},
+    "timeSeries": [],
+}

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -94,7 +94,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         data = response.data
         assert "timeSeries" in data
         assert len(data["timeSeries"]) == 0
-        assert data["meta"] == {}
+        assert "meta" not in data
 
     @pytest.mark.querybuilder
     def test_simple(self) -> None:

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -83,6 +83,19 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         with self.feature(features):
             return self.client.get(self.url if url is None else url, data=data, format="json")
 
+    def test_no_projects(self) -> None:
+        org = self.create_organization(owner=self.user)
+        self.login_as(user=self.user)
+
+        url = reverse(self.endpoint, kwargs={"organization_id_or_slug": org.slug})
+        response = self.do_request({}, url)
+
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert "timeSeries" in data
+        assert len(data["timeSeries"]) == 0
+        assert data["meta"] == {}
+
     @pytest.mark.querybuilder
     def test_simple(self) -> None:
         response = self.do_request(


### PR DESCRIPTION
- This makes the response of the timeseries endpoint consistent with whether there's projects or not
- Without this the frontend would crash since it expects a valid StatsResponse
- Closes ENG-5712