### PR TITLE
fix(aci): Update permissions logic to allow editing detector/workflow connections for system-created detectors

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -419,7 +419,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         queryset = self.filter_detectors(request, organization)
 
         # If explicitly filtering by IDs and some were not found, return 400
-        if request.GET.getlist("id") and len(queryset) != len(request.GET.getlist("id")):
+        if request.GET.getlist("id") and len(queryset) != len(set(request.GET.getlist("id"))):
             return Response(
                 {
                     "detail": "Some detectors were not found or you do not have permission to update them."
@@ -491,7 +491,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         queryset = self.filter_detectors(request, organization)
 
         # If explicitly filtering by IDs and some were not found, return 400
-        if request.GET.getlist("id") and len(queryset) != len(request.GET.getlist("id")):
+        if request.GET.getlist("id") and len(queryset) != len(set(request.GET.getlist("id"))):
             return Response(
                 {
                     "detail": "Some detectors were not found or you do not have permission to delete them."

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -15,7 +15,8 @@ from sentry import audit_log, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import OrganizationAlertRulePermission, OrganizationEndpoint
+from sentry.api.bases import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationDetectorPermission
 from sentry.api.event_search import SearchConfig, SearchFilter, SearchKey, default_config
 from sentry.api.event_search import parse_search_query as base_parse_search_query
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -145,9 +146,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
     }
     owner = ApiOwner.ISSUES
 
-    # TODO: We probably need a specific permission for detectors. Possibly specific detectors have different perms
-    # too?
-    permission_classes = (OrganizationAlertRulePermission,)
+    permission_classes = (OrganizationDetectorPermission,)
 
     def filter_detectors(self, request: Request, organization) -> QuerySet[Detector]:
         """
@@ -419,6 +418,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
 
         queryset = self.filter_detectors(request, organization)
 
+        # If explicitly filtering by IDs and some were not found, return 400
         if request.GET.getlist("id") and len(queryset) != len(request.GET.getlist("id")):
             return Response(
                 {
@@ -490,6 +490,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
 
         queryset = self.filter_detectors(request, organization)
 
+        # If explicitly filtering by IDs and some were not found, return 400
         if request.GET.getlist("id") and len(queryset) != len(request.GET.getlist("id")):
             return Response(
                 {

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -419,6 +419,14 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
 
         queryset = self.filter_detectors(request, organization)
 
+        if request.GET.getlist("id") and len(queryset) != len(request.GET.getlist("id")):
+            return Response(
+                {
+                    "detail": "Some detectors were not found or you do not have permission to update them."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         if not queryset:
             return Response(
                 {"detail": "No detectors found."},
@@ -481,6 +489,14 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
             )
 
         queryset = self.filter_detectors(request, organization)
+
+        if request.GET.getlist("id") and len(queryset) != len(request.GET.getlist("id")):
+            return Response(
+                {
+                    "detail": "Some detectors were not found or you do not have permission to delete them."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         if not queryset:
             return Response(

--- a/src/sentry/workflow_engine/endpoints/organization_detector_workflow_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_workflow_details.py
@@ -26,7 +26,9 @@ from sentry.utils.audit import create_audit_entry
 from sentry.workflow_engine.endpoints.serializers.detector_workflow_serializer import (
     DetectorWorkflowSerializer,
 )
-from sentry.workflow_engine.endpoints.validators.detector_workflow import can_edit_detector
+from sentry.workflow_engine.endpoints.validators.detector_workflow import (
+    can_edit_detector_workflow_connections,
+)
 from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
 
 
@@ -96,7 +98,7 @@ class OrganizationDetectorWorkflowDetailsEndpoint(OrganizationEndpoint):
         """
         Delete a DetectorWorkflow
         """
-        if not can_edit_detector(detector_workflow.detector, request):
+        if not can_edit_detector_workflow_connections(detector_workflow.detector, request):
             raise PermissionDenied
 
         RegionScheduledDeletion.schedule(detector_workflow, days=0, actor=request.user)

--- a/src/sentry/workflow_engine/endpoints/organization_detector_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_workflow_index.py
@@ -25,7 +25,7 @@ from sentry.workflow_engine.endpoints.serializers.detector_workflow_serializer i
 )
 from sentry.workflow_engine.endpoints.validators.detector_workflow import (
     DetectorWorkflowValidator,
-    can_edit_detector,
+    can_edit_detector_workflow_connections,
 )
 from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
 
@@ -135,9 +135,9 @@ class OrganizationDetectorWorkflowIndexEndpoint(OrganizationEndpoint):
         if not queryset:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        # check that the user has permission to edit all detectors before deleting
+        # check that the user has permission to edit all detectors connections before deleting
         for detector_workflow in queryset:
-            if not can_edit_detector(detector_workflow.detector, request):
+            if not can_edit_detector_workflow_connections(detector_workflow.detector, request):
                 raise PermissionDenied
 
         for detector_workflow in queryset:

--- a/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
@@ -24,9 +24,10 @@ def is_system_created_detector(detector: Detector) -> bool:
 
 def can_edit_system_created_detectors(request: Request) -> bool:
     """
-    Only those with organizaiton write permissions can edit error detectors
+    Only those with organization write permissions can edit system-created detectors
+    (e.g. error detectors).
     """
-    return request.access.has_scope("org:admin") or request.access.has_scope("org:write")
+    return request.access.has_scope("org:write")
 
 
 def has_alert_write_access(request: Request, project: Project) -> bool:

--- a/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
@@ -35,10 +35,8 @@ def can_edit_detectors(detectors: QuerySet[Detector], request: Request) -> bool:
     """
     Determine if the requesting user has access to edit the given detectors.
     """
-    if can_edit_error_detectors(request):
-        return True
-    elif any(detector.type == ErrorGroupType.slug for detector in detectors):
-        return False
+    if any(detector.type == ErrorGroupType.slug for detector in detectors):
+        return can_edit_error_detectors(request)
 
     projects = Project.objects.filter(
         id__in=detectors.values_list("project_id", flat=True).distinct()

--- a/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
@@ -9,6 +9,7 @@ from rest_framework.request import Request
 
 from sentry import audit_log
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
+from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.utils.audit import create_audit_entry
@@ -17,37 +18,33 @@ from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
 from sentry.workflow_engine.models.workflow import Workflow
 
 
+def can_edit_error_detectors(request: Request) -> bool:
+    """
+    Only those with organizaiton write permissions can edit error detectors
+    """
+    return request.access.has_scope("org:admin") or request.access.has_scope("org:write")
+
+
+def has_alert_write_access(request: Request, project: Project) -> bool:
+    return can_edit_error_detectors(request) or request.access.has_project_scope(
+        project, "alerts:write"
+    )
+
+
 def can_edit_detectors(detectors: QuerySet[Detector], request: Request) -> bool:
     """
     Determine if the requesting user has access to edit the given detectors.
-    If the request does not have the "alerts:write" permission, then we must verify that the user is a team admin
-    with "project:write" access to the project(s) in their request.
     """
-    if request.access.has_scope("org:admin") or request.access.has_scope("org:write"):
+    if can_edit_error_detectors(request):
         return True
+    elif any(detector.type == ErrorGroupType.slug for detector in detectors):
+        return False
 
     projects = Project.objects.filter(
         id__in=detectors.values_list("project_id", flat=True).distinct()
     )
 
-    for project in projects:
-        detectors_for_project = detectors.filter(project=project.id)
-
-        has_project_access = request.access.has_project_scope(project, "project:read")
-        has_alerts_write = request.access.has_project_scope(project, "alerts:write")
-
-        if has_alerts_write and has_project_access:
-            # team admins can modify all detectors for projects they have access to
-            has_team_admin_access = request.access.has_project_scope(project, "project:write")
-            if has_team_admin_access:
-                continue
-            # members can modify user-created detectors for projects they have access to
-            if all(detector.created_by_id is not None for detector in detectors_for_project):
-                continue
-
-        return False
-
-    return True
+    return all(has_alert_write_access(request, project) for project in projects)
 
 
 def can_edit_detector(detector: Detector, request: Request) -> bool:
@@ -56,23 +53,18 @@ def can_edit_detector(detector: Detector, request: Request) -> bool:
     permission, then we must verify that the user is a team admin with "alerts:write" access to the project(s)
     in their request.
     """
-    # if the requesting user has any of these org-level permissions, then they can create an alert
-    if request.access.has_scope("org:admin") or request.access.has_scope("org:write"):
-        return True
+    if detector.type == ErrorGroupType.slug and not can_edit_error_detectors(request):
+        return False
 
-    project = detector.project
+    return has_alert_write_access(request, detector.project)
 
-    if request.access.has_project_scope(project, "alerts:write"):
-        # team admins can modify all detectors for projects they have access to
-        has_team_admin_access = request.access.has_project_scope(project, "project:write")
-        if has_team_admin_access:
-            return True
-        # members can modify user-created detectors for projects they have access to
-        has_project_access = request.access.has_project_scope(project, "project:read")
-        if has_project_access and detector.created_by_id is not None:
-            return True
 
-    return False
+def can_edit_detector_workflow_connections(detector: Detector, request: Request) -> bool:
+    """
+    Anyone with alert write access to the project can connect/disconnect detectors of any type,
+    which is slightly different from full edit access which differs by detector type.
+    """
+    return has_alert_write_access(request, detector.project)
 
 
 def validate_detectors_exist_and_have_permissions(
@@ -161,7 +153,7 @@ class DetectorWorkflowValidator(CamelSnakeSerializer):
                     project__organization=self.context["organization"],
                     id=validated_data["detector_id"],
                 )
-                if not can_edit_detector(detector, self.context["request"]):
+                if not can_edit_detector_workflow_connections(detector, self.context["request"]):
                     raise PermissionDenied
                 workflow = Workflow.objects.get(
                     organization=self.context["organization"], id=validated_data["workflow_id"]

--- a/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
@@ -37,6 +37,8 @@ def can_edit_user_created_detectors(request: Request, project: Project) -> bool:
 def can_edit_detectors(detectors: QuerySet[Detector], request: Request) -> bool:
     """
     Determine if the requesting user has access to edit the given detectors.
+    System created detectors lock edit access to org:write, while user created detectors
+    are more permissive.
     """
     required_scopes = (
         SYSTEM_CREATED_DETECTOR_REQUIRED_SCOPES

--- a/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
@@ -26,8 +26,8 @@ def is_system_created_detector(detector: Detector) -> bool:
     return detector.type in (ErrorGroupType.slug,)
 
 
-def can_edit_system_created_detectors(request: Request) -> bool:
-    return request.access.has_any_scope(SYSTEM_CREATED_DETECTOR_REQUIRED_SCOPES)
+def can_edit_system_created_detectors(request: Request, project: Project) -> bool:
+    return request.access.has_any_project_scope(project, SYSTEM_CREATED_DETECTOR_REQUIRED_SCOPES)
 
 
 def can_edit_user_created_detectors(request: Request, project: Project) -> bool:
@@ -61,7 +61,9 @@ def can_edit_detector(detector: Detector, request: Request) -> bool:
     permission, then we must verify that the user is a team admin with "alerts:write" access to the project(s)
     in their request.
     """
-    if is_system_created_detector(detector) and not can_edit_system_created_detectors(request):
+    if is_system_created_detector(detector) and not can_edit_system_created_detectors(
+        request, detector.project
+    ):
         return False
 
     return can_edit_user_created_detectors(request, detector.project)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1396,20 +1396,22 @@ class OrganizationDetectorIndexPutTest(OrganizationDetectorIndexBaseTest):
         assert self.error_detector.enabled is True
 
     def test_update_detectors_org_manager_permission(self) -> None:
+        """
+        Test that an organization manager can update any type of detector, including error detectors.
+        """
         self.login_as(user=self.org_manager_user)
 
         self.get_success_response(
             self.organization.slug,
-            qs_params=[("id", str(self.detector.id)), ("id", str(self.detector_two.id))],
+            qs_params=[("id", str(self.detector.id)), ("id", str(self.error_detector.id))],
             enabled=False,
             status_code=200,
         )
 
-        # Verify detectors were updated
         self.detector.refresh_from_db()
-        self.detector_two.refresh_from_db()
+        self.error_detector.refresh_from_db()
         assert self.detector.enabled is False
-        assert self.detector_two.enabled is False
+        assert self.error_detector.enabled is False
 
     def test_update_owner_query_by_project(self) -> None:
         new_project = self.create_project(organization=self.organization)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1392,8 +1392,8 @@ class OrganizationDetectorIndexPutTest(OrganizationDetectorIndexBaseTest):
         )
 
         # Verify detector was not modified
-        self.detector.refresh_from_db()
-        assert self.detector.enabled is True
+        self.error_detector.refresh_from_db()
+        assert self.error_detector.enabled is True
 
     def test_update_detectors_org_manager_permission(self) -> None:
         self.login_as(user=self.org_manager_user)
@@ -1448,9 +1448,9 @@ class OrganizationDetectorIndexPutTest(OrganizationDetectorIndexBaseTest):
 
         # Verify neither detector was modified
         self.user_detector.refresh_from_db()
-        self.detector.refresh_from_db()
+        self.error_detector.refresh_from_db()
         assert self.user_detector.enabled is True
-        assert self.detector.enabled is True
+        assert self.error_detector.enabled is True
 
 
 @region_silo_test

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_workflow_details.py
@@ -212,25 +212,6 @@ class OrganizationDetectorWorkflowDetailsDeleteTest(OrganizationDetectorWorkflow
                 status_code=403,
             )
 
-    def test_member_cannot_disconnect_sentry_detectors(self) -> None:
-        self.organization.flags.allow_joinleave = False
-        self.organization.save()
-        self.login_as(user=self.member_user)
-
-        sentry_detector = self.create_detector(
-            project=self.create_project(organization=self.organization),
-        )
-        detector_workflow = self.create_detector_workflow(
-            detector=sentry_detector,
-            workflow=self.workflow,
-        )
-        with outbox_runner():
-            self.get_error_response(
-                self.organization.slug,
-                detector_workflow.id,
-                status_code=403,
-            )
-
     def test_member_cannot_disconnect_detectors_when_alerts_member_write_disabled(self) -> None:
         self.organization.update_option("sentry:alerts_member_write", False)
         self.organization.flags.allow_joinleave = True


### PR DESCRIPTION
I ran into an issue when trying to create a new automation and connect it to the existing error detector. I got a 403 because I do not have permission to edit that detector (because it is an error monitor). Users with `alerts:write` should be able to create automations and connect to error monitors, so we need to modify the permissions to allow editing of those connections.

While refactoring this, I also simplified some of the logic and fixed an issue with `created_by_id`. We cannot use `created_by_id` to describe system-created detectors because it is null for some metric/cron/uptime detectors.

Current permissions rules:

- Users with `alerts:write` scope can edit any detectors (including workflow/detector connections) with `created_by_id != null` 
- Org admins can edit any detector

New permissions rules:

- Users with `alerts:write` scope can edit any detectors besides `type=error`.
- Users with `alerts:write` can edit workflow/detector connections for any detector type
- Org admins can edit any detector