### PR TITLE
feat(stories): add import statement to component pages

### DIFF
--- a/static/app/components/core/alert/alert.mdx
+++ b/static/app/components/core/alert/alert.mdx
@@ -1,7 +1,9 @@
 ---
 title: Alert
 description: Alerts provide contextual feedback messages to users with different severity levels and optional interactive elements.
-source: 'sentry/components/core/alert'
+import:
+  name: Alert
+  from: '@sentry/scraps/alert'
 resources:
   js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/alert/index.tsx
   figma: https://www.figma.com/design/eTJz6aPgudMY9E6mzyZU0B/ChonkUI--App-Components--WIP-?node-id=3040-309&p=f&t=waV9nlkQ95W3UZtu-0

--- a/static/app/components/core/avatar/index.mdx
+++ b/static/app/components/core/avatar/index.mdx
@@ -1,7 +1,9 @@
 ---
 title: Avatar
 description: Avatars display an image of users, teams, organizations, and other Sentry-specific items.
-source: 'sentry/components/core/avatar'
+import:
+  name: Avatar
+  from: '@sentry/scraps/avatar'
 resources:
   js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/alert/index.tsx
 ---

--- a/static/app/components/core/badge/badge.mdx
+++ b/static/app/components/core/badge/badge.mdx
@@ -1,7 +1,9 @@
 ---
 title: Badge
 description: Badges and Tags are highlighted text elements intended to provide quick, at-a-glance contextual information such as status.
-source: 'sentry/components/core/badge'
+import:
+  name: Badge
+  from: '@sentry/scraps/badge'
 resources:
   figma: https://www.figma.com/design/eTJz6aPgudMY9E6mzyZU0B/ChonkUI--App-Components--WIP-?node-id=3574-5336
   js: https://github.com/getsentry/sentry/blob/481d8d642e9cf549eb46fbaac1d0527395e8b490/static/app/components/core/badge/index.tsx

--- a/static/app/components/core/button/button.mdx
+++ b/static/app/components/core/button/button.mdx
@@ -1,7 +1,9 @@
 ---
 title: Button
 description: Buttons are clickable elements that trigger an action that does not change the current URL.
-source: 'sentry/components/core/button'
+import:
+  name: Button
+  from: '@sentry/scraps/button'
 resources:
   figma: https://www.figma.com/design/eTJz6aPgudMY9E6mzyZU0B/ChonkUI--App-Components--WIP-?node-id=384-2119&t=DdXZ7WIgTdURJlRv-4
   js: https://github.com/getsentry/sentry/blob/481d8d642e9cf549eb46fbaac1d0527395e8b490/static/app/components/core/button/index.tsx#L22

--- a/static/app/components/core/checkbox/checkbox.mdx
+++ b/static/app/components/core/checkbox/checkbox.mdx
@@ -1,7 +1,9 @@
 ---
 title: Checkbox
 description: Checkboxes are used to let users select one or more items from a set of options, or to indicate a binary choice.
-source: 'sentry/components/core/checkbox'
+import:
+  name: Checkbox
+  from: '@sentry/scraps/checkbox'
 resources:
   figma: https://www.figma.com/design/eTJz6aPgudMY9E6mzyZU0B/ChonkUI--App-Components--WIP-?node-id=384-2119&t=DdXZ7WIgTdURJlRv-4
   js: https://github.com/getsentry/sentry/blob/481d8d642e9cf549eb46fbaac1d0527395e8b490/static/app/components/core/checkbox/index.tsx#L35

--- a/static/app/components/core/code/codeBlock.mdx
+++ b/static/app/components/core/code/codeBlock.mdx
@@ -1,7 +1,9 @@
 ---
 title: CodeBlock
 description: CodeBlock displays multi-line code snippets with syntax highlighting, copy functionality, and support for tabs, filenames, and line highlighting.
-source: 'sentry/components/core/code'
+import:
+  name: CodeBlock
+  from: '@sentry/scraps/code'
 resources:
   js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/code/codeBlock.tsx
   a11y:

--- a/static/app/components/core/code/inlineCode.mdx
+++ b/static/app/components/core/code/inlineCode.mdx
@@ -1,7 +1,9 @@
 ---
 title: InlineCode
 description: InlineCode provides styling for short snippets of code within text content, such as variable names, function names, or short commands.
-source: 'sentry/components/core/code'
+import:
+  name: InlineCode
+  from: '@sentry/scraps/code'
 status: stable
 resources:
   js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/inlineCode/index.tsx

--- a/static/app/components/core/image/image.mdx
+++ b/static/app/components/core/image/image.mdx
@@ -1,7 +1,9 @@
 ---
 title: Image
 description: A flexible image component with built-in lazy loading, object-fit support, and error handling capabilities.
