### PR TITLE
chore(timeseries): Mark `TimeSeries` meta property as optional

### DIFF
--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -162,10 +162,10 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
 }
 
 type EventsTimeSeriesResponse = {
-  meta: {
+  timeSeries: TimeSeries[];
+  meta?: {
     dataset: DiscoverDatasets;
     end: number;
     start: number;
   };
-  timeSeries: TimeSeries[];
 };


### PR DESCRIPTION
Meta is not currently in use, but _also_ it might be omitted completely if the request ran into an error and no data was found.
