### PR TITLE
feat(aci): Move edit actions for monitor/automation to footer

### DIFF
--- a/static/app/views/automations/components/editAutomationActions.tsx
+++ b/static/app/views/automations/components/editAutomationActions.tsx
@@ -8,7 +8,6 @@ import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {AutomationFeedbackButton} from 'sentry/views/automations/components/automationFeedbackButton';
 import {
   useDeleteAutomationMutation,
   useUpdateAutomation,
@@ -59,7 +58,6 @@ export function EditAutomationActions({automation}: EditAutomationActionsProps) 
   return (
     <div>
       <ButtonBar>
-        <AutomationFeedbackButton />
         <Button
           priority="default"
           size="sm"

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -13,6 +13,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {FullHeightForm} from 'sentry/components/workflowEngine/form/fullHeightForm';
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
+import {StickyFooter} from 'sentry/components/workflowEngine/ui/footer';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import type {Automation, NewAutomation} from 'sentry/types/workflowEngine/automations';
@@ -27,6 +28,7 @@ import {
   useAutomationBuilderReducer,
 } from 'sentry/views/automations/components/automationBuilderContext';
 import {AutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
+import {AutomationFeedbackButton} from 'sentry/views/automations/components/automationFeedbackButton';
 import AutomationForm from 'sentry/views/automations/components/automationForm';
 import type {AutomationFormData} from 'sentry/views/automations/components/automationFormData';
 import {
@@ -168,9 +170,7 @@ function AutomationEditForm({automation}: {automation: Automation}) {
               </Layout.Title>
             </Layout.HeaderContent>
             <div>
-              <Flex>
-                <EditAutomationActions automation={automation} />
-              </Flex>
+              <AutomationFeedbackButton />
             </div>
           </HeaderInner>
         </StyledLayoutHeader>
@@ -198,6 +198,11 @@ function AutomationEditForm({automation}: {automation: Automation}) {
           </Layout.Main>
         </StyledBody>
       </Layout.Page>
+      <StickyFooter>
+        <Flex style={{maxWidth}} align="center" gap="md" justify="end">
+          <EditAutomationActions automation={automation} />
+        </Flex>
+      </StickyFooter>
     </FullHeightForm>
   );
 }

--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -67,11 +67,6 @@ export function EditDetectorLayout<
         <div>
           <EditLayout.Actions>
             <MonitorFeedbackButton />
-            <DisableDetectorAction detector={detector} />
-            <DeleteDetectorAction detector={detector} />
-            <Button type="submit" priority="primary" size="sm">
-              {t('Save')}
-            </Button>
           </EditLayout.Actions>
         </div>
 
@@ -82,6 +77,14 @@ export function EditDetectorLayout<
       </EditLayout.Header>
 
       <EditLayout.Body maxWidth={maxWidth}>{children}</EditLayout.Body>
+
+      <EditLayout.Footer maxWidth={maxWidth}>
+        <DisableDetectorAction detector={detector} />
+        <DeleteDetectorAction detector={detector} />
+        <Button type="submit" priority="primary" size="sm">
+          {t('Save')}
+        </Button>
+      </EditLayout.Footer>
     </EditLayout>
   );
 }

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -1,8 +1,8 @@
 import {Link} from 'react-router-dom';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
-import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {ExternalLink} from 'sentry/components/core/link';
 import {Text} from 'sentry/components/core/text';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -15,6 +15,7 @@ import {space} from 'sentry/styles/space';
 import type {ErrorDetector} from 'sentry/types/workflowEngine/detectors';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromId from 'sentry/utils/useProjectFromId';
+import {AutomationFeedbackButton} from 'sentry/views/automations/components/automationFeedbackButton';
 import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
 import {EditDetectorBreadcrumbs} from 'sentry/views/detectors/components/forms/common/breadcrumbs';
 import {useEditDetectorFormSubmit} from 'sentry/views/detectors/hooks/useEditDetectorFormSubmit';
@@ -110,6 +111,8 @@ export function NewErrorDetectorForm() {
 
 export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetector}) {
   const project = useProjectFromId({project_id: detector.projectId});
+  const theme = useTheme();
+  const maxWidth = theme.breakpoints.xl;
 
   const handleFormSubmit = useEditDetectorFormSubmit({
     detector,
@@ -138,21 +141,20 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
           <EditDetectorBreadcrumbs detector={detector} />
           <EditLayout.Title title={detector.name} project={project} />
         </EditLayout.HeaderContent>
-
         <EditLayout.Actions>
-          <div>
-            <ButtonBar>
-              <Button type="submit" priority="primary" size="sm">
-                {t('Save')}
-              </Button>
-            </ButtonBar>
-          </div>
+          <AutomationFeedbackButton />
         </EditLayout.Actions>
       </EditLayout.Header>
 
       <EditLayout.Body>
         <ErrorDetectorForm detector={detector} />
       </EditLayout.Body>
+
+      <EditLayout.Footer maxWidth={maxWidth}>
+        <Button type="submit" priority="primary" size="sm">
+          {t('Save')}
+        </Button>
+      </EditLayout.Footer>
     </EditLayout>
   );
 }


### PR DESCRIPTION
Puts controls in a sticky footer, more similar to alerts and the builder. Feedback should continue to be in the header

<img width="1497" height="1217" alt="image" src="https://github.com/user-attachments/assets/12701dbb-3fde-4474-9c9c-e39f497db9b2" />
