### PR TITLE
fix(prevent): Allow members to update config

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -437,6 +437,7 @@ from sentry.preprod.api.endpoints import urls as preprod_urls
 from sentry.prevent.endpoints.organization_github_repos import (
     OrganizationPreventGitHubReposEndpoint,
 )
+from sentry.prevent.endpoints.pr_review_config import OrganizationPreventGitHubConfigEndpoint
 from sentry.releases.endpoints.organization_release_assemble import (
     OrganizationReleaseAssembleEndpoint,
 )
@@ -2144,6 +2145,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-organization-repository-commits",
     ),
     # Prevent AI endpoints
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/prevent/github/config/$",
+        OrganizationPreventGitHubConfigEndpoint.as_view(),
+        name="sentry-api-0-organization-prevent-github-config",
+    ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/prevent/github/repos/$",
         OrganizationPreventGitHubReposEndpoint.as_view(),

--- a/src/sentry/prevent/endpoints/pr_review_config.py
+++ b/src/sentry/prevent/endpoints/pr_review_config.py
@@ -24,9 +24,7 @@ class PreventAIConfigPermission(OrganizationPermission):
 @region_silo_endpoint
 class OrganizationPreventGitHubConfigEndpoint(OrganizationEndpoint):
     """
-    Update the PR review config for a Sentry organization
-
-    PUT /organizations/{organization_id_or_slug}/prevent/github/config/
+    Get and set the GitHub PR review config for a Sentry organization
     """
 
     owner = ApiOwner.CODECOV

--- a/src/sentry/prevent/endpoints/pr_review_config.py
+++ b/src/sentry/prevent/endpoints/pr_review_config.py
@@ -1,0 +1,72 @@
+from jsonschema import validate
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import audit_log
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.models.organization import Organization
+from sentry.types.prevent_config import PREVENT_AI_CONFIG_GITHUB_DEFAULT, PREVENT_AI_CONFIG_SCHEMA
+
+PREVENT_AI_CONFIG_GITHUB_OPTION = "sentry:prevent_ai_config_github"
+
+
+class PreventAIConfigPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read", "org:write", "org:admin"],
+        # allow any organization member to update the PR review config
+        "PUT": ["org:read", "org:write", "org:admin"],
+    }
+
+
+@region_silo_endpoint
+class OrganizationPreventGitHubConfigEndpoint(OrganizationEndpoint):
+    """
+    Update the PR review config for a Sentry organization
+
+    PUT /organizations/{organization_id_or_slug}/prevent/github/config/
+    """
+
+    owner = ApiOwner.CODECOV
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+        "PUT": ApiPublishStatus.EXPERIMENTAL,
+    }
+    permission_classes = (PreventAIConfigPermission,)
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        """
+        Get the Prevent AI GitHub configuration for an organization.
+        If not explicitly set, return the default.
+        """
+        config = organization.get_option(PREVENT_AI_CONFIG_GITHUB_OPTION)
+        if config is None:
+            config = PREVENT_AI_CONFIG_GITHUB_DEFAULT
+        return Response({"preventAiConfigGithub": config}, status=200)
+
+    def put(self, request: Request, organization: Organization) -> Response:
+        """
+        Update the Prevent AI GitHub configuration for an organization.
+        """
+        config = request.data.get("config")
+        if config is None:
+            return Response({"detail": "Missing 'config' parameter"}, status=400)
+
+        try:
+            validate(config, PREVENT_AI_CONFIG_SCHEMA)
+        except Exception:
+            return Response({"detail": "Invalid config"}, status=400)
+
+        organization.update_option(PREVENT_AI_CONFIG_GITHUB_OPTION, config)
+
+        self.create_audit_entry(
+            request=request,
+            organization=organization,
+            target_object=organization.id,
+            event=audit_log.get_event_id("ORG_EDIT"),
+            data={"preventAiConfigGithub": "updated"},
+        )
+
+        return Response({"preventAiConfigGithub": config}, status=200)

--- a/tests/sentry/prevent/endpoints/test_pr_review_config.py
+++ b/tests/sentry/prevent/endpoints/test_pr_review_config.py
@@ -1,0 +1,74 @@
+from unittest import mock
+
+from sentry.testutils.cases import APITestCase
+from sentry.types.prevent_config import PREVENT_AI_CONFIG_GITHUB_DEFAULT
+
+VALID_CONFIG = {
+    "schema_version": "v1",
+    "default_org_config": {
+        "org_defaults": {
+            "bug_prediction": {
+                "enabled": True,
+                "sensitivity": "medium",
+                "triggers": {"on_command_phrase": True, "on_ready_for_review": True},
+            },
+            "test_generation": {
+                "enabled": False,
+                "triggers": {"on_command_phrase": True, "on_ready_for_review": False},
+            },
+            "vanilla": {
+                "enabled": False,
+                "sensitivity": "medium",
+                "triggers": {"on_command_phrase": True, "on_ready_for_review": False},
+            },
+        },
+        "repo_overrides": {},
+    },
+    "github_organizations": {},
+}
+
+INVALID_CONFIG = {
+    "schema_version": "v1",
+    "default_org_config": {
+        "org_defaults": {},
+    },
+}
+
+
+class OrganizationPreventGitHubConfigTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.org = self.create_organization(owner=self.user)
+        self.login_as(self.user)
+        self.url = f"/api/0/organizations/{self.org.slug}/prevent/github/config/"
+
+    def test_missing_config_param_returns_400(self):
+        resp = self.client.put(self.url, data={}, format="json")
+        assert resp.status_code == 400
+        assert resp.data["detail"] == "Missing 'config' parameter"
+
+    def test_invalid_config_schema_returns_400(self):
+        resp = self.client.put(self.url, data={"config": INVALID_CONFIG}, format="json")
+        assert resp.status_code == 400
+        assert "'github_organizations' is a required property" in resp.data["detail"]
+
+    def test_valid_config_succeeds_and_sets_option(self):
+        resp = self.client.put(self.url, data={"config": VALID_CONFIG}, format="json")
+        assert resp.status_code == 200
+        assert resp.data["preventAiConfigGithub"] == VALID_CONFIG
+        assert self.org.get_option("sentry:prevent_ai_config_github") == VALID_CONFIG
+
+    @mock.patch("sentry.api.base.create_audit_entry")
+    def test_audit_entry_created(self, mock_create_audit_entry):
+        self.client.put(self.url, data={"config": VALID_CONFIG}, format="json")
+        assert mock_create_audit_entry.called
+
+    def test_set_and_get_endpoint_returns_config(self):
+        resp = self.client.get(self.url)
+        assert resp.status_code == 200
+        assert resp.data == {"preventAiConfigGithub": PREVENT_AI_CONFIG_GITHUB_DEFAULT}
+
+        self.client.put(self.url, data={"config": VALID_CONFIG}, format="json")
+        resp = self.client.get(self.url)
+        assert resp.status_code == 200
+        assert resp.data == {"preventAiConfigGithub": VALID_CONFIG}


### PR DESCRIPTION
We got feedback that we want members to be allowed to update config for the PR Review in order to change the type and frequency of reviews. Since this is in beta, there are no billing implications (where a member can create much higher usage that would then get billed). This is aligned with like Seer project [settings](https://sentry.sentry.io/settings/seer/) and Github Integrations [settings](https://sentry.sentry.io/settings/integrations/github/) which allows members to edit. 
