### PR TITLE
bug(preprod): Fix CI comparisons not creating PENDING comparison, breaking size comparisons

### DIFF
--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db import transaction
+from django.db import router, transaction
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -9,7 +9,6 @@ from sentry import analytics, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.db import router
 from sentry.preprod.analytics import (
     PreprodArtifactApiSizeAnalysisCompareGetEvent,
     PreprodArtifactApiSizeAnalysisComparePostEvent,

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -60,7 +60,7 @@ def compare_preprod_artifact_size_analysis(
         return
 
     comparisons = []
-    preprod_artifact_status_check_updates = []
+    preprod_artifact_status_check_updates = [artifact.id]
 
     # Create all comparisons with artifact as head
     base_artifact = artifact.get_base_artifact_for_commit().first()
@@ -110,7 +110,6 @@ def compare_preprod_artifact_size_analysis(
                     comparisons.append(
                         {"head_metric": matching_head_size_metric, "base_metric": base_metric},
                     )
-                    preprod_artifact_status_check_updates.append(artifact.id)
                 else:
                     logger.info(
                         "preprod.size_analysis.compare.no_matching_base_size_metric",
@@ -202,6 +201,7 @@ def compare_preprod_artifact_size_analysis(
                     "preprod_artifact_id": artifact_id,
                 }
             )
+
 
 @instrumented_task(
     name="sentry.preprod.tasks.manual_size_analysis_comparison",

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -177,10 +177,10 @@ def compare_preprod_artifact_size_analysis(
                 )
 
     # Create PENDING comparison records in DB and run comparisons
-    for comparison in comparisons:
-        head_metric = comparison["head_metric"]
-        base_metric = comparison["base_metric"]
-        with transaction.atomic(router.db_for_write(PreprodArtifactSizeComparison)):
+    with transaction.atomic(router.db_for_write(PreprodArtifactSizeComparison)):
+        for comparison in comparisons:
+            head_metric = comparison["head_metric"]
+            base_metric = comparison["base_metric"]
             comparison = PreprodArtifactSizeComparison.objects.create(
                 head_size_analysis=head_metric,
                 base_size_analysis=base_metric,
@@ -189,11 +189,11 @@ def compare_preprod_artifact_size_analysis(
             )
             comparison.save()
 
-        logger.info(
-            "preprod.size_analysis.compare.running_comparisonn",
-            extra={"head_metric_id": head_metric.id, "base_metric_id": base_metric.id},
-        )
-        _run_size_analysis_comparison(org_id, head_metric, base_metric)
+            logger.info(
+                "preprod.size_analysis.compare.running_comparison",
+                extra={"head_metric_id": head_metric.id, "base_metric_id": base_metric.id},
+            )
+            _run_size_analysis_comparison(org_id, head_metric, base_metric)
 
         for artifact_id in preprod_artifact_status_check_updates:
             # Update all artifact's status check with the new comparison
@@ -316,13 +316,6 @@ def _run_size_analysis_comparison(
     head_size_metric: PreprodArtifactSizeMetrics,
     base_size_metric: PreprodArtifactSizeMetrics,
 ):
-    logger.info(
-        "preprod.size_analysis.compare._run_size_analysis_comparison",
-        extra={
-            "head_artifact_size_metric_id": head_size_metric.id,
-            "base_artifact_size_metric_id": base_size_metric.id,
-        },
-    )
     comparison = None
     try:
         comparison = PreprodArtifactSizeComparison.objects.get(
@@ -395,18 +388,11 @@ def _run_size_analysis_comparison(
             comparison.save()
         return
 
-    logger.info(
-        "preprod.size_analysis.compare.running_comparisonss",
-        extra={
-            "head_artifact_size_metric_id": head_size_metric.id,
-            "base_artifact_size_metric_id": base_size_metric.id,
-        },
-    )
     head_size_analysis_results = SizeAnalysisResults.parse_raw(head_analysis_file.getfile().read())
     base_size_analysis_results = SizeAnalysisResults.parse_raw(base_analysis_file.getfile().read())
 
     logger.info(
-        "preprod.size_analysis.compare.running_comparisonssss",
+        "preprod.size_analysis.compare.running_comparison",
         extra={
             "head_artifact_size_metric_id": head_size_metric.id,
             "base_artifact_size_metric_id": base_size_metric.id,

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -59,7 +59,10 @@ def compare_preprod_artifact_size_analysis(
         )
         return
 
-    # Run all comparisons with artifact as head
+    comparisons = []
+    preprod_artifact_status_check_updates = []
+
+    # Create all comparisons with artifact as head
     base_artifact = artifact.get_base_artifact_for_commit().first()
     if base_artifact:
         if artifact.build_configuration != base_artifact.build_configuration:
@@ -98,18 +101,16 @@ def compare_preprod_artifact_size_analysis(
                 matching_head_size_metric = head_metrics_map.get(key)
                 if matching_head_size_metric:
                     logger.info(
-                        "preprod.size_analysis.compare.running_comparison",
+                        "preprod.size_analysis.compare.create_comparison",
                         extra={
                             "head_artifact_id": artifact_id,
                             "base_artifact_id": base_artifact.id,
-                            "size_metric_id": (
-                                matching_head_size_metric.id
-                                if matching_head_size_metric.identifier
-                                else None
-                            ),
                         },
                     )
-                    _run_size_analysis_comparison(org_id, matching_head_size_metric, base_metric)
+                    comparisons.append(
+                        {"head_metric": matching_head_size_metric, "base_metric": base_metric},
+                    )
+                    preprod_artifact_status_check_updates.append(artifact.id)
                 else:
                     logger.info(
                         "preprod.size_analysis.compare.no_matching_base_size_metric",
@@ -121,14 +122,7 @@ def compare_preprod_artifact_size_analysis(
                 extra={"head_artifact_id": artifact_id, "base_artifact_id": base_artifact.id},
             )
 
-    # Update the current artifact's status check with the new comparison
-    create_preprod_status_check_task.apply_async(
-        kwargs={
-            "preprod_artifact_id": artifact_id,
-        }
-    )
-
-    # Also run comparisons with artifact as base
+    # Also create comparisons with artifact as base
     head_artifacts = artifact.get_head_artifacts_for_commit()
     for head_artifact in head_artifacts:
         if head_artifact.build_configuration != artifact.build_configuration:
@@ -162,30 +156,52 @@ def compare_preprod_artifact_size_analysis(
         head_metrics_map = build_size_metrics_map(head_size_metrics)
         base_metrics_map = build_size_metrics_map(base_size_metrics)
 
-        should_update_status_check = False
         for key, head_metric in head_metrics_map.items():
             matching_base_size_metric = base_metrics_map.get(key)
             if matching_base_size_metric:
-                should_update_status_check = True
                 logger.info(
-                    "preprod.size_analysis.compare.running_comparison",
-                    extra={"base_artifact_id": artifact_id, "head_artifact_id": head_artifact.id},
+                    "preprod.size_analysis.compare.create_comparison",
+                    extra={
+                        "head_artifact_id": head_artifact.id,
+                        "base_artifact_id": artifact.id,
+                    },
                 )
-                _run_size_analysis_comparison(org_id, head_metric, matching_base_size_metric)
+                comparisons.append(
+                    {"head_metric": head_metric, "base_metric": matching_base_size_metric},
+                )
+                preprod_artifact_status_check_updates.append(head_artifact.id)
             else:
                 logger.info(
                     "preprod.size_analysis.compare.no_matching_base_size_metric",
                     extra={"head_artifact_id": head_artifact.id, "size_metric_id": head_metric.id},
                 )
 
-        if should_update_status_check:
-            # Update the head artifact's status check with the new comparison
+    # Create PENDING comparison records in DB and run comparisons
+    for comparison in comparisons:
+        head_metric = comparison["head_metric"]
+        base_metric = comparison["base_metric"]
+        with transaction.atomic(router.db_for_write(PreprodArtifactSizeComparison)):
+            comparison = PreprodArtifactSizeComparison.objects.create(
+                head_size_analysis=head_metric,
+                base_size_analysis=base_metric,
+                organization_id=org_id,
+                state=PreprodArtifactSizeComparison.State.PENDING,
+            )
+            comparison.save()
+
+        logger.info(
+            "preprod.size_analysis.compare.running_comparisonn",
+            extra={"head_metric_id": head_metric.id, "base_metric_id": base_metric.id},
+        )
+        _run_size_analysis_comparison(org_id, head_metric, base_metric)
+
+        for artifact_id in preprod_artifact_status_check_updates:
+            # Update all artifact's status check with the new comparison
             create_preprod_status_check_task.apply_async(
                 kwargs={
-                    "preprod_artifact_id": head_artifact.id,
+                    "preprod_artifact_id": artifact_id,
                 }
             )
-
 
 @instrumented_task(
     name="sentry.preprod.tasks.manual_size_analysis_comparison",
@@ -300,6 +316,13 @@ def _run_size_analysis_comparison(
     head_size_metric: PreprodArtifactSizeMetrics,
     base_size_metric: PreprodArtifactSizeMetrics,
 ):
+    logger.info(
+        "preprod.size_analysis.compare._run_size_analysis_comparison",
+        extra={
+            "head_artifact_size_metric_id": head_size_metric.id,
+            "base_artifact_size_metric_id": base_size_metric.id,
+        },
+    )
     comparison = None
     try:
         comparison = PreprodArtifactSizeComparison.objects.get(
@@ -324,16 +347,6 @@ def _run_size_analysis_comparison(
             )
             return
 
-        # PENDING state - transition to PROCESSING
-        if comparison.state == PreprodArtifactSizeComparison.State.PENDING:
-            logger.info(
-                "preprod.size_analysis.compare.transitioning_pending_to_processing",
-                extra={
-                    "head_artifact_size_metric_id": head_size_metric.id,
-                    "base_artifact_size_metric_id": base_size_metric.id,
-                },
-            )
-
     except PreprodArtifactSizeComparison.DoesNotExist:
         logger.info(
             "preprod.size_analysis.compare.no_existing_comparison",
@@ -350,7 +363,7 @@ def _run_size_analysis_comparison(
                 state=PreprodArtifactSizeComparison.State.FAILED,
             )
             comparison.save()
-        pass
+        return
 
     try:
         head_analysis_file = File.objects.get(id=head_size_metric.analysis_file_id)
@@ -362,8 +375,9 @@ def _run_size_analysis_comparison(
                 "head_artifact_id": head_size_metric.preprod_artifact.id,
             },
         )
-        comparison.state = PreprodArtifactSizeComparison.State.FAILED
-        comparison.save()
+        with transaction.atomic(router.db_for_write(PreprodArtifactSizeComparison)):
+            comparison.state = PreprodArtifactSizeComparison.State.FAILED
+            comparison.save()
         return
 
     try:
@@ -381,11 +395,18 @@ def _run_size_analysis_comparison(
             comparison.save()
         return
 
+    logger.info(
+        "preprod.size_analysis.compare.running_comparisonss",
+        extra={
+            "head_artifact_size_metric_id": head_size_metric.id,
+            "base_artifact_size_metric_id": base_size_metric.id,
+        },
+    )
     head_size_analysis_results = SizeAnalysisResults.parse_raw(head_analysis_file.getfile().read())
     base_size_analysis_results = SizeAnalysisResults.parse_raw(base_analysis_file.getfile().read())
 
     logger.info(
-        "preprod.size_analysis.compare.running_comparison",
+        "preprod.size_analysis.compare.running_comparisonssss",
         extra={
             "head_artifact_size_metric_id": head_size_metric.id,
             "base_artifact_size_metric_id": base_size_metric.id,
@@ -395,6 +416,13 @@ def _run_size_analysis_comparison(
     # Update existing PENDING comparison or create new one
     with transaction.atomic(router.db_for_write(PreprodArtifactSizeComparison)):
         if comparison:
+            logger.info(
+                "preprod.size_analysis.compare.transitioning_pending_to_processing",
+                extra={
+                    "head_artifact_size_metric_id": head_size_metric.id,
+                    "base_artifact_size_metric_id": base_size_metric.id,
+                },
+            )
             comparison.state = PreprodArtifactSizeComparison.State.PROCESSING
             comparison.save()
         else:
@@ -405,14 +433,13 @@ def _run_size_analysis_comparison(
                     "base_artifact_size_metric_id": base_size_metric.id,
                 },
             )
-            with transaction.atomic(router.db_for_write(PreprodArtifactSizeComparison)):
-                comparison = PreprodArtifactSizeComparison.objects.create(
-                    head_size_analysis=head_size_metric,
-                    base_size_analysis=base_size_metric,
-                    organization_id=org_id,
-                    state=PreprodArtifactSizeComparison.State.FAILED,
-                )
-                comparison.save()
+            comparison = PreprodArtifactSizeComparison.objects.create(
+                head_size_analysis=head_size_metric,
+                base_size_analysis=base_size_metric,
+                organization_id=org_id,
+                state=PreprodArtifactSizeComparison.State.FAILED,
+            )
+            comparison.save()
             return
 
     comparison_results = compare_size_analysis(

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -178,9 +178,9 @@ def compare_preprod_artifact_size_analysis(
 
     # Create PENDING comparison records in DB and run comparisons
     with transaction.atomic(router.db_for_write(PreprodArtifactSizeComparison)):
-        for comparison in comparisons:
-            head_metric = comparison["head_metric"]
-            base_metric = comparison["base_metric"]
+        for comp in comparisons:
+            head_metric = comp["head_metric"]
+            base_metric = comp["base_metric"]
             comparison = PreprodArtifactSizeComparison.objects.create(
                 head_size_analysis=head_metric,
                 base_size_analysis=base_metric,

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -177,30 +177,39 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
         }
 
         # Create size metrics
-        self._create_size_metrics_with_analysis_file(head_artifact, head_analysis_data)
-        self._create_size_metrics_with_analysis_file(base_artifact, base_analysis_data)
+        head_size_metrics = self._create_size_metrics_with_analysis_file(
+            head_artifact, head_analysis_data
+        )
+        base_size_metrics = self._create_size_metrics_with_analysis_file(
+            base_artifact, base_analysis_data
+        )
 
-        with (
-            patch(
-                "sentry.preprod.size_analysis.tasks._run_size_analysis_comparison"
-            ) as mock_run_comparison,
-            patch(
-                "sentry.preprod.size_analysis.tasks.create_preprod_status_check_task"
-            ) as mock_status_check_task,
-        ):
+        # Verify no comparison exists before the test
+        initial_comparisons = PreprodArtifactSizeComparison.objects.filter(
+            head_size_analysis=head_size_metrics,
+            base_size_analysis=base_size_metrics,
+        )
+        assert len(initial_comparisons) == 0
+
+        with patch(
+            "sentry.preprod.size_analysis.tasks.create_preprod_status_check_task"
+        ) as mock_status_check_task:
             compare_preprod_artifact_size_analysis(
                 project_id=self.project.id,
                 org_id=self.organization.id,
                 artifact_id=head_artifact.id,
             )
 
-            # Should call _run_size_analysis_comparison with head and base metrics
-            mock_run_comparison.assert_called_once()
-            call_args = mock_run_comparison.call_args[0]
-            # Verify that the call was made with the correct parameters
-            assert call_args[0] == self.organization.id
-            assert call_args[1].preprod_artifact.id == head_artifact.id
-            assert call_args[2].preprod_artifact.id == base_artifact.id
+            # Verify comparison was created
+            comparisons = PreprodArtifactSizeComparison.objects.filter(
+                head_size_analysis=head_size_metrics,
+                base_size_analysis=base_size_metrics,
+            )
+            assert len(comparisons) == 1
+            comparison = comparisons[0]
+            assert comparison.state == PreprodArtifactSizeComparison.State.SUCCESS
+            assert comparison.organization_id == self.organization.id
+            assert comparison.file_id is not None
 
             # Should call create_preprod_status_check_task for the head artifact
             mock_status_check_task.apply_async.assert_called_once_with(
@@ -272,8 +281,12 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
         }
 
         # Create size metrics
-        self._create_size_metrics_with_analysis_file(base_artifact, analysis_data)
-        self._create_size_metrics_with_analysis_file(head_artifact, analysis_data)
+        base_size_metrics = self._create_size_metrics_with_analysis_file(
+            base_artifact, analysis_data
+        )
+        head_size_metrics = self._create_size_metrics_with_analysis_file(
+            head_artifact, analysis_data
+        )
 
         with (
             patch(
@@ -289,13 +302,16 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
                 artifact_id=base_artifact.id,
             )
 
-            # Should call _run_size_analysis_comparison with head and base metrics
-            mock_run_comparison.assert_called_once()
-            call_args = mock_run_comparison.call_args[0]
-            # Verify that the call was made with the correct parameters
-            assert call_args[0] == self.organization.id
-            assert call_args[1].preprod_artifact.id == head_artifact.id
-            assert call_args[2].preprod_artifact.id == base_artifact.id
+            # Verify comparison was created
+            comparisons = PreprodArtifactSizeComparison.objects.filter(
+                head_size_analysis=head_size_metrics,
+                base_size_analysis=base_size_metrics,
+            )
+            assert len(comparisons) == 1
+            comparison = comparisons[0]
+            assert comparison.state == PreprodArtifactSizeComparison.State.SUCCESS
+            assert comparison.organization_id == self.organization.id
+            assert comparison.file_id is not None
 
             # Should call create_preprod_status_check_task twice:
             # 1. For the base artifact (current artifact)
@@ -726,6 +742,14 @@ class RunSizeAnalysisComparisonTest(TestCase):
         head_size_metrics = self._create_size_metrics_with_analysis_file(head_analysis_data)
         base_size_metrics = self._create_size_metrics_with_analysis_file(base_analysis_data)
 
+        # Create existing comparison in PENDING state
+        PreprodArtifactSizeComparison.objects.create(
+            head_size_analysis=head_size_metrics,
+            base_size_analysis=base_size_metrics,
+            organization_id=self.organization.id,
+            state=PreprodArtifactSizeComparison.State.PENDING,
+        )
+
         # Run comparison
         _run_size_analysis_comparison(
             self.organization.id,
@@ -849,18 +873,13 @@ class RunSizeAnalysisComparisonTest(TestCase):
             {"download_size": 800, "install_size": 1500}
         )
 
-        with patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger:
-            _run_size_analysis_comparison(
-                self.organization.id,
-                head_size_metrics,
-                base_size_metrics,
-            )
+        _run_size_analysis_comparison(
+            self.organization.id,
+            head_size_metrics,
+            base_size_metrics,
+        )
 
-            mock_logger.exception.assert_called_once()
-            call_args = mock_logger.exception.call_args
-            assert "preprod.size_analysis.compare.head_analysis_file_not_found" in call_args[0]
-
-        # Verify no comparison was created
+        # Verify failed comparison was created
         comparisons = PreprodArtifactSizeComparison.objects.filter(
             head_size_analysis=head_size_metrics,
             base_size_analysis=base_size_metrics,
@@ -887,18 +906,13 @@ class RunSizeAnalysisComparisonTest(TestCase):
             analysis_file_id=99999,  # Nonexistent file
         )
 
-        with patch("sentry.preprod.size_analysis.tasks.logger") as mock_logger:
-            _run_size_analysis_comparison(
-                self.organization.id,
-                head_size_metrics,
-                base_size_metrics,
-            )
+        _run_size_analysis_comparison(
+            self.organization.id,
+            head_size_metrics,
+            base_size_metrics,
+        )
 
-            mock_logger.exception.assert_called_once()
-            call_args = mock_logger.exception.call_args
-            assert "preprod.size_analysis.compare.base_analysis_file_not_found" in call_args[0]
-
-        # Verify no comparison was created
+        # Verify failed comparison was created
         comparisons = PreprodArtifactSizeComparison.objects.filter(
             head_size_analysis=head_size_metrics,
             base_size_analysis=base_size_metrics,
@@ -948,15 +962,13 @@ class RunSizeAnalysisComparisonTest(TestCase):
             analysis_file_id=base_analysis_file.id,
         )
 
-        # Should raise an exception due to invalid JSON
-        with pytest.raises(Exception):
-            _run_size_analysis_comparison(
-                self.organization.id,
-                head_size_metrics,
-                base_size_metrics,
-            )
+        _run_size_analysis_comparison(
+            self.organization.id,
+            head_size_metrics,
+            base_size_metrics,
+        )
 
-        # Verify no comparison was created
+        # Verify failed comparison was created
         comparisons = PreprodArtifactSizeComparison.objects.filter(
             head_size_analysis=head_size_metrics,
             base_size_analysis=base_size_metrics,

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -1,8 +1,6 @@
 from io import BytesIO
 from unittest.mock import patch
 
-import pytest
-
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.files.file import File
 from sentry.preprod.models import (
@@ -288,14 +286,9 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
             head_artifact, analysis_data
         )
 
-        with (
-            patch(
-                "sentry.preprod.size_analysis.tasks._run_size_analysis_comparison"
-            ) as mock_run_comparison,
-            patch(
-                "sentry.preprod.size_analysis.tasks.create_preprod_status_check_task"
-            ) as mock_status_check_task,
-        ):
+        with patch(
+            "sentry.preprod.size_analysis.tasks.create_preprod_status_check_task"
+        ) as mock_status_check_task:
             compare_preprod_artifact_size_analysis(
                 project_id=self.project.id,
                 org_id=self.organization.id,


### PR DESCRIPTION
I added PENDING records for manual comparisons yesterday in https://github.com/getsentry/sentry/pull/101454, but I forgot to add for CI triggered comparisons. This adds PENDING comparisons for CI comparisons and fixes a few other minor bugs.

Also improves our tests to validate that the DB models are properly created after running comparison tasks/functions, which should catch similar bugs like these in the future.