### PR TITLE
feat(dashboards): Enable rate functions to metrics endpoint

### DIFF
--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -63,7 +63,6 @@ class SessionMetricKey(Enum):
     UNHANDLED_RATE = "session.unhandled_rate"
     UNHANDLED_USER_RATE = "session.unhandled_user_rate"
     UNHEALTHY_RATE = "session.unhealthy_rate"
-    UNHEALTHY_USER_RATE = "session.unhealthy_user_rate"
 
 
 class TransactionMetricKey(Enum):

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -56,6 +56,14 @@ class SessionMetricKey(Enum):
     ERRORED_SET = "sessions.errored.unique"
     ANR_RATE = "session.anr_rate"
     FOREGROUND_ANR_RATE = "session.foreground_anr_rate"
+    ABNORMAL_RATE = "session.abnormal_rate"
+    ABNORMAL_USER_RATE = "session.abnormal_user_rate"
+    ERRORED_RATE = "session.errored_rate"
+    ERRORED_USER_RATE = "session.errored_user_rate"
+    UNHANDLED_RATE = "session.unhandled_rate"
+    UNHANDLED_USER_RATE = "session.unhandled_user_rate"
+    UNHEALTHY_RATE = "session.unhealthy_rate"
+    UNHEALTHY_USER_RATE = "session.unhealthy_user_rate"
 
 
 class TransactionMetricKey(Enum):

--- a/tests/sentry/releases/endpoints/test_organization_release_health_data.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_health_data.py
@@ -2492,3 +2492,224 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
             interval="1m",
         )
         assert response.status_code == 200
