### PR TITLE
ref(content-blocks): Convert go-iris

### DIFF
--- a/static/app/gettingStartedDocs/go/iris.tsx
+++ b/static/app/gettingStartedDocs/go/iris.tsx
@@ -1,6 +1,3 @@
-import {Fragment} from 'react';
-
-import {Alert} from 'sentry/components/core/alert';
 import {ExternalLink} from 'sentry/components/core/link';
 import type {
   Docs,
@@ -126,11 +123,15 @@ const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct('Install our Go Iris SDK using [code:go get]:', {
-        code: <code />,
-      }),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: tct('Install our Go Iris SDK using [code:go get]:', {
+            code: <code />,
+          }),
+        },
+        {
+          type: 'code',
           language: 'bash',
           code: 'go get github.com/getsentry/sentry-go/iris',
         },
@@ -140,27 +141,34 @@ const onboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        "Import and initialize the Sentry SDK early in your application's setup:"
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: t(
+            "Import and initialize the Sentry SDK early in your application's setup:"
+          ),
+        },
+        {
+          type: 'code',
           language: 'go',
           code: getConfigureSnippet(params),
         },
         {
-          description: (
-            <Fragment>
-              <strong>{t('Options')}</strong>
-              <p>
-                {tct(
-                  '[code:sentryiris] accepts a struct of [code:Options] that allows you to configure how the handler will behave.',
-                  {code: <code />}
-                )}
-              </p>
-              {t('Currently it respects 3 options:')}
-            </Fragment>
-          ),
+          type: 'subheader',
+          text: t('Options'),
+        },
+        {
+          type: 'text',
+          text: [
+            tct(
+              '[code:sentryiris] accepts a struct of [code:Options] that allows you to configure how the handler will behave.',
+              {code: <code />}
+            ),
+            t('Currently it respects 3 options:'),
+          ],
+        },
+        {
+          type: 'code',
           language: 'go',
           code: getOptionsSnippet(),
         },
@@ -168,40 +176,41 @@ const onboarding: OnboardingConfig = {
     },
     {
       title: t('Usage'),
-      description: (
-        <Fragment>
-          <p>
-            {tct(
-              "[code:sentryiris] attaches an instance of [sentryHubLink:*sentry.Hub] to the [code:iris.Context], which makes it available throughout the rest of the request's lifetime. You can access it by using the [code:sentryiris.GetHubFromContext()] method on the context itself in any of your proceeding middleware and routes. And it should be used instead of the global [code:sentry.CaptureMessage], [code:sentry.CaptureException], or any other calls, as it keeps the separation of data between the requests.",
-              {
-                code: <code />,
-                sentryHubLink: (
-                  <ExternalLink href="https://pkg.go.dev/github.com/getsentry/sentry-go#Hub" />
-                ),
-              }
-            )}
-          </p>
-          <Alert type="info" showIcon={false}>
-            {tct(
-              "Keep in mind that [code:*sentry.Hub] won't be available in middleware attached before [code:sentryiris]!",
-              {code: <code />}
-            )}
-          </Alert>
-        </Fragment>
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: tct(
+            "[code:sentryiris] attaches an instance of [sentryHubLink:*sentry.Hub] to the [code:iris.Context], which makes it available throughout the rest of the request's lifetime. You can access it by using the [code:sentryiris.GetHubFromContext()] method on the context itself in any of your proceeding middleware and routes. And it should be used instead of the global [code:sentry.CaptureMessage], [code:sentry.CaptureException], or any other calls, as it keeps the separation of data between the requests.",
+            {
+              code: <code />,
+              sentryHubLink: (
+                <ExternalLink href="https://pkg.go.dev/github.com/getsentry/sentry-go#Hub" />
+              ),
+            }
+          ),
+        },
+        {
+          type: 'alert',
+          alertType: 'info',
+          showIcon: false,
+          text: tct(
+            "Keep in mind that [code:*sentry.Hub] won't be available in middleware attached before [code:sentryiris]!",
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
           language: 'go',
           code: getUsageSnippet(),
         },
         {
-          description: (
-            <strong>
-              {tct('Accessing Request in [beforeSendCode:BeforeSend] callback', {
-                beforeSendCode: <code />,
-              })}
-            </strong>
-          ),
+          type: 'subheader',
+          text: tct('Accessing Request in [beforeSendCode:BeforeSend] callback', {
+            beforeSendCode: <code />,
+          }),
+        },
+        {
+          type: 'code',
           language: 'go',
           code: getBeforeSendSnippet(params),
         },
@@ -233,9 +242,14 @@ const crashReportOnboarding: OnboardingConfig = {
   configure: () => [
     {
       type: StepType.CONFIGURE,
-      description: getCrashReportModalConfigDescription({
-        link: 'https://docs.sentry.io/platforms/go/guides/iris/user-feedback/configuration/#crash-report-modal',
-      }),
+      content: [
+        {
+          type: 'text',
+          text: getCrashReportModalConfigDescription({
+            link: 'https://docs.sentry.io/platforms/go/guides/iris/user-feedback/configuration/#crash-report-modal',
+          }),
+        },
+      ],
     },
   ],
   verify: () => [],


### PR DESCRIPTION
part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)