### PR TITLE
fix(tracemetrics): Switch experimental backend to kwarg rate

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2767,12 +2767,6 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "tracemetrics.sentry_sdk_metrics_backend_rate",
-    type=Float,
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # TODO: For now, only a small number of projects are going through a grouping config transition at
 # any given time, so we're sampling at 100% in order to be able to get good signal. Once we've fully


### PR DESCRIPTION
### Summary
Based on some digging, last time we tried to use an option with metrics it caused INC-1101 and INC-1130 with spikes hitting db in production as some metrics are module/import level. This will be slower (as it needs a deploy to change volume) but we can still kill switch via tracemetrics-ingestion in relay.

