### PR TITLE
chore(llm-detector): Use option instead of flag for allow list

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -621,8 +621,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:profiling-ingest-unsampled-profiles", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     manager.add("projects:project-detail-apple-app-hang-rate", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enabled LLM Issue Detection
-    manager.add("projects:llm-issue-detection", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # fmt: on
 
     # Partner oauth

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3556,3 +3556,11 @@ register(
     default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Allow list for projects with LLM issue detection enabled
+register(
+    "issue-detection.llm-detection.projects-allowlist",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
updating to use an option to store the list of projects we want to test on rather than a feature flag. should make finding the projects easier, rather than iterating through projects and looking for the ones with the flag. 