### PR TITLE
feat(replays): Query project options directly without going through the project

### DIFF
--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -235,21 +235,21 @@ def commit_recording_message(recording: ProcessedEvent) -> None:
     # Write to GCS.
     storage_kv.set(recording.filename, recording.filedata)
 
-    try:
-        project = Project.objects.get_from_cache(id=recording.context["project_id"])
-        assert isinstance(project, Project)
-    except Project.DoesNotExist as exc:
-        logger.warning(
-            "Recording segment was received for a project that does not exist.",
-            extra={
-                "project_id": recording.context["project_id"],
-                "replay_id": recording.context["replay_id"],
-            },
-        )
-        raise DropEvent("Could not find project.") from exc
-
     # Write to billing consumer if its a billable event.
     if recording.context["segment_id"] == 0:
+        try:
+            project = Project.objects.get_from_cache(id=recording.context["project_id"])
+            assert isinstance(project, Project)
+        except Project.DoesNotExist as exc:
+            logger.warning(
+                "Recording segment was received for a project that does not exist.",
+                extra={
+                    "project_id": recording.context["project_id"],
+                    "replay_id": recording.context["replay_id"],
+                },
+            )
+            raise DropEvent("Could not find project.") from exc
+
         _track_initial_segment_event(
             recording.context["org_id"],
             project,
@@ -277,7 +277,7 @@ def commit_recording_message(recording: ProcessedEvent) -> None:
         emit_replay_events(
             recording.actions_event,
             recording.context["org_id"],
-            project,
+            recording.context["project_id"],
             recording.context["replay_id"],
             recording.context["retention_days"],
             recording.replay_event,
@@ -290,7 +290,7 @@ def commit_recording_message(recording: ProcessedEvent) -> None:
 def emit_replay_events(
     event_meta: ParsedEventMeta,
     org_id: int,
-    project: Project,
+    project_id: int,
     replay_id: str,
     retention_days: int,
     replay_event: dict[str, Any] | None,
@@ -299,7 +299,7 @@ def emit_replay_events(
 
     emit_click_events(
         event_meta.click_events,
-        project.id,
+        project_id,
         replay_id,
         retention_days,
         start_time=time.time(),
@@ -308,20 +308,20 @@ def emit_replay_events(
 
     emit_tap_events(
         event_meta.tap_events,
-        project.id,
+        project_id,
         replay_id,
         retention_days,
         start_time=time.time(),
         environment=environment,
     )
     emit_request_response_metrics(event_meta)
-    log_canvas_size(event_meta, org_id, project.id, replay_id)
-    log_mutation_events(event_meta, project.id, replay_id)
-    log_option_events(event_meta, project.id, replay_id)
-    log_multiclick_events(event_meta, project.id, replay_id)
-    log_rage_click_events(event_meta, project.id, replay_id)
-    report_hydration_error(event_meta, project, replay_id, replay_event)
-    report_rage_click(event_meta, project, replay_id, replay_event)
+    log_canvas_size(event_meta, org_id, project_id, replay_id)
+    log_mutation_events(event_meta, project_id, replay_id)
+    log_option_events(event_meta, project_id, replay_id)
+    log_multiclick_events(event_meta, project_id, replay_id)
+    log_rage_click_events(event_meta, project_id, replay_id)
+    report_hydration_error(event_meta, project_id, replay_id, replay_event)
+    report_rage_click(event_meta, project_id, replay_id, replay_event)
 
 
 def _track_initial_segment_event(

--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, TypedDict
 import sentry_sdk
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
-from sentry.models.project import Project
+from sentry.models.options.project_option import ProjectOption
 from sentry.replays.lib.eap.write import write_trace_items
 from sentry.replays.lib.kafka import publish_replay_event
 from sentry.replays.usecases.ingest.event_parser import ClickEvent, ParsedEventMeta, TapEvent
@@ -295,7 +295,7 @@ def log_rage_click_events(
 @sentry_sdk.trace
 def report_hydration_error(
     event_meta: ParsedEventMeta,
-    project: Project,
+    project_id: int,
     replay_id: str,
     replay_event: dict[str, Any] | None,
 ) -> None:
@@ -305,13 +305,13 @@ def report_hydration_error(
     if (
         len(event_meta.hydration_errors) == 0
         or not replay_event
-        or not _should_report_hydration_error_issue(project)
+        or not _should_report_hydration_error_issue(project_id)
     ):
         return None
 
     for error in event_meta.hydration_errors:
         report_hydration_error_issue_with_replay_event(
-            project.id,
+            project_id,
             replay_id,
             error.timestamp,
             error.url,
@@ -369,12 +369,12 @@ def gen_rage_clicks(
 @sentry_sdk.trace
 def report_rage_click(
     event_meta: ParsedEventMeta,
-    project: Project,
+    project_id: int,
     replay_id: str,
     replay_event: dict[str, Any] | None,
 ) -> None:
-    clicks = list(gen_rage_clicks(event_meta, project.id, replay_id, replay_event))
-    if len(clicks) == 0 or not _should_report_rage_click_issue(project):
+    clicks = list(gen_rage_clicks(event_meta, project_id, replay_id, replay_event))
+    if len(clicks) == 0 or not _should_report_rage_click_issue(project_id):
         return None
 
     metrics.incr("replay.rage_click_detected", amount=len(clicks))
@@ -398,19 +398,27 @@ def emit_trace_items_to_eap(trace_items: list[TraceItem]) -> None:
 
 
 @sentry_sdk.trace
-def _should_report_hydration_error_issue(project: Project) -> bool:
+def _should_report_hydration_error_issue(project_id: int) -> bool:
     """
     Checks the project option, controlled by a project owner.
     """
-    return project.get_option("sentry:replay_hydration_error_issues")
+    return ProjectOption.objects.get_value(
+        project_id,
+        "sentry:replay_hydration_error_issues",
+        default=False,
+    )
 
 
 @sentry_sdk.trace
-def _should_report_rage_click_issue(project: Project) -> bool:
+def _should_report_rage_click_issue(project_id: int) -> bool:
     """
     Checks the project option, controlled by a project owner.
     """
-    return project.get_option("sentry:replay_rage_click_issues")
+    return ProjectOption.objects.get_value(
+        project_id,
+        "sentry:replay_rage_click_issues",
+        default=False,
+    )
 
 
 def encode_as_uuid(message: str) -> str:

--- a/tests/sentry/replays/integration/test_ingest_options.py
+++ b/tests/sentry/replays/integration/test_ingest_options.py
@@ -1,4 +1,5 @@
 from sentry.models.options.project_option import ProjectOption
+from sentry.models.project import Project
 from sentry.replays.usecases.ingest.event_logger import (
     _should_report_hydration_error_issue,
     _should_report_rage_click_issue,
@@ -7,13 +8,13 @@ from sentry.testutils.pytest.fixtures import django_db_all
 
 
 @django_db_all
-def test_should_report_hydration_error_issue_no_value(default_project):
+def test_should_report_hydration_error_issue_no_value(default_project: Project) -> None:
     result = _should_report_hydration_error_issue(default_project.id)
     assert result is False
 
 
 @django_db_all
-def test_should_report_hydration_error_issue(default_project):
+def test_should_report_hydration_error_issue(default_project: Project) -> None:
     ProjectOption.objects.set_value(
         project=default_project, key="sentry:replay_hydration_error_issues", value=True
     )
@@ -23,28 +24,29 @@ def test_should_report_hydration_error_issue(default_project):
 
 
 @django_db_all
-def test_should_report_hydration_error_issue_no_project():
+def test_should_report_hydration_error_issue_no_project() -> None:
     result = _should_report_hydration_error_issue(210492104914)
     assert result is False
 
 
 @django_db_all
-def test_should_report_rage_click_issue_no_value(default_project):
+def test_should_report_rage_click_issue_no_value(default_project: Project) -> None:
     result = _should_report_rage_click_issue(default_project.id)
     assert result is False
 
 
 @django_db_all
-def test_should_report_rage_click_issue_no_project():
+def test_should_report_rage_click_issue_no_project() -> None:
     result = _should_report_rage_click_issue(210492104914)
     assert result is False
 
 
 @django_db_all
-def test_should_report_rage_click_issue(default_project):
+def test_should_report_rage_click_issue(default_project: Project) -> None:
     ProjectOption.objects.set_value(
         project=default_project, key="sentry:replay_rage_click_issues", value=True
     )
 
     result = _should_report_rage_click_issue(default_project.id)
+    assert result is True
     assert result is True

--- a/tests/sentry/replays/integration/test_ingest_options.py
+++ b/tests/sentry/replays/integration/test_ingest_options.py
@@ -1,0 +1,50 @@
+from sentry.models.options.project_option import ProjectOption
+from sentry.replays.usecases.ingest.event_logger import (
+    _should_report_hydration_error_issue,
+    _should_report_rage_click_issue,
+)
+from sentry.testutils.pytest.fixtures import django_db_all
+
+
+@django_db_all
+def test_should_report_hydration_error_issue_no_value(default_project):
+    result = _should_report_hydration_error_issue(default_project.id)
+    assert result is False
+
+
+@django_db_all
+def test_should_report_hydration_error_issue(default_project):
+    ProjectOption.objects.set_value(
+        project=default_project, key="sentry:replay_hydration_error_issues", value=True
+    )
+
+    result = _should_report_hydration_error_issue(default_project.id)
+    assert result is True
+
+
+@django_db_all
+def test_should_report_hydration_error_issue_no_project():
+    result = _should_report_hydration_error_issue(210492104914)
+    assert result is False
+
+
+@django_db_all
+def test_should_report_rage_click_issue_no_value(default_project):
+    result = _should_report_rage_click_issue(default_project.id)
+    assert result is False
+
+
+@django_db_all
+def test_should_report_rage_click_issue_no_project():
+    result = _should_report_rage_click_issue(210492104914)
+    assert result is False
+
+
+@django_db_all
+def test_should_report_rage_click_issue(default_project):
+    ProjectOption.objects.set_value(
+        project=default_project, key="sentry:replay_rage_click_issues", value=True
+    )
+
+    result = _should_report_rage_click_issue(default_project.id)
+    assert result is True


### PR DESCRIPTION
This is a preparatory pull request so we can eventually being caching these queries in a less memory intensive way.