### PR TITLE
fix(inc-1453): More assertions & sentry-kafka-schemas 2.1.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     # [end] jsonschema format validators
     "sentry-arroyo>=2.29.6",
     "sentry-forked-email-reply-parser>=0.5.12.post1",
-    "sentry-kafka-schemas>=2.1.7",
+    "sentry-kafka-schemas>=2.1.9",
     "sentry-ophio>=1.1.3",
     "sentry-protos>=0.4.1",
     "sentry-redis-tools>=0.5.0",

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -186,6 +186,9 @@ def process_batch(
             # those assertions here but later will crash the consumer and is
             # also violating mypy types.
             assert val["end_timestamp"] is not None
+            assert val["start_timestamp"] is not None
+            assert val["trace_id"] is not None
+            assert val["span_id"] is not None
 
             span = Span(
                 trace_id=val["trace_id"],

--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -3,7 +3,7 @@ from typing import Any, cast
 import orjson
 import sentry_sdk
 from google.protobuf.timestamp_pb2 import Timestamp
-from sentry_kafka_schemas.schema_types.buffered_segments_v1 import SpanLink
+from sentry_kafka_schemas.schema_types.buffered_segments_v1 import _SpanLinkObject as SpanLink
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, TraceItem
 
@@ -69,16 +69,15 @@ def convert_span_to_item(span: CompatibleSpan) -> TraceItem:
             attributes[eap_name] = attributes.pop(convention_name)
 
     try:
-        # TODO: Move this to Relay
         attributes["sentry.duration_ms"] = AnyValue(
-            int_value=int(1000 * (span["end_timestamp"] - span["start_timestamp"]))
+            int_value=int(1000 * (span["end_timestamp"] - span["start_timestamp"]))  # type: ignore[operator]  # checked in process-spans
         )
     except Exception:
         sentry_sdk.capture_exception()
 
     if links := span.get("links"):
         try:
-            sanitized_links = [_sanitize_span_link(link) for link in links]
+            sanitized_links = [_sanitize_span_link(link) for link in links if link is not None]
             attributes["sentry.links"] = _anyvalue(sanitized_links)
         except Exception:
             sentry_sdk.capture_exception()
@@ -87,10 +86,10 @@ def convert_span_to_item(span: CompatibleSpan) -> TraceItem:
     return TraceItem(
         organization_id=span["organization_id"],
         project_id=span["project_id"],
-        trace_id=span["trace_id"],
-        item_id=int(span["span_id"], 16).to_bytes(16, "little"),
+        trace_id=span["trace_id"],  # type: ignore[arg-type]  # checked in process-spans
+        item_id=int(span["span_id"], 16).to_bytes(16, "little"),  # type: ignore[arg-type]  # checked in process-spans
         item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
-        timestamp=_timestamp(span["start_timestamp"]),
+        timestamp=_timestamp(span["start_timestamp"]),  # type: ignore[arg-type]  # checked in process-spans
         attributes=attributes,
         client_sample_rate=client_sample_rate,
         server_sample_rate=server_sample_rate,
@@ -133,10 +132,11 @@ def _sanitize_span_link(link: SpanLink) -> SpanLink:
     attributes, so span links are stored as a JSON-encoded string. In order to
     prevent unbounded storage, we only support well-known attributes.
     """
+
     sanitized_link = cast(SpanLink, {**link})
 
     allowed_attributes = {}
-    attributes = link.get("attributes", {}) or {}
+    attributes = link.get("attributes") or {}
 
     # In the future, we want Relay to drop unsupported attributes, so there
     # might be an intermediary state where there is a pre-existing dropped

--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
 
-from sentry.spans.consumers.process_segments.types import Attributes, attribute_value, get_span_op
+from sentry.spans.consumers.process_segments.types import Attribute, attribute_value, get_span_op
 
 # Keys of shared sentry attributes that are shared across all spans in a segment. This list
 # is taken from `extract_shared_tags` in Relay.
@@ -213,7 +213,7 @@ def _us(timestamp: float) -> int:
 def compute_breakdowns(
     spans: Sequence[SpanEvent],
     breakdowns_config: dict[str, dict[str, Any]],
-) -> Attributes:
+) -> dict[str, Attribute]:
     """
     Computes breakdowns from all spans and writes them to the segment span.
 
@@ -222,7 +222,7 @@ def compute_breakdowns(
     are converted into attributes on the span trace item.
     """
 
-    ret: Attributes = {}
+    ret: dict[str, Attribute] = {}
     for breakdown_name, breakdown_config in breakdowns_config.items():
         ty = breakdown_config.get("type")
 

--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
 
-from sentry.spans.consumers.process_segments.types import attribute_value, get_span_op
+from sentry.spans.consumers.process_segments.types import Attributes, attribute_value, get_span_op
 
 # Keys of shared sentry attributes that are shared across all spans in a segment. This list
 # is taken from `extract_shared_tags` in Relay.
@@ -92,7 +92,7 @@ class TreeEnricher:
             # Assume that Relay has extracted the shared tags into `data` on the
             # root span. Once `sentry_tags` is removed, the logic from
             # `extract_shared_tags` should be moved here.
-            segment_attrs = self._segment_span.get("attributes", {})
+            segment_attrs = self._segment_span.get("attributes") or {}
             shared_attrs = {k: v for k, v in segment_attrs.items() if k in SHARED_SENTRY_ATTRIBUTES}
 
             is_mobile = attribute_value(self._segment_span, "sentry.mobile") == "true"
@@ -110,9 +110,9 @@ class TreeEnricher:
                         "value": mobile_start_type,
                     }
 
-            if self._ttid_ts is not None and span["end_timestamp"] <= self._ttid_ts:
+            if self._ttid_ts is not None and span["end_timestamp"] <= self._ttid_ts:  # type: ignore[operator]  # checked in process-spans
                 attributes["sentry.ttid"] = {"type": "string", "value": "ttid"}
-            if self._ttfd_ts is not None and span["end_timestamp"] <= self._ttfd_ts:
+            if self._ttfd_ts is not None and span["end_timestamp"] <= self._ttfd_ts:  # type: ignore[operator]  # checked in process-spans
                 attributes["sentry.ttfd"] = {"type": "string", "value": "ttfd"}
 
             for key, value in shared_attrs.items():
@@ -134,7 +134,7 @@ class TreeEnricher:
         of all time intervals where no child span was active.
         """
 
-        intervals = self._span_map.get(span["span_id"], [])
+        intervals = self._span_map.get(span["span_id"], [])  # type: ignore[arg-type]  # checked in process-spans
         # Sort by start ASC, end DESC to skip over nested intervals efficiently
         intervals.sort(key=lambda x: (x[0], -x[1]))
 
@@ -200,7 +200,8 @@ def _timestamp_by_op(spans: list[SpanEvent], op: str) -> float | None:
 
 def _span_interval(span: SpanEvent) -> tuple[int, int]:
     """Get the start and end timestamps of a span in microseconds."""
-    return _us(span["start_timestamp"]), _us(span["end_timestamp"])
+
+    return _us(span["start_timestamp"]), _us(span["end_timestamp"])  # type: ignore[arg-type]  # checked in process-spans
 
 
 def _us(timestamp: float) -> int:
@@ -212,7 +213,7 @@ def _us(timestamp: float) -> int:
 def compute_breakdowns(
     spans: Sequence[SpanEvent],
     breakdowns_config: dict[str, dict[str, Any]],
-) -> dict[str, Any]:
+) -> Attributes:
     """
     Computes breakdowns from all spans and writes them to the segment span.
 
@@ -221,7 +222,7 @@ def compute_breakdowns(
     are converted into attributes on the span trace item.
     """
 
-    ret = {}
+    ret: Attributes = {}
     for breakdown_name, breakdown_config in breakdowns_config.items():
         ty = breakdown_config.get("type")
 
@@ -231,7 +232,7 @@ def compute_breakdowns(
             continue
 
         for key, value in breakdowns.items():
-            ret[f"{breakdown_name}.{key}"] = {"value": value}
+            ret[f"{breakdown_name}.{key}"] = {"value": value, "type": "double"}
 
     return ret
 

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -145,7 +145,8 @@ def _compute_breakdowns(
 ) -> None:
     config = project.get_option("sentry:breakdowns")
     breakdowns = compute_breakdowns(spans, config)
-    segment.setdefault("attributes", {}).update(breakdowns)
+    segment["attributes"] = segment.get("attributes") or {}
+    segment["attributes"].update(breakdowns)  # type: ignore[union-attr]
 
 
 @metrics.wraps("spans.consumers.process_segments.create_models")
@@ -231,7 +232,7 @@ def _detect_performance_problems(
             culprit=event_data["transaction"],
             evidence_data=problem.evidence_data or {},
             evidence_display=problem.evidence_display,
-            detection_time=to_datetime(segment_span["end_timestamp"]),
+            detection_time=to_datetime(segment_span["end_timestamp"]),  # type: ignore[arg-type]  # checked in process-spans
             level="info",
         )
 
@@ -265,7 +266,7 @@ def _record_signals(
     )
 
     for module in insights_modules(
-        [FilterSpan.from_span_attributes(span.get("attributes", {})) for span in spans]
+        [FilterSpan.from_span_attributes(span.get("attributes") or {}) for span in spans]
     ):
         set_project_flag_and_signal(
             project,

--- a/src/sentry/spans/consumers/process_segments/shim.py
+++ b/src/sentry/spans/consumers/process_segments/shim.py
@@ -88,7 +88,7 @@ def build_shim_event_data(
         "received": segment_span["received"],
         "timestamp": segment_span["end_timestamp"],
         "start_timestamp": segment_span["start_timestamp"],
-        "datetime": to_datetime(segment_span["end_timestamp"]).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "datetime": to_datetime(segment_span["end_timestamp"]).strftime("%Y-%m-%dT%H:%M:%SZ"),  # type: ignore[arg-type]  # checked in process-spans
         "spans": [],
     }
 

--- a/src/sentry/spans/consumers/process_segments/shim.py
+++ b/src/sentry/spans/consumers/process_segments/shim.py
@@ -88,7 +88,7 @@ def build_shim_event_data(
         "received": segment_span["received"],
         "timestamp": segment_span["end_timestamp"],
         "start_timestamp": segment_span["start_timestamp"],
-        "datetime": to_datetime(segment_span["end_timestamp"]).strftime("%Y-%m-%dT%H:%M:%SZ"),  # type: ignore[arg-type]  # checked in process-spans
+        "datetime": to_datetime(segment_span["end_timestamp"]).strftime("%Y-%m-%dT%H:%M:%SZ"),  # type: ignore[union-attr]  # checked in process-spans
         "spans": [],
     }
 

--- a/src/sentry/spans/consumers/process_segments/types.py
+++ b/src/sentry/spans/consumers/process_segments/types.py
@@ -6,11 +6,9 @@ from sentry_kafka_schemas.schema_types.ingest_spans_v1 import (
     _FileColonIngestSpansFullStopV1FullStopSchemaFullStopJsonNumberSignDefinitionsAttributevalueObject,
 )
 
-Attributes = dict[
-    str,
-    None
-    | _FileColonIngestSpansFullStopV1FullStopSchemaFullStopJsonNumberSignDefinitionsAttributevalueObject,
-]
+Attribute = _FileColonIngestSpansFullStopV1FullStopSchemaFullStopJsonNumberSignDefinitionsAttributevalueObject
+
+Attributes = dict[str, None | Attribute]
 
 
 # The default span.op to assume if it is missing on the span. This should be

--- a/tests/sentry/spans/consumers/process/test_consumer.py
+++ b/tests/sentry/spans/consumers/process/test_consumer.py
@@ -50,6 +50,7 @@ def test_basic(kafka_slice_id: int | None) -> None:
                                     "project_id": 12,
                                     "span_id": "a" * 16,
                                     "trace_id": "b" * 32,
+                                    "start_timestamp": 1699999999.0,
                                     "end_timestamp": 1700000000.0,
                                 }
                             ),
@@ -84,6 +85,7 @@ def test_basic(kafka_slice_id: int | None) -> None:
                         "span_id": "aaaaaaaaaaaaaaaa",
                         "trace_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
                         "end_timestamp": 1700000000.0,
+                        "start_timestamp": 1699999999.0,
                     },
                 ],
             }

