### PR TITLE
chore(auto_source): Increase code mapping derivation deadline

### DIFF
--- a/src/sentry/tasks/auto_source_code_config.py
+++ b/src/sentry/tasks/auto_source_code_config.py
@@ -11,7 +11,7 @@ from sentry.taskworker.retry import Retry
 @instrumented_task(
     name="sentry.tasks.auto_source_code_config",
     namespace=issues_tasks,
-    processing_deadline_duration=10 * 60,
+    processing_deadline_duration=15 * 60,
     retry=Retry(times=3, delay=60 * 10),
 )
 def auto_source_code_config(project_id: int, event_id: str, group_id: int, **kwargs: Any) -> None:


### PR DESCRIPTION
We still see about seventy occurrences a day.
The last bump reduced 90% of occurrences.

Eventually we will have to change this sequential approach but for now this is our only option.

Fixes [SENTRY-4B4Q](https://sentry.sentry.io/issues/6792798563/)