### PR TITLE
feat(preprod): add e2e timing metrics

### DIFF
--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -209,7 +209,11 @@ def compare_preprod_artifact_size_analysis(
     metrics.distribution(
         "preprod.size_analysis.compare.results_e2e",
         e2e_size_analysis_compare_duration.total_seconds(),
-        tags={"project_id": project_id, "organization_id": org_id},
+        tags={
+            "project_id": project_id,
+            "organization_id": org_id,
+            "artifact_type": artifact.artifact_type.name.lower(),
+        },
     )
 
 

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -1,8 +1,8 @@
 import logging
-from datetime import timezone
 from io import BytesIO
 
 from django.db import router, transaction
+from django.utils import timezone
 
 from sentry.models.files.file import File
 from sentry.preprod.models import (

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -205,7 +205,7 @@ def compare_preprod_artifact_size_analysis(
             )
 
     time_now = timezone.now()
-    e2e_size_analysis_compare_duration = time_now - artifact.date_created
+    e2e_size_analysis_compare_duration = time_now - artifact.date_added
     metrics.distribution(
         "preprod.size_analysis.compare.results_e2e",
         e2e_size_analysis_compare_duration.total_seconds(),

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -209,6 +209,7 @@ def compare_preprod_artifact_size_analysis(
     metrics.distribution(
         "preprod.size_analysis.compare.results_e2e",
         e2e_size_analysis_compare_duration.total_seconds(),
+        sample_rate=1.0,
         tags={
             "project_id": project_id,
             "organization_id": org_id,

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -208,7 +208,7 @@ def compare_preprod_artifact_size_analysis(
     e2e_size_analysis_compare_duration = time_now - artifact.date_created
     metrics.distribution(
         "preprod.size_analysis.compare.results_e2e",
-        e2e_size_analysis_compare_duration,
+        e2e_size_analysis_compare_duration.total_seconds(),
         tags={"project_id": project_id, "organization_id": org_id},
     )
 

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -212,7 +212,9 @@ def compare_preprod_artifact_size_analysis(
         tags={
             "project_id": project_id,
             "organization_id": org_id,
-            "artifact_type": artifact.artifact_type.name.lower(),
+            "artifact_type": (
+                artifact.artifact_type.name.lower() if artifact.artifact_type else "unknown"
+            ),
         },
     )
 

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -453,6 +453,7 @@ def _assemble_preprod_artifact_size_analysis(
         metrics.distribution(
             "preprod.size_analysis.results_e2e",
             e2e_size_analysis_duration.total_seconds(),
+            sample_rate=1.0,
             tags={
                 "project_id": project.id,
                 "organization_id": org_id,

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -449,7 +449,7 @@ def _assemble_preprod_artifact_size_analysis(
         raise
 
     time_now = timezone.now()
-    e2e_size_analysis_duration = time_now - preprod_artifact.date_created
+    e2e_size_analysis_duration = time_now - preprod_artifact.date_added
     metrics.distribution(
         "preprod.size_analysis.results_e2e",
         e2e_size_analysis_duration.total_seconds(),

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -452,7 +452,7 @@ def _assemble_preprod_artifact_size_analysis(
     e2e_size_analysis_duration = time_now - preprod_artifact.date_created
     metrics.distribution(
         "preprod.size_analysis.results_e2e",
-        e2e_size_analysis_duration,
+        e2e_size_analysis_duration.total_seconds(),
         tags={"project_id": project.id, "organization_id": org_id},
     )
 

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -453,7 +453,11 @@ def _assemble_preprod_artifact_size_analysis(
         metrics.distribution(
             "preprod.size_analysis.results_e2e",
             e2e_size_analysis_duration.total_seconds(),
-            tags={"project_id": project.id, "organization_id": org_id},
+            tags={
+                "project_id": project.id,
+                "organization_id": org_id,
+                "artifact_type": preprod_artifact.artifact_type.name.lower(),
+            },
         )
 
         # Always trigger status check update (success or failure)

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -456,7 +456,11 @@ def _assemble_preprod_artifact_size_analysis(
             tags={
                 "project_id": project.id,
                 "organization_id": org_id,
-                "artifact_type": preprod_artifact.artifact_type.name.lower(),
+                "artifact_type": (
+                    preprod_artifact.artifact_type.name.lower()
+                    if preprod_artifact.artifact_type
+                    else "unknown"
+                ),
             },
         )
 


### PR DESCRIPTION
So we can track whether any particular org/project is taking longer to process builds.