### PR TITLE
ref(replay): change experimental icon to beta badge on ai summaries

### DIFF
--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -192,7 +192,6 @@ export default function Ai() {
             <Flex align="center" gap="xs">
               {t('Replay Summary')}
             </Flex>
-            <FeatureBadge type="experimental" tooltipProps={{disabled: true}} />
           </SummaryLeftTitle>
           <SummaryText>{summaryData.data.summary}</SummaryText>
         </SummaryLeft>

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -5,7 +5,6 @@ import aiBanner from 'sentry-images/spot/ai-suggestion-banner-stars.svg';
 import replayEmptyState from 'sentry-images/spot/replays-empty-state.svg';
 
 import AnalyticsArea, {useAnalyticsArea} from 'sentry/components/analyticsArea';
-import {FeatureBadge} from 'sentry/components/core/badge';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -6,9 +6,7 @@ import {FeatureBadge} from '@sentry/scraps/badge';
 
 import {Flex} from 'sentry/components/core/layout';
 import {TabList, Tabs} from 'sentry/components/core/tabs';
-import {Tooltip} from 'sentry/components/core/tooltip';
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
-import {IconLab} from 'sentry/icons/iconLab';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -2,6 +2,8 @@ import {useEffect, type ReactNode} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {FeatureBadge} from '@sentry/scraps/badge';
+
 import {Flex} from 'sentry/components/core/layout';
 import {TabList, Tabs} from 'sentry/components/core/tabs';
 import {Tooltip} from 'sentry/components/core/tooltip';
@@ -32,13 +34,7 @@ function getReplayTabs({
       !isVideoReplay ? (
         <Flex align="center" gap="sm">
           {t('AI Summary')}
-          <Tooltip
-            title={t(
-              'This feature is experimental! Try it out and let us know what you think. No promises!'
-            )}
-          >
-            <IconLab isSolid />
-          </Tooltip>
+          <FeatureBadge type="beta" />
         </Flex>
       ) : null,
     [TabKey.BREADCRUMBS]: t('Breadcrumbs'),


### PR DESCRIPTION
replay ai summaries are now 100% rolled out to open beta

old ui
<img width="649" height="208" alt="SCR-20251015-mkyb" src="https://github.com/user-attachments/assets/37a1dc4c-f6cc-4903-a928-d0a9aa7b80ff" />

new ui
<img width="644" height="346" alt="SCR-20251015-mkzp" src="https://github.com/user-attachments/assets/dbef1586-bb25-40fe-8486-2d6f2a05f31c" />
