### PR TITLE
fix(issues): show correct notification when deleting all issues in query

### DIFF
--- a/static/app/stores/groupStore.spec.tsx
+++ b/static/app/stores/groupStore.spec.tsx
@@ -3,6 +3,7 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import GroupStore from 'sentry/stores/groupStore';
+import IndicatorStore from 'sentry/stores/indicatorStore';
 import type {TimeseriesValue} from 'sentry/types/core';
 import type {Group, GroupStats} from 'sentry/types/group';
 import {GroupActivityType} from 'sentry/types/group';
@@ -229,35 +230,35 @@ describe('GroupStore', () => {
         expect(GroupStore.trigger).toHaveBeenCalledWith(new Set(['1', '2', '3']));
       });
 
-      it('should show generic message when itemIds is undefined (all in query selected)', () => {
-        const IndicatorStore = require('sentry/stores/indicatorStore').default;
+      it('should show generic message when itemIds is undefined', () => {
         const addMessageSpy = jest.spyOn(IndicatorStore, 'addMessage');
-
         GroupStore.onDeleteSuccess('1337', undefined, {});
 
-        expect(addMessageSpy).toHaveBeenCalledWith('Deleted selected issues', 'success', {duration: 4000});
+        expect(addMessageSpy).toHaveBeenCalledWith(
+          'Deleted selected issues',
+          'success',
+          {duration: 4000}
+        );
       });
 
       it('should show specific count when itemIds is provided', () => {
-        const IndicatorStore = require('sentry/stores/indicatorStore').default;
         const addMessageSpy = jest.spyOn(IndicatorStore, 'addMessage');
-
         GroupStore.onDeleteSuccess('1337', ['1', '2'], {});
 
-        expect(addMessageSpy).toHaveBeenCalledWith('Deleted 2 Issues', 'success', {duration: 4000});
+        expect(addMessageSpy).toHaveBeenCalledWith('Deleted 2 Issues', 'success', {
+          duration: 4000,
+        });
       });
 
       it('should show shortId for single issue deletion', () => {
-        const IndicatorStore = require('sentry/stores/indicatorStore').default;
         const addMessageSpy = jest.spyOn(IndicatorStore, 'addMessage');
-
-        // Mock the GroupStore.get method to return a group with shortId
         const mockGroup = g('1', {shortId: 'ABC-123'});
         jest.spyOn(GroupStore, 'get').mockReturnValue(mockGroup);
-
         GroupStore.onDeleteSuccess('1337', ['1'], {});
 
-        expect(addMessageSpy).toHaveBeenCalledWith('Deleted ABC-123', 'success', {duration: 4000});
+        expect(addMessageSpy).toHaveBeenCalledWith('Deleted ABC-123', 'success', {
+          duration: 4000,
+        });
       });
     });
 

