### PR TITLE
fix: remove <NoOverflow> from column that only displays a button

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
@@ -462,21 +462,19 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
           undefined
         );
       return (
-        <NoOverflow>
-          <AlignCenter>
-            {replayTarget &&
-            Object.keys(replayTarget).length > 0 &&
-            replayExists(row[key]) ? (
-              <Tooltip title={t('View Replay')}>
-                <LinkButton to={replayTarget} size="xs">
-                  <IconPlay size="xs" />
-                </LinkButton>
-              </Tooltip>
-            ) : (
-              <NoValue>{NO_VALUE}</NoValue>
-            )}
-          </AlignCenter>
-        </NoOverflow>
+        <AlignCenter>
+          {replayTarget &&
+          Object.keys(replayTarget).length > 0 &&
+          replayExists(row[key]) ? (
+            <Tooltip title={t('View Replay')}>
+              <LinkButton to={replayTarget} size="xs">
+                <IconPlay size="xs" />
+              </LinkButton>
+            </Tooltip>
+          ) : (
+            <NoValue>{NO_VALUE}</NoValue>
+          )}
+        </AlignCenter>
       );
     }
 


### PR DESCRIPTION
before:

<img width="268" height="379" alt="Screenshot 2025-10-17 at 16 31 52" src="https://github.com/user-attachments/assets/15bb52bd-3f35-4f68-b335-00a376da00ab" />

after:

<img width="274" height="429" alt="Screenshot 2025-10-17 at 16 37 56" src="https://github.com/user-attachments/assets/fa133e86-00ca-4807-a61c-4e0ec2ec614d" />
