### PR TITLE
fix(spans-migration): changed type and wording of dropped fields warnings

### DIFF
--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -101,7 +101,7 @@ type WidgetChangedReason = {
   }> | null;
   orderby: Array<{
     orderby: string;
-    reason: string;
+    reason: string | string[];
   }> | null;
   selected_columns: string[];
 };

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -113,54 +113,43 @@ export const useDroppedColumnsWarning = (widget: Widget): React.JSX.Element | nu
     return null;
   }
 
-  const baseWarning = t(
-    "This widget may look different from its original query. Here's why:"
-  );
-  const columnsWarning = [];
-  const equationsWarning = [];
-  const orderbyWarning = [];
+  const columnsDropped = [];
+  const equationsDropped = [];
+  const orderbyDropped = [];
   for (const changedReason of widget.changedReason) {
     if (changedReason.selected_columns.length > 0) {
-      columnsWarning.push(
-        tct(`The following fields were dropped: [columns].`, {
-          columns: changedReason.selected_columns.join(', '),
-        })
-      );
+      columnsDropped.push(changedReason.selected_columns);
     }
     if (changedReason.equations) {
-      equationsWarning.push(
-        ...changedReason.equations.map(equation =>
-          tct(`[equation] was dropped because [reason] is unsupported.`, {
-            equation: equation.equation,
-            reason:
-              typeof equation.reason === 'string'
-                ? equation.reason
-                : equation.reason.join(', '),
-          })
-        )
-      );
+      equationsDropped.push(changedReason.equations.map(equation => equation.equation));
     }
     if (changedReason.orderby) {
-      orderbyWarning.push(
-        ...changedReason.orderby.map(equation =>
-          tct(`[orderby] was dropped because [reason].`, {
-            orderby: equation.orderby,
-            reason: equation.reason,
-          })
+      orderbyDropped.push(
+        changedReason.orderby.flatMap(orderby =>
+          typeof orderby.reason === 'string' ? orderby.orderby : orderby.reason
         )
       );
     }
   }
 
-  const allWarnings = [...columnsWarning, ...equationsWarning, ...orderbyWarning];
+  const allWarningsSet = new Set(
+    ...columnsDropped,
+    ...equationsDropped,
+    ...orderbyDropped
+  );
+  const allWarnings = [...allWarningsSet];
 
   if (allWarnings.length > 0) {
     return (
-      <div style={{alignContent: 'flex-start'}}>
-        <StyledText as="p">{baseWarning}</StyledText>
-        {allWarnings.map((warning, index) => (
-          <StyledText key={index}>{warning}</StyledText>
-        ))}
+      <div>
+        <StyledText as="p">
+          {tct(
+            'This widget may look different from its original because [columns] is no longer supported',
+            {
+              columns: allWarnings.join(', '),
+            }
+          )}
+        </StyledText>
       </div>
     );
   }

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -157,7 +157,7 @@ export const useDroppedColumnsWarning = (widget: Widget): React.JSX.Element | nu
       <div>
         <StyledText as="p">
           {tct(
-            'This widget may look different from its original because [columns] is no longer supported',
+            'This widget may look different from its original because [columns] is no longer supported.',
             {
               columns: allWarnings.join(', '),
             }

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -157,7 +157,7 @@ export const useDroppedColumnsWarning = (widget: Widget): React.JSX.Element | nu
       <div>
         <StyledText as="p">
           {tct(
-            'This widget may look different from its original because [columns] is no longer supported.',
+            'This widget looks different because it was migrated to the spans dataset and [columns] is not supported.',
             {
               columns: allWarnings.join(', '),
             }

--- a/static/app/views/explore/hooks/useSaveQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.tsx
@@ -30,7 +30,7 @@ export type ExploreQueryChangedReason = {
   }> | null;
   orderby: Array<{
     orderby: string;
-    reason: string;
+    reason: string | string[];
   }> | null;
 };
 

--- a/static/app/views/explore/spans/droppedFieldsAlert.tsx
+++ b/static/app/views/explore/spans/droppedFieldsAlert.tsx
@@ -30,7 +30,7 @@ export function DroppedFieldsAlert(): React.JSX.Element | null {
   const changedReason = savedQuery.changedReason;
   if (changedReason.columns.length > 0) {
     columnsWarning.push(
-      tct(`The following fields were dropped: [columns]`, {
+      tct(`[columns] is no longer supported`, {
         columns: changedReason.columns.join(', '),
       })
     );
@@ -38,7 +38,7 @@ export function DroppedFieldsAlert(): React.JSX.Element | null {
   if (changedReason.equations) {
     equationsWarning.push(
       ...changedReason.equations.map(equation =>
-        tct(`[equation] was dropped because [reason] is unsupported`, {
+        tct(`[equation] is no longer supported because [reason] is unsupported`, {
           equation: equation.equation,
           reason:
             typeof equation.reason === 'string'
@@ -51,10 +51,14 @@ export function DroppedFieldsAlert(): React.JSX.Element | null {
   if (changedReason.orderby) {
     orderbyWarning.push(
       ...changedReason.orderby.map(equation =>
-        tct(`[orderby] was dropped because [reason]`, {
-          orderby: equation.orderby,
-          reason: equation.reason,
-        })
+        typeof equation.reason === 'string'
+          ? tct(`[orderby] is not supported in this query`, {
+              orderby: equation.orderby,
+            })
+          : tct(`[orderby] is not supported because [reason] is unsupported`, {
+              orderby: equation.orderby,
+              reason: equation.reason.join(', '),
+            })
       )
     );
   }


### PR DESCRIPTION
changed the changed reason types on the frontend to reflect the changes i've made to the backend. I've also changed up the wording for the frontend errors as suggested. Widgets have been simplified to one sentence and queries have slightly changed wording to not use "dropped"
