### PR TITLE
feat(aci): disable sentry app actions in outbox

### DIFF
--- a/src/sentry/deletions/defaults/sentry_app.py
+++ b/src/sentry/deletions/defaults/sentry_app.py
@@ -23,8 +23,3 @@ class SentryAppDeletionTask(ModelDeletionTask[SentryApp]):
             status = getattr(instance, "status", None)
             if status not in (SentryAppStatus.DELETION_IN_PROGRESS, None):
                 instance.update(status=SentryAppStatus.DELETION_IN_PROGRESS)
-
-    def delete_instance(self, instance: SentryApp) -> None:
-        # action service RPC goes here, iterating by region because children are deleted first
-
-        return super().delete_instance(instance)

--- a/src/sentry/hybridcloud/outbox/category.py
+++ b/src/sentry/hybridcloud/outbox/category.py
@@ -61,6 +61,7 @@ class OutboxCategory(IntEnum):
     FTC_CONSENT = 39
 
     SERVICE_HOOK_UPDATE = 40
+    SENTRY_APP_DELETE = 41
 
     @classmethod
     def as_choices(cls) -> Sequence[tuple[int, int]]:
@@ -302,6 +303,7 @@ class OutboxScope(IntEnum):
             OutboxCategory.SENTRY_APP_INSTALLATION_UPDATE,
             OutboxCategory.SENTRY_APP_UPDATE,
             OutboxCategory.SERVICE_HOOK_UPDATE,
+            OutboxCategory.SENTRY_APP_DELETE,
         },
     )
     # No longer in use

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3159,6 +3159,13 @@ register(
 )
 
 register(
+    "workflow_engine.sentry-app-actions-outbox",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "workflow_engine.num_cohorts",
     type=Int,
     default=1,

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -45,28 +45,26 @@ def process_integration_updates(object_identifier: int, region_name: str, **kwds
 
 @receiver(process_control_outbox, sender=OutboxCategory.SENTRY_APP_UPDATE)
 def process_sentry_app_updates(object_identifier: int, region_name: str, **kwds: Any):
-
-    # This function should only be used when the sentry app is being deleted.
-    # Currently this receiver is only used for deletion.
-    if options.get("workflow_engine.sentry-app-actions-outbox"):
-        logger.info(
-            "sentry_app_update.update_action_status",
-            extra={
-                "region_name": region_name,
-                "sentry_app_id": object_identifier,
-            },
-        )
-        action_service.update_action_status_for_sentry_app_via_sentry_app_id(
-            region_name=region_name,
-            status=ObjectStatus.DISABLED,
-            sentry_app_id=object_identifier,
-        )
-
     if (
         sentry_app := maybe_process_tombstone(
             model=SentryApp, object_identifier=object_identifier, region_name=region_name
         )
     ) is None:
+        # This function should only be used when the sentry app is being deleted.
+        if options.get("workflow_engine.sentry-app-actions-outbox"):
+            logger.info(
+                "sentry_app_update.update_action_status",
+                extra={
+                    "region_name": region_name,
+                    "sentry_app_id": object_identifier,
+                },
+            )
+            action_service.update_action_status_for_sentry_app_via_sentry_app_id(
+                region_name=region_name,
+                status=ObjectStatus.DISABLED,
+                sentry_app_id=object_identifier,
+            )
+
         return
 
     # Spawn a task to clear caches, as there can be 1000+ installations

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -14,6 +14,8 @@ from typing import Any
 
 from django.dispatch import receiver
 
+from sentry import options
+from sentry.constants import ObjectStatus
 from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.hybridcloud.outbox.signals import process_control_outbox
 from sentry.integrations.models.integration import Integration
@@ -25,6 +27,7 @@ from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.sentry_apps.services.hook.service import hook_service
 from sentry.sentry_apps.tasks.sentry_apps import clear_region_cache
+from sentry.workflow_engine.service.action.service import action_service
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +45,22 @@ def process_integration_updates(object_identifier: int, region_name: str, **kwds
 
 @receiver(process_control_outbox, sender=OutboxCategory.SENTRY_APP_UPDATE)
 def process_sentry_app_updates(object_identifier: int, region_name: str, **kwds: Any):
+
+    # This function should only be used when the sentry app is being deleted.
+    # Currently this receiver is only used for deletion.
+    if options.get("workflow_engine.sentry-app-actions-outbox"):
+        logger.info(
+            "sentry_app_update.update_action_status",
+            extra={
+                "region_name": region_name,
+                "sentry_app_id": object_identifier,
+            },
+        )
+        action_service.update_action_status_for_sentry_app_via_sentry_app_id(
+            region_name=region_name,
+            status=ObjectStatus.DISABLED,
+            sentry_app_id=object_identifier,
+        )
 
     if (
         sentry_app := maybe_process_tombstone(

--- a/tests/sentry/deletions/test_sentry_app.py
+++ b/tests/sentry/deletions/test_sentry_app.py
@@ -2,15 +2,20 @@ import pytest
 from django.db import connections, router
 
 from sentry import deletions
+from sentry.constants import ObjectStatus
 from sentry.models.apiapplication import ApiApplication
+from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.silo import control_silo_test, create_test_regions
 from sentry.users.models.user import User
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
-@control_silo_test
+@control_silo_test(regions=create_test_regions("us", "de"))
 class TestSentryAppDeletionTask(TestCase):
     def setUp(self) -> None:
         self.user = self.create_user()
@@ -54,3 +59,29 @@ class TestSentryAppDeletionTask(TestCase):
         )
 
         assert c.fetchone()[0] == 1
+
+    @override_options({"workflow_engine.sentry-app-actions-outbox": True})
+    def test_disables_actions(self) -> None:
+        action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": str(self.sentry_app.id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+        other_action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": "1212121212",
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+        deletions.exec_sync(self.sentry_app)
+
+        action.refresh_from_db()
+        assert action.status == ObjectStatus.DISABLED
+
+        other_action.refresh_from_db()
+        assert other_action.status == ObjectStatus.ACTIVE


### PR DESCRIPTION
When a Sentry app is deleted, outboxes are queued. Add updating Action statuses to a new outbox for deleting sentry apps.

Pulled out from https://github.com/getsentry/sentry/pull/100813