### PR TITLE
storybook: show import paths

### DIFF
--- a/static/app/components/charts/chartWidgetLoader.stories.tsx
+++ b/static/app/components/charts/chartWidgetLoader.stories.tsx
@@ -1,11 +1,11 @@
 import {Fragment} from 'react';
-import types from '!!type-loader!sentry/components/charts/chartWidgetLoader';
+import documentation from '!!type-loader!sentry/components/charts/chartWidgetLoader';
 
 import {CodeBlock} from 'sentry/components/core/code';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('ChartWidgetLoader', (story, APIReference) => {
-  APIReference(types.ChartWidgetLoader);
+  APIReference(documentation.props.ChartWidgetLoader);
 
   story('Getting Started', () => {
     return (

--- a/static/app/components/core/alert/alert.mdx
+++ b/static/app/components/core/alert/alert.mdx
@@ -19,11 +19,9 @@ import {Flex} from 'sentry/components/core/layout';
 import {IconAdd, IconDelete, IconEdit, IconMail} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 
-import APIReference from '!!type-loader!sentry/components/core/alert';
+import APIReference from '!!type-loader!@sentry/scraps/alert';
 
-export const types = {Alert: APIReference.Alert};
-
-<Storybook.ModuleExports exports={types} />
+export const types = APIReference;
 
 To create a basic alert, wrap your message in an `<Alert>` component and specify the appropriate type.
 

--- a/static/app/components/core/alert/alert.mdx
+++ b/static/app/components/core/alert/alert.mdx
@@ -19,9 +19,11 @@ import {Flex} from 'sentry/components/core/layout';
 import {IconAdd, IconDelete, IconEdit, IconMail} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 
-import APIReference from '!!type-loader!sentry/components/core/alert/index';
+import APIReference from '!!type-loader!sentry/components/core/alert';
 
 export const types = {Alert: APIReference.Alert};
+
+<Storybook.ModuleExports exports={types} />
 
 To create a basic alert, wrap your message in an `<Alert>` component and specify the appropriate type.
 

--- a/static/app/components/core/alert/alert.mdx
+++ b/static/app/components/core/alert/alert.mdx
@@ -19,9 +19,9 @@ import {Flex} from 'sentry/components/core/layout';
 import {IconAdd, IconDelete, IconEdit, IconMail} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 
-import APIReference from '!!type-loader!@sentry/scraps/alert';
+import documentation from '!!type-loader!@sentry/scraps/alert';
 
-export const types = APIReference;
+export {documentation};
 
 To create a basic alert, wrap your message in an `<Alert>` component and specify the appropriate type.
 

--- a/static/app/components/core/alert/index.tsx
+++ b/static/app/components/core/alert/index.tsx
@@ -1,2 +1,6 @@
+import {Alert} from './alert';
+
 export {Alert, type AlertProps} from './alert';
 export {AlertLink} from './alertLink';
+
+export default Alert;

--- a/static/app/components/core/alert/index.tsx
+++ b/static/app/components/core/alert/index.tsx
@@ -1,6 +1,2 @@
-import {Alert} from './alert';
-
 export {Alert, type AlertProps} from './alert';
 export {AlertLink} from './alertLink';
-
-export default Alert;

--- a/static/app/components/core/avatar/index.mdx
+++ b/static/app/components/core/avatar/index.mdx
@@ -22,13 +22,22 @@ import {SentryAppAvatar} from './sentryAppAvatar';
 import {TeamAvatar} from './teamAvatar';
 import {UserAvatar} from './userAvatar';
 
-import ProjectAvatarAPIReference from '!!type-loader!sentry/components/core/avatar/projectAvatar';
-import UserAvatarAPIReference from '!!type-loader!sentry/components/core/avatar/userAvatar';
+import ProjectAvatarDocumentation from '!!type-loader!@sentry/scraps/avatar/projectAvatar';
+import UserAvatarDocumentation from '!!type-loader!@sentry/scraps/avatar/userAvatar';
 
-export const types = {
-  UserAvatar: UserAvatarAPIReference.UserAvatar,
-  ProjectAvatar: ProjectAvatarAPIReference.ProjectAvatar,
+export const documentation = {
+  ...UserAvatarDocumentation,
+  ...ProjectAvatarDocumentation,
+  props: {
+    UserAvatar: UserAvatarDocumentation.props.UserAvatar,
+    ProjectAvatar: ProjectAvatarDocumentation.props.ProjectAvatar,
+  },
+  exports: {
+    ...UserAvatarDocumentation.exports,
+    ...ProjectAvatarDocumentation.exports,
+  },
 };
+
 export const PREVIEW_SIZE = 40;
 
 export const USER = {

--- a/static/app/components/core/avatar/index.mdx
+++ b/static/app/components/core/avatar/index.mdx
@@ -29,12 +29,12 @@ export const documentation = {
   ...UserAvatarDocumentation,
   ...ProjectAvatarDocumentation,
   props: {
-    UserAvatar: UserAvatarDocumentation.props.UserAvatar,
-    ProjectAvatar: ProjectAvatarDocumentation.props.ProjectAvatar,
+    ...ProjectAvatarDocumentation.props,
+    ...UserAvatarDocumentation.props,
   },
   exports: {
-    ...UserAvatarDocumentation.exports,
     ...ProjectAvatarDocumentation.exports,
+    ...UserAvatarDocumentation.exports,
   },
 };
 

--- a/static/app/components/core/badge/badge.mdx
+++ b/static/app/components/core/badge/badge.mdx
@@ -19,10 +19,10 @@ import {IconCheckmark, IconCircle, IconRefresh, IconWarning} from 'sentry/icons'
 import * as Storybook from 'sentry/stories';
 import {IncidentStatus} from 'sentry/views/alerts/types';
 
-import BadgeAPIReference from '!!type-loader!sentry/components/core/badge/index';
-import TagAPIReference from '!!type-loader!sentry/components/core/badge/tag';
+import BadgeDocumentation from '!!type-loader!@sentry/scraps/badge/index';
+import TagDocumentation from '!!type-loader!@sentry/scraps/badge/tag';
 
-export const types = {Badge: BadgeAPIReference.Badge, Tag: TagAPIReference.Tag};
+export const documentation = {Badge: BadgeDocumentation.Badge, Tag: TagDocumentation.Tag};
 
 Badges are a contextual highlighted text components that support specific use cases like `FeatureBadge`, `AlertBadge`, and `DeployBadge`.
 

--- a/static/app/components/core/button/button.mdx
+++ b/static/app/components/core/button/button.mdx
@@ -33,9 +33,16 @@ import {
 } from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 
-import APIReference from '!!type-loader!sentry/components/core/button/index';
+import ButtonDocumentation from '!!type-loader!@sentry/scraps/button/index';
 
-export const types = {Button: APIReference.Button};
+export const documentation = {
+  // We are going to omit some exports like StyledButton and ButtonLabel, because we
+  // don't want to encourage their usage.
+  ...ButtonDocumentation,
+  props: {
+    Button: ButtonDocumentation.props.Button,
+  },
+};
 
 To create a basic button, wrap text in a `<Button>` and pass an `onClick` callback.
 

--- a/static/app/components/core/button/button.mdx
+++ b/static/app/components/core/button/button.mdx
@@ -33,14 +33,22 @@ import {
 } from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 
-import ButtonDocumentation from '!!type-loader!@sentry/scraps/button/index';
+import ButtonDocumentation from '!!type-loader!@sentry/scraps/button';
 
 export const documentation = {
-  // We are going to omit some exports like StyledButton and ButtonLabel, because we
-  // don't want to encourage their usage.
-  ...ButtonDocumentation,
+  exports: {
+    module: ButtonDocumentation.exports.module,
+    exports: {
+      // Button has some exports that we don't want to document, strip them out until they are removed
+      ...Object.fromEntries(
+        Object.entries(ButtonDocumentation.exports.exports).filter(
+          ([key]) => key !== 'StyledButton' && key !== 'ButtonBar'
+        )
+      ),
+    },
+  },
   props: {
-    Button: ButtonDocumentation.props.Button,
+    ...ButtonDocumentation.props,
   },
 };
 

--- a/static/app/components/core/button/buttonBar.stories.tsx
+++ b/static/app/components/core/button/buttonBar.stories.tsx
@@ -1,12 +1,12 @@
 import {Fragment, useState} from 'react';
-import types from '!!type-loader!sentry/components/core/button/buttonBar';
+import documentation from '!!type-loader!sentry/components/core/button/buttonBar';
 
 import {Button, type ButtonProps} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('ButtonBar', (story, APIReference) => {
-  APIReference(types.ButtonBar);
+  APIReference(documentation.props.ButtonBar);
 
   story('Default', () => {
     const [active, setActive] = useState('One');

--- a/static/app/components/core/button/linkButton.mdx
+++ b/static/app/components/core/button/linkButton.mdx
@@ -33,9 +33,9 @@ import {
 } from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 
-import APIReference from '!!type-loader!sentry/components/core/button/linkButton';
+import documentation from '!!type-loader!@sentry/scraps/button/linkButton';
 
-export const types = {LinkButton: APIReference.LinkButton};
+export {documentation};
 
 LinkButtons combine the visual appearance of buttons with navigation functionality. Use LinkButton when you need to navigate to a different URL or route while maintaining consistent button styling.
 

--- a/static/app/components/core/checkbox/checkbox.mdx
+++ b/static/app/components/core/checkbox/checkbox.mdx
@@ -16,9 +16,9 @@ import {Checkbox} from 'sentry/components/core/checkbox';
 import {Stack} from 'sentry/components/core/layout';
 import * as Storybook from 'sentry/stories';
 
-import APIReference from '!!type-loader!sentry/components/core/checkbox';
+import documentation from '!!type-loader!@sentry/scraps/checkbox';
 
-export const types = {Checkbox: APIReference.Checkbox};
+export {documentation};
 
 Checkboxes are form controls that allow users to select one or more options from a set. They represent a binary choice and can be in one of three states: unchecked, checked, or indeterminate.
 

--- a/static/app/components/core/code/codeBlock.mdx
+++ b/static/app/components/core/code/codeBlock.mdx
@@ -16,9 +16,9 @@ import {CodeBlock} from 'sentry/components/core/code';
 import {IconStar} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 
-import types from '!!type-loader!sentry/components/core/code/codeBlock';
+import documentation from '!!type-loader!@sentry/scraps/code/codeBlock';
 
-export {types};
+export {documentation};
 
 export const sampleJavaScript = `Sentry.init({
   // Note, Replay is NOT instantiated below:

--- a/static/app/components/core/code/inlineCode.mdx
+++ b/static/app/components/core/code/inlineCode.mdx
@@ -15,9 +15,9 @@ import {Text} from 'sentry/components/core/text';
 import {Prose} from 'sentry/components/core/text/prose';
 import * as Storybook from 'sentry/stories';
 
-import types from '!!type-loader!sentry/components/core/code/inlineCode';
+import documentation from '!!type-loader!@sentry/scraps/code/inlineCode';
 
-export {types};
+export {documentation};
 
 The `<InlineCode>` component is designed for displaying short code snippets inline with text, such as variable names, function calls, or brief commands. It provides consistent monospace typography and subtle visual styling that distinguishes code from regular text.
 

--- a/static/app/components/core/disclosure/disclosure.mdx
+++ b/static/app/components/core/disclosure/disclosure.mdx
@@ -24,9 +24,9 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 
 import * as Storybook from 'sentry/stories';
 
-import types from '!!type-loader!sentry/components/core/disclosure/disclosure';
+import documentation from '!!type-loader!@sentry/scraps/disclosure/disclosure';
 
-export {types};
+export {documentation};
 
 To create a disclosure, wrap content in a `<Disclosure>` component.
 

--- a/static/app/components/core/image/image.mdx
+++ b/static/app/components/core/image/image.mdx
@@ -14,9 +14,9 @@ import image from 'sentry-images/spot/habitsSuccessfulCustomer.jpg';
 
 import {Image} from './image';
 
-import APIReference from '!!type-loader!sentry/components/core/image/image';
+import documentation from '!!type-loader!@sentry/scraps/image/image';
 
-export const types = {Image: APIReference.Image};
+export {documentation};
 
 The `Image` component is a styled wrapper around the HTML `<img>` element that provides sensible defaults for lazy loading and object-fit behavior. It extends all standard HTML image attributes while adding additional functionality for modern web applications.
 

--- a/static/app/components/core/input/input.stories.tsx
+++ b/static/app/components/core/input/input.stories.tsx
@@ -1,5 +1,5 @@
 import {Fragment, useState} from 'react';
-import types from '!!type-loader!sentry/components/core/input';
+import documentation from '!!type-loader!sentry/components/core/input';
 import styled from '@emotion/styled';
 
 import {Input} from 'sentry/components/core/input';
@@ -8,7 +8,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('Input', (story, APIReference) => {
-  APIReference(types.Input);
+  APIReference(documentation.props.Input);
 
   story('Sizes', () => {
     return (

--- a/static/app/components/core/input/inputGroup.stories.tsx
+++ b/static/app/components/core/input/inputGroup.stories.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import types from '!!type-loader!sentry/components/core/input/inputGroup';
+import documentation from '!!type-loader!sentry/components/core/input/inputGroup';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
@@ -10,7 +10,7 @@ import {space} from 'sentry/styles/space';
 import {InputGroup} from './inputGroup';
 
 export default Storybook.story('InputGroup', (story, APIReference) => {
-  APIReference(types.InputGroup);
+  APIReference(documentation.props.InputGroup);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/input/numberDragInput.stories.tsx
+++ b/static/app/components/core/input/numberDragInput.stories.tsx
@@ -1,12 +1,12 @@
 import {Fragment, useState} from 'react';
-import types from '!!type-loader!sentry/components/core/input/numberDragInput';
+import documentation from '!!type-loader!sentry/components/core/input/numberDragInput';
 import styled from '@emotion/styled';
 
 import {NumberDragInput} from 'sentry/components/core/input/numberDragInput';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('NumberDragInput', (story, APIReference) => {
-  APIReference(types.NumberDragInput);
+  APIReference(documentation.props.NumberDragInput);
 
   story('Default', () => {
     const [horizontalValue, setHorizontalValue] = useState(10);

--- a/static/app/components/core/input/numberInput.stories.tsx
+++ b/static/app/components/core/input/numberInput.stories.tsx
@@ -1,12 +1,12 @@
 import {Fragment} from 'react';
-import types from '!!type-loader!sentry/components/core/input/numberInput';
+import documentation from '!!type-loader!sentry/components/core/input/numberInput';
 
 import * as Storybook from 'sentry/stories';
 
 import {NumberInput} from './numberInput';
 
 export default Storybook.story('NumberInput', (story, APIReference) => {
-  APIReference(types.NumberInput);
+  APIReference(documentation.props.NumberInput);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/layout/container.mdx
+++ b/static/app/components/core/layout/container.mdx
@@ -9,9 +9,9 @@ resources:
 import {Container, Flex} from 'sentry/components/core/layout';
 import * as Storybook from 'sentry/stories';
 
-import APIReference from '!!type-loader!sentry/components/core/layout/container';
+import documentation from '!!type-loader!@sentry/scraps/layout/container';
 
-export const types = {Container: APIReference.Container};
+export {documentation};
 
 The `Container` component is a foundational layout component that extends HTML elements with responsive CSS properties through props. It serves as the building block for other layout components like `Flex` and `Grid` to provides a consistent API for spacing, sizing, positioning, and styling.
 

--- a/static/app/components/core/layout/flex.mdx
+++ b/static/app/components/core/layout/flex.mdx
@@ -9,9 +9,9 @@ resources:
 import {Container, Flex} from 'sentry/components/core/layout';
 import * as Storybook from 'sentry/stories';
 
-import APIReference from '!!type-loader!sentry/components/core/layout/flex';
+import documentation from '!!type-loader!@sentry/scraps/layout/flex';
 
-export const types = {Flex: APIReference.Flex};
+export {documentation};
 
 The `Flex` component is a layout component that extends the `Container` component with CSS flexbox properties. It combines the powerful spacing, sizing, and styling capabilities of `Container` with flexible positioning and alignment controls.
 

--- a/static/app/components/core/layout/flex.mdx
+++ b/static/app/components/core/layout/flex.mdx
@@ -13,6 +13,12 @@ import documentation from '!!type-loader!@sentry/scraps/layout/flex';
 
 export {documentation};
 
+export function LogDocumentation(props) {
+  console.log(props.documentation);
+}
+
+<LogDocumentation documentation={documentation} />
+
 The `Flex` component is a layout component that extends the `Container` component with CSS flexbox properties. It combines the powerful spacing, sizing, and styling capabilities of `Container` with flexible positioning and alignment controls.
 
 ## Basic Usage

--- a/static/app/components/core/layout/flex.mdx
+++ b/static/app/components/core/layout/flex.mdx
@@ -13,12 +13,6 @@ import documentation from '!!type-loader!@sentry/scraps/layout/flex';
 
 export {documentation};
 
-export function LogDocumentation(props) {
-  console.log(props.documentation);
-}
-
-<LogDocumentation documentation={documentation} />
-
 The `Flex` component is a layout component that extends the `Container` component with CSS flexbox properties. It combines the powerful spacing, sizing, and styling capabilities of `Container` with flexible positioning and alignment controls.
 
 ## Basic Usage

--- a/static/app/components/core/layout/grid.mdx
+++ b/static/app/components/core/layout/grid.mdx
@@ -9,9 +9,9 @@ resources:
 import {Container, Grid} from 'sentry/components/core/layout';
 import * as Storybook from 'sentry/stories';
 
-import APIReference from '!!type-loader!sentry/components/core/layout/grid';
+import documentation from '!!type-loader!@sentry/scraps/layout/grid';
 
-export const types = {Grid: APIReference.Grid};
+export {documentation};
 
 export function CustomComponent(props) {
   return <div {...props} />;

--- a/static/app/components/core/layout/stack.mdx
+++ b/static/app/components/core/layout/stack.mdx
@@ -9,9 +9,9 @@ resources:
 import {Container, Stack} from 'sentry/components/core/layout';
 import * as Storybook from 'sentry/stories';
 
-import APIReference from '!!type-loader!sentry/components/core/layout/stack';
+import documentation from '!!type-loader!@sentry/scraps/layout/stack';
 
-export const types = {Stack: APIReference.Stack};
+export {documentation};
 
 export function CustomComponent(props) {
   return <div {...props} />;

--- a/static/app/components/core/menuListItem/menuListItem.stories.tsx
+++ b/static/app/components/core/menuListItem/menuListItem.stories.tsx
@@ -1,4 +1,4 @@
-import types from '!!type-loader!sentry/components/core/menuListItem';
+import documentation from '!!type-loader!sentry/components/core/menuListItem';
 import styled from '@emotion/styled';
 
 import {MenuListItem} from 'sentry/components/core/menuListItem/index';
@@ -6,7 +6,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('MenuListItem', (story, APIReference) => {
-  APIReference(types.MenuListItem);
+  APIReference(documentation.props.MenuListItem);
 
   story('focused', () => {
     return <SizeVariants isFocused />;

--- a/static/app/components/core/radio/radio.stories.tsx
+++ b/static/app/components/core/radio/radio.stories.tsx
@@ -1,5 +1,5 @@
 import {Fragment, useState} from 'react';
-import types from '!!type-loader!sentry/components/core/radio';
+import documentation from '!!type-loader!sentry/components/core/radio';
 import styled from '@emotion/styled';
 
 import {Radio, type RadioProps} from 'sentry/components/core/radio';
@@ -7,7 +7,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('Radio', (story, APIReference) => {
-  APIReference(types.Radio);
+  APIReference(documentation.props.Radio);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/select/select.stories.tsx
+++ b/static/app/components/core/select/select.stories.tsx
@@ -1,12 +1,12 @@
 import {Fragment} from 'react';
-import types from '!!type-loader!sentry/components/core/select';
+import documentation from '!!type-loader!sentry/components/core/select';
 
 import {Select} from 'sentry/components/core/select';
 import {IconGraphBar} from 'sentry/icons/iconGraphBar';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('Select', (story, APIReference) => {
-  APIReference(types.Select);
+  APIReference(documentation.props.Select);
 
   story('Sizes', () => {
     return (

--- a/static/app/components/core/separator/separator.mdx
+++ b/static/app/components/core/separator/separator.mdx
@@ -11,9 +11,9 @@ import {Separator} from 'sentry/components/core/separator';
 import {Text} from 'sentry/components/core/text';
 import * as Storybook from 'sentry/stories';
 
-import APIReference from '!!type-loader!sentry/components/core/separator';
+import documentation from '!!type-loader!@sentry/scraps/separator';
 
-export const types = {Separator: APIReference.Separator};
+export {documentation};
 
 The `Separator` component creates visual divisions between content areas. It renders as an HTML `<hr>` element with flexible styling options and supports both horizontal and vertical orientations.
 

--- a/static/app/components/core/slider/slider.stories.tsx
+++ b/static/app/components/core/slider/slider.stories.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useState} from 'react';
 // We can't seem to load types from sentry/components/core/slider/index
 // for unclear reasons.
-import types from '!!type-loader!sentry/components/core/slider/slider.chonk';
+import documentation from '!!type-loader!sentry/components/core/slider/slider.chonk';
 import styled from '@emotion/styled';
 
 import {Slider} from 'sentry/components/core/slider';
@@ -9,7 +9,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('Slider', (story, APIReference) => {
-  APIReference(types.Slider);
+  APIReference(documentation.props.Slider);
   story('Default', () => {
     return (
       <Fragment>

--- a/static/app/components/core/switch/switch.stories.tsx
+++ b/static/app/components/core/switch/switch.stories.tsx
@@ -1,5 +1,5 @@
 import {Fragment, useState} from 'react';
-import types from '!!type-loader!sentry/components/core/switch';
+import documentation from '!!type-loader!sentry/components/core/switch';
 import styled from '@emotion/styled';
 
 import {Switch, type SwitchProps} from 'sentry/components/core/switch';
@@ -7,7 +7,7 @@ import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
 export default Storybook.story('Switch', (story, APIReference) => {
-  APIReference(types.Switch);
+  APIReference(documentation.props.Switch);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/text/heading.mdx
+++ b/static/app/components/core/text/heading.mdx
@@ -18,9 +18,9 @@ import {Container} from 'sentry/components/core/layout';
 import {Heading} from 'sentry/components/core/text';
 import * as Storybook from 'sentry/stories';
 
-import types from '!!type-loader!sentry/components/core/text/heading';
+import documentation from '!!type-loader!@sentry/scraps/text/heading';
 
-export {types};
+export {documentation};
 
 The `<Heading>` component creates semantic heading elements with appropriate default sizes and styling. It ensures proper heading hierarchy while providing visual consistency.
 

--- a/static/app/components/core/text/prose.mdx
+++ b/static/app/components/core/text/prose.mdx
@@ -15,9 +15,9 @@ import {Heading, Text} from 'sentry/components/core/text';
 import {Prose} from 'sentry/components/core/text/prose';
 import * as Storybook from 'sentry/stories';
 
-import types from '!!type-loader!sentry/components/core/text/prose';
+import documentation from '!!type-loader!@sentry/scraps/text/prose';
 
-export {types};
+export {documentation};
 
 The `<Prose>` component provides consistent vertical spacing and typography for rich text content. It automatically applies proper spacing between prose elements like headings, paragraphs, lists, tables, and blockquotes.
 

--- a/static/app/components/core/text/text.mdx
+++ b/static/app/components/core/text/text.mdx
@@ -16,9 +16,9 @@ import {Container, Flex, Stack} from 'sentry/components/core/layout';
 import {Heading, Text} from 'sentry/components/core/text';
 import * as Storybook from 'sentry/stories';
 
-import types from '!!type-loader!sentry/components/core/text/text';
+import documentation from '!!type-loader!@sentry/scraps/text/text';
 
-export {types};
+export {documentation};
 
 To create basic text, wrap content in a `<Text>` component. For semantic headings, use `<Heading>` with the appropriate `as` prop.
 

--- a/static/app/components/core/toast/toast.stories.tsx
+++ b/static/app/components/core/toast/toast.stories.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import types from '!!type-loader!sentry/components/core/toast';
+import documentation from '!!type-loader!sentry/components/core/toast';
 
 import {Toast, type ToastProps} from 'sentry/components/core/toast';
 import * as Storybook from 'sentry/stories';
@@ -19,7 +19,7 @@ function makeToastProps(type: 'success' | 'error' | 'loading' | 'undo'): ToastPr
   };
 }
 export default Storybook.story('Toast', (story, APIReference) => {
-  APIReference(types.Toast);
+  APIReference(documentation.props.Toast);
 
   story('Toast types', () => {
     return (

--- a/static/app/components/core/tooltip/tooltip.mdx
+++ b/static/app/components/core/tooltip/tooltip.mdx
@@ -16,9 +16,9 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
-import types from '!!type-loader!sentry/components/core/tooltip/index';
+import documentation from '!!type-loader!@sentry/scraps/tooltip/index';
 
-export {types};
+export {documentation};
 
 To create a basic tooltip, wrap any element with `<Tooltip>` and provide the `title` prop with the content to display.
 

--- a/static/app/components/dropdownMenu/index.stories.tsx
+++ b/static/app/components/dropdownMenu/index.stories.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import types from '!!type-loader!sentry/components/dropdownMenu';
+import documentation from '!!type-loader!sentry/components/dropdownMenu';
 
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
@@ -8,7 +8,7 @@ import {IconCopy, IconDelete, IconDownload, IconEdit} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('DropdownMenu', (story, APIReference) => {
-  APIReference(types.DropdownMenu);
+  APIReference(documentation.props.DropdownMenu);
 
   story('Default', () => {
     const items: MenuItemProps[] = [

--- a/static/app/stories/apiReference.tsx
+++ b/static/app/stories/apiReference.tsx
@@ -12,16 +12,16 @@ import * as Storybook from 'sentry/stories';
 import {fzf} from 'sentry/utils/profiling/fzf/fzf';
 
 interface APIReferenceProps {
-  types: TypeLoader.ComponentDocWithFilename | undefined;
+  componentProps: TypeLoader.ComponentDocWithFilename | undefined;
 }
 
 export function APIReference(props: APIReferenceProps) {
   const [query, setQuery] = useState('');
-  const nodes = usePropTree(props.types?.props ?? {}, query);
+  const nodes = usePropTree(props.componentProps?.props ?? {}, query);
 
   return (
     <Storybook.Section>
-      {props.types?.description && <p>{props.types.description}</p>}
+      {props.componentProps?.description && <p>{props.componentProps.description}</p>}
       <StoryTypesSearchContainer>
         <InputGroup>
           <InputGroup.LeadingItems disablePointerEvents>

--- a/static/app/stories/index.tsx
+++ b/static/app/stories/index.tsx
@@ -1,9 +1,10 @@
+export {APIReference} from './apiReference';
+export {Demo} from './demo';
 export {JSXNode, JSXProperty} from './jsx';
+export {ModuleExports} from './moduleExports';
 export {PropMatrix} from './props';
 export {Section} from './layout';
 export {SideBySide} from './layout';
 export {SizingWindow, Grid} from './layout';
-export {Demo} from './demo';
 export {story} from './storybook';
 export {ThemeSwitcher, ThemeToggle} from './theme';
-export {APIReference} from './apiReference';

--- a/static/app/stories/moduleExports.tsx
+++ b/static/app/stories/moduleExports.tsx
@@ -8,6 +8,25 @@ import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 export function ModuleExports(props: {
   exports: Record<string, TypeLoader.ComponentDocWithFilename>;
 }) {
+  const entries = Object.entries(props.exports);
+  if (entries.length === 0) return '';
+  // Assume all exports are from a single module, just take the first one's value.module
+  const modulePath = entries[0]?.[1]?.module;
+  const defaultExport = entries.find(([_key, value]) => value?.displayName === 'default');
+  const namedExports = entries.filter(
+    ([_key, value]) => value?.displayName !== 'default'
+  );
+
+  const lines = [];
+  if (defaultExport) {
+    const [key] = defaultExport;
+    lines.push(`import ${key} from '${modulePath}';`);
+  }
+  if (namedExports.length > 0) {
+    const namedList = namedExports.map(([_, value]) => value.displayName).join(', ');
+    lines.push(`import {${namedList}} from '${modulePath}';`);
+  }
+
   return (
     <Fragment>
       <Heading as="h3" size="lg">
@@ -16,11 +35,9 @@ export function ModuleExports(props: {
       <pre>
         <CodeBlock
           language="tsx"
-          onCopy={() => addSuccessMessage('Import paths copied to clipboard')}
+          onCopy={() => addSuccessMessage('Imports copied to clipboard')}
         >
-          {Object.entries(props.exports)
-            .map(([_key, value]) => value.importPath)
-            .join('\n')}
+          {lines.join('\n')}
         </CodeBlock>
       </pre>
     </Fragment>

--- a/static/app/stories/moduleExports.tsx
+++ b/static/app/stories/moduleExports.tsx
@@ -1,0 +1,28 @@
+import {Fragment} from 'react';
+
+import {CodeBlock} from '@sentry/scraps/code';
+import {Heading} from '@sentry/scraps/text';
+
+import {addSuccessMessage} from 'sentry/actionCreators/indicator';
+
+export function ModuleExports(props: {
+  exports: Record<string, TypeLoader.ComponentDocWithFilename>;
+}) {
+  return (
+    <Fragment>
+      <Heading as="h3" size="lg">
+        Import
+      </Heading>
+      <pre>
+        <CodeBlock
+          language="tsx"
+          onCopy={() => addSuccessMessage('Import paths copied to clipboard')}
+        >
+          {Object.entries(props.exports)
+            .map(([_key, value]) => value.importPath)
+            .join('\n')}
+        </CodeBlock>
+      </pre>
+    </Fragment>
+  );
+}

--- a/static/app/stories/moduleExports.tsx
+++ b/static/app/stories/moduleExports.tsx
@@ -25,6 +25,7 @@ export function ModuleExports(props: {exports: TypeLoader.TypeLoaderResult['expo
       </Heading>
       <pre>
         <CodeBlock
+          dark
           language="tsx"
           onCopy={() => addSuccessMessage('Imports copied to clipboard')}
         >

--- a/static/app/stories/moduleExports.tsx
+++ b/static/app/stories/moduleExports.tsx
@@ -4,28 +4,17 @@ import {Heading} from '@sentry/scraps/text';
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Stack} from 'sentry/components/core/layout';
 
-export function ModuleExports(props: {
-  exports: Record<string, TypeLoader.ComponentDocWithFilename>;
-}) {
-  const entries = Object.entries(props.exports);
-  if (entries.length === 0) return '';
-  // Assume all exports are from a single module, just take the first one's value.module
-  const modulePath = entries[0]?.[1]?.module;
-  const defaultExport = entries.find(([_key, value]) => value?.displayName === 'default');
-  const namedExports = entries.filter(
-    ([_key, value]) => value?.displayName !== 'default'
-  );
+export function ModuleExports(props: {exports: TypeLoader.TypeLoaderResult['exports']}) {
+  if (!props.exports || !props.exports.exports) return null;
 
   const lines = [];
-  if (defaultExport) {
-    const [key] = defaultExport;
-    lines.push(`import ${key} from '${modulePath}';`);
-  }
-  if (namedExports.length > 0) {
-    const namedList = namedExports.map(([_, value]) => value.displayName).join(', ');
-    lines.push(`import {${namedList}} from '${modulePath}';`);
-  }
 
+  if (Object.entries(props.exports.exports).length > 0) {
+    const namedList = Object.entries(props.exports.exports)
+      .map(([key, value]) => `${value.typeOnly ? `type ${value.name}` : value.name}`)
+      .join(', ');
+    lines.push(`import {${namedList}} from '${props.exports.module}';`);
+  }
   return (
     <Stack gap="md" paddingTop="xl">
       <Heading as="h3" size="lg">

--- a/static/app/stories/moduleExports.tsx
+++ b/static/app/stories/moduleExports.tsx
@@ -5,7 +5,7 @@ import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Stack} from 'sentry/components/core/layout';
 
 export function ModuleExports(props: {exports: TypeLoader.TypeLoaderResult['exports']}) {
-  if (!props.exports || !props.exports.exports) return null;
+  if (!props.exports?.exports) return null;
 
   const lines = [];
 

--- a/static/app/stories/moduleExports.tsx
+++ b/static/app/stories/moduleExports.tsx
@@ -11,10 +11,13 @@ export function ModuleExports(props: {exports: TypeLoader.TypeLoaderResult['expo
 
   if (Object.entries(props.exports.exports).length > 0) {
     const namedList = Object.entries(props.exports.exports)
-      .map(([key, value]) => `${value.typeOnly ? `type ${value.name}` : value.name}`)
+      .map(([_key, value]) => `${value.typeOnly ? `type ${value.name}` : value.name}`)
       .join(', ');
     lines.push(`import {${namedList}} from '${props.exports.module}';`);
   }
+
+  if (!lines.length) return null;
+
   return (
     <Stack gap="md" paddingTop="xl">
       <Heading as="h3" size="lg">

--- a/static/app/stories/moduleExports.tsx
+++ b/static/app/stories/moduleExports.tsx
@@ -1,9 +1,8 @@
-import {Fragment} from 'react';
-
 import {CodeBlock} from '@sentry/scraps/code';
 import {Heading} from '@sentry/scraps/text';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {Stack} from 'sentry/components/core/layout';
 
 export function ModuleExports(props: {
   exports: Record<string, TypeLoader.ComponentDocWithFilename>;
@@ -28,9 +27,9 @@ export function ModuleExports(props: {
   }
 
   return (
-    <Fragment>
+    <Stack gap="md" paddingTop="xl">
       <Heading as="h3" size="lg">
-        Import
+        Imports
       </Heading>
       <pre>
         <CodeBlock
@@ -40,6 +39,6 @@ export function ModuleExports(props: {
           {lines.join('\n')}
         </CodeBlock>
       </pre>
-    </Fragment>
+    </Stack>
   );
 }

--- a/static/app/stories/storybook.tsx
+++ b/static/app/stories/storybook.tsx
@@ -1,6 +1,7 @@
 import type {ReactNode} from 'react';
 import {Children, Fragment, useEffect} from 'react';
-import styled from '@emotion/styled';
+
+import {Container} from '@sentry/scraps/layout';
 
 import {Heading} from 'sentry/components/core/text';
 import {makeStorybookDocumentTitle} from 'sentry/stories/view/storyExports';
@@ -59,16 +60,12 @@ function Story(props: {name: string; render: StoryRenderFunction}) {
 
   return (
     <Storybook.Section>
-      <StoryHeadingContainer>
+      <Container borderBottom="primary">
         <StoryHeading as="h2" size="2xl">
           {props.name}
         </StoryHeading>
-      </StoryHeadingContainer>
+      </Container>
       {isOneChild ? children : <Storybook.SideBySide>{children}</Storybook.SideBySide>}
     </Storybook.Section>
   );
 }
-
-const StoryHeadingContainer = styled('div')`
-  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
-`;

--- a/static/app/stories/storybook.tsx
+++ b/static/app/stories/storybook.tsx
@@ -46,7 +46,7 @@ export function story(title: string, setup: SetupFunction): StoryRenderFunction 
           <Story key={i} name={name} render={render} />
         ))}
         {APIDocumentation.map((documentation, i) => (
-          <Storybook.APIReference key={i} types={documentation} />
+          <Storybook.APIReference key={i} componentProps={documentation} />
         ))}
       </Fragment>
     );

--- a/static/app/stories/type-loader.ts
+++ b/static/app/stories/type-loader.ts
@@ -33,6 +33,9 @@ function prodTypeloader(this: LoaderContext<any>, _source: string) {
       .filter(entry => entry.displayName && typeof entry.displayName === 'string')
       .map(entry => [entry.displayName, {...entry, filename: this.resourcePath}])
   );
+
+  // @ts-expect-error we are accessing a private property
+  typeIndex._importPath = this._module.rawRequest;
   return callback(null, `export default ${JSON.stringify(typeIndex)}`);
 }
 

--- a/static/app/stories/type-loader.ts
+++ b/static/app/stories/type-loader.ts
@@ -128,5 +128,13 @@ function extractRequest(module: LoaderContext<any>['_module']) {
   if (!module || !('rawRequest' in module) || typeof module.rawRequest !== 'string') {
     return '';
   }
-  return module.rawRequest.split('!')?.at(-1) ?? '';
+
+  let modulePath = module.rawRequest.split('!')?.at(-1) ?? '';
+
+  // @TODO: if we ever build on Windows, this will break... we should hopefully never need to build on Windows
+  if (modulePath.endsWith('/index')) {
+    modulePath = modulePath.slice(0, -6);
+  }
+
+  return modulePath;
 }

--- a/static/app/stories/type-loader.ts
+++ b/static/app/stories/type-loader.ts
@@ -27,12 +27,21 @@ function extractModuleExports(
         const declarations = exportSymbol.getDeclarations() || [];
 
         for (const decl of declarations) {
-          if (typescript.isExportSpecifier(decl)) {
-            acc[decl.name.getText()] = {
-              name: decl.name.getText(),
-              typeOnly: decl.isTypeOnly,
-            };
+          const name = exportSymbol.name;
+          let typeOnly = false;
+
+          // Determine if it's a type-only export
+          if (typescript.isInterfaceDeclaration(decl)) {
+            typeOnly = true;
+          } else if (typescript.isTypeAliasDeclaration(decl)) {
+            typeOnly = true;
+          } else if (typescript.isExportSpecifier(decl)) {
+            typeOnly = decl.isTypeOnly;
           }
+          // For VariableDeclaration, FunctionDeclaration, ClassDeclaration, etc.
+          // typeOnly remains false (these are value exports)
+
+          acc[name] = {name, typeOnly};
         }
         return acc;
       },

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -140,6 +140,7 @@ function StoryTabList() {
 
 function StoryTabPanels() {
   const {story} = useStory();
+
   if (!isMDXStory(story)) {
     return <StoryUsage />;
   }
@@ -152,6 +153,7 @@ function StoryTabPanels() {
   return (
     <TabPanels>
       <TabPanels.Item key="usage">
+        <StoryModuleExports exports={story.exports.types} />
         <StoryUsage />
       </TabPanels.Item>
       <TabPanels.Item key="api">
@@ -213,15 +215,17 @@ function StoryUsage() {
   );
 }
 
+function isSingleDefaultExport(
+  types: unknown
+): types is TypeLoader.ComponentDocWithFilename {
+  return typeof types === 'object' && types !== null && 'filename' in types;
+}
+
 function StoryAPI() {
   const {story} = useStory();
   if (!story.exports.types) return null;
 
-  if (
-    typeof story.exports.types === 'object' &&
-    story.exports.types !== null &&
-    'filename' in story.exports.types
-  ) {
+  if (isSingleDefaultExport(story.exports.types)) {
     return (
       <Storybook.APIReference
         types={story.exports.types as TypeLoader.ComponentDocWithFilename}
@@ -246,6 +250,21 @@ function StoryGrid(props: React.ComponentProps<typeof Grid>) {
       height="100%"
     />
   );
+}
+
+function StoryModuleExports(props: {
+  exports:
+    | TypeLoader.ComponentDocWithFilename
+    | Record<string, TypeLoader.ComponentDocWithFilename>
+    | undefined;
+}) {
+  if (!props.exports) return null;
+  if (isSingleDefaultExport(props.exports)) {
+    return (
+      <Storybook.ModuleExports exports={{[props.exports.filename]: props.exports}} />
+    );
+  }
+  return <Storybook.ModuleExports exports={props.exports} />;
 }
 
 const StoryContainer = styled('div')`

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -226,11 +226,7 @@ function StoryAPI() {
   if (!story.exports.types) return null;
 
   if (isSingleDefaultExport(story.exports.types)) {
-    return (
-      <Storybook.APIReference
-        types={story.exports.types as TypeLoader.ComponentDocWithFilename}
-      />
-    );
+    return <Storybook.APIReference types={story.exports.types} />;
   }
 
   return (

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -5,7 +5,7 @@ import {ErrorBoundary} from '@sentry/react';
 
 import {Alert} from 'sentry/components/core/alert';
 import {Tag} from 'sentry/components/core/badge/tag';
-import {Flex, Grid} from 'sentry/components/core/layout';
+import {Container, Flex, Grid} from 'sentry/components/core/layout';
 import {TabList, TabPanels, Tabs} from 'sentry/components/core/tabs';
 import {Heading, Text} from 'sentry/components/core/text';
 import {t} from 'sentry/locale';
@@ -42,9 +42,9 @@ function StoryLayout() {
       {isMDXStory(story) ? <MDXStoryTitle story={story} /> : null}
       <StoryGrid>
         <StoryContainer>
-          <StoryContent>
+          <Flex flexGrow={1}>
             <StoryTabPanels />
-          </StoryContent>
+          </Flex>
           <ErrorBoundary>
             <StorySourceLinks />
           </ErrorBoundary>
@@ -70,7 +70,13 @@ function MDXStoryTitle(props: {story: MDXStoryDescriptor}) {
   }, [title]);
 
   return (
-    <StoryHeader>
+    <Container
+      as="header"
+      background="secondary"
+      padding="3xl 0 0 0"
+      borderBottom="primary"
+      area="story-head"
+    >
       <StoryGrid>
         <StoryContainer style={{gap: theme.space['2xl']}}>
           <Flex
@@ -111,7 +117,7 @@ function MDXStoryTitle(props: {story: MDXStoryDescriptor}) {
         </StoryContainer>
         <StoryTableOfContentsPlaceholder />
       </StoryGrid>
-    </StoryHeader>
+    </Container>
   );
 }
 
@@ -232,13 +238,6 @@ function StoryAPI() {
   );
 }
 
-const StoryHeader = styled('header')`
-  background: ${p => p.theme.tokens.background.secondary};
-  padding: ${p => p.theme.space['3xl']} 0 0 0;
-  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
-  grid-area: story-head;
-`;
-
 function StoryGrid(props: React.ComponentProps<typeof Grid>) {
   return (
     <Grid
@@ -261,8 +260,4 @@ const StoryContainer = styled('div')`
     max-width: 832px;
     margin-inline: auto;
   }
-`;
-
-const StoryContent = styled('main')`
-  flex-grow: 1;
 `;

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -232,12 +232,7 @@ function StoryAPI() {
           TypeLoader.ComponentDocWithFilename
         >
       ).map(([key, value]) => {
-        return (
-          <Storybook.APIReference
-            key={key}
-            componentProps={value as TypeLoader.ComponentDocWithFilename}
-          />
-        );
+        return <Storybook.APIReference key={key} componentProps={value} />;
       })}
     </Fragment>
   );

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -129,7 +129,9 @@ function StoryTabList() {
   return (
     <TabList>
       <TabList.Item key="usage">{t('Usage')}</TabList.Item>
-      {story.exports.types ? <TabList.Item key="api">{t('API')}</TabList.Item> : null}
+      {story.exports.documentation ? (
+        <TabList.Item key="api">{t('API')}</TabList.Item>
+      ) : null}
 
       {isMDXStory(story) && story.exports.frontmatter?.resources ? (
         <TabList.Item key="resources">{t('Resources')}</TabList.Item>
@@ -153,7 +155,7 @@ function StoryTabPanels() {
   return (
     <TabPanels>
       <TabPanels.Item key="usage">
-        <StoryModuleExports exports={story.exports.types} />
+        <StoryModuleExports exports={story.exports.documentation?.props} />
         <StoryUsage />
       </TabPanels.Item>
       <TabPanels.Item key="api">
@@ -165,7 +167,10 @@ function StoryTabPanels() {
     </TabPanels>
   );
 }
-const EXPECTED_EXPORTS = new Set<keyof StoryExportValues>(['frontmatter', 'types']);
+const EXPECTED_EXPORTS = new Set<keyof StoryExportValues>([
+  'frontmatter',
+  'documentation',
+]);
 
 function StoryUsage() {
   const {
@@ -217,14 +222,27 @@ function StoryUsage() {
 
 function StoryAPI() {
   const {story} = useStory();
-  if (!story.exports.types) return null;
+  if (!story.exports.documentation && typeof story.exports.documentation !== 'object')
+    return null;
   return (
     <Fragment>
-      {Object.entries(story.exports.types).map(([key, value]) => {
-        return <Storybook.APIReference key={key} types={value} />;
+      {Object.entries(
+        (story.exports.documentation as TypeLoader.TypeLoaderResult).props as Record<
+          string,
+          TypeLoader.ComponentDocWithFilename
+        >
+      ).map(([key, value]) => {
+        return (
+          <Storybook.APIReference
+            key={key}
+            componentProps={value as TypeLoader.ComponentDocWithFilename}
+          />
+        );
       })}
     </Fragment>
   );
+
+  return null;
 }
 
 function StoryGrid(props: React.ComponentProps<typeof Grid>) {

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -215,20 +215,9 @@ function StoryUsage() {
   );
 }
 
-function isSingleDefaultExport(
-  types: unknown
-): types is TypeLoader.ComponentDocWithFilename {
-  return typeof types === 'object' && types !== null && 'filename' in types;
-}
-
 function StoryAPI() {
   const {story} = useStory();
   if (!story.exports.types) return null;
-
-  if (isSingleDefaultExport(story.exports.types)) {
-    return <Storybook.APIReference types={story.exports.types} />;
-  }
-
   return (
     <Fragment>
       {Object.entries(story.exports.types).map(([key, value]) => {
@@ -249,17 +238,9 @@ function StoryGrid(props: React.ComponentProps<typeof Grid>) {
 }
 
 function StoryModuleExports(props: {
-  exports:
-    | TypeLoader.ComponentDocWithFilename
-    | Record<string, TypeLoader.ComponentDocWithFilename>
-    | undefined;
+  exports: Record<string, TypeLoader.ComponentDocWithFilename> | undefined;
 }) {
   if (!props.exports) return null;
-  if (isSingleDefaultExport(props.exports)) {
-    return (
-      <Storybook.ModuleExports exports={{[props.exports.filename]: props.exports}} />
-    );
-  }
   return <Storybook.ModuleExports exports={props.exports} />;
 }
 

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -155,7 +155,7 @@ function StoryTabPanels() {
   return (
     <TabPanels>
       <TabPanels.Item key="usage">
-        <StoryModuleExports exports={story.exports.documentation?.props} />
+        <StoryModuleExports exports={story.exports.documentation?.exports} />
         <StoryUsage />
       </TabPanels.Item>
       <TabPanels.Item key="api">
@@ -251,7 +251,7 @@ function StoryGrid(props: React.ComponentProps<typeof Grid>) {
 }
 
 function StoryModuleExports(props: {
-  exports: Record<string, TypeLoader.ComponentDocWithFilename> | undefined;
+  exports: TypeLoader.TypeLoaderResult['exports'] | undefined;
 }) {
   if (!props.exports) return null;
   return <Storybook.ModuleExports exports={props.exports} />;

--- a/static/app/stories/view/useStoriesLoader.tsx
+++ b/static/app/stories/view/useStoriesLoader.tsx
@@ -24,9 +24,7 @@ export interface MDXStoryDescriptor {
       status?: 'in-progress' | 'experimental' | 'stable';
       types?: string;
     };
-    types?:
-      | TypeLoader.ComponentDocWithFilename
-      | Record<string, TypeLoader.ComponentDocWithFilename>;
+    types?: Record<string, TypeLoader.ComponentDocWithFilename>;
   };
   filename: string;
 }

--- a/static/app/stories/view/useStoriesLoader.tsx
+++ b/static/app/stories/view/useStoriesLoader.tsx
@@ -15,6 +15,7 @@ export interface StoryResources {
 export interface MDXStoryDescriptor {
   exports: {
     default: React.ComponentType | any;
+    documentation?: TypeLoader.TypeLoaderResult;
     frontmatter?: {
       description: string;
       title: string;
@@ -24,7 +25,6 @@ export interface MDXStoryDescriptor {
       status?: 'in-progress' | 'experimental' | 'stable';
       types?: string;
     };
-    types?: Record<string, TypeLoader.ComponentDocWithFilename>;
   };
   filename: string;
 }

--- a/static/app/types/type-loader.d.ts
+++ b/static/app/types/type-loader.d.ts
@@ -8,5 +8,7 @@ declare namespace TypeLoader {
   type ComponentDoc = import('react-docgen-typescript').ComponentDoc;
   interface ComponentDocWithFilename extends ComponentDoc {
     filename: string;
+    module: string;
+    importPath: string;
   }
 }

--- a/static/app/types/type-loader.d.ts
+++ b/static/app/types/type-loader.d.ts
@@ -1,13 +1,25 @@
-declare module '!!type-loader!*' {
-  const content: Record<string, TypeLoader.ComponentDocWithFilename>;
-  export default content;
-}
-
 declare namespace TypeLoader {
   type ComponentDoc = import('react-docgen-typescript').ComponentDoc;
+
   interface ComponentDocWithFilename extends ComponentDoc {
     filename: string;
     module: string;
-    importPath: string;
   }
+
+  interface TypeLoaderResult {
+    props?: Record<string, TypeLoader.ComponentDocWithFilename>;
+    exports?: {
+      module: string;
+      exports: Record<string, {name: string; typeOnly: boolean}>;
+    };
+  }
+}
+
+declare module '!!type-loader!*' {
+  const TypeLoaderResult: {
+    props: Record<string, TypeLoader.ComponentDocWithFilename>;
+    exports: Record<string, {name: string; typeOnly: boolean}[]>;
+  };
+
+  export default TypeLoaderResult;
 }

--- a/static/app/types/type-loader.d.ts
+++ b/static/app/types/type-loader.d.ts
@@ -1,6 +1,5 @@
 declare module '!!type-loader!*' {
   const content: Record<string, TypeLoader.ComponentDocWithFilename>;
-
   export default content;
 }
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -1,5 +1,5 @@
 import {Fragment, useEffect, useMemo, useState} from 'react';
-import types from '!!type-loader!sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import documentation from '!!type-loader!sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import shuffle from 'lodash/shuffle';
@@ -71,7 +71,7 @@ const releases = [
 ].filter(hasTimestamp);
 
 export default Storybook.story('TimeSeriesWidgetVisualization', (story, APIReference) => {
-  APIReference(types.TimeSeriesWidgetVisualization);
+  APIReference(documentation.props.TimeSeriesWidgetVisualization);
 
   story('Getting Started', () => {
     return (

--- a/static/app/views/dashboards/widgets/widget/widget.stories.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.stories.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import types from '!!type-loader!sentry/views/dashboards/widgets/widget/widget';
+import documentation from '!!type-loader!sentry/views/dashboards/widgets/widget/widget';
 import styled from '@emotion/styled';
 
 import {Tag} from 'sentry/components/core/badge/tag';
@@ -13,7 +13,7 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {Widget} from './widget';
 
 export default Storybook.story('Widget', (story, APIReference) => {
-  APIReference(types.exported);
+  APIReference(documentation.props.Widget);
 
   story('Getting Started', () => {
     return (


### PR DESCRIPTION
@natemoo-re I've added an alternative approach here by returning the import path from a loader. Do you know if there's a way to match the code styles here - we seem to use expressive code under the hood, and it's a bit unclear to me how we could use it here. 

<img width="843" height="288" alt="CleanShot 2025-10-16 at 14 30 48" src="https://github.com/user-attachments/assets/4a537686-4013-4eca-854e-be67d6d338fc" />

I would have ideally also liked for that first example to have the import path and usage example all in a single component, but we can't interpolate the variables directly in markdown, so we would need to find an alternative

The example I tried is basically this
```
${types.Alert.importPath} <- unable to interpolate
<Alert ... />
```

Feel free to take over and restyle this, but I think this might be a slightly easier way to go about the changes 