### PR TITLE
feat(preprod): add app name to status check

### DIFF
--- a/bin/preprod/trigger_size_status_check
+++ b/bin/preprod/trigger_size_status_check
@@ -29,6 +29,7 @@ COMMIT_SHA = "db2b4ae626b458b4be651019f1a7c112406c003e"
 # Build configurations - set to None to disable a build
 BUILD_1 = {
     "app_id": "com.emerge.hackernews.android",
+    "app_name": "HackerNews",
     "platform": "Android",
     "build_version": "1.0.3",
     "build_number": 42,
@@ -42,6 +43,7 @@ BUILD_1 = {
 
 BUILD_2 = {
     "app_id": "com.emerge.hackernews.ios",
+    "app_name": "HackerNews",
     "platform": "iOS",
     "build_version": "1.0.3",
     "build_number": 15,
@@ -255,6 +257,7 @@ def create_base_artifacts_for_comparison(
         base_artifact = PreprodArtifact.objects.create(
             project=project,
             app_id=build_config["app_id"],
+            app_name=build_config["app_name"],
             commit_comparison=base_commit_comparison,
             state=PreprodArtifact.ArtifactState.PROCESSED,
             build_version=build_config["build_version"],
@@ -473,6 +476,7 @@ def main() -> None:
             artifact_data = {
                 "project": project,
                 "app_id": build_config["app_id"],
+                "app_name": build_config["app_name"],
                 "commit_comparison": commit_comparison,
                 "state": artifact_state,
                 "build_version": build_config["build_version"],

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -58,6 +58,9 @@ def format_status_check_messages(
             # UPLOADING or UPLOADED states - artifacts can't have metrics yet
             processing_count += 1
 
+    if analyzed_count == 0 and processing_count == 0 and errored_count == 0:
+        raise ValueError("No metrics exist for VCS size status check")
+
     parts = []
     if analyzed_count > 0:
         parts.append(

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -48,13 +48,13 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
                 )
 
                 assert title == "Size Analysis"
-                assert subtitle == "1 build processing"
+                assert subtitle == "1 app processing"
                 assert "Processing..." in summary
                 assert "com.example.app" in summary
                 assert "1.0.0 (1)" in summary
 
     def test_processed_state_without_metrics(self):
-        """Test formatting for processed state without size metrics."""
+        """Test that processed state without size metrics is valid (size analysis is optional)."""
         artifact = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -64,12 +64,14 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         )
 
         title, subtitle, summary = format_status_check_messages(
-            [artifact], {}, StatusCheckStatus.FAILURE
+            [artifact], {}, StatusCheckStatus.SUCCESS
         )
 
         assert title == "Size Analysis"
-        assert subtitle == "1 build processing"  # Processed but no metrics = still processing
-        assert "Processing..." in summary
+        # No metrics means no counts - subtitle should be empty
+        assert subtitle == ""
+        # Table should still render but with no data rows
+        assert "| Name |" in summary  # Header exists
 
     def test_processed_state_with_metrics_no_previous(self):
         """Test formatting for processed state with metrics but no previous build."""
@@ -98,7 +100,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         )
 
         assert title == "Size Analysis"
-        assert subtitle == "1 build analyzed"
+        assert subtitle == "1 app analyzed"
         assert "1.0 MB" in summary
         assert "2.1 MB" in summary
         assert "N/A" in summary
@@ -153,7 +155,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         )
 
         assert title == "Size Analysis"
-        assert subtitle == "2 builds processing"
+        assert subtitle == "2 apps processing"
         assert "Processing..." in summary
         assert "com.example.app0" in summary
         assert "com.example.app1" in summary
@@ -197,7 +199,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         )
 
         assert title == "Size Analysis"
-        assert subtitle == "1 build processing"  # Still processing because watch is not complete
+        assert subtitle == "1 app analyzed, 1 app processing"
         # Should have two rows - main app shows sizes, watch shows processing
         assert "`com.example.app`" in summary
         assert "`com.example.app (Watch)`" in summary
@@ -231,7 +233,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         )
 
         assert title == "Size Analysis"
-        assert subtitle == "1 build processing"
+        assert subtitle == "1 app processing"
 
         # Verify processing state is shown in table
         assert "`com.example.processing`" in summary
@@ -265,7 +267,7 @@ class ErrorStateFormattingTest(StatusCheckTestBase):
         )
 
         assert title == "Size Analysis"
-        assert subtitle == "1 build errored"
+        assert subtitle == "1 app errored"
         assert "Build timeout" in summary
         assert "com.example.app" in summary
         assert "1.0.0 (1)" in summary
@@ -343,7 +345,7 @@ class ErrorStateFormattingTest(StatusCheckTestBase):
         )
 
         assert title == "Size Analysis"
-        assert subtitle == "1 build analyzed, 1 build processing, 1 build errored"
+        assert subtitle == "1 app analyzed, 1 app processing, 1 app errored"
         assert "Processing..." in summary  # Non-failed artifacts show as processing
         assert "Upload timeout" in summary  # Failed artifact error
         assert "com.example.processed" in summary