--- a/tests/sentry/spans/consumers/process_segments/test_convert.py
+++ b/tests/sentry/spans/consumers/process_segments/test_convert.py
@@ -155,7 +155,7 @@ def test_convert_span_to_item() -> None:
 
 def test_convert_falsy_fields() -> None:
     message: SpanEvent = {**SPAN_KAFKA_MESSAGE}
-    message["attributes"]["sentry.is_segment"] = {"type": "boolean", "value": False}
+    message["attributes"]["sentry.is_segment"] = {"type": "boolean", "value": False}  # type: ignore[index]
 
     item = convert_span_to_item(cast(CompatibleSpan, message))
 

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -92,8 +92,8 @@ class TestSpansTask(TestCase):
 
         assert len(processed_spans) == len(spans)
         child_span, segment_span = processed_spans
-        child_attrs = child_span["attributes"]
-        segment_data = segment_span["attributes"]
+        child_attrs = child_span["attributes"] or {}
+        segment_data = segment_span["attributes"] or {}
 
         assert child_attrs["sentry.transaction"] == segment_data["sentry.transaction"]
         assert child_attrs["sentry.transaction.method"] == segment_data["sentry.transaction.method"]

--- a/uv.lock
+++ b/uv.lock
@@ -2152,7 +2152,7 @@ requires-dist = [
     { name = "rfc3986-validator", specifier = ">=0.1.1" },
     { name = "sentry-arroyo", specifier = ">=2.29.6" },
     { name = "sentry-forked-email-reply-parser", specifier = ">=0.5.12.post1" },
-    { name = "sentry-kafka-schemas", specifier = ">=2.1.7" },
+    { name = "sentry-kafka-schemas", specifier = ">=2.1.9" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-protos", specifier = ">=0.4.1" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
@@ -2324,7 +2324,7 @@ wheels = [
 
 [[package]]
 name = "sentry-kafka-schemas"
-version = "2.1.7"
+version = "2.1.9"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "fastjsonschema", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2335,7 +2335,7 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_kafka_schemas-2.1.7-py2.py3-none-any.whl", hash = "sha256:b58f20ef5228c48c8061f90e863825a609040c73512b8bd2aa50747d0ba0e89e" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_kafka_schemas-2.1.9-py2.py3-none-any.whl", hash = "sha256:b5a8e48bb3cbcbecc93dcfe240baae6763f60e81672f460bd96d038219ac4b7c" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR 

- Adds more assertion to the `process-spans` consumer so it does not crash when specific span fields are `null`.
- Updates sentry-kafka-schemas to reflect that span fields can be `null`.
- Adds a couple of `type: ignore` comments where we access previously asserted fields. These comments will be removed again once we have made Relay validate those fields.

Fixes INGEST-602