### PR TITLE
ref(content-blocks): Convert react-router

### DIFF
--- a/static/app/gettingStartedDocs/javascript/react-router.tsx
+++ b/static/app/gettingStartedDocs/javascript/react-router.tsx
@@ -321,37 +321,49 @@ const onboarding: OnboardingConfig = {
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: t(
-        'First, expose the hooks in your app folder by running the reveal command:'
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: t(
+            'First, expose the hooks in your app folder by running the reveal command:'
+          ),
+        },
+        {
+          type: 'code',
           language: 'bash',
           code: 'npx react-router reveal',
         },
       ],
     },
     {
-      description: tct(
-        'Initialize the Sentry React Router SDK in your [code:entry.client.tsx] file, above where you call [code:hydrateRoot]:',
-        {code: <code />}
-      ),
       title: t('Client Setup'),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: tct(
+            'Initialize the Sentry React Router SDK in your [code:entry.client.tsx] file, above where you call [code:hydrateRoot]:',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
           language: 'tsx',
           code: getClientSetupSnippet(params),
         },
       ],
     },
     {
-      description: tct(
-        'Update your [code:app/root.tsx] file to report any unhandled errors from your error boundary component by adding [code:Sentry.captureException]:',
-        {code: <code />}
-      ),
       title: t('Error Boundary'),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: tct(
+            'Update your [code:app/root.tsx] file to report any unhandled errors from your error boundary component by adding [code:Sentry.captureException]:',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
           language: 'tsx',
           code: getRootErrorBoundarySnippet(),
         },
@@ -359,22 +371,25 @@ const onboarding: OnboardingConfig = {
     },
     {
       title: t('Server Setup'),
-      description: tct(
-        'Create an [code:instrument.server.mjs] file in the root of your app:',
-        {code: <code />}
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: tct(
+            'Create an [code:instrument.server.mjs] file in the root of your app:',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
           language: 'js',
           code: getServerSetupSnippet(params),
         },
-      ],
-    },
-    {
-      title: '',
-      description: tct('Update your [code:entry.server.tsx] file:', {code: <code />}),
-      configurations: [
         {
+          type: 'text',
+          text: tct('Update your [code:entry.server.tsx] file:', {code: <code />}),
+        },
+        {
+          type: 'code',
           language: 'tsx',
           code: getServerEntrySnippet(),
         },
@@ -382,11 +397,15 @@ const onboarding: OnboardingConfig = {
     },
     {
       title: t('Update Scripts'),
-      description: t(
-        'Update your package.json scripts to include the server instrumentation:'
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: t(
+            'Update your package.json scripts to include the server instrumentation:'
+          ),
+        },
+        {
+          type: 'code',
           language: 'json',
           code: getPackageJsonScriptsSnippet(),
         },
@@ -408,11 +427,15 @@ const onboarding: OnboardingConfig = {
   verify: params => [
     {
       type: StepType.VERIFY,
-      description: t(
-        'Create a route that throws an error to verify that Sentry is working. After opening this route in your browser, you should see the error in your Sentry issue stream.'
-      ),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: t(
+            'Create a route that throws an error to verify that Sentry is working. After opening this route in your browser, you should see the error in your Sentry issue stream.'
+          ),
+        },
+        {
+          type: 'code',
           language: 'tsx',
           code: getVerifySnippet(params),
         },
@@ -426,11 +449,15 @@ const replayOnboarding: OnboardingConfig = {
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: getReplayConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/react-router/session-replay/',
-      }),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: getReplayConfigureDescription({
+            link: 'https://docs.sentry.io/platforms/javascript/guides/react-router/session-replay/',
+          }),
+        },
+        {
+          type: 'code',
           language: 'tsx',
           code: getClientSetupSnippet(params),
         },
@@ -446,14 +473,18 @@ const feedbackOnboarding: OnboardingConfig = {
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      description: getFeedbackConfigureDescription({
-        linkConfig:
-          'https://docs.sentry.io/platforms/javascript/guides/react-router/user-feedback/configuration/',
-        linkButton:
-          'https://docs.sentry.io/platforms/javascript/guides/react-router/user-feedback/configuration/#bring-your-own-button',
-      }),
-      configurations: [
+      content: [
         {
+          type: 'text',
+          text: getFeedbackConfigureDescription({
+            linkConfig:
+              'https://docs.sentry.io/platforms/javascript/guides/react-router/user-feedback/configuration/',
+            linkButton:
+              'https://docs.sentry.io/platforms/javascript/guides/react-router/user-feedback/configuration/#bring-your-own-button',
+          }),
+        },
+        {
+          type: 'code',
           language: 'tsx',
           code: getClientSetupSnippet(params),
         },
@@ -470,9 +501,14 @@ const crashReportOnboarding: OnboardingConfig = {
   configure: () => [
     {
       type: StepType.CONFIGURE,
-      description: getCrashReportModalConfigDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/react-router/user-feedback/configuration/#crash-report-modal',
-      }),
+      content: [
+        {
+          type: 'text',
+          text: getCrashReportModalConfigDescription({
+            link: 'https://docs.sentry.io/platforms/javascript/guides/react-router/user-feedback/configuration/#crash-report-modal',
+          }),
+        },
+      ],
     },
   ],
   verify: () => [],


### PR DESCRIPTION
- part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)