### PR TITLE
fix(spans-migration): add validation for selected aggregate definition

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -128,14 +128,6 @@ class DashboardWidgetSerializer(Serializer):
                     transaction_query["selectedAggregate"],
                 )
             except Exception:
-                query_params = {"referrer": "dashboards.widget-transaction-deprecation-warning"}
-                url = organization_absolute_url(
-                    has_customer_domain=has_customer_domain(),
-                    slug=obj.dashboard.organization.slug,
-                    path="/explore/traces/",
-                    query=urlencode(query_params, doseq=True),
-                )
-                urls.append(url)
                 continue
 
             aggregate_equation_fields = [

--- a/src/sentry/explore/translation/dashboards_translation.py
+++ b/src/sentry/explore/translation/dashboards_translation.py
@@ -81,7 +81,9 @@ def translate_dashboard_widget_queries(
     new_aliases = []
     new_selected_aggregate = None
     selected_aggregate_field = (
-        original_fields[selected_aggregate] if selected_aggregate is not None else None
+        original_fields[selected_aggregate]
+        if selected_aggregate is not None and selected_aggregate < len(original_fields)
+        else None
     )
 
     field_index = 0

--- a/tests/sentry/explore/translation/test_dashboards_translation.py
+++ b/tests/sentry/explore/translation/test_dashboards_translation.py
@@ -596,6 +596,51 @@ class DashboardTranslationTestCase(TestCase):
         assert new_query.aggregates == []
         assert new_query.columns == ["transaction"]
 
+    def test_selected_aggregate_out_of_range(self) -> None:
+        transaction_widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=0,
+            title="transaction widget",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=DashboardWidgetTypes.TRANSACTION_LIKE,
+            interval="1d",
+        )
+        DashboardWidgetQuery.objects.create(
+            widget=transaction_widget,
+            fields=["count()", "count_unique(user)"],
+            columns=[],
+            aggregates=["count()", "count_unique(user)"],
+            conditions="transaction:foo",
+            selected_aggregate=14,
+            order=0,
+        )
+
+        translate_dashboard_widget(transaction_widget)
+        transaction_widget.refresh_from_db()
+
+        assert transaction_widget.widget_snapshot
+        assert transaction_widget.changed_reason is not None
+
+        snapshot_queries = transaction_widget.widget_snapshot["queries"]
+        assert len(snapshot_queries) == 1
+        original_snapshot_query = snapshot_queries[0]
+        assert original_snapshot_query["fields"] == ["count()", "count_unique(user)"]
+        assert original_snapshot_query["conditions"] == "transaction:foo"
+        assert original_snapshot_query["aggregates"] == ["count()", "count_unique(user)"]
+        assert original_snapshot_query["columns"] == []
+        assert original_snapshot_query["selectedAggregate"] == 14
+
+        new_queries = DashboardWidgetQuery.objects.filter(widget=transaction_widget)
+        assert new_queries.count() == 1
+        new_query = new_queries.first()
+        assert new_query is not None
+        assert new_query.widget_id == transaction_widget.id
+        assert new_query.fields == ["count(span.duration)", "count_unique(user)"]
+        assert new_query.conditions == "(transaction:foo) AND is_transaction:1"
+        assert new_query.aggregates == ["count(span.duration)", "count_unique(user)"]
+        assert new_query.columns == []
+        assert new_query.selected_aggregate is None
+
 
 class DashboardRestoreTransactionWidgetTestCase(TestCase):
     @property


### PR DESCRIPTION
I guess in some non-big-number widgets the selected aggregate is still there (i will follow up with a frontend fix for this too). But this would result in interesting indices for the selected aggregate which is causing these index errors.

Actually resolves [SENTRY-5AYX](https://sentry.sentry.io/issues/6951878920/)
