### PR TITLE
fix(spans): Unquote literal value in key eq val filters

### DIFF
--- a/src/sentry/search/eap/normalizer.py
+++ b/src/sentry/search/eap/normalizer.py
@@ -1,0 +1,5 @@
+def unquote_literal(value: str) -> str:
+    if len(value) < 2 or value[0] != '"' or value[-1] != '"':
+        return value
+    else:
+        return value[1:-1]

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -22,6 +22,7 @@ from sentry.search.eap.columns import (
     ResolvedArguments,
     ValueArgumentDefinition,
 )
+from sentry.search.eap.normalizer import unquote_literal
 from sentry.search.eap.spans.utils import WEB_VITALS_MEASUREMENTS, transform_vital_score_to_ratio
 from sentry.search.eap.validator import literal_validator, number_validator
 
@@ -67,6 +68,7 @@ def resolve_key_eq_value_filter(args: ResolvedArguments) -> tuple[AttributeKey, 
         elif key.type == AttributeKey.TYPE_INT:
             attr_value = AttributeValue(val_int=int(value))
         else:
+            value = unquote_literal(value)
             attr_value = AttributeValue(val_str=value)
     except ValueError:
         expected_type = "string"

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -5991,6 +5991,73 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         assert meta["fields"]["count_if(span.status,equals,success)"] == "integer"
         assert meta["units"]["count_if(span.status,equals,success)"] is None
 
+    def test_count_if_span_status_equation_quoted(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"status": "success"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "bar",
+                        "sentry_tags": {"status": ""},
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+        equation = 'equation|count_if(span.status,equals,"success")'
+        response = self.do_request(
+            {
+                "field": [equation],
+                "query": "",
+                "orderby": equation,
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data == [
+            {
+                equation: 1.0,
+            },
+        ]
+        assert meta["dataset"] == "spans"
+        assert meta["fields"][equation] == "integer"
+        assert meta["units"][equation] is None
+
+        equation = 'equation|count_if(span.status,equals,"")'
+        response = self.do_request(
+            {
+                "field": [equation],
+                "query": "",
+                "orderby": equation,
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data == [
+            {
+                equation: 1.0,
+            },
+        ]
+        assert meta["dataset"] == "spans"
+        assert meta["fields"][equation] == "integer"
+        assert meta["units"][equation] is None
+
     def test_count_if_numeric(self) -> None:
         self.store_spans(
             [


### PR DESCRIPTION
This allows quoted values like `count_if(foo,equals,"bar baz")`