### PR TITLE
feat(tracemetrics): Update aggregate to match type

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -90,7 +90,11 @@ export function AggregateDropdown({type}: {type: string}) {
   const previousType = usePrevious(type);
 
   useEffect(() => {
-    if (previousType !== type && defined(DEFAULT_YAXIS_BY_TYPE[type])) {
+    if (
+      defined(previousType) &&
+      previousType !== type &&
+      defined(DEFAULT_YAXIS_BY_TYPE[type])
+    ) {
       setVisualize(
         visualize.replace({
           yAxis: `${DEFAULT_YAXIS_BY_TYPE[type]}(${visualize.parsedFunction?.arguments?.[0] ?? ''})`,

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -84,16 +84,16 @@ const DEFAULT_YAXIS_BY_TYPE: Record<string, string> = {
   gauge: 'avg',
 };
 
-export function AggregateDropdown({type}: {type: string | undefined}) {
+export function AggregateDropdown({type}: {type: string}) {
   const visualize = useMetricVisualize();
   const setVisualize = useSetMetricVisualize();
   const previousType = usePrevious(type);
 
   useEffect(() => {
-    if (previousType !== type) {
+    if (previousType !== type && defined(DEFAULT_YAXIS_BY_TYPE[type])) {
       setVisualize(
         visualize.replace({
-          yAxis: `${DEFAULT_YAXIS_BY_TYPE[type ?? '']}(${visualize.parsedFunction?.arguments?.[0] ?? ''})`,
+          yAxis: `${DEFAULT_YAXIS_BY_TYPE[type]}(${visualize.parsedFunction?.arguments?.[0] ?? ''})`,
         })
       );
     }
@@ -104,9 +104,7 @@ export function AggregateDropdown({type}: {type: string | undefined}) {
       triggerProps={{
         prefix: t('Agg'),
       }}
-      options={
-        defined(type) && defined(OPTIONS_BY_TYPE[type]) ? OPTIONS_BY_TYPE[type] : []
-      }
+      options={defined(OPTIONS_BY_TYPE[type]) ? OPTIONS_BY_TYPE[type] : []}
       value={visualize.parsedFunction?.name ?? ''}
       onChange={option => {
         setVisualize(

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -1,6 +1,9 @@
+import {useEffect} from 'react';
+
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
+import usePrevious from 'sentry/utils/usePrevious';
 import {
   useMetricVisualize,
   useSetMetricVisualize,
@@ -75,9 +78,26 @@ const OPTIONS_BY_TYPE: Record<string, Array<{label: string; value: string}>> = {
   ],
 };
 
+const DEFAULT_YAXIS_BY_TYPE: Record<string, string> = {
+  counter: 'sum',
+  distribution: 'p75',
+  gauge: 'avg',
+};
+
 export function AggregateDropdown({type}: {type: string | undefined}) {
   const visualize = useMetricVisualize();
   const setVisualize = useSetMetricVisualize();
+  const previousType = usePrevious(type);
+
+  useEffect(() => {
+    if (previousType !== type) {
+      setVisualize(
+        visualize.replace({
+          yAxis: `${DEFAULT_YAXIS_BY_TYPE[type ?? '']}(${visualize.parsedFunction?.arguments?.[0] ?? ''})`,
+        })
+      );
+    }
+  }, [setVisualize, visualize, type, previousType]);
 
   return (
     <CompactSelect


### PR DESCRIPTION
If the type doesn't match when a selection is made, reset the aggregate to the default for the new type.