### PR TITLE
feat(monitors): Add top-level Monitors pages

### DIFF
--- a/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/automationTitleCell.tsx
@@ -3,6 +3,7 @@ import type {Automation} from 'sentry/types/workflowEngine/automations';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getAutomationActionsWarning} from 'sentry/views/automations/hooks/utils';
 import {makeAutomationDetailsPathname} from 'sentry/views/automations/pathnames';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 
 interface Props {
   automation: Automation;
@@ -10,13 +11,18 @@ interface Props {
 
 export default function AutomationTitleCell({automation}: Props) {
   const organization = useOrganization();
+  const {automationsLinkPrefix} = useMonitorViewContext();
 
   const warning = getAutomationActionsWarning(automation);
 
   return (
     <TitleCell
       name={automation.name}
-      link={makeAutomationDetailsPathname(organization.slug, automation.id)}
+      link={makeAutomationDetailsPathname(
+        organization.slug,
+        automation.id,
+        automationsLinkPrefix
+      )}
       systemCreated={!automation.createdBy}
       disabled={!automation.enabled}
       warning={warning}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1672,6 +1672,36 @@ function buildRoutes(): RouteObject[] {
     ],
   };
 
+  const monitorRoutes: SentryRouteObject = {
+    path: '/monitors/',
+    withOrgPath: true,
+    component: make(() => import('sentry/views/detectors/monitorViewContainer')),
+    children: [
+      ...detectorRoutes.children!,
+      automationRoutes,
+      {
+        path: 'my-monitors/',
+        component: make(() => import('sentry/views/detectors/list/myMonitors')),
+      },
+      {
+        path: 'errors/',
+        component: make(() => import('sentry/views/detectors/list/error')),
+      },
+      {
+        path: 'metrics/',
+        component: make(() => import('sentry/views/detectors/list/metric')),
+      },
+      {
+        path: 'crons/',
+        component: make(() => import('sentry/views/detectors/list/cron')),
+      },
+      {
+        path: 'uptime/',
+        component: make(() => import('sentry/views/detectors/list/uptime')),
+      },
+    ],
+  };
+
   const replayChildren: SentryRouteObject[] = [
     {
       index: true,
@@ -2935,6 +2965,7 @@ function buildRoutes(): RouteObject[] {
       feedbackv2Routes,
       issueRoutes,
       alertRoutes,
+      monitorRoutes,
       preventRoutes,
       preprodRoutes,
       pullRequestRoutes,

--- a/static/app/views/automations/components/automationHistoryList.tsx
+++ b/static/app/views/automations/components/automationHistoryList.tsx
@@ -14,6 +14,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useAutomationFireHistoryQuery} from 'sentry/views/automations/hooks';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 
 const DEFAULT_HISTORY_PER_PAGE = 10;
@@ -55,6 +56,7 @@ export default function AutomationHistoryList({
   emptyMessage = t('No history found'),
 }: Props) {
   const org = useOrganization();
+  const {monitorsLinkPrefix} = useMonitorViewContext();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -94,7 +96,13 @@ export default function AutomationHistoryList({
             </SimpleTable.RowCell>
             <SimpleTable.RowCell>
               {row.detector ? (
-                <StyledLink to={makeMonitorDetailsPathname(org.slug, row.detector.id)}>
+                <StyledLink
+                  to={makeMonitorDetailsPathname(
+                    org.slug,
+                    row.detector.id,
+                    monitorsLinkPrefix
+                  )}
+                >
                   <TruncatedText>{row.detector.name}</TruncatedText>
                 </StyledLink>
               ) : (

--- a/static/app/views/automations/components/editAutomationActions.tsx
+++ b/static/app/views/automations/components/editAutomationActions.tsx
@@ -13,6 +13,7 @@ import {
   useUpdateAutomation,
 } from 'sentry/views/automations/hooks';
 import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 
 interface EditAutomationActionsProps {
   automation: Automation;
@@ -20,6 +21,7 @@ interface EditAutomationActionsProps {
 
 export function EditAutomationActions({automation}: EditAutomationActionsProps) {
   const organization = useOrganization();
+  const {automationsLinkPrefix} = useMonitorViewContext();
   const navigate = useNavigate();
   const {mutateAsync: deleteAutomation, isPending: isDeleting} =
     useDeleteAutomationMutation();
@@ -50,10 +52,16 @@ export function EditAutomationActions({automation}: EditAutomationActionsProps) 
       priority: 'danger',
       onConfirm: async () => {
         await deleteAutomation(automation.id);
-        navigate(makeAutomationBasePathname(organization.slug));
+        navigate(makeAutomationBasePathname(organization.slug, automationsLinkPrefix));
       },
     });
-  }, [deleteAutomation, automation.id, navigate, organization.slug]);
+  }, [
+    deleteAutomation,
+    automation.id,
+    navigate,
+    organization.slug,
+    automationsLinkPrefix,
+  ]);
 
   return (
     <div>

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -44,11 +44,13 @@ import {
   makeAutomationEditPathname,
 } from 'sentry/views/automations/pathnames';
 import {useDetectorsQuery} from 'sentry/views/detectors/hooks';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 
 const AUTOMATION_DETECTORS_LIMIT = 10;
 
 function AutomationDetailContent({automation}: {automation: Automation}) {
   const organization = useOrganization();
+  const {automationsLinkPrefix} = useMonitorViewContext();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -82,7 +84,10 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
               crumbs={[
                 {
                   label: t('Automations'),
-                  to: makeAutomationBasePathname(organization.slug),
+                  to: makeAutomationBasePathname(
+                    organization.slug,
+                    automationsLinkPrefix
+                  ),
                 },
                 {label: automation.name},
               ]}
@@ -227,6 +232,7 @@ export default function AutomationDetail() {
 
 function Actions({automation}: {automation: Automation}) {
   const organization = useOrganization();
+  const {automationsLinkPrefix} = useMonitorViewContext();
   const {mutate: updateAutomation, isPending: isUpdating} = useUpdateAutomation();
 
   const toggleDisabled = useCallback(() => {
@@ -254,7 +260,11 @@ function Actions({automation}: {automation: Automation}) {
         {automation.enabled ? t('Disable') : t('Enable')}
       </Button>
       <LinkButton
-        to={makeAutomationEditPathname(organization.slug, automation.id)}
+        to={makeAutomationEditPathname(
+          organization.slug,
+          automation.id,
+          automationsLinkPrefix
+        )}
         priority="primary"
         icon={<IconEdit />}
         size="sm"

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -43,6 +43,7 @@ import {
   makeAutomationBasePathname,
   makeAutomationDetailsPathname,
 } from 'sentry/views/automations/pathnames';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 
 function AutomationDocumentTitle() {
   const title = useFormField('name');
@@ -52,13 +53,21 @@ function AutomationDocumentTitle() {
 function AutomationBreadcrumbs({automationId}: {automationId: string}) {
   const title = useFormField('name');
   const organization = useOrganization();
+  const {automationsLinkPrefix} = useMonitorViewContext();
   return (
     <Breadcrumbs
       crumbs={[
-        {label: t('Automation'), to: makeAutomationBasePathname(organization.slug)},
+        {
+          label: t('Automation'),
+          to: makeAutomationBasePathname(organization.slug, automationsLinkPrefix),
+        },
         {
           label: title,
-          to: makeAutomationDetailsPathname(organization.slug, automationId),
+          to: makeAutomationDetailsPathname(
+            organization.slug,
+            automationId,
+            automationsLinkPrefix
+          ),
         },
         {label: t('Configure')},
       ]}
@@ -92,6 +101,7 @@ export default function AutomationEdit() {
 function AutomationEditForm({automation}: {automation: Automation}) {
   const navigate = useNavigate();
   const organization = useOrganization();
+  const {automationsLinkPrefix} = useMonitorViewContext();
   const params = useParams<{automationId: string}>();
   const theme = useTheme();
   const maxWidth = theme.breakpoints.lg;
@@ -146,10 +156,23 @@ function AutomationEditForm({automation}: {automation: Automation}) {
           ...formData,
         };
         const updatedAutomation = await updateAutomation(updatedData);
-        navigate(makeAutomationDetailsPathname(organization.slug, updatedAutomation.id));
+        navigate(
+          makeAutomationDetailsPathname(
+            organization.slug,
+            updatedAutomation.id,
+            automationsLinkPrefix
+          )
+        );
       }
     },
-    [automation.id, organization.slug, navigate, updateAutomation, state]
+    [
+      automation.id,
+      organization.slug,
+      navigate,
+      updateAutomation,
+      state,
+      automationsLinkPrefix,
+    ]
   );
 
   return (

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -23,6 +23,7 @@ import {AutomationSearch} from 'sentry/views/automations/components/automationLi
 import {AUTOMATION_LIST_PAGE_LIMIT} from 'sentry/views/automations/constants';
 import {useAutomationsQuery} from 'sentry/views/automations/hooks';
 import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 
 export default function AutomationsList() {
   useWorkflowEngineFeatureGate({redirect: true});
@@ -136,11 +137,12 @@ function TableHeader() {
 
 function Actions() {
   const organization = useOrganization();
+  const {automationsLinkPrefix} = useMonitorViewContext();
   return (
     <Flex gap="sm">
       <AutomationFeedbackButton />
       <LinkButton
-        to={`${makeAutomationBasePathname(organization.slug)}new/`}
+        to={`${makeAutomationBasePathname(organization.slug, automationsLinkPrefix)}new/`}
         priority="primary"
         icon={<IconAdd />}
         size="sm"

--- a/static/app/views/automations/new-settings.tsx
+++ b/static/app/views/automations/new-settings.tsx
@@ -37,6 +37,7 @@ import {
   makeAutomationBasePathname,
   makeAutomationDetailsPathname,
 } from 'sentry/views/automations/pathnames';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 
 function AutomationDocumentTitle() {
   const title = useFormField('name');
@@ -50,10 +51,14 @@ function AutomationDocumentTitle() {
 function AutomationBreadcrumbs() {
   const title = useFormField('name');
   const organization = useOrganization();
+  const {automationsLinkPrefix} = useMonitorViewContext();
   return (
     <Breadcrumbs
       crumbs={[
-        {label: t('Automation'), to: makeAutomationBasePathname(organization.slug)},
+        {
+          label: t('Automation'),
+          to: makeAutomationBasePathname(organization.slug, automationsLinkPrefix),
+        },
         {label: title ? title : t('New Automation')},
       ]}
     />
@@ -71,6 +76,7 @@ export default function AutomationNewSettings() {
   const navigate = useNavigate();
   const location = useLocation();
   const organization = useOrganization();
+  const {automationsLinkPrefix} = useMonitorViewContext();
   useWorkflowEngineFeatureGate({redirect: true});
   const model = useMemo(() => new FormModel(), []);
   const {state, actions} = useAutomationBuilderReducer();
@@ -112,10 +118,16 @@ export default function AutomationNewSettings() {
         const automation = await createAutomation(
           getNewAutomationData(data as AutomationFormData, state)
         );
-        navigate(makeAutomationDetailsPathname(organization.slug, automation.id));
+        navigate(
+          makeAutomationDetailsPathname(
+            organization.slug,
+            automation.id,
+            automationsLinkPrefix
+          )
+        );
       }
     },
-    [createAutomation, state, navigate, organization.slug]
+    [createAutomation, state, navigate, organization.slug, automationsLinkPrefix]
   );
 
   return (
@@ -171,7 +183,7 @@ export default function AutomationNewSettings() {
           <Flex gap="md">
             <LinkButton
               priority="default"
-              to={`${makeAutomationBasePathname(organization.slug)}new/`}
+              to={`${makeAutomationBasePathname(organization.slug, automationsLinkPrefix)}new/`}
             >
               {t('Back')}
             </LinkButton>

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -18,14 +18,19 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {AutomationFeedbackButton} from 'sentry/views/automations/components/automationFeedbackButton';
 import {ConnectMonitorsContent} from 'sentry/views/automations/components/editConnectedMonitors';
 import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 import {makeMonitorCreatePathname} from 'sentry/views/detectors/pathnames';
 
 function AutomationBreadcrumbs() {
   const organization = useOrganization();
+  const {automationsLinkPrefix} = useMonitorViewContext();
   return (
     <Breadcrumbs
       crumbs={[
-        {label: t('Automations'), to: makeAutomationBasePathname(organization.slug)},
+        {
+          label: t('Automations'),
+          to: makeAutomationBasePathname(organization.slug, automationsLinkPrefix),
+        },
         {label: t('New Automation')},
       ]}
     />
@@ -35,6 +40,7 @@ function AutomationBreadcrumbs() {
 export default function AutomationNew() {
   const location = useLocation();
   const organization = useOrganization();
+  const {automationsLinkPrefix, monitorsLinkPrefix} = useMonitorViewContext();
   useWorkflowEngineFeatureGate({redirect: true});
   const theme = useTheme();
   const maxWidth = theme.breakpoints.lg;
@@ -75,7 +81,7 @@ export default function AutomationNew() {
               footerContent={
                 <LinkButton
                   icon={<IconAdd />}
-                  href={makeMonitorCreatePathname(organization.slug)}
+                  href={makeMonitorCreatePathname(organization.slug, monitorsLinkPrefix)}
                   external
                 >
                   {t('Create New Monitor')}
@@ -93,14 +99,14 @@ export default function AutomationNew() {
           <Flex gap="md">
             <LinkButton
               priority="default"
-              to={makeAutomationBasePathname(organization.slug)}
+              to={makeAutomationBasePathname(organization.slug, automationsLinkPrefix)}
             >
               {t('Cancel')}
             </LinkButton>
             <LinkButton
               priority="primary"
               to={{
-                pathname: `${makeAutomationBasePathname(organization.slug)}new/settings/`,
+                pathname: `${makeAutomationBasePathname(organization.slug, automationsLinkPrefix)}new/settings/`,
                 ...(connectedIds.length > 0 && {
                   query: {connectedIds},
                 }),

--- a/static/app/views/automations/pathnames.tsx
+++ b/static/app/views/automations/pathnames.tsx
@@ -1,15 +1,25 @@
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 
-export const makeAutomationBasePathname = (orgSlug: string) => {
-  return normalizeUrl(`/organizations/${orgSlug}/issues/automations/`);
+export const makeAutomationBasePathname = (orgSlug: string, linkPrefix: string) => {
+  return normalizeUrl(`/organizations/${orgSlug}/${linkPrefix}/`);
 };
 
-export const makeAutomationDetailsPathname = (orgSlug: string, automationId: string) => {
-  return normalizeUrl(`/organizations/${orgSlug}/issues/automations/${automationId}/`);
-};
-
-export const makeAutomationEditPathname = (orgSlug: string, automationId: string) => {
+export const makeAutomationDetailsPathname = (
+  orgSlug: string,
+  automationId: string,
+  linkPrefix: string
+) => {
   return normalizeUrl(
-    `/organizations/${orgSlug}/issues/automations/${automationId}/edit/`
+    `${makeAutomationBasePathname(orgSlug, linkPrefix)}${automationId}/`
+  );
+};
+
+export const makeAutomationEditPathname = (
+  orgSlug: string,
+  automationId: string,
+  linkPrefix: string
+) => {
+  return normalizeUrl(
+    `${makeAutomationBasePathname(orgSlug, linkPrefix)}${automationId}/edit/`
   );
 };

--- a/static/app/views/detectors/components/details/common/actions.tsx
+++ b/static/app/views/detectors/components/details/common/actions.tsx
@@ -12,6 +12,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUpdateDetector} from 'sentry/views/detectors/hooks';
 import {useDeleteDetectorMutation} from 'sentry/views/detectors/hooks/useDeleteDetectorMutation';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 import {
   makeMonitorBasePathname,
   makeMonitorDetailsPathname,
@@ -54,6 +55,7 @@ export function DisableDetectorAction({detector}: {detector: Detector}) {
 
 export function EditDetectorAction({detector}: {detector: Detector}) {
   const organization = useOrganization();
+  const {monitorsLinkPrefix} = useMonitorViewContext();
   const canEdit = useCanEditDetector({
     detectorType: detector.type,
     projectId: detector.projectId,
@@ -75,7 +77,7 @@ export function EditDetectorAction({detector}: {detector: Detector}) {
 
   return (
     <LinkButton
-      to={`${makeMonitorDetailsPathname(organization.slug, detector.id)}edit/`}
+      to={`${makeMonitorDetailsPathname(organization.slug, detector.id, monitorsLinkPrefix)}edit/`}
       priority="primary"
       icon={<IconEdit />}
       size="sm"
@@ -91,6 +93,7 @@ export function EditDetectorAction({detector}: {detector: Detector}) {
 export function DeleteDetectorAction({detector}: {detector: Detector}) {
   const organization = useOrganization();
   const navigate = useNavigate();
+  const {monitorsLinkPrefix} = useMonitorViewContext();
   const {mutateAsync: deleteDetector, isPending: isDeleting} =
     useDeleteDetectorMutation();
 
@@ -101,10 +104,10 @@ export function DeleteDetectorAction({detector}: {detector: Detector}) {
       priority: 'danger',
       onConfirm: async () => {
         await deleteDetector(detector.id);
-        navigate(makeMonitorBasePathname(organization.slug));
+        navigate(makeMonitorBasePathname(organization.slug, monitorsLinkPrefix));
       },
     });
-  }, [deleteDetector, detector.id, navigate, organization.slug]);
+  }, [deleteDetector, detector.id, navigate, organization.slug, monitorsLinkPrefix]);
 
   const canEdit = useCanEditDetector({
     detectorType: detector.type,

--- a/static/app/views/detectors/components/details/common/header.tsx
+++ b/static/app/views/detectors/components/details/common/header.tsx
@@ -9,6 +9,7 @@ import {
   EditDetectorAction,
 } from 'sentry/views/detectors/components/details/common/actions';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
 type DetectorDetailsHeaderProps = {
@@ -18,13 +19,17 @@ type DetectorDetailsHeaderProps = {
 
 export function DetectorDetailsHeader({detector, project}: DetectorDetailsHeaderProps) {
   const organization = useOrganization();
+  const {monitorsLinkPrefix} = useMonitorViewContext();
 
   return (
     <DetailLayout.Header>
       <DetailLayout.HeaderContent>
         <Breadcrumbs
           crumbs={[
-            {label: t('Monitors'), to: makeMonitorBasePathname(organization.slug)},
+            {
+              label: t('Monitors'),
+              to: makeMonitorBasePathname(organization.slug, monitorsLinkPrefix),
+            },
             {label: detector.name},
           ]}
         />

--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -28,6 +28,7 @@ import useProjectFromId from 'sentry/utils/useProjectFromId';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detectorTypeConfig';
 import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
@@ -205,13 +206,14 @@ function Details({detector}: {detector: Detector}) {
 
 export function DetectorLink({detector, className}: DetectorLinkProps) {
   const org = useOrganization();
+  const {monitorsLinkPrefix} = useMonitorViewContext();
   const project = useProjectFromId({project_id: detector.projectId});
 
   return (
     <TitleCell
       className={className}
       name={detector.name}
-      link={makeMonitorDetailsPathname(org.slug, detector.id)}
+      link={makeMonitorDetailsPathname(org.slug, detector.id, monitorsLinkPrefix)}
       systemCreated={!detectorTypeIsUserCreateable(detector.type)}
       disabled={!detector.enabled}
       details={

--- a/static/app/views/detectors/components/detectorListConnectedAutomations.tsx
+++ b/static/app/views/detectors/components/detectorListConnectedAutomations.tsx
@@ -14,6 +14,7 @@ import {AutomationActionSummary} from 'sentry/views/automations/components/autom
 import {useAutomationsQuery} from 'sentry/views/automations/hooks';
 import {getAutomationActions} from 'sentry/views/automations/hooks/utils';
 import {makeAutomationDetailsPathname} from 'sentry/views/automations/pathnames';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 
 type DetectorListConnectedAutomationsProps = {
   automationIds: string[];
@@ -21,6 +22,7 @@ type DetectorListConnectedAutomationsProps = {
 
 function ConnectedAutomationsHoverBody({automationIds}: {automationIds: string[]}) {
   const organization = useOrganization();
+  const {automationsLinkPrefix} = useMonitorViewContext();
   const shownAutomations = automationIds.slice(0, 5);
   const {data, isPending, isError} = useAutomationsQuery({
     ids: automationIds.slice(0, 5),
@@ -52,7 +54,11 @@ function ConnectedAutomationsHoverBody({automationIds}: {automationIds: string[]
         return (
           <HovercardRow
             key={automation.id}
-            to={makeAutomationDetailsPathname(organization.slug, automation.id)}
+            to={makeAutomationDetailsPathname(
+              organization.slug,
+              automation.id,
+              automationsLinkPrefix
+            )}
           >
             <InteractionStateLayer />
             <div>

--- a/static/app/views/detectors/components/forms/common/breadcrumbs.tsx
+++ b/static/app/views/detectors/components/forms/common/breadcrumbs.tsx
@@ -2,6 +2,7 @@ import Breadcrumbs from 'sentry/components/breadcrumbs';
 import {t} from 'sentry/locale';
 import type {Detector, DetectorType} from 'sentry/types/workflowEngine/detectors';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 import {
   makeMonitorBasePathname,
   makeMonitorDetailsPathname,
@@ -10,10 +11,14 @@ import {getDetectorTypeLabel} from 'sentry/views/detectors/utils/detectorTypeCon
 
 export function NewDetectorBreadcrumbs({detectorType}: {detectorType: DetectorType}) {
   const organization = useOrganization();
+  const {monitorsLinkPrefix} = useMonitorViewContext();
   return (
     <Breadcrumbs
       crumbs={[
-        {label: t('Monitors'), to: makeMonitorBasePathname(organization.slug)},
+        {
+          label: t('Monitors'),
+          to: makeMonitorBasePathname(organization.slug, monitorsLinkPrefix),
+        },
         {
           label: t('New %s Monitor', getDetectorTypeLabel(detectorType)),
         },
@@ -24,13 +29,21 @@ export function NewDetectorBreadcrumbs({detectorType}: {detectorType: DetectorTy
 
 export function EditDetectorBreadcrumbs({detector}: {detector: Detector}) {
   const organization = useOrganization();
+  const {monitorsLinkPrefix} = useMonitorViewContext();
   return (
     <Breadcrumbs
       crumbs={[
-        {label: t('Monitors'), to: makeMonitorBasePathname(organization.slug)},
+        {
+          label: t('Monitors'),
+          to: makeMonitorBasePathname(organization.slug, monitorsLinkPrefix),
+        },
         {
           label: detector.name,
-          to: makeMonitorDetailsPathname(organization.slug, detector.id),
+          to: makeMonitorDetailsPathname(
+            organization.slug,
+            detector.id,
+            monitorsLinkPrefix
+          ),
         },
         {label: t('Configure')},
       ]}

--- a/static/app/views/detectors/components/forms/common/footer.tsx
+++ b/static/app/views/detectors/components/forms/common/footer.tsx
@@ -3,16 +3,18 @@ import {LinkButton} from 'sentry/components/core/button/linkButton';
 import EditLayout from 'sentry/components/workflowEngine/layout/edit';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
 export function NewDetectorFooter({maxWidth}: {maxWidth?: string}) {
   const organization = useOrganization();
+  const {monitorsLinkPrefix} = useMonitorViewContext();
 
   return (
     <EditLayout.Footer label={t('Step 2 of 2')} maxWidth={maxWidth}>
       <LinkButton
         priority="default"
-        to={`${makeMonitorBasePathname(organization.slug)}new/`}
+        to={`${makeMonitorBasePathname(organization.slug, monitorsLinkPrefix)}new/`}
       >
         {t('Back')}
       </LinkButton>

--- a/static/app/views/detectors/hooks/useCreateDetectorFormSubmit.tsx
+++ b/static/app/views/detectors/hooks/useCreateDetectorFormSubmit.tsx
@@ -10,6 +10,7 @@ import type {
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useCreateDetector} from 'sentry/views/detectors/hooks';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 
 interface UseCreateDetectorFormSubmitOptions<TFormData, TUpdatePayload> {
@@ -30,6 +31,7 @@ export function useCreateDetectorFormSubmit<
   onSuccess,
 }: UseCreateDetectorFormSubmitOptions<TFormData, TUpdatePayload>): OnSubmitCallback {
   const organization = useOrganization();
+  const {monitorsLinkPrefix} = useMonitorViewContext();
   const navigate = useNavigate();
   const {mutateAsync: createDetector} = useCreateDetector();
 
@@ -49,7 +51,13 @@ export function useCreateDetectorFormSubmit<
         if (onSuccess) {
           onSuccess(resultDetector);
         } else {
-          navigate(makeMonitorDetailsPathname(organization.slug, resultDetector.id));
+          navigate(
+            makeMonitorDetailsPathname(
+              organization.slug,
+              resultDetector.id,
+              monitorsLinkPrefix
+            )
+          );
         }
 
         onSubmitSuccess?.(resultDetector);
@@ -67,6 +75,7 @@ export function useCreateDetectorFormSubmit<
       formDataToEndpointPayload,
       createDetector,
       organization.slug,
+      monitorsLinkPrefix,
       navigate,
       onSuccess,
       onError,

--- a/static/app/views/detectors/hooks/useEditDetectorFormSubmit.tsx
+++ b/static/app/views/detectors/hooks/useEditDetectorFormSubmit.tsx
@@ -10,6 +10,7 @@ import type {
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUpdateDetector} from 'sentry/views/detectors/hooks';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 
 interface UseEditDetectorFormSubmitOptions<TDetector, TFormData> {
@@ -32,6 +33,7 @@ export function useEditDetectorFormSubmit<
   onError,
 }: UseEditDetectorFormSubmitOptions<TDetector, TFormData>): OnSubmitCallback {
   const organization = useOrganization();
+  const {monitorsLinkPrefix} = useMonitorViewContext();
   const navigate = useNavigate();
   const {mutateAsync: updateDetector} = useUpdateDetector();
 
@@ -57,7 +59,13 @@ export function useEditDetectorFormSubmit<
         if (onSuccess) {
           onSuccess(resultDetector as TDetector);
         } else {
-          navigate(makeMonitorDetailsPathname(organization.slug, resultDetector.id));
+          navigate(
+            makeMonitorDetailsPathname(
+              organization.slug,
+              resultDetector.id,
+              monitorsLinkPrefix
+            )
+          );
         }
 
         onSubmitSuccess?.(resultDetector);
@@ -76,6 +84,7 @@ export function useEditDetectorFormSubmit<
       formDataToEndpointPayload,
       updateDetector,
       organization.slug,
+      monitorsLinkPrefix,
       navigate,
       onSuccess,
       onError,

--- a/static/app/views/detectors/list.tsx
+++ b/static/app/views/detectors/list.tsx
@@ -11,6 +11,7 @@ import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/use
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {DetectorType} from 'sentry/types/workflowEngine/detectors';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
@@ -23,7 +24,15 @@ import {DetectorSearch} from 'sentry/views/detectors/components/detectorSearch';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
 import {DETECTOR_LIST_PAGE_LIMIT} from 'sentry/views/detectors/constants';
 import {useDetectorsQuery} from 'sentry/views/detectors/hooks';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 import {makeMonitorCreatePathname} from 'sentry/views/detectors/pathnames';
+
+const DETECTOR_TYPE_TITLE_MAPPING: Record<DetectorType, string> = {
+  error: t('Error Monitors'),
+  metric_issue: t('Metric Monitors'),
+  monitor_check_in_failure: t('Cron Monitors'),
+  uptime_domain_failure: t('Uptime Monitors'),
+};
 
 export default function DetectorsList() {
   useWorkflowEngineFeatureGate({redirect: true});
@@ -31,6 +40,7 @@ export default function DetectorsList() {
   const location = useLocation();
   const navigate = useNavigate();
   const {selection, isReady} = usePageFilters();
+  const {detectorFilter, assigneeFilter} = useMonitorViewContext();
 
   const {
     sort: sorts,
@@ -45,6 +55,14 @@ export default function DetectorsList() {
   });
   const sort = sorts[0] ?? {kind: 'desc', field: 'latestGroup'};
 
+  // Build the query with detector type and assignee filters if provided
+  // Map DetectorType values to query values (e.g., 'monitor_check_in_failure' -> 'cron')
+  const typeFilterQuery = detectorFilter ? `type:${detectorFilter}` : undefined;
+  const assigneeFilterQuery = assigneeFilter ? `assignee:${assigneeFilter}` : undefined;
+  const finalQuery = [typeFilterQuery, assigneeFilterQuery, query]
+    .filter(Boolean)
+    .join(' ');
+
   const {
     data: detectors,
     isLoading,
@@ -54,7 +72,7 @@ export default function DetectorsList() {
   } = useDetectorsQuery(
     {
       cursor,
-      query,
+      query: finalQuery,
       sortBy: sort ? `${sort?.kind === 'asc' ? '' : '-'}${sort?.field}` : undefined,
       projects: selection.projects,
       limit: DETECTOR_LIST_PAGE_LIMIT,
@@ -78,10 +96,17 @@ export default function DetectorsList() {
     return links && !links.previous!.results && !links.next!.results;
   }, [pageLinks]);
 
+  // Determine the page title based on active filters
+  const pageTitle = detectorFilter
+    ? DETECTOR_TYPE_TITLE_MAPPING[detectorFilter]
+    : assigneeFilter === 'me'
+      ? t('My Monitors')
+      : t('Monitors');
+
   return (
-    <SentryDocumentTitle title={t('Monitors')}>
+    <SentryDocumentTitle title={pageTitle}>
       <PageFiltersContainer>
-        <ListLayout actions={<Actions />} title={t('Monitors')}>
+        <ListLayout actions={<Actions />} title={pageTitle}>
           <TableHeader />
           <div>
             <DetectorListTable
@@ -112,6 +137,7 @@ export default function DetectorsList() {
 function TableHeader() {
   const location = useLocation();
   const navigate = useNavigate();
+  const {detectorFilter, assigneeFilter} = useMonitorViewContext();
   const query = typeof location.query.query === 'string' ? location.query.query : '';
 
   const onSearch = (searchQuery: string) => {
@@ -121,11 +147,20 @@ function TableHeader() {
     });
   };
 
+  // Exclude filter keys when they're set in context
+  const excludeKeys = [detectorFilter && 'type', assigneeFilter && 'assignee'].filter(
+    v => v !== undefined
+  );
+
   return (
     <Flex gap="xl">
       <ProjectPageFilter />
       <div style={{flexGrow: 1}}>
-        <DetectorSearch initialQuery={query} onSearch={onSearch} />
+        <DetectorSearch
+          initialQuery={query}
+          onSearch={onSearch}
+          excludeKeys={excludeKeys}
+        />
       </div>
     </Flex>
   );
@@ -134,17 +169,25 @@ function TableHeader() {
 function Actions() {
   const organization = useOrganization();
   const {selection} = usePageFilters();
+  const {monitorsLinkPrefix, detectorFilter} = useMonitorViewContext();
 
   // Pass the first selected project id that is not the all access project
   const project = selection.projects.find(pid => pid !== ALL_ACCESS_PROJECTS);
+
+  // If detectorFilter is set, pass it as a query param to skip type selection
+  const createPath = makeMonitorCreatePathname(organization.slug, monitorsLinkPrefix);
+
+  const createQuery = detectorFilter
+    ? {project, detectorType: detectorFilter}
+    : {project};
 
   return (
     <Flex gap="sm">
       <MonitorFeedbackButton />
       <LinkButton
         to={{
-          pathname: makeMonitorCreatePathname(organization.slug),
-          query: {project},
+          pathname: createPath,
+          query: createQuery,
         }}
         priority="primary"
         icon={<IconAdd />}

--- a/static/app/views/detectors/list/cron.tsx
+++ b/static/app/views/detectors/list/cron.tsx
@@ -1,0 +1,20 @@
+import DetectorsList from 'sentry/views/detectors/list';
+import {
+  MonitorViewContext,
+  useMonitorViewContext,
+} from 'sentry/views/detectors/monitorViewContext';
+
+export default function CronDetectorsList() {
+  const parentContext = useMonitorViewContext();
+
+  return (
+    <MonitorViewContext.Provider
+      value={{
+        ...parentContext,
+        detectorFilter: 'monitor_check_in_failure',
+      }}
+    >
+      <DetectorsList />
+    </MonitorViewContext.Provider>
+  );
+}

--- a/static/app/views/detectors/list/error.tsx
+++ b/static/app/views/detectors/list/error.tsx
@@ -1,0 +1,20 @@
+import DetectorsList from 'sentry/views/detectors/list';
+import {
+  MonitorViewContext,
+  useMonitorViewContext,
+} from 'sentry/views/detectors/monitorViewContext';
+
+export default function ErrorDetectorsList() {
+  const parentContext = useMonitorViewContext();
+
+  return (
+    <MonitorViewContext.Provider
+      value={{
+        ...parentContext,
+        detectorFilter: 'error',
+      }}
+    >
+      <DetectorsList />
+    </MonitorViewContext.Provider>
+  );
+}

--- a/static/app/views/detectors/list/metric.tsx
+++ b/static/app/views/detectors/list/metric.tsx
@@ -1,0 +1,20 @@
+import DetectorsList from 'sentry/views/detectors/list';
+import {
+  MonitorViewContext,
+  useMonitorViewContext,
+} from 'sentry/views/detectors/monitorViewContext';
+
+export default function MetricDetectorsList() {
+  const parentContext = useMonitorViewContext();
+
+  return (
+    <MonitorViewContext.Provider
+      value={{
+        ...parentContext,
+        detectorFilter: 'metric_issue',
+      }}
+    >
+      <DetectorsList />
+    </MonitorViewContext.Provider>
+  );
+}

--- a/static/app/views/detectors/list/myMonitors.tsx
+++ b/static/app/views/detectors/list/myMonitors.tsx
@@ -1,0 +1,20 @@
+import DetectorsList from 'sentry/views/detectors/list';
+import {
+  MonitorViewContext,
+  useMonitorViewContext,
+} from 'sentry/views/detectors/monitorViewContext';
+
+export default function MyMonitorsList() {
+  const parentContext = useMonitorViewContext();
+
+  return (
+    <MonitorViewContext.Provider
+      value={{
+        ...parentContext,
+        assigneeFilter: 'me',
+      }}
+    >
+      <DetectorsList />
+    </MonitorViewContext.Provider>
+  );
+}

--- a/static/app/views/detectors/list/uptime.tsx
+++ b/static/app/views/detectors/list/uptime.tsx
@@ -1,0 +1,20 @@
+import DetectorsList from 'sentry/views/detectors/list';
+import {
+  MonitorViewContext,
+  useMonitorViewContext,
+} from 'sentry/views/detectors/monitorViewContext';
+
+export default function UptimeDetectorsList() {
+  const parentContext = useMonitorViewContext();
+
+  return (
+    <MonitorViewContext.Provider
+      value={{
+        ...parentContext,
+        detectorFilter: 'uptime_domain_failure',
+      }}
+    >
+      <DetectorsList />
+    </MonitorViewContext.Provider>
+  );
+}

--- a/static/app/views/detectors/monitorViewContainer.tsx
+++ b/static/app/views/detectors/monitorViewContainer.tsx
@@ -1,0 +1,16 @@
+import {Outlet} from 'react-router-dom';
+
+import {MonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
+
+export default function MonitorViewContainer() {
+  return (
+    <MonitorViewContext.Provider
+      value={{
+        monitorsLinkPrefix: `monitors`,
+        automationsLinkPrefix: `automations`,
+      }}
+    >
+      <Outlet />
+    </MonitorViewContext.Provider>
+  );
+}

--- a/static/app/views/detectors/monitorViewContext.tsx
+++ b/static/app/views/detectors/monitorViewContext.tsx
@@ -1,0 +1,25 @@
+import {createContext, useContext} from 'react';
+
+import type {DetectorType} from 'sentry/types/workflowEngine/detectors';
+
+interface MonitorViewContextValue {
+  automationsLinkPrefix: string;
+  monitorsLinkPrefix: string;
+  assigneeFilter?: string;
+  detectorFilter?: DetectorType;
+}
+
+const DEFAULT_MONITOR_VIEW_CONTEXT: MonitorViewContextValue = {
+  monitorsLinkPrefix: 'issues/monitors',
+  automationsLinkPrefix: 'issues/automations',
+  assigneeFilter: undefined,
+  detectorFilter: undefined,
+};
+
+export const MonitorViewContext = createContext<MonitorViewContextValue>(
+  DEFAULT_MONITOR_VIEW_CONTEXT
+);
+
+export function useMonitorViewContext(): MonitorViewContextValue {
+  return useContext(MonitorViewContext);
+}

--- a/static/app/views/detectors/new.tsx
+++ b/static/app/views/detectors/new.tsx
@@ -15,6 +15,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {DetectorTypeForm} from 'sentry/views/detectors/components/detectorTypeForm';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
+import {useMonitorViewContext} from 'sentry/views/detectors/monitorViewContext';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
 interface NewDetectorFormData {
@@ -24,12 +25,16 @@ interface NewDetectorFormData {
 
 function NewDetectorBreadcrumbs() {
   const organization = useOrganization();
+  const {monitorsLinkPrefix} = useMonitorViewContext();
   const newMonitorName = t('New Monitor');
 
   return (
     <Breadcrumbs
       crumbs={[
-        {label: t('Monitors'), to: makeMonitorBasePathname(organization.slug)},
+        {
+          label: t('Monitors'),
+          to: makeMonitorBasePathname(organization.slug, monitorsLinkPrefix),
+        },
         {label: newMonitorName},
       ]}
     />
@@ -39,6 +44,7 @@ function NewDetectorBreadcrumbs() {
 export default function DetectorNew() {
   const navigate = useNavigate();
   const organization = useOrganization();
+  const {monitorsLinkPrefix} = useMonitorViewContext();
   useWorkflowEngineFeatureGate({redirect: true});
   const location = useLocation();
   const {projects} = useProjects();
@@ -57,7 +63,7 @@ export default function DetectorNew() {
       // Form doesn't allow type to be defined, cast to the expected shape
       const data = formData as NewDetectorFormData;
       navigate({
-        pathname: `${makeMonitorBasePathname(organization.slug)}new/settings/`,
+        pathname: `${makeMonitorBasePathname(organization.slug, monitorsLinkPrefix)}new/settings/`,
         query: {
           detectorType: location.query.detectorType as DetectorType,
           project: data.project,
@@ -89,7 +95,10 @@ export default function DetectorNew() {
       </EditLayout.Body>
 
       <EditLayout.Footer label={t('Step 1 of 2')} maxWidth={maxWidth}>
-        <LinkButton priority="default" to={makeMonitorBasePathname(organization.slug)}>
+        <LinkButton
+          priority="default"
+          to={makeMonitorBasePathname(organization.slug, monitorsLinkPrefix)}
+        >
           {t('Cancel')}
         </LinkButton>
         <Tooltip

--- a/static/app/views/detectors/pathnames.tsx
+++ b/static/app/views/detectors/pathnames.tsx
@@ -1,13 +1,17 @@
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 
-export const makeMonitorBasePathname = (orgSlug: string) => {
-  return normalizeUrl(`/organizations/${orgSlug}/issues/monitors/`);
+export const makeMonitorBasePathname = (orgSlug: string, linkPrefix: string) => {
+  return normalizeUrl(`/organizations/${orgSlug}/${linkPrefix}/`);
 };
 
-export const makeMonitorDetailsPathname = (orgSlug: string, monitorId: string) => {
-  return normalizeUrl(`${makeMonitorBasePathname(orgSlug)}${monitorId}/`);
+export const makeMonitorDetailsPathname = (
+  orgSlug: string,
+  monitorId: string,
+  linkPrefix: string
+) => {
+  return normalizeUrl(`${makeMonitorBasePathname(orgSlug, linkPrefix)}${monitorId}/`);
 };
 
-export const makeMonitorCreatePathname = (orgSlug: string) => {
-  return normalizeUrl(`${makeMonitorBasePathname(orgSlug)}new/`);
+export const makeMonitorCreatePathname = (orgSlug: string, linkPrefix: string) => {
+  return normalizeUrl(`${makeMonitorBasePathname(orgSlug, linkPrefix)}new/`);
 };

--- a/static/app/views/insights/common/utils/getAlertsUrl.tsx
+++ b/static/app/views/insights/common/utils/getAlertsUrl.tsx
@@ -18,6 +18,7 @@ export function getAlertsUrl({
   dataset = Dataset.GENERIC_METRICS,
   eventTypes = 'transaction',
   referrer,
+  linkPrefix = 'issues/monitors',
 }: {
   aggregate: string;
   organization: Organization;
@@ -25,6 +26,7 @@ export function getAlertsUrl({
   dataset?: Dataset;
   eventTypes?: string;
   interval?: string;
+  linkPrefix?: string;
   name?: string;
   project?: Project;
   query?: string;
@@ -56,6 +58,7 @@ export function getAlertsUrl({
       name,
       query,
       referrer,
+      linkPrefix,
     });
     return `${loc.pathname}?${qs.stringify(loc.query)}`;
   }

--- a/static/app/views/insights/common/utils/getMetricMonitorUrl.tsx
+++ b/static/app/views/insights/common/utils/getMetricMonitorUrl.tsx
@@ -8,6 +8,7 @@ import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 type Params = {
   aggregate: string;
   dataset: Dataset;
+  linkPrefix: string;
   organization: Organization;
   project: Project | undefined;
   environment?: string | string[];
@@ -20,6 +21,7 @@ type Params = {
 export function getMetricMonitorUrl({
   aggregate,
   dataset,
+  linkPrefix,
   organization,
   project,
   name,
@@ -48,7 +50,7 @@ export function getMetricMonitorUrl({
   } as const;
 
   return {
-    pathname: `${makeMonitorBasePathname(organization.slug)}new/settings/`,
+    pathname: `${makeMonitorBasePathname(organization.slug, linkPrefix)}new/settings/`,
     query: queryParams,
   };
 }

--- a/static/app/views/nav/primary/config.tsx
+++ b/static/app/views/nav/primary/config.tsx
@@ -28,6 +28,10 @@ export const PRIMARY_NAV_GROUP_CONFIG: PrimaryNavGroupConfig = {
     basePaths: ['insights'],
     label: t('Insights'),
   },
+  [PrimaryNavGroup.MONITORS]: {
+    basePaths: ['monitors'],
+    label: t('Monitors'),
+  },
   [PrimaryNavGroup.SETTINGS]: {
     basePaths: ['settings'],
     label: t('Settings'),

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -13,6 +13,7 @@ import {
   IconIssues,
   IconPrevent,
   IconSettings,
+  IconSiren,
 } from 'sentry/icons';
 import {ChonkOptInBanner} from 'sentry/utils/theme/ChonkOptInBanner';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -160,6 +161,20 @@ export function PrimaryNavigationItems() {
         </Feature>
 
         <SeparatorItem />
+
+        <Feature features={['workflow-engine-ui']}>
+          <Container position="relative" height="100%">
+            <SidebarLink
+              to={`/${prefix}/monitors/`}
+              analyticsKey="monitors"
+              group={PrimaryNavGroup.MONITORS}
+              {...makeNavItemProps(PrimaryNavGroup.MONITORS)}
+            >
+              <IconSiren />
+            </SidebarLink>
+            <BetaBadge type="alpha" />
+          </Container>
+        </Feature>
 
         <NavTourElement
           id={StackedNavigationTour.SETTINGS}

--- a/static/app/views/nav/secondary/secondaryNavContent.tsx
+++ b/static/app/views/nav/secondary/secondaryNavContent.tsx
@@ -6,6 +6,7 @@ import {DashboardsSecondaryNav} from 'sentry/views/nav/secondary/sections/dashbo
 import {ExploreSecondaryNav} from 'sentry/views/nav/secondary/sections/explore/exploreSecondaryNav';
 import {InsightsSecondaryNav} from 'sentry/views/nav/secondary/sections/insights/insightsSecondaryNav';
 import {IssuesSecondaryNav} from 'sentry/views/nav/secondary/sections/issues/issuesSecondaryNav';
+import {MonitorsSecondaryNav} from 'sentry/views/nav/secondary/sections/monitors/monitorsSecondaryNav';
 import PreventSecondaryNav from 'sentry/views/nav/secondary/sections/prevent/preventSecondaryNav';
 import {SettingsSecondaryNav} from 'sentry/views/nav/secondary/sections/settings/settingsSecondaryNav';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
@@ -20,6 +21,8 @@ export function SecondaryNavContent({group}: {group: PrimaryNavGroup}): ReactNod
       return <DashboardsSecondaryNav />;
     case PrimaryNavGroup.EXPLORE:
       return <ExploreSecondaryNav />;
+    case PrimaryNavGroup.MONITORS:
+      return <MonitorsSecondaryNav />;
     case PrimaryNavGroup.PREVENT:
       return <PreventSecondaryNav />;
     case PrimaryNavGroup.SETTINGS:

--- a/static/app/views/nav/secondary/sections/monitors/monitorsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/monitors/monitorsSecondaryNav.tsx
@@ -1,0 +1,69 @@
+import {Fragment} from 'react';
+
+import Feature from 'sentry/components/acl/feature';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
+import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
+import {PrimaryNavGroup} from 'sentry/views/nav/types';
+
+export function MonitorsSecondaryNav() {
+  const organization = useOrganization();
+  const baseUrl = `/organizations/${organization.slug}/monitors`;
+
+  return (
+    <Fragment>
+      <SecondaryNav.Header>
+        {PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.MONITORS].label}
+      </SecondaryNav.Header>
+      <SecondaryNav.Body>
+        <SecondaryNav.Section id="monitors-views">
+          <SecondaryNav.Item to={`${baseUrl}/`} end analyticsItemName="monitors_all">
+            {t('All Monitors')}
+          </SecondaryNav.Item>
+          <SecondaryNav.Item
+            to={`${baseUrl}/my-monitors/`}
+            analyticsItemName="monitors_my"
+          >
+            {t('My Monitors')}
+          </SecondaryNav.Item>
+        </SecondaryNav.Section>
+
+        <SecondaryNav.Section id="monitors-data-types" title={t('By Data Type')}>
+          <SecondaryNav.Item
+            to={`${baseUrl}/errors/`}
+            analyticsItemName="monitors_errors"
+          >
+            {t('Errors')}
+          </SecondaryNav.Item>
+          <SecondaryNav.Item
+            to={`${baseUrl}/metrics/`}
+            analyticsItemName="monitors_metrics"
+          >
+            {t('Metrics')}
+          </SecondaryNav.Item>
+          <SecondaryNav.Item to={`${baseUrl}/crons/`} analyticsItemName="monitors_crons">
+            {t('Crons')}
+          </SecondaryNav.Item>
+          <Feature features={['uptime']}>
+            <SecondaryNav.Item
+              to={`${baseUrl}/uptime/`}
+              analyticsItemName="monitors_uptime"
+            >
+              {t('Uptime')}
+            </SecondaryNav.Item>
+          </Feature>
+        </SecondaryNav.Section>
+
+        <SecondaryNav.Section id="monitors-automations">
+          <SecondaryNav.Item
+            to={`${baseUrl}/automations/`}
+            analyticsItemName="monitors_automations"
+          >
+            {t('Automations')}
+          </SecondaryNav.Item>
+        </SecondaryNav.Section>
+      </SecondaryNav.Body>
+    </Fragment>
+  );
+}

--- a/static/app/views/nav/types.tsx
+++ b/static/app/views/nav/types.tsx
@@ -8,6 +8,7 @@ export enum PrimaryNavGroup {
   DASHBOARDS = 'dashboards',
   EXPLORE = 'explore',
   INSIGHTS = 'insights',
+  MONITORS = 'monitors',
   SETTINGS = 'settings',
   PREVENT = 'prevent',
   ADMIN = 'admin',


### PR DESCRIPTION
Adds support for filtered monitor list views using React context, enabling specialized views for different monitor types and assignee filters.

Changes:
- Create filtered list views for errors, metrics, crons, uptime, and my-monitors
- Add dynamic page titles based on active filters
- Update Create Monitor button to pass detectorType when filter is active
- Add secondary navigation for monitors with filter-specific routes
- Hide type/assignee search filters when set via context

This enables users to quickly navigate to specific monitor types through dedicated routes while maintaining a consistent list interface.

This does NOT yet remove monitors from the issues sub-navigation, and we continue to support that view until we are happy with this.

<img alt="clipboard.png" width="1525" src="https://i.imgur.com/8RohuGF.png" />