### PR TITLE
fix(sub v3): Layout tweaks + header card logic

### DIFF
--- a/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.spec.tsx
@@ -59,29 +59,4 @@ describe('BillingInfoCard', () => {
     await screen.findByText('No billing details on file');
     expect(screen.getByText('No payment method on file')).toBeInTheDocument();
   });
-
-  it('does not render for self-serve partner customers', () => {
-    const subscription = SubscriptionFixture({organization, isSelfServePartner: true});
-    render(<BillingInfoCard organization={organization} subscription={subscription} />);
-
-    expect(screen.queryByText('Billing information')).not.toBeInTheDocument();
-  });
-
-  it('does not render for managed customers', () => {
-    const subscription = SubscriptionFixture({organization, canSelfServe: false});
-    render(<BillingInfoCard organization={organization} subscription={subscription} />);
-
-    expect(screen.queryByText('Billing information')).not.toBeInTheDocument();
-  });
-
-  it('renders for managed customers with legacy invoiced OD', () => {
-    const subscription = SubscriptionFixture({
-      organization,
-      canSelfServe: false,
-      onDemandInvoiced: true,
-    });
-    render(<BillingInfoCard organization={organization} subscription={subscription} />);
-
-    expect(screen.getByText('Billing information')).toBeInTheDocument();
-  });
 });

