### PR TITLE
ref(feedback): remove seer spam detection logs

### DIFF
--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -284,14 +284,6 @@ def create_feedback_issue(
                     "referrer": source.value,
                 },
             )
-            logger.info(
-                "Seer spam detection result",
-                extra={
-                    "feedback_message": feedback_message[:20],
-                    "is_spam": is_message_spam,
-                    "is_spam_type": type(is_message_spam),
-                },
-            )
         else:
             try:
                 is_message_spam = is_spam(feedback_message)


### PR DESCRIPTION
relates to REPLAY-651

We added logs to ensure that user feedback was being routed to Seer for spam detection and that the feedback was being accurately classified as spam or not spam. Since we're confident that the spam detection is working and we're moving from EA to GA, let's remove the logs so that they don't become too noisy.