### PR TITLE
feat(aci): Hide transactions dataset option

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -19,20 +19,27 @@ import {
   DataConditionType,
   DetectorPriorityLevel,
 } from 'sentry/types/workflowEngine/dataConditions';
-import type {Detector, MetricDetectorConfig} from 'sentry/types/workflowEngine/detectors';
+import type {
+  Detector,
+  MetricDetector,
+  MetricDetectorConfig,
+} from 'sentry/types/workflowEngine/detectors';
 import {generateFieldAsString} from 'sentry/utils/discover/fields';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
   AlertRuleSensitivity,
   AlertRuleThresholdType,
+  Dataset,
 } from 'sentry/views/alerts/rules/metric/types';
 import {hasLogAlerts} from 'sentry/views/alerts/wizard/utils';
 import {TransactionsDatasetWarning} from 'sentry/views/detectors/components/details/metric/transactionsDatasetWarning';
 import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
 import {AssignSection} from 'sentry/views/detectors/components/forms/common/assignSection';
+import {useDetectorFormContext} from 'sentry/views/detectors/components/forms/context';
 import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDetectorLayout';
 import type {MetricDetectorFormData} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {
+  getBackendDataset,
   METRIC_DETECTOR_FORM_FIELDS,
   metricDetectorFormDataToEndpointPayload,
   metricSavedDetectorToFormData,
@@ -48,6 +55,7 @@ import {SectionLabel} from 'sentry/views/detectors/components/forms/sectionLabel
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {getStaticDetectorThresholdSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
+import {deprecateTransactionAlerts} from 'sentry/views/insights/common/utils/hasEAPAlerts';
 
 function MetricDetectorForm() {
   return (
@@ -212,16 +220,29 @@ function IntervalPicker() {
 function useDatasetChoices() {
   const organization = useOrganization();
 
+  const {detector} = useDetectorFormContext();
+  const savedDataset = (detector as MetricDetector | undefined)?.dataSources[0]?.queryObj
+    ?.snubaQuery?.dataset;
+  const isExistingTransactionsDetector =
+    Boolean(detector) &&
+    [Dataset.TRANSACTIONS, Dataset.GENERIC_METRICS].includes(savedDataset as Dataset);
+  const shouldHideTransactionsDataset =
+    !isExistingTransactionsDetector && deprecateTransactionAlerts(organization);
+
   return useMemo(() => {
     const datasetChoices: Array<SelectValue<DetectorDataset>> = [
       {
         value: DetectorDataset.ERRORS,
         label: t('Errors'),
       },
-      {
-        value: DetectorDataset.TRANSACTIONS,
-        label: t('Transactions'),
-      },
+      ...(shouldHideTransactionsDataset
+        ? []
+        : [
+            {
+              value: DetectorDataset.TRANSACTIONS,
+              label: t('Transactions'),
+            },
+          ]),
       ...(organization.features.includes('visibility-explore-view')
         ? [{value: DetectorDataset.SPANS, label: t('Spans')}]
         : []),
@@ -238,7 +259,7 @@ function useDatasetChoices() {
     ];
 
     return datasetChoices;
-  }, [organization]);
+  }, [organization, shouldHideTransactionsDataset]);
 }
 
 function DetectSection() {

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -39,7 +39,6 @@ import {useDetectorFormContext} from 'sentry/views/detectors/components/forms/co
 import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDetectorLayout';
 import type {MetricDetectorFormData} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {
-  getBackendDataset,
   METRIC_DETECTOR_FORM_FIELDS,
   metricDetectorFormDataToEndpointPayload,
   metricSavedDetectorToFormData,

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -346,6 +346,34 @@ describe('DetectorEdit', () => {
         })
       );
     });
+
+    it('hides transactions dataset when deprecateTransactionAlerts feature flag is enabled for new detectors', async () => {
+      const organizationWithDeprecation = OrganizationFixture({
+        features: [
+          'workflow-engine-ui',
+          'visibility-explore-view',
+          'discover-saved-queries-deprecation',
+        ],
+      });
+
+      render(<DetectorNewSettings />, {
+        organization: organizationWithDeprecation,
+        initialRouterConfig: metricRouterConfig,
+      });
+
+      // Open dataset dropdown
+      await userEvent.click(screen.getByText('Spans'));
+
+      // Verify transactions option is not available for new detectors
+      expect(
+        screen.queryByRole('menuitemradio', {name: 'Transactions'})
+      ).not.toBeInTheDocument();
+
+      // Verify other datasets are still available
+      expect(screen.getByRole('menuitemradio', {name: 'Errors'})).toBeInTheDocument();
+      expect(screen.getByRole('menuitemradio', {name: 'Spans'})).toBeInTheDocument();
+      expect(screen.getByRole('menuitemradio', {name: 'Releases'})).toBeInTheDocument();
+    });
   });
 
   describe('Uptime Detector', () => {


### PR DESCRIPTION
Hides the transactions dataset option except for editing existing transaction alerts
