### PR TITLE
Check github api for file before deriving mappings

### DIFF
--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -99,7 +99,7 @@ class CodeMappingTreesHelper:
     ) -> list[dict[str, str]]:
         """List all the files in a repo that match the frame_filename"""
         file_matches = []
-        
+
         # Get client if installation is provided for file verification
         client = None
         if installation is not None:
@@ -108,7 +108,7 @@ class CodeMappingTreesHelper:
             except Exception:
                 logger.exception("Failed to get client from installation for file verification")
                 client = None
-        
+
         for repo_full_name in self.trees.keys():
             repo_tree = self.trees[repo_full_name]
             matches = [
@@ -142,24 +142,30 @@ class CodeMappingTreesHelper:
                             class RepoStub:
                                 def __init__(self, name: str):
                                     self.name = name
-                            
+
                             repo_stub = RepoStub(repo_tree.repo.name)
                             # Check if file exists using GitHub API
-                            result = client.check_file(repo_stub, source_path, repo_tree.repo.branch)
+                            result = client.check_file(
+                                repo_stub, source_path, repo_tree.repo.branch
+                            )
                             if not result:
                                 logger.info(
                                     "File not found on GitHub, skipping match",
-                                    extra={**extra, "repo_name": repo_tree.repo.name, "branch": repo_tree.repo.branch}
+                                    extra={
+                                        **extra,
+                                        "repo_name": repo_tree.repo.name,
+                                        "branch": repo_tree.repo.branch,
+                                    },
                                 )
                                 continue
                         except Exception as e:
                             # If check fails, log and continue (don't add to matches)
                             logger.info(
                                 "GitHub API check failed for file, skipping match",
-                                extra={**extra, "repo_name": repo_tree.repo.name, "error": str(e)}
+                                extra={**extra, "repo_name": repo_tree.repo.name, "error": str(e)},
                             )
                             continue
-                    
+
                     file_matches.append(
                         {
                             "filename": file,

--- a/src/sentry/issues/auto_source_code_config/derived_code_mappings_endpoint.py
+++ b/src/sentry/issues/auto_source_code_config/derived_code_mappings_endpoint.py
@@ -22,7 +22,7 @@ def get_file_and_repo_matches(request: Request, organization: Organization) -> l
         return []
     trees = installation.get_trees_for_org()
     trees_helper = CodeMappingTreesHelper(trees)
-    return trees_helper.get_file_and_repo_matches(frame_info)
+    return trees_helper.get_file_and_repo_matches(frame_info, installation=installation)
 
 
 def get_frame_info_from_request(request: Request) -> FrameInfo:

--- a/tests/sentry/api/endpoints/issues/test_organization_derive_code_mappings.py
+++ b/tests/sentry/api/endpoints/issues/test_organization_derive_code_mappings.py
@@ -102,7 +102,9 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
 
     @patch("sentry.integrations.github.client.GitHubBaseClient.check_file")
     @patch("sentry.integrations.github.integration.GitHubIntegration.get_trees_for_org")
-    def test_get_start_with_backslash(self, mock_get_trees_for_org: Any, mock_check_file: Any) -> None:
+    def test_get_start_with_backslash(
+        self, mock_get_trees_for_org: Any, mock_check_file: Any
+    ) -> None:
         file = "stack/root/file.py"
         config_data = {"stacktraceFilename": f"/{file}"}
         expected_matches = [
@@ -190,7 +192,9 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
 
     @patch("sentry.integrations.github.client.GitHubBaseClient.check_file")
     @patch("sentry.integrations.github.integration.GitHubIntegration.get_trees_for_org")
-    def test_get_unsupported_frame_info(self, mock_get_trees_for_org: Any, mock_check_file: Any) -> None:
+    def test_get_unsupported_frame_info(
+        self, mock_get_trees_for_org: Any, mock_check_file: Any
+    ) -> None:
         config_data = {
             "stacktraceFilename": "top_level_file.py",
         }
@@ -209,7 +213,9 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
 
     @patch("sentry.integrations.github.client.GitHubBaseClient.check_file")
     @patch("sentry.integrations.github.integration.GitHubIntegration.get_trees_for_org")
-    def test_get_file_not_found_on_github(self, mock_get_trees_for_org: Any, mock_check_file: Any) -> None:
+    def test_get_file_not_found_on_github(
+        self, mock_get_trees_for_org: Any, mock_check_file: Any
+    ) -> None:
         """Test that files not found on GitHub API are excluded from matches"""
         config_data = {
             "stacktraceFilename": "stack/root/file.py",


### PR DESCRIPTION
<!-- Describe your PR here. -->
This PR enhances the `derive-code-mappings` API by adding a real-time check against GitHub's API to verify the existence of potential source code files.

**Why this change?**
Previously, derived code mappings relied solely on cached repository tree data, which could become stale or inaccurate, leading to suggestions for files that no longer existed in the repository.

By introducing a GitHub API call (`client.check_file`) for each potential file match, we ensure that all suggested code mappings correspond to actual, verifiable files on the specified branch in GitHub. This improves the accuracy and reliability of the derived code mappings, providing users with more relevant and up-to-date suggestions. Files that are not found via the GitHub API or cause an API error are now gracefully excluded from the results.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/D09259VQFAP/p1760536058422289?thread_ts=1760536058.422289&cid=D09259VQFAP)

<a href="https://cursor.com/background-agent?bcId=bc-428e235f-9e64-437b-935b-7fdb22796a36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-428e235f-9e64-437b-935b-7fdb22796a36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

