### PR TITLE
ref(onboarding): Move node cloudflare to content block

### DIFF
--- a/static/app/gettingStartedDocs/node/cloudflare-workers.tsx
+++ b/static/app/gettingStartedDocs/node/cloudflare-workers.tsx
@@ -13,7 +13,7 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {t, tct} from 'sentry/locale';
 import {
-  getInstallConfig,
+  getInstallCodeBlock,
   getNodeAgentMonitoringOnboarding,
   getNodeLogsOnboarding,
   getNodeMcpOnboarding,
@@ -83,42 +83,48 @@ setTimeout(() => {
 const onboarding: OnboardingConfig = {
   introduction: () =>
     t(
-      'In this quick guide you’ll set up and configure the Sentry Cloudflare SDK for the use in your Cloudflare Workers application.'
+      "In this quick guide you'll set up and configure the Sentry Cloudflare SDK for the use in your Cloudflare Workers application."
     ),
   install: params => [
     {
       type: StepType.INSTALL,
-      description: t('Add the Sentry Cloudflare SDK as a dependency:'),
-      configurations: getInstallConfig(params, {
-        basePackage: '@sentry/cloudflare',
-      }),
+      content: [
+        {
+          type: 'text',
+          text: t('Add the Sentry Cloudflare SDK as a dependency:'),
+        },
+        getInstallCodeBlock(params, {basePackage: '@sentry/cloudflare'}),
+      ],
     },
   ],
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        "Configuration should happen as early as possible in your application's lifecycle."
-      ),
-      configurations: [
+      content: [
         {
-          description: tct(
-            "To use the SDK, you'll need to set either the [code:nodejs_compat] or [code:nodejs_als] compatibility flags in your [code:wrangler.json]/[code:wrangler.toml]. This is because the SDK needs access to the [code:AsyncLocalStorage] API to work correctly.",
-            {
-              code: <code />,
-            }
+          type: 'text',
+          text: t(
+            "Configuration should happen as early as possible in your application's lifecycle."
           ),
-          code: [
+        },
+        {
+          type: 'text',
+          text: tct(
+            "To use the SDK, you'll need to set either the [code:nodejs_compat] or [code:nodejs_als] compatibility flags in your [code:wrangler.json]/[code:wrangler.toml]. This is because the SDK needs access to the [code:AsyncLocalStorage] API to work correctly.",
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JSON',
-              value: 'json',
               language: 'json',
               filename: 'wrangler.json',
               code: getSdkConfigureSnippetJson(),
             },
             {
               label: 'Toml',
-              value: 'toml',
               language: 'toml',
               filename: 'wrangler.toml',
               code: getSdkConfigureSnippetToml(),
@@ -126,7 +132,8 @@ const onboarding: OnboardingConfig = {
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'In order to initialize the SDK, wrap your handler with the [code:withSentry] function. Note that you can turn off almost all side effects using the respective options.',
             {
               code: <code />,
@@ -135,10 +142,12 @@ const onboarding: OnboardingConfig = {
               ),
             }
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'TypeScript',
-              value: 'typescript',
               language: 'typescript',
               code: getSdkSetupSnippet(params),
             },
@@ -155,11 +164,15 @@ const onboarding: OnboardingConfig = {
   verify: (params: Params) => [
     {
       type: StepType.VERIFY,
-      description: t(
-        "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: t(
+            "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+          ),
+        },
+        {
+          type: 'code',
           language: 'javascript',
           code: getVerifySnippet(params),
         },
@@ -199,9 +212,14 @@ const crashReportOnboarding: OnboardingConfig = {
   configure: () => [
     {
       type: StepType.CONFIGURE,
-      description: getCrashReportModalConfigDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/cloudflare/user-feedback/configuration/#crash-report-modal',
-      }),
+      content: [
+        {
+          type: 'text',
+          text: getCrashReportModalConfigDescription({
+            link: 'https://docs.sentry.io/platforms/javascript/guides/cloudflare/user-feedback/configuration/#crash-report-modal',
+          }),
+        },
+      ],
     },
   ],
   verify: () => [],


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks