### PR TITLE
ref(content-blocks): Convert rest of java

### DIFF
--- a/static/app/gettingStartedDocs/java/java.tsx
+++ b/static/app/gettingStartedDocs/java/java.tsx
@@ -408,13 +408,16 @@ export const feedbackOnboardingCrashApiJava: OnboardingConfig = {
   install: () => [
     {
       type: StepType.INSTALL,
-      description: getCrashReportInstallDescription(),
-      configurations: [
+      content: [
         {
-          code: [
+          type: 'text',
+          text: getCrashReportInstallDescription(),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'Java',
-              value: 'java',
               language: 'java',
               code: `import io.sentry.Sentry;
 import io.sentry.UserFeedback;
@@ -429,7 +432,6 @@ Sentry.captureUserFeedback(userFeedback);`,
             },
             {
               label: 'Kotlin',
-              value: 'kotlin',
               language: 'kotlin',
               code: `import io.sentry.Sentry
 import io.sentry.UserFeedback


### PR DESCRIPTION
- part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)