### PR TITLE
chore(eco): remove sentry app outbox flag

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3175,13 +3175,6 @@ register(
 )
 
 register(
-    "workflow_engine.sentry-app-actions-outbox",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
     "workflow_engine.num_cohorts",
     type=Int,
     default=1,

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -14,7 +14,6 @@ from typing import Any
 
 from django.dispatch import receiver
 
-from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.hybridcloud.outbox.signals import process_control_outbox
@@ -65,27 +64,17 @@ def process_sentry_app_deletes(
     payload: Mapping[str, Any],
     **kwds: Any,
 ):
-    # This function should only be used when the sentry app is being deleted.
-    # Currently this receiver is only used for deletion.
-    if options.get("workflow_engine.sentry-app-actions-outbox"):
-        logger.info(
-            "sentry_app_update.update_action_status",
-            extra={
-                "region_name": region_name,
-                "sentry_app_id": object_identifier,
-            },
-        )
-        action_service.update_action_status_for_sentry_app_via_sentry_app_id(
+    action_service.update_action_status_for_sentry_app_via_sentry_app_id(
+        region_name=region_name,
+        status=ObjectStatus.DISABLED,
+        sentry_app_id=object_identifier,
+    )
+    if slug := payload.get("slug"):
+        action_service.update_action_status_for_webhook_via_sentry_app_slug(
             region_name=region_name,
             status=ObjectStatus.DISABLED,
-            sentry_app_id=object_identifier,
+            sentry_app_slug=slug,
         )
-        if slug := payload.get("slug"):
-            action_service.update_action_status_for_webhook_via_sentry_app_slug(
-                region_name=region_name,
-                status=ObjectStatus.DISABLED,
-                sentry_app_slug=slug,
-            )
 
 
 @receiver(process_control_outbox, sender=OutboxCategory.SENTRY_APP_INSTALLATION_DELETE)
@@ -96,21 +85,11 @@ def process_sentry_app_installation_deletes(
     payload: Mapping[str, Any],
     **kwds: Any,
 ):
-    # This function should only be used when the sentry app is being deleted.
-    # Currently this receiver is only used for deletion.
-    if options.get("workflow_engine.sentry-app-actions-outbox"):
-        logger.info(
-            "sentry_app_installation_delete.update_action_status",
-            extra={
-                "region_name": region_name,
-                "sentry_app_install_uuid": payload["uuid"],
-            },
-        )
-        action_service.update_action_status_for_sentry_app_via_uuid__region(
-            region_name=region_name,
-            status=ObjectStatus.DISABLED,
-            sentry_app_install_uuid=payload["uuid"],
-        )
+    action_service.update_action_status_for_sentry_app_via_uuid__region(
+        region_name=region_name,
+        status=ObjectStatus.DISABLED,
+        sentry_app_install_uuid=payload["uuid"],
+    )
 
 
 @receiver(process_control_outbox, sender=OutboxCategory.API_APPLICATION_UPDATE)

--- a/tests/sentry/deletions/test_sentry_app.py
+++ b/tests/sentry/deletions/test_sentry_app.py
@@ -8,7 +8,6 @@ from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test, create_test_regions
 from sentry.users.models.user import User
 from sentry.workflow_engine.models import Action
@@ -60,7 +59,6 @@ class TestSentryAppDeletionTask(TestCase):
 
         assert c.fetchone()[0] == 1
 
-    @override_options({"workflow_engine.sentry-app-actions-outbox": True})
     def test_disables_actions(self) -> None:
         action = self.create_action(
             type=Action.Type.SENTRY_APP,

--- a/tests/sentry/deletions/test_sentry_app_installations.py
+++ b/tests/sentry/deletions/test_sentry_app_installations.py
@@ -17,7 +17,6 @@ from sentry.sentry_apps.models.servicehook import ServiceHook
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.workflow_engine.models import Action
@@ -112,7 +111,6 @@ class TestSentryAppInstallationDeletionTask(TestCase):
 
         assert c.fetchone()[0] == 1
 
-    @override_options({"workflow_engine.sentry-app-actions-outbox": True})
     def test_disables_actions(self) -> None:
         action = self.create_action(
             type=Action.Type.SENTRY_APP,

--- a/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -16,7 +16,6 @@ from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallat
 from sentry.sentry_apps.token_exchange.grant_exchanger import GrantExchanger
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test
 from sentry.users.services.user.service import user_service
@@ -108,7 +107,6 @@ class GetSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
 class DeleteSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
     @responses.activate
     @patch("sentry.analytics.record")
-    @override_options({"workflow_engine.sentry-app-actions-outbox": True})
     def test_delete_install(self, record: MagicMock) -> None:
         responses.add(url="https://example.com/webhook", method=responses.POST, body=b"")
         self.login_as(user=self.user)

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
@@ -850,7 +850,6 @@ class DeleteSentryAppDetailsTest(SentryAppDetailsTest):
 
         self.get_error_response(self.internal_integration.slug, status_code=403)
 
-    @override_options({"workflow_engine.sentry-app-actions-outbox": True})
     def test_disables_actions(self) -> None:
         action = self.create_action(
             type=Action.Type.SENTRY_APP,


### PR DESCRIPTION
I got some logs that indicate the outboxes are running, so removing the flag.