### PR TITLE
fix(ui): align LazyLoad fallback in grid layout

### DIFF
--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -42,7 +42,7 @@ function LazyLoad<C extends React.LazyExoticComponent<any>>({
       <Suspense
         fallback={
           loadingFallback ?? (
-            <Flex flex="1" align="center">
+            <Flex flex="1" align="center" column="1 / -1">
               <LoadingIndicator />
             </Flex>
           )


### PR DESCRIPTION
inside a grid layout, the `LazyLoad` fallback would only consume the first column, thus potentially not stretching it. I stumbled upon this when creating more nested layouts that are lazy-loaded where the parent has already rendered a `<Layout.Body>`.

This fix makes sure the fallback can always consume all columns when in a grid layout.

before:

<img width="1382" height="715" alt="Screenshot 2025-10-15 at 15 45 30" src="https://github.com/user-attachments/assets/38cb24b9-86ab-4d53-9cba-b2d8b59e050d" />

after:

<img width="1382" height="715" alt="Screenshot 2025-10-15 at 15 44 58" src="https://github.com/user-attachments/assets/daaa3b86-5832-4f25-ba95-8ad360c83599" />
