### PR TITLE
feat(llm-detector): Add Experimental LLM Detected Issue Group type 

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -618,6 +618,19 @@ class ProfileFunctionRegressionType(GroupType):
 
 
 @dataclass(frozen=True)
+class LLMDetectedExperimentalGroupType(GroupType):
+    type_id = 3501
+    slug = "llm_detected_experimental"
+    description = "LLM Detected Issue"
+    category = GroupCategory.PERFORMANCE.value
+    category_v2 = GroupCategory.METRIC.value
+    default_priority = PriorityLevel.MEDIUM
+    released = False
+    enable_auto_resolve = False
+    enable_escalation_detection = False
+
+
+@dataclass(frozen=True)
 class ReplayRageClickType(ReplayGroupTypeDefaults, GroupType):
     type_id = 5002
     slug = "replay_click_rage"


### PR DESCRIPTION
adds a experimental group type which will be used for LLM detected issues initially. 

https://linear.app/getsentry/issue/ID-1010/define-issue-platform-group-for-llm-detected-issue