### PR TITLE
fix(redis): Make quiet_redis_noise group RedisClusterExceptions that escape

### DIFF
--- a/tests/sentry/utils/test_exceptions.py
+++ b/tests/sentry/utils/test_exceptions.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from typing import Any
 from unittest.mock import Mock, patch
 
-from rediscluster.exceptions import RedisClusterException
+from rediscluster.exceptions import RedisClusterException  # type: ignore[attr-defined]
 
 from sentry.taskworker.state import CurrentTaskState
 from sentry.taskworker.workerchild import ProcessingDeadlineExceeded


### PR DESCRIPTION
The aim of quiet_redis_noise is to apply standard refinements to Redis error reporting to code within the context.
RedisClusterExceptions are grouped because they can be raised nearly anywhere, but that grouping is lost when (as is common) they escape the context.
This ensures they are reported within the context, avoiding violating expectations.