### PR TITLE
fix(aci): Add counter for the no-detector case in SubscriptionProcessor

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -766,6 +766,7 @@ class SubscriptionProcessor:
                                 "project_id": self.subscription.project.id,
                             },
                         )
+                        metrics.incr(f"{metric_prefix}.no_detector")
                         if self._has_workflow_engine_processing_only:
                             # Nothing more we can do.
                             return


### PR DESCRIPTION
We're seeing an odd metrics inconsistency where counters for overall processing with workflow engine
show numbers up to 10% higher than what can be accounted for in single processing metrics.
The no aggregation value case is counted, and we can get good estimates at the no detector case in logs,
but they still don't add up.
Explicitly counting the no-detector case should be interesting, and should allow us to do more reliable direct comparison.
If that doesn't account for the total, we know something odd is happening.