### PR TITLE
fix(settings): Remove deprecated route props from notification pref

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -358,7 +358,6 @@ function buildRoutes(): RouteObject[] {
                 'sentry/views/settings/account/notifications/notificationSettingsController'
               )
           ),
-          deprecatedRouteProps: true,
         },
         {
           path: ':fineTuneType/',
@@ -369,7 +368,6 @@ function buildRoutes(): RouteObject[] {
                 'sentry/views/settings/account/accountNotificationFineTuningController'
               )
           ),
-          deprecatedRouteProps: true,
         },
       ],
     },

--- a/static/app/views/settings/account/accountNotificationFineTuningController.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuningController.tsx
@@ -1,5 +1,4 @@
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import {useParams} from 'sentry/utils/useParams';
 import withOrganizations from 'sentry/utils/withOrganizations';
@@ -8,8 +7,7 @@ import {getNotificationTypeFromPathname} from 'sentry/views/settings/account/not
 
 import AccountNotificationFineTuning from './accountNotificationFineTuning';
 
-interface AccountNotificationFineTuningControllerProps
-  extends RouteComponentProps<{fineTuneType: string}> {
+interface AccountNotificationFineTuningControllerProps {
   organizations: Organization[];
   organizationsLoading?: boolean;
 }

--- a/static/app/views/settings/account/notifications/notificationSettingsController.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsController.tsx
@@ -1,11 +1,10 @@
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import withOrganizations from 'sentry/utils/withOrganizations';
 
 import NotificationSettings from './notificationSettings';
 
-interface NotificationSettingsControllerProps extends RouteComponentProps {
+interface NotificationSettingsControllerProps {
   organizations: Organization[];
   organizationsLoading?: boolean;
 }


### PR DESCRIPTION
props were spread but that component didn't use them either