### PR TITLE
fix(releases): Set current_release_version to the latest release in a group when resolving in next release (semver)

### DIFF
--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -3166,21 +3166,21 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         # a group
         grp_resolution = GroupResolution.objects.get(group=group)
 
-        assert grp_resolution.current_release_version == release_21_1_2.version
+        assert grp_resolution.current_release_version == release_21_1_1.version
 
         # "resolvedInNextRelease" with semver releases is considered as "resolvedInRelease"
         assert grp_resolution.type == GroupResolution.Type.in_release
         assert grp_resolution.status == GroupResolution.Status.resolved
 
-        # Add release that is between 2 and 3 to ensure that any release after release 2 should
+        # Add release that is between 1.1 and 1.2 to ensure that any release after release 1.1 should
         # not have a resolution
         release_21_1_1_plus_1 = self.create_release(version="fake_package@21.1.1+1")
         release_21_1_3 = self.create_release(version="fake_package@21.1.3")
 
-        for release in [release_21_1_0, release_21_1_1, release_21_1_1_plus_1, release_21_1_2]:
+        for release in [release_21_1_0, release_21_1_1]:
             assert GroupResolution.has_resolution(group=group, release=release)
 
-        for release in [release_21_1_3]:
+        for release in [release_21_1_1_plus_1, release_21_1_2, release_21_1_3]:
             assert not GroupResolution.has_resolution(group=group, release=release)
 
         # Ensure that Activity has `current_release_version` set on `Resolved in next release`
@@ -3190,7 +3190,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             ident=grp_resolution.id,
         )
 
-        assert activity.data["current_release_version"] == release_21_1_2.version
+        assert activity.data["current_release_version"] == release_21_1_1.version
 
     def test_in_non_semver_projects_group_resolution_stores_current_release_version(self) -> None:
         """


### PR DESCRIPTION
Previously, we were using `greatest_semver_release(group.project)` to get the `current_release_version` when resolving in next release and using semver. However, this gets the greatest semver release in the whole project, regardless of whether that release has seen the group or not.

The associated test `get_current_release_version_of_group()` was also testing the wrong expectation--that the greatest semver release be obtained, even if it's not associated with the group.

Here we switch to `get_first_last_release_for_group()`, which will only look for releases associated with the group.

Demo: We have a group which is associated _only_ with release 1.0.0. We also have other groups associated with releases 2.0.0 and 3.0.0. So `greatest_semver_release()` will return 3.0.0, while `get_first_last_release_for_group()` will return 1.0.0.

Before: current_release_version set to 3.0.0
<img width="289" height="71" alt="Screenshot 2025-10-17 at 4 20 43 PM" src="https://github.com/user-attachments/assets/00b00460-4cd1-4558-b549-fc737e525801" />
<img width="362" height="59" alt="Screenshot 2025-10-17 at 4 42 30 PM" src="https://github.com/user-attachments/assets/f4c66523-e80e-474e-a672-71a5fec8422c" />

After: current_release_version set to 1.0.0
<img width="289" height="71" alt="Screenshot 2025-10-17 at 4 22 14 PM" src="https://github.com/user-attachments/assets/2f1363c5-978f-4f59-91b6-72b5eb804227" />

However, we are setting the ResolutionBox release version to `current_release_version` with resolution type `in_release` (since the next release exists). So the ResolutionBox will now also say we've resolved it _in_ 1.0.0 instead of _after_:
<img width="397" height="59" alt="Screenshot 2025-10-17 at 4 40 25 PM" src="https://github.com/user-attachments/assets/4444bdf7-b1aa-40d7-a5e1-45af0b04eb98" />

So let's instead display "in versions greater than" instead of "in version", so that the messages are consistent:
<img width="473" height="59" alt="Screenshot 2025-10-17 at 4 43 10 PM" src="https://github.com/user-attachments/assets/eba0fe35-f92a-427e-ab36-0538159e0bf4" />

This change is in the frontend PR: https://github.com/getsentry/sentry/pull/101769