### PR TITLE
bug(preprod): Create PENDING record for comparisons in POST handler to prevent empty state in compare page

### DIFF
--- a/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
+++ b/src/sentry/preprod/api/models/size_analysis/project_preprod_size_analysis_compare_models.py
@@ -29,4 +29,4 @@ class SizeAnalysisCompareGETResponse(BaseModel):
 class SizeAnalysisComparePOSTResponse(BaseModel):
     status: str
     message: str
-    existing_comparisons: list[SizeAnalysisComparison] | None
+    comparisons: list[SizeAnalysisComparison] | None

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -363,16 +363,18 @@ def _run_size_analysis_comparison(
     )
 
     # Update existing PENDING comparison or create new one
-    if comparison:
-        comparison.state = PreprodArtifactSizeComparison.State.PROCESSING
-        comparison.save()
-    else:
-        comparison = PreprodArtifactSizeComparison.objects.create(
-            head_size_analysis=head_size_metric,
-            base_size_analysis=base_size_metric,
-            organization_id=org_id,
-            state=PreprodArtifactSizeComparison.State.PROCESSING,
-        )
+    with transaction.atomic(router.db_for_write(PreprodArtifactSizeComparison)):
+        if comparison:
+            comparison.state = PreprodArtifactSizeComparison.State.PROCESSING
+            comparison.save()
+        else:
+            comparison = PreprodArtifactSizeComparison.objects.create(
+                head_size_analysis=head_size_metric,
+                base_size_analysis=base_size_metric,
+                organization_id=org_id,
+                state=PreprodArtifactSizeComparison.State.PROCESSING,
+            )
+            comparison.save()
 
     comparison_results = compare_size_analysis(
         head_size_analysis=head_size_metric,

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -102,9 +102,7 @@ def compare_preprod_artifact_size_analysis(
                             ),
                         },
                     )
-                    _run_size_analysis_comparison(
-                        project_id, org_id, matching_head_size_metric, base_metric
-                    )
+                    _run_size_analysis_comparison(org_id, matching_head_size_metric, base_metric)
                 else:
                     logger.info(
                         "preprod.size_analysis.compare.no_matching_base_size_metric",

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -271,10 +271,9 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
             mock_run_comparison.assert_called_once()
             call_args = mock_run_comparison.call_args[0]
             # Verify that the call was made with the correct parameters
-            assert call_args[0] == self.project.id
-            assert call_args[1] == self.organization.id
-            assert call_args[2].preprod_artifact.id == head_artifact.id
-            assert call_args[3].preprod_artifact.id == base_artifact.id
+            assert call_args[0] == self.organization.id
+            assert call_args[1].preprod_artifact.id == head_artifact.id
+            assert call_args[2].preprod_artifact.id == base_artifact.id
 
     def test_compare_preprod_artifact_size_analysis_no_matching_artifacts(self):
         """Test compare_preprod_artifact_size_analysis with no matching artifacts."""
@@ -528,7 +527,6 @@ class ManualSizeAnalysisComparisonTest(TestCase):
             )
 
             mock_run_comparison.assert_called_once_with(
-                self.project.id,
                 self.organization.id,
                 head_size_metrics,
                 base_size_metrics,
@@ -659,7 +657,6 @@ class RunSizeAnalysisComparisonTest(TestCase):
 
         # Run comparison
         _run_size_analysis_comparison(
-            self.project.id,
             self.organization.id,
             head_size_metrics,
             base_size_metrics,
@@ -706,7 +703,6 @@ class RunSizeAnalysisComparisonTest(TestCase):
 
         with patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger:
             _run_size_analysis_comparison(
-                self.project.id,
                 self.organization.id,
                 head_size_metrics,
                 base_size_metrics,
@@ -745,7 +741,6 @@ class RunSizeAnalysisComparisonTest(TestCase):
 
         with patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger:
             _run_size_analysis_comparison(
-                self.project.id,
                 self.organization.id,
                 head_size_metrics,
                 base_size_metrics,
@@ -785,7 +780,6 @@ class RunSizeAnalysisComparisonTest(TestCase):
 
         with patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger:
             _run_size_analysis_comparison(
-                self.project.id,
                 self.organization.id,
                 head_size_metrics,
                 base_size_metrics,
@@ -800,7 +794,8 @@ class RunSizeAnalysisComparisonTest(TestCase):
             head_size_analysis=head_size_metrics,
             base_size_analysis=base_size_metrics,
         )
-        assert len(comparisons) == 0
+        assert len(comparisons) == 1
+        assert comparisons[0].state == PreprodArtifactSizeComparison.State.FAILED
 
     def test_run_size_analysis_comparison_missing_base_analysis_file(self):
         """Test _run_size_analysis_comparison with missing base analysis file."""
@@ -823,7 +818,6 @@ class RunSizeAnalysisComparisonTest(TestCase):
 
         with patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger:
             _run_size_analysis_comparison(
-                self.project.id,
                 self.organization.id,
                 head_size_metrics,
                 base_size_metrics,
@@ -838,7 +832,8 @@ class RunSizeAnalysisComparisonTest(TestCase):
             head_size_analysis=head_size_metrics,
             base_size_analysis=base_size_metrics,
         )
-        assert len(comparisons) == 0
+        assert len(comparisons) == 1
+        assert comparisons[0].state == PreprodArtifactSizeComparison.State.FAILED
 
     def test_run_size_analysis_comparison_invalid_json(self):
         """Test _run_size_analysis_comparison with invalid JSON in analysis files."""
@@ -885,7 +880,6 @@ class RunSizeAnalysisComparisonTest(TestCase):
         # Should raise an exception due to invalid JSON
         with pytest.raises(Exception):
             _run_size_analysis_comparison(
-                self.project.id,
                 self.organization.id,
                 head_size_metrics,
                 base_size_metrics,
@@ -896,4 +890,5 @@ class RunSizeAnalysisComparisonTest(TestCase):
             head_size_analysis=head_size_metrics,
             base_size_analysis=base_size_metrics,
         )
-        assert len(comparisons) == 0
+        assert len(comparisons) == 1
+        assert comparisons[0].state == PreprodArtifactSizeComparison.State.FAILED

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -185,10 +185,9 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
             mock_run_comparison.assert_called_once()
             call_args = mock_run_comparison.call_args[0]
             # Verify that the call was made with the correct parameters
-            assert call_args[0] == self.project.id
-            assert call_args[1] == self.organization.id
-            assert call_args[2].preprod_artifact.id == head_artifact.id
-            assert call_args[3].preprod_artifact.id == base_artifact.id
+            assert call_args[0] == self.organization.id
+            assert call_args[1].preprod_artifact.id == head_artifact.id
+            assert call_args[2].preprod_artifact.id == base_artifact.id
 
     def test_compare_preprod_artifact_size_analysis_success_as_base(self):
         """Test compare_preprod_artifact_size_analysis with artifact as base."""


### PR DESCRIPTION
Creates a PENDING record for all comparisons as part of the POST compare endpoint (manual triggering). This ensures that when a user is redirected to the compare page after triggering a comparison, they no longer see an empty state and instead see the processing state.

Resolves EME-388