### PR TITLE
feat(eco): Implements credentials leasing service

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2785,6 +2785,11 @@ SEER_AUTOFIX_FORCE_USE_REPOS: list[dict] = []
 # For encrypting the access token for the GHE integration
 SEER_GHE_ENCRYPT_KEY: str | None = os.getenv("SEER_GHE_ENCRYPT_KEY")
 
+# For encrypting short-lived credentials for integrations
+INTEGRATION_CREDENTIALS_LEASE_ENCRYPTION_KEY: str | None = os.getenv(
+    "INTEGRATION_CREDENTIALS_LEASE_ENCRYPTION_KEY"
+)
+
 # Used to validate RPC requests from the Overwatch service
 OVERWATCH_RPC_SHARED_SECRET: list[str] | None = None
 if (val := os.environ.get("OVERWATCH_RPC_SHARED_SECRET")) is not None:

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -514,6 +514,20 @@ class IntegrationInstallation(abc.ABC):
     def metadata(self) -> dict[str, Any]:
         return self.model.metadata
 
+    def _update_integration_model(self) -> None:
+        from sentry.integrations.services.integration.service import integration_service
+
+        updated_model: RpcIntegration | Integration | None = None
+        if isinstance(self.model, Integration):
+            updated_model = Integration.objects.get(id=self.model.id)
+        else:
+            updated_model = integration_service.get_integration(self.model.id)
+
+        if updated_model is None:
+            raise IntegrationError("Integration model not found")
+
+        self.model = updated_model
+
     def uninstall(self) -> None:
         """
         For integrations that need additional steps for uninstalling

--- a/src/sentry/integrations/credentials_service/service.py
+++ b/src/sentry/integrations/credentials_service/service.py
@@ -142,8 +142,9 @@ class ScmIntegrationCredentialsService:
             return org_integration.integration
 
         elif resource_type == ResourceType.SENTRY_INSTALLATION:
+            install_id = int(resource_identifier)
             installation = installation_query.filter(
-                id=resource_identifier,
+                id=install_id,
             ).get()
             return installation.integration
 

--- a/src/sentry/integrations/credentials_service/service.py
+++ b/src/sentry/integrations/credentials_service/service.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta
+from enum import StrEnum
+from typing import Protocol
+
+import orjson
+from cryptography.fernet import Fernet
+from django.conf import settings
+from django.db.models import QuerySet
+
+from sentry.constants import ObjectStatus
+from sentry.integrations.credentials_service.types import (
+    CredentialLeasable,
+    CredentialLease,
+    InvalidCredentialLeaseTarget,
+)
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.silo.base import control_silo_function
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LeasedCredentials:
+    access_token: str
+    permissions: dict[str, str] | None
+    expires_at: datetime | None
+    lease_duration_seconds: int
+    sentry_organization_id: str
+    external_installation_id: str
+    resource_identifier: str
+    resource_type: str
+    integration_provider: str
+
+
+class ResourceType(StrEnum):
+    ORGANIZATION = "organization"
+    # PROVIDER_INSTALLATION = "provider_installation"
+    SENTRY_INSTALLATION = "sentry_installation"
+
+
+class CredentialLeaseProtocol(Protocol):
+    def get_maximum_lease_duration_seconds(self) -> int: ...
+
+    def refresh_access_token_with_minimum_validity_time(
+        self, token_minimum_validity_time: timedelta
+    ) -> None: ...
+
+
+# TODO(Gabe): Fix these inane comments
+class ScmIntegrationCredentialsService:
+    @control_silo_function
+    def get_credentials_by_resource(
+        self,
+        sentry_organization_id: int,
+        integration_provider: str,
+        token_minimum_validity_seconds: int,
+        resource_type: ResourceType,
+        resource_identifier: str,
+    ) -> str:
+        """Get credentials for a resource, refreshing if necessary based on minimum validity time."""
+        integration = self._get_integration_by_resource(
+            sentry_organization_id=sentry_organization_id,
+            integration_provider=integration_provider,
+            resource_type=resource_type,
+            resource_identifier=resource_identifier,
+        )
+
+        leased_credentials = self._get_credentials_from_integration(
+            integration=integration,
+            sentry_organization_id=sentry_organization_id,
+            resource_type=resource_type,
+            resource_identifier=resource_identifier,
+            token_minimum_validity_seconds=token_minimum_validity_seconds,
+        )
+
+        return self._encrypt_credentials(leased_credentials)
+
+    @control_silo_function
+    def rotate_credentials_by_resource(
+        self,
+        sentry_organization_id: int,
+        integration_provider: str,
+        resource_type: ResourceType,
+        resource_identifier: str,
+    ) -> str:
+        """Force refresh credentials for a resource, regardless of expiry time."""
+        integration = self._get_integration_by_resource(
+            sentry_organization_id=sentry_organization_id,
+            integration_provider=integration_provider,
+            resource_type=resource_type,
+            resource_identifier=resource_identifier,
+        )
+
+        leased_credentials = self._get_credentials_from_integration(
+            integration=integration,
+            sentry_organization_id=sentry_organization_id,
+            resource_type=resource_type,
+            resource_identifier=resource_identifier,
+            force_refresh=True,
+        )
+
+        return self._encrypt_credentials(leased_credentials)
+
+    def _get_integration_by_resource(
+        self,
+        sentry_organization_id: int,
+        integration_provider: str,
+        resource_type: ResourceType,
+        resource_identifier: str,
+    ) -> Integration:
+        """
+        Retrieves an integration by the given combination of sentry organization
+        and resource. This method should perform validation that an _active_
+        OrganizationIntegration exists prior to returning the parent integration.
+        This validates that the organization has a valid installation.
+        """
+        installation_query = self._get_installation_query_for_organization(sentry_organization_id)
+        if resource_type == ResourceType.ORGANIZATION:
+            installation_query = installation_query.filter(
+                integration__provider=integration_provider,
+                status=ObjectStatus.ACTIVE,
+                integration__name=resource_identifier,
+            )
+
+            if installation_query.count() < 1:
+                raise OrganizationIntegration.DoesNotExist(
+                    f"Integration {resource_identifier} has no installation"
+                )
+
+            if installation_query.count() > 1:
+                raise OrganizationIntegration.MultipleObjectsReturned(
+                    f"Integration {resource_identifier} has multiple installations with the same name"
+                )
+
+            org_integration = installation_query.first()
+            assert org_integration is not None
+
+            return org_integration.integration
+
+        elif resource_type == ResourceType.SENTRY_INSTALLATION:
+            installation = installation_query.filter(
+                id=resource_identifier,
+            ).get()
+            return installation.integration
+
+        # Superfluous for now, but enforces that new resource types have
+        # explicit handling.
+        raise ValueError(f"Unsupported resource_type: {resource_type}")
+
+    def _get_installation_query_for_organization(
+        self, sentry_organization_id: int
+    ) -> QuerySet[OrganizationIntegration]:
+        integrations = OrganizationIntegration.objects.filter(
+            organization_id=sentry_organization_id,
+            status=ObjectStatus.ACTIVE,
+        ).prefetch_related("integration")
+
+        return integrations
+
+    def _get_credentials_from_integration(
+        self,
+        integration: Integration,
+        sentry_organization_id: int,
+        resource_type: ResourceType,
+        resource_identifier: str,
+        token_minimum_validity_seconds: int = 10,
+        force_refresh: bool = False,
+    ) -> LeasedCredentials:
+        """Extract or refresh credentials from integration."""
+
+        installation = integration.get_installation(organization_id=sentry_organization_id)
+
+        if not isinstance(installation, CredentialLeasable):
+            raise InvalidCredentialLeaseTarget("Integration does not support credential leasing")
+
+        if installation.get_maximum_lease_duration_seconds() < token_minimum_validity_seconds:
+            raise ValueError(
+                "Token minimum validity time is greater than the maximum lease duration for the provider"
+            )
+
+        credential_lease: CredentialLease | None = None
+        if force_refresh:
+            credential_lease = installation.force_refresh_access_token()
+        elif installation.does_access_token_expire_within(
+            token_minimum_validity_time=timedelta(seconds=token_minimum_validity_seconds)
+        ):
+            credential_lease = installation.refresh_access_token_with_minimum_validity_time(
+                token_minimum_validity_time=timedelta(seconds=token_minimum_validity_seconds)
+            )
+        else:
+            credential_lease = installation.get_active_access_token()
+
+        return LeasedCredentials(
+            access_token=credential_lease.access_token,
+            permissions=credential_lease.permissions,
+            expires_at=credential_lease.expires_at,
+            lease_duration_seconds=token_minimum_validity_seconds,
+            sentry_organization_id=str(sentry_organization_id),
+            external_installation_id=integration.external_id,
+            resource_identifier=resource_identifier,
+            resource_type=resource_type.value,
+            integration_provider=integration.provider,
+        )
+
+    def _encrypt_credentials(self, credentials: LeasedCredentials) -> str:
+        """Encrypt LeasedCredentials using Fernet."""
+        try:
+            key = self._get_fernet_key_for_encryption()
+            f = Fernet(key)
+        except Exception:
+            logger.exception("sentry.credentials_service.invalid_fernet_key")
+            raise
+
+        credentials_json = orjson.dumps(asdict(credentials))
+        encrypted_data = f.encrypt(credentials_json)
+
+        return encrypted_data.decode("utf-8")
+
+    def _get_fernet_key_for_encryption(self) -> str:
+        key = settings.INTEGRATION_CREDENTIALS_LEASE_ENCRYPTION_KEY.encode("utf-8")
+        if not key:
+            raise ValueError("INTEGRATION_CREDENTIALS_LEASE_ENCRYPTION_KEY is not set")
+        return key

--- a/src/sentry/integrations/credentials_service/service.py
+++ b/src/sentry/integrations/credentials_service/service.py
@@ -123,7 +123,6 @@ class ScmIntegrationCredentialsService:
         if resource_type == ResourceType.ORGANIZATION:
             installation_query = installation_query.filter(
                 integration__provider=integration_provider,
-                status=ObjectStatus.ACTIVE,
                 integration__name=resource_identifier,
             )
 

--- a/src/sentry/integrations/credentials_service/service.py
+++ b/src/sentry/integrations/credentials_service/service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 from enum import StrEnum
 from typing import Protocol
 
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 class LeasedCredentials:
     access_token: str
     permissions: dict[str, str] | None
-    expires_at: datetime | None
+    expires_at: str | None
     lease_duration_seconds: int
     sentry_organization_id: str
     external_installation_id: str
@@ -198,7 +198,9 @@ class ScmIntegrationCredentialsService:
         return LeasedCredentials(
             access_token=credential_lease.access_token,
             permissions=credential_lease.permissions,
-            expires_at=credential_lease.expires_at,
+            expires_at=(
+                credential_lease.expires_at.isoformat() if credential_lease.expires_at else None
+            ),
             lease_duration_seconds=token_minimum_validity_seconds,
             sentry_organization_id=str(sentry_organization_id),
             external_installation_id=integration.external_id,
@@ -221,8 +223,8 @@ class ScmIntegrationCredentialsService:
 
         return encrypted_data.decode("utf-8")
 
-    def _get_fernet_key_for_encryption(self) -> str:
-        key = settings.INTEGRATION_CREDENTIALS_LEASE_ENCRYPTION_KEY.encode("utf-8")
+    def _get_fernet_key_for_encryption(self) -> bytes:
+        key = settings.INTEGRATION_CREDENTIALS_LEASE_ENCRYPTION_KEY
         if not key:
             raise ValueError("INTEGRATION_CREDENTIALS_LEASE_ENCRYPTION_KEY is not set")
-        return key
+        return key.encode("utf-8")

--- a/src/sentry/integrations/credentials_service/types.py
+++ b/src/sentry/integrations/credentials_service/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 
@@ -18,13 +19,13 @@ class CredentialLeasable(ABC):
     @abstractmethod
     def refresh_access_token_with_minimum_validity_time(
         self, token_minimum_validity_time: timedelta
-    ) -> str: ...
+    ) -> CredentialLease: ...
 
     @abstractmethod
-    def force_refresh_access_token(self) -> str: ...
+    def force_refresh_access_token(self) -> CredentialLease: ...
 
     @abstractmethod
-    def get_active_access_token(self) -> str: ...
+    def get_active_access_token(self) -> CredentialLease: ...
 
     @abstractmethod
     def get_current_access_token_expiration(self) -> datetime | None: ...
@@ -39,6 +40,13 @@ class CredentialLeasable(ABC):
 
         minimum_expiry_time = datetime.now(UTC) + token_minimum_validity_time
         return expires_at < minimum_expiry_time
+
+
+@dataclass
+class CredentialLease:
+    access_token: str
+    permissions: dict[str, str] | None
+    expires_at: datetime
 
 
 class InvalidCredentialLeaseTarget(Exception):

--- a/src/sentry/integrations/credentials_service/types.py
+++ b/src/sentry/integrations/credentials_service/types.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from datetime import timedelta
+
+
+class CredentialLeasableMixin(ABC):
+    """
+    Interface for integrations that can lease credentials to other services.
+
+    This is largely abstract, but is mainly used to flag which integration
+    providers support this functionality.
+    """
+
+    @abstractmethod
+    def get_maximum_lease_duration_seconds(self) -> int: ...
+
+    @abstractmethod
+    def refresh_access_token_with_minimum_validity_time(
+        self, token_minimum_validity_time: timedelta
+    ) -> str: ...
+
+    @abstractmethod
+    def force_refresh_access_token(self) -> str: ...
+
+    @abstractmethod
+    def get_active_access_token(self) -> str: ...
+
+    @abstractmethod
+    def does_access_token_expire_within(self, token_minimum_validity_time: timedelta) -> bool: ...
+
+
+class InvalidCredentialLeaseTarget(Exception):
+    pass

--- a/src/sentry/integrations/credentials_service/types.py
+++ b/src/sentry/integrations/credentials_service/types.py
@@ -46,7 +46,7 @@ class CredentialLeasable(ABC):
 class CredentialLease:
     access_token: str
     permissions: dict[str, str] | None
-    expires_at: datetime
+    expires_at: datetime | None
 
 
 class InvalidCredentialLeaseTarget(Exception):

--- a/src/sentry/integrations/credentials_service/types.py
+++ b/src/sentry/integrations/credentials_service/types.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from datetime import UTC, datetime, timedelta
 
 
-class CredentialLeasableMixin(ABC):
+class CredentialLeasable(ABC):
     """
     Interface for integrations that can lease credentials to other services.
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -120,6 +120,7 @@ class GithubProxyClient(IntegrationProxyClient):
     class AccessTokenData(TypedDict):
         access_token: str
         permissions: dict[str, str] | None