-source: 'sentry/components/core/image'
+import:
+  name: Image
+  from: '@sentry/scraps/image'
 resources:
   js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/image/image.tsx
 ---

--- a/static/app/components/core/separator/separator.mdx
+++ b/static/app/components/core/separator/separator.mdx
@@ -1,7 +1,10 @@
 ---
 title: Separator
 description: A flexible separator component that creates visual divisions between content with customizable orientation and styling.
-source: 'sentry/components/core/separator'
+source: '@sentry/scraps/separator'
+import:
+  name: Separator
+  from: '@sentry/scraps/separator'
 resources:
   js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/separator/separator.tsx
 ---

--- a/static/app/components/core/text/heading.mdx
+++ b/static/app/components/core/text/heading.mdx
@@ -1,7 +1,9 @@
 ---
 title: Heading
 description: Heading components display semantic heading elements with appropriate typography and styling controls.
-source: 'sentry/components/core/text'
+import:
+  name: Heading
+  from: '@sentry/scraps/text'
 resources:
   js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/text/heading.tsx
   a11y:

--- a/static/app/components/core/text/prose.mdx
+++ b/static/app/components/core/text/prose.mdx
@@ -1,8 +1,9 @@
 ---
 title: Prose
 description: Prose provides consistent spacing and typography for rich text content including headings, paragraphs, lists, and other prose elements.
-source: 'sentry/components/core/text'
-status: in-progress
+import:
+  name: Prose
+  from: '@sentry/scraps/text'
 resources:
   js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/text/prose.tsx
   a11y:

--- a/static/app/components/core/text/text.mdx
+++ b/static/app/components/core/text/text.mdx
@@ -1,7 +1,9 @@
 ---
 title: Text
 description: Text components display text content with various typography options and styling controls.
-source: 'sentry/components/core/text'
+import:
+  name: Text
+  from: '@sentry/scraps/text'
 resources:
   js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/text/text.tsx
   a11y:

--- a/static/app/components/core/tooltip/tooltip.mdx
+++ b/static/app/components/core/tooltip/tooltip.mdx
@@ -1,7 +1,9 @@
 ---
 title: Tooltip
 description: Tooltips provide contextual information about an element when users hover over it.
-source: 'sentry/components/core/tooltip'
+import:
+  name: Tooltip
+  from: '@sentry/scraps/tooltip'
 resources:
   js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/tooltip/index.tsx
   a11y:

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -3,6 +3,9 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {ErrorBoundary} from '@sentry/react';
 
+import {InlineCode} from '@sentry/scraps/code';
+
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Alert} from 'sentry/components/core/alert';
 import {Tag} from 'sentry/components/core/badge/tag';
 import {Flex, Grid} from 'sentry/components/core/layout';
@@ -138,14 +141,25 @@ function StoryTabPanels() {
     return <StoryUsage />;
   }
 
+  const source = story.exports.frontmatter?.import;
   // A document is just a single page
   if (story.exports.frontmatter?.layout === 'document') {
     return <StoryUsage />;
   }
-
+  const importStatement = source
+    ? `import {${source.name}} from '${source.from}';`
+    : undefined;
   return (
     <TabPanels>
       <TabPanels.Item key="usage">
+        {importStatement && (
+          <StoryStickyContainer>
+            <Flex background="primary" padding="lg 0" align="center" justify="between">
+              <InlineCode>{importStatement}</InlineCode>
+              <CopyToClipboardButton size="zero" text={importStatement} />
+            </Flex>
+          </StoryStickyContainer>
+        )}
         <StoryUsage />
       </TabPanels.Item>
       <TabPanels.Item key="api">
@@ -265,4 +279,10 @@ const StoryContainer = styled('div')`
 
 const StoryContent = styled('main')`
   flex-grow: 1;
+`;
+
+const StoryStickyContainer = styled('div')`
+  position: sticky;
+  top: 53px;
+  z-index: ${p => p.theme.zIndex.header - 1};
 `;

--- a/static/app/stories/view/useStoriesLoader.tsx
+++ b/static/app/stories/view/useStoriesLoader.tsx
@@ -18,9 +18,9 @@ export interface MDXStoryDescriptor {
     frontmatter?: {
       description: string;
       title: string;
+      import?: {from: string; name: string};
       layout?: 'document';
       resources?: StoryResources;
-      source?: string;
       status?: 'in-progress' | 'experimental' | 'stable';
       types?: string;
     };


### PR DESCRIPTION
Adds a sticky header with `import { Component } from "@sentry/scraps/module";` to MDX stories. Also updates imports for existing stories to use `@sentry/scraps`.