### PR TITLE
fix(trace-view): Prefer description in OTel-friendly view

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -103,7 +103,8 @@ export function SpanDescription({
     return formatter.toString(dbQueryText ?? span.description ?? '');
   }, [span.description, resolvedModule, dbSystem, dbQueryText]);
 
-  const exploreUsingName = shouldUseOTelFriendlyUI && span.name !== span.op;
+  const exploreUsingName =
+    shouldUseOTelFriendlyUI && !span.description && span.name !== span.op;
   const exploreAttributeName = exploreUsingName
     ? SpanFields.NAME
     : SpanFields.SPAN_DESCRIPTION;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -235,7 +235,10 @@ export function SpanDescription({
         node={node}
         attributes={attributes}
       />
-    ) : shouldUseOTelFriendlyUI && span.name && span.name !== span.op ? (
+    ) : shouldUseOTelFriendlyUI &&
+      !span.description &&
+      span.name &&
+      span.name !== span.op ? (
       <DescriptionWrapper>
         <FormattedDescription>{span.name}</FormattedDescription>
         <CopyToClipboardButton

--- a/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
@@ -110,6 +110,7 @@ export function TraceSpanRow(
             )}
             {shouldUseOTelFriendlyUI &&
             isEAPSpanNode(props.node) &&
+            !props.node.value.description &&
             props.node.value.name &&
             props.node.value.name !== props.node.value.op ? (
               <React.Fragment>


### PR DESCRIPTION
This is a follow-up for https://github.com/getsentry/sentry/pull/101208.

Right now we're still in a transition period where SDKs send spans with descriptions via our SDKs, while OTel is sending spans with names. In order to not degrade the Sentry SDK experience with the OTel-friendly UI flag on, if the span has a description, prefer that to the (likely generated) `name`.