### PR TITLE
feat(crons): Add copy button on detector details

### DIFF
--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -1,9 +1,11 @@
 import {Fragment, useCallback, useState} from 'react';
 import sortBy from 'lodash/sortBy';
 
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
+import {Text} from 'sentry/components/core/text';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import useDrawer from 'sentry/components/globalDrawer';
 import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
@@ -183,7 +185,16 @@ export function CronDetectorDetails({detector, project}: CronDetectorDetailsProp
             <DetectorExtraDetails>
               <KeyValueTableRow
                 keyName={t('Monitor slug')}
-                value={dataSource.queryObj.slug}
+                value={
+                  <Flex gap="xs" align="center">
+                    <Text ellipsis>{dataSource.queryObj.slug}</Text>
+                    <CopyToClipboardButton
+                      text={dataSource.queryObj.slug}
+                      size="zero"
+                      borderless
+                    />
+                  </Flex>
+                }
               />
               <KeyValueTableRow
                 keyName={t('Next check-in')}


### PR DESCRIPTION
Fixes [NEW-566: The monitor slug should be copyable](https://linear.app/getsentry/issue/NEW-566/the-monitor-slug-should-be-copyable)