### PR TITLE
chore(spans-migration): null `changed_reason` when a spans query/widget is saved

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -909,6 +909,12 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         widget.dataset_source = new_dataset_source
         widget.detail = {"layout": data.get("layout", prev_layout)}
 
+        if (
+            new_dataset_source == DatasetSourcesTypes.USER.value
+            and widget.widget_type == DashboardWidgetTypes.SPANS
+        ):
+            widget.changed_reason = None
+
         if widget.widget_type not in [
             DashboardWidgetTypes.DISCOVER,
             DashboardWidgetTypes.TRANSACTION_LIKE,
@@ -918,12 +924,6 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             # a discover/errors/transactions widget
             widget.discover_widget_split = None
             widget.dataset_source = DatasetSourcesTypes.UNKNOWN.value
-
-        if (
-            new_dataset_source == DatasetSourcesTypes.USER.value
-            and widget.widget_type == DashboardWidgetTypes.SPANS
-        ):
-            widget.changed_reason = None
 
         widget.save()
 

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -905,7 +905,8 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             "discover_widget_split", widget.discover_widget_split
         )
         widget.limit = data.get("limit", widget.limit)
-        widget.dataset_source = data.get("dataset_source", widget.dataset_source)
+        new_dataset_source = data.get("dataset_source", widget.dataset_source)
+        widget.dataset_source = new_dataset_source
         widget.detail = {"layout": data.get("layout", prev_layout)}
 
         if widget.widget_type not in [
@@ -917,6 +918,12 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             # a discover/errors/transactions widget
             widget.discover_widget_split = None
             widget.dataset_source = DatasetSourcesTypes.UNKNOWN.value
+
+        if (
+            new_dataset_source == DatasetSourcesTypes.USER.value
+            and widget.widget_type == DashboardWidgetTypes.SPANS
+        ):
+            widget.changed_reason = None
 
         widget.save()
 

--- a/src/sentry/explore/endpoints/explore_saved_query_detail.py
+++ b/src/sentry/explore/endpoints/explore_saved_query_detail.py
@@ -23,11 +23,7 @@ from sentry.apidocs.examples.explore_saved_query_examples import ExploreExamples
 from sentry.apidocs.parameters import ExploreSavedQueryParams, GlobalParams
 from sentry.explore.endpoints.bases import ExploreSavedQueryPermission
 from sentry.explore.endpoints.serializers import ExploreSavedQuerySerializer
-from sentry.explore.models import (
-    ExploreSavedQuery,
-    ExploreSavedQueryDataset,
-    ExploreSavedQueryLastVisited,
-)
+from sentry.explore.models import ExploreSavedQuery, ExploreSavedQueryLastVisited
 from sentry.models.organization import Organization
 
 
@@ -133,9 +129,7 @@ class ExploreSavedQueryDetailEndpoint(ExploreSavedQueryBase):
             name=data["name"],
             query=data["query"],
             dataset=data["dataset"],
-            changed_reason=(
-                None if data["dataset"] == ExploreSavedQueryDataset.SPANS else query.changed_reason
-            ),
+            changed_reason=None,
         )
 
         query.set_projects(data["project_ids"])

--- a/src/sentry/explore/endpoints/explore_saved_query_detail.py
+++ b/src/sentry/explore/endpoints/explore_saved_query_detail.py
@@ -23,7 +23,11 @@ from sentry.apidocs.examples.explore_saved_query_examples import ExploreExamples
 from sentry.apidocs.parameters import ExploreSavedQueryParams, GlobalParams
 from sentry.explore.endpoints.bases import ExploreSavedQueryPermission
 from sentry.explore.endpoints.serializers import ExploreSavedQuerySerializer
-from sentry.explore.models import ExploreSavedQuery, ExploreSavedQueryLastVisited
+from sentry.explore.models import (
+    ExploreSavedQuery,
+    ExploreSavedQueryDataset,
+    ExploreSavedQueryLastVisited,
+)
 from sentry.models.organization import Organization
 
 
@@ -128,6 +132,10 @@ class ExploreSavedQueryDetailEndpoint(ExploreSavedQueryBase):
             organization=organization,
             name=data["name"],
             query=data["query"],
+            dataset=data["dataset"],
+            changed_reason=(
+                None if data["dataset"] == ExploreSavedQueryDataset.SPANS else query.changed_reason
+            ),
         )
 
         query.set_projects(data["project_ids"])


### PR DESCRIPTION
Once a migrated saved query or widget is saved by the user, the `changed_reason` field should get reset to null. We're putting that logic in the `PUT` requests for the respective endpoints.
