### PR TITLE
ref(content-blocks): Convert bun and cordova

### DIFF
--- a/static/app/gettingStartedDocs/bun/bun.tsx
+++ b/static/app/gettingStartedDocs/bun/bun.tsx
@@ -19,13 +19,6 @@ import {getNodeLogsOnboarding} from 'sentry/utils/gettingStartedDocs/node';
 
 type Params = DocsParams;
 
-const getInstallConfig = () => [
-  {
-    language: 'bash',
-    code: 'bun add @sentry/bun',
-  },
-];
-
 const getConfigureSnippet = (params: Params) => `
 //...
 import * as Sentry from "@sentry/bun";
@@ -56,20 +49,33 @@ const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: t(
-        "Sentry captures data by using an SDK within your application's runtime."
-      ),
-      configurations: getInstallConfig(),
+      content: [
+        {
+          type: 'text',
+          text: t(
+            "Sentry captures data by using an SDK within your application's runtime."
+          ),
+        },
+        {
+          type: 'code',
+          language: 'bash',
+          code: 'bun add @sentry/bun',
+        },
+      ],
     },
   ],
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        "Initialize Sentry as early as possible in your application's lifecycle."
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: t(
+            "Initialize Sentry as early as possible in your application's lifecycle."
+          ),
+        },
+        {
+          type: 'code',
           language: 'javascript',
           code: getConfigureSnippet(params),
         },
@@ -79,11 +85,15 @@ const onboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: t(
+            "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+          ),
+        },
+        {
+          type: 'code',
           language: 'javascript',
           code: getVerifySnippet(),
         },

--- a/static/app/gettingStartedDocs/cordova/cordova.tsx
+++ b/static/app/gettingStartedDocs/cordova/cordova.tsx
@@ -1,5 +1,3 @@
-import {Fragment} from 'react';
-
 import {ExternalLink} from 'sentry/components/core/link';
 import type {
   Docs,
@@ -26,9 +24,13 @@ const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: t('Install our SDK using the cordova command:'),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: t('Install our SDK using the cordova command:'),
+        },
+        {
+          type: 'code',
           language: 'bash',
           code: 'cordova plugin add sentry-cordova',
         },
@@ -38,17 +40,21 @@ const onboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        'You should [code:init] the SDK in the [code:deviceReady] function, to make sure the native integrations runs. For more details about Cordova [link:click here]',
+      content: [
         {
-          code: <code />,
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/cordova/" />
+          type: 'text',
+          text: tct(
+            'You should [code:init] the SDK in the [code:deviceReady] function, to make sure the native integrations runs. For more details about Cordova [link:click here]',
+            {
+              code: <code />,
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/cordova/" />
+              ),
+            }
           ),
-        }
-      ),
-      configurations: [
+        },
         {
+          type: 'code',
           language: 'javascript',
           code: getConfigureSnippet(params),
         },
@@ -58,16 +64,15 @@ const onboarding: OnboardingConfig = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: (
-        <Fragment>
-          {t(
-            'One way to verify your setup is by intentionally causing an error that breaks your application.'
-          )}
-          <p>{t('Calling an undefined function will throw an exception:')}</p>
-        </Fragment>
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: t(
+            'Test your Sentry configuration by intentionally triggering an error, such as calling an undefined function:'
+          ),
+        },
+        {
+          type: 'code',
           language: 'javascript',
           code: 'myUndefinedFunction();',
         },


### PR DESCRIPTION
- part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)