### PR TITLE
feat(replay): add some mobile breadcrumb logs

### DIFF
--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -130,6 +130,9 @@ class EventType(Enum):
     NAVIGATION_SPAN = 22
     MULTI_CLICK = 23
     TAP = 24
+    DEVICE_BATTERY = 25
+    DEVICE_ORIENTATION = 26
+    DEVICE_CONNECTIVITY = 27
 
 
 def which(event: dict[str, Any]) -> EventType:
@@ -195,6 +198,12 @@ def which(event: dict[str, Any]) -> EventType:
                     return EventType.FEEDBACK
                 elif category == "ui.tap":
                     return EventType.TAP
+                elif category == "device.battery":
+                    return EventType.DEVICE_BATTERY
+                elif category == "device.orientation":
+                    return EventType.DEVICE_ORIENTATION
+                elif category == "device.connectivity":
+                    return EventType.DEVICE_CONNECTIVITY
                 else:
                     return EventType.UNKNOWN
             elif event["data"]["tag"] == "performanceSpan":
@@ -276,6 +285,9 @@ def get_timestamp_unit(event_type: EventType) -> Literal["s", "ms"]:
             | EventType.UNKNOWN
             | EventType.FEEDBACK  # feedback breadcrumbs from the SDK have MS timestamps.
             | EventType.TAP
+            | EventType.DEVICE_BATTERY
+            | EventType.DEVICE_ORIENTATION
+            | EventType.DEVICE_CONNECTIVITY
         ):
             return "ms"
 
@@ -591,6 +603,12 @@ def as_trace_item_context(event_type: EventType, event: dict[str, Any]) -> Trace
                 "timestamp": float(payload["startTimestamp"]),
             }
         case EventType.NAVIGATION_SPAN:
+            return None
+        case EventType.DEVICE_BATTERY:
+            return None
+        case EventType.DEVICE_ORIENTATION:
+            return None
+        case EventType.DEVICE_CONNECTIVITY:
             return None
 
 

--- a/src/sentry/replays/usecases/summarize.py
+++ b/src/sentry/replays/usecases/summarize.py
@@ -398,6 +398,19 @@ def as_log_message(event: dict[str, Any]) -> str | None:
                 return f"Application largest contentful paint: {duration} ms and has a {rating} rating at {timestamp}"
             case EventType.HYDRATION_ERROR:
                 return f"There was a hydration error on the page at {timestamp}"
+            case EventType.TAP:
+                message = event["data"]["payload"]["message"]
+                return f"User tapped on {message} at {timestamp}"
+            case EventType.DEVICE_BATTERY:
+                charging = event["data"]["payload"]["data"]["charging"]
+                level = event["data"]["payload"]["data"]["level"]
+                return f"Device battery was {level}% and {'charging' if charging else 'not charging'} at {timestamp}"
+            case EventType.DEVICE_ORIENTATION:
+                position = event["data"]["payload"]["data"]["position"]
+                return f"Device orientation was changed to {position} at {timestamp}"
+            case EventType.DEVICE_CONNECTIVITY:
+                state = event["data"]["payload"]["data"]["state"]
+                return f"Device connectivity was changed to {state} at {timestamp}"
             case EventType.MUTATIONS:
                 return None
             case EventType.UNKNOWN:
@@ -425,8 +438,6 @@ def as_log_message(event: dict[str, Any]) -> str | None:
             case EventType.NAVIGATION:
                 return None  # we favor NAVIGATION_SPAN since the frontend favors navigation span events in the breadcrumb tab
             case EventType.MULTI_CLICK:
