### PR TITLE
ref(replay): use default trace sample rate for summaries get

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -59,6 +59,7 @@ class ProjectReplaySummaryEndpoint(ProjectEndpoint):
 
     def __init__(self, **kw) -> None:
         storage.initialize_client()
+        # Trace sample rates for each method. Uses the default when not set (=0).
         self.sample_rate_post = options.get(
             "replay.endpoints.project_replay_summary.trace_sample_rate_post"
         )
@@ -127,7 +128,9 @@ class ProjectReplaySummaryEndpoint(ProjectEndpoint):
         with sentry_sdk.start_transaction(
             name="replays.endpoints.project_replay_summary.get",
             op="replays.endpoints.project_replay_summary.get",
-            custom_sampling_context={"sample_rate": self.sample_rate_get},
+            custom_sampling_context=(
+                {"sample_rate": self.sample_rate_get} if self.sample_rate_get else None
+            ),
         ):
 
             if not self.has_replay_summary_access(project, request):
@@ -152,7 +155,9 @@ class ProjectReplaySummaryEndpoint(ProjectEndpoint):
         with sentry_sdk.start_transaction(
             name="replays.endpoints.project_replay_summary.post",
             op="replays.endpoints.project_replay_summary.post",
-            custom_sampling_context={"sample_rate": self.sample_rate_post},
+            custom_sampling_context=(
+                {"sample_rate": self.sample_rate_post} if self.sample_rate_post else None
+            ),
         ):
 
             if not self.has_replay_summary_access(project, request):


### PR DESCRIPTION
We're using an option to control the trace sample rates for these, when it's unset let's just use the default.
I'd also be fine with removing these cause it seems like trace explorer UI does it's own sampling anyway. DD is better for the aggregate counts