+        expires_at: datetime
 
     def _get_installation_id(self) -> str:
         """
@@ -175,6 +176,7 @@ class GithubProxyClient(IntegrationProxyClient):
         return {
             "access_token": access_token,
             "permissions": permissions,
+            "expires_at": expires_at,
         }
 
     @control_silo_function

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -153,7 +153,8 @@ class GithubProxyClient(IntegrationProxyClient):
         )
         data = self.post(f"/app/installations/{self._get_installation_id()}/access_tokens")
         access_token = data["token"]
-        expires_at = datetime.strptime(data["expires_at"], "%Y-%m-%dT%H:%M:%SZ").isoformat()
+        expiration_time = datetime.strptime(data["expires_at"], "%Y-%m-%dT%H:%M:%SZ")
+        expires_at = expiration_time.isoformat()
         permissions = data.get("permissions")
         integration.metadata.update(
             {
@@ -176,7 +177,7 @@ class GithubProxyClient(IntegrationProxyClient):
         return {
             "access_token": access_token,
             "permissions": permissions,
-            "expires_at": expires_at,
+            "expires_at": expiration_time,
         }
 
     @control_silo_function

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -120,7 +120,7 @@ class GithubProxyClient(IntegrationProxyClient):
     class AccessTokenData(TypedDict):
         access_token: str
         permissions: dict[str, str] | None
-        expires_at: datetime
+        expires_at: datetime | None
 
     def _get_installation_id(self) -> str:
         """
