### PR TITLE
feat(llm-detector): Add option to enable LLM issue detection 

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3548,3 +3548,11 @@ register(
     default=False,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Killswich for LLM issue detection
+register(
+    "issue-detection.llm-detection.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
adds system option for enabling LLM issue detection - project flag which determines if a project has access will be added in a separate pr

https://linear.app/getsentry/issue/ID-1016/add-killswitch-for-llm-detection-task