### PR TITLE
ref(seer): debug log for waterfall short id query

### DIFF
--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -208,6 +208,7 @@ def get_trace_waterfall(trace_id: str, organization_id: int) -> EAPTrace | None:
                 end=window_end,
                 projects=projects,
                 organization=organization,
+                debug=True,
             )
 
             subquery_result = Spans.run_table_query(

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -231,8 +231,8 @@ def get_trace_waterfall(trace_id: str, organization_id: int) -> EAPTrace | None:
                         "organization_id": organization_id,
                         "trace_id": trace_id,
                         "subquery_result": subquery_result,
-                        "start": window_start,
-                        "end": window_end,
+                        "start": window_start.isoformat(),
+                        "end": window_end.isoformat(),
                     },
                 )
 


### PR DESCRIPTION
Log the whole query result when no data's returned. Since we're not seeing sentry errors this is the reason our trace waterfall tool is failing. Seeing the meta may help (set debug=True). 
Also removes the sort for performance. Imo the trace we return in case of shared prefix doesn't matter