--- a/static/app/stores/groupStore.spec.tsx
+++ b/static/app/stores/groupStore.spec.tsx
@@ -232,16 +232,16 @@ describe('GroupStore', () => {
       it('should show generic message when itemIds is undefined (all in query selected)', () => {
         const IndicatorStore = require('sentry/stores/indicatorStore').default;
         const addMessageSpy = jest.spyOn(IndicatorStore, 'addMessage');
-        
+
         GroupStore.onDeleteSuccess('1337', undefined, {});
 
-        expect(addMessageSpy).toHaveBeenCalledWith('Deleted all selected issues', 'success', {duration: 4000});
+        expect(addMessageSpy).toHaveBeenCalledWith('Deleted selected issues', 'success', {duration: 4000});
       });
 
       it('should show specific count when itemIds is provided', () => {
         const IndicatorStore = require('sentry/stores/indicatorStore').default;
         const addMessageSpy = jest.spyOn(IndicatorStore, 'addMessage');
-        
+
         GroupStore.onDeleteSuccess('1337', ['1', '2'], {});
 
         expect(addMessageSpy).toHaveBeenCalledWith('Deleted 2 Issues', 'success', {duration: 4000});
@@ -250,11 +250,11 @@ describe('GroupStore', () => {
       it('should show shortId for single issue deletion', () => {
         const IndicatorStore = require('sentry/stores/indicatorStore').default;
         const addMessageSpy = jest.spyOn(IndicatorStore, 'addMessage');
-        
+
         // Mock the GroupStore.get method to return a group with shortId
         const mockGroup = g('1', {shortId: 'ABC-123'});
         jest.spyOn(GroupStore, 'get').mockReturnValue(mockGroup);
-        
+
         GroupStore.onDeleteSuccess('1337', ['1'], {});
 
         expect(addMessageSpy).toHaveBeenCalledWith('Deleted ABC-123', 'success', {duration: 4000});

--- a/static/app/stores/groupStore.spec.tsx
+++ b/static/app/stores/groupStore.spec.tsx
@@ -228,6 +228,37 @@ describe('GroupStore', () => {
         expect(GroupStore.trigger).toHaveBeenCalledTimes(1);
         expect(GroupStore.trigger).toHaveBeenCalledWith(new Set(['1', '2', '3']));
       });
+
+      it('should show generic message when itemIds is undefined (all in query selected)', () => {
+        const IndicatorStore = require('sentry/stores/indicatorStore').default;
+        const addMessageSpy = jest.spyOn(IndicatorStore, 'addMessage');
+        
+        GroupStore.onDeleteSuccess('1337', undefined, {});
+
+        expect(addMessageSpy).toHaveBeenCalledWith('Deleted all selected issues', 'success', {duration: 4000});
+      });
+
+      it('should show specific count when itemIds is provided', () => {
+        const IndicatorStore = require('sentry/stores/indicatorStore').default;
+        const addMessageSpy = jest.spyOn(IndicatorStore, 'addMessage');
+        
+        GroupStore.onDeleteSuccess('1337', ['1', '2'], {});
+
+        expect(addMessageSpy).toHaveBeenCalledWith('Deleted 2 Issues', 'success', {duration: 4000});
+      });
+
+      it('should show shortId for single issue deletion', () => {
+        const IndicatorStore = require('sentry/stores/indicatorStore').default;
+        const addMessageSpy = jest.spyOn(IndicatorStore, 'addMessage');
+        
+        // Mock the GroupStore.get method to return a group with shortId
+        const mockGroup = g('1', {shortId: 'ABC-123'});
+        jest.spyOn(GroupStore, 'get').mockReturnValue(mockGroup);
+        
+        GroupStore.onDeleteSuccess('1337', ['1'], {});
+
+        expect(addMessageSpy).toHaveBeenCalledWith('Deleted ABC-123', 'success', {duration: 4000});
+      });
     });
 
     describe('onAssignToSuccess()', () => {

--- a/static/app/stores/groupStore.spec.tsx
+++ b/static/app/stores/groupStore.spec.tsx
@@ -234,11 +234,9 @@ describe('GroupStore', () => {
         const addMessageSpy = jest.spyOn(IndicatorStore, 'addMessage');
         GroupStore.onDeleteSuccess('1337', undefined, {});
 
-        expect(addMessageSpy).toHaveBeenCalledWith(
-          'Deleted selected issues',
-          'success',
-          {duration: 4000}
-        );
+        expect(addMessageSpy).toHaveBeenCalledWith('Deleted selected issues', 'success', {
+          duration: 4000,
+        });
       });
 
       it('should show specific count when itemIds is provided', () => {

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -366,7 +366,7 @@ const storeConfig: GroupStoreDefinition = {
     const ids = this.itemIdsOrAll(itemIds);
 
     if (itemIds === undefined) {
-      showAlert(t('Deleted all selected issues'), 'success');
+      showAlert(t('Deleted selected issues'), 'success');
     } else if (ids.length > 1) {
       showAlert(t('Deleted %d Issues', ids.length), 'success');
     } else {

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -365,7 +365,9 @@ const storeConfig: GroupStoreDefinition = {
   onDeleteSuccess(_changeId, itemIds, _response) {
     const ids = this.itemIdsOrAll(itemIds);
 
-    if (ids.length > 1) {
+    if (itemIds === undefined) {
+      showAlert(t('Deleted all selected issues'), 'success');
+    } else if (ids.length > 1) {
       showAlert(t('Deleted %d Issues', ids.length), 'success');
     } else {
       const shortId = ids.map(item => GroupStore.get(item)?.shortId).join('');


### PR DESCRIPTION
### 🐛 **Bug Identified**
The issue was in `sentry/static/app/stores/groupStore.tsx` in the `onDeleteSuccess` method. When users selected "all in query" and deleted more than 25 issues, the notification showed "25 issues deleted" instead of the actual count because:

1. When `allInQuerySelected` is true, `itemIds` is passed as `undefined` to `bulkDelete`
2. The backend deletes all matching issues but returns `204 No Content` with no count
3. The frontend's `onDeleteSuccess` method called `this.itemIdsOrAll(itemIds)` which returned `this.getAllItemIds()` when `itemIds` was `undefined`
4. `getAllItemIds()` only returned the IDs of issues currently loaded in the store (typically 25), not the actual number deleted

### 🔧 **Fix Implemented**
Modified the `onDeleteSuccess` method to handle the `undefined` case properly:

```typescript
// Before: Always showed count based on loaded items (incorrect for "all in query")
if (ids.length > 1) {
  showAlert(t('Deleted %d Issues', ids.length), 'success');
} else {
  const shortId = ids.map(item => GroupStore.get(item)?.shortId).join('');
  showAlert(t('Deleted %s', shortId), 'success');
}

// After: Handle undefined case with generic message
if (itemIds === undefined) {
  showAlert(t('Deleted selected issues'), 'success');
} else if (ids.length > 1) {
  showAlert(t('Deleted %d Issues', ids.length), 'success');
} else {
  const shortId = ids.map(item => GroupStore.get(item)?.shortId).join('');
  showAlert(t('Deleted %s', shortId), 'success');
}
```

### ✅ **Expected Result**
Now when users delete more than 25 issues using "Select all in query":
- **Before**: "25 issues deleted" (incorrect count)
- **After**: "Issues deleted" (generic but accurate message)

### 🧪 **Tests Added**
Added comprehensive tests to verify the fix:
- Test for generic message when `itemIds` is `undefined`
- Test for specific count when `itemIds` is provided
- Test for single issue deletion with shortId

### 📁 **Files Modified**
1. `/home/shahed/Documents/sentry/static/app/stores/groupStore.tsx` - Main fix
2. `/home/shahed/Documents/sentry/static/app/stores/groupStore.spec.tsx` - Tests


### Issue: https://github.com/getsentry/sentry/issues/100277

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
