### PR TITLE
ref(listbox): Make keyDownHandler an optional prop

### DIFF
--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -34,13 +34,6 @@ interface ListBoxProps
       | 'autoFocus'
     > {
   /**
-   * Keyboard event handler, to be attached to the list (`ul`) element, to seamlessly
-   * move focus from one composite list to another when an arrow key is pressed. Returns
-   * a boolean indicating whether the keyboard event was intercepted. If yes, then no
-   * further callback function should be run.
-   */
-  keyDownHandler: (e: React.KeyboardEvent<HTMLUListElement>) => boolean;
-  /**
    * Object containing the selection state and focus position, needed for
    * `useListBox()`.
    */
@@ -55,6 +48,13 @@ interface ListBoxProps
    * Set of keys that are hidden from the user (e.g. because not matching search query)
    */
   hiddenOptions?: Set<SelectKey>;
+  /**
+   * Keyboard event handler, to be attached to the list (`ul`) element, to seamlessly
+   * move focus from one composite list to another when an arrow key is pressed. Returns
+   * a boolean indicating whether the keyboard event was intercepted. If yes, then no
+   * further callback function should be run.
+   */
+  keyDownHandler?: (e: React.KeyboardEvent<HTMLUListElement>) => boolean;
   /**
    * Text label to be rendered as heading on top of grid list.
    */
@@ -92,6 +92,7 @@ interface ListBoxProps
 }
 
 const EMPTY_SET = new Set<never>();
+const DEFAULT_KEY_DOWN_HANDLER = () => true;
 
 /**
  * A list box with accessibile behaviors & attributes.
@@ -111,7 +112,7 @@ export function ListBox({
   shouldFocusOnHover = true,
   onSectionToggle,
   sizeLimitMessage,
-  keyDownHandler,
+  keyDownHandler = DEFAULT_KEY_DOWN_HANDLER,
   label,
   hiddenOptions = EMPTY_SET,
   hasSearch,

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -318,7 +318,6 @@ function OverlayContent<T extends SelectOptionOrSectionWithKey<string>>({
           listState={state}
           hasSearch={!!filterValue}
           hiddenOptions={hiddenOptions}
-          keyDownHandler={() => true}
           overlayIsOpen={isOpen}
           size="sm"
         />

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -174,7 +174,6 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
               listState={state}
               hasSearch={!!filterValue}
               hiddenOptions={hiddenOptions}
-              keyDownHandler={() => true}
               overlayIsOpen={isOpen}
               showSectionHeaders={!filterValue}
               size="sm"

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -263,7 +263,6 @@ function FilterKeyMenuContent<T extends SelectOptionOrSectionWithKey<string>>({
           listState={state}
           hasSearch={selectedSection === RECENT_SEARCH_CATEGORY_VALUE}
           hiddenOptions={hiddenOptions}
-          keyDownHandler={() => true}
           overlayIsOpen
           showSectionHeaders={!selectedSection}
           size="sm"

--- a/static/app/components/tokenizedInput/token/comboBox.tsx
+++ b/static/app/components/tokenizedInput/token/comboBox.tsx
@@ -339,7 +339,6 @@ export function ComboBox({
             listState={state}
             hasSearch={!!filterValue}
             hiddenOptions={hiddenOptions}
-            keyDownHandler={() => true}
             overlayIsOpen={isOpen}
             size="sm"
           />

--- a/static/app/debug/notifications/components/debugNotificationsSearch.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsSearch.tsx
@@ -124,7 +124,6 @@ function SearchComboBox<T extends SearchItem>(props: SearchComboBoxProps<T>) {
             listState={state}
             hasSearch={!!state.inputValue}
             hiddenOptions={new Set([])}
-            keyDownHandler={() => false}
             overlayIsOpen={state.isOpen}
             size="sm"
             {...listBoxProps}

--- a/static/app/stories/view/storySearch.tsx
+++ b/static/app/stories/view/storySearch.tsx
@@ -228,7 +228,6 @@ function SearchComboBox(props: SearchComboBoxProps) {
             listState={state}
             hasSearch={!!state.inputValue}
             hiddenOptions={new Set([])}
-            keyDownHandler={() => false}
             overlayIsOpen={state.isOpen}
             size="sm"
             {...listBoxProps}


### PR DESCRIPTION
This has been reused in a few places, but only CompactSelect uses it so I don't think it needs to be a required prop.