### PR TITLE
fix(onboarding): Add dotnet-uwp to desktop category

### DIFF
--- a/static/app/data/platformPickerCategories.tsx
+++ b/static/app/data/platformPickerCategories.tsx
@@ -138,6 +138,7 @@ const desktop: Set<PlatformKey> = new Set([
   'dotnet-maui',
   'dotnet-winforms',
   'dotnet-wpf',
+  'dotnet-uwp',
   'electron',
   'dart',
   'flutter',


### PR DESCRIPTION
It seems this platform was missing, which is why it can’t be found when creating a new project, even though we have onboarding documentation for it. I tried to check whether it was removed intentionally, but so far I haven’t found any indication of that.