--- a/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.tsx
@@ -18,13 +18,6 @@ function BillingInfoCard({
   organization: Organization;
   subscription: Subscription;
 }) {
-  if (
-    subscription.isSelfServePartner ||
-    (!subscription.canSelfServe && !subscription.onDemandInvoiced)
-  ) {
-    return null;
-  }
-
   return (
     <SubscriptionHeaderCard
       title={t('Billing information')}

--- a/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
@@ -36,10 +36,12 @@ function getCards(organization: Organization, subscription: Subscription) {
     );
   }
 
-  if (
-    (subscription.planDetails.allowOnDemand || subscription.onDemandInvoiced) &&
-    hasBillingPerms
-  ) {
+  const canUpdatePayg =
+    subscription.planDetails.allowOnDemand &&
+    subscription.supportsOnDemand &&
+    hasBillingPerms;
+
+  if (canUpdatePayg) {
     cards.push(
       <PaygCard key="payg" subscription={subscription} organization={organization} />
     );
@@ -47,7 +49,8 @@ function getCards(organization: Organization, subscription: Subscription) {
 
   if (
     hasBillingPerms &&
-    (subscription.canSelfServe || subscription.onDemandInvoiced) &&
+    (canUpdatePayg ||
+      (subscription.canSelfServe && isDeveloperPlan(subscription.planDetails))) &&
     !subscription.isSelfServePartner
   ) {
     cards.push(

--- a/static/gsApp/views/subscriptionPage/onDemandSettings.tsx
+++ b/static/gsApp/views/subscriptionPage/onDemandSettings.tsx
@@ -1,10 +1,11 @@
 import {useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Container} from '@sentry/scraps/layout';
+
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {ResponseMeta} from 'sentry/api';
 import {ExternalLink} from 'sentry/components/core/link';
-import Panel from 'sentry/components/panels/panel';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t, tct} from 'sentry/locale';
@@ -73,7 +74,7 @@ export function OnDemandSettings({subscription, organization}: OnDemandSettingsP
     Boolean(subscription.onDemandBudgets);
 
   return (
-    <Panel>
+    <Container background="primary" border="primary" radius="md">
       <PanelHeader
         // Displays the edit button when user has budgets enabled
         hasButtons={
@@ -135,7 +136,7 @@ export function OnDemandSettings({subscription, organization}: OnDemandSettingsP
           showSave
         />
       )}
-    </Panel>
+    </Container>
   );
 }
 

--- a/static/gsApp/views/subscriptionPage/ondemandDisabled.tsx
+++ b/static/gsApp/views/subscriptionPage/ondemandDisabled.tsx
@@ -59,32 +59,30 @@ function OnDemandDisabled({subscription}: Props) {
   }
 
   return (
-    <Alert.Container>
-      <Alert type="error" data-test-id="ondemand-disabled-alert" showIcon={false}>
-        <span>
-          {tct(
-            "[Name] billing is disabled for your organization due to an unpaid [lowercase_name] invoice. This may impact your organization's ability to accept data into Sentry. [docs_link:Learn more about this process].",
-            {
-              Name: name,
-              lowercase_name: name.toLowerCase(),
-              docs_link: (
-                <ExternalLink href="https://sentry.zendesk.com/hc/en-us/articles/23622477256987-We-can-t-pay-our-on-demand-pay-as-you-go-invoice-and-have-an-annual-contract-What-happens" />
-              ),
-            }
-          )}
-        </span>{' '}
-        <span>
-          {tct(
-            'Please contact [contact_link:support@sentry.io] to pay [receipts_link:closed/outstanding invoices] to re-enable [lowercase_name] billing.',
-            {
-              lowercase_name: name.toLowerCase(),
-              receipts_link: <NavLink to="/settings/billing/receipts/" />,
-              contact_link: <a href="mailto:support@sentry.io" />,
-            }
-          )}
-        </span>
-      </Alert>
-    </Alert.Container>
+    <Alert type="error" data-test-id="ondemand-disabled-alert" showIcon={false}>
+      <span>
+        {tct(
+          "[Name] billing is disabled for your organization due to an unpaid [lowercase_name] invoice. This may impact your organization's ability to accept data into Sentry. [docs_link:Learn more about this process].",
+          {
+            Name: name,
+            lowercase_name: name.toLowerCase(),
+            docs_link: (
+              <ExternalLink href="https://sentry.zendesk.com/hc/en-us/articles/23622477256987-We-can-t-pay-our-on-demand-pay-as-you-go-invoice-and-have-an-annual-contract-What-happens" />
+            ),
+          }
+        )}
+      </span>{' '}
+      <span>
+        {tct(
+          'Please contact [contact_link:support@sentry.io] to pay [receipts_link:closed/outstanding invoices] to re-enable [lowercase_name] billing.',
+          {
+            lowercase_name: name.toLowerCase(),
+            receipts_link: <NavLink to="/settings/billing/receipts/" />,
+            contact_link: <a href="mailto:support@sentry.io" />,
+          }
+        )}
+      </span>
+    </Alert>
   );
 }
 

--- a/static/gsApp/views/subscriptionPage/overview.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useEffect} from 'react';
-import styled from '@emotion/styled';
 import type {Location} from 'history';
 
 import {Flex} from 'sentry/components/core/layout';
@@ -10,7 +9,6 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconSupport} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {DataCategory} from 'sentry/types/core';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
@@ -189,7 +187,7 @@ function Overview({location, subscription, promotionData}: Props) {
         0 || false;
 
     return (
-      <TotalsWrapper>
+      <Fragment>
         {sortCategories(subscription.categories)
           .filter(
             categoryHistory =>
@@ -307,7 +305,7 @@ function Overview({location, subscription, promotionData}: Props) {
             />
           );
         })}
-      </TotalsWrapper>
+      </Fragment>
     );
   }
 
@@ -323,8 +321,6 @@ function Overview({location, subscription, promotionData}: Props) {
         background="primary"
         radius="md"
         border="primary"
-        // TODO(isabella): move spacing to the parent
-        marginTop="xl"
       >
         <Flex align="center" gap="sm">
           <IconSupport />
@@ -437,18 +433,14 @@ function Overview({location, subscription, promotionData}: Props) {
       ) : isError ? (
         <LoadingError onRetry={refetchUsage} />
       ) : (
-        <div>
+        <Flex direction="column" gap="xl">
           {hasBillingPerms
             ? contentWithBillingPerms(usage, subscription.planDetails)
             : contentWithoutBillingPerms(usage)}
-        </div>
+        </Flex>
       )}
     </SubscriptionPageContainer>
   );
 }
 
 export default withSubscription(withPromotions(Overview));
-
-const TotalsWrapper = styled('div')`
-  margin-bottom: ${space(3)};
-`;