-                return None
-            case EventType.TAP:
                 return None
     except (KeyError, ValueError, TypeError):
         logger.exception(

--- a/tests/sentry/replays/unit/test_event_parser.py
+++ b/tests/sentry/replays/unit/test_event_parser.py
@@ -993,21 +993,19 @@ def test_which() -> None:
 
     assert which(event) == EventType.TAP
 
-    event = (
-        {
-            "type": 5,
-            "timestamp": 1753203886279,
-            "data": {
-                "tag": "breadcrumb",
-                "payload": {
-                    "type": "default",
-                    "timestamp": 1753203886.279,
-                    "category": "device.battery",
-                    "data": {"level": 100.0, "charging": False},
-                },
+    event = {
+        "type": 5,
+        "timestamp": 1753203886279,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "type": "default",
+                "timestamp": 1753203886.279,
+                "category": "device.battery",
+                "data": {"level": 100.0, "charging": False},
             },
         },
-    )
+    }
     assert which(event) == EventType.DEVICE_BATTERY
 
     event = {
@@ -1026,21 +1024,19 @@ def test_which() -> None:
     }
     assert which(event) == EventType.DEVICE_ORIENTATION
 
-    event = (
-        {
-            "type": 5,
-            "timestamp": 1758733250547,
-            "data": {
-                "tag": "breadcrumb",
-                "payload": {
-                    "type": "default",
-                    "timestamp": 1758733250.547,
-                    "category": "device.connectivity",
-                    "data": {"state": "wifi"},
-                },
+    event = {
+        "type": 5,
+        "timestamp": 1758733250547,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "type": "default",
+                "timestamp": 1758733250.547,
+                "category": "device.connectivity",
+                "data": {"state": "wifi"},
             },
         },
-    )
+    }
     assert which(event) == EventType.DEVICE_CONNECTIVITY
 
     assert which({}) == EventType.UNKNOWN

--- a/tests/sentry/replays/unit/test_event_parser.py
+++ b/tests/sentry/replays/unit/test_event_parser.py
@@ -993,6 +993,56 @@ def test_which() -> None:
 
     assert which(event) == EventType.TAP
 
+    event = (
+        {
+            "type": 5,
+            "timestamp": 1753203886279,
+            "data": {
+                "tag": "breadcrumb",
+                "payload": {
+                    "type": "default",
+                    "timestamp": 1753203886.279,
+                    "category": "device.battery",
+                    "data": {"level": 100.0, "charging": False},
+                },
+            },
+        },
+    )
+    assert which(event) == EventType.DEVICE_BATTERY
+
+    event = {
+        "type": 5,
+        "timestamp": 1758212033534,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "level": "none",
+                "category": "device.orientation",
+                "timestamp": 1758212033.534864,
+                "data": {"position": "landscape"},
+                "type": "default",
+            },
+        },
+    }
+    assert which(event) == EventType.DEVICE_ORIENTATION
+
+    event = (
+        {
+            "type": 5,
+            "timestamp": 1758733250547,
+            "data": {
+                "tag": "breadcrumb",
+                "payload": {
+                    "type": "default",
+                    "timestamp": 1758733250.547,
+                    "category": "device.connectivity",
+                    "data": {"state": "wifi"},
+                },
+            },
+        },
+    )
+    assert which(event) == EventType.DEVICE_CONNECTIVITY
+
     assert which({}) == EventType.UNKNOWN
 
 

--- a/tests/sentry/replays/usecases/test_summarize.py
+++ b/tests/sentry/replays/usecases/test_summarize.py
@@ -237,6 +237,38 @@ def test_as_log_message_click() -> None:
     assert get_timestamp_unit(which(event)) == "ms"
 
 
+def test_as_log_message_tap() -> None:
+    event = (
+        {
+            "data": {
+                "tag": "breadcrumb",
+                "payload": {
+                    "level": "info",
+                    "timestamp": 1758212015.458114,
+                    "category": "ui.tap",
+                    "data": {
+                        "path": [
+                            {"name": "View"},
+                            {"name": "ScrollView"},
+                            {"name": "AnimatedComponent(ScrollView)"},
+                            {"name": "ScrollView"},
+                        ]
+                    },
+                    "message": "ScrollView > AnimatedComponent(ScrollView) > ScrollView > View",
+                    "type": "default",
+                },
+            },
+            "type": 5,
+            "timestamp": 1758212015458,
+        },
+    )
+    assert (
+        as_log_message(event)
+        == "User tapped on ScrollView > AnimatedComponent(ScrollView) > ScrollView > View at 1758212015458.0"
+    )
+    assert get_timestamp_unit(which(event)) == "ms"
+
+
 def test_as_log_message_lcp() -> None:
     event = {
         "type": 5,
@@ -827,6 +859,65 @@ def test_as_log_message_resource_script() -> None:
     }
     assert as_log_message(event) is None
     assert get_timestamp_unit(which(event)) == "s"
+
+
+def test_as_log_message_device_battery() -> None:
+    event = (
+        {
+            "type": 5,
+            "timestamp": 1753203886279,
+            "data": {
+                "tag": "breadcrumb",
+                "payload": {
+                    "type": "default",
+                    "timestamp": 1753203886.279,
+                    "category": "device.battery",
+                    "data": {"level": 100.0, "charging": False},
+                },
+            },
+        },
+    )
+    assert as_log_message(event) == "Device battery was 100.0% and not charging at 1753203886279.0"
+    assert get_timestamp_unit(which(event)) == "ms"
+
+
+def test_as_log_message_device_orientation() -> None:
+    event = (
+        {
+            "type": 5,
+            "timestamp": 1758212033534,
+            "data": {
+                "tag": "breadcrumb",
+                "payload": {
+                    "level": "none",
+                    "category": "device.orientation",
+                    "timestamp": 1758212033.534864,
+                    "data": {"position": "landscape"},
+                    "type": "default",
+                },
+            },
+        },
+    )
+    assert as_log_message(event) == "Device orientation was changed to landscape at 1758212033534.0"
+    assert get_timestamp_unit(which(event)) == "ms"
+
+
+def test_as_log_message_device_connectivity() -> None:
+    event = {
+        "type": 5,
+        "timestamp": 1758733250547,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "type": "default",
+                "timestamp": 1758733250.547,
+                "category": "device.connectivity",
+                "data": {"state": "wifi"},
+            },
+        },
+    }
+    assert as_log_message(event) == "Device connectivity was changed to wifi at 1758733250547.0"
+    assert get_timestamp_unit(which(event)) == "ms"
 
 
 def test_parse_iso_timestamp_to_ms() -> None:

