### PR TITLE
feat(trace-tree-node): Fixing link to code in eap traces

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -73,7 +73,7 @@ export function SpanDescription({
   hideNodeActions?: boolean;
 }) {
   const {data: event} = useEventDetails({
-    eventId: node.event?.eventID,
+    eventId: node.value.transaction_id,
     projectSlug: project?.slug,
   });
   const span = node.value;
@@ -143,7 +143,7 @@ export function SpanDescription({
           to={getSearchInExploreTarget(
             organization,
             location,
-            node.event?.projectID,
+            project?.id,
             exploreAttributeName,
             exploreAttributeValue,
             TraceDrawerActionKind.INCLUDE
@@ -169,6 +169,8 @@ export function SpanDescription({
   const codeLineNumber = findSpanAttributeValue(attributes, 'code.lineno');
   const codeFunction = findSpanAttributeValue(attributes, 'code.function');
 
+  const requestMethod = findSpanAttributeValue(attributes, 'http.request.method');
+
   // `"url.full"` is semantic, but `"url"` is common
   const spanURL =
     findSpanAttributeValue(attributes, 'url.full') ??
@@ -185,7 +187,7 @@ export function SpanDescription({
         </StyledCodeSnippet>
         {codeFilepath ? (
           <StackTraceMiniFrame
-            projectId={node.event?.projectID}
+            projectId={project?.id}
             event={event}
             frame={{
               filename: codeFilepath,
@@ -198,11 +200,11 @@ export function SpanDescription({
         )}
       </CodeSnippetWrapper>
     ) : resolvedModule === ModuleName.HTTP && span.op === 'http.client' && spanURL ? (
-      <Flex direction="column">
+      <Flex direction="column" width="100%">
         <Flex align="start" justify="between" gap="xs" padding="md">
           <Flex align="start" paddingLeft="md" paddingTop="sm" paddingBottom="sm">
             <Flex gap="xs">
-              <Text>{findSpanAttributeValue(attributes, 'http.request.method')}</Text>
+              {requestMethod && <Text>{requestMethod}</Text>}
               <Text wordBreak="break-word">{spanURL}</Text>
             </Flex>
             <LinkHint value={spanURL} />
@@ -216,7 +218,7 @@ export function SpanDescription({
         </Flex>
         {codeFilepath && (
           <StackTraceMiniFrame
-            projectId={node.event?.projectID}
+            projectId={project?.id}
             event={event}
             frame={{
               filename: codeFilepath,
@@ -330,7 +332,7 @@ function ResourceImageDescription({
       ) : (
         <DisabledImages
           onClickShowLinks={() => setShowLinks(true)}
-          projectSlug={span.project_slug ?? node.event?.projectSlug}
+          projectSlug={span.project_slug}
         />
       )}
     </StyledDescriptionWrapper>


### PR DESCRIPTION
Before: 
<img width="633" height="152" alt="Screenshot 2025-10-15 at 11 14 58 AM" src="https://github.com/user-attachments/assets/e40e3b8f-ca89-42cf-b993-382359f0ba68" />

After: 
<img width="715" height="141" alt="Screenshot 2025-10-15 at 11 33 42 AM" src="https://github.com/user-attachments/assets/ff0e9f6e-9c4b-4deb-8b10-7e3e1ae75063" />

Note: 
This confusion won't exist when the new `BaseNode` class replaces `TraceTreeNode`. `node.event` only exists as a property in `SpanNodes` in the new implementation: [link](https://github.com/getsentry/sentry/blob/master/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.tsx#L16)