### PR TITLE
ref(onboarding): Move minidump to content block

### DIFF
--- a/static/app/gettingStartedDocs/minidump/minidump.tsx
+++ b/static/app/gettingStartedDocs/minidump/minidump.tsx
@@ -1,8 +1,4 @@
-import {Fragment} from 'react';
-
 import {ExternalLink} from 'sentry/components/core/link';
-import List from 'sentry/components/list';
-import ListItem from 'sentry/components/list/listItem';
 import {StoreCrashReportsConfig} from 'sentry/components/onboarding/gettingStartedDoc/storeCrashReportsConfig';
 import type {
   Docs,
@@ -23,63 +19,75 @@ const onboarding: OnboardingConfig = {
   install: params => [
     {
       title: t('Creating and Uploading Minidumps'),
-      description: (
-        <Fragment>
-          {t(
-            'Depending on your operating system and programming language, there are various alternatives to create minidumps and upload them to Sentry. See the following resources for libraries that support generating minidump crash reports:'
-          )}
-          <List symbol="bullet">
-            <ListItem>
-              <ExternalLink href="https://docs.sentry.io/platforms/native/">
-                Native SDK
-              </ExternalLink>
-            </ListItem>
-            <ListItem>
-              <ExternalLink href="https://docs.sentry.io/platforms/native/guides/breakpad/">
-                Google Breakpad
-              </ExternalLink>
-            </ListItem>
-            <ListItem>
-              <ExternalLink href="https://docs.sentry.io/platforms/native/guides/crashpad/">
-                Google Crashpad
-              </ExternalLink>
-            </ListItem>
-          </List>
-        </Fragment>
-      ),
-      configurations: [
+      content: [
         {
-          description: tct(
+          type: 'text',
+          text: t(
+            'Depending on your operating system and programming language, there are various alternatives to create minidumps and upload them to Sentry. See the following resources for libraries that support generating minidump crash reports:'
+          ),
+        },
+        {
+          type: 'list',
+          items: [
+            tct('[link:Native SDK]', {
+              link: <ExternalLink href="https://docs.sentry.io/platforms/native/" />,
+            }),
+            tct('[link:Google Breakpad]', {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/native/guides/breakpad/" />
+              ),
+            }),
+            tct('[link:Google Crashpad]', {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/native/guides/crashpad/" />
+              ),
+            }),
+          ],
+        },
+        {
+          type: 'text',
+          text: tct(
             'If you have already integrated a library that generates minidumps and would just like to upload them to Sentry, you need to configure the [italic:Minidump Endpoint URL], which can be found at [italic:Project Settings > Client Keys (DSN)]. This endpoint expects a [code:POST] request with the minidump in the [code:upload_file_minidump] field:',
             {
               code: <code />,
               italic: <i />,
             }
           ),
+        },
+        {
+          type: 'code',
           language: 'bash',
           code: getCurlSnippet(params),
         },
-      ],
-      additionalInfo: tct(
-        'To send additional information, add more form fields to this request. For a full description of fields accepted by Sentry, see [passingAdditionalDataLink:Passing Additional Data].',
         {
-          passingAdditionalDataLink: (
-            <ExternalLink href="https://docs.sentry.io/platforms/native/guides/minidumps/" />
+          type: 'text',
+          text: tct(
+            'To send additional information, add more form fields to this request. For a full description of fields accepted by Sentry, see [passingAdditionalDataLink:Passing Additional Data].',
+            {
+              passingAdditionalDataLink: (
+                <ExternalLink href="https://docs.sentry.io/platforms/native/guides/minidumps/" />
+              ),
+            }
           ),
-        }
-      ),
+        },
+      ],
     },
   ],
   configure: () => [],
   verify: params => [
     {
       title: t('Further Settings'),
-      description: (
-        <StoreCrashReportsConfig
-          organization={params.organization}
-          projectSlug={params.project.slug}
-        />
-      ),
+      content: [
+        {
+          type: 'custom',
+          content: (
+            <StoreCrashReportsConfig
+              organization={params.organization}
+              projectSlug={params.project.slug}
+            />
+          ),
+        },
+      ],
     },
   ],
 };


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks