### PR TITLE
ref(onboarding): Move cloudflare pages to content block

### DIFF
--- a/static/app/gettingStartedDocs/node/cloudflare-pages.tsx
+++ b/static/app/gettingStartedDocs/node/cloudflare-pages.tsx
@@ -13,7 +13,7 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {t, tct} from 'sentry/locale';
 import {
-  getInstallConfig,
+  getInstallCodeBlock,
   getNodeAgentMonitoringOnboarding,
   getNodeLogsOnboarding,
   getNodeMcpOnboarding,
@@ -89,37 +89,43 @@ const onboarding: OnboardingConfig = {
   install: params => [
     {
       type: StepType.INSTALL,
-      description: t('Add the Sentry Cloudflare SDK as a dependency:'),
-      configurations: getInstallConfig(params, {
-        basePackage: '@sentry/cloudflare',
-      }),
+      content: [
+        {
+          type: 'text',
+          text: t('Add the Sentry Cloudflare SDK as a dependency:'),
+        },
+        getInstallCodeBlock(params, {basePackage: '@sentry/cloudflare'}),
+      ],
     },
   ],
   configure: params => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        "Configuration should happen as early as possible in your application's lifecycle."
-      ),
-      configurations: [
+      content: [
         {
-          description: tct(
-            "To use the SDK, you'll need to set either the [code:nodejs_compat] or [code:nodejs_als] compatibility flags in your [code:wrangler.toml]. This is because the SDK needs access to the [code:AsyncLocalStorage] API to work correctly.",
-            {
-              code: <code />,
-            }
+          type: 'text',
+          text: t(
+            "Configuration should happen as early as possible in your application's lifecycle."
           ),
-          code: [
+        },
+        {
+          type: 'text',
+          text: tct(
+            "To use the SDK, you'll need to set either the [code:nodejs_compat] or [code:nodejs_als] compatibility flags in your [code:wrangler.toml]. This is because the SDK needs access to the [code:AsyncLocalStorage] API to work correctly.",
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JSON',
-              value: 'json',
               language: 'json',
               filename: 'wrangler.json',
               code: getSdkConfigureSnippetJson(),
             },
             {
               label: 'Toml',
-              value: 'toml',
               language: 'toml',
               filename: 'wrangler.toml',
               code: getSdkConfigureSnippetToml(),
@@ -127,7 +133,8 @@ const onboarding: OnboardingConfig = {
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'Add the [code:sentryPagesPlugin] as [guideLink:middleware to your Cloudflare Pages application]. We recommend adding a [code:functions/_middleware.js] for the middleware setup so that Sentry is initialized for your entire app.',
             {
               code: <code />,
@@ -136,10 +143,12 @@ const onboarding: OnboardingConfig = {
               ),
             }
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'JavaScript',
-              value: 'javascript',
               language: 'javascript',
               filename: 'functions/_middleware.js',
               code: getSdkSetupSnippet(params),
@@ -157,16 +166,16 @@ const onboarding: OnboardingConfig = {
   verify: (params: Params) => [
     {
       type: StepType.VERIFY,
-      description: tct(
-        "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected. To trigger it, you need to access the [code:/customerror] path on your deployment.",
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: [
+          type: 'text',
+          text: tct(
+            "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected. To trigger it, you need to access the [code:/customerror] path on your deployment.",
+            {code: <code />}
+          ),
+        },
         {
-          label: 'JavaScript',
-          value: 'javascript',
+          type: 'code',
           language: 'javascript',
           filename: 'functions/customerror.js',
           code: getVerifySnippet(params),
@@ -207,9 +216,14 @@ const crashReportOnboarding: OnboardingConfig = {
   configure: () => [
     {
       type: StepType.CONFIGURE,
-      description: getCrashReportModalConfigDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/cloudflare/user-feedback/configuration/#crash-report-modal',
-      }),
+      content: [
+        {
+          type: 'text',
+          text: getCrashReportModalConfigDescription({
+            link: 'https://docs.sentry.io/platforms/javascript/guides/cloudflare/user-feedback/configuration/#crash-report-modal',
+          }),
+        },
+      ],
     },
   ],
   verify: () => [],


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks