### PR TITLE
fix(explorer): Allow interaction when panel is minimized

### DIFF
--- a/static/app/views/seerExplorer/panelContainers.tsx
+++ b/static/app/views/seerExplorer/panelContainers.tsx
@@ -28,6 +28,7 @@ function PanelContainers({
           {panelSize === 'max' && (
             <Backdrop
               key="backdrop"
+              isMinimized={isMinimized}
               initial={{opacity: 0}}
               animate={{opacity: isMinimized ? 0 : 1}}
               exit={{opacity: 0}}
@@ -64,7 +65,7 @@ function PanelContainers({
 
 export default PanelContainers;
 
-const Backdrop = styled(motion.div)`
+const Backdrop = styled(motion.div)<{isMinimized: boolean}>`
   position: fixed;
   top: 0;
   left: 0;
@@ -72,7 +73,7 @@ const Backdrop = styled(motion.div)`
   height: 100vh;
   background: rgba(0, 0, 0, 0.5);
   z-index: 9999;
-  pointer-events: auto;
+  pointer-events: ${p => (p.isMinimized ? 'none' : 'auto')};
 `;
 
 const PanelContainer = styled(motion.div)<{


### PR DESCRIPTION
When minimizing the max-size panel, all clicks on the screen were blocked accidentally. This fixes it