### PR TITLE
fix(sub v3): Correct header cards for sub trials

### DIFF
--- a/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
@@ -3,7 +3,7 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import type {Organization} from 'sentry/types/organization';
 
 import type {Subscription} from 'getsentry/types';
-import {hasNewBillingUI, isDeveloperPlan} from 'getsentry/utils/billing';
+import {hasNewBillingUI, isDeveloperPlan, isTrialPlan} from 'getsentry/utils/billing';
 import BillingInfoCard from 'getsentry/views/subscriptionPage/headerCards/billingInfoCard';
 import LinksCard from 'getsentry/views/subscriptionPage/headerCards/linksCard';
 import NextBillCard from 'getsentry/views/subscriptionPage/headerCards/nextBillCard';
@@ -21,12 +21,10 @@ interface HeaderCardsProps {
 function getCards(organization: Organization, subscription: Subscription) {
   const hasBillingPerms = organization.access?.includes('org:billing');
   const cards: React.ReactNode[] = [];
+  const isTrialOrFreePlan =
+    isTrialPlan(subscription.plan) || isDeveloperPlan(subscription.planDetails);
 
-  if (
-    subscription.canSelfServe &&
-    !isDeveloperPlan(subscription.planDetails) &&
-    hasBillingPerms
-  ) {
+  if (subscription.canSelfServe && !isTrialOrFreePlan && hasBillingPerms) {
     cards.push(
       <NextBillCard
         key="next-bill"
@@ -50,7 +48,9 @@ function getCards(organization: Organization, subscription: Subscription) {
   if (
     hasBillingPerms &&
     (canUpdatePayg ||
-      (subscription.canSelfServe && isDeveloperPlan(subscription.planDetails))) &&
+      (subscription.canSelfServe &&
+        isTrialOrFreePlan &&
+        !subscription.isEnterpriseTrial)) &&
     !subscription.isSelfServePartner
   ) {
     cards.push(

--- a/static/gsApp/views/subscriptionPage/subscriptionHeader.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionHeader.spec.tsx
@@ -260,6 +260,70 @@ describe('SubscriptionHeader', () => {
     });
   });
 
+  it('renders new header cards for self-serve customers on subscription trial', async () => {
+    const organization = OrganizationFixture({
+      features: ['subscriptions-v3'],
+      access: ['org:billing'],
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_t',
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+    render(
+      <SubscriptionHeader organization={organization} subscription={subscription} />
+    );
+    await assertNewHeaderCards({
+      organization,
+      hasNextBillCard: false,
+      hasBillingInfoCard: true,
+      hasPaygCard: false,
+    });
+  });
+
+  it('renders new header cards for self-serve paid customers on plan trial', async () => {
+    const organization = OrganizationFixture({
+      features: ['subscriptions-v3'],
+      access: ['org:billing'],
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_team',
+      isTrial: true,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+    render(
+      <SubscriptionHeader organization={organization} subscription={subscription} />
+    );
+    await assertNewHeaderCards({
+      organization,
+      hasNextBillCard: true,
+      hasBillingInfoCard: true,
+      hasPaygCard: true,
+    });
+  });
+
+  it('renders new header cards for customers on subscription enterprise trial', async () => {
+    const organization = OrganizationFixture({
+      features: ['subscriptions-v3'],
+      access: ['org:billing'],
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_t_ent',
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+    render(
+      <SubscriptionHeader organization={organization} subscription={subscription} />
+    );
+    await assertNewHeaderCards({
+      organization,
+      hasNextBillCard: false,
+      hasBillingInfoCard: false,
+      hasPaygCard: false,
+    });
+  });
+
   it('does not render editable sections for YY partnership', async () => {
     const organization = OrganizationFixture({
       features: ['usage-log'],

--- a/tests/js/getsentry-test/fixtures/subscription.ts
+++ b/tests/js/getsentry-test/fixtures/subscription.ts
@@ -12,7 +12,7 @@ import type {Organization} from 'sentry/types/organization';
 import {RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
 import type {Plan, Subscription as TSubscription} from 'getsentry/types';
 import {AddOnCategory, BillingType} from 'getsentry/types';
-import {isTrialPlan} from 'getsentry/utils/billing';
+import {isEnterprise, isTrialPlan} from 'getsentry/utils/billing';
 
 type Props = Partial<TSubscription> & {organization: Organization};
 
@@ -44,6 +44,7 @@ export function SubscriptionFixture(props: Props): TSubscription {
   const safeCategories = planDetails?.planCategories || {};
 
   const isTrial = isTrialPlan(planDetails.id);
+  const isEnterpriseTrial = isTrial && isEnterprise(planDetails.id);
   const reservedBudgets = [];
   if (hasSeer) {
     if (isTrial) {
@@ -71,7 +72,7 @@ export function SubscriptionFixture(props: Props): TSubscription {
     hadCustomDynamicSampling: false,
     id: '',
     isBundleEligible: false,
-    isEnterpriseTrial: false,
+    isEnterpriseTrial,
     isExemptFromForcedTrial: false,
     isForcedTrial: false,
     isOverMemberLimit: false,


### PR DESCRIPTION
- Subscription trials should show Billing Info card and Links card
- Enterprise subscription trials should show just the Links card
- Plan trials should not affect the logic, which depends on the state of the subscription's actual plan