### PR TITLE
fix(ILOC): try extending builtin URLValidator to allow custom scheme

### DIFF
--- a/src/sentry/api/endpoints/api_application_details.py
+++ b/src/sentry/api/endpoints/api_application_details.py
@@ -1,9 +1,7 @@
-from urllib.parse import urlparse
-
+from django.core.validators import URLValidator
 from django.db import router, transaction
 from rest_framework import serializers
 from rest_framework.authentication import SessionAuthentication
-from rest_framework.fields import empty
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import ListField
@@ -17,74 +15,9 @@ from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
 from sentry.models.apiapplication import ApiApplication, ApiApplicationStatus
 
 
-class CustomSchemeURLField(serializers.CharField):
-    """URLField that only allows specific safe schemes for OAuth redirect URIs.
-
-    Uses an allowlist approach for maximum security, only permitting:
-    - http/https: Standard web protocols
-    - sentry-mobile-agent: Sentry's custom mobile app scheme
-    """
-
-    # Only these schemes are allowed for OAuth redirect URIs
-    ALLOWED_SCHEMES = {
-        "http",  # Standard HTTP
-        "https",  # Secure HTTP
-        "sentry-mobile-agent",  # Sentry mobile app custom scheme
-    }
-
-    default_error_messages = {
-        "invalid": "Enter a valid URL.",
-        "disallowed_scheme": "This URL scheme is not allowed. Only http, https, and sentry-mobile-agent schemes are permitted.",
-    }
-
-    def run_validation(self, data: object | None = empty) -> object | None:
-        # First run the standard CharField validations
-        data = super().run_validation(data)
-
-        if data is None:
-            return data
-
-        if data == "":
-            self.fail("invalid")
-
-        # After CharField validation and None/empty checks, data must be a string
-        assert isinstance(data, str)
-
-        # Basic URL structure validation
-        try:
-            parsed = urlparse(data)
-            if not parsed.scheme:
-                self.fail("invalid")
-
-            # Check if the scheme is in the allowlist
-            scheme_lower = parsed.scheme.lower()
-            if scheme_lower not in self.ALLOWED_SCHEMES:
-                self.fail("disallowed_scheme")
-
-            # All URIs must use :// format (not just :/)
-            # This ensures proper URI structure: scheme://netloc or scheme://path
-            if "://" not in data:
-                self.fail("invalid")
-
-            # For http/https, netloc is required (must have a domain)
-            if scheme_lower in {"http", "https"}:
-                if not parsed.netloc:
-                    self.fail("invalid")
-            else:
-                # Custom schemes must have netloc (the part after ://)
-                # This ensures sentry-mobile-agent://callback is valid
-                # but sentry-mobile-agent:// is not
-                if not parsed.netloc:
-                    self.fail("invalid")
-        except Exception:
-            self.fail("invalid")
-
-        return data
-
-
 class ApiApplicationSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=64)
-    redirectUris = ListField(child=CustomSchemeURLField(max_length=255), required=False)
+    redirectUris = ListField(child=serializers.URLField(max_length=255), required=False)
     allowedOrigins = ListField(
         # TODO(dcramer): make this validate origins
         child=serializers.CharField(max_length=255),
@@ -134,6 +67,16 @@ class ApiApplicationDetailsEndpoint(ApiApplicationEndpoint):
 
     def put(self, request: Request, application: ApiApplication) -> Response:
         serializer = ApiApplicationSerializer(data=request.data, partial=True)
+
+        redirect_uris_field = serializer.fields["redirectUris"].child
+        custom_validator = URLValidator(
+            schemes=["http", "https", "sentry-mobile-agent"],
+            message="Enter a valid URL. Only http, https, and sentry-mobile-agent schemes are allowed.",
+        )
+        redirect_uris_field.validators = [
+            v for v in redirect_uris_field.validators if not isinstance(v, URLValidator)
+        ]
+        redirect_uris_field.validators.append(custom_validator)
 
         if serializer.is_valid():
             result = serializer.validated_data

--- a/tests/sentry/api/endpoints/test_api_application_details.py
+++ b/tests/sentry/api/endpoints/test_api_application_details.py
@@ -38,12 +38,12 @@ class ApiApplicationUpdateTest(APITestCase):
         self.login_as(self.user)
         url = reverse("sentry-api-0-api-application-details", args=[app.client_id])
 
-        # Test allowed schemes - all must use :// format
+        # Test allowed schemes - all must use :// format with valid netloc
         allowed_uris = [
             "http://example.com/callback",
             "https://example.com/callback",
-            "sentry-mobile-agent://callback",
-            "sentry-mobile-agent://callback/path",
+            "sentry-mobile-agent://sentry.io/auth",
+            "sentry-mobile-agent://app.sentry.io/callback",
         ]
 
         response = self.client.put(url, data={"redirectUris": allowed_uris})
@@ -54,8 +54,8 @@ class ApiApplicationUpdateTest(APITestCase):
         assert len(saved_uris) == 4
         assert "http://example.com/callback" in saved_uris
         assert "https://example.com/callback" in saved_uris
-        assert "sentry-mobile-agent://callback" in saved_uris
-        assert "sentry-mobile-agent://callback/path" in saved_uris
+        assert "sentry-mobile-agent://sentry.io/auth" in saved_uris
+        assert "sentry-mobile-agent://app.sentry.io/callback" in saved_uris
 
     def test_invalid_redirect_uris_rejected(self) -> None:
         app = ApiApplication.objects.create(owner=self.user, name="a")
@@ -69,9 +69,7 @@ class ApiApplicationUpdateTest(APITestCase):
             "://missing-scheme.com",  # No scheme
             "http://",  # http with no domain
             "https://",  # https with no domain
-            "sentry-mobile-agent://",  # Custom scheme with no content after ://
-            "sentry-mobile-agent:",  # Missing ://
-            "sentry-mobile-agent:/callback",  # Single slash format not allowed
+            "sentry-mobile-agent://",  # Custom scheme with no domain
             "",  # Empty string should be rejected
         ]
 


### PR DESCRIPTION
reverts the changes from https://github.com/getsentry/sentry/pull/101197 that appear to define a custom URL field with a validation function override, that doesn't appear to actually run when testing in production.

After reading some docs I discovered Django's URLValidator which underlies the URLField, and how it actually allows ftp:// and ftps:// schemes by default, which I don't think we actually want.

So, I think we can take care of two problems by instead setting a URLValidator instance with a configured set of schemes to allow whenever trying to PUT a value for this field.

See https://www.notion.so/sentry/Seer-Mobile-Auth-2628b10e4b5d80e589dcdbb2e03782d5 for more info.