### PR TITLE
fix(sub v3): Make row clickability more obvious

### DIFF
--- a/static/gsApp/views/subscriptionPage/usageOverview.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview.spec.tsx
@@ -174,16 +174,14 @@ describe('UsageOverview', () => {
       />
     );
     expect(screen.getByRole('cell', {name: 'Seer'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: 'Collapse Seer details'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('row', {name: 'Collapse Seer details'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: 'Issue Fixes'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: 'Issue Scans'})).toBeInTheDocument();
 
     // Org has Prevent flag but did not buy Prevent add on
     expect(screen.getByRole('cell', {name: 'Prevent'})).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', {name: 'Collapse Prevent details'})
+      screen.queryByRole('row', {name: 'Collapse Prevent details'})
     ).not.toBeInTheDocument();
     // We test it this way to ensure we don't show the cell with the proper display name or the raw DataCategory
     expect(screen.queryByRole('cell', {name: /Prevent*Users/})).not.toBeInTheDocument();


### PR DESCRIPTION
Tweaks the Usage Overview table to make it more obvious when you can click a row. Changes:
- changes row background on hover
- surfaces button on hover
- add-on dropdown behavior now occurs on whole row, as opposed to just on a button in the first column for that add-on
- adjusted some column widths for larger screens
- opening a new drawer should replace the browser URL instead of adding to the browser history

https://github.com/user-attachments/assets/a9f2087e-f751-4733-a4c8-df63e5478bd9

Closes BIL-1671 and BIL-1679