### PR TITLE
fix(aci): Don't log project id deletion on every chunk

### DIFF
--- a/src/sentry/workflow_engine/processors/schedule.py
+++ b/src/sentry/workflow_engine/processors/schedule.py
@@ -211,10 +211,10 @@ def mark_projects_processed(
                 deleted = buffer_client.mark_project_ids_as_processed(dict(chunk))
                 deleted_project_ids.update(deleted)
 
-                logger.info(
-                    "process_buffered_workflows.project_ids_deleted",
-                    extra={
-                        "deleted_project_ids": sorted(deleted_project_ids),
-                        "processed_project_ids": sorted(processed_project_ids),
-                    },
-                )
+        logger.info(
+            "process_buffered_workflows.project_ids_deleted",
+            extra={
+                "deleted_project_ids": sorted(deleted_project_ids),
+                "processed_project_ids": sorted(processed_project_ids),
+            },
+        )


### PR DESCRIPTION
The logging is intended to be comprehensive, so once per chunk is incorrect and noisy.
This was due to a bad merge, but should have no effect on behavior.
We could also do chunk-specific logging, but a single log is simpler.
