### PR TITLE
test(ui): Deprecate router returned from initializeOrg

### DIFF
--- a/tests/js/sentry-test/initializeOrg.tsx
+++ b/tests/js/sentry-test/initializeOrg.tsx
@@ -25,6 +25,9 @@ interface InitializeOrgOptions<RouterParams> {
   organization?: Partial<Organization>;
   project?: Partial<Project>;
   projects?: Array<Partial<Project>>;
+  /**
+   * @deprecated Use `initialRouterConfig` and the router returned from `render` instead.
+   */
   router?: PartialInjectedRouter<RouterParams>;
 }
 
@@ -77,6 +80,9 @@ export function initializeOrg<RouterParams = {orgId: string; projectId: string}>
     organization,
     project: project!,
     projects,
+    /**
+     * @deprecated Use `initialRouterConfig` and the router returned from `render` instead.
+     */
     router,
     routerProps,
   };


### PR DESCRIPTION
Try to point people towards the router returned from render, has no use in the new test environment.
