### PR TITLE
fix(ai-insights): llm calls count

### DIFF
--- a/static/app/views/insights/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/agents/components/tracesTable.tsx
@@ -25,7 +25,6 @@ import {LLMCosts} from 'sentry/views/insights/agents/components/llmCosts';
 import {useCombinedQuery} from 'sentry/views/insights/agents/hooks/useCombinedQuery';
 import {ErrorCell, NumberPlaceholder} from 'sentry/views/insights/agents/utils/cells';
 import {
-  AI_GENERATION_OPS,
   getAgentRunsFilter,
   getAITracesFilter,
 } from 'sentry/views/insights/agents/utils/query';
@@ -75,11 +74,6 @@ const rightAlignColumns = new Set([
   'timestamp',
 ]);
 
-// FIXME: This is potentially not correct, we need to find a way for it to work with the new filter
-const GENERATION_COUNTS = AI_GENERATION_OPS.map(
-  op => `count_if(span.op,equals,${op})` as const
-);
-
 export function TracesTable() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -108,7 +102,7 @@ export function TracesTable() {
       search: `${getAgentRunsFilter({negated: true})} trace:[${tracesRequest.data?.data.map(span => span.trace).join(',')}]`,
       fields: [
         'trace',
-        ...GENERATION_COUNTS,
+        'count_if(gen_ai.operation.type,equals,ai_client)',
         'count_if(span.op,equals,gen_ai.execute_tool)',
         'sum(gen_ai.usage.total_tokens)',
         'sum(gen_ai.usage.total_cost)',
@@ -146,14 +140,11 @@ export function TracesTable() {
     return spansRequest.data.reduce(
       (acc, span) => {
         acc[span.trace] = {
-          llmCalls: GENERATION_COUNTS.reduce<number>(
-            (sum, key) => sum + (span[key] ?? 0),
-            0
-          ),
-          toolCalls: span['count_if(span.op,equals,gen_ai.execute_tool)'] ?? 0,
+          llmCalls: Number(span['count_if(gen_ai.operation.type,equals,ai_client)'] ?? 0),
+          toolCalls: Number(span['count_if(span.op,equals,gen_ai.execute_tool)'] ?? 0),
           totalTokens: Number(span['sum(gen_ai.usage.total_tokens)'] ?? 0),
           totalCost: Number(span['sum(gen_ai.usage.total_cost)'] ?? 0),
-          totalErrors: errors[span.trace] ?? 0,
+          totalErrors: Number(errors[span.trace] ?? 0),
         };
         return acc;
       },

--- a/static/app/views/insights/agents/utils/query.tsx
+++ b/static/app/views/insights/agents/utils/query.tsx
@@ -10,30 +10,6 @@ const AI_RUN_OPS = [
   'ai.pipeline.stream_object',
 ];
 
-// AI Generations - equivalent to OTEL Inference span
-// https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#inference
-export const AI_GENERATION_OPS = [
-  'ai.run.doGenerate',
-  'gen_ai.chat',
-  'gen_ai.generate_content',
-  'gen_ai.generate_text',
-  'gen_ai.generate_object',
-  'gen_ai.stream_text',
-  'gen_ai.stream_object',
-  'gen_ai.embed', // AI SDK
-  'gen_ai.embed_many', // AI SDK
-  'gen_ai.embeddings', // Python OpenAI
-  'gen_ai.text_completion',
-  'gen_ai.responses',
-  // Span ops coming from seer, remove ASAP
-  'gen_ai.generate structured',
-  'gen_ai.generate text',
-  'gen_ai.gemini stream',
-  'gen_ai.gemini generation with grounding',
-  'gen_ai.bug prediction formatter',
-  'gen_ai.anthropic generation',
-];
-
 export const AI_CREATE_AGENT_OPS = ['gen_ai.create_agent'];
 
 const NON_GENERATION_OPS = [

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -105,6 +105,7 @@ export enum SpanFields {
   GEN_AI_USAGE_OUTPUT_TOKENS_REASONING = 'gen_ai.usage.output_tokens.reasoning',
   GEN_AI_USAGE_TOTAL_COST = 'gen_ai.usage.total_cost',
   GEN_AI_USAGE_TOTAL_TOKENS = 'gen_ai.usage.total_tokens',
+  GEN_AI_OPERATION_TYPE = 'gen_ai.operation.type',
   MCP_CLIENT_NAME = 'mcp.client.name',
   MCP_TRANSPORT = 'mcp.transport',
   MCP_TOOL_NAME = 'mcp.tool.name',


### PR DESCRIPTION
Closes: [TET-1280: Traces table displays 0 LLM calls](https://linear.app/getsentry/issue/TET-1280/traces-table-displays-0-llm-calls)

Uses `gen_ai.operation.type` to determine the count of LLM calls in a trace

Before:

https://github.com/user-attachments/assets/457aaad5-9b89-445e-b5fa-905885cbdec4


After:
<img width="1400" height="488" alt="image" src="https://github.com/user-attachments/assets/739ff937-02de-4689-9a14-43ef688ad63a" />
