### PR TITLE
feat(explorer): Show tool statuses with dot color

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -37,6 +37,48 @@ function hasValidContent(content: string): boolean {
   return trimmed.length > 0 && trimmed !== '.'; // sometimes the LLM just says '.' when calling a tool
 }
 
+/**
+ * Determine the dot color based on tool execution status
+ */
+function getToolStatus(
+  block: Block
+): 'loading' | 'content' | 'success' | 'failure' | 'mixed' {
+  if (block.loading) {
+    return 'loading';
+  }
+
+  const hasContent = hasValidContent(block.message.content);
+  if (hasContent) {
+    return 'content';
+  }
+
+  // Check tool_links for empty_results metadata
+  const toolLinks = block.tool_links || [];
+  if (toolLinks.length === 0) {
+    // No metadata available, assume success
+    return 'success';
+  }
+
+  let hasSuccess = false;
+  let hasFailure = false;
+
+  toolLinks.forEach(link => {
+    if (link?.params?.empty_results === true) {
+      hasFailure = true;
+    } else if (link !== null) {
+      hasSuccess = true;
+    }
+  });
+
+  if (hasFailure && hasSuccess) {
+    return 'mixed';
+  }
+  if (hasFailure) {
+    return 'failure';
+  }
+  return 'success';
+}
+
 function BlockComponent({
   block,
   blockIndex: _blockIndex,
@@ -200,7 +242,7 @@ function BlockComponent({
           ) : (
             <BlockRow>
               <ResponseDot
-                isLoading={block.loading}
+                status={getToolStatus(block)}
                 hasOnlyTools={!hasContent && hasTools}
               />
               <BlockContentWrapper hasOnlyTools={!hasContent && hasTools}>
@@ -293,17 +335,35 @@ const BlockChevronIcon = styled(IconChevron)`
   flex-shrink: 0;
 `;
 
-const ResponseDot = styled('div')<{hasOnlyTools?: boolean; isLoading?: boolean}>`
+const ResponseDot = styled('div')<{
+  status: 'loading' | 'content' | 'success' | 'failure' | 'mixed';
+  hasOnlyTools?: boolean;
+}>`
   width: 8px;
   height: 8px;
   border-radius: 50%;
   margin-top: ${p => (p.hasOnlyTools ? '12px' : '22px')};
   margin-left: ${space(2)};
   flex-shrink: 0;
-  background: ${p => (p.isLoading ? p.theme.pink400 : p.theme.purple400)};
+  background: ${p => {
+    switch (p.status) {
+      case 'loading':
+        return p.theme.pink400;
+      case 'content':
+        return p.theme.purple400;
+      case 'success':
+        return p.theme.green400;
+      case 'failure':
+        return p.theme.red400;
+      case 'mixed':
+        return p.theme.yellow400;
+      default:
+        return p.theme.purple400;
+    }
+  }};
 
   ${p =>
-    p.isLoading &&
+    p.status === 'loading' &&
     `
     animation: blink 1s infinite;
 

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -106,6 +106,7 @@ export function buildToolLinkUrl(
       // Transform backend params to frontend format
       const queryParams: Record<string, any> = {
         query: query || '',
+        project: null,
       };
 
       const aggregateFields: any[] = [];


### PR DESCRIPTION
Change the color of the block dot indicator on tool-only blocks based on the status of its tool calls.
<img width="619" height="362" alt="Screenshot 2025-10-17 at 10 19 05 AM" src="https://github.com/user-attachments/assets/18cb6d61-73dc-4110-8e2d-150b6be0f4ea" />
