### PR TITLE
feat(utils): Support multiple order_by columns in RangeQuerySetWrapper

### DIFF
--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -33,7 +33,7 @@ class Tuple(Func):
 
     function = ""  # Empty string renders as (expr, ...) without function name
 
-    def __init__(self, *expressions: Any, output_field: Field | None = None, **extra: Any) -> None:
+    def __init__(self, *expressions: Any, output_field: Any = None, **extra: Any) -> None:
         if output_field is None:
             output_field = Field()
         super().__init__(*expressions, output_field=output_field, **extra)
@@ -248,7 +248,7 @@ class RangeQuerySetWrapper[V]:
             op = "lte" if self.desc else "gte"
             return Q(**{f"{self.order_by_fields[0]}__{op}": cur_values[0]})
 
-        lookup = BuiltinLookup(
+        lookup: Any = BuiltinLookup(
             Tuple(*[F(field) for field in self.order_by_fields]),
             Tuple(*[Value(v) for v in cur_values]),
         )


### PR DESCRIPTION
This is an attempt to allow `ORDER BY` while using `RangeQuerySetWrapper`. This allows to iterate more efficiently when filtering large datasets with existing indexes. 

We still require a unique column at the very end to ensure consistent iteration, usually the PK. We also do support `min_value` and `result_value_getter` but only on the unique column.

This uses tuple comparison to create a concise filter for the cursor queries, which also works if it includes nullable columns. Since Django I could not find native support for tuples in Django ORM, this uses a workaround with a custom `Tuple` type based on `Func` to reuse as much serialization logic as possible, along with a manual `Lookup` expression to render the comparison. This creates queries like this:

```sql
WHERE (x, y, id) >= ($x, $y, $id)
ORDER BY x, y, id
```

The alternative would be unrolling the tuple comparsion. However, I've read that this often leads to suboptimal use of existing indexes in postgres. Apart from that, it would create rather large expressions that grow with the number of fields:

```sql
WHERE (x > $x) 
   OR (x = $x AND y > $y)
   OR (x = $x AND y = $y AND id >= $id)
ORDER BY x, y, id
```

Ref FS-105