### PR TITLE
fix(explorer): Fix grouped charts

### DIFF
--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -59,21 +59,21 @@ def execute_trace_query_chart(
     # Always normalize to the nested {"metric": {"data": [...]}} format for consistency
     metric_is_single = len(y_axes) == 1
     metric_name = y_axes[0] if metric_is_single else None
+    if metric_name and metric_is_single:
+        # Handle grouped data with single metric: wrap each group's data in the metric name
+        if group_by:
+            return {
+                group_value: (
+                    {metric_name: group_data}
+                    if isinstance(group_data, dict) and "data" in group_data
+                    else group_data
+                )
+                for group_value, group_data in data.items()
+            }
 
-    # Handle grouped data with single metric: wrap each group's data in the metric name
-    if group_by and metric_is_single:
-        return {
-            group_value: (
-                {metric_name: group_data}
-                if isinstance(group_data, dict) and "data" in group_data
-                else group_data
-            )
-            for group_value, group_data in data.items()
-        }
-
-    # Handle non-grouped data with single metric: wrap data in the metric name
-    if metric_is_single and isinstance(data, dict) and "data" in data:
-        return {metric_name: data}
+        # Handle non-grouped data with single metric: wrap data in the metric name
+        if isinstance(data, dict) and "data" in data:
+            return {metric_name: data}
 
     return data
 

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -258,10 +258,20 @@ class TestExplorerTools(APITransactionTestCase, SnubaTestCase, SpanTestCase):
         # Should have different span.op values like "db", "http.client", etc.
         assert len(result) > 0
 
-        # Each group should have the metric
+        # Each group should have the metric wrapped in normalized format
+        # Format: {"group_value": {"count()": {"data": [...]}}}
         for group_value, metrics in result.items():
-            if isinstance(metrics, dict) and "count()" in metrics:
-                assert "data" in metrics["count()"]
+            assert isinstance(
+                metrics, dict
+            ), f"Expected dict for {group_value}, got {type(metrics)}"
+            assert (
+                "count()" in metrics
+            ), f"Missing count() in metrics for {group_value}: {metrics.keys()}"
+            assert "data" in metrics["count()"], f"Missing data in count() for {group_value}"
+
+            # Verify we can get actual count data
+            data_points = metrics["count()"]["data"]
+            assert isinstance(data_points, list)
 
     def test_execute_trace_query_table_with_groupby(self):
         """Test table query with group_by for aggregates mode"""


### PR DESCRIPTION
Apply the formatting we use for single metric charts to those with group-bys as well. This will fix a bug where charts are not getting processed in Seer correctly