### PR TITLE
feat(tracemetrics): Add cross-querying constraints to sample table 

### DIFF
--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -22,7 +22,10 @@ export type SamplingMode = (typeof SAMPLING_MODE)[keyof typeof SAMPLING_MODE];
 export type SpansRPCQueryExtras = {
   caseInsensitive?: CaseInsensitive;
   disableAggregateExtrapolation?: string;
+  logQueries?: string[];
+  metricQueries?: string[];
   samplingMode?: SamplingMode;
+  spanQueries?: string[];
 };
 
 interface ProgressiveQueryOptions<TQueryFn extends (...args: any[]) => any> {

--- a/static/app/views/explore/metrics/metricInfoTabs/samplesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/samplesTab.tsx
@@ -59,6 +59,7 @@ export function SamplesTab({metricName}: SamplesTabProps) {
 
   const spanQueries = useMemo(() => [new MutableSearch('has:span.description')], []);
   const logQueries = useMemo(() => [new MutableSearch('has:message')], []);
+  const metricQueries = useMemo(() => [new MutableSearch('has:value')], []);
 
   const options = {
     enabled: Boolean(metricName),
@@ -76,6 +77,7 @@ export function SamplesTab({metricName}: SamplesTabProps) {
     ...options,
     spanQueries,
     logQueries,
+    metricQueries,
   });
 
   const {
@@ -84,6 +86,7 @@ export function SamplesTab({metricName}: SamplesTabProps) {
     fields: anyFields,
   } = useMetricSamplesTable({
     ...options,
+    metricQueries,
   });
 
   const shouldUseCrossQuery = crossQueryResult.data?.length && !crossQueryResult.isError;

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -114,6 +114,7 @@ function useSpansQueryBase<T>({
     disableAggregateExtrapolation: queryExtras?.disableAggregateExtrapolation,
     spanQueries: queryExtras?.spanQueries,
     logQueries: queryExtras?.logQueries,
+    metricQueries: queryExtras?.metricQueries,
   });
 
   if (trackResponseAnalytics) {

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -112,6 +112,8 @@ function useSpansQueryBase<T>({
     caseInsensitive: queryExtras?.caseInsensitive,
     samplingMode: queryExtras?.samplingMode,
     disableAggregateExtrapolation: queryExtras?.disableAggregateExtrapolation,
+    spanQueries: queryExtras?.spanQueries,
+    logQueries: queryExtras?.logQueries,
   });
 
   if (trackResponseAnalytics) {
@@ -239,10 +241,13 @@ type WrappedDiscoverQueryProps<T> = {
   initialData?: T;
   keepPreviousData?: boolean;
   limit?: number;
+  logQueries?: string[];
+  metricQueries?: string[];
   noPagination?: boolean;
   referrer?: string;
   refetchInterval?: number;
   samplingMode?: SamplingMode;
+  spanQueries?: string[];
 };
 
 function useWrappedDiscoverQueryBase<T>({
@@ -256,6 +261,9 @@ function useWrappedDiscoverQueryBase<T>({
   noPagination,
   allowAggregateConditions,
   disableAggregateExtrapolation,
+  logQueries,
+  metricQueries,
+  spanQueries,
   samplingMode,
   pageFiltersReady,
   additionalQueryKey,
@@ -267,7 +275,7 @@ function useWrappedDiscoverQueryBase<T>({
   const location = useLocation();
   const organization = useOrganization();
 
-  const queryExtras: Record<string, string> = {};
+  const queryExtras: Record<string, string | string[]> = {};
   if (eventView.dataset === DiscoverDatasets.SPANS) {
     if (samplingMode) {
       queryExtras.sampling = samplingMode;
@@ -280,6 +288,18 @@ function useWrappedDiscoverQueryBase<T>({
     if (disableAggregateExtrapolation) {
       queryExtras.disableAggregateExtrapolation = '1';
     }
+  }
+
+  if (logQueries) {
+    queryExtras.logQueries = logQueries;
+  }
+
+  if (metricQueries) {
+    queryExtras.metricQueries = metricQueries;
+  }
+
+  if (spanQueries) {
+    queryExtras.spanQueries = spanQueries;
   }
 
   if (allowAggregateConditions !== undefined) {


### PR DESCRIPTION
This makes a second query (we can eventually switch the 'enabled' to only query one at once) with cross-query constraints
