### PR TITLE
core: fix list scrolling problem

### DIFF
--- a/static/app/components/core/compactSelect/gridList/index.tsx
+++ b/static/app/components/core/compactSelect/gridList/index.tsx
@@ -115,9 +115,9 @@ function GridList({
     <Fragment>
       {listItems.length !== 0 && <ListSeparator role="separator" />}
       {listItems.length !== 0 && label && <ListLabel id={labelId}>{label}</ListLabel>}
-      <ListWrap {...mergeProps(gridProps, props)} onKeyDown={onKeyDown} ref={ref}>
-        {overlayIsOpen &&
-          listItems.map(item => {
+      {overlayIsOpen && (
+        <ListWrap {...mergeProps(gridProps, props)} onKeyDown={onKeyDown} ref={ref}>
+          {listItems.map(item => {
             if (item.type === 'section') {
               return (
                 <GridListSection
@@ -140,12 +140,13 @@ function GridList({
             );
           })}
 
-        {!search && hiddenOptions.size > 0 && (
-          <SizeLimitMessage>
-            {sizeLimitMessage ?? t('Use search to find more options…')}
-          </SizeLimitMessage>
-        )}
-      </ListWrap>
+          {!search && hiddenOptions.size > 0 && (
+            <SizeLimitMessage>
+              {sizeLimitMessage ?? t('Use search to find more options…')}
+            </SizeLimitMessage>
+          )}
+        </ListWrap>
+      )}
     </Fragment>
   );
 }

--- a/static/app/components/core/compactSelect/gridList/option.tsx
+++ b/static/app/components/core/compactSelect/gridList/option.tsx
@@ -54,14 +54,18 @@ export function GridListOption({node, listState, size}: GridListOptionProps) {
   } = useGridListSelectionCheckbox({key: node.key}, listState);
 
   // Move focus to this item on hover
-  const {hoverProps} = useHover({onHoverStart: () => ref.current?.focus()});
+  const {hoverProps} = useHover({
+    // We rely on these props for styling the focus and hover effect
+    onHoverStart: () => setFocusWithin(true),
+    onHoverEnd: () => setFocusWithin(false),
+  });
 
   // Show focus effect when document focus is on or inside the item
   const [isFocusWithin, setFocusWithin] = useState(false);
   const {focusWithinProps} = useFocusWithin({onFocusWithinChange: setFocusWithin});
 
   const rowPropsMemo = useMemo(
-    () => mergeProps(rowProps, focusWithinProps, hoverProps),
+    () => mergeProps(rowProps, hoverProps, focusWithinProps),
     // Only update optionProps when a relevant state (selection/focus/disable) changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [isSelected, isDisabled]


### PR DESCRIPTION
Fix DE-287

The overlay was triggering focus, which was in turn triggering scroll. This you end up in a loop where hover -> focus - > scroll can repeat after the scroll effect, as the cursor position will intersect with the new item that has been scrolled into view, essentially repeating until you end up at the top or bottom of the list.