### PR TITLE
feat(onboarding): Smaller subheadings

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/contentBlocks/defaultRenderers.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/contentBlocks/defaultRenderers.tsx
@@ -123,8 +123,18 @@ const TextBlockWrapper = styled('div')`
 function SubHeaderBlock(block: Extract<ContentBlock, {type: 'subheader'}>) {
   // TODO(aknaus): Use <Heading/> throughout the onboarding docs codebase
   // <Heading as="h5"> has a different styling and does not match the other headings we currently use
-  return <h5 css={baseBlockStyles}>{block.text}</h5>;
+  return (
+    <SubHeaderBlockWrapper css={baseBlockStyles}>{block.text}</SubHeaderBlockWrapper>
+  );
 }
+
+// TODO(aknaus): use <Heading/> instead
+const SubHeaderBlockWrapper = styled('h5')`
+  ${baseBlockStyles}
+  font-size: ${p => p.theme.fontSize.lg};
+  font-weight: ${p => p.theme.fontWeight.bold};
+  ${p => coloredCodeStyles(p.theme)}
+`;
 
 function ListBlock(block: Extract<ContentBlock, {type: 'list'}>) {
   return (

--- a/static/app/components/onboarding/gettingStartedDoc/contentBlocks/defaultRenderers.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/contentBlocks/defaultRenderers.tsx
@@ -123,9 +123,7 @@ const TextBlockWrapper = styled('div')`
 function SubHeaderBlock(block: Extract<ContentBlock, {type: 'subheader'}>) {
   // TODO(aknaus): Use <Heading/> throughout the onboarding docs codebase
   // <Heading as="h5"> has a different styling and does not match the other headings we currently use
-  return (
-    <SubHeaderBlockWrapper css={baseBlockStyles}>{block.text}</SubHeaderBlockWrapper>
-  );
+  return <SubHeaderBlockWrapper>{block.text}</SubHeaderBlockWrapper>;
 }
 
 // TODO(aknaus): use <Heading/> instead


### PR DESCRIPTION
### Before
Subheading were almost as big as normal headings.
<img width="295" height="182" alt="Screenshot 2025-10-17 at 09 34 34" src="https://github.com/user-attachments/assets/61fdea7c-5d70-4121-a9de-c21c7b06c721" />

### After
<img width="295" height="182" alt="Screenshot 2025-10-17 at 09 34 40" src="https://github.com/user-attachments/assets/22d6e6f2-d782-43f0-aabb-e1c1de66210b" />

Note: In the future we should change this to use the new typography components from our design system.