### PR TITLE
fix(ci): Increase migration test fail-slow to 120s

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: run tests
         run: |
-          PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations --migrations --reruns 0" make test-python-ci
+          PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations --migrations --reruns 0 --fail-slow=120s" make test-python-ci
 
       - name: Inspect failure
         if: failure()


### PR DESCRIPTION
<!-- Describe your PR here. -->
Increases the `--fail-slow` threshold for migration tests to 120s to address intermittent failures. This change specifically targets migration tests, overriding the default 60s value, as discussed in Slack.

---
[Slack Thread](https://sentry.slack.com/archives/CUHS29QJ0/p1760711346616679?thread_ts=1760711346.616679&cid=CUHS29QJ0)

<a href="https://cursor.com/background-agent?bcId=bc-2826f473-4222-4f43-bf1c-37c97cd25ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2826f473-4222-4f43-bf1c-37c97cd25ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

