### PR TITLE
ui(feedback, replay): remove Seer icon from replay & UF AI summaries

### DIFF
--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -7,7 +7,6 @@ import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrga
 import FeedbackCategories from 'sentry/components/feedback/summaryCategories/feedbackCategories';
 import FeedbackSummary from 'sentry/components/feedback/summaryCategories/feedbackSummary';
 import {IconThumb} from 'sentry/icons';
-import {IconSeer} from 'sentry/icons/iconSeer';
 import {t} from 'sentry/locale';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -54,7 +53,6 @@ export default function FeedbackSummaryCategories() {
 
   return (
     <SummaryIconContainer>
-      <IconSeer size="xs" />
       <SummaryContainer>
         <Flex justify="between" align="center">
           <SummaryHeader>

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -5,7 +5,7 @@ import aiBanner from 'sentry-images/spot/ai-suggestion-banner-stars.svg';
 import replayEmptyState from 'sentry-images/spot/replays-empty-state.svg';
 
 import AnalyticsArea, {useAnalyticsArea} from 'sentry/components/analyticsArea';
-import {FeatureBadge} from 'sentry/components/core/badge';
+import {Badge, FeatureBadge} from 'sentry/components/core/badge';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
@@ -192,7 +192,7 @@ export default function Ai() {
             <Flex align="center" gap="xs">
               {t('Replay Summary')}
             </Flex>
-            <FeatureBadge type="experimental" />
+            <FeatureBadge type="experimental" tooltipProps={{disabled: true}} />
           </SummaryLeftTitle>
           <SummaryText>{summaryData.data.summary}</SummaryText>
         </SummaryLeft>

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -5,7 +5,7 @@ import aiBanner from 'sentry-images/spot/ai-suggestion-banner-stars.svg';
 import replayEmptyState from 'sentry-images/spot/replays-empty-state.svg';
 
 import AnalyticsArea, {useAnalyticsArea} from 'sentry/components/analyticsArea';
-import {Badge} from 'sentry/components/core/badge';
+import {FeatureBadge} from 'sentry/components/core/badge';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
@@ -192,7 +192,7 @@ export default function Ai() {
             <Flex align="center" gap="xs">
               {t('Replay Summary')}
             </Flex>
-            <Badge type="experimental">{t('Experimental')}</Badge>
+            <FeatureBadge type="experimental" />
           </SummaryLeftTitle>
           <SummaryText>{summaryData.data.summary}</SummaryText>
         </SummaryLeft>

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -5,7 +5,7 @@ import aiBanner from 'sentry-images/spot/ai-suggestion-banner-stars.svg';
 import replayEmptyState from 'sentry-images/spot/replays-empty-state.svg';
 
 import AnalyticsArea, {useAnalyticsArea} from 'sentry/components/analyticsArea';
-import {Badge, FeatureBadge} from 'sentry/components/core/badge';
+import {FeatureBadge} from 'sentry/components/core/badge';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -11,7 +11,7 @@ import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
 import {Text} from 'sentry/components/core/text';
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
-import {IconSeer, IconSync, IconThumb} from 'sentry/icons';
+import {IconSync, IconThumb} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
@@ -191,7 +191,6 @@ export default function Ai() {
           <SummaryLeftTitle>
             <Flex align="center" gap="xs">
               {t('Replay Summary')}
-              <IconSeer />
             </Flex>
             <Badge type="experimental">{t('Experimental')}</Badge>
           </SummaryLeftTitle>


### PR DESCRIPTION
Since, going forward, we are only branding issue debugging features as Seer, let's remove the Seer icons from the user feedback AI summaries & categories and the replay AI summary.

Also, replay AI summary is using a different badge component. Let's switch over to using the same one as UF for consistency.

Before:
<img width="683" height="99" alt="Screenshot 2025-10-14 at 3 04 24 PM" src="https://github.com/user-attachments/assets/337eda93-96ff-4e77-bc0a-d3ed9291bdd1" />

<img width="462" height="98" alt="Screenshot 2025-10-14 at 3 06 36 PM" src="https://github.com/user-attachments/assets/d5250d1a-5966-4940-a66a-a4cee7fa06f1" />

After: 
<img width="685" height="89" alt="Screenshot 2025-10-14 at 3 24 43 PM" src="https://github.com/user-attachments/assets/e961ac97-01c4-4283-ada7-95c4445c3eab" />

<img width="462" height="98" alt="Screenshot 2025-10-14 at 3 04 50 PM" src="https://github.com/user-attachments/assets/0a368164-b18a-434d-b68e-38e33e029b17" />