### PR TITLE
feat(snuba): Preprocess group redirects in group_ids

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -823,6 +823,7 @@ register(
 )
 register("snuba.search.hits-sample-size", default=100, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("snuba.track-outcomes-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("snuba.preprocess-group-redirects", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # The percentage of tagkeys that we want to cache. Set to 1.0 in order to cache everything, <=0.0 to stop caching
 register(

--- a/src/sentry/services/eventstore/query_preprocessing.py
+++ b/src/sentry/services/eventstore/query_preprocessing.py
@@ -1,0 +1,15 @@
+from collections.abc import Sequence
+
+from django.db.models import Q
+
+from sentry.models.groupredirect import GroupRedirect
+
+
+def get_all_merged_group_ids(group_ids: Sequence[str | int]) -> set[str | int]:
+    group_id_set = set(group_ids)
+    all_related_rows = GroupRedirect.objects.filter(
+        Q(group_id__in=group_id_set) | Q(previous_group_id__in=group_id_set)
+    ).values_list("group_id", "previous_group_id")
+    for r in all_related_rows:
+        group_id_set.update(r)
+    return group_id_set

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -27,6 +27,7 @@ from snuba_sdk import Column, DeleteQuery, Function, MetricsQuery, Request
 from snuba_sdk.legacy import json_to_snql
 from snuba_sdk.query import SelectableExpression
 
+from sentry import options
 from sentry.api.helpers.error_upsampling import (
     UPSAMPLED_ERROR_AGGREGATION,
     are_any_projects_error_upsampled,
@@ -40,6 +41,7 @@ from sentry.models.projectkey import ProjectKey
 from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.net.http import connection_from_url
+from sentry.services.eventstore.query_preprocessing import get_all_merged_group_ids
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.events import Columns
 from sentry.snuba.query_sources import QuerySource
@@ -921,6 +923,33 @@ class SnubaQueryParams:
         self.referrer = referrer
         self.is_grouprelease = is_grouprelease
         self.kwargs = kwargs
+
+        # Groups can be merged together, but snuba is immutable(ish). In order to
+        # account for merges, here we expand queries to include all group IDs that have
+        # been merged together.
+
+        if options.get("snuba.preprocess-group-redirects") and self.dataset in {
+            Dataset.Events,
+            Dataset.IssuePlatform,
+        }:
+            if "group_id" in self.filter_keys:
+                self.filter_keys["group_id"] = get_all_merged_group_ids(
+                    self.filter_keys["group_id"]
+                )
+            for i in range(len(self.conditions)):
+                triple = self.conditions[i]
+                if triple[0] == "group_id":
+                    if triple[1] in {"IN", "NOT IN"}:
+                        self.conditions[i] = [
+                            "group_id",
+                            triple[1],
+                            get_all_merged_group_ids(triple[2]),
+                        ]
+                        continue
+                    elif triple[1] in {"=", "!="}:
+                        op = "IN" if triple[1] == "=" else "NOT IN"
+                        self.conditions[i] = ["group_id", op, get_all_merged_group_ids([triple[2]])]
+                        continue
 
 
 def raw_query(

--- a/tests/sentry/services/eventstore/test_query_preprocessing.py
+++ b/tests/sentry/services/eventstore/test_query_preprocessing.py
@@ -1,0 +1,30 @@
+from sentry.models.groupredirect import GroupRedirect
+from sentry.services.eventstore.query_preprocessing import get_all_merged_group_ids
+from sentry.testutils.cases import TestCase
+from sentry.testutils.skips import requires_snuba
+
+pytestmark = [requires_snuba]
+
+
+class TestQueryPreprocessing(TestCase):
+    def test_get_all_merged_group_ids(self) -> None:
+        g1 = self.create_group(id=1)
+        g2 = self.create_group(id=2)
+        g3 = self.create_group(id=3)
+        self.create_group(id=4)
+
+        GroupRedirect.objects.create(
+            organization_id=g1.project.organization_id,
+            group_id=g1.id,
+            previous_group_id=g2.id,
+        )
+        GroupRedirect.objects.create(
+            organization_id=g1.project.organization_id,
+            group_id=g1.id,
+            previous_group_id=g3.id,
+        )
+
+        assert get_all_merged_group_ids([g1.id]) == {g1.id, g2.id, g3.id}
+        assert get_all_merged_group_ids([g2.id]) == {g1.id, g2.id}
+        assert get_all_merged_group_ids([g3.id]) == {g1.id, g3.id}
+        assert get_all_merged_group_ids([g2.id, g3.id]) == {g1.id, g2.id, g3.id}


### PR DESCRIPTION
We're trying to build an alternative to the mutability-in-clickhouse problem for group merges (with an eye towards EAP).

Still need to polish up the tests.