### PR TITLE
fix(sub v3): Don't show notifications page without flag

### DIFF
--- a/static/gsApp/views/subscriptionPage/headerCards/linksCard.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/linksCard.spec.tsx
@@ -1,0 +1,46 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import LinksCard from 'getsentry/views/subscriptionPage/headerCards/linksCard';
+
+describe('LinksCard', () => {
+  it('renders for user with billing perms and org with spend visibility notifications', () => {
+    const organization = OrganizationFixture({
+      features: ['subscriptions-v3', 'spend-visibility-notifications'],
+      access: ['org:billing'],
+    });
+    render(<LinksCard organization={organization} />);
+    expect(screen.getByText('Receipts & notifications')).toBeInTheDocument();
+    expect(screen.queryByText('Activity log')).not.toBeInTheDocument();
+    expect(screen.getByText('View all receipts')).toBeInTheDocument();
+    expect(screen.getByText('View activity')).toBeInTheDocument();
+    expect(screen.getByText('Manage spend notifications')).toBeInTheDocument();
+  });
+
+  it('renders for user with billing perms and org without spend visibility notifications', () => {
+    const organization = OrganizationFixture({
+      features: ['subscriptions-v3'],
+      access: ['org:billing'],
+    });
+    render(<LinksCard organization={organization} />);
+    expect(screen.getByText('Receipts & notifications')).toBeInTheDocument();
+    expect(screen.queryByText('Activity log')).not.toBeInTheDocument();
+    expect(screen.getByText('View all receipts')).toBeInTheDocument();
+    expect(screen.getByText('View activity')).toBeInTheDocument();
+    expect(screen.queryByText('Manage spend notifications')).not.toBeInTheDocument();
+  });
+
+  it('renders for user without billing perms', () => {
+    const organization = OrganizationFixture({
+      features: ['subscriptions-v3', 'spend-visibility-notifications'],
+      access: ['org:read'],
+    });
+    render(<LinksCard organization={organization} />);
+    expect(screen.getByText('Activity log')).toBeInTheDocument();
+    expect(screen.queryByText('Receipts & notifications')).not.toBeInTheDocument();
+    expect(screen.getByText('View activity')).toBeInTheDocument();
+    expect(screen.queryByText('View all receipts')).not.toBeInTheDocument();
+    expect(screen.queryByText('Manage spend notifications')).not.toBeInTheDocument();
+  });
+});

--- a/static/gsApp/views/subscriptionPage/headerCards/linksCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/linksCard.tsx
@@ -8,9 +8,11 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 
 import SubscriptionHeaderCard from 'getsentry/views/subscriptionPage/headerCards/subscriptionHeaderCard';
+import {hasSpendVisibilityNotificationsFeature} from 'getsentry/views/subscriptionPage/utils';
 
 function LinksCard({organization}: {organization: Organization}) {
   const hasBillingPerms = organization.access?.includes('org:billing');
+  const hasSpendNotifications = hasSpendVisibilityNotificationsFeature(organization);
 
   return (
     <SubscriptionHeaderCard
@@ -37,15 +39,17 @@ function LinksCard({organization}: {organization: Organization}) {
                   {t('View activity')}
                 </Text>
               </LinkButton>
-              <LinkButton
-                priority="link"
-                icon={<IconSubscribed />}
-                to="/settings/billing/notifications/"
-              >
-                <Text size="sm" variant="accent">
-                  {t('Manage spend notifications')}
-                </Text>
-              </LinkButton>
+              {hasSpendNotifications && (
+                <LinkButton
+                  priority="link"
+                  icon={<IconSubscribed />}
+                  to="/settings/billing/notifications/"
+                >
+                  <Text size="sm" variant="accent">
+                    {t('Manage spend notifications')}
+                  </Text>
+                </LinkButton>
+              )}
             </Fragment>
           ) : (
             <LinkButton

--- a/static/gsApp/views/subscriptionPage/notifications.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/notifications.spec.tsx
@@ -14,6 +14,7 @@ describe('Subscription > Notifications', () => {
   const subscription = SubscriptionFixture({organization});
 
   beforeEach(() => {
+    jest.clearAllMocks();
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/spend-notifications/`,
@@ -45,7 +46,7 @@ describe('Subscription > Notifications', () => {
     });
 
     organization.access = ['org:billing'];
-    organization.features = [];
+    organization.features = ['spend-visibility-notifications'];
     subscription.planDetails.allowOnDemand = false;
     SubscriptionStore.set(organization.slug, subscription);
   });
@@ -91,8 +92,23 @@ describe('Subscription > Notifications', () => {
     expect(screen.getByRole('button', {name: 'Save changes'})).toBeDisabled();
   });
 
+  it('redirects without flag', () => {
+    organization.features = [];
+    const {router} = render(
+      <Notifications {...RouteComponentPropsFixture()} subscription={subscription} />,
+      {organization}
+    );
+
+    expect(router.location).toEqual(
+      expect.objectContaining({
+        pathname: '/settings/chum-bucket/billing/overview/',
+        query: {},
+      })
+    );
+  });
+
   it('renders for new billing UI', async () => {
-    organization.features = ['subscriptions-v3'];
+    organization.features.push('subscriptions-v3');
     render(
       <Notifications {...RouteComponentPropsFixture()} subscription={subscription} />,
       {organization}

--- a/static/gsApp/views/subscriptionPage/notifications.tsx
+++ b/static/gsApp/views/subscriptionPage/notifications.tsx
@@ -19,6 +19,7 @@ import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelFooter from 'sentry/components/panels/panelFooter';
 import PanelHeader from 'sentry/components/panels/panelHeader';
+import Redirect from 'sentry/components/redirect';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconCheckmark, IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -34,6 +35,7 @@ import type {Subscription} from 'getsentry/types';
 import {displayBudgetName, hasNewBillingUI} from 'getsentry/utils/billing';
 import ContactBillingMembers from 'getsentry/views/contactBillingMembers';
 import SubscriptionPageContainer from 'getsentry/views/subscriptionPage/components/subscriptionPageContainer';
+import {hasSpendVisibilityNotificationsFeature} from 'getsentry/views/subscriptionPage/utils';
 
 import SubscriptionHeader from './subscriptionHeader';
 
@@ -108,6 +110,10 @@ function SubscriptionNotifications({subscription}: SubscriptionNotificationsProp
   };
 
   const hasBillingPerms = organization.access?.includes('org:billing');
+
+  if (!hasSpendVisibilityNotificationsFeature(organization)) {
+    return <Redirect to={`/settings/${organization.slug}/billing/overview/`} />;
+  }
 
   if (!isNewBillingUI) {
     if (!hasBillingPerms) {


### PR DESCRIPTION
- Don't show a link to the notifications page without the `spend-visibility-notifications` flag
- Redirect the user if they try to go directly to `/notifications` without the `spend-visibility-notifications` flag
<img width="328" height="164" alt="Screenshot 2025-10-16 at 9 55 45 AM" src="https://github.com/user-attachments/assets/476c92e5-a8fb-443d-b517-54db03fbbfff" />