+
+    def test_abnormal_rate_sessions_and_users(self) -> None:
+        # Users abnormal rate
+        # foobar@1.0 -> 0.5
+        # foobar@2.0 -> 1
+        for tags, values in (
+            ({"release": "foobar@1.0"}, [1, 2, 4, 8]),
+            ({"session.status": "abnormal", "release": "foobar@1.0"}, [1, 2]),
+            ({"release": "foobar@2.0"}, [3, 5]),
+        ):
+            for value in values:
+                self.store_release_health_metric(
+                    name=SessionMRI.RAW_USER.value,
+                    tags=tags,
+                    value=value,
+                )
+
+        # Abnormal rate
+        # foobar@1.0 -> 0.75
+        # foobar@2.0 -> 0.25
+
+        for tag_value, release_tag_value, value, second in (
+            ("init", "foobar@1.0", 4, 4),
+            ("abnormal", "foobar@1.0", 1, 2),
+            ("init", "foobar@2.0", 4, 4),
+            ("abnormal", "foobar@2.0", 3, 2),
+        ):
+            self.store_release_health_metric(
+                name=SessionMRI.RAW_SESSION.value,
+                tags={"session.status": tag_value, "release": release_tag_value},
+                value=value,
+            )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            field=[
+                "session.abnormal_rate",
+                "session.abnormal_user_rate",
+            ],
+            statsPeriod="1h",
+            interval="1h",
+            groupBy="release",
+            orderBy="-session.abnormal_user_rate",
+        )
+        group = response.data["groups"][0]
+        assert group["by"]["release"] == "foobar@1.0"
+        assert group["totals"]["session.abnormal_rate"] == 0.25
+        assert group["totals"]["session.abnormal_user_rate"] == 0.5
+
+        group = response.data["groups"][1]
+        assert group["by"]["release"] == "foobar@2.0"
+        assert group["totals"]["session.abnormal_rate"] == 0.75
+        assert group["totals"]["session.abnormal_user_rate"] == 0.0
+
+    def test_errored_rate_sessions_and_users(self) -> None:
+        # Users errored rate
+        # foobar@1.0 -> 0.5
+        # foobar@2.0 -> 1
+        for tags, values in (
+            ({"release": "foobar@1.0"}, [1, 2, 4, 8]),
+            ({"session.status": "errored", "release": "foobar@1.0"}, [1, 2]),
+            ({"release": "foobar@2.0"}, [3, 5]),
+        ):
+            for value in values:
+                self.store_release_health_metric(
+                    name=SessionMRI.RAW_USER.value,
+                    tags=tags,
+                    value=value,
+                )
+
+        # Errored rate
+        # foobar@1.0 -> 0.75
+        # foobar@2.0 -> 0.25
+
+        for tag_value, release_tag_value, value in (
+            ("init", "foobar@1.0", 4),
+            ("errored_preaggr", "foobar@1.0", 1),
+            ("init", "foobar@2.0", 4),
+            ("errored_preaggr", "foobar@2.0", 3),
+        ):
+            self.store_release_health_metric(
+                name=SessionMRI.RAW_SESSION.value,
+                tags={"session.status": tag_value, "release": release_tag_value},
+                value=value,
+            )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            field=[
+                "session.errored_rate",
+                "session.errored_user_rate",
+                "sum(sentry.sessions.session)",
+            ],
+            statsPeriod="1h",
+            interval="1h",
+            groupBy="release",
+            orderBy="sum(sentry.sessions.session)",
+        )
+        group = response.data["groups"][0]
+        assert group["by"]["release"] == "foobar@1.0"
+        assert group["totals"]["session.errored_rate"] == 0.25
+        assert group["totals"]["session.errored_user_rate"] == 0.5
+
+        group = response.data["groups"][1]
+        assert group["by"]["release"] == "foobar@2.0"
+        assert group["totals"]["session.errored_rate"] == 0.75
+        assert group["totals"]["session.errored_user_rate"] == 0.0
+
+    def test_unhandled_rate_sessions_and_users(self) -> None:
+        # Users unhandled rate
+        # foobar@1.0 -> 0.5
+        # foobar@2.0 -> 1
+        for tags, values in (
+            ({"release": "foobar@1.0"}, [1, 2, 4, 8]),
+            ({"session.status": "unhandled", "release": "foobar@1.0"}, [1, 2]),
+            ({"release": "foobar@2.0"}, [3, 5]),
+        ):
+            for value in values:
+                self.store_release_health_metric(
+                    name=SessionMRI.RAW_USER.value,
+                    tags=tags,
+                    value=value,
+                )
+
+        # Unhandled rate
+        # foobar@1.0 -> 0.75
+        # foobar@2.0 -> 0.25
+
+        for tag_value, release_tag_value, value in (
+            ("init", "foobar@1.0", 4),
+            ("unhandled", "foobar@1.0", 1),
+            ("init", "foobar@2.0", 4),
+            ("unhandled", "foobar@2.0", 3),
+        ):
+            self.store_release_health_metric(
+                name=SessionMRI.RAW_SESSION.value,
+                tags={"session.status": tag_value, "release": release_tag_value},
+                value=value,
+            )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            field=[
+                "session.unhandled_rate",
+                "session.unhandled_user_rate",
+                "sum(sentry.sessions.session)",
+            ],
+            statsPeriod="1h",
+            interval="1h",
+            groupBy="release",
+            orderBy="sum(sentry.sessions.session)",
+        )
+        group = response.data["groups"][0]
+        assert group["by"]["release"] == "foobar@1.0"
+        assert group["totals"]["session.unhandled_rate"] == 0.25
+        assert group["totals"]["session.unhandled_user_rate"] == 0.5
+
+        group = response.data["groups"][1]
+        assert group["by"]["release"] == "foobar@2.0"
+        assert group["totals"]["session.unhandled_rate"] == 0.75
+        assert group["totals"]["session.unhandled_user_rate"] == 0.0
+
+    def test_unhealthy_rate_sessions_and_users(self) -> None:
+        # Users unhealthy rate
+        # foobar@1.0 -> 0.5
+        # foobar@2.0 -> 1
+        for tags, values in (
+            ({"release": "foobar@1.0"}, [1, 2, 4, 8]),
+            ({"session.status": "unhealthy", "release": "foobar@1.0"}, [1, 2]),
+            ({"release": "foobar@2.0"}, [3, 5]),
+        ):
+            for value in values:
+                self.store_release_health_metric(
+                    name=SessionMRI.RAW_USER.value,
+                    tags=tags,
+                    value=value,
+                )
+
+        # Unhealthy rate
+        # foobar@1.0 -> 0.75
+        # foobar@2.0 -> 0.25
+        for tag_value, release_tag_value, value in (
+            ("init", "foobar@1.0", 4),
+            ("errored_preaggr", "foobar@1.0", 1),
+            ("init", "foobar@2.0", 4),
+        ):
+            self.store_release_health_metric(
+                name=SessionMRI.RAW_SESSION.value,
+                tags={"session.status": tag_value, "release": release_tag_value},
+                value=value,
+            )
+        # Unhealthy rate relies on RAW_ERROR metric
+        for tag_value, release_tag_value, value in (
+            ("abnormal", "foobar@2.0", 1),
+            ("unhandled", "foobar@2.0", 2),
+            ("crashed", "foobar@2.0", 3),
+        ):
+            self.store_release_health_metric(
+                name=SessionMRI.RAW_ERROR.value,
+                tags={"release": release_tag_value},
+                value=value,
+            )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            field=[
+                "session.unhealthy_rate",
+                "sum(sentry.sessions.session)",
+            ],
+            statsPeriod="1h",
+            interval="1h",
+            groupBy="release",
+            orderBy="-sum(sentry.sessions.session)",
+        )
+        group = response.data["groups"][0]
+        assert group["by"]["release"] == "foobar@1.0"
+        assert group["totals"]["session.unhealthy_rate"] == 0.25
+
+        group = response.data["groups"][1]
+        assert group["by"]["release"] == "foobar@2.0"
+        assert group["totals"]["session.unhealthy_rate"] == 0.75

