### PR TITLE
fix(comparative workflows): Include buckets in baseline

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -226,10 +226,14 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsV2Endpoin
                         break
 
         # Add remaining cohort_2 buckets that weren't in cohort_1 (exist only in baseline)
-        for attribute_name, buckets in cohort_2_distribution_map.items():
-            for bucket in buckets:
-                if (attribute_name, bucket["label"]) not in processed_cohort_2_buckets:
-                    cohort_2_distribution.append((attribute_name, bucket["label"], bucket["value"]))
+        cohort_2_distribution.extend(
+            [
+                (attribute_name, bucket["label"], bucket["value"])
+                for attribute_name, buckets in cohort_2_distribution_map.items()
+                for bucket in buckets
+                if (attribute_name, bucket["label"]) not in processed_cohort_2_buckets
+            ]
+        )
 
         total_outliers = (
             int(totals_1_result["data"][0]["count(span.duration)"])

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -228,7 +228,7 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsV2Endpoin
         # Add remaining cohort_2 buckets that weren't in cohort_1 (exist only in baseline)
         cohort_2_distribution.extend(
             [
-                (attribute_name, bucket["label"], bucket["value"])
+                (attribute_name, cast(str, bucket["label"]), cast(float, bucket["value"]))
                 for attribute_name, buckets in cohort_2_distribution_map.items()
                 for bucket in buckets
                 if (attribute_name, bucket["label"]) not in processed_cohort_2_buckets

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -196,6 +196,7 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsV2Endpoin
 
         cohort_2_distribution = []
         cohort_2_distribution_map = defaultdict(list)
+        processed_cohort_2_buckets = set()
 
         for attribute in cohort_2_data.results[0].attribute_distributions.attributes:
             for bucket in attribute.buckets:
@@ -221,7 +222,14 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsV2Endpoin
                         cohort_2_distribution.append(
                             (attribute.attribute_name, bucket.label, baseline_value)
                         )
+                        processed_cohort_2_buckets.add((attribute.attribute_name, bucket.label))
                         break
+
+        # Add remaining cohort_2 buckets that weren't in cohort_1 (exist only in baseline)
+        for attribute_name, buckets in cohort_2_distribution_map.items():
+            for bucket in buckets:
+                if (attribute_name, bucket["label"]) not in processed_cohort_2_buckets:
+                    cohort_2_distribution.append((attribute_name, bucket["label"], bucket["value"]))
 
         total_outliers = (
             int(totals_1_result["data"][0]["count(span.duration)"])


### PR DESCRIPTION
- After looking at the logs and reviewing the details in a notebook, found that we are NOT including values in the baseline set which are still important for scoring when it comes to the normalization step in our scoring function
- Adds the respective values to cohort_2 which is sent as the baseline for scoring