### PR TITLE
ref(onboarding): Move node to content block

### DIFF
--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -266,27 +266,24 @@ logger.fatal("Database connection pool exhausted", {
             ? `
 const Sentry = require("@sentry/node");
 
-Sentry.startSpan(
-  {
-    op: "test",
-    name: "My First Test Span",
-  },
-  () => {
-    try {${
-      params.isLogsSelected
-        ? `
-      // Send a log before throwing the error
-      Sentry.logger.info('User triggered test error', {
-        action: 'test_error_span',
-      });`
-        : ''
-    }
-      foo();
-    } catch (e) {
-      Sentry.captureException(e);
-    }
+Sentry.startSpan({
+  op: "test",
+  name: "My First Test Span",
+}, () => {
+  try {${
+    params.isLogsSelected
+      ? `
+    // Send a log before throwing the error
+    Sentry.logger.info('User triggered test error', {
+      action: 'test_error_span',
+    });`
+      : ''
   }
-);`
+    foo();
+  } catch (e) {
+    Sentry.captureException(e);
+  }
+});`
             : `
 const Sentry = require("@sentry/node");
 ${

--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -52,26 +52,40 @@ const onboarding: OnboardingConfig = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      description: t('Add the Sentry Node SDK as a dependency:'),
-      configurations: getInstallConfig(params),
+      content: [
+        {
+          type: 'text',
+          text: t('Add the Sentry Node SDK as a dependency:'),
+        },
+        {
+          type: 'code',
+          tabs: getInstallConfig(params)[0]!.code,
+        },
+      ],
     },
   ],
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        "Initialize Sentry as early as possible in your application's lifecycle."
-      ),
-      configurations: [
+      content: [
         {
-          description: tct(
+          type: 'text',
+          text: t(
+            "Initialize Sentry as early as possible in your application's lifecycle."
+          ),
+        },
+        {
+          type: 'text',
+          text: tct(
             'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs].',
             {code: <code />}
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               language: 'javascript',
               filename: 'instrument.(js|mjs)',
               code: getSdkInitSnippet(params, 'node'),
@@ -79,7 +93,8 @@ const onboarding: OnboardingConfig = {
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             "Make sure to import [code:instrument.js/mjs] at the top of your file. Set up the error handler after all controllers and before any other error middleware. This setup is typically done in your application's entry point file, which is usually [code:index.(js|ts)]. If you're running your application in ESM mode, or looking for alternative ways to set up Sentry, read about [docs:installation methods in our docs].",
             {
               code: <code />,
@@ -88,10 +103,12 @@ const onboarding: OnboardingConfig = {
               ),
             }
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               language: 'javascript',
               filename: 'instrument.(js|mjs)',
               code: getSdkSetupSnippet(),
@@ -232,36 +249,40 @@ logger.fatal("Database connection pool exhausted", {
 `,
     }),
   ],
-  verify: params => [
+  verify: (params: Params) => [
     {
       type: StepType.VERIFY,
-      description: t(
-        "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: t(
+            "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+          ),
+        },
+        {
+          type: 'code',
           language: 'javascript',
           code: params.isPerformanceSelected
             ? `
 const Sentry = require("@sentry/node");
 
 Sentry.startSpan({
-  op: "test",
-  name: "My First Test Span",
+op: "test",
+name: "My First Test Span",
 }, () => {
-  try {${
-    params.isLogsSelected
-      ? `
-    // Send a log before throwing the error
-    Sentry.logger.info('User triggered test error', {
-      action: 'test_error_span',
-    });`
-      : ''
-  }
-    foo();
-  } catch (e) {
-    Sentry.captureException(e);
-  }
+try {${
+                params.isLogsSelected
+                  ? `
+  // Send a log before throwing the error
+  Sentry.logger.info('User triggered test error', {
+    action: 'test_error_span',
+  });`
+                  : ''
+              }
+  foo();
+} catch (e) {
+  Sentry.captureException(e);
+}
 });`
             : `
 const Sentry = require("@sentry/node");
@@ -270,14 +291,14 @@ ${
     ? `
 // Send a log before throwing the error
 Sentry.logger.info('User triggered test error', {
-  action: 'test_error_basic',
+action: 'test_error_basic',
 });`
     : ''
 }
 try {
-  foo();
+foo();
 } catch (e) {
-  Sentry.captureException(e);
+Sentry.captureException(e);
 }`,
         },
       ],
@@ -307,9 +328,14 @@ const crashReportOnboarding: OnboardingConfig = {
   configure: () => [
     {
       type: StepType.CONFIGURE,
-      description: getCrashReportModalConfigDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/node/user-feedback/configuration/#crash-report-modal',
-      }),
+      content: [
+        {
+          type: 'text',
+          text: getCrashReportModalConfigDescription({
+            link: 'https://docs.sentry.io/platforms/javascript/guides/node/user-feedback/configuration/#crash-report-modal',
+          }),
+        },
+      ],
     },
   ],
   verify: () => [],
@@ -324,10 +350,18 @@ const performanceOnboarding: OnboardingConfig = {
   install: params => [
     {
       type: StepType.INSTALL,
-      description: tct('Install our Node.js SDK using [code:npm] or [code:yarn]', {
-        code: <code />,
-      }),
-      configurations: getInstallConfig(params),
+      content: [
+        {
+          type: 'text',
+          text: tct('Install our Node.js SDK using [code:npm] or [code:yarn]', {
+            code: <code />,
+          }),
+        },
+        {
+          type: 'code',
+          tabs: getInstallConfig(params)[0]!.code,
+        },
+      ],
     },
   ],
   configure: params => [

--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -266,24 +266,27 @@ logger.fatal("Database connection pool exhausted", {
             ? `
 const Sentry = require("@sentry/node");
 
-Sentry.startSpan({
-op: "test",
-name: "My First Test Span",
-}, () => {
-try {${
-                params.isLogsSelected
-                  ? `
-  // Send a log before throwing the error
-  Sentry.logger.info('User triggered test error', {
-    action: 'test_error_span',
-  });`
-                  : ''
-              }
-  foo();
-} catch (e) {
-  Sentry.captureException(e);
-}
-});`
+Sentry.startSpan(
+  {
+    op: "test",
+    name: "My First Test Span",
+  },
+  () => {
+    try {${
+      params.isLogsSelected
+        ? `
+      // Send a log before throwing the error
+      Sentry.logger.info('User triggered test error', {
+        action: 'test_error_span',
+      });`
+        : ''
+    }
+      foo();
+    } catch (e) {
+      Sentry.captureException(e);
+    }
+  }
+);`
             : `
 const Sentry = require("@sentry/node");
 ${
@@ -291,14 +294,14 @@ ${
     ? `
 // Send a log before throwing the error
 Sentry.logger.info('User triggered test error', {
-action: 'test_error_basic',
+  action: 'test_error_basic',
 });`
     : ''
 }
 try {
-foo();
+  foo();
 } catch (e) {
-Sentry.captureException(e);
+  Sentry.captureException(e);
 }`,
         },
       ],


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks