### PR TITLE
feat(sub v3): Focus PAYG inline form on hash

### DIFF
--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -601,11 +601,25 @@ export function getProductIcon(product: AddOnCategory, size?: IconSize) {
   }
 }
 
+/**
+ * Returns true if the subscription can use pay-as-you-go.
+ */
+export function supportsPayg(subscription: Subscription) {
+  return subscription.planDetails.allowOnDemand && subscription.supportsOnDemand;
+}
+
+/**
+ * Returns true if the current user has billing perms.
+ */
+export function hasBillingAccess(organization: Organization) {
+  return organization.access.includes('org:billing');
+}
+
 export function hasAccessToSubscriptionOverview(
   subscription: Subscription,
   organization: Organization
 ) {
-  return organization.access.includes('org:billing') || subscription.canSelfServe;
+  return hasBillingAccess(organization) || subscription.canSelfServe;
 }
 
 /**

--- a/static/gsApp/views/onDemandBudgets/editOnDemandButton.tsx
+++ b/static/gsApp/views/onDemandBudgets/editOnDemandButton.tsx
@@ -1,14 +1,20 @@
 import {css} from '@emotion/react';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
 import {IconEdit} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Theme} from 'sentry/utils/theme';
 
 import type {Subscription} from 'getsentry/types';
-import {hasBillingAccess, hasNewBillingUI, supportsPayg} from 'getsentry/utils/billing';
+import {
+  displayBudgetName,
+  hasBillingAccess,
+  hasNewBillingUI,
+  supportsPayg,
+} from 'getsentry/utils/billing';
 import OnDemandBudgetEditModal from 'getsentry/views/onDemandBudgets/onDemandBudgetEditModal';
 
 interface EditOnDemandButtonProps {
@@ -40,7 +46,14 @@ export function openOnDemandBudgetEditModal({
         modalCss: theme && isNewBillingUI ? modalCss(theme) : undefined,
       }
     );
+    return;
   }
+
+  addErrorMessage(
+    tct("You don't have permission to edit [budgetTerm] budgets.", {
+      budgetTerm: displayBudgetName(subscription.planDetails),
+    })
+  );
 }
 
 export function EditOnDemandButton(props: EditOnDemandButtonProps) {

--- a/static/gsApp/views/onDemandBudgets/editOnDemandButton.tsx
+++ b/static/gsApp/views/onDemandBudgets/editOnDemandButton.tsx
@@ -8,7 +8,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {Theme} from 'sentry/utils/theme';
 
 import type {Subscription} from 'getsentry/types';
-import {hasNewBillingUI} from 'getsentry/utils/billing';
+import {hasBillingAccess, hasNewBillingUI, supportsPayg} from 'getsentry/utils/billing';
 import OnDemandBudgetEditModal from 'getsentry/views/onDemandBudgets/onDemandBudgetEditModal';
 
 interface EditOnDemandButtonProps {
@@ -23,20 +23,24 @@ export function openOnDemandBudgetEditModal({
   theme,
 }: EditOnDemandButtonProps) {
   const isNewBillingUI = hasNewBillingUI(organization);
+  const hasBillingPerms = hasBillingAccess(organization);
+  const canUsePayg = supportsPayg(subscription);
 
-  openModal(
-    modalProps => (
-      <OnDemandBudgetEditModal
-        {...modalProps}
-        subscription={subscription}
-        organization={organization}
-      />
-    ),
-    {
-      closeEvents: 'escape-key',
-      modalCss: theme && isNewBillingUI ? modalCss(theme) : undefined,
-    }
-  );
+  if (hasBillingPerms && canUsePayg) {
+    openModal(
+      modalProps => (
+        <OnDemandBudgetEditModal
+          {...modalProps}
+          subscription={subscription}
+          organization={organization}
+        />
+      ),
+      {
+        closeEvents: 'escape-key',
+        modalCss: theme && isNewBillingUI ? modalCss(theme) : undefined,
+      }
+    );
+  }
 }
 
 export function EditOnDemandButton(props: EditOnDemandButtonProps) {

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
@@ -17,7 +17,7 @@ import OnDemandBudgets from 'getsentry/views/onDemandBudgets';
 import OnDemandBudgetEdit from 'getsentry/views/onDemandBudgets/onDemandBudgetEdit';
 
 describe('OnDemandBudgets', () => {
-  const organization = OrganizationFixture();
+  const organization = OrganizationFixture({access: ['org:billing']});
 
   const getComponent = (
     props: Omit<React.ComponentProps<typeof OnDemandBudgets>, 'organization'>

--- a/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
@@ -3,7 +3,13 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import type {Organization} from 'sentry/types/organization';
 
 import type {Subscription} from 'getsentry/types';
-import {hasNewBillingUI, isDeveloperPlan, isTrialPlan} from 'getsentry/utils/billing';
+import {
+  hasBillingAccess,
+  hasNewBillingUI,
+  isDeveloperPlan,
+  isTrialPlan,
+  supportsPayg,
+} from 'getsentry/utils/billing';
 import BillingInfoCard from 'getsentry/views/subscriptionPage/headerCards/billingInfoCard';
 import LinksCard from 'getsentry/views/subscriptionPage/headerCards/linksCard';
 import NextBillCard from 'getsentry/views/subscriptionPage/headerCards/nextBillCard';
@@ -19,10 +25,11 @@ interface HeaderCardsProps {
 }
 
 function getCards(organization: Organization, subscription: Subscription) {
-  const hasBillingPerms = organization.access?.includes('org:billing');
+  const hasBillingPerms = hasBillingAccess(organization);
   const cards: React.ReactNode[] = [];
   const isTrialOrFreePlan =
     isTrialPlan(subscription.plan) || isDeveloperPlan(subscription.planDetails);
+  const canUsePayg = supportsPayg(subscription);
 
   if (subscription.canSelfServe && !isTrialOrFreePlan && hasBillingPerms) {
     cards.push(
@@ -34,10 +41,7 @@ function getCards(organization: Organization, subscription: Subscription) {
     );
   }
 
-  const canUpdatePayg =
-    subscription.planDetails.allowOnDemand &&
-    subscription.supportsOnDemand &&
-    hasBillingPerms;
+  const canUpdatePayg = canUsePayg && hasBillingPerms;
 
   if (canUpdatePayg) {
     cards.push(

--- a/static/gsApp/views/subscriptionPage/headerCards/paygCard.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/paygCard.spec.tsx
@@ -13,7 +13,10 @@ import {OnDemandBudgetMode} from 'getsentry/types';
 import PaygCard from 'getsentry/views/subscriptionPage/headerCards/paygCard';
 
 describe('PaygCard', () => {
-  const organization = OrganizationFixture({features: ['subscriptions-v3']});
+  const organization = OrganizationFixture({
+    features: ['subscriptions-v3'],
+    access: ['org:billing'],
+  });
 
   beforeEach(() => {
     setMockDate(new Date('2022-06-09'));

--- a/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
@@ -21,7 +21,7 @@ import {
   type OnDemandBudgets,
   type Subscription,
 } from 'getsentry/types';
-import {displayBudgetName, hasBillingAccess} from 'getsentry/utils/billing';
+import {displayBudgetName} from 'getsentry/utils/billing';
 import {displayPrice} from 'getsentry/views/amCheckout/utils';
 import {openOnDemandBudgetEditModal} from 'getsentry/views/onDemandBudgets/editOnDemandButton';
 import {
@@ -86,10 +86,7 @@ function PaygCard({
   const hasBudgetModes = subscription.planDetails.hasOnDemandModes;
 
   useEffect(() => {
-    if (
-      window.location.hash === '#open-ondemand-modal' &&
-      hasBillingAccess(organization)
-    ) {
+    if (window.location.hash === '#open-ondemand-modal') {
       if (hasBudgetModes) {
         openOnDemandBudgetEditModal({organization, subscription, theme});
       } else {

--- a/static/gsApp/views/subscriptionPage/headerCards/subscriptionHeaderCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/subscriptionHeaderCard.tsx
@@ -5,7 +5,7 @@ import {Heading, Text} from 'sentry/components/core/text';
 
 interface SubscriptionHeaderCardProps {
   sections: React.ReactNode[];
-  isFocused?: boolean;
+  isHighlighted?: boolean;
   isMainCard?: boolean;
   subtitle?: React.ReactNode;
   title?: React.ReactNode;
@@ -16,14 +16,14 @@ function SubscriptionHeaderCard({
   sections,
   isMainCard = false,
   subtitle,
-  isFocused = false,
+  isHighlighted = false,
 }: SubscriptionHeaderCardProps) {
   return (
     <Flex
       direction="column"
       padding="xl"
       background={isMainCard ? 'secondary' : 'primary'}
-      border={isFocused ? 'accent' : 'primary'}
+      border={isHighlighted ? 'accent' : 'primary'}
       radius="md"
       gap="lg"
     >

--- a/static/gsApp/views/subscriptionPage/headerCards/subscriptionHeaderCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/subscriptionHeaderCard.tsx
@@ -5,6 +5,7 @@ import {Heading, Text} from 'sentry/components/core/text';
 
 interface SubscriptionHeaderCardProps {
   sections: React.ReactNode[];
+  isFocused?: boolean;
   isMainCard?: boolean;
   subtitle?: React.ReactNode;
   title?: React.ReactNode;
@@ -15,13 +16,14 @@ function SubscriptionHeaderCard({
   sections,
   isMainCard = false,
   subtitle,
+  isFocused = false,
 }: SubscriptionHeaderCardProps) {
   return (
     <Flex
       direction="column"
       padding="xl"
       background={isMainCard ? 'secondary' : 'primary'}
-      border="primary"
+      border={isFocused ? 'accent' : 'primary'}
       radius="md"
       gap="lg"
     >

--- a/static/gsApp/views/subscriptionPage/onDemandSettings.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/onDemandSettings.spec.tsx
@@ -17,6 +17,7 @@ import {OnDemandSettings} from './onDemandSettings';
 describe('edit on-demand budget', () => {
   const organization = OrganizationFixture({
     features: ['ondemand-budgets'],
+    access: ['org:billing'],
   });
   const onDemandOrg = OrganizationFixture({
     features: ['ondemand-budgets'],

--- a/static/gsApp/views/subscriptionPage/overview.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.tsx
@@ -27,11 +27,7 @@ import type {
   Subscription,
 } from 'getsentry/types';
 import {PlanTier} from 'getsentry/types';
-import {
-  hasAccessToSubscriptionOverview,
-  hasBillingAccess,
-  hasNewBillingUI,
-} from 'getsentry/utils/billing';
+import {hasAccessToSubscriptionOverview, hasNewBillingUI} from 'getsentry/utils/billing';
 import {
   getCategoryInfoFromPlural,
   isPartOfReservedBudget,
@@ -135,13 +131,9 @@ function Overview({location, subscription, promotionData}: Props) {
       openCodecovModal({organization});
     }
 
-    // Open on-demand budget modal if hash fragment present and user has billing access
-    if (
-      window.location.hash === '#open-ondemand-modal' &&
-      subscription.supportsOnDemand &&
-      hasBillingAccess(organization) &&
-      !isNewBillingUI
-    ) {
+    // Open on-demand budget modal if hash fragment present
+    // Modal logic handles checking perms
+    if (window.location.hash === '#open-ondemand-modal' && !isNewBillingUI) {
       openOnDemandBudgetEditModal({organization, subscription});
 
       // Clear hash to prevent modal reopening on refresh

--- a/static/gsApp/views/subscriptionPage/overview.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.tsx
@@ -27,7 +27,11 @@ import type {
   Subscription,
 } from 'getsentry/types';
 import {PlanTier} from 'getsentry/types';
-import {hasAccessToSubscriptionOverview, hasNewBillingUI} from 'getsentry/utils/billing';
+import {
+  hasAccessToSubscriptionOverview,
+  hasBillingAccess,
+  hasNewBillingUI,
+} from 'getsentry/utils/billing';
 import {
   getCategoryInfoFromPlural,
   isPartOfReservedBudget,
@@ -131,11 +135,12 @@ function Overview({location, subscription, promotionData}: Props) {
       openCodecovModal({organization});
     }
 
-    // Open on-demand budget modal if hash fragment present and user has access
+    // Open on-demand budget modal if hash fragment present and user has billing access
     if (
       window.location.hash === '#open-ondemand-modal' &&
       subscription.supportsOnDemand &&
-      hasAccessToSubscriptionOverview(subscription, organization)
+      hasBillingAccess(organization) &&
+      !isNewBillingUI
     ) {
       openOnDemandBudgetEditModal({organization, subscription});
 
@@ -146,7 +151,15 @@ function Overview({location, subscription, promotionData}: Props) {
         window.location.pathname + window.location.search
       );
     }
-  }, [organization, location.query, subscription, promotionData, api, navigate]);
+  }, [
+    organization,
+    location.query,
+    subscription,
+    promotionData,
+    api,
+    navigate,
+    isNewBillingUI,
+  ]);
 
   // Sales managed accounts do not allow members to view the billing page.
   // Whilst self-serve accounts do.

--- a/static/gsApp/views/subscriptionPage/usageOverview.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview.tsx
@@ -56,7 +56,6 @@ import {
   getPotentialProductTrial,
   getReservedBudgetCategoryForAddOn,
   MILLISECONDS_IN_HOUR,
-  supportsPayg,
 } from 'getsentry/utils/billing';
 import {
   getCategoryInfoFromPlural,
@@ -336,7 +335,7 @@ function UsageOverviewTable({subscription, organization, usageData}: UsageOvervi
             category
           );
 
-          const isPaygOnly = reserved === 0 && supportsPayg(subscription);
+          const isPaygOnly = reserved === 0 && subscription.supportsOnDemand;
           const hasAccess = activeProductTrial
             ? true
             : isPaygOnly

--- a/static/gsApp/views/subscriptionPage/usageOverview.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview.tsx
@@ -56,6 +56,7 @@ import {
   getPotentialProductTrial,
   getReservedBudgetCategoryForAddOn,
   MILLISECONDS_IN_HOUR,
+  supportsPayg,
 } from 'getsentry/utils/billing';
 import {
   getCategoryInfoFromPlural,
@@ -335,7 +336,7 @@ function UsageOverviewTable({subscription, organization, usageData}: UsageOvervi
             category
           );
 
-          const isPaygOnly = reserved === 0 && subscription.supportsOnDemand;
+          const isPaygOnly = reserved === 0 && supportsPayg(subscription);
           const hasAccess = activeProductTrial
             ? true
             : isPaygOnly


### PR DESCRIPTION
Currently, when `open-ondemand-modal` is in the hash for the current URL, we open the PAYG edit modal:
<img width="1029" height="1072" alt="Screenshot 2025-10-16 at 2 52 30 PM" src="https://github.com/user-attachments/assets/908bcc96-1a63-4972-b677-ef403c216a97" />

Now for plans without budget modes (errors-only legacy and modern plans), we highlight the inline form:
<img width="445" height="183" alt="Screenshot 2025-10-16 at 3 00 45 PM" src="https://github.com/user-attachments/assets/cc4c2075-647b-4e35-bbf9-8e7a2c6906fa" />
<img width="330" height="175" alt="Screenshot 2025-10-16 at 3 00 31 PM" src="https://github.com/user-attachments/assets/f2737765-8d26-49a4-8b96-dcc4cf96001d" />
