### PR TITLE
feat(explorer): More obvious actions

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.spec.tsx
+++ b/static/app/views/seerExplorer/blockComponents.spec.tsx
@@ -75,11 +75,11 @@ describe('BlockComponent', () => {
 
     it('calls onClick when response block is clicked', async () => {
       const block = createResponseBlock();
-      render(<BlockComponent block={block} blockIndex={0} onClick={mockOnClick} />);
-
-      await userEvent.click(
-        screen.getByText('This error indicates a null pointer exception.')
+      const {container} = render(
+        <BlockComponent block={block} blockIndex={0} onClick={mockOnClick} />
       );
+      const blockElement = container.firstChild;
+      await userEvent.click(blockElement as HTMLElement);
       expect(mockOnClick).toHaveBeenCalledTimes(1);
     });
   });

--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -54,6 +54,8 @@ function BlockComponent({
   const hasTools = toolsUsed.length > 0;
   const hasContent = hasValidContent(block.message.content);
 
+  const [isHovered, setIsHovered] = useState(false);
+
   // State to track selected tool link (for navigation)
   const [selectedLinkIndex, setSelectedLinkIndex] = useState(0);
   const selectedLinkIndexRef = useRef(selectedLinkIndex);
@@ -174,8 +176,16 @@ function BlockComponent({
     }
   };
 
+  const showActions = (isFocused || isHovered) && !block.loading;
+
   return (
-    <Block ref={ref} isLast={isLast} onClick={onClick}>
+    <Block
+      ref={ref}
+      isLast={isLast}
+      onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
       <AnimatePresence>
         <motion.div
           initial={{opacity: 0, y: 10}}
@@ -216,32 +226,41 @@ function BlockComponent({
             </BlockRow>
           )}
           {isFocused && <FocusIndicator />}
-          {isFocused && !block.loading && (
-            <ActionButtonBar gap="sm">
-              <Button size="xs" priority="default" onClick={handleDeleteClick}>
-                Rethink from here ⌫
-              </Button>
-              {hasValidLinks && (
-                <ButtonBar merged gap="0">
-                  {validToolLinks.map((_, idx) => (
-                    <Button
-                      key={idx}
-                      size="xs"
-                      priority={idx === selectedLinkIndex ? 'primary' : 'default'}
-                      onClick={e => handleNavigateClick(e, idx)}
-                    >
-                      {idx === 0
-                        ? validToolLinks.length === 1
-                          ? 'Navigate'
-                          : 'Navigate #1'
-                        : `#${idx + 1}`}
-                      {idx === selectedLinkIndex && ' ⏎'}
-                    </Button>
-                  ))}
-                </ButtonBar>
-              )}
-            </ActionButtonBar>
-          )}
+          <AnimatePresence>
+            {showActions && (
+              <motion.div
+                initial={{opacity: 0, y: 5}}
+                animate={{opacity: 1, y: 0}}
+                exit={{opacity: 0, y: 5}}
+                transition={{duration: 0.1}}
+              >
+                <ActionButtonBar gap="sm">
+                  <Button size="xs" priority="default" onClick={handleDeleteClick}>
+                    Rethink from here ⌫
+                  </Button>
+                  {hasValidLinks && (
+                    <ButtonBar merged gap="0">
+                      {validToolLinks.map((_, idx) => (
+                        <Button
+                          key={idx}
+                          size="xs"
+                          priority={idx === selectedLinkIndex ? 'primary' : 'default'}
+                          onClick={e => handleNavigateClick(e, idx)}
+                        >
+                          {idx === 0
+                            ? validToolLinks.length === 1
+                              ? 'Navigate'
+                              : 'Navigate #1'
+                            : `#${idx + 1}`}
+                          {idx === selectedLinkIndex && ' ⏎'}
+                        </Button>
+                      ))}
+                    </ButtonBar>
+                  )}
+                </ActionButtonBar>
+              </motion.div>
+            )}
+          </AnimatePresence>
         </motion.div>
       </AnimatePresence>
     </Block>

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -178,6 +178,7 @@ function ExplorerPanel({isVisible = false}: ExplorerPanelProps) {
       isOpen={isVisible}
       isMinimized={isMinimized}
       panelSize={panelSize}
+      onUnminimize={() => setIsMinimized(false)}
     >
       <BlocksContainer ref={scrollContainerRef} onClick={handlePanelBackgroundClick}>
         {blocks.length === 0 ? (

--- a/static/app/views/seerExplorer/panelContainers.tsx
+++ b/static/app/views/seerExplorer/panelContainers.tsx
@@ -154,6 +154,7 @@ const MinimizedOverlay = styled(motion.div)`
   justify-content: center;
   padding-top: ${p => p.theme.space.lg};
   border-radius: ${p => p.theme.borderRadius};
+  border: 1px solid ${p => p.theme.border};
   z-index: 1;
   cursor: pointer;
 

--- a/static/app/views/seerExplorer/panelContainers.tsx
+++ b/static/app/views/seerExplorer/panelContainers.tsx
@@ -2,15 +2,19 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 
-import {space} from 'sentry/styles/space';
+import {Flex} from '@sentry/scraps/layout';
 
-import type {PanelSize} from './types';
+import {Text} from 'sentry/components/core/text';
+import {IconSeer} from 'sentry/icons';
+import {space} from 'sentry/styles/space';
+import type {PanelSize} from 'sentry/views/seerExplorer/types';
 
 interface PanelContainersProps {
   children: React.ReactNode;
   isMinimized: boolean;
   isOpen: boolean;
   panelSize: PanelSize;
+  onUnminimize?: () => void;
   ref?: React.Ref<HTMLDivElement>;
 }
 
@@ -19,6 +23,7 @@ function PanelContainers({
   isMinimized,
   panelSize,
   children,
+  onUnminimize,
   ref,
 }: PanelContainersProps) {
   return (
@@ -55,6 +60,22 @@ function PanelContainers({
           >
             <PanelContent ref={ref} data-seer-explorer-root="">
               {children}
+              {isMinimized && (
+                <MinimizedOverlay
+                  initial={{opacity: 0}}
+                  animate={{opacity: 1}}
+                  exit={{opacity: 0}}
+                  transition={{duration: 0.2}}
+                  onClick={onUnminimize}
+                >
+                  <Flex direction="column" align="center" gap="lg">
+                    <IconSeer variant="waiting" size="lg" color="purple400" />
+                    <Text variant="muted">
+                      Press Tab ⇥ or click to continue with Seer
+                    </Text>
+                  </Flex>
+                </MinimizedOverlay>
+              )}
             </PanelContent>
           </PanelContainer>
         </Fragment>
@@ -119,4 +140,34 @@ export const BlocksContainer = styled('div')`
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+`;
+
+const MinimizedOverlay = styled(motion.div)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: ${p => p.theme.background};
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: ${p => p.theme.space.lg};
+  border-radius: ${p => p.theme.borderRadius};
+  z-index: 1;
+  cursor: pointer;
+
+  /* Purple tint */
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: ${p => p.theme.purple200};
+    border-radius: inherit;
+    z-index: -1;
+    pointer-events: none;
+  }
 `;


### PR DESCRIPTION
- show action buttons on hover and add a little animation to them
- make it more obvious when the panel is minimized and how to get it back (see screenshot)

<img width="946" height="315" alt="Screenshot 2025-10-16 at 2 16 05 PM" src="https://github.com/user-attachments/assets/1546f18d-a7d9-44fb-af4a-9ed63f86a726" />
