### PR TITLE
fix(eap): Span fields should hide internal

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -22,12 +22,14 @@ from sentry.api.event_search import translate_escape_sequences
 from sentry.api.paginator import ChainPaginator
 from sentry.api.serializers import serialize
 from sentry.api.utils import handle_query_errors
+from sentry.auth.staff import is_active_staff
+from sentry.auth.superuser import is_active_superuser
 from sentry.models.organization import Organization
 from sentry.search.eap import constants
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
-from sentry.search.eap.utils import translate_internal_to_public_alias
+from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_public_alias
 from sentry.search.events.types import SnubaParams
 from sentry.snuba.referrer import Referrer
 from sentry.tagstore.types import TagValue
@@ -118,12 +120,19 @@ class OrganizationSpansFieldsEndpoint(OrganizationSpansFieldsEndpointBase):
 
             rpc_response = snuba_rpc.attribute_names_rpc(rpc_request)
 
+        include_internal = is_active_superuser(request) or is_active_staff(request)
+
         paginator = ChainPaginator(
             [
                 [
                     as_tag_key(attribute.name, serialized["type"])
                     for attribute in rpc_response.attributes
                     if attribute.name
+                    and can_expose_attribute(
+                        attribute.name,
+                        SupportedTraceItemType.SPANS,
+                        include_internal=include_internal,
+                    )
                 ],
             ],
             max_limit=max_span_tags,


### PR DESCRIPTION
### Summary
Span fields should probably be eventually removed, but for the time being we still shouldn't show hidden attribute names


