### PR TITLE
fix(prevent): Add all repos dropdown and fix default settings

### DIFF
--- a/static/app/views/prevent/preventAI/hooks/useUpdatePreventAIFeature.spec.tsx
+++ b/static/app/views/prevent/preventAI/hooks/useUpdatePreventAIFeature.spec.tsx
@@ -266,5 +266,16 @@ describe('useUpdatePreventAIFeature', () => {
         config.github_organizations?.['org-1']?.repo_overrides?.['repo-456']
       ).toBeUndefined();
     });
+
+    it('should error if repo name is not provided when feature is use_org_defaults', () => {
+      const config = structuredClone(mockOrg.preventAiConfigGithub!);
+      expect(() =>
+        makePreventAIConfig(config, {
+          feature: 'use_org_defaults',
+          enabled: true,
+          orgName: 'org-1',
+        })
+      ).toThrow('Repo name is required when feature is use_org_defaults');
+    });
   });
 });

--- a/static/app/views/prevent/preventAI/hooks/useUpdatePreventAIFeature.spec.tsx
+++ b/static/app/views/prevent/preventAI/hooks/useUpdatePreventAIFeature.spec.tsx
@@ -205,5 +205,66 @@ describe('useUpdatePreventAIFeature', () => {
           ?.bug_prediction;
       expect(feature?.sensitivity).toBe('low');
     });
+
+    it('should delete repo override when use_org_defaults is enabled', () => {
+      const config = structuredClone(mockOrg.preventAiConfigGithub!);
+      if (config.github_organizations?.['org-1']?.repo_overrides) {
+        config.github_organizations['org-1'].repo_overrides['repo-123'] = {
+          vanilla: {
+            enabled: true,
+            triggers: {on_command_phrase: true, on_ready_for_review: false},
+            sensitivity: 'high',
+          },
+          test_generation: {
+            enabled: true,
+            triggers: {on_command_phrase: false, on_ready_for_review: false},
+          },
+          bug_prediction: {
+            enabled: true,
+            triggers: {on_command_phrase: true, on_ready_for_review: true},
+            sensitivity: 'critical',
+          },
+        };
+      }
+
+      const updatedConfig = makePreventAIConfig(config, {
+        feature: 'use_org_defaults',
+        enabled: true,
+        orgName: 'org-1',
+        repoName: 'repo-123',
+      });
+
+      // The repo override should be deleted
+      expect(
+        updatedConfig.github_organizations?.['org-1']?.repo_overrides?.['repo-123']
+      ).toBeUndefined();
+    });
+
+    it('should create repo override when use_org_defaults is disabled', () => {
+      const config = structuredClone(mockOrg.preventAiConfigGithub!);
+      // No repo override exists initially
+      expect(
+        config.github_organizations?.['org-1']?.repo_overrides?.['repo-456']
+      ).toBeUndefined();
+
+      const updatedConfig = makePreventAIConfig(config, {
+        feature: 'use_org_defaults',
+        enabled: false,
+        orgName: 'org-1',
+        repoName: 'repo-456',
+      });
+
+      // A repo override should be created, cloned from org_defaults
+      const repoOverride =
+        updatedConfig.github_organizations?.['org-1']?.repo_overrides?.['repo-456'];
+      expect(repoOverride).toBeDefined();
+      expect(repoOverride).toEqual(
+        updatedConfig.github_organizations?.['org-1']?.org_defaults
+      );
+      // Should not mutate original
+      expect(
+        config.github_organizations?.['org-1']?.repo_overrides?.['repo-456']
+      ).toBeUndefined();
+    });
   });
 });

