### PR TITLE
chore(profiling): Remove deprecatedRouteProps from profiling routes

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.spec.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.spec.tsx
@@ -1,18 +1,12 @@
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {setWindowLocation} from 'sentry-test/utils';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {FlamegraphRendererDOM as mockFlameGraphRenderer} from 'sentry/utils/profiling/renderers/testUtils';
-import {useParams} from 'sentry/utils/useParams';
 import ProfileFlamegraph from 'sentry/views/profiling/profileFlamechart';
 import ProfilesAndTransactionProvider from 'sentry/views/profiling/transactionProfileProvider';
-
-jest.mock('sentry/utils/useParams', () => ({
-  useParams: jest.fn(),
-}));
 
 window.ResizeObserver =
   window.ResizeObserver ||
@@ -105,12 +99,6 @@ describe('Flamegraph', () => {
       statusCode: 404,
     });
 
-    jest.mocked(useParams).mockReturnValue({
-      orgId: 'org-slug',
-      projectId: 'foo-project',
-      eventId: 'profile-id',
-    });
-
     render(<ProfilesAndTransactionProvider />, {
       initialRouterConfig: {
         location: {
@@ -142,12 +130,6 @@ describe('Flamegraph', () => {
     MockApiClient.addMockResponse({
       url: `/projects/org-slug/foo-project/events/${flamechart.transaction.id}/`,
       statusCode: 404,
-    });
-
-    jest.mocked(useParams).mockReturnValue({
-      orgId: 'org-slug',
-      projectId: 'foo-project',
-      eventId: 'profile-id',
     });
 
     render(<ProfilesAndTransactionProvider />, {
@@ -182,12 +164,6 @@ describe('Flamegraph', () => {
     MockApiClient.addMockResponse({
       url: `/projects/org-slug/foo-project/events/${flamechart.transaction.id}/`,
       statusCode: 404,
-    });
-
-    jest.mocked(useParams).mockReturnValue({
-      orgId: 'org-slug',
-      projectId: 'foo-project',
-      eventId: 'profile-id',
     });
 
     setWindowLocation(
@@ -228,11 +204,6 @@ describe('Flamegraph', () => {
     MockApiClient.addMockResponse({
       url: `/projects/org-slug/foo-project/events/${flamechart.transaction.id}/`,
       statusCode: 404,
-    });
-
-    jest.mocked(useParams).mockReturnValue({
-      projectId: 'foo-project',
-      eventId: 'profile-id',
     });
 
     setWindowLocation('http://localhost/?query=profiling+transaction');

--- a/static/app/components/profiling/flamegraph/flamegraph.spec.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.spec.tsx
@@ -98,6 +98,7 @@ describe('Flamegraph', () => {
     act(() => ProjectsStore.loadInitialData([project]));
     setWindowLocation('http://localhost/');
   });
+
   it('renders a missing profile', async () => {
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/foo-project/profiling/profiles/profile-id/',
@@ -111,7 +112,6 @@ describe('Flamegraph', () => {
     });
 
     render(<ProfilesAndTransactionProvider />, {
-      organization: initializeOrg().organization,
       initialRouterConfig: {
         location: {
           pathname: '/explore/profiling/profile/foo-project/profile-id/flamegraph/',
@@ -151,7 +151,6 @@ describe('Flamegraph', () => {
     });
 
     render(<ProfilesAndTransactionProvider />, {
-      organization: initializeOrg().organization,
       initialRouterConfig: {
         location: {
           pathname: '/explore/profiling/profile/foo-project/profile-id/flamegraph/',
@@ -196,7 +195,6 @@ describe('Flamegraph', () => {
     );
 
     render(<ProfilesAndTransactionProvider />, {
-      organization: initializeOrg().organization,
       initialRouterConfig: {
         location: {
           pathname: '/explore/profiling/profile/foo-project/profile-id/flamegraph/',
@@ -240,7 +238,6 @@ describe('Flamegraph', () => {
     setWindowLocation('http://localhost/?query=profiling+transaction');
 
     render(<ProfilesAndTransactionProvider />, {
-      organization: initializeOrg().organization,
       initialRouterConfig: {
         location: {
           pathname: '/explore/profiling/profile/foo-project/profile-id/flamegraph/',

--- a/static/app/components/profiling/flamegraph/flamegraph.spec.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.spec.tsx
@@ -110,12 +110,21 @@ describe('Flamegraph', () => {
       eventId: 'profile-id',
     });
 
-    render(
-      <ProfilesAndTransactionProvider>
-        <ProfileFlamegraph />
-      </ProfilesAndTransactionProvider>,
-      {organization: initializeOrg().organization}
-    );
+    render(<ProfilesAndTransactionProvider />, {
+      organization: initializeOrg().organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/explore/profiling/profile/foo-project/profile-id/flamegraph/',
+        },
+        route: '/explore/profiling/profile/:projectId/:eventId/',
+        children: [
+          {
+            path: 'flamegraph/',
+            element: <ProfileFlamegraph />,
+          },
+        ],
+      },
+    });
 
     expect(
       await screen.findByText(
@@ -141,12 +150,21 @@ describe('Flamegraph', () => {
       eventId: 'profile-id',
     });
 
-    render(
-      <ProfilesAndTransactionProvider>
-        <ProfileFlamegraph />
-      </ProfilesAndTransactionProvider>,
-      {organization: initializeOrg().organization}
-    );
+    render(<ProfilesAndTransactionProvider />, {
+      organization: initializeOrg().organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/explore/profiling/profile/foo-project/profile-id/flamegraph/',
+        },
+        route: '/explore/profiling/profile/:projectId/:eventId/',
+        children: [
+          {
+            path: 'flamegraph/',
+            element: <ProfileFlamegraph />,
+          },
+        ],
+      },
+    });
 
     const frames = await screen.findAllByTestId('flamegraph-frame', undefined, {
       timeout: 5000,
@@ -177,12 +195,21 @@ describe('Flamegraph', () => {
       'http://localhost/?colorCoding=by+library&query=&sorting=alphabetical&tid=0&view=bottom+up'
     );
 
-    render(
-      <ProfilesAndTransactionProvider>
-        <ProfileFlamegraph />
-      </ProfilesAndTransactionProvider>,
-      {organization: initializeOrg().organization}
-    );
+    render(<ProfilesAndTransactionProvider />, {
+      organization: initializeOrg().organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/explore/profiling/profile/foo-project/profile-id/flamegraph/',
+        },
+        route: '/explore/profiling/profile/:projectId/:eventId/',
+        children: [
+          {
+            path: 'flamegraph/',
+            element: <ProfileFlamegraph />,
+          },
+        ],
+      },
+    });
 
     expect(await screen.findByRole('radio', {name: 'Alphabetical'})).toBeChecked();
     expect(await screen.findByRole('radio', {name: 'Bottom Up'})).toBeChecked();
@@ -206,19 +233,27 @@ describe('Flamegraph', () => {
     });
 
     jest.mocked(useParams).mockReturnValue({
-      orgId: 'org-slug',
       projectId: 'foo-project',
       eventId: 'profile-id',
     });
 
     setWindowLocation('http://localhost/?query=profiling+transaction');
 
-    render(
-      <ProfilesAndTransactionProvider>
-        <ProfileFlamegraph />
-      </ProfilesAndTransactionProvider>,
-      {organization: initializeOrg().organization}
-    );
+    render(<ProfilesAndTransactionProvider />, {
+      organization: initializeOrg().organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/explore/profiling/profile/foo-project/profile-id/flamegraph/',
+        },
+        route: '/explore/profiling/profile/:projectId/:eventId/',
+        children: [
+          {
+            path: 'flamegraph/',
+            element: <ProfileFlamegraph />,
+          },
+        ],
+      },
+    });
 
     expect(await screen.findByPlaceholderText('Find Frames')).toHaveValue(
       'profiling transaction'

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2209,12 +2209,10 @@ function buildRoutes(): RouteObject[] {
     {
       index: true,
       component: make(() => import('sentry/views/profiling/content')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'summary/:projectId/',
       component: make(() => import('sentry/views/profiling/profileSummary')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'profile/:projectId/differential-flamegraph/',
@@ -2224,7 +2222,6 @@ function buildRoutes(): RouteObject[] {
     {
       path: 'profile/:projectId/',
       component: make(() => import('sentry/views/profiling/continuousProfileProvider')),
-      deprecatedRouteProps: true,
       children: [
         {
           path: 'flamegraph/',
@@ -2237,7 +2234,6 @@ function buildRoutes(): RouteObject[] {
     {
       path: 'profile/:projectId/:eventId/',
       component: make(() => import('sentry/views/profiling/transactionProfileProvider')),
-      deprecatedRouteProps: true,
       children: [
         {
           path: 'flamegraph/',
@@ -2251,7 +2247,6 @@ function buildRoutes(): RouteObject[] {
     component: make(() => import('sentry/views/profiling')),
     withOrgPath: true,
     children: profilingChildren,
-    deprecatedRouteProps: true,
   };
 
   const exploreChildren: SentryRouteObject[] = [

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -33,6 +33,7 @@ import {browserHistory} from 'sentry/utils/browserHistory';
 import {useProfileEvents} from 'sentry/utils/profiling/hooks/useProfileEvents';
 import {formatError, formatSort} from 'sentry/utils/profiling/hooks/utils';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
@@ -48,10 +49,6 @@ const LEFT_WIDGET_CURSOR = 'leftCursor';
 const RIGHT_WIDGET_CURSOR = 'rightCursor';
 const CURSOR_PARAMS = [LEFT_WIDGET_CURSOR, RIGHT_WIDGET_CURSOR];
 
-interface ProfilingContentProps {
-  location: Location;
-}
-
 function validateTab(tab: unknown): tab is 'flamegraph' | 'transactions' {
   return tab === 'flamegraph' || tab === 'transactions';
 }
@@ -62,10 +59,11 @@ function decodeTab(tab: unknown): 'flamegraph' | 'transactions' {
   return validateTab(tab) ? tab : 'transactions';
 }
 
-export default function ProfilingContent({location}: ProfilingContentProps) {
+export default function ProfilingContent() {
   const {selection} = usePageFilters();
   const organization = useOrganization();
   const {projects} = useProjects();
+  const location = useLocation();
 
   const dispatchDataState = useLandingAnalytics();
   const updateWidget1DataState = useCallback(

--- a/static/app/views/profiling/continuousProfileProvider.spec.tsx
+++ b/static/app/views/profiling/continuousProfileProvider.spec.tsx
@@ -13,18 +13,7 @@ describe('ContinuousProfileProvider', () => {
     MockApiClient.clearMockResponses();
   });
   it('fetches chunk', async () => {
-    const {organization, project, router} = initializeOrg({
-      router: {
-        location: {
-          query: {
-            start: new Date().toISOString(),
-            end: new Date().toISOString(),
-            profilerId: uuid4(),
-            eventId: '1',
-          },
-        },
-      },
-    });
+    const {organization, project} = initializeOrg();
     ProjectsStore.loadInitialData([project]);
 
     const captureMessage = jest.spyOn(Sentry, 'captureMessage');
@@ -38,10 +27,20 @@ describe('ContinuousProfileProvider', () => {
       body: {},
     });
 
-    render(<ContinuosProfileProvider>{null}</ContinuosProfileProvider>, {
-      router,
+    render(<ContinuosProfileProvider />, {
       organization,
-      deprecatedRouterMocks: true,
+      initialRouterConfig: {
+        route: '/explore/profiling/profile/:projectId/:eventId/',
+        location: {
+          pathname: `/explore/profiling/profile/${project.slug}/1/`,
+          query: {
+            start: new Date().toISOString(),
+            end: new Date().toISOString(),
+            profilerId: uuid4(),
+            eventId: '1',
+          },
+        },
+      },
     });
 
     await waitFor(() => expect(chunkRequest).toHaveBeenCalled());
@@ -54,28 +53,26 @@ describe('ContinuousProfileProvider', () => {
       [new Date().toISOString(), undefined, uuid4()],
       [new Date().toISOString(), new Date().toISOString(), undefined],
     ]) {
-      const {organization, project, router} = initializeOrg({
-        // params: {orgId: organization.slug, projectId: project.slug},
-        router: {
-          location: {
-            query: {
-              start,
-              end,
-              profilerId,
-              eventId: '1',
-            },
-          },
-        },
-      });
+      const {organization, project} = initializeOrg();
       MockApiClient.addMockResponse({
         url: `/projects/${organization.slug}/${project.slug}/events/1/`,
         body: {},
       });
       const captureMessage = jest.spyOn(Sentry, 'captureMessage');
-      render(<ContinuosProfileProvider>{null}</ContinuosProfileProvider>, {
-        router,
+      render(<ContinuosProfileProvider />, {
         organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          route: '/explore/profiling/profile/:projectId/:eventId/',
+          location: {
+            pathname: `/explore/profiling/profile/${project.slug}/1/`,
+            query: {
+              start: start ?? '',
+              end: end ?? '',
+              profilerId: profilerId ?? '',
+              eventId: '1',
+            },
+          },
+        },
       });
 
       await waitFor(() =>

--- a/static/app/views/profiling/continuousProfileProvider.tsx
+++ b/static/app/views/profiling/continuousProfileProvider.tsx
@@ -1,4 +1,5 @@
 import {useMemo, useState} from 'react';
+import {Outlet} from 'react-router-dom';
 
 import {ContinuousProfileHeader} from 'sentry/components/profiling/continuousProfileHeader';
 import type {RequestState} from 'sentry/types/core';
@@ -15,13 +16,7 @@ function isValidDate(date: string): boolean {
   return !isNaN(Date.parse(date));
 }
 
-interface FlamegraphViewProps {
-  children: React.ReactNode;
-}
-
-export default function ProfileAndTransactionProvider(
-  props: FlamegraphViewProps
-): React.ReactElement {
+export default function ProfileAndTransactionProvider(): React.ReactElement {
   const organization = useOrganization();
   const params = useParams();
   const location = useLocation();
@@ -72,7 +67,7 @@ export default function ProfileAndTransactionProvider(
             profileTransaction.type === 'resolved' ? profileTransaction.data : null
           }
         />
-        {props.children}
+        <Outlet />
       </ProfileTransactionContext>
     </ContinuousProfileProvider>
   );

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -1,6 +1,5 @@
 import {useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
-import type {Location} from 'history';
 
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
@@ -20,7 +19,6 @@ import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
-import type {PageFiltersState} from 'sentry/components/organizations/pageFilters/types';
 import {TransactionSearchQueryBuilder} from 'sentry/components/performance/transactionSearchQueryBuilder';
 import PerformanceDuration from 'sentry/components/performanceDuration';
 import {AggregateFlamegraph} from 'sentry/components/profiling/flamegraph/aggregateFlamegraph';
@@ -32,8 +30,6 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconPanel} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {PageFilters} from 'sentry/types/core';
-import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {DeepPartial} from 'sentry/types/utils';
 import {defined} from 'sentry/utils';
@@ -60,7 +56,6 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {
   FlamegraphProvider,

--- a/static/app/views/profiling/profileSummary/profileSummaryPage.spec.tsx
+++ b/static/app/views/profiling/profileSummary/profileSummaryPage.spec.tsx
@@ -1,5 +1,3 @@
-import type {Location} from 'history';
-import {GlobalSelectionFixture} from 'sentry-fixture/globalSelection';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
@@ -62,23 +60,17 @@ describe('ProfileSummaryPage', () => {
       body: [],
     });
 
-    render(
-      <ProfileSummaryPage
-        view="flamegraph"
-        params={{}}
-        selection={GlobalSelectionFixture()}
-        location={
-          {
-            query: {transaction: 'fancyservice'},
-          } as unknown as Location
-        }
-      />,
-      {
-        organization: OrganizationFixture({
-          features: ['profiling-summary-redesign'],
-        }),
-      }
-    );
+    render(<ProfileSummaryPage />, {
+      organization: OrganizationFixture({
+        features: ['profiling-summary-redesign'],
+      }),
+      initialRouterConfig: {
+        location: {
+          pathname: '/profiling/summary/project-slug',
+          query: {transaction: 'fancyservice'},
+        },
+      },
+    });
 
     expect(await screen.findByTestId(/profile-summary-redesign/i)).toBeInTheDocument();
   });

--- a/static/app/views/profiling/transactionProfileProvider.tsx
+++ b/static/app/views/profiling/transactionProfileProvider.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {Outlet} from 'react-router-dom';
 
 import {ProfileHeader} from 'sentry/components/profiling/profileHeader';
 import type {RequestState} from 'sentry/types/core';
@@ -20,13 +21,7 @@ function getTransactionId(input: Profiling.ProfileInput): string | null {
   return null;
 }
 
-interface FlamegraphViewProps {
-  children: React.ReactNode;
-}
-
-export default function ProfileAndTransactionProvider(
-  props: FlamegraphViewProps
-): React.ReactElement {
+export default function ProfileAndTransactionProvider(): React.ReactElement {
   const organization = useOrganization();
   const params = useParams();
 
@@ -58,7 +53,7 @@ export default function ProfileAndTransactionProvider(
             profileTransaction.type === 'resolved' ? profileTransaction.data : null
           }
         />
-        {props.children}
+        <Outlet />
       </ProfileTransactionContext>
     </TransactionProfileProvider>
   );


### PR DESCRIPTION
This PR is part of the FE TSC effort to remove `deprecatedRouteProps` from our FE routes. This PR removes them from the various profiling routes, and updates the tests to get them passing again.