### PR TITLE
ref(content-blocks): Convert go-fasthttp

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/contentBlocks/defaultRenderers.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/contentBlocks/defaultRenderers.tsx
@@ -41,7 +41,7 @@ function AlertBlock({
   icon,
 }: Extract<ContentBlock, {type: 'alert'}>) {
   return (
-    <div css={baseBlockStyles}>
+    <div css={[baseBlockStyles, coloredCodeStyles]}>
       <Alert
         type={alertType}
         showIcon={showIcon}

--- a/static/app/gettingStartedDocs/go/fasthttp.tsx
+++ b/static/app/gettingStartedDocs/go/fasthttp.tsx
@@ -1,6 +1,3 @@
-import {Fragment} from 'react';
-
-import {Alert} from 'sentry/components/core/alert';
 import {ExternalLink} from 'sentry/components/core/link';
 import type {
   Docs,
@@ -142,11 +139,15 @@ const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct('Install our Go FastHTTP SDK using [code:go get]:', {
-        code: <code />,
-      }),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: tct('Install our Go FastHTTP SDK using [code:go get]:', {
+            code: <code />,
+          }),
+        },
+        {
+          type: 'code',
           language: 'bash',
           code: 'go get github.com/getsentry/sentry-go/fasthttp',
         },
@@ -156,27 +157,35 @@ const onboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        "Import and initialize the Sentry SDK early in your application's setup:"
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: t(
+            "Import and initialize the Sentry SDK early in your application's setup:"
+          ),
+        },
+        {
+          type: 'code',
           language: 'go',
           code: getConfigureSnippet(params),
         },
         {
-          description: (
-            <Fragment>
-              <strong>{t('Options')}</strong>
-              <p>
-                {tct(
-                  '[code:sentryfasthttp] accepts a struct of [code:Options] that allows you to configure how the handler will behave.',
-                  {code: <code />}
-                )}
-              </p>
-              {t('Currently it respects 3 options:')}
-            </Fragment>
+          type: 'subheader',
+          text: t('Options'),
+        },
+        {
+          type: 'text',
+          text: tct(
+            '[code:sentryfasthttp] accepts a struct of [code:Options] that allows you to configure how the handler will behave.',
+            {code: <code />}
           ),
+        },
+        {
+          type: 'text',
+          text: t('Currently it respects 3 options:'),
+        },
+        {
+          type: 'code',
           language: 'go',
           code: getOptionsSnippet(),
         },
@@ -184,40 +193,41 @@ const onboarding: OnboardingConfig = {
     },
     {
       title: t('Usage'),
-      description: (
-        <Fragment>
-          <p>
-            {tct(
-              "[code:sentryfasthttp] attaches an instance of [sentryHubLink:*sentry.Hub] to the request's context, which makes it available throughout the rest of the request's lifetime. You can access it by using the [code:sentryfasthttp.GetHubFromContext()] method on the context itself in any of your proceeding middleware and routes. And it should be used instead of the global [code:sentry.CaptureMessage], [code:sentry.CaptureException], or any other calls, as it keeps the separation of data between the requests.",
-              {
-                sentryHubLink: (
-                  <ExternalLink href="https://pkg.go.dev/github.com/getsentry/sentry-go#Hub" />
-                ),
-                code: <code />,
-              }
-            )}
-          </p>
-          <Alert type="info" showIcon={false}>
-            {tct(
-              "Keep in mind that [code:*sentry.Hub] won't be available in middleware attached before [code:sentryfasthttp]!",
-              {code: <code />}
-            )}
-          </Alert>
-        </Fragment>
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: tct(
+            "[code:sentryfasthttp] attaches an instance of [sentryHubLink:*sentry.Hub] to the request's context, which makes it available throughout the rest of the request's lifetime. You can access it by using the [code:sentryfasthttp.GetHubFromContext()] method on the context itself in any of your proceeding middleware and routes. And it should be used instead of the global [code:sentry.CaptureMessage], [code:sentry.CaptureException], or any other calls, as it keeps the separation of data between the requests.",
+            {
+              sentryHubLink: (
+                <ExternalLink href="https://pkg.go.dev/github.com/getsentry/sentry-go#Hub" />
+              ),
+              code: <code />,
+            }
+          ),
+        },
+        {
+          type: 'alert',
+          alertType: 'info',
+          showIcon: false,
+          text: tct(
+            "Keep in mind that [code:*sentry.Hub] won't be available in middleware attached before [code:sentryfasthttp]!",
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
           language: 'go',
           code: getUsageSnippet(),
         },
         {
-          description: (
-            <strong>
-              {tct('Accessing Request in [beforeSendCode:BeforeSend] callback', {
-                beforeSendCode: <code />,
-              })}
-            </strong>
-          ),
+          type: 'subheader',
+          text: tct('Accessing Request in [beforeSendCode:BeforeSend] callback', {
+            beforeSendCode: <code />,
+          }),
+        },
+        {
+          type: 'code',
           language: 'go',
           code: getBeforeSendSnippet(params),
         },
@@ -249,9 +259,14 @@ const crashReportOnboarding: OnboardingConfig = {
   configure: () => [
     {
       type: StepType.CONFIGURE,
-      description: getCrashReportModalConfigDescription({
-        link: 'https://docs.sentry.io/platforms/go/guides/fasthttp/user-feedback/configuration/#crash-report-modal',
-      }),
+      content: [
+        {
+          type: 'text',
+          text: getCrashReportModalConfigDescription({
+            link: 'https://docs.sentry.io/platforms/go/guides/fasthttp/user-feedback/configuration/#crash-report-modal',
+          }),
+        },
+      ],
     },
   ],
   verify: () => [],

--- a/static/app/gettingStartedDocs/go/fasthttp.tsx
+++ b/static/app/gettingStartedDocs/go/fasthttp.tsx
@@ -175,14 +175,13 @@ const onboarding: OnboardingConfig = {
         },
         {
           type: 'text',
-          text: tct(
-            '[code:sentryfasthttp] accepts a struct of [code:Options] that allows you to configure how the handler will behave.',
-            {code: <code />}
-          ),
-        },
-        {
-          type: 'text',
-          text: t('Currently it respects 3 options:'),
+          text: [
+            tct(
+              '[code:sentryfasthttp] accepts a struct of [code:Options] that allows you to configure how the handler will behave.',
+              {code: <code />}
+            ),
+            t('Currently it respects 3 options:'),
+          ],
         },
         {
           type: 'code',


### PR DESCRIPTION
Also add code styles to alerts.
- part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)