### PR TITLE
feat(llm-detector): Add project flag for LLM issue detection 

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -621,6 +621,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:profiling-ingest-unsampled-profiles", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     manager.add("projects:project-detail-apple-app-hang-rate", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enabled LLM Issue Detection
+    manager.add("projects:llm-issue-detection", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # fmt: on
 
     # Partner oauth


### PR DESCRIPTION
choosing to use a project flag, not an org flag so we can test with specific projects

https://linear.app/getsentry/issue/ID-1005/define-feature-flag-for-llm-detected-issue-eligibility