--- a/static/gsApp/views/subscriptionPage/overviewDisplayModeToggle.tsx
+++ b/static/gsApp/views/subscriptionPage/overviewDisplayModeToggle.tsx
@@ -71,7 +71,6 @@ const SpendToggleWrapper = styled('div')`
   display: flex;
   gap: ${space(1)};
   align-items: center;
-  margin-bottom: ${space(2)};
 `;
 
 const RadioLabel = styled('label')`

--- a/static/gsApp/views/subscriptionPage/recurringCredits.tsx
+++ b/static/gsApp/views/subscriptionPage/recurringCredits.tsx
@@ -2,7 +2,8 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
-import Panel from 'sentry/components/panels/panel';
+import {Container} from '@sentry/scraps/layout';
+
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -86,7 +87,12 @@ function RecurringCredits({displayType, planDetails}: Props) {
   };
 
   return (
-    <Panel data-test-id="recurring-credits-panel">
+    <Container
+      background="primary"
+      border="primary"
+      radius="md"
+      data-test-id="recurring-credits-panel"
+    >
       <StyledPanelBody withPadding>
         <div>
           <h4>{t('Recurring Credits')}</h4>
@@ -132,7 +138,7 @@ function RecurringCredits({displayType, planDetails}: Props) {
           </AlertStripedTable>
         </div>
       </StyledPanelBody>
-    </Panel>
+    </Container>
   );
 }
 

--- a/static/gsApp/views/subscriptionPage/subscriptionHeader.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionHeader.spec.tsx
@@ -201,7 +201,7 @@ describe('SubscriptionHeader', () => {
     });
     const subscription = SubscriptionFixture({
       organization,
-      plan: 'am3_f',
+      plan: 'am3_business_ent_auf',
       canSelfServe: false,
       supportsOnDemand: false,
     });
@@ -224,9 +224,8 @@ describe('SubscriptionHeader', () => {
     });
     const subscription = SubscriptionFixture({
       organization,
-      plan: 'am3_f',
+      plan: 'am3_business_ent_auf',
       canSelfServe: false,
-      onDemandInvoiced: true,
       supportsOnDemand: true,
     });
     SubscriptionStore.set(organization.slug, subscription);

--- a/static/gsApp/views/subscriptionPage/trial/trialEnded.tsx
+++ b/static/gsApp/views/subscriptionPage/trial/trialEnded.tsx
@@ -19,14 +19,12 @@ function TrialEnded({subscription}: Props) {
   const supportLink = <ZendeskLink subject="Request Another Trial" source="trial" />;
 
   return (
-    <Alert.Container>
-      <Alert type="info" showIcon={false}>
-        {tct(
-          'Your free trial has ended. You may [supportLink:contact support] to request another trial.',
-          {supportLink}
-        )}
-      </Alert>
-    </Alert.Container>
+    <Alert type="info" showIcon={false}>
+      {tct(
+        'Your free trial has ended. You may [supportLink:contact support] to request another trial.',
+        {supportLink}
+      )}
+    </Alert>
   );
 }
 

--- a/static/gsApp/views/subscriptionPage/usageAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/usageAlert.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
-import Panel from 'sentry/components/panels/panel';
+import {Container, Flex} from '@sentry/scraps/layout';
+
 import {IconFire, IconStats, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -116,7 +117,12 @@ function UsageAlert({subscription, usage}: Props) {
     }
 
     return (
-      <Panel data-test-id="projected-overage-alert">
+      <Container
+        background="primary"
+        border="primary"
+        radius="md"
+        data-test-id="projected-overage-alert"
+      >
         <SubscriptionBody withPadding>
           <UsageInfo>
             <IconStats size="md" color="blue300" />
@@ -133,13 +139,18 @@ function UsageAlert({subscription, usage}: Props) {
           </UsageInfo>
           {renderPrimaryCTA('projected-overage')}
         </SubscriptionBody>
-      </Panel>
+      </Container>
     );
   }
 
   function renderGracePeriodInfo() {
     return (
-      <Panel data-test-id="grace-period-alert">
+      <Container
+        background="primary"
+        border="primary"
+        radius="md"
+        data-test-id="grace-period-alert"
+      >
         <SubscriptionBody withPadding>
           <UsageInfo>
             <IconWarning size="md" color="yellow300" />
@@ -158,7 +169,7 @@ function UsageAlert({subscription, usage}: Props) {
           </UsageInfo>
           {renderPrimaryCTA('grace-period')}
         </SubscriptionBody>
-      </Panel>
+      </Container>
     );
   }
 
@@ -193,7 +204,12 @@ function UsageAlert({subscription, usage}: Props) {
           });
 
     return (
-      <Panel data-test-id="usage-exceeded-alert">
+      <Container
+        background="primary"
+        border="primary"
+        radius="md"
+        data-test-id="usage-exceeded-alert"
+      >
         <SubscriptionBody withPadding>
           <UsageInfo>
             <IconFire size="md" color="red300" />
@@ -210,7 +226,7 @@ function UsageAlert({subscription, usage}: Props) {
           </UsageInfo>
           {renderPrimaryCTA('exceded-quota')}
         </SubscriptionBody>
-      </Panel>
+      </Container>
     );
   }
 
@@ -275,11 +291,11 @@ function UsageAlert({subscription, usage}: Props) {
   const showProjected = !hasExceeded && !subscription.isGracePeriod;
 
   return (
-    <div data-test-id="usage-alert">
+    <Flex direction="column" gap="xl" data-test-id="usage-alert">
       {hasExceeded && renderExceededInfo()}
       {subscription.isGracePeriod && renderGracePeriodInfo()}
       {showProjected && renderProjectedInfo(projectedOverages)}
-    </div>
+    </Flex>
   );
 }
 

--- a/static/gsApp/views/subscriptionPage/usageTotals.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.tsx
@@ -3,7 +3,8 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import colorFn from 'color';
 
-import Card from 'sentry/components/card';
+import {Container} from '@sentry/scraps/layout';
+
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {IconChevron, IconLock} from 'sentry/icons';
@@ -515,7 +516,13 @@ export function UsageTotals({
     reserved !== null && (reserved === UNLIMITED_RESERVED || reserved > 0);
 
   return (
-    <SubscriptionCard data-test-id={`usage-card-${category}`}>
+    <Container
+      background="primary"
+      border="primary"
+      radius="md"
+      data-test-id={`usage-card-${category}`}
+      padding="xl"
+    >
       <CardBody>
         <UsageProgress>
           <BaseRow>
@@ -777,7 +784,7 @@ export function UsageTotals({
             })}
         </Fragment>
       )}
-    </SubscriptionCard>
+    </Container>
   );
 }
 
@@ -1010,7 +1017,13 @@ export function CombinedUsageTotals({
   let categoryForUnusedOnDemand = firstCategory;
 
   return (
-    <SubscriptionCard data-test-id={`usage-card-${apiName}`}>
+    <Container
+      background="primary"
+      border="primary"
+      radius="md"
+      data-test-id={`usage-card-${apiName}`}
+      padding="xl"
+    >
       <CardBody>
         <UsageProgress>
           <BaseRow>
@@ -1262,13 +1275,9 @@ export function CombinedUsageTotals({
           })}
         </Fragment>
       )}
-    </SubscriptionCard>
+    </Container>
   );
 }
-
-const SubscriptionCard = styled(Card)`
-  padding: ${space(2)};
-`;
 
 const CardBody = styled('div')`
   display: grid;


### PR DESCRIPTION
- Move Overview page spacing to the parent rather than having each child have a margin bottom or margin top

<img width="2487" height="1066" alt="Screenshot 2025-10-15 at 9 48 08 AM" src="https://github.com/user-attachments/assets/7224dc9a-004c-477e-b7c0-d7e5396a116d" />

- Fix header card logic so PAYG and Billing Info cards show up for any org that has access to PAYG (with the latter additionally showing for free orgs which don't have access to PAYG)