### PR TITLE
fix(ui): align border radius of InteractionStateLayer with radius of MeterBarContainer

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/webVitalMetersWithIssues.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMetersWithIssues.tsx
@@ -224,7 +224,7 @@ function VitalContainer({
       onClick={() => webVitalExists && onClick?.(webVital)}
       clickable={webVitalExists}
     >
-      {webVitalExists && <InteractionStateLayer />}
+      {webVitalExists && <StyledInteractionStateLayer />}
       {webVitalExists && meterBody}
       {!webVitalExists && (
         <StyledTooltip
@@ -286,6 +286,10 @@ const StyledIssuesButton = styled(LinkButton)`
   }
 `;
 
+const StyledInteractionStateLayer = styled(InteractionStateLayer)`
+  border-radius: ${p => p.theme.borderRadius};
+`;
+
 // This style explicitly hides InteractionStateLayer when the Issues button is hovered
 // This is to prevent hover styles displayed on multiple overlapping components simultaneously
 const MeterBarContainer = styled('div')<{clickable?: boolean}>`
@@ -296,7 +300,7 @@ const MeterBarContainer = styled('div')<{clickable?: boolean}>`
   cursor: ${p => (p.clickable ? 'pointer' : 'default')};
   min-width: 180px;
 
-  :has(${StyledIssuesButton}:hover) > ${InteractionStateLayer} {
+  :has(${StyledIssuesButton}:hover) > ${StyledInteractionStateLayer} {
     display: none;
   }
 `;


### PR DESCRIPTION
Hovering the cards showed the `InteractionStateLayer` without border-radius, which was especially visible in UI2 dark mode:

before:

<img width="610" height="224" alt="Screenshot 2025-10-17 at 16 55 13" src="https://github.com/user-attachments/assets/e8c0a44a-1cff-4291-8800-dff14d49c355" />

after:

<img width="615" height="220" alt="Screenshot 2025-10-17 at 16 54 58" src="https://github.com/user-attachments/assets/1737a1a7-95fb-4cc8-a201-3d027c4a7abb" />

it’s a small win as `InteractionStateLayer` is already deprecated and the current hover effect is also not great in UI2 for an interactive element.

I think @getsentry/design-engineering should provide an `InteractiveCard` component out of the box.