### PR TITLE
fix(spans-migrations): parsing, nonetype and index errors from dashboards migration

### DIFF
--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -248,7 +248,10 @@ def translate_columns(columns, need_equation=False):
     """
     translated_columns = []
 
-    for column in columns:
+    # need to drop columns after they have been translated to avoid issues with percentile()
+    final_columns, dropped_columns = drop_unsupported_columns(columns)
+
+    for column in final_columns:
         match = fields.is_function(column)
 
         if not match:
@@ -272,10 +275,7 @@ def translate_columns(columns, need_equation=False):
         new_function = add_equation_prefix_if_needed(f"{raw_function}({new_arg})", need_equation)
         translated_columns.append(new_function)
 
-    # need to drop columns after they have been translated to avoid issues with percentile()
-    final_columns, dropped_columns = drop_unsupported_columns(translated_columns)
-
-    return final_columns, dropped_columns
+    return translated_columns, dropped_columns
 
 
 def translate_equations(equations):

--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -301,6 +301,11 @@ def translate_equations(equations):
         else:
             arithmetic_equation = equation
 
+        # case where equation is empty, don't try to parse it
+        if arithmetic_equation == "":
+            translated_equations.append(equation)
+            continue
+
         # function to flatten the parsed + updated equation
         def _flatten(seq):
             for item in seq:

--- a/src/sentry/explore/translation/dashboards_translation.py
+++ b/src/sentry/explore/translation/dashboards_translation.py
@@ -23,7 +23,8 @@ def snapshot_widget(widget: DashboardWidget):
     ):
 
         serialized_widget = serialize(widget)
-        serialized_widget["dateCreated"] = serialized_widget["dateCreated"].timestamp()
+        if serialized_widget and serialized_widget["dateCreated"]:
+            serialized_widget["dateCreated"] = serialized_widget["dateCreated"].timestamp()
         widget.widget_snapshot = serialized_widget
         widget.save()
 

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -237,8 +237,8 @@ def test_mep_to_eap_simple_selected_columns(
             [],
         ),
         pytest.param(
-            ["equation|(sum(transaction.duration) + 5) + count_miserable(user,300)"],
-            [],
+            ["equation|(sum(transaction.duration) + 5) + count_miserable(user,300)", "equation|"],
+            ["equation|"],
             [
                 {
                     "equation": "equation|(sum(transaction.duration) + 5) + count_miserable(user,300)",

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -145,7 +145,7 @@ def test_mep_to_eap_simple_query(input: str, expected: str) -> None:
         pytest.param(
             ["any(transaction.duration)", "count_miserable(user,300)", "transaction", "count()"],
             ["transaction", "count(span.duration)"],
-            ["any(span.duration)", "count_miserable(user,300)"],
+            ["any(transaction.duration)", "count_miserable(user,300)"],
         ),
         pytest.param(
             ["platform.name", "count()"],
@@ -346,7 +346,7 @@ def test_mep_to_eap_simple_equations(
                 },
                 {
                     "orderby": "any(transaction.duration)",
-                    "reason": ["any(span.duration)"],
+                    "reason": ["any(transaction.duration)"],
                 },
             ],
         ),

--- a/tests/sentry/explore/translation/test_dashboards_translation.py
+++ b/tests/sentry/explore/translation/test_dashboards_translation.py
@@ -590,6 +590,7 @@ class DashboardTranslationTestCase(TestCase):
 
         new_query = new_queries.first()
 
+        assert new_query is not None
         assert new_query.fields == ["transaction"]
         assert new_query.conditions == "(transaction:*whatsapp*) AND is_transaction:1"
         assert new_query.aggregates == []

--- a/tests/sentry/explore/translation/test_dashboards_translation.py
+++ b/tests/sentry/explore/translation/test_dashboards_translation.py
@@ -547,6 +547,54 @@ class DashboardTranslationTestCase(TestCase):
 
         assert not DashboardWidgetQuery.objects.filter(id=query.id).exists()
 
+    def test_widget_with_translatable_dropped_fields(self) -> None:
+        transaction_widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=0,
+            title="transaction widget",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=DashboardWidgetTypes.TRANSACTION_LIKE,
+            interval="1d",
+            detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+        )
+
+        DashboardWidgetQuery.objects.create(
+            widget=transaction_widget,
+            # any(transaction.duration) has transaction.duration that could be translated to span.duration but shouldn't
+            fields=["transaction", "any(transaction.duration)"],
+            columns=["transaction"],
+            field_aliases=[""],
+            aggregates=["any(transaction.duration)"],
+            conditions="title:*whatsapp*",
+            orderby="-transaction",
+            order=0,
+        )
+
+        translate_dashboard_widget(transaction_widget)
+        transaction_widget.refresh_from_db()
+
+        assert transaction_widget.widget_snapshot
+        assert transaction_widget.changed_reason is not None
+        assert isinstance(transaction_widget.changed_reason, list)
+        assert len(transaction_widget.changed_reason) == 1
+        dropped_fields = transaction_widget.changed_reason[0]
+        assert "any(transaction.duration)" in dropped_fields["selected_columns"]
+        assert dropped_fields["equations"] == []
+        assert len(dropped_fields["orderby"]) == 0
+
+        snapshot_queries = transaction_widget.widget_snapshot["queries"]
+        assert len(snapshot_queries) == 1
+
+        new_queries = DashboardWidgetQuery.objects.filter(widget=transaction_widget)
+        assert new_queries.count() == 1
+
+        new_query = new_queries.first()
+
+        assert new_query.fields == ["transaction"]
+        assert new_query.conditions == "(transaction:*whatsapp*) AND is_transaction:1"
+        assert new_query.aggregates == []
+        assert new_query.columns == ["transaction"]
+
 
 class DashboardRestoreTransactionWidgetTestCase(TestCase):
     @property

--- a/tests/sentry/explore/translation/test_discover_translation.py
+++ b/tests/sentry/explore/translation/test_discover_translation.py
@@ -197,6 +197,7 @@ class DiscoverToExploreTranslationTest(TestCase):
                 "apdex()",
                 "count_miserable(users)",
                 "max(measurements.cls)",
+                "any(transaction.duration)",
             ],
             "orderby": "-count_miserable_users",
             "display": "top5",
@@ -214,6 +215,7 @@ class DiscoverToExploreTranslationTest(TestCase):
         assert new_explore_query.changed_reason["columns"] == [
             "total.count",
             "count_miserable(users)",
+            "any(transaction.duration)",
         ]
         assert new_explore_query.changed_reason["equations"] == []
         assert new_explore_query.changed_reason["orderby"] == [


### PR DESCRIPTION
We had a few types of errors come up during the dashboards migration. Here is an example of each type:
[SENTRY-5AQP](https://sentry.sentry.io/issues/6947094951/)
[SENTRY-5AQN](https://sentry.sentry.io/issues/6947094947/)
[SENTRY-5AQW](https://sentry.sentry.io/issues/6947380535/)

this creates failsafes for these errors as well as fixes an issue we had with the translation layer that was causing the index error (and probably propagating to the nonetype error)
