### PR TITLE
fix(replay): Adding Safety Checking for Parse Tap Event

### DIFF
--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -740,12 +740,12 @@ def parse_network_content_lengths(event: dict[str, Any]) -> tuple[int | None, in
 
 
 def parse_tap_event(payload: dict[str, Any]) -> TapEvent | None:
-    payload_data = payload["data"]
+    payload_data = payload.get("data", {})
     return TapEvent(
         timestamp=int(payload["timestamp"]),
-        message=payload["message"],
-        view_class=payload_data["view.class"],
-        view_id=payload_data["view.id"],
+        message=payload.get("message", ""),
+        view_class=payload_data.get("view.class", ""),
+        view_id=payload_data.get("view.id", ""),
     )
 
 

--- a/tests/sentry/replays/unit/test_event_parser.py
+++ b/tests/sentry/replays/unit/test_event_parser.py
@@ -287,6 +287,31 @@ def test_parse_highlighted_events_with_tap_event() -> None:
     assert builder.result.tap_events[0].view_id == "send_user_feedback"
 
 
+def test_parse_highlighted_events_with_tap_event_missing_fields() -> None:
+    event = {
+        "type": 5,
+        "timestamp": 1758523985314,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "type": "default",
+                "timestamp": 1758523985.314,
+                "category": "ui.tap",
+                "message": "send_user_feedback",
+                "data": {},
+            },
+        },
+    }
+
+    builder = HighlightedEventsBuilder()
+    builder.add(which(event), event, sampled=True)
+    assert len(builder.result.tap_events) == 1
+    assert builder.result.tap_events[0].timestamp == int(1758523985.314)
+    assert builder.result.tap_events[0].message == "send_user_feedback"
+    assert builder.result.tap_events[0].view_class == ""
+    assert builder.result.tap_events[0].view_id == ""
+
+
 # Click parsing.
 
 


### PR DESCRIPTION
The previous event_parser changes implements a new parse_tap_event function which creates a TapEvent based from the SDK. However, it seems like some outdated events are missing fields resulting in:

<img width="2664" height="642" alt="image" src="https://github.com/user-attachments/assets/50d18b42-b95c-44c6-9342-099482188b78" />
