### PR TITLE
feat(notif-platform): Onboard data export emails into the notification platform

### DIFF
--- a/src/sentry/data_export/models.py
+++ b/src/sentry/data_export/models.py
@@ -22,6 +22,13 @@ from sentry.db.models import (
 )
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.models.files.file import File
+from sentry.notifications.platform.service import NotificationService
+from sentry.notifications.platform.target import GenericNotificationTarget
+from sentry.notifications.platform.templates.data_export import DataExportFailure, DataExportSuccess
+from sentry.notifications.platform.types import (
+    NotificationProviderKey,
+    NotificationTargetResourceType,
+)
 from sentry.users.services.user.service import user_service
 
 from .base import DEFAULT_EXPIRATION, ExportQueryType, ExportStatus
@@ -108,14 +115,32 @@ class ExportedData(Model):
         url = self.organization.absolute_url(
             reverse("sentry-data-export-details", args=[self.organization.slug, self.id])
         )
-        msg = MessageBuilder(
-            subject="Your data is ready.",
-            context={"url": url, "expiration": self.format_date(self.date_expired)},
-            type="organization.export-data",
-            template="sentry/emails/data-export-success.txt",
-            html_template="sentry/emails/data-export-success.html",
+
+        if not user_email:
+            return
+
+        data = DataExportSuccess(
+            export_url=url,
+            expiration_date=self.date_expired,
         )
-        if user_email is not None:
+        if NotificationService.has_access(self.organization, data.source):
+            NotificationService(data=data).notify(
+                targets=[
+                    GenericNotificationTarget(
+                        provider_key=NotificationProviderKey.EMAIL,
+                        resource_type=NotificationTargetResourceType.EMAIL,
+                        resource_id=user_email,
+                    )
+                ]
+            )
+        else:
+            msg = MessageBuilder(
+                subject="Your data is ready.",
+                context={"url": url, "expiration": self.format_date(self.date_expired)},
+                type="organization.export-data",
+                template="sentry/emails/data-export-success.txt",
+                html_template="sentry/emails/data-export-success.html",
+            )
             msg.send_async([user_email])
 
     def email_failure(self, message: str) -> None:
@@ -124,21 +149,38 @@ class ExportedData(Model):
         if self.user_id is None:
             return
         user = user_service.get_user(user_id=self.user_id)
-        if user is None:
+        if user is None or not user.email:
             return
 
-        msg = MessageBuilder(
-            subject="We couldn't export your data.",
-            context={
-                "creation": self.format_date(self.date_added),
-                "error_message": message,
-                "payload": orjson.dumps(self.payload).decode(),
-            },
-            type="organization.export-data",
-            template="sentry/emails/data-export-failure.txt",
-            html_template="sentry/emails/data-export-failure.html",
+        data = DataExportFailure(
+            error_message=message,
+            error_payload=self.payload,
+            creation_date=self.date_added,
         )
-        msg.send_async([user.email])
+        if NotificationService.has_access(self.organization, data.source):
+            NotificationService(data=data).notify(
+                targets=[
+                    GenericNotificationTarget(
+                        provider_key=NotificationProviderKey.EMAIL,
+                        resource_type=NotificationTargetResourceType.EMAIL,
+                        resource_id=user.email,
+                    )
+                ]
+            )
+
+        else:
+            msg = MessageBuilder(
+                subject="We couldn't export your data.",
+                context={
+                    "creation": self.format_date(self.date_added),
+                    "error_message": message,
+                    "payload": orjson.dumps(self.payload).decode(),
+                },
+                type="organization.export-data",
+                template="sentry/emails/data-export-failure.txt",
+                html_template="sentry/emails/data-export-failure.html",
+            )
+            msg.send_async([user.email])
         self.delete()
 
     def _get_file(self) -> File | None:

--- a/src/sentry/notifications/apps.py
+++ b/src/sentry/notifications/apps.py
@@ -6,6 +6,7 @@ class Config(AppConfig):
 
     def ready(self) -> None:
         import sentry.notifications.platform.sample  # NOQA
+        import sentry.notifications.platform.templates  # NOQA
 
         # Register the NotificationProviders for the platform
         from sentry.notifications.platform.discord.provider import (  # NOQA

--- a/src/sentry/notifications/platform/templates/__init__.py
+++ b/src/sentry/notifications/platform/templates/__init__.py
@@ -1,0 +1,6 @@
+from .data_export import DataExportFailureTemplate, DataExportSuccessTemplate
+
+__all__ = (
+    "DataExportSuccessTemplate",
+    "DataExportFailureTemplate",
+)

--- a/src/sentry/notifications/platform/templates/data_export.py
+++ b/src/sentry/notifications/platform/templates/data_export.py
@@ -1,0 +1,86 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import orjson
+from django.utils import timezone
+
+from sentry.notifications.platform.registry import template_registry
+from sentry.notifications.platform.types import (
+    NotificationCategory,
+    NotificationData,
+    NotificationRenderedAction,
+    NotificationRenderedTemplate,
+    NotificationTemplate,
+)
+
+
+def format_date(date: datetime) -> str:
+    return date.strftime("%I:%M %p on %B %d, %Y (%Z)")
+
+
+@dataclass(frozen=True)
+class DataExportSuccess(NotificationData):
+    source = "data-export-success"
+    export_url: str
+    expiration_date: datetime
+
+
+@template_registry.register(DataExportSuccess.source)
+class DataExportSuccessTemplate(NotificationTemplate[DataExportSuccess]):
+    category = NotificationCategory.DATA_EXPORT
+    example_data = DataExportSuccess(
+        export_url="https://example.com/export",
+        expiration_date=timezone.now(),
+    )
+
+    def render(self, data: DataExportSuccess) -> NotificationRenderedTemplate:
+        return NotificationRenderedTemplate(
+            subject="Your data is ready.",
+            body=(
+                "See, that wasn't so bad. We're all done assembling your download. Now have at it."
+            ),
+            actions=[
+                NotificationRenderedAction(label="Take Me There", link=data.export_url),
+            ],
+            footer=f"This download file expires at {format_date(data.expiration_date)}. So don't get attached.",
+        )
+
+
+@dataclass(frozen=True)
+class DataExportFailure(NotificationData):
+    source = "data-export-failure"
+    error_message: str
+    error_payload: dict[str, Any]
+    creation_date: datetime
+
+
+@template_registry.register(DataExportFailure.source)
+class DataExportFailureTemplate(NotificationTemplate[DataExportFailure]):
+    category = NotificationCategory.DATA_EXPORT
+    example_data = DataExportFailure(
+        error_message="An error occurred while exporting your data.",
+        error_payload={
+            "export_type": "Issues-by-Tag",
+            "project": [1234567890],
+            "key": "user",
+        },
+        creation_date=timezone.now(),
+    )
+
+    def render(self, data: DataExportFailure) -> NotificationRenderedTemplate:
+        return NotificationRenderedTemplate(
+            subject="We couldn't export your data.",
+            body=(
+                f"Well, this is a little awkward. The data export you created at {format_date(data.creation_date)} didn't work. Sorry about that."
+                f"It looks like there was an error: {data.error_message}."
+                f"The error payload is: {data.error_payload}."
+                f"This is what you sent us. Maybe it'll help you sort this out: {orjson.dumps(data.error_payload).decode()}."
+            ),
+            actions=[
+                NotificationRenderedAction(label="Documentation", link="https://docs.sentry.io/"),
+                NotificationRenderedAction(
+                    label="Help Center", link="https://sentry.zendesk.com/hc/en-us"
+                ),
+            ],
+        )

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -17,6 +17,7 @@ class NotificationCategory(StrEnum):
 
     # TODO(ecosystem): Connect this to NotificationSettingEnum
     DEBUG = "debug"
+    DATA_EXPORT = "data-export"
 
     def get_sources(self) -> list[str]:
         return NOTIFICATION_SOURCE_MAP[self]
@@ -30,6 +31,10 @@ NOTIFICATION_SOURCE_MAP = {
         "slow-load-metric-alert",
         "performance-monitoring",
         "team-communication",
+    ],
+    NotificationCategory.DATA_EXPORT: [
+        "data-export-success",
+        "data-export-failure",
     ],
 }
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2994,6 +2994,16 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Notification Options - Start
+# Options for migrating to the notification platform
+register(
+    "notifications.platform-rate.data-export",
+    type=Float,
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Notification Options - End
+
 # List of organizations with increased rate limits for organization_events API
 register(
     "api.organization_events.rate-limit-increased.orgs",


### PR DESCRIPTION
 I think this should be an E2E onboarding of the data export notifications.

Some things I noted:
- We should use a `templates/` directory as I've done here. We need the `@template_registry` decorators to populate the registry and devs shouldn't have to think about how their modules will be initialized. It's not perfect since a dev will still have to modify `__init__.py` but it works
- We should probably modify `body` to be a list of rendered blocks in different paragraphs, maybe even with styles. This will allow line breaks in the middle of the message. I noted this for the data-export-error notification which has many blocks get jumbled when rendered inline and without styles :(


https://github.com/user-attachments/assets/a12e8a67-cfa3-41c3-b330-4b0ea7908eef


<img width="666" height="201" alt="image (1)" src="https://github.com/user-attachments/assets/f48c92c5-2b8a-40d0-b7c1-694f2878723d" />
<img width="1450" height="572" alt="image (2)" src="https://github.com/user-attachments/assets/2e561d73-92be-47f4-ae15-78a94e49f9b8" />