@@ -386,7 +388,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         )
 
         assert title == "Size Analysis"
-        assert subtitle == "2 builds analyzed"
+        assert subtitle == "2 apps analyzed"
         assert "1.0 MB" in summary  # First artifact download size
         assert "2.1 MB" in summary  # Second artifact download size
         assert "com.example.app0" in summary
@@ -429,10 +431,10 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         )
 
         assert title == "Size Analysis"
-        assert subtitle == "1 build analyzed"
+        assert subtitle == "2 apps analyzed"
         # Should have two rows - main app and watch app
-        assert "`com.example.app`" in summary  # Main app
-        assert "`com.example.app (Watch)`" in summary  # Watch app
+        assert "com.example.app" in summary  # Both main and watch show app_id
+        assert "`-- (Watch)`" in summary  # Watch app label
         assert "1.0 MB" in summary  # Main app download
         assert "524.3 KB" in summary  # Watch app download
         assert "2.1 MB" in summary  # Main app install
@@ -441,9 +443,9 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         main_row_idx = None
         watch_row_idx = None
         for i, line in enumerate(lines):
-            if "`com.example.app`" in line and "(Watch)" not in line:
+            if "com.example.app" in line and "(Watch)" not in line:
                 main_row_idx = i
-            elif "`com.example.app (Watch)`" in line:
+            elif "`-- (Watch)`" in line:
                 watch_row_idx = i
         assert main_row_idx is not None
         assert watch_row_idx is not None
@@ -487,14 +489,14 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         )
 
         assert title == "Size Analysis"
-        assert subtitle == "1 build analyzed"
+        assert subtitle == "2 apps analyzed"
         # Should have two rows - main app and dynamic feature
-        assert "`com.example.android`" in summary  # Main app
-        assert "`com.example.android (Dynamic Feature)`" in summary  # Dynamic feature
-        assert "4.2 MB" in summary  # Main app download
+        assert "com.example.android" in summary  # Main app and dynamic feature both show app_id
+        assert "`-- (Dynamic Feature)`" in summary  # Dynamic feature label
+        assert "4.2 MB" in summary  # Main app download (note: rounds to 4.2 not 4.0)
         assert "1.0 MB" in summary  # Dynamic feature download
         assert "8.4 MB" in summary  # Main app install
-        assert "2.1 MB" in summary  # Dynamic feature install
+        assert "2.1 MB" in summary  # Dynamic feature install (note: rounds to 2.1 not 2.0)
 
     def test_size_changes_with_base_artifacts(self):
         """Test size change calculations when base artifacts exist for comparison."""
@@ -557,7 +559,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         )
 
         assert title == "Size Analysis"
-        assert subtitle == "1 build analyzed"
+        assert subtitle == "1 app analyzed"
 
         # Verify that size changes are calculated and displayed
         assert "4.2 MB" in summary  # Current download size
@@ -599,7 +601,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         )
 
         assert title == "Size Analysis"
-        assert subtitle == "1 build analyzed"
+        assert subtitle == "1 app analyzed"
         assert "1.0 MB" in summary
         assert "2.1 MB" in summary
         # Should show N/A for changes when no base exists
@@ -687,7 +689,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
 
         # Watch artifact should show N/A (no matching base watch metrics)
         lines = summary.split("\n")
-        watch_line = next(line for line in lines if "com.example.ios (Watch)" in line)
+        watch_line = next(line for line in lines if "(Watch)" in line)
         # Count N/A occurrences in the watch line - should be 3 (change columns + approval)
         na_count = watch_line.count("N/A")
         assert na_count >= 2  # At least 2 N/A for the change columns

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -196,8 +196,8 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         assert title == "Size Analysis"
         assert subtitle == "1 app analyzed, 1 app processing"
         # Should have two rows - main app shows sizes, watch shows processing
-        assert "`com.example.app`" in summary
-        assert "`com.example.app (Watch)`" in summary
+        assert "com.example.app" in summary
+        assert "`-- (Watch)`" in summary
         assert "1.0 MB" in summary  # Main app completed
         assert "Processing..." in summary  # Watch app processing
 
@@ -231,7 +231,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         assert subtitle == "1 app processing"
 
         # Verify processing state is shown in table
-        assert "`com.example.processing`" in summary
+        assert "com.example.processing" in summary
         assert "2.1.0 (15)" in summary
         assert "Processing..." in summary
 


### PR DESCRIPTION
Fixes a few issues I noticed with our status check:
- fixes the title to count the number of size metrics processed, it looked weird saying we processed 2 builds despite showing 3 rows in the table
- updated the copy to say "apps" instead of "builds" since we can generate more than one size metric per build
- adds the app name to the name column
- adds a new Configuration column

<img width="997" height="434" alt="Screenshot 2025-10-14 at 5 05 33 PM" src="https://github.com/user-attachments/assets/67ce6a48-e9e1-42c8-bcd9-2e3f1d5451c1" />
