### PR TITLE
chore(opsgenie): Add JSM URL as an opsgenie option

### DIFF
--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -82,6 +82,7 @@ metadata = IntegrationMetadata(
 OPSGENIE_BASE_URL_TO_DOMAIN_NAME = {
     "https://api.opsgenie.com/": "app.opsgenie.com",
     "https://api.eu.opsgenie.com/": "app.eu.opsgenie.com",
+    "https://api.atlassian.com/": "atlassian.net",
 }
 
 
@@ -91,6 +92,7 @@ class InstallationForm(forms.Form):
         choices=[
             ("https://api.opsgenie.com/", "api.opsgenie.com"),
             ("https://api.eu.opsgenie.com/", "api.eu.opsgenie.com"),
+            ("https://api.atlassian.com/", "api.atlassian.com"),
         ],
     )
     provider = forms.CharField(

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -82,7 +82,7 @@ metadata = IntegrationMetadata(
 OPSGENIE_BASE_URL_TO_DOMAIN_NAME = {
     "https://api.opsgenie.com/": "app.opsgenie.com",
     "https://api.eu.opsgenie.com/": "app.eu.opsgenie.com",
-    "https://api.atlassian.com/": "atlassian.net",
+    "https://api.atlassian.com/jsm/ops/integration/": "atlassian.net",
 }
 
 
@@ -92,7 +92,7 @@ class InstallationForm(forms.Form):
         choices=[
             ("https://api.opsgenie.com/", "api.opsgenie.com"),
             ("https://api.eu.opsgenie.com/", "api.eu.opsgenie.com"),
-            ("https://api.atlassian.com/", "api.atlassian.com"),
+            ("https://api.atlassian.com/jsm/ops/integration/", "api.atlassian.com (JSM)"),
         ],
     )
     provider = forms.CharField(


### PR DESCRIPTION
Adds the option when installing an OpsGenie integration to use the JSM base URL.
<img width="583" height="246" alt="image" src="https://github.com/user-attachments/assets/1dfc6842-8439-4ce6-94e6-9f08ed170c70" />

Tested it with a JSM instance and seemed to work as expected!
<img width="1268" height="271" alt="image" src="https://github.com/user-attachments/assets/4a623333-0eec-4d55-8918-c972fd13c988" />

Lifted a commit from #101067 (by @nathanmartins) and made a change suggested by @edds, which yielded the expected behavior when testing locally. Thank you all! 
