### PR TITLE
fix(alert): Delete IncidentTrigger as child of AlertRuleTrigger

### DIFF
--- a/src/sentry/deletions/defaults/alert_rule_trigger.py
+++ b/src/sentry/deletions/defaults/alert_rule_trigger.py
@@ -5,9 +5,11 @@ from sentry.incidents.models.alert_rule import AlertRuleTrigger
 class AlertRuleTriggerDeletionTask(ModelDeletionTask[AlertRuleTrigger]):
     def get_child_relations(self, instance: AlertRuleTrigger) -> list[BaseRelation]:
         from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+        from sentry.incidents.models.incident import IncidentTrigger
         from sentry.workflow_engine.models import DataConditionAlertRuleTrigger
 
         return [
             ModelRelation(AlertRuleTriggerAction, {"alert_rule_trigger_id": instance.id}),
+            ModelRelation(IncidentTrigger, {"alert_rule_trigger_id": instance.id}),
             ModelRelation(DataConditionAlertRuleTrigger, {"alert_rule_trigger_id": instance.id}),
         ]


### PR DESCRIPTION
There can be 10s-100s of thousands of IncidentTrigger rows associated with an AlertRuleTrigger.
In SENTRY-4A76, we see repeated failed attempts to delete an AlertRuleTrigger with 15k IncidentTriggers, and this change will hopefully help there.