--- a/static/app/views/prevent/preventAI/manageRepos.spec.tsx
+++ b/static/app/views/prevent/preventAI/manageRepos.spec.tsx
@@ -56,10 +56,10 @@ describe('PreventAIManageRepos', () => {
 
   it('opens the settings panel when the settings button is clicked', async () => {
     render(<ManageReposPage installedOrgs={installedOrgs} />, {organization});
-    expect(screen.queryByText(/AI Code Review Settings/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('manage-repos-panel')).not.toBeInTheDocument();
     const settingsButton = await screen.findByTestId('manage-repos-settings-button');
     await userEvent.click(settingsButton);
-    expect(await screen.findByText(/AI Code Review Settings/i)).toBeInTheDocument();
+    expect(await screen.findByTestId('manage-repos-panel')).toBeInTheDocument();
   });
 
   it('renders the illustration image', async () => {
@@ -72,20 +72,8 @@ describe('PreventAIManageRepos', () => {
   it('starts with "All Repos" selected by default', async () => {
     render(<ManageReposPage installedOrgs={installedOrgs} />, {organization});
     const repoButton = await screen.findByRole('button', {
-      name: /All Repos \(Organization Defaults\)/i,
+      name: /All Repos/i,
     });
     expect(repoButton).toBeInTheDocument();
-  });
-
-  it('shows organization defaults message in panel when "All Repos" is selected', async () => {
-    render(<ManageReposPage installedOrgs={installedOrgs} />, {organization});
-    const settingsButton = await screen.findByTestId('manage-repos-settings-button');
-    await userEvent.click(settingsButton);
-
-    expect(
-      await screen.findByText(
-        'These settings apply as defaults to all repositories in this organization. Individual repositories can override these settings.'
-      )
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/prevent/preventAI/manageRepos.spec.tsx
+++ b/static/app/views/prevent/preventAI/manageRepos.spec.tsx
@@ -68,4 +68,24 @@ describe('PreventAIManageRepos', () => {
     expect(img).toBeInTheDocument();
     expect(img.tagName).toBe('IMG');
   });
+
+  it('starts with "All Repos" selected by default', async () => {
+    render(<ManageReposPage installedOrgs={installedOrgs} />, {organization});
+    const repoButton = await screen.findByRole('button', {
+      name: /All Repos \(Organization Defaults\)/i,
+    });
+    expect(repoButton).toBeInTheDocument();
+  });
+
+  it('shows organization defaults message in panel when "All Repos" is selected', async () => {
+    render(<ManageReposPage installedOrgs={installedOrgs} />, {organization});
+    const settingsButton = await screen.findByTestId('manage-repos-settings-button');
+    await userEvent.click(settingsButton);
+
+    expect(
+      await screen.findByText(
+        'These settings apply as defaults to all repositories in this organization. Individual repositories can override these settings.'
+      )
+    ).toBeInTheDocument();
+  });
 });

--- a/static/app/views/prevent/preventAI/manageRepos.tsx
+++ b/static/app/views/prevent/preventAI/manageRepos.tsx
@@ -37,7 +37,6 @@ function ManageReposPage({installedOrgs}: {installedOrgs: PreventAIOrg[]}) {
 
   // Ditto for repos
   const selectedRepo = useMemo(() => {
-    // If "All Repos" is selected, return null to indicate org defaults
     if (selectedRepoName === ALL_REPOS_VALUE) {
       return null;
     }
@@ -63,7 +62,6 @@ function ManageReposPage({installedOrgs}: {installedOrgs: PreventAIOrg[]}) {
   );
 
   const isOrgSelected = !!selectedOrg;
-  // "All Repos" is considered a valid selection (for org defaults)
   const isRepoSelected = selectedRepoName === ALL_REPOS_VALUE || !!selectedRepo;
 
   return (

--- a/static/app/views/prevent/preventAI/manageRepos.tsx
+++ b/static/app/views/prevent/preventAI/manageRepos.tsx
@@ -14,7 +14,9 @@ import {IconSettings} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {PreventAIOrg} from 'sentry/types/prevent';
 import ManageReposPanel from 'sentry/views/prevent/preventAI/manageReposPanel';
-import ManageReposToolbar from 'sentry/views/prevent/preventAI/manageReposToolbar';
+import ManageReposToolbar, {
+  ALL_REPOS_VALUE,
+} from 'sentry/views/prevent/preventAI/manageReposToolbar';
 
 import {FeatureOverview} from './onboarding';
 
@@ -25,9 +27,7 @@ function ManageReposPage({installedOrgs}: {installedOrgs: PreventAIOrg[]}) {
   const [selectedOrgName, setSelectedOrgName] = useState(
     () => installedOrgs[0]?.name ?? ''
   );
-  const [selectedRepoName, setSelectedRepoName] = useState(
-    () => installedOrgs[0]?.repos?.[0]?.name ?? ''
-  );
+  const [selectedRepoName, setSelectedRepoName] = useState(() => ALL_REPOS_VALUE);
 
   // If the selected org is not present in the list of orgs, use the first org
   const selectedOrg = useMemo(() => {
@@ -37,28 +37,34 @@ function ManageReposPage({installedOrgs}: {installedOrgs: PreventAIOrg[]}) {
 
   // Ditto for repos
   const selectedRepo = useMemo(() => {
+    // If "All Repos" is selected, return null to indicate org defaults
+    if (selectedRepoName === ALL_REPOS_VALUE) {
+      return null;
+    }
     const found = selectedOrg?.repos?.find(repo => repo.name === selectedRepoName);
     return found ?? selectedOrg?.repos?.[0];
   }, [selectedOrg, selectedRepoName]);
 
   // When the org changes, if the selected repo is not present in the new org,
-  // use the first repo in the new org
+  // reset to "All Repos"
   const setSelectedOrgNameWithCascadeRepoName = useCallback(
     (orgName: string) => {
       setSelectedOrgName(orgName);
       const newSelectedOrgData = installedOrgs.find(org => org.name === orgName);
       if (
         newSelectedOrgData &&
+        selectedRepoName !== ALL_REPOS_VALUE &&
         !newSelectedOrgData.repos.some(repo => repo.name === selectedRepoName)
       ) {
-        setSelectedRepoName(newSelectedOrgData.repos[0]?.name ?? '');
+        setSelectedRepoName(ALL_REPOS_VALUE);
       }
     },
     [installedOrgs, selectedRepoName]
   );
 
   const isOrgSelected = !!selectedOrg;
-  const isRepoSelected = !!selectedRepo;
+  // "All Repos" is considered a valid selection (for org defaults)
+  const isRepoSelected = selectedRepoName === ALL_REPOS_VALUE || !!selectedRepo;
 
   return (
     <Flex direction="column" maxWidth="1000px" gap="xl">
@@ -142,6 +148,8 @@ function ManageReposPage({installedOrgs}: {installedOrgs: PreventAIOrg[]}) {
         onClose={() => setIsPanelOpen(false)}
         orgName={selectedOrg?.name ?? ''}
         repoName={selectedRepo?.name ?? ''}
+        allRepos={selectedOrg?.repos ?? []}
+        isEditingOrgDefaults={selectedRepoName === ALL_REPOS_VALUE}
       />
     </Flex>
   );

--- a/static/app/views/prevent/preventAI/manageReposPanel.spec.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPanel.spec.tsx
@@ -19,6 +19,7 @@ describe('ManageReposPanel', () => {
     repoName: 'repo-1',
     orgName: 'org-1',
     repoFullName: 'org-1/repo-1',
+    isEditingOrgDefaults: false,
   };
 
   beforeEach(() => {
@@ -69,8 +70,23 @@ describe('ManageReposPanel', () => {
     expect(defaultProps.onClose).toHaveBeenCalled();
   });
 
-  it('shows feature toggles with correct initial state', async () => {
-    render(<ManageReposPanel {...defaultProps} />, {organization: mockOrganization});
+  it('shows feature toggles with correct initial state when repo has overrides', async () => {
+    const defaultOrgConfig = mockOrganization.preventAiConfigGithub!.default_org_config;
+    const orgWithOverride = OrganizationFixture({
+      preventAiConfigGithub: {
+        schema_version: 'v1',
+        default_org_config: defaultOrgConfig,
+        github_organizations: {
+          'org-1': {
+            org_defaults: defaultOrgConfig.org_defaults,
+            repo_overrides: {
+              'repo-1': defaultOrgConfig.org_defaults, // Use org defaults as the override
+            },
+          },
+        },
+      },
+    });
+    render(<ManageReposPanel {...defaultProps} />, {organization: orgWithOverride});
     expect(await screen.findByLabelText(/Enable PR Review/i)).toBeChecked();
     expect(await screen.findByLabelText(/Enable Test Generation/i)).not.toBeChecked();
     expect(await screen.findByLabelText(/Enable Error Prediction/i)).toBeChecked();
@@ -80,15 +96,76 @@ describe('ManageReposPanel', () => {
     expect(await screen.findByLabelText(/Run when mentioned/i)).toBeChecked();
   });
 
-  it('disables toggles when loading', async () => {
+  it('disables toggles when loading and repo has overrides', async () => {
     mockUpdatePreventAIFeatureReturn = {
       ...mockUpdatePreventAIFeatureReturn,
       isLoading: true,
     };
-    render(<ManageReposPanel {...defaultProps} />, {organization: mockOrganization});
+    const defaultOrgConfig = mockOrganization.preventAiConfigGithub!.default_org_config;
+    const orgWithOverride = OrganizationFixture({
+      preventAiConfigGithub: {
+        schema_version: 'v1',
+        default_org_config: defaultOrgConfig,
+        github_organizations: {
+          'org-1': {
+            org_defaults: defaultOrgConfig.org_defaults,
+            repo_overrides: {
+              'repo-1': defaultOrgConfig.org_defaults,
+            },
+          },
+        },
+      },
+    });
+    render(<ManageReposPanel {...defaultProps} />, {organization: orgWithOverride});
     expect(await screen.findByLabelText(/Enable PR Review/i)).toBeDisabled();
     expect(await screen.findByLabelText(/Enable Test Generation/i)).toBeDisabled();
     expect(await screen.findByLabelText(/Enable Error Prediction/i)).toBeDisabled();
+  });
+
+  it('hides all feature toggles when using org defaults', () => {
+    render(<ManageReposPanel {...defaultProps} />, {organization: mockOrganization});
+    // Repo is using org defaults, so all feature toggles should be hidden
+    expect(screen.queryByLabelText(/Enable PR Review/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Enable Test Generation/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Enable Error Prediction/i)).not.toBeInTheDocument();
+  });
+
+  it('shows feature toggles when repo has overrides', async () => {
+    const defaultOrgConfig = mockOrganization.preventAiConfigGithub!.default_org_config;
+    const orgWithOverride = OrganizationFixture({
+      preventAiConfigGithub: {
+        schema_version: 'v1',
+        default_org_config: defaultOrgConfig,
+        github_organizations: {
+          'org-1': {
+            org_defaults: defaultOrgConfig.org_defaults,
+            repo_overrides: {
+              'repo-1': {
+                bug_prediction: {
+                  enabled: true,
+                  triggers: {on_command_phrase: true, on_ready_for_review: false},
+                  sensitivity: 'high',
+                },
+                test_generation: {
+                  enabled: false,
+                  triggers: {on_command_phrase: false, on_ready_for_review: false},
+                },
+                vanilla: {
+                  enabled: true,
+                  triggers: {on_command_phrase: false, on_ready_for_review: false},
+                  sensitivity: 'medium',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    render(<ManageReposPanel {...defaultProps} />, {organization: orgWithOverride});
+    // Repo has overrides, so feature toggles should be enabled
+    expect(await screen.findByLabelText(/Enable PR Review/i)).toBeEnabled();
+    expect(await screen.findByLabelText(/Enable Test Generation/i)).toBeEnabled();
+    expect(await screen.findByLabelText(/Enable Error Prediction/i)).toBeEnabled();
   });
 
   it('shows error message if updateError is present', async () => {
@@ -101,8 +178,23 @@ describe('ManageReposPanel', () => {
     expect(await screen.findByText(/Could not update settings/i)).toBeInTheDocument();
   });
 
-  it('shows sensitivity options when feature is enabled', async () => {
-    render(<ManageReposPanel {...defaultProps} />, {organization: mockOrganization});
+  it('shows sensitivity options when feature is enabled and repo has overrides', async () => {
+    const defaultOrgConfig = mockOrganization.preventAiConfigGithub!.default_org_config;
+    const orgWithOverride = OrganizationFixture({
+      preventAiConfigGithub: {
+        schema_version: 'v1',
+        default_org_config: defaultOrgConfig,
+        github_organizations: {
+          'org-1': {
+            org_defaults: defaultOrgConfig.org_defaults,
+            repo_overrides: {
+              'repo-1': defaultOrgConfig.org_defaults,
+            },
+          },
+        },
+      },
+    });
+    render(<ManageReposPanel {...defaultProps} />, {organization: orgWithOverride});
     const prReviewCheckbox = await screen.findByLabelText(/Enable PR Review/i);
     const errorPredictionCheckbox = await screen.findByLabelText(
       /Enable Error Prediction/i
@@ -117,7 +209,131 @@ describe('ManageReposPanel', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows toggle for overriding organization defaults', async () => {
+    render(<ManageReposPanel {...defaultProps} />, {organization: mockOrganization});
+    expect(await screen.findByText('Override Organization Defaults')).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        /When enabled, you can customize settings for this repository/i
+      )
+    ).toBeInTheDocument();
+    const toggle = await screen.findByLabelText('Override Organization Defaults');
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).not.toBeChecked(); // Should be unchecked since repo uses org defaults
+  });
+
+  it('calls updatePreventAIFeature when toggle is clicked', async () => {
+    const mockUpdatePreventAIFeature = jest.fn();
+    mockUpdatePreventAIFeatureReturn = {
+      updatePreventAIFeature: mockUpdatePreventAIFeature,
+      isLoading: false,
+    };
+    render(<ManageReposPanel {...defaultProps} />, {organization: mockOrganization});
+    const toggle = await screen.findByLabelText('Override Organization Defaults');
+    await userEvent.click(toggle);
+
+    // Currently doesUseOrgDefaults=true (no overrides), clicking to add overrides
+    // Need to create override, so pass enabled=false (inverse of doesUseOrgDefaults)
+    expect(mockUpdatePreventAIFeature).toHaveBeenCalledWith({
+      feature: 'use_org_defaults',
+      enabled: false, // !doesUseOrgDefaults to create override
+      orgName: 'org-1',
+      repoName: 'repo-1',
+    });
+  });
+
+  it('does not show toggle when editing organization defaults', async () => {
+    render(<ManageReposPanel {...defaultProps} repoName="" isEditingOrgDefaults />, {
+      organization: mockOrganization,
+    });
+    expect(
+      await screen.findByText(
+        /These settings apply as defaults to all repositories in this organization/i
+      )
+    ).toBeInTheDocument();
+    // Should not show repo link when editing org defaults
+    expect(screen.queryByRole('link', {name: /repo-1/i})).not.toBeInTheDocument();
+    // Should not show the toggle when editing org defaults
+    expect(
+      screen.queryByLabelText('Override Organization Defaults')
+    ).not.toBeInTheDocument();
+  });
+
+  it('toggle is checked when repo has custom overrides', () => {
+    const defaultOrgConfig = mockOrganization.preventAiConfigGithub!.default_org_config;
+    const orgWithOverride = OrganizationFixture({
+      preventAiConfigGithub: {
+        schema_version: 'v1',
+        default_org_config: defaultOrgConfig,
+        github_organizations: {
+          'org-1': {
+            org_defaults: defaultOrgConfig.org_defaults,
+            repo_overrides: {
+              'repo-1': {
+                bug_prediction: {
+                  enabled: false,
+                  triggers: {on_command_phrase: false, on_ready_for_review: false},
+                },
+                test_generation: {
+                  enabled: true,
+                  triggers: {on_command_phrase: false, on_ready_for_review: false},
+                },
+                vanilla: {
+                  enabled: false,
+                  triggers: {on_command_phrase: false, on_ready_for_review: false},
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    render(<ManageReposPanel {...defaultProps} />, {organization: orgWithOverride});
+    const toggle = screen.getByLabelText('Override Organization Defaults');
+    expect(toggle).toBeChecked();
+  });
+
   describe('getRepoConfig', () => {
+    it('returns org defaults when repoName is null', () => {
+      const orgConfig: PreventAIOrgConfig = {
+        org_defaults: {
+          bug_prediction: {
+            enabled: true,
+            triggers: {on_command_phrase: true, on_ready_for_review: false},
+          },
+          test_generation: {
+            enabled: false,
+            triggers: {on_command_phrase: false, on_ready_for_review: false},
+          },
+          vanilla: {
+            enabled: true,
+            triggers: {on_command_phrase: false, on_ready_for_review: false},
+          },
+        },
+        repo_overrides: {
+          'repo-1': {
+            bug_prediction: {
+              enabled: false,
+              triggers: {on_command_phrase: false, on_ready_for_review: false},
+            },
+            test_generation: {
+              enabled: true,
+              triggers: {on_command_phrase: false, on_ready_for_review: false},
+            },
+            vanilla: {
+              enabled: false,
+              triggers: {on_command_phrase: false, on_ready_for_review: false},
+            },
+          },
+        },
+      };
+      const result = getRepoConfig(orgConfig, null);
+      expect(result).toEqual({
+        doesUseOrgDefaults: true,
+        repoConfig: orgConfig.org_defaults,
+      });
+    });
+
     it('returns repo override config when present', () => {
       const orgConfig: PreventAIOrgConfig = {
         org_defaults: {

--- a/static/app/views/prevent/preventAI/manageReposPanel.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPanel.tsx
@@ -94,6 +94,7 @@ function ManageReposPanel({
       collapsed={collapsed}
       slidePosition="right"
       ariaLabel="Settings Panel"
+      data-test-id="manage-repos-panel"
     >
       <Flex direction="column">
         <Flex
@@ -124,7 +125,7 @@ function ManageReposPanel({
               </Fragment>
             ) : (
               <Fragment>
-                <Heading as="h3">{t('Repository AI Settings')}</Heading>
+                <Heading as="h3">{t('AI Code Review Repository Settings')}</Heading>
                 <Text variant="muted" size="sm">
                   {tct(
                     'These settings apply to the selected [repoLink] repository. To switch, use the repository selector in the page header.',

--- a/static/app/views/prevent/preventAI/manageReposPanel.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPanel.tsx
@@ -104,20 +104,29 @@ function ManageReposPanel({
           background="secondary"
         >
           <Flex direction="column" gap="xs">
-            <Heading as="h3">{t('AI Code Review Settings')}</Heading>
-            <Text variant="muted" size="sm">
-              {isEditingOrgDefaults
-                ? tct(
-                    'These settings apply as defaults to all repositories in this organization. Individual repositories can override these settings. These repos currently have overrides applied: [reposWithOverrides]',
+            {isEditingOrgDefaults ? (
+              <Fragment>
+                <Heading as="h3">{t('AI Code Review Default Settings')}</Heading>
+                <Text variant="muted" size="sm">
+                  {tct(
+                    'These settings apply to all repositories by default. Individual repositories can override these defaults. The following repositories have custom settings applied: [reposWithOverrides]',
                     {
                       reposWithOverrides: (
                         <Text as="span" monospace>
-                          {repoNamesWithOverrides.join(',')}
+                          {repoNamesWithOverrides.length > 0
+                            ? repoNamesWithOverrides.join(',')
+                            : '[none]'}
                         </Text>
                       ),
                     }
-                  )
-                : tct(
+                  )}
+                </Text>
+              </Fragment>
+            ) : (
+              <Fragment>
+                <Heading as="h3">{t('Repository AI Settings')}</Heading>
+                <Text variant="muted" size="sm">
+                  {tct(
                     'These settings apply to the selected [repoLink] repository. To switch, use the repository selector in the page header.',
                     {
                       repoLink: (
@@ -127,7 +136,9 @@ function ManageReposPanel({
                       ),
                     }
                   )}
-            </Text>
+                </Text>
+              </Fragment>
+            )}
           </Flex>
           <Button
             priority="transparent"

--- a/static/app/views/prevent/preventAI/manageReposPanel.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPanel.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
@@ -16,9 +18,11 @@ import {useUpdatePreventAIFeature} from 'sentry/views/prevent/preventAI/hooks/us
 
 interface ManageReposPanelProps {
   collapsed: boolean;
+  isEditingOrgDefaults: boolean;
   onClose: () => void;
   orgName: string;
   repoName: string;
+  allRepos?: Array<{id: string; name: string}>;
 }
 
 interface SensitivityOption {
@@ -28,21 +32,25 @@ interface SensitivityOption {
 }
 
 const sensitivityOptions: SensitivityOption[] = [
-  {value: 'low', label: 'Low', details: 'Post all potential issues for maximum breadth.'},
+  {
+    value: 'low',
+    label: t('Low'),
+    details: t('Post all potential issues for maximum breadth.'),
+  },
   {
     value: 'medium',
-    label: 'Medium',
-    details: 'Post likely issues for a balance of thoroughness and noise.',
+    label: t('Medium'),
+    details: t('Post likely issues for a balance of thoroughness and noise.'),
   },
   {
     value: 'high',
-    label: 'High',
-    details: 'Post only major issues to highlight most impactful findings.',
+    label: t('High'),
+    details: t('Post only major issues to highlight most impactful findings.'),
   },
   {
     value: 'critical',
-    label: 'Critical',
-    details: 'Post only high-impact, high-sensitivity issues for maximum focus.',
+    label: t('Critical'),
+    details: t('Post only high-impact, high-sensitivity issues for maximum focus.'),
   },
 ];
 
@@ -51,6 +59,8 @@ function ManageReposPanel({
   onClose,
   orgName,
   repoName,
+  allRepos = [],
+  isEditingOrgDefaults,
 }: ManageReposPanelProps) {
   const organization = useOrganization();
   const {enableFeature, isLoading, error: updateError} = useUpdatePreventAIFeature();
@@ -75,6 +85,10 @@ function ManageReposPanel({
 
   const {doesUseOrgDefaults, repoConfig} = getRepoConfig(orgConfig, repoName);
 
+  const repoNamesWithOverrides = Object.keys(orgConfig.repo_overrides || {}).filter(
+    repoKey => allRepos.some(repo => repo.name === repoKey)
+  );
+
   return (
     <SlideOverPanel
       collapsed={collapsed}
@@ -92,16 +106,27 @@ function ManageReposPanel({
           <Flex direction="column" gap="xs">
             <Heading as="h3">{t('AI Code Review Settings')}</Heading>
             <Text variant="muted" size="sm">
-              {tct(
-                'These settings apply to the selected [repoLink] repository. To switch, use the repository selector in the page header.',
-                {
-                  repoLink: (
-                    <ExternalLink href={`https://github.com/${orgName}/${repoName}`}>
-                      {repoName}
-                    </ExternalLink>
-                  ),
-                }
-              )}
+              {isEditingOrgDefaults
+                ? tct(
+                    'These settings apply as defaults to all repositories in this organization. Individual repositories can override these settings. These repos currently have overrides applied: [reposWithOverrides]',
+                    {
+                      reposWithOverrides: (
+                        <Text as="span" monospace>
+                          {repoNamesWithOverrides.join(',')}
+                        </Text>
+                      ),
+                    }
+                  )
+                : tct(
+                    'These settings apply to the selected [repoLink] repository. To switch, use the repository selector in the page header.',
+                    {
+                      repoLink: (
+                        <ExternalLink href={`https://github.com/${orgName}/${repoName}`}>
+                          {repoName}
+                        </ExternalLink>
+                      ),
+                    }
+                  )}
             </Text>
           </Flex>
           <Button
@@ -118,241 +143,301 @@ function ManageReposPanel({
         {updateError && (
           <Alert type="error">{'Could not update settings. Please try again.'}</Alert>
         )}
-        {doesUseOrgDefaults && (
-          <Flex direction="column" padding="xl xl 0 xl">
-            <Alert type="info">
-              {t("This repository is using the organization's defaults")}
-            </Alert>
-          </Flex>
-        )}
         <Flex direction="column" gap="xl" padding="2xl">
-          {/* PR Review Feature */}
-          <Flex direction="column">
+          {/* Override Organization Defaults Toggle */}
+          {!isEditingOrgDefaults && (
             <Flex
               border="muted"
               radius="md"
-              background="secondary"
               padding="lg xl"
               align="center"
               justify="between"
             >
               <Flex direction="column" gap="sm">
-                <Text size="md">{t('Enable PR Review')}</Text>
+                <Text size="md">{t('Override Organization Defaults')}</Text>
                 <Text variant="muted" size="sm">
-                  {t('Run when @sentry review is commented on a PR.')}
+                  {t(
+                    'When enabled, you can customize settings for this repository. When disabled, this repository will use the organization default settings.'
+                  )}
                 </Text>
               </Flex>
               <Switch
                 size="lg"
-                checked={repoConfig.vanilla.enabled}
+                checked={!doesUseOrgDefaults}
                 disabled={isLoading || !canEditSettings}
                 onChange={async () => {
-                  const newValue = !repoConfig.vanilla.enabled;
                   await enableFeature({
-                    feature: 'vanilla',
-                    enabled: newValue,
+                    feature: 'use_org_defaults',
                     orgName,
                     repoName,
+                    enabled: !doesUseOrgDefaults,
                   });
                 }}
-                aria-label="Enable PR Review"
+                aria-label="Override Organization Defaults"
               />
             </Flex>
-            {repoConfig.vanilla.enabled && (
-              <Flex paddingLeft="xl" direction="column">
-                <Flex direction="column" borderLeft="muted" paddingLeft="md">
-                  <FieldGroup
-                    label={<Text size="md">{t('Sensitivity')}</Text>}
-                    help={
-                      <Text size="xs" variant="muted">
-                        {t('Set the sensitivity level for PR review analysis.')}
-                      </Text>
+          )}
+          {(isEditingOrgDefaults || !doesUseOrgDefaults) && (
+            <Fragment>
+              {/* PR Review Feature */}
+              <Flex direction="column">
+                <Flex
+                  border="muted"
+                  radius="md"
+                  background="secondary"
+                  padding="lg xl"
+                  align="center"
+                  justify="between"
+                >
+                  <Flex direction="column" gap="sm">
+                    <Text size="md">{t('Enable PR Review')}</Text>
+                    <Text variant="muted" size="sm">
+                      {t('Run when @sentry review is commented on a PR.')}
+                    </Text>
+                  </Flex>
+                  <Switch
+                    size="lg"
+                    checked={repoConfig.vanilla.enabled}
+                    disabled={
+                      isLoading ||
+                      !canEditSettings ||
+                      (!isEditingOrgDefaults && doesUseOrgDefaults)
                     }
-                    alignRight
-                    flexibleControlStateSize
-                  >
-                    <CompactSelect
-                      value={repoConfig.vanilla.sensitivity ?? 'medium'}
-                      options={sensitivityOptions}
-                      disabled={isLoading || !canEditSettings}
-                      onChange={async option =>
-                        await enableFeature({
-                          feature: 'vanilla',
-                          enabled: true,
-                          orgName,
-                          repoName,
-                          sensitivity: option.value,
-                        })
-                      }
-                      aria-label="PR Review Sensitivity"
-                      menuWidth={350}
-                      maxMenuWidth={500}
-                      data-test-id="pr-review-sensitivity-dropdown"
-                    />
-                  </FieldGroup>
+                    onChange={async () => {
+                      const newValue = !repoConfig.vanilla.enabled;
+                      await enableFeature({
+                        feature: 'vanilla',
+                        enabled: newValue,
+                        orgName,
+                        repoName,
+                      });
+                    }}
+                    aria-label="Enable PR Review"
+                  />
+                </Flex>
+                {repoConfig.vanilla.enabled && (
+                  <Flex paddingLeft="xl" direction="column">
+                    <Flex direction="column" borderLeft="muted" paddingLeft="md">
+                      <FieldGroup
+                        label={<Text size="md">{t('Sensitivity')}</Text>}
+                        help={
+                          <Text size="xs" variant="muted">
+                            {t('Set the sensitivity level for PR review analysis.')}
+                          </Text>
+                        }
+                        alignRight
+                        flexibleControlStateSize
+                      >
+                        <CompactSelect
+                          value={repoConfig.vanilla.sensitivity ?? 'medium'}
+                          options={sensitivityOptions}
+                          disabled={
+                            isLoading ||
+                            !canEditSettings ||
+                            (!isEditingOrgDefaults && doesUseOrgDefaults)
+                          }
+                          onChange={async option =>
+                            await enableFeature({
+                              feature: 'vanilla',
+                              enabled: true,
+                              orgName,
+                              repoName,
+                              sensitivity: option.value,
+                            })
+                          }
+                          aria-label="PR Review Sensitivity"
+                          menuWidth={350}
+                          maxMenuWidth={500}
+                          data-test-id="pr-review-sensitivity-dropdown"
+                        />
+                      </FieldGroup>
+                    </Flex>
+                  </Flex>
+                )}
+              </Flex>
+
+              {/* Test Generation Feature */}
+              <Flex direction="column">
+                <Flex
+                  border="muted"
+                  radius="md"
+                  background="secondary"
+                  padding="lg xl"
+                  align="center"
+                  justify="between"
+                >
+                  <Flex direction="column" gap="sm">
+                    <Text size="md">{t('Enable Test Generation')}</Text>
+                    <Text variant="muted" size="sm">
+                      {t('Run when @sentry generate-test is commented on a PR.')}
+                    </Text>
+                  </Flex>
+                  <Switch
+                    size="lg"
+                    checked={repoConfig.test_generation.enabled}
+                    disabled={
+                      isLoading ||
+                      !canEditSettings ||
+                      (!isEditingOrgDefaults && doesUseOrgDefaults)
+                    }
+                    onChange={async () => {
+                      const newValue = !repoConfig.test_generation.enabled;
+                      await enableFeature({
+                        feature: 'test_generation',
+                        enabled: newValue,
+                        orgName,
+                        repoName,
+                      });
+                    }}
+                    aria-label="Enable Test Generation"
+                  />
                 </Flex>
               </Flex>
-            )}
-          </Flex>
 
-          {/* Test Generation Feature */}
-          <Flex direction="column">
-            <Flex
-              border="muted"
-              radius="md"
-              background="secondary"
-              padding="lg xl"
-              align="center"
-              justify="between"
-            >
-              <Flex direction="column" gap="sm">
-                <Text size="md">{t('Enable Test Generation')}</Text>
-                <Text variant="muted" size="sm">
-                  {t('Run when @sentry generate-test is commented on a PR.')}
-                </Text>
-              </Flex>
-              <Switch
-                size="lg"
-                checked={repoConfig.test_generation.enabled}
-                disabled={isLoading || !canEditSettings}
-                onChange={async () => {
-                  const newValue = !repoConfig.test_generation.enabled;
-                  await enableFeature({
-                    feature: 'test_generation',
-                    enabled: newValue,
-                    orgName,
-                    repoName,
-                  });
-                }}
-                aria-label="Enable Test Generation"
-              />
-            </Flex>
-          </Flex>
-
-          {/* Error Prediction Feature with SubItems */}
-          <Flex direction="column">
-            <Flex
-              border="muted"
-              radius="md"
-              background="secondary"
-              padding="lg xl"
-              align="center"
-              justify="between"
-            >
-              <Flex direction="column" gap="sm">
-                <Text size="md">{t('Enable Error Prediction')}</Text>
-                <Text variant="muted" size="sm">
-                  {t('Allow organization members to review potential bugs.')}
-                </Text>
-              </Flex>
-              <Switch
-                size="lg"
-                checked={repoConfig.bug_prediction.enabled}
-                disabled={isLoading || !canEditSettings}
-                onChange={async () => {
-                  const newValue = !repoConfig.bug_prediction.enabled;
-                  await enableFeature({
-                    feature: 'bug_prediction',
-                    enabled: newValue,
-                    orgName,
-                    repoName,
-                  });
-                }}
-                aria-label="Enable Error Prediction"
-              />
-            </Flex>
-            {repoConfig.bug_prediction.enabled && (
-              <Flex paddingLeft="xl" direction="column">
-                <Flex direction="column" borderLeft="muted" paddingLeft="md">
-                  <FieldGroup
-                    label={<Text size="md">{t('Sensitivity')}</Text>}
-                    help={
-                      <Text size="xs" variant="muted">
-                        {t('Set the sensitivity level for error prediction.')}
-                      </Text>
+              {/* Error Prediction Feature with SubItems */}
+              <Flex direction="column">
+                <Flex
+                  border="muted"
+                  radius="md"
+                  background="secondary"
+                  padding="lg xl"
+                  align="center"
+                  justify="between"
+                >
+                  <Flex direction="column" gap="sm">
+                    <Text size="md">{t('Enable Error Prediction')}</Text>
+                    <Text variant="muted" size="sm">
+                      {t('Allow organization members to review potential bugs.')}
+                    </Text>
+                  </Flex>
+                  <Switch
+                    size="lg"
+                    checked={repoConfig.bug_prediction.enabled}
+                    disabled={
+                      isLoading ||
+                      !canEditSettings ||
+                      (!isEditingOrgDefaults && doesUseOrgDefaults)
                     }
-                    alignRight
-                    flexibleControlStateSize
-                  >
-                    <CompactSelect
-                      value={repoConfig.bug_prediction.sensitivity ?? 'medium'}
-                      options={sensitivityOptions}
-                      disabled={isLoading || !canEditSettings}
-                      onChange={async option =>
-                        await enableFeature({
-                          feature: 'bug_prediction',
-                          enabled: true,
-                          orgName,
-                          repoName,
-                          sensitivity: option.value,
-                        })
-                      }
-                      aria-label="Error Prediction Sensitivity"
-                      menuWidth={350}
-                      maxMenuWidth={500}
-                      data-test-id="error-prediction-sensitivity-dropdown"
-                    />
-                  </FieldGroup>
-                  <FieldGroup
-                    label={<Text size="md">{t('Auto Run on Opened Pull Requests')}</Text>}
-                    help={
-                      <Text size="xs" variant="muted">
-                        {t('Run when a PR is published, ignoring new pushes.')}
-                      </Text>
-                    }
-                    alignRight
-                    flexibleControlStateSize
-                  >
-                    <Switch
-                      size="lg"
-                      checked={repoConfig.bug_prediction.triggers.on_ready_for_review}
-                      disabled={isLoading || !canEditSettings}
-                      onChange={async () => {
-                        const newValue =
-                          !repoConfig.bug_prediction.triggers.on_ready_for_review;
-                        await enableFeature({
-                          feature: 'bug_prediction',
-                          trigger: {on_ready_for_review: newValue},
-                          enabled: true,
-                          orgName,
-                          repoName,
-                        });
-                      }}
-                      aria-label="Auto Run on Opened Pull Requests"
-                    />
-                  </FieldGroup>
-                  <FieldGroup
-                    label={<Text size="md">{t('Run When Mentioned')}</Text>}
-                    help={
-                      <Text size="xs" variant="muted">
-                        {t('Run when @sentry review is commented on a PR.')}
-                      </Text>
-                    }
-                    alignRight
-                    flexibleControlStateSize
-                  >
-                    <Switch
-                      size="lg"
-                      checked={repoConfig.bug_prediction.triggers.on_command_phrase}
-                      disabled={isLoading || !canEditSettings}
-                      onChange={async () => {
-                        const newValue =
-                          !repoConfig.bug_prediction.triggers.on_command_phrase;
-                        await enableFeature({
-                          feature: 'bug_prediction',
-                          trigger: {on_command_phrase: newValue},
-                          enabled: true,
-                          orgName,
-                          repoName,
-                        });
-                      }}
-                      aria-label="Run When Mentioned"
-                    />
-                  </FieldGroup>
+                    onChange={async () => {
+                      const newValue = !repoConfig.bug_prediction.enabled;
+                      await enableFeature({
+                        feature: 'bug_prediction',
+                        enabled: newValue,
+                        orgName,
+                        repoName,
+                      });
+                    }}
+                    aria-label="Enable Error Prediction"
+                  />
                 </Flex>
+                {repoConfig.bug_prediction.enabled && (
+                  <Flex paddingLeft="xl" direction="column">
+                    <Flex direction="column" borderLeft="muted" paddingLeft="md">
+                      <FieldGroup
+                        label={<Text size="md">{t('Sensitivity')}</Text>}
+                        help={
+                          <Text size="xs" variant="muted">
+                            {t('Set the sensitivity level for error prediction.')}
+                          </Text>
+                        }
+                        alignRight
+                        flexibleControlStateSize
+                      >
+                        <CompactSelect
+                          value={repoConfig.bug_prediction.sensitivity ?? 'medium'}
+                          options={sensitivityOptions}
+                          disabled={
+                            isLoading ||
+                            !canEditSettings ||
+                            (!isEditingOrgDefaults && doesUseOrgDefaults)
+                          }
+                          onChange={async option =>
+                            await enableFeature({
+                              feature: 'bug_prediction',
+                              enabled: true,
+                              orgName,
+                              repoName,
+                              sensitivity: option.value,
+                            })
+                          }
+                          aria-label="Error Prediction Sensitivity"
+                          menuWidth={350}
+                          maxMenuWidth={500}
+                          data-test-id="error-prediction-sensitivity-dropdown"
+                        />
+                      </FieldGroup>
+                      <FieldGroup
+                        label={
+                          <Text size="md">{t('Auto Run on Opened Pull Requests')}</Text>
+                        }
+                        help={
+                          <Text size="xs" variant="muted">
+                            {t('Run when a PR is published, ignoring new pushes.')}
+                          </Text>
+                        }
+                        alignRight
+                        flexibleControlStateSize
+                      >
+                        <Switch
+                          size="lg"
+                          checked={repoConfig.bug_prediction.triggers.on_ready_for_review}
+                          disabled={
+                            isLoading ||
+                            !canEditSettings ||
+                            (!isEditingOrgDefaults && doesUseOrgDefaults)
+                          }
+                          onChange={async () => {
+                            const newValue =
+                              !repoConfig.bug_prediction.triggers.on_ready_for_review;
+                            await enableFeature({
+                              feature: 'bug_prediction',
+                              trigger: {on_ready_for_review: newValue},
+                              enabled: true,
+                              orgName,
+                              repoName,
+                            });
+                          }}
+                          aria-label="Auto Run on Opened Pull Requests"
+                        />
+                      </FieldGroup>
+                      <FieldGroup
+                        label={<Text size="md">{t('Run When Mentioned')}</Text>}
+                        help={
+                          <Text size="xs" variant="muted">
+                            {t('Run when @sentry review is commented on a PR.')}
+                          </Text>
+                        }
+                        alignRight
+                        flexibleControlStateSize
+                      >
+                        <Switch
+                          size="lg"
+                          checked={repoConfig.bug_prediction.triggers.on_command_phrase}
+                          disabled={
+                            isLoading ||
+                            !canEditSettings ||
+                            (!isEditingOrgDefaults && doesUseOrgDefaults)
+                          }
+                          onChange={async () => {
+                            const newValue =
+                              !repoConfig.bug_prediction.triggers.on_command_phrase;
+                            await enableFeature({
+                              feature: 'bug_prediction',
+                              trigger: {on_command_phrase: newValue},
+                              enabled: true,
+                              orgName,
+                              repoName,
+                            });
+                          }}
+                          aria-label="Run When Mentioned"
+                        />
+                      </FieldGroup>
+                    </Flex>
+                  </Flex>
+                )}
               </Flex>
-            )}
-          </Flex>
+            </Fragment>
+          )}
         </Flex>
       </Flex>
     </SlideOverPanel>

--- a/static/app/views/prevent/preventAI/manageReposToolbar.spec.tsx
+++ b/static/app/views/prevent/preventAI/manageReposToolbar.spec.tsx
@@ -120,7 +120,7 @@ describe('ManageReposToolbar', () => {
     expect(await screen.findByText('All Repos')).toBeInTheDocument();
   });
 
-  it('calls onRepoChange with "__ALL_REPOS__" when "All Repos" is selected', async () => {
+  it('calls onRepoChange with "__$ALL_REPOS__" when "All Repos" is selected', async () => {
     render(<ManageReposToolbar {...defaultProps} />);
     const repoTrigger = await screen.findByRole('button', {name: /repo-1/i});
     await userEvent.click(repoTrigger);
@@ -128,6 +128,6 @@ describe('ManageReposToolbar', () => {
     const allReposOption = await screen.findByText('All Repos');
     await userEvent.click(allReposOption);
 
-    expect(defaultProps.onRepoChange).toHaveBeenCalledWith('__ALL_REPOS__');
+    expect(defaultProps.onRepoChange).toHaveBeenCalledWith('__$ALL_REPOS__');
   });
 });

--- a/static/app/views/prevent/preventAI/manageReposToolbar.spec.tsx
+++ b/static/app/views/prevent/preventAI/manageReposToolbar.spec.tsx
@@ -111,4 +111,23 @@ describe('ManageReposToolbar', () => {
     expect(repoOptionTexts).not.toContain('repo-1');
     expect(repoOptionTexts).not.toContain('repo-2');
   });
+
+  it('shows "All Repos" option at the top of repository dropdown', async () => {
+    render(<ManageReposToolbar {...defaultProps} />);
+    const repoTrigger = await screen.findByRole('button', {name: /repo-1/i});
+    await userEvent.click(repoTrigger);
+
+    expect(await screen.findByText('All Repos')).toBeInTheDocument();
+  });
+
+  it('calls onRepoChange with "__ALL_REPOS__" when "All Repos" is selected', async () => {
+    render(<ManageReposToolbar {...defaultProps} />);
+    const repoTrigger = await screen.findByRole('button', {name: /repo-1/i});
+    await userEvent.click(repoTrigger);
+
+    const allReposOption = await screen.findByText('All Repos');
+    await userEvent.click(allReposOption);
+
+    expect(defaultProps.onRepoChange).toHaveBeenCalledWith('__ALL_REPOS__');
+  });
 });

--- a/static/app/views/prevent/preventAI/manageReposToolbar.tsx
+++ b/static/app/views/prevent/preventAI/manageReposToolbar.tsx
@@ -7,6 +7,8 @@ import {IconBuilding, IconRepository} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {PreventAIOrg} from 'sentry/types/prevent';
 
+export const ALL_REPOS_VALUE = '__$ALL_REPOS__';
+
 function ManageReposToolbar({
   installedOrgs,
   onOrgChange,
@@ -31,12 +33,19 @@ function ManageReposToolbar({
 
   const repositoryOptions = useMemo(() => {
     const org = installedOrgs.find(o => o.name === selectedOrg);
-    return (
+    const repoOptions =
       org?.repos.map(repo => ({
         value: repo.name,
         label: repo.name,
-      })) ?? []
-    );
+      })) ?? [];
+
+    return [
+      {
+        value: ALL_REPOS_VALUE,
+        label: t('All Repos'),
+      },
+      ...repoOptions,
+    ];
   }, [installedOrgs, selectedOrg]);
 
   return (


### PR DESCRIPTION
This PR updates 2 things in the PR Review Configuration page.
1. Allows you to make settings for "All Repos" in an org by selecting that from the dropdown (the "org defaults")
2. Lets you go back and forth between applying the "org defaults" for a given repo or a specific override

There may be pending design changes to the "Override org defaults" toggle design. In the meantime, the basic concept/logic will stay the same. Note only internal feature flagged testing orgs can access this for now.

Screenshots:
<img width="1486" height="518" alt="Screenshot 2025-10-17 at 12 20 56 PM" src="https://github.com/user-attachments/assets/4952b9a1-b09f-44ba-996b-26ea58fbc544" />
<img width="1487" height="478" alt="Screenshot 2025-10-17 at 12 21 10 PM" src="https://github.com/user-attachments/assets/cf6971a7-94de-430b-b0b5-7a7933a23162" />
<img width="1491" height="424" alt="Screenshot 2025-10-17 at 12 21 19 PM" src="https://github.com/user-attachments/assets/f157f7db-922c-4feb-8033-549f7d35e76f" />


Closes https://linear.app/getsentry/issue/PREVENT-395/add-all-repos-to-the-dropdown-in-the-ui
Closes https://linear.app/getsentry/issue/PREVENT-396/make-the-use-org-defaults-a-toggle-and-change-the-copy