### PR TITLE
feat(explorer): add navigation URLs for trace waterfall and span details tools

### DIFF
--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -47,6 +47,13 @@ const TOOL_FORMATTERS: Record<string, ToolFormatter> = {
       ? `Viewing waterfall for trace ${id.slice(0, 8)}...`
       : `Viewed waterfall for trace ${id.slice(0, 8)}`;
   },
+
+  get_span_details: (args, isLoading) => {
+    const spanId = args.span_id || '';
+    return isLoading
+      ? `Digging into span ${spanId.slice(0, 8)}...`
+      : `Dug into span ${spanId.slice(0, 8)}`;
+  },
 };
 
 /**
@@ -131,6 +138,44 @@ export function buildToolLinkUrl(
       return {
         pathname: `/organizations/${orgSlug}/traces/`,
         query: queryParams,
+      };
+    }
+    case 'get_trace_waterfall': {
+      const {trace_id, timestamp} = toolLink.params;
+      if (!trace_id) {
+        return null;
+      }
+
+      const pathname = `/explore/traces/trace/${trace_id}/`;
+      const query: Record<string, string> = {};
+
+      if (timestamp) {
+        query.timestamp = timestamp;
+      }
+
+      return {
+        pathname,
+        query,
+      };
+    }
+    case 'get_span_details': {
+      const {trace_id, span_id, timestamp} = toolLink.params;
+      if (!trace_id || !span_id) {
+        return null;
+      }
+
+      const pathname = `/explore/traces/trace/${trace_id}/`;
+      const query: Record<string, string> = {
+        node: `span-${span_id}`,
+      };
+
+      if (timestamp) {
+        query.timestamp = timestamp;
+      }
+
+      return {
+        pathname,
+        query,
       };
     }
     default:


### PR DESCRIPTION
Forms URLs for navigation based on the metadata for these tools, being captured in https://github.com/getsentry/seer/pull/3672