--- a/tests/sentry/replays/usecases/test_summarize.py
+++ b/tests/sentry/replays/usecases/test_summarize.py
@@ -238,30 +238,28 @@ def test_as_log_message_click() -> None:
 
 
 def test_as_log_message_tap() -> None:
-    event = (
-        {
-            "data": {
-                "tag": "breadcrumb",
-                "payload": {
-                    "level": "info",
-                    "timestamp": 1758212015.458114,
-                    "category": "ui.tap",
-                    "data": {
-                        "path": [
-                            {"name": "View"},
-                            {"name": "ScrollView"},
-                            {"name": "AnimatedComponent(ScrollView)"},
-                            {"name": "ScrollView"},
-                        ]
-                    },
-                    "message": "ScrollView > AnimatedComponent(ScrollView) > ScrollView > View",
-                    "type": "default",
+    event = {
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "level": "info",
+                "timestamp": 1758212015.458114,
+                "category": "ui.tap",
+                "data": {
+                    "path": [
+                        {"name": "View"},
+                        {"name": "ScrollView"},
+                        {"name": "AnimatedComponent(ScrollView)"},
+                        {"name": "ScrollView"},
+                    ]
                 },
+                "message": "ScrollView > AnimatedComponent(ScrollView) > ScrollView > View",
+                "type": "default",
             },
-            "type": 5,
-            "timestamp": 1758212015458,
         },
-    )
+        "type": 5,
+        "timestamp": 1758212015458,
+    }
     assert (
         as_log_message(event)
         == "User tapped on ScrollView > AnimatedComponent(ScrollView) > ScrollView > View at 1758212015458.0"
@@ -862,42 +860,38 @@ def test_as_log_message_resource_script() -> None:
 
 
 def test_as_log_message_device_battery() -> None:
-    event = (
-        {
-            "type": 5,
-            "timestamp": 1753203886279,
-            "data": {
-                "tag": "breadcrumb",
-                "payload": {
-                    "type": "default",
-                    "timestamp": 1753203886.279,
-                    "category": "device.battery",
-                    "data": {"level": 100.0, "charging": False},
-                },
+    event = {
+        "type": 5,
+        "timestamp": 1753203886279,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "type": "default",
+                "timestamp": 1753203886.279,
+                "category": "device.battery",
+                "data": {"level": 100.0, "charging": False},
             },
         },
-    )
+    }
     assert as_log_message(event) == "Device battery was 100.0% and not charging at 1753203886279.0"
     assert get_timestamp_unit(which(event)) == "ms"
 
 
 def test_as_log_message_device_orientation() -> None:
-    event = (
-        {
-            "type": 5,
-            "timestamp": 1758212033534,
-            "data": {
-                "tag": "breadcrumb",
-                "payload": {
-                    "level": "none",
-                    "category": "device.orientation",
-                    "timestamp": 1758212033.534864,
-                    "data": {"position": "landscape"},
-                    "type": "default",
-                },
+    event = {
+        "type": 5,
+        "timestamp": 1758212033534,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "level": "none",
+                "category": "device.orientation",
+                "timestamp": 1758212033.534864,
+                "data": {"position": "landscape"},
+                "type": "default",
             },
         },
-    )
+    }
     assert as_log_message(event) == "Device orientation was changed to landscape at 1758212033534.0"
     assert get_timestamp_unit(which(event)) == "ms"
 


### PR DESCRIPTION
- add tap, battery level, orientation, & connectivity breadcrumb logs so that we can get replay AI summaries for mobile replays.
- relates to https://linear.app/getsentry/issue/REPLAY-662/mobile-summaries

mobile-specific crumbs:
- [x] tap
- [x] device battery level
- [x] device orientation
- [x] device connectivity
- [ ] app background
- [ ] app foreground
- [ ] swipe
- [ ] scroll
- [ ] navigation --> will have to bring `navigation` logs back for video replays since they don’t use `performanceSpan` events