### PR TITLE
chore(feedback): Change UF AI summaries & categories feature badge to beta

### DIFF
--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -58,7 +58,7 @@ export default function FeedbackSummaryCategories() {
       <SummaryContainer>
         <Flex justify="between" align="center">
           <SummaryHeader>
-            {t('Summary')} <FeatureBadge type="experimental" />
+            {t('Summary')} <FeatureBadge type="beta" />
           </SummaryHeader>
           <Flex gap="xs">
             {feedbackButton({type: 'positive'})}


### PR DESCRIPTION
Since we are open beta'ing user feedback AI summaries and categories, let's change the feature badge from experimental to beta.

Before
<img width="459" height="99" alt="Screenshot 2025-10-14 at 2 44 48 PM" src="https://github.com/user-attachments/assets/5822fd3e-484c-4975-a5f3-81c69160e82f" />

After
<img width="459" height="99" alt="Screenshot 2025-10-14 at 2 44 31 PM" src="https://github.com/user-attachments/assets/267b8240-5f7b-416e-8f12-6d688fd91c43" />
