### PR TITLE
fix(seer explorer): Try highest accuracy sampling

### DIFF
--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -7,6 +7,7 @@ from sentry.constants import ObjectStatus
 from sentry.models.apikey import ApiKey
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.search.eap import constants
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
 from sentry.seer.sentry_data_models import EAPTrace
@@ -199,7 +200,7 @@ def get_trace_waterfall(trace_id: str, organization_id: int) -> EAPTrace | None:
             limit=1,
             referrer=Referrer.SEER_RPC,
             config=SearchResolverConfig(),
-            sampling_mode="BEST_EFFORT",  # Prioritize performance to avoid timeouts - we only need 1 span.
+            sampling_mode=constants.SAMPLING_MODE_HIGHEST_ACCURACY,  # Maximize likelihood of finding a span.
         )
         full_trace_id = (
             subquery_result["data"][0].get("trace") if subquery_result.get("data") else None


### PR DESCRIPTION
The get trace waterfall tool still almost always fails with "trace not found from short id" in internal testing. Maybe we need high accuracy sampling rather than best effort to increase the chances of finding a span?

If this works, it might cause timeouts because of the broad date range, but we can monitor for that (probably will raise errors) and follow up with a strategy for that as well.