### PR TITLE
fix(ai): Cursor should be reset if env, proj or date changes

### DIFF
--- a/static/app/views/insights/agents/views/overview.tsx
+++ b/static/app/views/insights/agents/views/overview.tsx
@@ -17,6 +17,7 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
@@ -74,6 +75,7 @@ function AgentsOverviewPage() {
   const datePageFilterProps = limitMaxPickableDays(organization);
   const [searchQuery, setSearchQuery] = useLocationSyncedState('query', decodeScalar);
   useDefaultToAllProjects();
+  const location = useLocation();
 
   const {activeTable, onActiveTableChange} = useActiveTable();
 
@@ -153,6 +155,11 @@ function AgentsOverviewPage() {
     ? undefined
     : agentRunsRequest.data?.length > 0;
 
+  const resetParamsOnChange = useMemo(
+    () => Object.keys(location.query).filter(key => key.toLowerCase().includes('cursor')),
+    [location.query]
+  );
+
   return (
     <SearchQueryBuilderProvider {...eapSpanSearchQueryProviderProps}>
       <ModuleFeature moduleName={ModuleName.AGENTS}>
@@ -162,9 +169,14 @@ function AgentsOverviewPage() {
               <ModuleLayout.Full>
                 <ToolRibbon>
                   <PageFilterBar condensed>
-                    <InsightsProjectSelector />
-                    <InsightsEnvironmentSelector />
-                    <DatePageFilter {...datePageFilterProps} />
+                    <InsightsProjectSelector resetParamsOnChange={resetParamsOnChange} />
+                    <InsightsEnvironmentSelector
+                      resetParamsOnChange={resetParamsOnChange}
+                    />
+                    <DatePageFilter
+                      {...datePageFilterProps}
+                      resetParamsOnChange={resetParamsOnChange}
+                    />
                   </PageFilterBar>
                   {!showOnboarding && (
                     <QueryBuilderWrapper>


### PR DESCRIPTION
**Problem**
Users who have paginated a table (with tableCursor in the URL) may encounter an empty page when they change the project, environment, or date. This happens because the pagination cursor points to a page that may not exist in the new context, even though results are available.

**Solution**
We should follow the behaviour of Discover tables and reset pagination cursors whenever the project, environment, or date changes.