### PR TITLE
feat(search-bar): Replace to replace raw keys on paste

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -137,6 +137,7 @@ export function SearchQueryBuilderProvider({
     disabled,
     displayAskSeerFeedback,
     setDisplayAskSeerFeedback,
+    replaceRawSearchKeys,
   });
 
   const stableFieldDefinitionGetter = useMemo(

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
@@ -42,6 +42,42 @@ describe('replaceFreeTextTokens', () => {
         },
       },
       {
+        description: 'when the replace raw search keys is empty',
+        input: {
+          action: {
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
+            text: '',
+            tokens: [],
+            focusOverride: undefined,
+          },
+          getFieldDefinition: () => null,
+          rawSearchReplacement: [],
+          currentQuery: '',
+        },
+        expected: {
+          query: undefined,
+          focusOverride: undefined,
+        },
+      },
+      {
+        description: 'when the replace raw search keys is an empty string',
+        input: {
+          action: {
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
+            text: '',
+            tokens: [],
+            focusOverride: undefined,
+          },
+          getFieldDefinition: () => null,
+          rawSearchReplacement: [''],
+          currentQuery: '',
+        },
+        expected: {
+          query: undefined,
+          focusOverride: undefined,
+        },
+      },
+      {
         description: 'when there is no raw search replacement',
         input: {
           action: {

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
@@ -1,0 +1,239 @@
+import type {FocusOverride} from 'sentry/components/searchQueryBuilder/types';
+import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
+
+import {
+  replaceFreeTextTokens,
+  type ReplaceTokensWithTextOnPasteAction,
+} from './useQueryBuilderState';
+
+describe('replaceFreeTextTokens', () => {
+  describe('when there are free text tokens', () => {
+    type TestCase = {
+      description: string;
+      expected: {
+        focusOverride: FocusOverride | undefined;
+        query: string | undefined;
+      };
+      input: {
+        action: ReplaceTokensWithTextOnPasteAction;
+        currentQuery: string;
+        getFieldDefinition: () => null;
+        rawSearchReplacement: string[];
+      };
+    };
+
+    const testCases: TestCase[] = [
+      {
+        description: 'when there are no tokens',
+        input: {
+          action: {
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
+            text: '',
+            tokens: [],
+            focusOverride: undefined,
+          },
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          currentQuery: '',
+        },
+        expected: {
+          query: undefined,
+          focusOverride: undefined,
+        },
+      },
+      {
+        description: 'when there is no raw search replacement',
+        input: {
+          action: {
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
+            text: '',
+            tokens: [],
+            focusOverride: undefined,
+          },
+          getFieldDefinition: () => null,
+          rawSearchReplacement: [],
+          currentQuery: `browser.name:${WildcardOperators.CONTAINS}"firefox"`,
+        },
+        expected: {
+          query: undefined,
+          focusOverride: undefined,
+        },
+      },
+      {
+        description: 'when there are no free text tokens',
+        input: {
+          action: {
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
+            text: '',
+            tokens: [],
+            focusOverride: undefined,
+          },
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          currentQuery: `browser.name:${WildcardOperators.CONTAINS}"firefox"`,
+        },
+        expected: {
+          query: undefined,
+          focusOverride: undefined,
+        },
+      },
+      {
+        description: 'when there only valid action tokens',
+        input: {
+          action: {
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
+            text: 'span.op:eq',
+            tokens: [],
+            focusOverride: undefined,
+          },
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          currentQuery: '',
+        },
+        expected: {
+          query: undefined,
+          focusOverride: undefined,
+        },
+      },
+      {
+        description: 'when there only space free text tokens in the action',
+        input: {
+          action: {
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
+            text: 'span.op:eq    ',
+            tokens: [],
+            focusOverride: undefined,
+          },
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          currentQuery: '',
+        },
+        expected: {
+          query: undefined,
+          focusOverride: undefined,
+        },
+      },
+      {
+        description: 'when there is one free text token',
+        input: {
+          action: {
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
+            text: 'test',
+            tokens: [],
+            focusOverride: undefined,
+          },
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          currentQuery: '',
+        },
+        expected: {
+          query: `span.description:${WildcardOperators.CONTAINS}test`,
+          focusOverride: {itemKey: 'freeText:1'},
+        },
+      },
+      {
+        description: 'when there is one free text token that has a space',
+        input: {
+          action: {
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
+            text: 'test test',
+            tokens: [],
+            focusOverride: undefined,
+          },
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          currentQuery: '',
+        },
+        expected: {
+          query: `span.description:${WildcardOperators.CONTAINS}"test test"`,
+          focusOverride: {itemKey: 'freeText:1'},
+        },
+      },
+      {
+        description: 'when there is already a token present',
+        input: {
+          action: {
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
+            text: 'test',
+            tokens: [],
+            focusOverride: undefined,
+          },
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          currentQuery: 'span.op:eq',
+        },
+        expected: {
+          query: `span.op:eq span.description:${WildcardOperators.CONTAINS}test`,
+          focusOverride: {itemKey: 'freeText:2'},
+        },
+      },
+      {
+        description: 'when there is already a replace token present',
+        input: {
+          action: {
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
+            text: 'test2',
+            tokens: [],
+            focusOverride: undefined,
+          },
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          currentQuery: `span.description:${WildcardOperators.CONTAINS}test`,
+        },
+        expected: {
+          query: `span.description:${WildcardOperators.CONTAINS}[test,test2]`,
+          focusOverride: {itemKey: 'freeText:1'},
+        },
+      },
+      {
+        description: 'when there is already a replace token present with a space',
+        input: {
+          action: {
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
+            text: 'other value',
+            tokens: [],
+            focusOverride: undefined,
+          },
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          currentQuery: `span.description:${WildcardOperators.CONTAINS}test`,
+        },
+        expected: {
+          query: `span.description:${WildcardOperators.CONTAINS}[test,"other value"]`,
+          focusOverride: {itemKey: 'freeText:1'},
+        },
+      },
+      {
+        description:
+          'when there is already a replace token present with a different operator',
+        input: {
+          action: {
+            type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
+            text: 'other value',
+            tokens: [],
+            focusOverride: undefined,
+          },
+          getFieldDefinition: () => null,
+          rawSearchReplacement: ['span.description'],
+          currentQuery: `span.description:test`,
+        },
+        expected: {
+          query: `span.description:test span.description:${WildcardOperators.CONTAINS}"other value"`,
+          focusOverride: {itemKey: 'freeText:2'},
+        },
+      },
+    ];
+
+    it.each(testCases)('$description', ({input, expected}) => {
+      const result = replaceFreeTextTokens(
+        input.action,
+        input.getFieldDefinition,
+        input.rawSearchReplacement,
+        input.currentQuery
+      );
+
+      expect(result?.newQuery).toBe(expected.query);
+      expect(result?.focusOverride).toStrictEqual(expected.focusOverride);
+    });
+  });
+});

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -752,8 +752,7 @@ export function replaceFreeTextTokens(
   const newParsedQuery = parseQueryBuilderValue(newQuery, getFieldDefinition) ?? [];
   const cursorPosition = (tokens[0]?.location.start.offset ?? 0) + action.text.length; // TODO: Ensure this is sorted
   const focusedToken = newParsedQuery?.findLast(
-    (token: any) =>
-      token.type === Token.FREE_TEXT && token.location.end.offset >= cursorPosition
+    token => token.type === Token.FREE_TEXT && token.location.end.offset >= cursorPosition
   );
 
   const focusOverride = focusedToken

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -697,9 +697,6 @@ export function replaceFreeTextTokens(
   }
 
   const tokens = parseQueryBuilderValue(currentQuery, getFieldDefinition) ?? [];
-  if (tokens.length === 0) {
-    return undefined;
-  }
 
   const primarySearchKey = replaceRawSearchKeys[0] ?? '';
   let replaceToken: TokenResult<Token.FILTER> | undefined;

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -878,9 +878,8 @@ export function useQueryBuilderState({
           });
 
           if (
-            replaceRawSearchKeys &&
-            replaceRawSearchKeys?.length === 0 &&
-            !hasWildcardOperators
+            !hasWildcardOperators ||
+            (replaceRawSearchKeys && replaceRawSearchKeys.length === 0)
           ) {
             return newState;
           }

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -881,7 +881,8 @@ export function useQueryBuilderState({
 
           if (
             !hasWildcardOperators ||
-            (replaceRawSearchKeys && replaceRawSearchKeys.length === 0)
+            !replaceRawSearchKeys ||
+            replaceRawSearchKeys.length === 0
           ) {
             return newState;
           }

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -707,6 +707,7 @@ export function replaceFreeTextTokens(
 
   const tokens = parseQueryBuilderValue(currentQuery, getFieldDefinition) ?? [];
 
+  // TS doesn't know that replaceRawSearchKeys is always defined and non-empty
   const primarySearchKey = replaceRawSearchKeys[0] ?? '';
   let tokenToBeReplaced: TokenResult<Token.FILTER> | undefined;
   const freeTextToken = actionTokens.find(

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -755,10 +755,7 @@ export function replaceFreeTextTokens(
   const newQuery = Array.from(filteredTokens).join(' ');
 
   const newParsedQuery = parseQueryBuilderValue(newQuery, getFieldDefinition) ?? [];
-  const cursorPosition = (tokens[0]?.location.start.offset ?? 0) + action.text.length; // TODO: Ensure this is sorted
-  const focusedToken = newParsedQuery?.findLast(
-    token => token.type === Token.FREE_TEXT && token.location.end.offset >= cursorPosition
-  );
+  const focusedToken = newParsedQuery?.findLast(token => token.type === Token.FREE_TEXT);
 
   const focusOverride = focusedToken
     ? {itemKey: makeTokenKey(focusedToken, newParsedQuery)}

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -664,7 +664,7 @@ function isReplaceToken(
 ): token is TokenResult<Token.FILTER> {
   return (
     token.type === Token.FILTER &&
-    token.text.includes(primarySearchKey) &&
+    getKeyName(token.key) === primarySearchKey &&
     token.operator === TermOperator.CONTAINS
   );
 }

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -687,7 +687,12 @@ export function replaceFreeTextTokens(
   replaceRawSearchKeys: string[],
   currentQuery: string
 ) {
-  if (!action.text || action.text === '' || replaceRawSearchKeys.length === 0) {
+  if (
+    !action.text ||
+    action.text === '' ||
+    replaceRawSearchKeys.length === 0 ||
+    (replaceRawSearchKeys.length !== 0 && replaceRawSearchKeys[0] === '')
+  ) {
     return undefined;
   }
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4270,6 +4270,93 @@ describe('SearchQueryBuilder', () => {
           })
         ).toBeInTheDocument();
       });
+
+      it('should replace raw search keys on paste', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery=""
+            replaceRawSearchKeys={['span.description']}
+          />,
+          {organization: {features: ['search-query-builder-wildcard-operators']}}
+        );
+
+        await userEvent.click(getLastInput());
+        await userEvent.paste('randomValue');
+
+        // Should have tokenized the pasted text
+        expect(
+          screen.getByRole('row', {
+            name: `span.description:${WildcardOperators.CONTAINS}randomValue`,
+          })
+        ).toBeInTheDocument();
+        // Focus should be at the end of the pasted text
+        expect(
+          screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)
+        ).toHaveFocus();
+      });
+
+      it('should replace raw search keys on paste, leaving other tokens intact', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery="browser.name:firefox span.description:test"
+            replaceRawSearchKeys={['span.description']}
+          />,
+          {organization: {features: ['search-query-builder-wildcard-operators']}}
+        );
+
+        await userEvent.click(getLastInput());
+        await userEvent.paste('randomValue');
+
+        // leaves unrelated filter key tokens intact
+        expect(
+          screen.getByRole('row', {name: 'browser.name:firefox'})
+        ).toBeInTheDocument();
+
+        // leaves the same filter key minus the wildcard contains operator intact
+        expect(
+          screen.getByRole('row', {name: 'span.description:test'})
+        ).toBeInTheDocument();
+
+        // Should have tokenized the pasted text
+        expect(
+          screen.getByRole('row', {
+            name: `span.description:${WildcardOperators.CONTAINS}randomValue`,
+          })
+        ).toBeInTheDocument();
+        // Focus should be at the end of the pasted text
+        expect(
+          screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)
+        ).toHaveFocus();
+      });
+
+      it('should replace raw search keys on paste, merging with existing tokens', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery={`span.description:${WildcardOperators.CONTAINS}test`}
+            replaceRawSearchKeys={['span.description']}
+          />,
+          {organization: {features: ['search-query-builder-wildcard-operators']}}
+        );
+
+        await userEvent.click(getLastInput());
+        await userEvent.paste('randomValue');
+        // the filter key combobox is opened, so we need to close it
+        await userEvent.keyboard('{Escape}');
+
+        // Should have tokenized the pasted text
+        expect(
+          screen.getByRole('row', {
+            name: `span.description:${WildcardOperators.CONTAINS}[test,randomValue]`,
+          })
+        ).toBeInTheDocument();
+        // Focus should be at the end of the pasted text
+        expect(
+          screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)
+        ).toHaveFocus();
+      });
     });
   });
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4343,7 +4343,7 @@ describe('SearchQueryBuilder', () => {
 
         await userEvent.click(getLastInput());
         await userEvent.paste('randomValue');
-        // the filter key combobox is opened, so we need to close it
+        // the new filter key combobox is opened, when we get moved to the new token
         await userEvent.keyboard('{Escape}');
 
         // Should have tokenized the pasted text
@@ -4353,9 +4353,7 @@ describe('SearchQueryBuilder', () => {
           })
         ).toBeInTheDocument();
         // Focus should be at the end of the pasted text
-        expect(
-          screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1)
-        ).toHaveFocus();
+        expect(getLastInput()).toHaveFocus();
       });
     });
   });


### PR DESCRIPTION
This PR updates the search bar to auto-replace raw text values on paste when there are a set of `replaceRawSearchKeys` configured for a given search query builder.

Currently this is only setup for the traces search query builder behind a flag, which will convert pasted raw text values to `span.description:contains<pasted values>`, while retaining any previous filters, and merging new values into `span.description`

Example:

https://github.com/user-attachments/assets/ba9e0bf3-7a60-4c18-8100-3e1ec02f274f

Ticket: EXP-547