### PR TITLE
fix(timeseries): Add a check that the other series has data

### DIFF
--- a/src/sentry/api/endpoints/timeseries.py
+++ b/src/sentry/api/endpoints/timeseries.py
@@ -29,7 +29,7 @@ class SeriesMeta(TypedDict):
 
 class GroupBy(TypedDict):
     key: str
-    value: str
+    value: str | None
 
 
 class TimeSeries(TypedDict):

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -405,7 +405,7 @@ def create_result_key(
     groupby = create_groupby_dict(result_row, fields, issues)
     groupby_values: list[str] = []
     for value in groupby:
-        groupby_values.append(value["value"])
+        groupby_values.append(str(value["value"]))
     result = ",".join(groupby_values)
     # If the result would be identical to the other key, include the field name
     # only need the first field since this would only happen with a single field
@@ -415,7 +415,10 @@ def create_result_key(
 
 
 def create_groupby_dict(
-    result_row: SnubaRow, fields: list[str], issues: Mapping[int, str | None]
+    result_row: SnubaRow,
+    fields: list[str],
+    issues: Mapping[int, str | None],
+    stringify_none: bool = True,
 ) -> list[GroupBy]:
     values = []
     for field in fields:
@@ -439,7 +442,10 @@ def create_groupby_dict(
                     value = f"[{','.join(filtered_value)}]"
                 else:
                     value = ""
-            values.append(GroupBy(key=field, value=str(value)))
+            if stringify_none:
+                values.append(GroupBy(key=field, value=str(value)))
+            else:
+                values.append(GroupBy(key=field, value=str(value) if value is not None else None))
     return values
 
 

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -749,7 +749,7 @@ class RPCBase:
         # Top Events actually has the order, so we need to iterate through it, regenerate the result keys
         for index, row in enumerate(top_events["data"]):
             result_key = create_result_key(row, groupby_columns, {})
-            result_groupby = create_groupby_dict(row, groupby_columns, {})
+            result_groupby = create_groupby_dict(row, groupby_columns, {}, stringify_none=False)
             result = cls.process_timeseries_list(map_result_key_to_timeseries[result_key])
             final_result[result_key] = SnubaTSResult(
                 {

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -87,7 +87,7 @@ class TableRequest:
 def check_timeseries_has_data(timeseries: SnubaData, y_axes: list[str]):
     for row in timeseries:
         for axis in y_axes:
-            if row[axis] > 0:
+            if row[axis] and row[axis] != 0:
                 return True
     return False
 

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -615,7 +615,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             self.start, 60_000, [0, 1, 0, 0, 0, 0], ignore_accuracy=True
         )
         assert timeseries["groupBy"] == [
-            {"key": "foo", "value": "None"},
+            {"key": "foo", "value": None},
         ]
         assert timeseries["meta"] == {
             "dataScanned": "full",

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -525,6 +525,107 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "order": 2,
         }
 
+    def test_top_events_with_none_as_groupby(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {"sentry_tags": {"transaction": "foo"}, "tags": {"foo": "a"}},
+                    start_ts=self.start + timedelta(minutes=1),
+                    duration=2001,
+                ),
+                self.create_span(
+                    {"sentry_tags": {"transaction": "bar"}, "tags": {"foo": "b"}},
+                    start_ts=self.start + timedelta(minutes=1),
+                    duration=2000,
+                ),
+                # Without the foo tag this groupby will be None
+                self.create_span(
+                    {"sentry_tags": {"transaction": "baz"}},
+                    start_ts=self.start + timedelta(minutes=1),
+                    duration=1999,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        self.end = self.start + timedelta(minutes=6)
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1m",
+                "yAxis": "count()",
+                "groupBy": ["foo", "sum(span.self_time)"],
+                "orderby": ["-sum(span.self_time)"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "excludeOther": 0,
+                "topEvents": 3,
+            },
+        )
+        assert response.status_code == 200, response.content
+
+        assert response.data["meta"] == {
+            "dataset": "spans",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeSeries"]) == 3
+
+        timeseries = response.data["timeSeries"][0]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["yAxis"] == "count()"
+        assert timeseries["values"] == build_expected_timeseries(
+            self.start, 60_000, [0, 1, 0, 0, 0, 0], ignore_accuracy=True
+        )
+        assert timeseries["groupBy"] == [
+            {"key": "foo", "value": "a"},
+        ]
+        assert timeseries["meta"] == {
+            "dataScanned": "full",
+            "valueType": "integer",
+            "valueUnit": None,
+            "interval": 60_000,
+            "isOther": False,
+            "order": 0,
+        }
+
+        timeseries = response.data["timeSeries"][1]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["yAxis"] == "count()"
+        assert timeseries["values"] == build_expected_timeseries(
+            self.start, 60_000, [0, 1, 0, 0, 0, 0], ignore_accuracy=True
+        )
+        assert timeseries["groupBy"] == [
+            {"key": "foo", "value": "b"},
+        ]
+        assert timeseries["meta"] == {
+            "dataScanned": "full",
+            "valueType": "integer",
+            "valueUnit": None,
+            "interval": 60_000,
+            "isOther": False,
+            "order": 1,
+        }
+
+        timeseries = response.data["timeSeries"][2]
+        assert len(timeseries["values"]) == 6
+        assert timeseries["yAxis"] == "count()"
+        assert timeseries["values"] == build_expected_timeseries(
+            self.start, 60_000, [0, 1, 0, 0, 0, 0], ignore_accuracy=True
+        )
+        assert timeseries["groupBy"] == [
+            {"key": "foo", "value": "None"},
+        ]
+        assert timeseries["meta"] == {
+            "dataScanned": "full",
+            "valueType": "integer",
+            "valueUnit": None,
+            "interval": 60_000,
+            "isOther": False,
+            "order": 2,
+        }
+
     def test_top_events_empty_other(self) -> None:
         self.store_spans(
             [


### PR DESCRIPTION
- This attempts to fix a bug where the other series was being included even when it has no data
- Fixes the order of the other series when there's less than topEvents timeseries
- Changes the top events groupby to have a None rather than the string None when there's a None value