### PR TITLE
fix(bug-prediction): Raise if no projects found

### DIFF
--- a/src/sentry/seer/fetch_issues/utils.py
+++ b/src/sentry/seer/fetch_issues/utils.py
@@ -89,13 +89,16 @@ def get_repo_and_projects(
             repository_id=repo.id,
         )
     )
+    projects = [config.project for config in repo_configs]
+    if not projects:
+        raise ValueError("No Sentry projects found for repo")
     return RepoProjects(
         organization_id=organization_id,
         provider=provider,
         external_id=external_id,
         repo=repo,
         repo_configs=repo_configs,
-        projects=[config.project for config in repo_configs],
+        projects=projects,
     )
 
 

--- a/tests/sentry/seer/fetch_issues/test_utils.py
+++ b/tests/sentry/seer/fetch_issues/test_utils.py
@@ -88,31 +88,6 @@ class TestGetRepoAndProjects(TestCase):
                 external_id="nonexistent",
             )
 
-    @patch("sentry_sdk.set_tags")
-    def test_get_repo_and_projects_sets_sentry_tags(self, mock_set_tags):
-        self.create_repo(
-            project=self.project,
-            name="getsentry/sentry",
-            provider="integrations:github",
-            external_id="123",
-        )
-
-        get_repo_and_projects(
-            organization_id=self.organization.id,
-            provider="integrations:github",
-            external_id="123",
-            run_id=456,
-        )
-
-        mock_set_tags.assert_called_once_with(
-            {
-                "organization_id": self.organization.id,
-                "provider": "integrations:github",
-                "external_id": "123",
-                "run_id": 456,
-            }
-        )
-
 
 class TestAsIssueDetails(TestCase):
     def test_as_issue_details_success(self):

--- a/tests/sentry/seer/fetch_issues/test_utils.py
+++ b/tests/sentry/seer/fetch_issues/test_utils.py
@@ -64,22 +64,19 @@ class TestGetRepoAndProjects(TestCase):
         assert project_ids == {self.project.id, project2.id}
 
     def test_get_repo_and_projects_no_configs(self):
-        repo = self.create_repo(
+        self.create_repo(
             project=self.project,
             name="getsentry/sentry",
             provider="integrations:github",
             external_id="123",
         )
 
-        result = get_repo_and_projects(
-            organization_id=self.organization.id,
-            provider="integrations:github",
-            external_id="123",
-        )
-
-        assert result.repo == repo
-        assert len(result.repo_configs) == 0
-        assert len(result.projects) == 0
+        with pytest.raises(ValueError, match="No Sentry projects found for repo"):
+            get_repo_and_projects(
+                organization_id=self.organization.id,
+                provider="integrations:github",
+                external_id="123",
+            )
 
     def test_get_repo_and_projects_repo_not_found(self):
         from sentry.models.repository import Repository


### PR DESCRIPTION
all fetch issues tools filter by sentry projects. i verified that the tools either return nothing or fail when no projects are found, sometimes w/ more obscure errors, e.g., [an IndexError here](https://github.com/getsentry/sentry/blob/72723742a2330d69c59f69fcc96693f7bfb5438d/src/sentry/issues/issue_search.py#L434)

this PR just makes the tool fail early and clearly. on seer's side, this message gets passed to the agent along w/ "don't use this tool again"