### PR TITLE
fix(sub v3): only record replays for new UI

### DIFF
--- a/static/gsApp/views/subscriptionPage/components/subscriptionPageContainer.tsx
+++ b/static/gsApp/views/subscriptionPage/components/subscriptionPageContainer.tsx
@@ -25,12 +25,15 @@ function SubscriptionPageContainer({
   paddingOverride?: ContainerProps['padding'];
   useBorderTopLogic?: boolean;
 }) {
+  const isNewBillingUI = hasNewBillingUI(organization);
+
   useEffect(() => {
     // record replays for all usage and billing settings pages
-    Sentry.getReplay()?.start();
-  }, []);
+    if (isNewBillingUI) {
+      Sentry.getReplay()?.start();
+    }
+  }, [isNewBillingUI]);
 
-  const isNewBillingUI = hasNewBillingUI(organization);
   useRouteAnalyticsParams({
     isNewBillingUI,
   });


### PR DESCRIPTION
Only record replays for the new UI, since these pages get a lot more views.

We will stop recording post-EA.