### PR TITLE
fix(aci): Allow submitting of cron monitor with defaults

### DIFF
--- a/static/app/views/detectors/components/forms/cron/index.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.tsx
@@ -43,6 +43,7 @@ export function NewCronDetectorForm() {
       formDataToEndpointPayload={cronFormDataToEndpointPayload}
       initialFormData={{
         scheduleType: CRON_DEFAULT_SCHEDULE_TYPE,
+        name: 'New Monitor',
       }}
     >
       <CronDetectorForm />

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -1,5 +1,9 @@
 import {AutomationFixture} from 'sentry-fixture/automations';
-import {MetricDetectorFixture, UptimeDetectorFixture} from 'sentry-fixture/detectors';
+import {
+  CronDetectorFixture,
+  MetricDetectorFixture,
+  UptimeDetectorFixture,
+} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
@@ -539,6 +543,59 @@ describe('DetectorEdit', () => {
       expect(
         screen.queryByText('Uptime check for different-site.com')
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Cron Detector', () => {
+    const cronRouterConfig = {
+      ...initialRouterConfig,
+      location: {
+        ...initialRouterConfig.location,
+        query: {detectorType: 'monitor_check_in_failure', project: project.id},
+      },
+    };
+
+    it('submits default cron config with no changes', async () => {
+      const mockCreateDetector = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/`,
+        method: 'POST',
+        body: CronDetectorFixture({id: '999'}),
+      });
+
+      render(<DetectorNewSettings />, {
+        organization,
+        initialRouterConfig: cronRouterConfig,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'Create Monitor'}));
+
+      await waitFor(() => {
+        expect(mockCreateDetector).toHaveBeenCalled();
+      });
+
+      expect(mockCreateDetector).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/detectors/`,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: 'monitor_check_in_failure',
+            name: 'New Monitor',
+            projectId: project.id,
+            workflowIds: [],
+            dataSource: expect.objectContaining({
+              name: 'New Monitor',
+              config: expect.objectContaining({
+                schedule: '0 0 * * *',
+                schedule_type: 'crontab',
+                timezone: 'UTC',
+                checkin_margin: 1,
+                failure_issue_threshold: 1,
+                max_runtime: 30,
+                recovery_threshold: 1,
+              }),
+            }),
+          }),
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
Pre-fills name with default, like the other monitors. Mostly adds tests for this form where there weren't any before.
