### PR TITLE
ref(content-blocks): Convert java-logback

### DIFF
--- a/static/app/gettingStartedDocs/java/logback.tsx
+++ b/static/app/gettingStartedDocs/java/logback.tsx
@@ -1,5 +1,3 @@
-import {Fragment} from 'react';
-
 import {ExternalLink, Link} from 'sentry/components/core/link';
 import type {
   BasePlatformOptions,
@@ -240,138 +238,178 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
   install: params => [
     {
       type: StepType.INSTALL,
-      description: t(
-        "Install Sentry's integration with Logback using %s:",
-        params.platformOptions.packageManager === PackageManager.GRADLE
-          ? 'Gradle'
-          : 'Maven'
-      ),
-      configurations: [
+      content: [
         {
-          description: tct(
+          type: 'text',
+          text: t(
+            "Install Sentry's integration with Logback using %s:",
+            params.platformOptions.packageManager === PackageManager.GRADLE
+              ? 'Gradle'
+              : 'Maven'
+          ),
+        },
+        {
+          type: 'text',
+          text: tct(
             'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
             {
               link: <Link to={`/settings/${params.organization.slug}/auth-tokens/`} />,
             }
           ),
+        },
+        {
+          type: 'code',
           language: 'bash',
           code: 'SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___',
         },
-        ...(params.platformOptions.packageManager === PackageManager.GRADLE
-          ? [
-              {
-                description: tct(
-                  'The [link:Sentry Gradle Plugin] automatically installs the Sentry SDK as well as available integrations for your dependencies. Add the following to your [code:build.gradle] file:',
-                  {
-                    code: <code />,
-                    link: (
-                      <ExternalLink href="https://github.com/getsentry/sentry-android-gradle-plugin" />
-                    ),
-                  }
-                ),
-                language: 'groovy',
-                code: getGradleInstallSnippet(params),
-              },
-            ]
-          : []),
-        ...(params.platformOptions.packageManager === PackageManager.MAVEN
-          ? [
-              {
-                language: 'xml',
-                description: tct(
-                  'The [link:Sentry Maven Plugin] automatically installs the Sentry SDK as well as available integrations for your dependencies. Add the following to your [code:pom.xml] file:',
-                  {
-                    code: <code />,
-                    link: (
-                      <ExternalLink href="https://github.com/getsentry/sentry-maven-plugin" />
-                    ),
-                  }
-                ),
-                code: getMavenInstallSnippet(params),
-              },
-            ]
-          : []),
-        ...(params.platformOptions.opentelemetry === YesNo.YES
-          ? [
-              {
-                description: tct(
-                  "When running your application, please add our [code:sentry-opentelemetry-agent] to the [code:java] command. You can download the latest version of the [code:sentry-opentelemetry-agent.jar] from [linkMC:MavenCentral]. It's also available as a [code:ZIP] containing the [code:JAR] used on this page on [linkGH:GitHub].",
-                  {
-                    code: <code />,
-                    linkMC: (
-                      <ExternalLink href="https://search.maven.org/artifact/io.sentry/sentry-opentelemetry-agent" />
-                    ),
-                    linkGH: (
-                      <ExternalLink href="https://github.com/getsentry/sentry-java/releases/" />
-                    ),
-                  }
-                ),
-                language: 'bash',
-                code: getOpenTelemetryRunSnippet(params),
-              },
-            ]
-          : []),
-      ],
-      additionalInfo: tct(
-        'If you prefer to manually upload your source code to Sentry, please refer to [link:Manually Uploading Source Context].',
         {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/java/source-context/#manually-uploading-source-context" />
+          type: 'conditional',
+          condition: params.platformOptions.packageManager === PackageManager.GRADLE,
+          content: [
+            {
+              type: 'text',
+              text: tct(
+                'The [link:Sentry Gradle Plugin] automatically installs the Sentry SDK as well as available integrations for your dependencies. Add the following to your [code:build.gradle] file:',
+                {
+                  code: <code />,
+                  link: (
+                    <ExternalLink href="https://github.com/getsentry/sentry-android-gradle-plugin" />
+                  ),
+                }
+              ),
+            },
+            {
+              type: 'code',
+              language: 'groovy',
+              code: getGradleInstallSnippet(params),
+            },
+          ],
+        },
+        {
+          type: 'conditional',
+          condition: params.platformOptions.packageManager === PackageManager.MAVEN,
+          content: [
+            {
+              type: 'text',
+              text: tct(
+                'The [link:Sentry Maven Plugin] automatically installs the Sentry SDK as well as available integrations for your dependencies. Add the following to your [code:pom.xml] file:',
+                {
+                  code: <code />,
+                  link: (
+                    <ExternalLink href="https://github.com/getsentry/sentry-maven-plugin" />
+                  ),
+                }
+              ),
+            },
+            {
+              type: 'code',
+              language: 'xml',
+              code: getMavenInstallSnippet(params),
+            },
+          ],
+        },
+        {
+          type: 'conditional',
+          condition: params.platformOptions.opentelemetry === YesNo.YES,
+          content: [
+            {
+              type: 'text',
+              text: tct(
+                "When running your application, please add our [code:sentry-opentelemetry-agent] to the [code:java] command. You can download the latest version of the [code:sentry-opentelemetry-agent.jar] from [linkMC:MavenCentral]. It's also available as a [code:ZIP] containing the [code:JAR] used on this page on [linkGH:GitHub].",
+                {
+                  code: <code />,
+                  linkMC: (
+                    <ExternalLink href="https://search.maven.org/artifact/io.sentry/sentry-opentelemetry-agent" />
+                  ),
+                  linkGH: (
+                    <ExternalLink href="https://github.com/getsentry/sentry-java/releases/" />
+                  ),
+                }
+              ),
+            },
+            {
+              type: 'code',
+              language: 'bash',
+              code: getOpenTelemetryRunSnippet(params),
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: tct(
+            'If you prefer to manually upload your source code to Sentry, please refer to [link:Manually Uploading Source Context].',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/java/source-context/#manually-uploading-source-context" />
+              ),
+            }
           ),
-        }
-      ),
+        },
+      ],
     },
   ],
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        "Configure Sentry as soon as possible in your application's lifecycle:"
-      ),
-      configurations: [
-        ...(params.platformOptions.opentelemetry === YesNo.YES
-          ? [
-              {
-                type: StepType.CONFIGURE,
-                description: tct(
-                  "Here's the [code:sentry.properties] file that goes with the [code:java] command above:",
-                  {
-                    code: <code />,
-                  }
-                ),
-                configurations: [
-                  {
-                    label: 'Properties',
-                    value: 'properties',
-                    language: 'properties',
-                    code: getSentryPropertiesSnippet(params),
-                  },
-                ],
-              },
-            ]
-          : []),
+      content: [
         {
-          language: 'xml',
-          description: t(
-            'The following example configures a ConsoleAppender that logs to standard out at the INFO level, and a SentryAppender that logs to the Sentry server at the ERROR level. This only an example of a non-Sentry appender set to a different logging threshold, similar to what you may already have in your project.'
+          type: 'text',
+          text: t(
+            "Configure Sentry as soon as possible in your application's lifecycle:"
           ),
-          code: getConsoleAppenderSnippet(params),
-          ...(params.platformOptions.opentelemetry === YesNo.YES
-            ? {}
-            : {
-                additionalInfo: tct(
-                  "You'll also need to configure your DSN (client key) if it's not already in the [code:logback.xml] configuration. Learn more in [link:our documentation for DSN configuration].",
-                  {
-                    code: <code />,
-                    link: (
-                      <ExternalLink href="https://docs.sentry.io/platforms/java/guides/logback/#configure" />
-                    ),
-                  }
-                ),
-              }),
         },
         {
-          description: tct(
+          type: 'conditional',
+          condition: params.platformOptions.opentelemetry === YesNo.YES,
+          content: [
+            {
+              type: 'text',
+              text: tct(
+                "Here's the [code:sentry.properties] file that goes with the [code:java] command above:",
+                {
+                  code: <code />,
+                }
+              ),
+            },
+            {
+              type: 'code',
+              language: 'properties',
+              code: getSentryPropertiesSnippet(params),
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: t(
+            'The following example configures a ConsoleAppender that logs to standard out at the INFO level, and a SentryAppender that logs to the Sentry server at the ERROR level. This only an example of a non-Sentry appender set to a different logging threshold, similar to what you may already have in your project.'
+          ),
+        },
+        {
+          type: 'code',
+          language: 'xml',
+          code: getConsoleAppenderSnippet(params),
+        },
+        {
+          type: 'conditional',
+          condition: params.platformOptions.opentelemetry === YesNo.NO,
+          content: [
+            {
+              type: 'text',
+              text: tct(
+                "You'll also need to configure your DSN (client key) if it's not already in the [code:logback.xml] configuration. Learn more in [link:our documentation for DSN configuration].",
+                {
+                  code: <code />,
+                  link: (
+                    <ExternalLink href="https://docs.sentry.io/platforms/java/guides/logback/#configure" />
+                  ),
+                }
+              ),
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: tct(
             "Next, you'll need to set your log levels, as illustrated here. You can learn more about [link:configuring log levels] in our documentation.",
             {
               link: (
@@ -379,12 +417,11 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
               ),
             }
           ),
-          configurations: [
-            {
-              language: 'xml',
-              code: getLogLevelSnippet(params),
-            },
-          ],
+        },
+        {
+          type: 'code',
+          language: 'xml',
+          code: getLogLevelSnippet(params),
         },
       ],
     },
@@ -392,53 +429,57 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        'Last, create an intentional error, so you can test that everything is working:'
-      ),
-      configurations: [
+      content: [
         {
-          language: 'java',
-          code: [
+          type: 'text',
+          text: t(
+            'Last, create an intentional error, so you can test that everything is working:'
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
-              language: 'java',
               label: 'Java',
-              value: 'java',
+              language: 'java',
               code: getVerifyJavaSnippet(),
             },
             {
-              language: 'kotlin',
               label: 'Kotlin',
-              value: 'kotlin',
+              language: 'kotlin',
               code: getVerifyKotlinSnippet(),
             },
           ],
         },
+        {
+          type: 'text',
+          text: t(
+            "If you're new to Sentry, use the email alert to access your account and complete a product tour."
+          ),
+        },
+        {
+          type: 'text',
+          text: t(
+            "If you're an existing user and have disabled alerts, you won't receive this email."
+          ),
+        },
       ],
-      additionalInfo: (
-        <Fragment>
-          <p>
-            {t(
-              "If you're new to Sentry, use the email alert to access your account and complete a product tour."
-            )}
-          </p>
-          <p>
-            {t(
-              "If you're an existing user and have disabled alerts, you won't receive this email."
-            )}
-          </p>
-        </Fragment>
-      ),
     },
     {
       title: t('Other build tools'),
-      additionalInfo: tct(
-        'For other dependency managers see the [link:central Maven repository].',
+      content: [
         {
-          link: (
-            <ExternalLink href="https://search.maven.org/artifact/io.sentry/sentry-logback" />
+          type: 'text',
+          text: tct(
+            'For other dependency managers see the [link:central Maven repository].',
+            {
+              link: (
+                <ExternalLink href="https://search.maven.org/artifact/io.sentry/sentry-logback" />
+              ),
+            }
           ),
-        }
-      ),
+        },
+      ],
     },
   ],
   nextSteps: () => [


### PR DESCRIPTION
- part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)