### PR TITLE
feat(feedback): Remove extra data from Feedback alerts

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -476,6 +476,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:user-feedback-seer-spam-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable User Feedback v2 UI
     manager.add("organizations:user-feedback-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable the streamlining of feedback alerts, some data that are useful on issues are noisy on Feedback
+    manager.add("organizations:user-feedback-streamline-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable view hierarchies options
     manager.add("organizations:view-hierarchies-options-dev", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable aggregates table editor on the new explore page


### PR DESCRIPTION
A lot of the data that applies to Issue Alerts isnt really interesting for feedbacks. Where issues can have multiple events, and we batch together alerts, Feedbacks will never have muiltiple events. So we can strink the amount of space taken up by a single alert and make slack/teams a happier place

Relates to REPLAY-609