### PR TITLE
ref(crons): Consistently use getNextCheckInEnv

### DIFF
--- a/static/app/views/alerts/rules/crons/details.tsx
+++ b/static/app/views/alerts/rules/crons/details.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
-import sortBy from 'lodash/sortBy';
 
 import {updateMonitor} from 'sentry/actionCreators/monitors';
 import {SectionHeading} from 'sentry/components/charts/styles';
@@ -33,7 +32,7 @@ import type {Monitor, MonitorBucket} from 'sentry/views/insights/crons/types';
 import {useMonitorProcessingErrors} from 'sentry/views/insights/crons/useMonitorProcessingErrors';
 import {makeMonitorDetailsQueryKey} from 'sentry/views/insights/crons/utils';
 
-import {getMonitorRefetchInterval} from './utils';
+import {getMonitorRefetchInterval, getNextCheckInEnv} from './utils';
 
 type Props = RouteComponentProps<{monitorSlug: string; projectId: string}>;
 
@@ -125,8 +124,6 @@ function MonitorDetails({params, location}: Props) {
     );
   }
 
-  const envsSortedByLastCheck = sortBy(monitor.environments, e => e.lastCheckIn);
-
   return (
     <Layout.Page>
       <SentryDocumentTitle title={`${monitor.name} — Alerts`} />
@@ -193,7 +190,7 @@ function MonitorDetails({params, location}: Props) {
           </Layout.Main>
           <Layout.Side>
             <DetailsSidebar
-              monitorEnv={envsSortedByLastCheck[envsSortedByLastCheck.length - 1]}
+              monitorEnv={getNextCheckInEnv(monitor.environments)}
               monitor={monitor}
               showUnknownLegend={showUnknownLegend}
             />

--- a/static/app/views/detectors/components/details/cron/index.tsx
+++ b/static/app/views/detectors/components/details/cron/index.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useCallback, useState} from 'react';
-import sortBy from 'lodash/sortBy';
 
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Alert} from 'sentry/components/core/alert';
@@ -24,6 +23,7 @@ import type {CronDetector} from 'sentry/types/workflowEngine/detectors';
 import toArray from 'sentry/utils/array/toArray';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {getNextCheckInEnv} from 'sentry/views/alerts/rules/crons/utils';
 import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details/common/assignee';
 import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
@@ -45,12 +45,8 @@ type CronDetectorDetailsProps = {
 };
 
 function getLatestCronMonitorEnv(detector: CronDetector) {
-  const dataSource = detector.dataSources[0];
-  const envsSortedByLastCheck = sortBy(
-    dataSource.queryObj.environments,
-    e => e.lastCheckIn
-  );
-  return envsSortedByLastCheck[envsSortedByLastCheck.length - 1];
+  const environments = detector.dataSources[0].queryObj.environments;
+  return getNextCheckInEnv(environments);
 }
 
 function hasLastCheckIn(envs: MonitorEnvironment[]) {

--- a/static/app/views/insights/crons/components/detailsTimeline.tsx
+++ b/static/app/views/insights/crons/components/detailsTimeline.tsx
@@ -1,6 +1,5 @@
 import {useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
-import sortBy from 'lodash/sortBy';
 
 import {
   deleteMonitorEnvironment,
@@ -21,6 +20,7 @@ import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {getNextCheckInEnv} from 'sentry/views/alerts/rules/crons/utils';
 import type {Monitor, MonitorBucket} from 'sentry/views/insights/crons/types';
 import {makeMonitorDetailsQueryKey} from 'sentry/views/insights/crons/utils';
 
@@ -46,11 +46,11 @@ export function DetailsTimeline({monitor, onStatsLoaded}: Props) {
   const {width: containerWidth} = useDimensions<HTMLDivElement>({elementRef});
   const timelineWidth = useDebouncedValue(containerWidth, 500);
 
-  // Use the nextCheckIn timestamp as a queryKey for computing the
-  // timeWindowConfig. This means when the nextCheckIn date changes we will
-  // recompute the timeWindowConfig timestamps. This is important when a
-  // period is used (like last hour)
-  const nextCheckIn = sortBy(monitor.environments, e => e.nextCheckIn)[0]?.nextCheckIn;
+  // Use the nextCheckIn timestamp from the earliest scheduled environment as a
+  // queryKey for computing the timeWindowConfig. This means when the
+  // nextCheckIn date changes we will recompute the timeWindowConfig
+  // timestamps. This is important when a period is used (like last hour)
+  const nextCheckIn = getNextCheckInEnv(monitor.environments)?.nextCheckIn;
 
   const timeWindowConfig = useTimeWindowConfig({
     timelineWidth,

--- a/static/app/views/insights/crons/components/monitorCheckIns.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckIns.tsx
@@ -1,11 +1,11 @@
 import {Fragment, useEffect} from 'react';
-import sortBy from 'lodash/sortBy';
 
 import LoadingError from 'sentry/components/loadingError';
 import Pagination from 'sentry/components/pagination';
 import type {Project} from 'sentry/types/project';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {getNextCheckInEnv} from 'sentry/views/alerts/rules/crons/utils';
 import type {MonitorEnvironment} from 'sentry/views/insights/crons/types';
 import {useMonitorCheckIns} from 'sentry/views/insights/crons/utils/useMonitorCheckIns';
 
@@ -23,10 +23,10 @@ export function MonitorCheckIns({monitorSlug, monitorEnvs, project}: Props) {
   const location = useLocation();
   const organization = useOrganization();
 
-  // Use the nextCheckIn timestamp as a key for forcing a refetch of the
-  // check-in list. We do this since we know when this value changes there are
-  // new check-ins present.
-  const nextCheckIn = sortBy(monitorEnvs, e => e.nextCheckIn)[0]?.nextCheckIn;
+  // Use the nextCheckIn timestamp from the earliest scheduled environment as a
+  // key for forcing a refetch of the check-in list. We do this since we know
+  // when this value changes there are new check-ins present.
+  const nextCheckIn = getNextCheckInEnv(monitorEnvs)?.nextCheckIn;
 
   const {
     data: checkInList,


### PR DESCRIPTION
We had this logic duplicated in a few places for picking the relevant
environment to display details from.