### PR TITLE
fix(aci): Make validator clean up partial Detector state, not send_new_detector_data

### DIFF
--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -226,7 +226,14 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
         detector = super().create(validated_data)
 
         if detector.config.get("detection_type") == AlertRuleDetectionType.DYNAMIC.value:
-            send_new_detector_data(detector)
+            try:
+                send_new_detector_data(detector)
+            except Exception:
+                # Sending historical data failed; Detector won't be save, but we
+                # need to clean up database state that has already been created.
+                detector.workflow_condition_group.delete()
+
+                raise
 
         schedule_update_project_config(detector)
         return detector

--- a/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
+++ b/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
@@ -41,6 +41,9 @@ seer_anomaly_detection_connection_pool = connection_from_url(
 
 
 def send_new_detector_data(detector: Detector) -> None:
+    """
+    Send historical data for a new Detector to Seer.
+    """
     # XXX: it is technically possible (though not used today) that a detector could have multiple data sources
     data_source_detector = DataSourceDetector.objects.filter(detector_id=detector.id).first()
     if not data_source_detector:
@@ -78,12 +81,8 @@ def send_new_detector_data(detector: Detector) -> None:
             detector, data_source, data_condition, snuba_query, detector.project, SeerMethod.CREATE
         )
     except (TimeoutError, MaxRetryError, ParseError, ValidationError):
-        data_condition_group = data_condition.condition_group
-        data_condition.delete()
-        data_condition_group.delete()
         raise ValidationError("Couldn't send data to Seer, unable to create detector")
-    else:
-        metrics.incr("anomaly_detection_monitor.created")
+    metrics.incr("anomaly_detection_monitor.created")
 
 
 def handle_send_historical_data_to_seer(


### PR DESCRIPTION
The code for populating Seer shouldn't be handling validator cleanup, and it doing so makes it hard
to use in other contexts (like a getsentry job we need to run).

Existing tests already cover the clean-up logic.
