### PR TITLE
feat(tracemetrics): Add a 2 min delay to fetching samples

### DIFF
--- a/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
@@ -1,8 +1,11 @@
 import {useMemo} from 'react';
+import moment from 'moment-timezone';
 
+import {PageFilters} from 'sentry/types';
 import type {NewQuery} from 'sentry/types/organization';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
@@ -10,13 +13,20 @@ import {
   useQueryParamsSearch,
   useQueryParamsSortBys,
 } from 'sentry/views/explore/queryParams/context';
-import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery';
+import {
+  DATE_FORMAT,
+  useSpansQuery,
+} from 'sentry/views/insights/common/queries/useSpansQuery';
+import {INGESTION_DELAY} from 'sentry/views/insights/settings';
+
+const MILLISECONDS_PER_SECOND = 1000;
 
 interface UseMetricSamplesTableOptions {
   enabled: boolean;
   fields: string[];
   limit: number;
   metricName: string;
+  ingestionDelaySeconds?: number;
 }
 
 interface MetricSamplesTableResult {
@@ -30,8 +40,15 @@ export function useMetricSamplesTable({
   limit,
   metricName,
   fields,
+  ingestionDelaySeconds,
 }: UseMetricSamplesTableOptions) {
-  return useMetricSamplesTableImp({enabled, limit, metricName, fields});
+  return useMetricSamplesTableImp({
+    enabled,
+    limit,
+    metricName,
+    fields,
+    ingestionDelaySeconds,
+  });
 }
 
 function useMetricSamplesTableImp({
@@ -39,6 +56,7 @@ function useMetricSamplesTableImp({
   limit,
   metricName,
   fields,
+  ingestionDelaySeconds = INGESTION_DELAY,
 }: UseMetricSamplesTableOptions): MetricSamplesTableResult {
   const {selection} = usePageFilters();
   const searchQuery = useQueryParamsSearch();
@@ -52,6 +70,30 @@ function useMetricSamplesTableImp({
     return currentSearch.formatString();
   }, [metricName, searchQuery]);
 
+  // Calculate adjusted datetime values with ingestion delay applied
+  // This is memoized separately to prevent recalculating on every render
+  const adjustedDatetime: PageFilters['datetime'] = useMemo(() => {
+    const {start, end, period, utc} = selection.datetime;
+
+    // Only apply delay for relative time periods (statsPeriod), not absolute timestamps
+    // because absolute timestamps are explicitly set by the user
+    const periodMs = period ? intervalToMilliseconds(period) : 0;
+    if (period && periodMs > ingestionDelaySeconds * MILLISECONDS_PER_SECOND && !end) {
+      const startTime = moment().subtract(periodMs, 'milliseconds');
+      const delayedEndTime = moment().subtract(ingestionDelaySeconds, 'seconds');
+
+      return {
+        start: startTime.format(DATE_FORMAT),
+        end: delayedEndTime.format(DATE_FORMAT),
+        period: null, // Clear period since we now have explicit timestamps
+        utc,
+      };
+    }
+
+    return {start, end, period, utc};
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selection.datetime.period, ingestionDelaySeconds]); // Only recalc when period or delay changes
+
   const eventView = useMemo(() => {
     const discoverQuery: NewQuery = {
       id: undefined,
@@ -63,8 +105,11 @@ function useMetricSamplesTableImp({
       dataset: DiscoverDatasets.TRACEMETRICS,
     };
 
-    return EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
-  }, [fields, query, selection, sortBys]);
+    return EventView.fromNewQueryWithPageFilters(discoverQuery, {
+      ...selection,
+      datetime: adjustedDatetime,
+    });
+  }, [fields, query, selection, adjustedDatetime, sortBys]);
 
   const result = useSpansQuery({
     enabled: enabled && Boolean(metricName),

--- a/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 import moment from 'moment-timezone';
 
-import {PageFilters} from 'sentry/types';
+import type {PageFilters} from 'sentry/types/core';
 import type {NewQuery} from 'sentry/types/organization';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';

--- a/static/app/views/explore/metrics/metricInfoTabs/samplesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/samplesTab.tsx
@@ -45,6 +45,7 @@ import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
 const TABLE_HEIGHT = 230;
 const RESULT_LIMIT = 50;
+const TWO_MINUTE_DELAY = 120;
 
 interface SamplesTabProps {
   metricName: string;
@@ -60,6 +61,7 @@ export function SamplesTab({metricName}: SamplesTabProps) {
     limit: RESULT_LIMIT,
     metricName,
     fields: ['timestamp', 'value', 'trace'],
+    ingestionDelaySeconds: TWO_MINUTE_DELAY,
   });
 
   // Extract trace IDs from the result

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -4,8 +4,8 @@ import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import {defined} from 'sentry/utils';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
-import type {EventsMetaType, MetaType} from 'sentry/utils/discover/eventView';
 import type EventView from 'sentry/utils/discover/eventView';
+import type {EventsMetaType, MetaType} from 'sentry/utils/discover/eventView';
 import {encodeSort} from 'sentry/utils/discover/eventView';
 import type {DiscoverQueryProps} from 'sentry/utils/discover/genericDiscoverQuery';
 import {useGenericDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
@@ -25,7 +25,7 @@ import {
 } from 'sentry/views/insights/common/utils/retryHandlers';
 import {TrackResponse} from 'sentry/views/insights/common/utils/trackResponse';
 
-const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
+export const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
 
 const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000;
 const FOURTEEN_DAYS = 14 * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
This adjusts relative time period requests to trim off the last 2 minutes to account for the ingestion delay. Without this, we may produce samples that haven't fully ingested spans and the UX would appear broken if those traces were opened.
