### PR TITLE
feat(aci): Set max monitor/automation builder page width

### DIFF
--- a/static/app/components/workflowEngine/layout/edit.tsx
+++ b/static/app/components/workflowEngine/layout/edit.tsx
@@ -53,14 +53,17 @@ const HeaderInner = styled('div')<{maxWidth?: string}>`
 const StyledBody = styled(Layout.Body)<{maxWidth?: string}>`
   display: flex;
   flex-direction: column;
-  gap: ${space(3)};
+  gap: ${p => p.theme.space['2xl']};
   padding: 0;
-  margin: ${space(2)};
+  margin: ${p => p.theme.space.xl};
   max-width: ${p => p.maxWidth};
 
   @media (min-width: ${p => p.theme.breakpoints.md}) {
     padding: 0;
-    margin: ${p => (p.noRowGap ? `${space(2)} ${space(4)}` : `${space(3)} ${space(4)}`)};
+    margin: ${p =>
+      p.noRowGap
+        ? `${p.theme.space.xl} ${p.theme.space['3xl']}`
+        : `${p.theme.space['2xl']} ${p.theme.space['3xl']}`};
   }
 `;
 

--- a/static/app/components/workflowEngine/layout/edit.tsx
+++ b/static/app/components/workflowEngine/layout/edit.tsx
@@ -39,10 +39,29 @@ const StyledLayoutHeader = styled(Layout.Header)`
   background-color: ${p => p.theme.background};
 `;
 
-const StyledBody = styled(Layout.Body)`
+const HeaderInner = styled('div')<{maxWidth?: string}>`
+  display: contents;
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    max-width: ${p => p.maxWidth};
+    width: 100%;
+  }
+`;
+
+const StyledBody = styled(Layout.Body)<{maxWidth?: string}>`
   display: flex;
   flex-direction: column;
   gap: ${space(3)};
+  padding: 0;
+  margin: ${space(2)};
+  max-width: ${p => p.maxWidth};
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    padding: 0;
+    margin: ${p => (p.noRowGap ? `${space(2)} ${space(4)}` : `${space(3)} ${space(4)}`)};
+  }
 `;
 
 const FullWidthContent = styled('div')`
@@ -60,8 +79,12 @@ interface HeaderProps extends RequiredChildren {
   noActionWrap?: boolean;
 }
 
-function Header({children, noActionWrap}: HeaderProps) {
-  return <StyledLayoutHeader noActionWrap={noActionWrap}>{children}</StyledLayoutHeader>;
+function Header({children, noActionWrap, maxWidth}: HeaderProps & {maxWidth?: string}) {
+  return (
+    <StyledLayoutHeader noActionWrap={noActionWrap}>
+      <HeaderInner maxWidth={maxWidth}>{children}</HeaderInner>
+    </StyledLayoutHeader>
+  );
 }
 
 function HeaderContent({children}: RequiredChildren) {
@@ -89,9 +112,9 @@ function HeaderFields({children}: RequiredChildren) {
   return <FullWidthContent>{children}</FullWidthContent>;
 }
 
-function Body({children}: RequiredChildren) {
+function Body({children, maxWidth}: RequiredChildren & {maxWidth?: string}) {
   return (
-    <StyledBody>
+    <StyledBody maxWidth={maxWidth}>
       <Layout.Main fullWidth>{children}</Layout.Main>
     </StyledBody>
   );
@@ -99,18 +122,21 @@ function Body({children}: RequiredChildren) {
 
 interface FooterProps extends RequiredChildren {
   label?: string;
+  maxWidth?: string;
 }
 
-function Footer({children, label}: FooterProps) {
+function Footer({children, label, maxWidth}: FooterProps) {
   return (
     <StickyFooter>
-      {label && (
-        <Text variant="muted" size="md">
-          {label}
-        </Text>
-      )}
-      <Flex gap="md" flex={label ? undefined : 1} justify="end">
-        {children}
+      <Flex style={{maxWidth}} align="center" gap="md" justify="end">
+        {label && (
+          <Text variant="muted" size="md">
+            {label}
+          </Text>
+        )}
+        <Flex gap="md" flex={label ? undefined : 1} justify="end">
+          {children}
+        </Flex>
       </Flex>
     </StickyFooter>
   );

--- a/static/app/components/workflowEngine/ui/footer.tsx
+++ b/static/app/components/workflowEngine/ui/footer.tsx
@@ -13,8 +13,6 @@ const StickyFooterBase = styled('div')`
   background: ${p => p.theme.background};
   border-top: 1px solid ${p => p.theme.translucentGray200};
   box-shadow: none;
