### PR TITLE
Add os build tag

### DIFF
--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -203,7 +203,12 @@ class BrowserContextType(ContextType):
 @contexttype
 class OsContextType(ContextType):
     type = "os"
-    context_to_tag_mapping = {"": "{os}", "name": "{name}", "rooted": "{rooted}"}
+    context_to_tag_mapping = {
+        "": "{os}",
+        "name": "{name}",
+        "rooted": "{rooted}",
+        "build": "{build}",
+    }
     # build, rooted
 
 

--- a/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_os_normalization.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_os_normalization.pysnap
@@ -5,6 +5,8 @@ errors: null
 tags:
 - - os
   - Windows 7
+- - os.build
+  - '7601'
 - - os.name
   - Windows
 to_json:


### PR DESCRIPTION
Adds is build as a context -> tag mapping so you can see the breakdown of OS build versions affecting a particular issue. This will make it possible to identify patterns such as issues only happening in beta builds of a particular OS version

Tested by sending an event from the iOS simulator locally
<img width="878" height="168" alt="Screenshot 2025-10-14 at 4 18 56 PM" src="https://github.com/user-attachments/assets/269cfe31-2690-4afa-8fed-e8092ce31e68" />
