### PR TITLE
fix(logs): fix(logs): Logs are not grouped in the chart

### DIFF
--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -50,7 +50,7 @@ import type {SpanFields, SpanFunctions} from 'sentry/views/insights/types';
 
 const {warn} = Sentry.logger;
 
-type SeriesMap = Record<string, TimeSeries[]>;
+export type SeriesMap = Record<string, TimeSeries[]>;
 
 interface Options<Fields> {
   caseInsensitive?: CaseInsensitive;


### PR DESCRIPTION
I broke this in https://github.com/getsentry/sentry/pull/100532, which changed the `yAxis` value of the `TimeSeries` object to be correct. `useStreamingTimeSeriesResult` relies on the old format, though, where the `yAxis` contains the name of the group! This PR is a hotfix while we think of a better solution. It effectively reverts to the old data structure just for logs, so streaming can continue to work.