@@ -236,6 +236,7 @@ class GithubProxyClient(IntegrationProxyClient):
             return {
                 "access_token": access_token,
                 "permissions": self.integration.metadata.get("permissions"),
+                "expires_at": datetime.fromisoformat(expires_at) if expires_at else None,
             }
 
         return None

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -28,7 +28,7 @@ from sentry.integrations.base import (
     IntegrationMetadata,
     IntegrationProvider,
 )
-from sentry.integrations.credentials_service.types import CredentialLeasableMixin
+from sentry.integrations.credentials_service.types import CredentialLeasable
 from sentry.integrations.github.constants import ISSUE_LOCKED_ERROR_MESSAGE, RATE_LIMITED_MESSAGE
 from sentry.integrations.github.tasks.codecov_account_link import codecov_account_link
 from sentry.integrations.github.tasks.link_all_repos import link_all_repos
@@ -230,7 +230,7 @@ class GitHubIntegration(
     IssueSyncIntegration,
     CommitContextIntegration,
     RepoTreesIntegration,
-    CredentialLeasableMixin,
+    CredentialLeasable,
 ):
     integration_name = IntegrationProviderSlug.GITHUB
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -39,6 +39,7 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.referrer_ids import GITHUB_OPEN_PR_BOT_REFERRER, GITHUB_PR_BOT_REFERRER
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.repository import RpcRepository, repository_service
 from sentry.integrations.source_code_management.commit_context import (
     OPEN_PR_MAX_FILES_CHANGED,
@@ -282,7 +283,8 @@ class GitHubIntegration(
         expiration_time = None
         # Annoying quirk that the underlying client may update the integration
         # model, but the model reference on this class isn't updated.
-        self.model.refresh_from_db()
+        # self.model.refresh_from_db()
+        self._update_integration_model()
         if self.model.metadata.get("expires_at"):
             expiration_time = datetime.fromisoformat(
                 self.model.metadata.get("expires_at")
@@ -293,6 +295,18 @@ class GitHubIntegration(
             permissions=self.model.metadata.get("permissions"),
             expires_at=expiration_time,
         )
+
+    def _update_integration_model(self) -> None:
+        updated_model: RpcIntegration | Integration | None = None
+        if isinstance(self.model, Integration):
+            updated_model = Integration.objects.get(id=self.model.id)
+        else:
+            updated_model = integration_service.get_integration(self.model.id)
+
+        if updated_model is None:
+            raise IntegrationError("Integration model not found")
+
+        self.model = updated_model
 
     # IntegrationInstallation methods
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import datetime
 import logging
 import re
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
-from datetime import timedelta
+from datetime import datetime, timedelta
 from enum import StrEnum
 from typing import Any, TypedDict
 from urllib.parse import parse_qsl
@@ -272,16 +271,11 @@ class GitHubIntegration(
         assert access_token_data is not None, "Expected Integration to have an access token"
         return access_token_data["access_token"]
 
-    def does_access_token_expire_within(self, token_minimum_validity_time: timedelta) -> bool:
-        if "access_token" not in self.model.metadata:
-            return True
-
-        expires_at = self.model.metadata.get("expires_at")
-        if not expires_at:
-            return True
-        expires_at = datetime.datetime.fromisoformat(expires_at).replace(tzinfo=datetime.UTC)
-        minimum_expiry_time = datetime.datetime.now(datetime.UTC) + token_minimum_validity_time
-        return expires_at < minimum_expiry_time
+    def get_current_access_token_expiration(self) -> datetime | None:
+        expiration = self.model.metadata.get("expires_at")
+        if not expiration:
+            return None
+        return datetime.fromisoformat(expiration)
 
     # IntegrationInstallation methods
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -39,7 +39,6 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.referrer_ids import GITHUB_OPEN_PR_BOT_REFERRER, GITHUB_PR_BOT_REFERRER
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.repository import RpcRepository, repository_service
 from sentry.integrations.source_code_management.commit_context import (
     OPEN_PR_MAX_FILES_CHANGED,
@@ -297,18 +296,6 @@ class GitHubIntegration(
             permissions=self.model.metadata.get("permissions"),
             expires_at=expiration_time,
         )
-
-    def _update_integration_model(self) -> None:
-        updated_model: RpcIntegration | Integration | None = None
-        if isinstance(self.model, Integration):
-            updated_model = Integration.objects.get(id=self.model.id)
-        else:
-            updated_model = integration_service.get_integration(self.model.id)
-
-        if updated_model is None:
-            raise IntegrationError("Integration model not found")
-
-        self.model = updated_model
 
     # IntegrationInstallation methods
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import Any, TypedDict
 from urllib.parse import parse_qsl
@@ -28,7 +28,7 @@ from sentry.integrations.base import (
     IntegrationMetadata,
     IntegrationProvider,
 )
-from sentry.integrations.credentials_service.types import CredentialLeasable
+from sentry.integrations.credentials_service.types import CredentialLeasable, CredentialLease
 from sentry.integrations.github.constants import ISSUE_LOCKED_ERROR_MESSAGE, RATE_LIMITED_MESSAGE
 from sentry.integrations.github.tasks.codecov_account_link import codecov_account_link
 from sentry.integrations.github.tasks.link_all_repos import link_all_repos
@@ -255,27 +255,44 @@ class GitHubIntegration(
 
     def refresh_access_token_with_minimum_validity_time(
         self, token_minimum_validity_time: timedelta
-    ) -> str:
+    ) -> CredentialLease:
         access_token_data = self.get_client().get_access_token(
             token_minimum_validity_time=token_minimum_validity_time
         )
 
         assert access_token_data is not None, "Expected Integration to have an access token"
-        return access_token_data["access_token"]
 
-    def force_refresh_access_token(self) -> str:
+        return self._credential_lease_from_model()
+
+    def force_refresh_access_token(self) -> CredentialLease:
         raise NotImplementedError("Force refresh access token is not supported for GitHub")
 
-    def get_active_access_token(self) -> str:
+    def get_active_access_token(self) -> CredentialLease:
         access_token_data = self.get_client().get_access_token()
         assert access_token_data is not None, "Expected Integration to have an access token"
-        return access_token_data["access_token"]
+        return self._credential_lease_from_model()
 
     def get_current_access_token_expiration(self) -> datetime | None:
         expiration = self.model.metadata.get("expires_at")
         if not expiration:
             return None
-        return datetime.fromisoformat(expiration)
+        return datetime.fromisoformat(expiration).astimezone(UTC)
+
+    def _credential_lease_from_model(self) -> CredentialLease:
+        expiration_time = None
+        # Annoying quirk that the underlying client may update the integration
+        # model, but the model reference on this class isn't updated.
+        self.model.refresh_from_db()
+        if self.model.metadata.get("expires_at"):
+            expiration_time = datetime.fromisoformat(
+                self.model.metadata.get("expires_at")
+            ).astimezone(UTC)
+
+        return CredentialLease(
+            access_token=self.model.metadata.get("access_token"),
+            permissions=self.model.metadata.get("permissions"),
+            expires_at=expiration_time,
+        )
 
     # IntegrationInstallation methods
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -285,13 +285,15 @@ class GitHubIntegration(
         # model, but the model reference on this class isn't updated.
         # self.model.refresh_from_db()
         self._update_integration_model()
-        if self.model.metadata.get("expires_at"):
-            expiration_time = datetime.fromisoformat(
-                self.model.metadata.get("expires_at")
-            ).astimezone(UTC)
+        model_expiration_str = self.model.metadata.get("expires_at")
+        if model_expiration_str:
+            expiration_time = datetime.fromisoformat(model_expiration_str).astimezone(UTC)
+
+        access_token = self.model.metadata.get("access_token")
+        assert access_token is not None, "Expected Integration to have an access token"
 
         return CredentialLease(
-            access_token=self.model.metadata.get("access_token"),
+            access_token=access_token,
             permissions=self.model.metadata.get("permissions"),
             expires_at=expiration_time,
         )

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -73,6 +73,7 @@ from sentry.organizations.services.organization.model import (
 from sentry.pipeline.views.base import PipelineView, render_react_view
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.shared_integrations.exceptions import ApiError, ApiInvalidRequestError, IntegrationError
+from sentry.silo.base import control_silo_function
 from sentry.snuba.referrer import Referrer
 from sentry.templatetags.sentry_helpers import small_count
 from sentry.users.models.user import User
@@ -264,15 +265,18 @@ class GitHubIntegration(
 
         return self._credential_lease_from_model()
 
+    @control_silo_function
     def force_refresh_access_token(self) -> CredentialLease:
         raise NotImplementedError("Force refresh access token is not supported for GitHub")
 
+    @control_silo_function
     def get_active_access_token(self) -> CredentialLease:
         self._update_integration_model()
         access_token_data = self.get_client().get_access_token()
         assert access_token_data is not None, "Expected Integration to have an access token"
         return self._credential_lease_from_model()
 
+    @control_silo_function
     def get_current_access_token_expiration(self) -> datetime | None:
         self._update_integration_model()
         expiration = self.model.metadata.get("expires_at")
@@ -280,6 +284,7 @@ class GitHubIntegration(
             return None
         return datetime.fromisoformat(expiration).astimezone(UTC)
 
+    @control_silo_function
     def _credential_lease_from_model(self) -> CredentialLease:
         expiration_time = None
         # Annoying quirk that the underlying client may update the integration

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import datetime
 import logging
 import re
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from datetime import timedelta
 from enum import StrEnum
 from typing import Any, TypedDict
 from urllib.parse import parse_qsl
@@ -27,6 +29,7 @@ from sentry.integrations.base import (
     IntegrationMetadata,
     IntegrationProvider,
 )
+from sentry.integrations.credentials_service.types import CredentialLeasableMixin
 from sentry.integrations.github.constants import ISSUE_LOCKED_ERROR_MESSAGE, RATE_LIMITED_MESSAGE
 from sentry.integrations.github.tasks.codecov_account_link import codecov_account_link
 from sentry.integrations.github.tasks.link_all_repos import link_all_repos
@@ -228,6 +231,7 @@ class GitHubIntegration(
     IssueSyncIntegration,
     CommitContextIntegration,
     RepoTreesIntegration,
+    CredentialLeasableMixin,
 ):
     integration_name = IntegrationProviderSlug.GITHUB
 
@@ -244,6 +248,40 @@ class GitHubIntegration(
         if not self.org_integration:
             raise IntegrationError("Organization Integration does not exist")
         return GitHubApiClient(integration=self.model, org_integration_id=self.org_integration.id)
+
+    # CredentialLeasableMixin methods
+
+    def get_maximum_lease_duration_seconds(self) -> int:
+        return 60 * 60  # Access tokens are valid for an hour by default.
+
+    def refresh_access_token_with_minimum_validity_time(
+        self, token_minimum_validity_time: timedelta
+    ) -> str:
+        access_token_data = self.get_client().get_access_token(
+            token_minimum_validity_time=token_minimum_validity_time
+        )
+
+        assert access_token_data is not None, "Expected Integration to have an access token"
+        return access_token_data["access_token"]
+
+    def force_refresh_access_token(self) -> str:
+        raise NotImplementedError("Force refresh access token is not supported for GitHub")
+
+    def get_active_access_token(self) -> str:
+        access_token_data = self.get_client().get_access_token()
+        assert access_token_data is not None, "Expected Integration to have an access token"
+        return access_token_data["access_token"]
+
+    def does_access_token_expire_within(self, token_minimum_validity_time: timedelta) -> bool:
+        if "access_token" not in self.model.metadata:
+            return True
+
+        expires_at = self.model.metadata.get("expires_at")
+        if not expires_at:
+            return True
+        expires_at = datetime.datetime.fromisoformat(expires_at).replace(tzinfo=datetime.UTC)
+        minimum_expiry_time = datetime.datetime.now(datetime.UTC) + token_minimum_validity_time
+        return expires_at < minimum_expiry_time
 
     # IntegrationInstallation methods
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -268,11 +268,13 @@ class GitHubIntegration(
         raise NotImplementedError("Force refresh access token is not supported for GitHub")
 
     def get_active_access_token(self) -> CredentialLease:
+        self._update_integration_model()
         access_token_data = self.get_client().get_access_token()
         assert access_token_data is not None, "Expected Integration to have an access token"
         return self._credential_lease_from_model()
 
     def get_current_access_token_expiration(self) -> datetime | None:
+        self._update_integration_model()
         expiration = self.model.metadata.get("expires_at")
         if not expiration:
             return None

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -19,6 +19,7 @@ from sentry.integrations.base import (
     IntegrationFeatures,
     IntegrationMetadata,
 )
+from sentry.integrations.credentials_service.types import CredentialLeasable
 from sentry.integrations.github.constants import ISSUE_LOCKED_ERROR_MESSAGE, RATE_LIMITED_MESSAGE
 from sentry.integrations.github.integration import GitHubIntegrationProvider, build_repository_query
 from sentry.integrations.github.issues import GitHubIssuesSpec
@@ -153,7 +154,7 @@ API_ERRORS = {
 
 
 class GitHubEnterpriseIntegration(
-    RepositoryIntegration, GitHubIssuesSpec, CommitContextIntegration
+    RepositoryIntegration, GitHubIssuesSpec, CommitContextIntegration, CredentialLeasable
 ):
     codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
 

--- a/tests/sentry/integrations/credentials_service/test_credentials_leasable_abc.py
+++ b/tests/sentry/integrations/credentials_service/test_credentials_leasable_abc.py
@@ -1,0 +1,68 @@
+from datetime import UTC, datetime, timedelta
+from unittest import TestCase, mock
+
+from sentry.integrations.credentials_service.types import CredentialLeasable, CredentialLease
+from sentry.testutils.helpers.datetime import freeze_time
+
+
+class MockClass(CredentialLeasable):
+    def get_maximum_lease_duration_seconds(self) -> int:
+        return 3600
+
+    def refresh_access_token_with_minimum_validity_time(
+        self, token_minimum_validity_time: timedelta
+    ) -> CredentialLease:
+        return CredentialLease(
+            access_token="access_token",
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+            permissions=None,
+        )
+
+    def force_refresh_access_token(self) -> CredentialLease:
+        return CredentialLease(
+            access_token="access_token",
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+            permissions=None,
+        )
+
+    def get_active_access_token(self) -> CredentialLease:
+        return CredentialLease(
+            access_token="access_token",
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+            permissions=None,
+        )
+
+    def get_current_access_token_expiration(self) -> datetime | None:
+        raise NotImplementedError
+
+
+class CredentialsLeasableMixinTest(TestCase):
+    def setUp(self) -> None:
+        self.mock_class = MockClass()
+        self.patcher = mock.patch.object(
+            self.mock_class, "get_current_access_token_expiration", return_value=None
+        )
+        self.mock_get_expiration = self.patcher.start()
+
+    def tearDown(self) -> None:
+        self.patcher.stop()
+
+    def test_does_access_token_expire_within__no_expiry(self) -> None:
+        self.mock_get_expiration.return_value = None
+        assert self.mock_class.does_access_token_expire_within(timedelta(hours=1)) is True
+
+    @freeze_time("2025-01-01T12:00:00Z")
+    def test_does_access_token_expire_within__already_expired(self) -> None:
+        # Token just expired, any positive timedelta should return True
+        self.mock_get_expiration.return_value = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+        assert self.mock_class.does_access_token_expire_within(timedelta(seconds=1)) is True
+
+        self.mock_get_expiration.return_value = datetime(2025, 1, 1, 11, 59, 0, tzinfo=UTC)
+        assert self.mock_class.does_access_token_expire_within(timedelta(seconds=2)) is True
+
+    @freeze_time("2025-01-01T12:00:00Z")
+    def test_does_access_token_expire_within__under_expiry(self) -> None:
+        # Token expires in 1 minute, check boundaries around this
+        self.mock_get_expiration.return_value = datetime(2025, 1, 1, 12, 0, 1, tzinfo=UTC)
+        assert self.mock_class.does_access_token_expire_within(timedelta(seconds=1)) is False
+        assert self.mock_class.does_access_token_expire_within(timedelta(seconds=2)) is True

--- a/tests/sentry/integrations/credentials_service/test_credentials_service.py
+++ b/tests/sentry/integrations/credentials_service/test_credentials_service.py
@@ -21,7 +21,7 @@ from sentry.utils import json
 
 
 @control_silo_test()
-class TestService(TestCase):
+class TestCredentialsService(TestCase):
     encryption_key = Fernet.generate_key().decode("utf-8")
 
     def setUp(self) -> None:

--- a/tests/sentry/integrations/credentials_service/test_credentials_service.py
+++ b/tests/sentry/integrations/credentials_service/test_credentials_service.py
@@ -137,7 +137,7 @@ class TestCredentialsService(TestCase):
             integration_provider="github",
             token_minimum_validity_seconds=10,
             resource_type=ResourceType.SENTRY_INSTALLATION,
-            resource_identifier=installation.id,
+            resource_identifier=str(installation.id),
         )
         assert credentials == "<fake_encrypted_data>"
 
@@ -163,7 +163,7 @@ class TestCredentialsService(TestCase):
                 integration_provider="github",
                 token_minimum_validity_seconds=10,
                 resource_type=ResourceType.SENTRY_INSTALLATION,
-                resource_identifier=installation.id,
+                resource_identifier=str(installation.id),
             )
 
     @responses.activate

--- a/tests/sentry/integrations/credentials_service/test_credentials_service.py
+++ b/tests/sentry/integrations/credentials_service/test_credentials_service.py
@@ -322,7 +322,11 @@ class TestCredentialsService(TestCase):
         assert decrypted_credentials == LeasedCredentials(
             access_token=refreshed_credential_lease.access_token,
             permissions=refreshed_credential_lease.permissions,
-            expires_at=refreshed_credential_lease.expires_at.isoformat(),
+            expires_at=(
+                refreshed_credential_lease.expires_at.isoformat()
+                if refreshed_credential_lease.expires_at
+                else None
+            ),
             lease_duration_seconds=10,
             sentry_organization_id=str(self.organization.id),
             external_installation_id="123",

--- a/tests/sentry/integrations/credentials_service/test_service.py
+++ b/tests/sentry/integrations/credentials_service/test_service.py
@@ -1,0 +1,332 @@
+import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+import responses
+from cryptography.fernet import Fernet
+from django.test import override_settings
+
+from sentry.integrations.credentials_service.service import (
+    LeasedCredentials,
+    ResourceType,
+    ScmIntegrationCredentialsService,
+)
+from sentry.integrations.credentials_service.types import CredentialLeasable, CredentialLease
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+from sentry.utils import json
+
+
+@control_silo_test()
+class TestService(TestCase):
+    encryption_key = Fernet.generate_key().decode("utf-8")
+
+    def setUp(self) -> None:
+        self.organization = self.create_organization(owner=self.create_user())
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="Test Integration",
+            external_id="123",
+        )
+        self.mock_installation = Mock(spec=CredentialLeasable)
+        self.mock_installation.get_maximum_lease_duration_seconds.return_value = 100
+
+    def decrypt_credentials(
+        self, encrypted_credentials: str, encryption_key: str
+    ) -> LeasedCredentials:
+        f = Fernet(encryption_key.encode("utf-8"))
+        decrypted = f.decrypt(encrypted_credentials.encode("utf-8"))
+        decrypted_str = decrypted.decode("utf-8")
+        decrypted_dict = json.loads(decrypted_str)
+
+        return LeasedCredentials(**decrypted_dict)
+
+    # Responses isn't strictly required, but it prevents us from accidentally
+    # making external API calls if we miss a mock.
+    @responses.activate
+    @patch.object(Integration, "get_installation")
+    @patch.object(ScmIntegrationCredentialsService, "_encrypt_credentials")
+    def test_get_credentials_by_resource__organization(
+        self, mock_encrypt_credentials, mock_get_installation
+    ) -> None:
+        mock_get_installation.return_value = self.mock_installation
+
+        expected_credential_lease = CredentialLease(
+            access_token="access_token",
+            expires_at=datetime.datetime.fromisoformat("3030-01-01T12:00:00Z"),
+            permissions=None,
+        )
+
+        self.mock_installation.get_active_access_token.return_value = expected_credential_lease
+        mock_encrypt_credentials.return_value = "<fake_encrypted_data>"
+
+        service = ScmIntegrationCredentialsService()
+        credentials = service.get_credentials_by_resource(
+            sentry_organization_id=self.organization.id,
+            integration_provider="github",
+            token_minimum_validity_seconds=10,
+            resource_type=ResourceType.ORGANIZATION,
+            resource_identifier="Test Integration",
+        )
+
+        assert credentials == "<fake_encrypted_data>"
+
+    @patch.object(Integration, "get_installation")
+    @patch.object(ScmIntegrationCredentialsService, "_encrypt_credentials")
+    def test_get_credentials_by_resource__sentry_installation(
+        self, mock_encrypt_credentials, mock_get_installation
+    ) -> None:
+        mock_get_installation.return_value = self.mock_installation
+        mock_encrypt_credentials.return_value = "<fake_encrypted_data>"
+        service = ScmIntegrationCredentialsService()
+        credentials = service.get_credentials_by_resource(
+            sentry_organization_id=self.organization.id,
+            integration_provider="github",
+            token_minimum_validity_seconds=10,
+            resource_type=ResourceType.SENTRY_INSTALLATION,
+            resource_identifier=self.integration.id,
+        )
+        assert credentials == "<fake_encrypted_data>"
+
+    @patch.object(Integration, "get_installation")
+    @patch.object(ScmIntegrationCredentialsService, "_encrypt_credentials")
+    def test_get_credentials_by_resource__sentry_installation_not_found(
+        self, mock_encrypt_credentials, mock_get_installation
+    ) -> None:
+        mock_get_installation.return_value = self.mock_installation
+        mock_encrypt_credentials.return_value = "<fake_encrypted_data>"
+        service = ScmIntegrationCredentialsService()
+        with pytest.raises(OrganizationIntegration.DoesNotExist):
+            service.get_credentials_by_resource(
+                sentry_organization_id=self.organization.id,
+                integration_provider="github",
+                token_minimum_validity_seconds=10,
+                resource_type=ResourceType.SENTRY_INSTALLATION,
+                resource_identifier="123",
+            )
+
+    @responses.activate
+    @patch.object(Integration, "get_installation")
+    def test_get_credentials_by_resource__get_active_access_token_raises_exception(
+        self, mock_get_installation
+    ) -> None:
+        mock_get_installation.return_value = self.mock_installation
+        self.mock_installation.get_active_access_token.side_effect = Exception("API Error")
+        self.mock_installation.does_access_token_expire_within.return_value = False
+
+        service = ScmIntegrationCredentialsService()
+        with pytest.raises(Exception, match="API Error"):
+            service.get_credentials_by_resource(
+                sentry_organization_id=self.organization.id,
+                integration_provider="github",
+                token_minimum_validity_seconds=10,
+                resource_type=ResourceType.ORGANIZATION,
+                resource_identifier="Test Integration",
+            )
+
+    @responses.activate
+    @patch.object(Integration, "get_installation")
+    @patch.object(ScmIntegrationCredentialsService, "_encrypt_credentials")
+    def test_get_credentials_by_resource__returns_active_credential_lease(
+        self, mock_encrypt_credentials, mock_get_installation
+    ) -> None:
+        mock_get_installation.return_value = self.mock_installation
+
+        expected_credential_lease = CredentialLease(
+            access_token="active_token",
+            expires_at=datetime.datetime.fromisoformat("3030-01-01T12:00:00Z"),
+            permissions={"repo": "read"},
+        )
+
+        self.mock_installation.get_active_access_token.return_value = expected_credential_lease
+        self.mock_installation.does_access_token_expire_within.return_value = False
+        mock_encrypt_credentials.return_value = "<fake_encrypted_data>"
+
+        service = ScmIntegrationCredentialsService()
+        credentials = service.get_credentials_by_resource(
+            sentry_organization_id=self.organization.id,
+            integration_provider="github",
+            token_minimum_validity_seconds=10,
+            resource_type=ResourceType.ORGANIZATION,
+            resource_identifier="Test Integration",
+        )
+
+        assert credentials == "<fake_encrypted_data>"
+        self.mock_installation.get_active_access_token.assert_called_once()
+
+    @responses.activate
+    @patch.object(Integration, "get_installation")
+    @patch.object(ScmIntegrationCredentialsService, "_encrypt_credentials")
+    def test_get_credentials_by_resource__expires_below_threshold_refreshes(
+        self, mock_encrypt_credentials, mock_get_installation
+    ) -> None:
+        mock_get_installation.return_value = self.mock_installation
+
+        refreshed_credential_lease = CredentialLease(
+            access_token="refreshed_token",
+            expires_at=datetime.datetime.fromisoformat("3030-01-02T12:00:00Z"),
+            permissions={"repo": "write"},
+        )
+
+        self.mock_installation.does_access_token_expire_within.return_value = True
+        self.mock_installation.refresh_access_token_with_minimum_validity_time.return_value = (
+            refreshed_credential_lease
+        )
+        mock_encrypt_credentials.return_value = "<fake_encrypted_data>"
+
+        service = ScmIntegrationCredentialsService()
+        credentials = service.get_credentials_by_resource(
+            sentry_organization_id=self.organization.id,
+            integration_provider="github",
+            token_minimum_validity_seconds=10,
+            resource_type=ResourceType.ORGANIZATION,
+            resource_identifier="Test Integration",
+        )
+
+        assert credentials == "<fake_encrypted_data>"
+        self.mock_installation.refresh_access_token_with_minimum_validity_time.assert_called_once()
+        self.mock_installation.get_active_access_token.assert_not_called()
+
+    @responses.activate
+    @patch.object(Integration, "get_installation")
+    @patch.object(ScmIntegrationCredentialsService, "_encrypt_credentials")
+    def test_get_credentials_by_resource__expires_above_threshold_returns_active(
+        self, mock_encrypt_credentials, mock_get_installation
+    ) -> None:
+        mock_get_installation.return_value = self.mock_installation
+
+        active_credential_lease = CredentialLease(
+            access_token="active_token",
+            expires_at=datetime.datetime.fromisoformat("3030-01-05T12:00:00Z"),
+            permissions=None,
+        )
+
+        self.mock_installation.does_access_token_expire_within.return_value = False
+        self.mock_installation.get_active_access_token.return_value = active_credential_lease
+        mock_encrypt_credentials.return_value = "<fake_encrypted_data>"
+
+        service = ScmIntegrationCredentialsService()
+        credentials = service.get_credentials_by_resource(
+            sentry_organization_id=self.organization.id,
+            integration_provider="github",
+            token_minimum_validity_seconds=10,
+            resource_type=ResourceType.ORGANIZATION,
+            resource_identifier="Test Integration",
+        )
+
+        assert credentials == "<fake_encrypted_data>"
+        self.mock_installation.get_active_access_token.assert_called_once()
+        self.mock_installation.refresh_access_token_with_minimum_validity_time.assert_not_called()
+
+    @responses.activate
+    @patch.object(Integration, "get_installation")
+    @patch.object(ScmIntegrationCredentialsService, "_encrypt_credentials")
+    def test_rotate_credentials_by_resource__force_refreshes_token(
+        self, mock_encrypt_credentials, mock_get_installation
+    ) -> None:
+        mock_get_installation.return_value = self.mock_installation
+
+        force_refreshed_credential_lease = CredentialLease(
+            access_token="force_refreshed_token",
+            expires_at=datetime.datetime.fromisoformat("3030-01-03T12:00:00Z"),
+            permissions={"repo": "admin"},
+        )
+
+        self.mock_installation.force_refresh_access_token.return_value = (
+            force_refreshed_credential_lease
+        )
+        mock_encrypt_credentials.return_value = "<fake_encrypted_data>"
+
+        service = ScmIntegrationCredentialsService()
+        credentials = service.rotate_credentials_by_resource(
+            sentry_organization_id=self.organization.id,
+            integration_provider="github",
+            resource_type=ResourceType.ORGANIZATION,
+            resource_identifier="Test Integration",
+        )
+
+        assert credentials == "<fake_encrypted_data>"
+        self.mock_installation.force_refresh_access_token.assert_called_once()
+        self.mock_installation.get_active_access_token.assert_not_called()
+        self.mock_installation.refresh_access_token_with_minimum_validity_time.assert_not_called()
+
+    @responses.activate
+    @patch.object(ScmIntegrationCredentialsService, "_encrypt_credentials")
+    @patch.object(Integration, "get_installation")
+    def test_get_credentials_by_resource__expiration_none_triggers_refresh(
+        self, mock_get_installation, mock_encrypt_credentials
+    ) -> None:
+        mock_get_installation.return_value = self.mock_installation
+
+        refreshed_credential_lease = CredentialLease(
+            access_token="refreshed_token",
+            expires_at=datetime.datetime.fromisoformat("3030-01-04T12:00:00Z"),
+            permissions=None,
+        )
+
+        self.mock_installation.get_current_access_token_expiration.return_value = None
+        self.mock_installation.does_access_token_expire_within.return_value = True
+        self.mock_installation.refresh_access_token_with_minimum_validity_time.return_value = (
+            refreshed_credential_lease
+        )
+        mock_encrypt_credentials.return_value = "<fake_encrypted_data>"
+
+        service = ScmIntegrationCredentialsService()
+        credentials = service.get_credentials_by_resource(
+            sentry_organization_id=self.organization.id,
+            integration_provider="github",
+            token_minimum_validity_seconds=10,
+            resource_type=ResourceType.ORGANIZATION,
+            resource_identifier="Test Integration",
+        )
+
+        self.mock_installation.refresh_access_token_with_minimum_validity_time.assert_called_once()
+        assert credentials == "<fake_encrypted_data>"
+
+    @responses.activate
+    @patch.object(Integration, "get_installation")
+    def test_get_credentials_by_resource__properly_encrypts_credentials(
+        self, mock_get_installation
+    ) -> None:
+        mock_get_installation.return_value = self.mock_installation
+
+        refreshed_credential_lease = CredentialLease(
+            access_token="refreshed_token",
+            expires_at=datetime.datetime.fromisoformat("3030-01-04T12:00:00Z"),
+            permissions=None,
+        )
+
+        self.mock_installation.get_current_access_token_expiration.return_value = None
+        self.mock_installation.does_access_token_expire_within.return_value = True
+        self.mock_installation.refresh_access_token_with_minimum_validity_time.return_value = (
+            refreshed_credential_lease
+        )
+
+        with override_settings(INTEGRATION_CREDENTIALS_LEASE_ENCRYPTION_KEY=self.encryption_key):
+            service = ScmIntegrationCredentialsService()
+            credentials = service.get_credentials_by_resource(
+                sentry_organization_id=self.organization.id,
+                integration_provider="github",
+                token_minimum_validity_seconds=10,
+                resource_type=ResourceType.ORGANIZATION,
+                resource_identifier="Test Integration",
+            )
+
+        self.mock_installation.refresh_access_token_with_minimum_validity_time.assert_called_once()
+        decrypted_credentials = self.decrypt_credentials(credentials, self.encryption_key)
+
+        assert decrypted_credentials == LeasedCredentials(
+            access_token=refreshed_credential_lease.access_token,
+            permissions=refreshed_credential_lease.permissions,
+            expires_at=refreshed_credential_lease.expires_at.isoformat(),
+            lease_duration_seconds=10,
+            sentry_organization_id=str(self.organization.id),
+            external_installation_id="123",
+            resource_identifier="Test Integration",
+            resource_type=ResourceType.ORGANIZATION.value,
+            integration_provider=IntegrationProviderSlug.GITHUB.value,
+        )

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -568,6 +568,7 @@ class GithubProxyClientTest(TestCase):
                 "metadata": "read",
                 "pull_requests": "read",
             },
+            "expires_at": datetime.fromisoformat("3000-01-01T00:00:00Z"),
         }
 
     @responses.activate

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest import mock
 from unittest.mock import ANY, MagicMock, patch
@@ -50,6 +50,7 @@ from sentry.testutils.asserts import (
 )
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.integrations import get_installation_of_type
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -1724,3 +1725,114 @@ class GitHubIntegrationTest(IntegrationTestCase):
         assert not OrganizationIntegration.objects.filter(
             integration=integration, organization_id=self.organization.id
         ).exists()
+
+
+@control_silo_test
+class GithubIntegrationCredentialLeasingTest(IntegrationTestCase):
+    base_url = "https://api.github.com"
+    access_token = "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
+
+    def setUp(self) -> None:
+        self.organization = self.create_organization(owner=self.create_user("test@example.com"))
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="Test Integration",
+            external_id="123",
+        )
+
+    @pytest.fixture(autouse=True)
+    def stub_get_jwt(self):
+        with mock.patch.object(client, "get_jwt", return_value="jwt_token_1"):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def stub_get_jwt_function(self):
+        with mock.patch("sentry.integrations.github.utils.get_jwt", return_value="jwt_token_1"):
+            yield
+
+    def _stub_github_credentials(self):
+        responses.add(
+            responses.POST,
+            "https://github.com/login/oauth/access_token",
+            body=f"access_token={self.access_token}",
+        )
+
+        responses.add(responses.GET, self.base_url + "/user", json={"login": "octocat"})
+
+        responses.add(
+            responses.POST,
+            self.base_url + f"/app/installations/{self.integration.external_id}/access_tokens",
+            json={
+                "token": self.access_token,
+                "expires_at": "2025-01-01T12:00:00Z",
+                "permissions": {
+                    "administration": "read",
+                    "contents": "read",
+                    "issues": "write",
+                    "metadata": "read",
+                    "pull_requests": "read",
+                },
+                "repository_selection": "all",
+            },
+        )
+
+    @responses.activate
+    def test_get_active_access_token(self) -> None:
+        self._stub_github_credentials()
+        installation = self.integration.get_installation(organization_id=self.organization.id)
+        assert installation is not None
+        assert installation.get_active_access_token() == self.access_token
+
+    @responses.activate
+    def test_get_maximum_lease_duration_seconds(self) -> None:
+        installation = self.integration.get_installation(organization_id=self.organization.id)
+        assert installation is not None
+        assert installation.get_maximum_lease_duration_seconds() == 3600
+
+    @responses.activate
+    def test_refresh_access_token_with_minimum_validity_time(self) -> None:
+        self._stub_github_credentials()
+        installation = self.integration.get_installation(organization_id=self.organization.id)
+        assert installation is not None
+        assert (
+            installation.refresh_access_token_with_minimum_validity_time(timedelta(minutes=1))
+            == self.access_token
+        )
+
+    @responses.activate
+    def test_does_access_token_expire_within(self) -> None:
+        self._stub_github_credentials()
+        installation = self.integration.get_installation(organization_id=self.organization.id)
+        assert installation is not None
+
+        # Without token, with 1 hour to expiration
+        with freeze_time("2025-01-01T11:00:00Z"):
+            assert installation.does_access_token_expire_within(timedelta(minutes=1)) is True
+
+        assert installation.get_active_access_token() is not None
+        # Annoying quirk with our "installations", we have to refresh the model
+        # before calling `get_installation` for it to populate the metadata
+        # after the token is refreshed.
+        self.integration.refresh_from_db()
+        installation = self.integration.get_installation(organization_id=self.organization.id)
+
+        assert self.integration.metadata["access_token"] is not None
+
+        # With 0 time left to expiration
+        with freeze_time("2025-01-01T12:00:00Z"):
+            assert installation.does_access_token_expire_within(timedelta(minutes=1)) is True
+            assert installation.does_access_token_expire_within(timedelta(seconds=1)) is True
+
+        # with 1 second left
+        with freeze_time("2025-01-01T11:01:00Z"):
+            assert installation.does_access_token_expire_within(timedelta(seconds=1)) is False
+
+        with freeze_time("2025-01-01T11:59:01Z"):
+            assert installation.does_access_token_expire_within(timedelta(minutes=1)) is True
+            assert installation.does_access_token_expire_within(timedelta(minutes=2)) is True
+
+        # With 1 hour
+        with freeze_time("2025-01-01T11:00:01Z"):
+            assert installation.does_access_token_expire_within(timedelta(seconds=3599)) is False
+            assert installation.does_access_token_expire_within(timedelta(seconds=3600)) is True


### PR DESCRIPTION
Continuation of #101264

Adds the wrapping credential lease service for Overwatch Bridge and Seer to use when requesting integration auth tokens.

