### PR TITLE
fix(trace-waterfall): Fix `http.client` description not filling parent

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -198,7 +198,7 @@ export function SpanDescription({
         )}
       </CodeSnippetWrapper>
     ) : resolvedModule === ModuleName.HTTP && span.op === 'http.client' && spanURL ? (
-      <Flex direction="column">
+      <Flex direction="column" width="100%">
         <Flex align="start" justify="between" gap="xs" padding="md">
           <Flex align="start" paddingLeft="md" paddingTop="sm" paddingBottom="sm">
             <Flex gap="xs">


### PR DESCRIPTION
Right now they don't stretch the fill the parent, so they look awkward if the description is short. Fix it so the description stretches to fit.

**e.g.,**
<img width="596" height="131" alt="Screenshot 2025-10-15 at 10 26 26 AM" src="https://github.com/user-attachments/assets/d6564d52-1847-4361-8c11-ccce87d3e07d" />