-  display: flex;
-  align-items: center;
   justify-content: flex-end;
   gap: ${p => p.theme.space.lg};
   z-index: ${p => p.theme.zIndex.initial};

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useMemo, useState} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
@@ -90,6 +91,8 @@ function AutomationEditForm({automation}: {automation: Automation}) {
   const navigate = useNavigate();
   const organization = useOrganization();
   const params = useParams<{automationId: string}>();
+  const theme = useTheme();
+  const maxWidth = theme.breakpoints.lg;
 
   const initialData = useMemo((): Record<string, FieldValue> | undefined => {
     if (!automation) {
@@ -157,17 +160,21 @@ function AutomationEditForm({automation}: {automation: Automation}) {
       <AutomationDocumentTitle />
       <Layout.Page>
         <StyledLayoutHeader>
-          <Layout.HeaderContent>
-            <AutomationBreadcrumbs automationId={params.automationId} />
-            <Layout.Title>
-              <EditableAutomationName />
-            </Layout.Title>
-          </Layout.HeaderContent>
-          <Flex>
-            <EditAutomationActions automation={automation} />
-          </Flex>
+          <HeaderInner maxWidth={maxWidth}>
+            <Layout.HeaderContent>
+              <AutomationBreadcrumbs automationId={params.automationId} />
+              <Layout.Title>
+                <EditableAutomationName />
+              </Layout.Title>
+            </Layout.HeaderContent>
+            <div>
+              <Flex>
+                <EditAutomationActions automation={automation} />
+              </Flex>
+            </div>
+          </HeaderInner>
         </StyledLayoutHeader>
-        <Layout.Body>
+        <StyledBody maxWidth={maxWidth}>
           <Layout.Main fullWidth>
             <AutomationBuilderErrorContext.Provider
               value={{
@@ -189,7 +196,7 @@ function AutomationEditForm({automation}: {automation: Automation}) {
               </AutomationBuilderContext.Provider>
             </AutomationBuilderErrorContext.Provider>
           </Layout.Main>
-        </Layout.Body>
+        </StyledBody>
       </Layout.Page>
     </FullHeightForm>
   );
@@ -197,4 +204,29 @@ function AutomationEditForm({automation}: {automation: Automation}) {
 
 const StyledLayoutHeader = styled(Layout.Header)`
   background-color: ${p => p.theme.background};
+`;
+
+const HeaderInner = styled('div')<{maxWidth?: string}>`
+  display: contents;
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    max-width: ${p => p.maxWidth};
+    width: 100%;
+  }
+`;
+
+const StyledBody = styled(Layout.Body)<{maxWidth?: string}>`
+  max-width: ${p => p.maxWidth};
+  padding: 0;
+  margin: ${p => p.theme.space.xl};
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    padding: 0;
+    margin: ${p =>
+      p.noRowGap
+        ? `${p.theme.space.xl} ${p.theme.space['3xl']}`
+        : `${p.theme.space['2xl']} ${p.theme.space['3xl']}`};
+  }
 `;

--- a/static/app/views/automations/new-settings.tsx
+++ b/static/app/views/automations/new-settings.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useMemo, useState} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
@@ -73,6 +74,8 @@ export default function AutomationNewSettings() {
   useWorkflowEngineFeatureGate({redirect: true});
   const model = useMemo(() => new FormModel(), []);
   const {state, actions} = useAutomationBuilderReducer();
+  const theme = useTheme();
+  const maxWidth = theme.breakpoints.lg;
 
   const [automationBuilderErrors, setAutomationBuilderErrors] = useState<
     Record<string, string>
@@ -125,15 +128,19 @@ export default function AutomationNewSettings() {
       <AutomationDocumentTitle />
       <Layout.Page>
         <StyledLayoutHeader>
-          <Layout.HeaderContent>
-            <AutomationBreadcrumbs />
-            <Layout.Title>
-              <EditableAutomationName />
-            </Layout.Title>
-          </Layout.HeaderContent>
-          <AutomationFeedbackButton />
+          <HeaderInner maxWidth={maxWidth}>
+            <Layout.HeaderContent>
+              <AutomationBreadcrumbs />
+              <Layout.Title>
+                <EditableAutomationName />
+              </Layout.Title>
+            </Layout.HeaderContent>
+            <div>
+              <AutomationFeedbackButton />
+            </div>
+          </HeaderInner>
         </StyledLayoutHeader>
-        <Layout.Body>
+        <StyledBody maxWidth={maxWidth}>
           <Layout.Main fullWidth>
             <AutomationBuilderErrorContext.Provider
               value={{
@@ -154,22 +161,24 @@ export default function AutomationNewSettings() {
               </AutomationBuilderContext.Provider>
             </AutomationBuilderErrorContext.Provider>
           </Layout.Main>
-        </Layout.Body>
+        </StyledBody>
       </Layout.Page>
       <StickyFooter>
-        <Text variant="muted" size="md">
-          {t('Step 2 of 2')}
-        </Text>
-        <Flex gap="md">
-          <LinkButton
-            priority="default"
-            to={`${makeAutomationBasePathname(organization.slug)}new/`}
-          >
-            {t('Back')}
-          </LinkButton>
-          <Button priority="primary" type="submit">
-            {t('Create Automation')}
-          </Button>
+        <Flex style={{maxWidth}} align="center" gap="md" justify="end">
+          <Text variant="muted" size="md">
+            {t('Step 2 of 2')}
+          </Text>
+          <Flex gap="md">
+            <LinkButton
+              priority="default"
+              to={`${makeAutomationBasePathname(organization.slug)}new/`}
+            >
+              {t('Back')}
+            </LinkButton>
+            <Button priority="primary" type="submit">
+              {t('Create Automation')}
+            </Button>
+          </Flex>
         </Flex>
       </StickyFooter>
     </FullHeightForm>
@@ -178,4 +187,29 @@ export default function AutomationNewSettings() {
 
 const StyledLayoutHeader = styled(Layout.Header)`
   background-color: ${p => p.theme.background};
+`;
+
+const HeaderInner = styled('div')<{maxWidth?: string}>`
+  display: contents;
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    max-width: ${p => p.maxWidth};
+    width: 100%;
+  }
+`;
+
+const StyledBody = styled(Layout.Body)<{maxWidth?: string}>`
+  max-width: ${p => p.maxWidth};
+  padding: 0;
+  margin: ${p => p.theme.space.xl};
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    padding: 0;
+    margin: ${p =>
+      p.noRowGap
+        ? `${p.theme.space.xl} ${p.theme.space['3xl']}`
+        : `${p.theme.space['2xl']} ${p.theme.space['3xl']}`};
+  }
 `;

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
@@ -35,6 +36,8 @@ export default function AutomationNew() {
   const location = useLocation();
   const organization = useOrganization();
   useWorkflowEngineFeatureGate({redirect: true});
+  const theme = useTheme();
+  const maxWidth = theme.breakpoints.lg;
 
   const [connectedIds, setConnectedIds] = useState<Automation['detectorIds']>(() => {
     const connectedIdsQuery = location.query.connectedIds as
@@ -52,15 +55,19 @@ export default function AutomationNew() {
 
   return (
     <SentryDocumentTitle title={t('New Automation')}>
-      <Layout.Page>
+      <StyledLayoutPage>
         <StyledLayoutHeader>
-          <Layout.HeaderContent>
-            <AutomationBreadcrumbs />
-            <Layout.Title>{t('New Automation')}</Layout.Title>
-          </Layout.HeaderContent>
-          <AutomationFeedbackButton />
+          <HeaderInner maxWidth={maxWidth}>
+            <Layout.HeaderContent>
+              <AutomationBreadcrumbs />
+              <Layout.Title>{t('New Automation')}</Layout.Title>
+            </Layout.HeaderContent>
+            <div>
+              <AutomationFeedbackButton />
+            </div>
+          </HeaderInner>
         </StyledLayoutHeader>
-        <Layout.Body>
+        <StyledBody maxWidth={maxWidth}>
           <Layout.Main fullWidth>
             <ConnectMonitorsContent
               initialIds={connectedIds}
@@ -76,36 +83,67 @@ export default function AutomationNew() {
               }
             />
           </Layout.Main>
-        </Layout.Body>
-      </Layout.Page>
+        </StyledBody>
+      </StyledLayoutPage>
       <StickyFooter>
-        <Text variant="muted" size="md">
-          {t('Step 1 of 2')}
-        </Text>
-        <Flex gap="md">
-          <LinkButton
-            priority="default"
-            to={makeAutomationBasePathname(organization.slug)}
-          >
-            {t('Cancel')}
-          </LinkButton>
-          <LinkButton
-            priority="primary"
-            to={{
-              pathname: `${makeAutomationBasePathname(organization.slug)}new/settings/`,
-              ...(connectedIds.length > 0 && {
-                query: {connectedIds},
-              }),
-            }}
-          >
-            {t('Next')}
-          </LinkButton>
+        <Flex style={{maxWidth}} align="center" gap="md" justify="end">
+          <Text variant="muted" size="md">
+            {t('Step 1 of 2')}
+          </Text>
+          <Flex gap="md">
+            <LinkButton
+              priority="default"
+              to={makeAutomationBasePathname(organization.slug)}
+            >
+              {t('Cancel')}
+            </LinkButton>
+            <LinkButton
+              priority="primary"
+              to={{
+                pathname: `${makeAutomationBasePathname(organization.slug)}new/settings/`,
+                ...(connectedIds.length > 0 && {
+                  query: {connectedIds},
+                }),
+              }}
+            >
+              {t('Next')}
+            </LinkButton>
+          </Flex>
         </Flex>
       </StickyFooter>
     </SentryDocumentTitle>
   );
 }
 
+const StyledLayoutPage = styled(Layout.Page)`
+  background-color: ${p => p.theme.background};
+`;
+
 const StyledLayoutHeader = styled(Layout.Header)`
   background-color: ${p => p.theme.background};
+`;
+
+const HeaderInner = styled('div')<{maxWidth?: string}>`
+  display: contents;
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    max-width: ${p => p.maxWidth};
+    width: 100%;
+  }
+`;
+
+const StyledBody = styled(Layout.Body)<{maxWidth?: string}>`
+  max-width: ${p => p.maxWidth};
+  padding: 0;
+  margin: ${p => p.theme.space.xl};
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    padding: 0;
+    margin: ${p =>
+      p.noRowGap
+        ? `${p.theme.space.xl} ${p.theme.space['3xl']}`
+        : `${p.theme.space['2xl']} ${p.theme.space['3xl']}`};
+  }
 `;

--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -129,7 +129,6 @@ function MonitorTypeField() {
 const FormContainer = styled('div')`
   display: flex;
   flex-direction: column;
-  max-width: ${p => p.theme.breakpoints.xl};
   gap: ${p => p.theme.space.xl};
 `;
 

--- a/static/app/views/detectors/components/forms/common/footer.tsx
+++ b/static/app/views/detectors/components/forms/common/footer.tsx
@@ -5,11 +5,11 @@ import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
-export function NewDetectorFooter() {
+export function NewDetectorFooter({maxWidth}: {maxWidth?: string}) {
   const organization = useOrganization();
 
   return (
-    <EditLayout.Footer label={t('Step 2 of 2')}>
+    <EditLayout.Footer label={t('Step 2 of 2')} maxWidth={maxWidth}>
       <LinkButton
         priority="default"
         to={`${makeMonitorBasePathname(organization.slug)}new/`}

--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -1,4 +1,5 @@
 import {useMemo} from 'react';
+import {useTheme} from '@emotion/react';
 
 import {Button} from 'sentry/components/core/button';
 import type {Data} from 'sentry/components/forms/types';
@@ -38,6 +39,9 @@ export function EditDetectorLayout<
   savedDetectorToFormData,
   mapFormErrors,
 }: EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload>) {
+  const theme = useTheme();
+  const maxWidth = theme.breakpoints.xl;
+
   const handleFormSubmit = useEditDetectorFormSubmit({
     detector,
     formDataToEndpointPayload,
@@ -55,19 +59,21 @@ export function EditDetectorLayout<
 
   return (
     <EditLayout formProps={formProps}>
-      <EditLayout.Header>
+      <EditLayout.Header maxWidth={maxWidth}>
         <EditLayout.HeaderContent>
           <EditDetectorBreadcrumbs detector={detector} />
         </EditLayout.HeaderContent>
 
-        <EditLayout.Actions>
-          <MonitorFeedbackButton />
-          <DisableDetectorAction detector={detector} />
-          <DeleteDetectorAction detector={detector} />
-          <Button type="submit" priority="primary" size="sm">
-            {t('Save')}
-          </Button>
-        </EditLayout.Actions>
+        <div>
+          <EditLayout.Actions>
+            <MonitorFeedbackButton />
+            <DisableDetectorAction detector={detector} />
+            <DeleteDetectorAction detector={detector} />
+            <Button type="submit" priority="primary" size="sm">
+              {t('Save')}
+            </Button>
+          </EditLayout.Actions>
+        </div>
 
         <EditLayout.HeaderFields>
           <DetectorBaseFields />
@@ -75,7 +81,7 @@ export function EditDetectorLayout<
         </EditLayout.HeaderFields>
       </EditLayout.Header>
 
-      <EditLayout.Body>{children}</EditLayout.Body>
+      <EditLayout.Body maxWidth={maxWidth}>{children}</EditLayout.Body>
     </EditLayout>
   );
 }

--- a/static/app/views/detectors/components/forms/newDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/newDetectorLayout.tsx
@@ -1,4 +1,5 @@
 import {useMemo} from 'react';
+import {useTheme} from '@emotion/react';
 
 import type {FormProps} from 'sentry/components/forms/form';
 import type {Data} from 'sentry/components/forms/types';
@@ -37,6 +38,8 @@ export function NewDetectorLayout<
 }: NewDetectorLayoutProps<TFormData, TUpdatePayload>) {
   const location = useLocation();
   const {projects} = useProjects();
+  const theme = useTheme();
+  const maxWidth = theme.breakpoints.xl;
 
   const formSubmitHandler = useCreateDetectorFormSubmit({
     formDataToEndpointPayload,
@@ -70,12 +73,14 @@ export function NewDetectorLayout<
 
   return (
     <EditLayout formProps={formProps}>
-      <EditLayout.Header>
+      <EditLayout.Header maxWidth={maxWidth}>
         <EditLayout.HeaderContent>
           <NewDetectorBreadcrumbs detectorType={detectorType} />
         </EditLayout.HeaderContent>
 
-        <MonitorFeedbackButton />
+        <div>
+          <MonitorFeedbackButton />
+        </div>
 
         <EditLayout.HeaderFields>
           <DetectorBaseFields />
@@ -83,9 +88,9 @@ export function NewDetectorLayout<
         </EditLayout.HeaderFields>
       </EditLayout.Header>
 
-      <EditLayout.Body>{children}</EditLayout.Body>
+      <EditLayout.Body maxWidth={maxWidth}>{children}</EditLayout.Body>
 
-      <NewDetectorFooter />
+      <NewDetectorFooter maxWidth={maxWidth} />
     </EditLayout>
   );
 }

--- a/static/app/views/detectors/new.tsx
+++ b/static/app/views/detectors/new.tsx
@@ -1,3 +1,5 @@
+import {useTheme} from '@emotion/react';
+
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
@@ -40,6 +42,8 @@ export default function DetectorNew() {
   useWorkflowEngineFeatureGate({redirect: true});
   const location = useLocation();
   const {projects} = useProjects();
+  const theme = useTheme();
+  const maxWidth = theme.breakpoints.xl;
   const detectorType = location.query.detectorType as DetectorType;
 
   const projectIdFromLocation =
@@ -70,19 +74,21 @@ export default function DetectorNew() {
     <EditLayout formProps={formProps}>
       <SentryDocumentTitle title={newMonitorName} />
 
-      <EditLayout.Header>
+      <EditLayout.Header maxWidth={maxWidth}>
         <EditLayout.HeaderContent>
           <NewDetectorBreadcrumbs />
           <EditLayout.Title title={newMonitorName} />
         </EditLayout.HeaderContent>
-        <MonitorFeedbackButton />
+        <div>
+          <MonitorFeedbackButton />
+        </div>
       </EditLayout.Header>
 
-      <EditLayout.Body>
+      <EditLayout.Body maxWidth={maxWidth}>
         <DetectorTypeForm />
       </EditLayout.Body>
 
-      <EditLayout.Footer label={t('Step 1 of 2')}>
+      <EditLayout.Footer label={t('Step 1 of 2')} maxWidth={maxWidth}>
         <LinkButton priority="default" to={makeMonitorBasePathname(organization.slug)}>
           {t('Cancel')}
         </LinkButton>


### PR DESCRIPTION
A bit tricky because we want header boarder lines to still stretch the entire width of the page.

<img width="1594" height="1221" alt="image" src="https://github.com/user-attachments/assets/cd8a12bf-da3d-484e-bf1d-cdffc084ef28" />

<img width="1586" height="1244" alt="image" src="https://github.com/user-attachments/assets/d2aea5e4-9892-43b0-95c4-26289e423b32" />
