### PR TITLE
chore(launchpad): add org id to vcs log

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -127,7 +127,10 @@ def create_preprod_status_check_task(preprod_artifact_id: int) -> None:
     if check_id is None:
         logger.error(
             "preprod.status_checks.create.failed",
-            extra={"artifact_id": preprod_artifact.id},
+            extra={
+                "artifact_id": preprod_artifact.id,
+                "organization_id": preprod_artifact.project.organization_id,
+            },
         )
         return
 
@@ -137,6 +140,7 @@ def create_preprod_status_check_task(preprod_artifact_id: int) -> None:
             "artifact_id": preprod_artifact.id,
             "status": status.value,
             "check_id": check_id,
+            "organization_id": preprod_artifact.project.organization_id,
         },
     )
 


### PR DESCRIPTION
add org id to preprod logs

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
