### PR TITLE
ref(content-blocks): Convert go-martini

### DIFF
--- a/static/app/gettingStartedDocs/go/martini.tsx
+++ b/static/app/gettingStartedDocs/go/martini.tsx
@@ -1,6 +1,3 @@
-import {Fragment} from 'react';
-
-import {Alert} from 'sentry/components/core/alert';
 import {ExternalLink} from 'sentry/components/core/link';
 import type {
   Docs,
@@ -124,11 +121,15 @@ const onboarding: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct('Install our Go Martini SDK using [code:go get]:', {
-        code: <code />,
-      }),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: tct('Install our Go Martini SDK using [code:go get]:', {
+            code: <code />,
+          }),
+        },
+        {
+          type: 'code',
           language: 'bash',
           code: 'go get github.com/getsentry/sentry-go/martini',
         },
@@ -138,27 +139,34 @@ const onboarding: OnboardingConfig = {
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        "Import and initialize the Sentry SDK early in your application's setup:"
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: t(
+            "Import and initialize the Sentry SDK early in your application's setup:"
+          ),
+        },
+        {
+          type: 'code',
           language: 'go',
           code: getConfigureSnippet(params),
         },
         {
-          description: (
-            <Fragment>
-              <strong>{t('Options')}</strong>
-              <p>
-                {tct(
-                  '[code:sentrymartini] accepts a struct of [code:Options] that allows you to configure how the handler will behave.',
-                  {code: <code />}
-                )}
-              </p>
-              {t('Currently it respects 3 options:')}
-            </Fragment>
-          ),
+          type: 'subheader',
+          text: t('Options'),
+        },
+        {
+          type: 'text',
+          text: [
+            tct(
+              '[code:sentrymartini] accepts a struct of [code:Options] that allows you to configure how the handler will behave.',
+              {code: <code />}
+            ),
+            t('Currently it respects 3 options:'),
+          ],
+        },
+        {
+          type: 'code',
           language: 'go',
           code: getOptionsSnippet(),
         },
@@ -166,40 +174,41 @@ const onboarding: OnboardingConfig = {
     },
     {
       title: t('Usage'),
-      description: (
-        <Fragment>
-          <p>
-            {tct(
-              "[code:sentrymartini] maps an instance of [sentryHubLink:*sentry.Hub] as one of the services available throughout the rest of the request's lifetime. You can access it by providing a hub [code:*sentry.Hub] parameter in any of your proceeding middleware and routes. And it should be used instead of the global [code:sentry.CaptureMessage], [code:sentry.CaptureException], or any other calls, as it keeps the separation of data between the requests.",
-              {
-                code: <code />,
-                sentryHubLink: (
-                  <ExternalLink href="https://pkg.go.dev/github.com/getsentry/sentry-go#Hub" />
-                ),
-              }
-            )}
-          </p>
-          <Alert type="info" showIcon={false}>
-            {tct(
-              "Keep in mind that [code:*sentry.Hub] won't be available in middleware attached before [code:sentrymartini]!",
-              {code: <code />}
-            )}
-          </Alert>
-        </Fragment>
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: tct(
+            "[code:sentrymartini] maps an instance of [sentryHubLink:*sentry.Hub] as one of the services available throughout the rest of the request's lifetime. You can access it by providing a hub [code:*sentry.Hub] parameter in any of your proceeding middleware and routes. And it should be used instead of the global [code:sentry.CaptureMessage], [code:sentry.CaptureException], or any other calls, as it keeps the separation of data between the requests.",
+            {
+              code: <code />,
+              sentryHubLink: (
+                <ExternalLink href="https://pkg.go.dev/github.com/getsentry/sentry-go#Hub" />
+              ),
+            }
+          ),
+        },
+        {
+          type: 'alert',
+          alertType: 'info',
+          showIcon: false,
+          text: tct(
+            "Keep in mind that [code:*sentry.Hub] won't be available in middleware attached before [code:sentrymartini]!",
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
           language: 'go',
           code: getUsageSnippet(),
         },
         {
-          description: (
-            <strong>
-              {tct('Accessing Request in [beforeSendCode:BeforeSend] callback', {
-                beforeSendCode: <code />,
-              })}
-            </strong>
-          ),
+          type: 'subheader',
+          text: tct('Accessing Request in [beforeSendCode:BeforeSend] callback', {
+            beforeSendCode: <code />,
+          }),
+        },
+        {
+          type: 'code',
           language: 'go',
           code: getBeforeSendSnippet(params),
         },
@@ -231,9 +240,14 @@ const crashReportOnboarding: OnboardingConfig = {
   configure: () => [
     {
       type: StepType.CONFIGURE,
-      description: getCrashReportModalConfigDescription({
-        link: 'https://docs.sentry.io/platforms/go/guides/martini/user-feedback/configuration/#crash-report-modal',
-      }),
+      content: [
+        {
+          type: 'text',
+          text: getCrashReportModalConfigDescription({
+            link: 'https://docs.sentry.io/platforms/go/guides/martini/user-feedback/configuration/#crash-report-modal',
+          }),
+        },
+      ],
     },
   ],
   verify: () => [],


### PR DESCRIPTION
- part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)

Note: This platform seems to be deprecated. Will verify and remove in a separate PR.