### PR TITLE
fix(replay) - fix use fetch parallel pages

### DIFF
--- a/static/app/utils/api/useFetchParallelPages.tsx
+++ b/static/app/utils/api/useFetchParallelPages.tsx
@@ -98,10 +98,10 @@ export default function useFetchParallelPages<Data>({
 
   const responsePages = useRef<Map<string, ResponsePage<Data>>>(new Map());
 
-  const pages = Math.ceil(hits / perPage);
   const cursors = useMemo(
-    () => new Array(pages).fill(0).map((_, i) => `0:${perPage * i}:0`),
-    [pages, perPage]
+    () =>
+      new Array(Math.ceil(hits / perPage)).fill(0).map((_, i) => `0:${perPage * i}:0`),
+    [hits, perPage]
   );
 
   const [state, setState] = useState<State<Data>>({

--- a/static/app/utils/api/useFetchParallelPages.tsx
+++ b/static/app/utils/api/useFetchParallelPages.tsx
@@ -129,7 +129,6 @@ export default function useFetchParallelPages<Data>({
           const [data, , resp] = await queryClient.fetchQuery({
             queryKey: getQueryKey({cursor, per_page: perPage}),
             queryFn: fetchDataQuery<Data>,
-            staleTime: Infinity,
           });
 
           responsePages.current.set(cursor, {

--- a/static/app/utils/api/useFetchParallelPages.tsx
+++ b/static/app/utils/api/useFetchParallelPages.tsx
@@ -129,6 +129,7 @@ export default function useFetchParallelPages<Data>({
           const [data, , resp] = await queryClient.fetchQuery({
             queryKey: getQueryKey({cursor, per_page: perPage}),
             queryFn: fetchDataQuery<Data>,
+            staleTime: Infinity,
           });
 
           responsePages.current.set(cursor, {


### PR DESCRIPTION
When building the background refresh, Billy and I encountered some bugs with useFetchParallelPages.

a. It doesn't refetch with a different hits value:

1. (First call) `useFetchParallelPages({hits = 12, perPage = 100})`, then we would have pages=1
2. (Second call) `useFetchParallelPages({hits = 15, perPage = 100})`, then we would **still** have pages=1 and the old version of `cursors`. The  useEffect later wouldn't run `fetch()` on re-render when it should.    



