### PR TITLE
feat(aci): disable already selected automation triggers

### DIFF
--- a/static/app/views/automations/components/dataConditionNodeList.spec.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.spec.tsx
@@ -6,12 +6,14 @@ import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary
 
 import type {DataConditionHandler} from 'sentry/types/workflowEngine/dataConditions';
 import {
+  DataConditionGroupLogicType,
   DataConditionHandlerGroupType,
   DataConditionHandlerSubgroupType,
   DataConditionType,
 } from 'sentry/types/workflowEngine/dataConditions';
 import {MatchType} from 'sentry/views/automations/components/actionFilters/constants';
 import {AutomationBuilderConflictContext} from 'sentry/views/automations/components/automationBuilderConflictContext';
+import {AutomationBuilderContext} from 'sentry/views/automations/components/automationBuilderContext';
 import {AutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import DataConditionNodeList from 'sentry/views/automations/components/dataConditionNodeList';
 
@@ -49,6 +51,32 @@ describe('DataConditionNodeList', () => {
     updateCondition: mockUpdateCondition,
     label: 'Add condition',
   };
+  const defaultContextProps = {
+    state: {
+      triggers: {
+        id: 'triggers',
+        conditions: [],
+        logicType: DataConditionGroupLogicType.ANY,
+      },
+      actionFilters: [],
+    },
+    actions: {
+      addWhenCondition: jest.fn(),
+      removeWhenCondition: jest.fn(),
+      updateWhenCondition: jest.fn(),
+      updateWhenLogicType: jest.fn(),
+      addIf: jest.fn(),
+      removeIf: jest.fn(),
+      addIfCondition: jest.fn(),
+      removeIfCondition: jest.fn(),
+      updateIfCondition: jest.fn(),
+      updateIfLogicType: jest.fn(),
+      addIfAction: jest.fn(),
+      removeIfAction: jest.fn(),
+      updateIfAction: jest.fn(),
+    },
+    showTriggerLogicTypeSelector: false,
+  };
   const defaultConflictContextProps = {
     conflictingConditionGroups: {},
     conflictReason: null,
@@ -70,12 +98,13 @@ describe('DataConditionNodeList', () => {
 
   it('renders correct condition options', async () => {
     render(
-      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
-        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
-          <DataConditionNodeList {...defaultProps} />
-        </AutomationBuilderConflictContext.Provider>
-        ,
-      </AutomationBuilderErrorContext.Provider>,
+      <AutomationBuilderContext.Provider value={defaultContextProps}>
+        <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+          <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+            <DataConditionNodeList {...defaultProps} />
+          </AutomationBuilderConflictContext.Provider>
+        </AutomationBuilderErrorContext.Provider>
+      </AutomationBuilderContext.Provider>,
       {
         organization,
       }
@@ -94,11 +123,13 @@ describe('DataConditionNodeList', () => {
 
   it('adds conditions', async () => {
     render(
-      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
-        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
-          <DataConditionNodeList {...defaultProps} />
-        </AutomationBuilderConflictContext.Provider>
-      </AutomationBuilderErrorContext.Provider>,
+      <AutomationBuilderContext.Provider value={defaultContextProps}>
+        <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+          <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+            <DataConditionNodeList {...defaultProps} />
+          </AutomationBuilderConflictContext.Provider>
+        </AutomationBuilderErrorContext.Provider>
+      </AutomationBuilderContext.Provider>,
       {
         organization,
       }
@@ -112,14 +143,16 @@ describe('DataConditionNodeList', () => {
 
   it('updates existing conditions', async () => {
     render(
-      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
-        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
-          <DataConditionNodeList
-            {...defaultProps}
-            conditions={[DataConditionFixture()]}
-          />
-        </AutomationBuilderConflictContext.Provider>
-      </AutomationBuilderErrorContext.Provider>,
+      <AutomationBuilderContext.Provider value={defaultContextProps}>
+        <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+          <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+            <DataConditionNodeList
+              {...defaultProps}
+              conditions={[DataConditionFixture()]}
+            />
+          </AutomationBuilderConflictContext.Provider>
+        </AutomationBuilderErrorContext.Provider>
+      </AutomationBuilderContext.Provider>,
       {organization}
     );
 
@@ -131,14 +164,16 @@ describe('DataConditionNodeList', () => {
 
   it('deletes existing condition', async () => {
     render(
-      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
-        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
-          <DataConditionNodeList
-            {...defaultProps}
-            conditions={[DataConditionFixture()]}
-          />
-        </AutomationBuilderConflictContext.Provider>
-      </AutomationBuilderErrorContext.Provider>,
+      <AutomationBuilderContext.Provider value={defaultContextProps}>
+        <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+          <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+            <DataConditionNodeList
+              {...defaultProps}
+              conditions={[DataConditionFixture()]}
+            />
+          </AutomationBuilderConflictContext.Provider>
+        </AutomationBuilderErrorContext.Provider>
+      </AutomationBuilderContext.Provider>,
       {organization}
     );
 
@@ -149,16 +184,18 @@ describe('DataConditionNodeList', () => {
   it('shows conflicting condition warning for action filters', () => {
     const conflictReason = 'The conditions highlighted in red are in conflict.';
     render(
-      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
-        <AutomationBuilderConflictContext.Provider
-          value={{
-            conflictingConditionGroups: {[groupId]: new Set(['1'])},
-            conflictReason,
-          }}
-        >
-          <DataConditionNodeList {...defaultProps} />
-        </AutomationBuilderConflictContext.Provider>
-      </AutomationBuilderErrorContext.Provider>,
+      <AutomationBuilderContext.Provider value={defaultContextProps}>
+        <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+          <AutomationBuilderConflictContext.Provider
+            value={{
+              conflictingConditionGroups: {[groupId]: new Set(['1'])},
+              conflictReason,
+            }}
+          >
+            <DataConditionNodeList {...defaultProps} />
+          </AutomationBuilderConflictContext.Provider>
+        </AutomationBuilderErrorContext.Provider>
+      </AutomationBuilderContext.Provider>,
       {
         organization,
       }
@@ -171,19 +208,21 @@ describe('DataConditionNodeList', () => {
     const conflictReason = 'The conditions highlighted in red are in conflict.';
     // Only one conflicting condition should not show the warning
     render(
-      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
-        <AutomationBuilderConflictContext.Provider
-          value={{
-            conflictingConditionGroups: {[groupId]: new Set(['1'])},
-            conflictReason,
-          }}
-        >
-          <DataConditionNodeList
-            {...defaultProps}
-            handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
-          />
-        </AutomationBuilderConflictContext.Provider>
-      </AutomationBuilderErrorContext.Provider>,
+      <AutomationBuilderContext.Provider value={defaultContextProps}>
+        <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+          <AutomationBuilderConflictContext.Provider
+            value={{
+              conflictingConditionGroups: {[groupId]: new Set(['1'])},
+              conflictReason,
+            }}
+          >
+            <DataConditionNodeList
+              {...defaultProps}
+              handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
+            />
+          </AutomationBuilderConflictContext.Provider>
+        </AutomationBuilderErrorContext.Provider>
+      </AutomationBuilderContext.Provider>,
       {organization}
     );
 
@@ -191,19 +230,21 @@ describe('DataConditionNodeList', () => {
 
     // Two or more conflicting conditions should show the warning
     render(
-      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
-        <AutomationBuilderConflictContext.Provider
-          value={{
-            conflictingConditionGroups: {[groupId]: new Set(['1', '2'])},
-            conflictReason,
-          }}
-        >
-          <DataConditionNodeList
-            {...defaultProps}
-            handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
-          />
-        </AutomationBuilderConflictContext.Provider>
-      </AutomationBuilderErrorContext.Provider>,
+      <AutomationBuilderContext.Provider value={defaultContextProps}>
+        <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+          <AutomationBuilderConflictContext.Provider
+            value={{
+              conflictingConditionGroups: {[groupId]: new Set(['1', '2'])},
+              conflictReason,
+            }}
+          >
+            <DataConditionNodeList
+              {...defaultProps}
+              handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
+            />
+          </AutomationBuilderConflictContext.Provider>
+        </AutomationBuilderErrorContext.Provider>
+      </AutomationBuilderContext.Provider>,
       {organization}
     );
 
@@ -217,16 +258,18 @@ describe('DataConditionNodeList', () => {
     const errorMessage = 'This condition has an error';
 
     render(
-      <AutomationBuilderErrorContext.Provider
-        value={{
-          ...defaultErrorContextProps,
-          errors: {'condition-with-error': errorMessage},
-        }}
-      >
-        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
-          <DataConditionNodeList {...defaultProps} conditions={[conditionWithError]} />
-        </AutomationBuilderConflictContext.Provider>
-      </AutomationBuilderErrorContext.Provider>,
+      <AutomationBuilderContext.Provider value={defaultContextProps}>
+        <AutomationBuilderErrorContext.Provider
+          value={{
+            ...defaultErrorContextProps,
+            errors: {'condition-with-error': errorMessage},
+          }}
+        >
+          <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+            <DataConditionNodeList {...defaultProps} conditions={[conditionWithError]} />
+          </AutomationBuilderConflictContext.Provider>
+        </AutomationBuilderErrorContext.Provider>
+      </AutomationBuilderContext.Provider>,
       {organization}
     );
 
@@ -235,11 +278,13 @@ describe('DataConditionNodeList', () => {
 
   it('shows warning message for occurrence-based monitors', async () => {
     render(
-      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
-        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
-          <DataConditionNodeList {...defaultProps} />
-        </AutomationBuilderConflictContext.Provider>
-      </AutomationBuilderErrorContext.Provider>,
+      <AutomationBuilderContext.Provider value={defaultContextProps}>
+        <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+          <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+            <DataConditionNodeList {...defaultProps} />
+          </AutomationBuilderConflictContext.Provider>
+        </AutomationBuilderErrorContext.Provider>
+      </AutomationBuilderContext.Provider>,
       {organization}
     );
 

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -13,6 +13,7 @@ import {
   DataConditionType,
 } from 'sentry/types/workflowEngine/dataConditions';
 import {useAutomationBuilderConflictContext} from 'sentry/views/automations/components/automationBuilderConflictContext';
+import {useAutomationBuilderContext} from 'sentry/views/automations/components/automationBuilderContext';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import AutomationBuilderRow from 'sentry/views/automations/components/automationBuilderRow';
 import {
@@ -36,6 +37,7 @@ interface DataConditionNodeListProps {
 interface Option {
   label: string;
   value: DataConditionType;
+  disabled?: boolean;
 }
 
 export default function DataConditionNodeList({
@@ -53,12 +55,20 @@ export default function DataConditionNodeList({
     useAutomationBuilderConflictContext();
   const conflictingConditions = conflictingConditionGroups[groupId];
   const {errors} = useAutomationBuilderErrorContext();
+  const {state} = useAutomationBuilderContext();
 
   const options = useMemo(() => {
     if (handlerGroup === DataConditionHandlerGroupType.WORKFLOW_TRIGGER) {
+      // Get the types of already selected trigger conditions
+      const selectedTriggerTypes = new Set(
+        state.triggers.conditions.map(condition => condition.type)
+      );
+
+      // Disable already selected trigger condition types instead of filtering them out
       return dataConditionHandlers.map(handler => ({
         value: handler.type,
         label: dataConditionNodesMap.get(handler.type)?.label || handler.type,
+        disabled: selectedTriggerTypes.has(handler.type),
       }));
     }
 
@@ -130,7 +140,7 @@ export default function DataConditionNodeList({
         options: otherOptions,
       },
     ];
-  }, [dataConditionHandlers, handlerGroup]);
+  }, [dataConditionHandlers, handlerGroup, state.triggers.conditions]);
 
   return (
     <Fragment>

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -64,12 +64,13 @@ export default function DataConditionNodeList({
         state.triggers.conditions.map(condition => condition.type)
       );
 
-      // Disable already selected trigger condition types instead of filtering them out
-      return dataConditionHandlers.map(handler => ({
-        value: handler.type,
-        label: dataConditionNodesMap.get(handler.type)?.label || handler.type,
-        disabled: selectedTriggerTypes.has(handler.type),
-      }));
+      // Filter out already selected trigger condition types
+      return dataConditionHandlers
+        .filter(handler => !selectedTriggerTypes.has(handler.type))
+        .map(handler => ({
+          value: handler.type,
+          label: dataConditionNodesMap.get(handler.type)?.label || handler.type,
+        }));
     }
 
     const issueAttributeOptions: Option[] = [];
@@ -171,15 +172,18 @@ export default function DataConditionNodeList({
         ((handlerGroup === DataConditionHandlerGroupType.ACTION_FILTER &&
           conflictingConditions.size > 0) ||
           conflictingConditions.size > 1) && <Alert type="error">{conflictReason}</Alert>}
-      <StyledSelectControl
-        options={options}
-        onChange={(obj: any) => {
-          onAddRow(obj.value);
-        }}
-        placeholder={placeholder}
-        value={null}
-        aria-label={label}
-      />
+      {/* Only show dropdown if there are available options */}
+      {options.length > 0 && (
+        <StyledSelectControl
+          options={options}
+          onChange={(obj: any) => {
+            onAddRow(obj.value);
+          }}
+          placeholder={placeholder}
+          value={null}
+          aria-label={label}
+        />
+      )}
     </Fragment>
   );
 }


### PR DESCRIPTION
we should only show trigger options that have not been selected, to avoid duplicates. we also remove the dropdown when there are no options left
<img width="385" height="229" alt="Screenshot 2025-10-15 at 3 45 50 PM" src="https://github.com/user-attachments/assets/13e83341-0720-4c02-951b-2ecbb8dad7a8" />
<img width="378" height="255" alt="Screenshot 2025-10-15 at 3 46 01 PM" src="https://github.com/user-attachments/assets/1ce6a27e-ae93-4ef0-bdd0-26dc61f3680a" />


