### PR TITLE
chore(preprod): Add alternative icons insights support

### DIFF
--- a/static/app/views/preprod/types/appSizeTypes.ts
+++ b/static/app/views/preprod/types/appSizeTypes.ts
@@ -176,6 +176,7 @@ interface AudioCompressionInsightResult extends FilesInsightResult {}
 interface VideoCompressionInsightResult extends FilesInsightResult {}
 
 export interface AppleInsightResults {
+  alternate_icons_optimization?: ImageOptimizationInsightResult;
   audio_compression?: AudioCompressionInsightResult;
   duplicate_files?: DuplicateFilesInsightResult;
   hermes_debug_info?: HermesDebugInfoInsightResult;

--- a/static/app/views/preprod/utils/insightProcessing.ts
+++ b/static/app/views/preprod/utils/insightProcessing.ts
@@ -118,6 +118,12 @@ const INSIGHT_CONFIGS: InsightConfig[] = [
     name: 'Compress video files',
     description: 'Video files can be compressed to reduce size.',
   },
+  {
+    key: 'alternate_icons_optimization',
+    name: 'Optimize alternate app icons',
+    description:
+      'Alternate icons don’t need full size quality because they are only shown downscaled in the homescreen.',
+  },
 ];
 
 /**
@@ -132,6 +138,40 @@ export function processInsights(
   if (insights.image_optimization?.total_savings) {
     const insight = insights.image_optimization;
     const config = INSIGHT_CONFIGS.find(c => c.key === 'image_optimization');
+    if (config) {
+      const optimizableFiles = Array.isArray(insight.optimizable_files)
+        ? insight.optimizable_files
+        : [];
+
+      processedInsights.push({
+        name: config.name,
+        description: config.description,
+        totalSavings: insight.total_savings,
+        percentage: (insight.total_savings / totalSize) * 100,
+        files: optimizableFiles.map((file: OptimizableImageFile) => {
+          const maxSavings = Math.max(
+            file.minify_savings || 0,
+            file.conversion_savings || 0
+          );
+          return {
+            path: file.file_path,
+            savings: maxSavings,
+            percentage: (maxSavings / totalSize) * 100,
+            data: {
+              fileType: 'optimizable_image' as const,
+              minifyPercentage: ((file.minify_savings || 0) / totalSize) * 100,
+              conversionPercentage: ((file.conversion_savings || 0) / totalSize) * 100,
+              originalFile: file,
+            },
+          };
+        }),
+      });
+    }
+  }
+
+  if (insights.alternate_icons_optimization?.total_savings) {
+    const insight = insights.alternate_icons_optimization;
+    const config = INSIGHT_CONFIGS.find(c => c.key === 'alternate_icons_optimization');
     if (config) {
       const optimizableFiles = Array.isArray(insight.optimizable_files)
         ? insight.optimizable_files


### PR DESCRIPTION
So that the insights will show up! Will follow up with a PR to allow the user to either download the optimized images on demand or provide them a command they can run on their images

<img width="1934" height="1129" alt="image" src="https://github.com/user-attachments/assets/1d9668f4-7cf0-4ad6-81f4-e3789648f528" />