--- a/tests/sentry/releases/endpoints/test_organization_release_health_data.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_health_data.py
@@ -2654,22 +2654,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert group["totals"]["session.unhandled_rate"] == 0.75
         assert group["totals"]["session.unhandled_user_rate"] == 0.0
 
-    def test_unhealthy_rate_sessions_and_users(self) -> None:
-        # Users unhealthy rate
-        # foobar@1.0 -> 0.5
-        # foobar@2.0 -> 1
-        for tags, values in (
-            ({"release": "foobar@1.0"}, [1, 2, 4, 8]),
-            ({"session.status": "unhealthy", "release": "foobar@1.0"}, [1, 2]),
-            ({"release": "foobar@2.0"}, [3, 5]),
-        ):
-            for value in values:
-                self.store_release_health_metric(
-                    name=SessionMRI.RAW_USER.value,
-                    tags=tags,
-                    value=value,
-                )
-
+    def test_unhealthy_rate_sessions(self) -> None:
         # Unhealthy rate
         # foobar@1.0 -> 0.75
         # foobar@2.0 -> 0.25

--- a/tests/sentry/releases/endpoints/test_organization_release_health_data.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_health_data.py
@@ -2494,9 +2494,6 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert response.status_code == 200
 
     def test_abnormal_rate_sessions_and_users(self) -> None:
-        # Users abnormal rate
-        # foobar@1.0 -> 0.5
-        # foobar@2.0 -> 1
         for tags, values in (
             ({"release": "foobar@1.0"}, [1, 2, 4, 8]),
             ({"session.status": "abnormal", "release": "foobar@1.0"}, [1, 2]),
@@ -2508,10 +2505,6 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                     tags=tags,
                     value=value,
                 )
-
-        # Abnormal rate
-        # foobar@1.0 -> 0.75
-        # foobar@2.0 -> 0.25
 
         for tag_value, release_tag_value, value, second in (
             ("init", "foobar@1.0", 4, 4),
@@ -2547,9 +2540,6 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert group["totals"]["session.abnormal_user_rate"] == 0.0
 
     def test_errored_rate_sessions_and_users(self) -> None:
-        # Users errored rate
-        # foobar@1.0 -> 0.5
-        # foobar@2.0 -> 1
         for tags, values in (
             ({"release": "foobar@1.0"}, [1, 2, 4, 8]),
             ({"session.status": "errored", "release": "foobar@1.0"}, [1, 2]),
@@ -2561,10 +2551,6 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                     tags=tags,
                     value=value,
                 )
-
-        # Errored rate
-        # foobar@1.0 -> 0.75
-        # foobar@2.0 -> 0.25
 
         for tag_value, release_tag_value, value in (
             ("init", "foobar@1.0", 4),
@@ -2601,9 +2587,6 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert group["totals"]["session.errored_user_rate"] == 0.0
 
     def test_unhandled_rate_sessions_and_users(self) -> None:
-        # Users unhandled rate
-        # foobar@1.0 -> 0.5
-        # foobar@2.0 -> 1
         for tags, values in (
             ({"release": "foobar@1.0"}, [1, 2, 4, 8]),
             ({"session.status": "unhandled", "release": "foobar@1.0"}, [1, 2]),
@@ -2615,10 +2598,6 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                     tags=tags,
                     value=value,
                 )
-
-        # Unhandled rate
-        # foobar@1.0 -> 0.75
-        # foobar@2.0 -> 0.25
 
         for tag_value, release_tag_value, value in (
             ("init", "foobar@1.0", 4),
@@ -2655,9 +2634,6 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert group["totals"]["session.unhandled_user_rate"] == 0.0
 
     def test_unhealthy_rate_sessions(self) -> None:
-        # Unhealthy rate
-        # foobar@1.0 -> 0.75
-        # foobar@2.0 -> 0.25
         for tag_value, release_tag_value, value in (
             ("init", "foobar@1.0", 4),
             ("errored_preaggr", "foobar@1.0", 1),


### PR DESCRIPTION
Adds abnormal, errored, unhandled, and unhealthy rate session/release functions to the `metrics/data/` endpoint public fields. 

Release widgets in Dashboards use both the `sessions/` endpoint and `metrics/data/` so we need to support the same rate functionality in both. Implementation was done in this pr, https://github.com/getsentry/sentry/pull/101289, they just needed to be enabled.