### PR TITLE
ref(onboarding): Move symfony to content block

### DIFF
--- a/static/app/gettingStartedDocs/php/symfony.tsx
+++ b/static/app/gettingStartedDocs/php/symfony.tsx
@@ -1,4 +1,3 @@
-import {Alert} from 'sentry/components/core/alert';
 import {ExternalLink} from 'sentry/components/core/link';
 import type {
   Docs,
@@ -31,42 +30,57 @@ const onboarding: OnboardingConfig = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      configurations: [
+      content: [
         {
-          language: 'bash',
-          description: tct('Install the [code:sentry/sentry-symfony] bundle:', {
+          type: 'text',
+          text: tct('Install the [code:sentry/sentry-symfony] bundle:', {
             code: <code />,
           }),
+        },
+        {
+          type: 'code',
+          language: 'bash',
           code: 'composer require sentry/sentry-symfony',
         },
-        ...(params.isProfilingSelected
-          ? [
-              {
-                description: t('Install the Excimer extension via PECL:'),
-                language: 'bash',
-                code: 'pecl install excimer',
-              },
-              {
-                description: tct(
-                  "The Excimer PHP extension supports PHP 7.2 and up. Excimer requires Linux or macOS and doesn't support Windows. For additional ways to install Excimer, see [sentryPhpDocumentationLink: Sentry documentation].",
-                  {
-                    sentryPhpDocumentationLink: (
-                      <ExternalLink href="https://docs.sentry.io/platforms/php/profiling/#installation" />
-                    ),
-                  }
-                ),
-              },
-            ]
-          : []),
+        {
+          type: 'conditional',
+          condition: params.isProfilingSelected,
+          content: [
+            {
+              type: 'text',
+              text: t('Install the Excimer extension via PECL:'),
+            },
+            {
+              type: 'code',
+              language: 'bash',
+              code: 'pecl install excimer',
+            },
+            {
+              type: 'text',
+              text: tct(
+                "The Excimer PHP extension supports PHP 7.2 and up. Excimer requires Linux or macOS and doesn't support Windows. For additional ways to install Excimer, see [sentryPhpDocumentationLink: Sentry documentation].",
+                {
+                  sentryPhpDocumentationLink: (
+                    <ExternalLink href="https://docs.sentry.io/platforms/php/profiling/#installation" />
+                  ),
+                }
+              ),
+            },
+          ],
+        },
       ],
     },
   ],
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      configurations: [
+      content: [
         {
-          description: tct('Add your DSN to your [code:.env] file:', {code: <code />}),
+          type: 'text',
+          text: tct('Add your DSN to your [code:.env] file:', {code: <code />}),
+        },
+        {
+          type: 'code',
           language: 'shell',
           code: `
 ###> sentry/sentry-symfony ###
@@ -74,15 +88,21 @@ SENTRY_DSN="${params.dsn.public}"
 ###< sentry/sentry-symfony ###
           `,
         },
-        ...(params.isPerformanceSelected || params.isProfilingSelected
-          ? [
-              {
-                description: tct(
-                  'Add further configuration options to your [code:config/packages/sentry.yaml] file:',
-                  {code: <code />}
-                ),
-                language: 'yaml',
-                code: `when@prod:
+        {
+          type: 'conditional',
+          condition: params.isPerformanceSelected || params.isProfilingSelected,
+          content: [
+            {
+              type: 'text',
+              text: tct(
+                'Add further configuration options to your [code:config/packages/sentry.yaml] file:',
+                {code: <code />}
+              ),
+            },
+            {
+              type: 'code',
+              language: 'yaml',
+              code: `when@prod:
       sentry:
           dsn: '%env(SENTRY_DSN)%'${
             params.isPerformanceSelected || params.isProfilingSelected
@@ -102,21 +122,16 @@ SENTRY_DSN="${params.dsn.public}"
               profiles_sample_rate: 1.0`
               : ''
           }`,
-              },
-            ]
-          : []),
+            },
+          ],
+        },
         {
-          description: (
-            <Alert.Container>
-              <Alert type="warning" showIcon={false}>
-                {tct(
-                  'In order to receive stack trace arguments in your errors, make sure to set [code:zend.exception_ignore_args: Off] in your php.ini',
-                  {
-                    code: <code />,
-                  }
-                )}
-              </Alert>
-            </Alert.Container>
+          type: 'alert',
+          alertType: 'warning',
+          showIcon: false,
+          text: tct(
+            'In order to receive stack trace arguments in your errors, make sure to set [code:zend.exception_ignore_args: Off] in your php.ini',
+            {code: <code />}
           ),
         },
       ],
@@ -125,8 +140,9 @@ SENTRY_DSN="${params.dsn.public}"
   verify: () => [
     {
       type: StepType.VERIFY,
-      configurations: [
+      content: [
         {
+          type: 'code',
           language: 'php',
           code: `
   <?php
@@ -162,11 +178,14 @@ SENTRY_DSN="${params.dsn.public}"
   }
           `,
         },
+        {
+          type: 'text',
+          text: tct(
+            "After you visit the [code:/_sentry-test page], you can view and resolve the recorded error by logging into [sentryLink:sentry.io] and opening your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.",
+            {sentryLink: <ExternalLink href="https://sentry.io" />, code: <code />}
+          ),
+        },
       ],
-      additionalInfo: tct(
-        "After you visit the [code:/_sentry-test page], you can view and resolve the recorded error by logging into [sentryLink:sentry.io] and opening your project. Clicking on the error's title will open a page where you can see detailed information and mark it as resolved.",
-        {sentryLink: <ExternalLink href="https://sentry.io" />, code: <code />}
-      ),
     },
   ],
   nextSteps: () => [],
@@ -178,9 +197,14 @@ const crashReportOnboarding: OnboardingConfig = {
   configure: () => [
     {
       type: StepType.CONFIGURE,
-      description: getCrashReportModalConfigDescription({
-        link: 'https://docs.sentry.io/platforms/php/guides/symfony/user-feedback/configuration/#crash-report-modal',
-      }),
+      content: [
+        {
+          type: 'text',
+          text: getCrashReportModalConfigDescription({
+            link: 'https://docs.sentry.io/platforms/php/guides/symfony/user-feedback/configuration/#crash-report-modal',
+          }),
+        },
+      ],
     },
   ],
   verify: () => [],
@@ -198,42 +222,57 @@ const profilingOnboarding: OnboardingConfig = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      configurations: [
+      content: [
         {
-          language: 'bash',
-          description: tct('Install the [code:sentry/sentry-symfony] bundle:', {
+          type: 'text',
+          text: tct('Install the [code:sentry/sentry-symfony] bundle:', {
             code: <code />,
           }),
+        },
+        {
+          type: 'code',
+          language: 'bash',
           code: 'composer require sentry/sentry-symfony',
         },
-        ...(params.isProfilingSelected
-          ? [
-              {
-                description: t('Install the Excimer extension via PECL:'),
-                language: 'bash',
-                code: 'pecl install excimer',
-              },
-              {
-                description: tct(
-                  "The Excimer PHP extension supports PHP 7.2 and up. Excimer requires Linux or macOS and doesn't support Windows. For additional ways to install Excimer, see [sentryPhpDocumentationLink: Sentry documentation].",
-                  {
-                    sentryPhpDocumentationLink: (
-                      <ExternalLink href="https://docs.sentry.io/platforms/php/profiling/#installation" />
-                    ),
-                  }
-                ),
-              },
-            ]
-          : []),
+        {
+          type: 'conditional',
+          condition: params.isProfilingSelected,
+          content: [
+            {
+              type: 'text',
+              text: t('Install the Excimer extension via PECL:'),
+            },
+            {
+              type: 'code',
+              language: 'bash',
+              code: 'pecl install excimer',
+            },
+            {
+              type: 'text',
+              text: tct(
+                "The Excimer PHP extension supports PHP 7.2 and up. Excimer requires Linux or macOS and doesn't support Windows. For additional ways to install Excimer, see [sentryPhpDocumentationLink: Sentry documentation].",
+                {
+                  sentryPhpDocumentationLink: (
+                    <ExternalLink href="https://docs.sentry.io/platforms/php/profiling/#installation" />
+                  ),
+                }
+              ),
+            },
+          ],
+        },
       ],
     },
   ],
   configure: (params: Params) => [
     {
       type: StepType.CONFIGURE,
-      configurations: [
+      content: [
         {
-          description: tct('Add your DSN to your [code:.env] file:', {code: <code />}),
+          type: 'text',
+          text: tct('Add your DSN to your [code:.env] file:', {code: <code />}),
+        },
+        {
+          type: 'code',
           language: 'shell',
           code: `
 ###> sentry/sentry-symfony ###
@@ -241,15 +280,21 @@ SENTRY_DSN="${params.dsn.public}"
 ###< sentry/sentry-symfony ###
           `,
         },
-        ...(params.isPerformanceSelected || params.isProfilingSelected
-          ? [
-              {
-                description: tct(
-                  'Add further configuration options to your [code:config/packages/sentry.yaml] file:',
-                  {code: <code />}
-                ),
-                language: 'yaml',
-                code: `when@prod:
+        {
+          type: 'conditional',
+          condition: params.isPerformanceSelected || params.isProfilingSelected,
+          content: [
+            {
+              type: 'text',
+              text: tct(
+                'Add further configuration options to your [code:config/packages/sentry.yaml] file:',
+                {code: <code />}
+              ),
+            },
+            {
+              type: 'code',
+              language: 'yaml',
+              code: `when@prod:
       sentry:
           dsn: '%env(SENTRY_DSN)%'${
             params.isPerformanceSelected || params.isProfilingSelected
@@ -269,9 +314,9 @@ SENTRY_DSN="${params.dsn.public}"
               profiles_sample_rate: 1.0`
               : ''
           }`,
-              },
-            ]
-          : []),
+            },
+          ],
+        },
       ],
     },
   ],


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks