### PR TITLE
fix(spans-migration): changed reason format

### DIFF
--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -25,7 +25,7 @@ class QueryParts(TypedDict):
 class DroppedFields(TypedDict):
     selected_columns: list[str]
     equations: list[dict[str, list[str]]]
-    orderby: list[dict[str, str]]
+    orderby: list[dict[str, str | list[str]]]
 
 
 COLUMNS_TO_DROP = (
@@ -357,14 +357,14 @@ def translate_orderbys(orderbys, equations, dropped_equations, new_equations):
 
             # checks if equation index is out of bounds
             if len(equations) < equation_index + 1:
-                dropped_orderby_reason = "equation at this index doesn't exist"
+                dropped_orderby_reason = "equation issue"
 
             # if there are equations
             elif len(equations) > 0:
                 selected_equation = equations[equation_index]
                 # if equation was dropped, drop the orderby too
                 if selected_equation in dropped_equations:
-                    dropped_orderby_reason = "equation was dropped"
+                    dropped_orderby_reason = "dropped"
                     decoded_orderby = (
                         selected_equation if not is_negated else f"-{selected_equation}"
                     )
@@ -376,12 +376,12 @@ def translate_orderbys(orderbys, equations, dropped_equations, new_equations):
                         new_equation_index = new_equations.index(translated_equation)
                         translated_orderby = [f"equation[{new_equation_index}]"]
                     except (IndexError, ValueError):
-                        dropped_orderby_reason = "equation was dropped"
+                        dropped_orderby_reason = "dropped"
                         decoded_orderby = (
                             selected_equation if not is_negated else f"-{selected_equation}"
                         )
             else:
-                dropped_orderby_reason = "no equations in this query"
+                dropped_orderby_reason = "no equations"
                 decoded_orderby = orderby
 
         # if orderby is an equation
@@ -390,9 +390,7 @@ def translate_orderbys(orderbys, equations, dropped_equations, new_equations):
                 [orderby_without_neg]
             )
             if len(dropped_orderby_equation) > 0:
-                dropped_orderby_reason = "fields were dropped: " + ", ".join(
-                    dropped_orderby_equation[0]["reason"]
-                )
+                dropped_orderby_reason = dropped_orderby_equation[0]["reason"]
 
         # if orderby is a field/function
         else:
@@ -400,7 +398,7 @@ def translate_orderbys(orderbys, equations, dropped_equations, new_equations):
                 [orderby_without_neg], need_equation=True
             )
             if len(dropped_orderby) > 0:
-                dropped_orderby_reason = "fields were dropped: " + ", ".join(dropped_orderby)
+                dropped_orderby_reason = dropped_orderby
 
         # add translated orderby to the list and record dropped orderbys
         if dropped_orderby_reason is None:

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -338,15 +338,15 @@ def test_mep_to_eap_simple_equations(
             [
                 {
                     "orderby": "-count_miserable(user,300)",
-                    "reason": "fields were dropped: count_miserable(user,300)",
+                    "reason": ["count_miserable(user,300)"],
                 },
                 {
                     "orderby": "count_web_vitals(user,300)",
-                    "reason": "fields were dropped: count_web_vitals(user,300)",
+                    "reason": ["count_web_vitals(user,300)"],
                 },
                 {
                     "orderby": "any(transaction.duration)",
-                    "reason": "fields were dropped: any(span.duration)",
+                    "reason": ["any(span.duration)"],
                 },
             ],
         ),
@@ -366,14 +366,14 @@ def test_mep_to_eap_simple_equations(
             [
                 {
                     "orderby": "equation|count_miserable(user,300) + 3",
-                    "reason": "equation was dropped",
+                    "reason": "dropped",
                 }
             ],
         ),
         pytest.param(
             ["equation[3453]"],
             [],
-            [{"orderby": "equation[3453]", "reason": "equation at this index doesn't exist"}],
+            [{"orderby": "equation[3453]", "reason": "equation issue"}],
         ),
     ],
 )

--- a/tests/sentry/explore/translation/test_discover_translation.py
+++ b/tests/sentry/explore/translation/test_discover_translation.py
@@ -219,7 +219,7 @@ class DiscoverToExploreTranslationTest(TestCase):
         assert new_explore_query.changed_reason["orderby"] == [
             {
                 "orderby": "-count_miserable(users)",
-                "reason": "fields were dropped: count_miserable(users)",
+                "reason": ["count_miserable(users)"],
             }
         ]
 


### PR DESCRIPTION
To display more cohesive warning messaging for dropped fields in the frontend we're changing the way dropped fields are being passed back for orderbys. We are changing it to mimic the columns and equations fields where the reason can be a list of fields that were dropped as part of the orderby.
