### PR TITLE
ref(seer): update explorer get_issue_details response type

### DIFF
--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -280,7 +280,7 @@ def get_issue_details(
     issue_id: int | str,
     organization_id: int,
     selected_event: str,
-) -> dict[str, int | str | dict | None] | None:
+) -> dict[str, Any] | None:
     """
     Args:
         issue_id: The issue/group ID (integer) or short ID (string) to look up.

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -277,13 +277,13 @@ def rpc_get_trace_waterfall(trace_id: str, organization_id: int) -> dict[str, An
 
 def get_issue_details(
     *,
-    issue_id: int | str,
+    issue_id: str,
     organization_id: int,
     selected_event: str,
 ) -> dict[str, Any] | None:
     """
     Args:
-        issue_id: The issue/group ID (integer) or short ID (string) to look up.
+        issue_id: The issue/group ID (numeric) or short ID (string) to look up.
         organization_id: The ID of the issue's organization.
         selected_event: The event to return - "oldest", "latest", "recommended", or the event's UUID.
 
@@ -308,12 +308,12 @@ def get_issue_details(
         return None
 
     try:
-        if isinstance(issue_id, int):
+        if issue_id.isdigit():
             org_project_ids = Project.objects.filter(
                 organization=organization, status=ObjectStatus.ACTIVE
             ).values_list("id", flat=True)
 
-            group = Group.objects.get(project_id__in=org_project_ids, id=issue_id)
+            group = Group.objects.get(project_id__in=org_project_ids, id=int(issue_id))
         else:
             group = Group.objects.by_qualified_short_id(organization_id, issue_id)
 

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -650,7 +650,7 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, OccurrenceTestM
             events[1].event_id[:8],
         ]:
             result = get_issue_details(
-                issue_id=group.qualified_short_id if use_short_id else group.id,
+                issue_id=group.qualified_short_id if use_short_id else str(group.id),
                 organization_id=self.organization.id,
                 selected_event=selected_event,
             )
@@ -711,7 +711,7 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, OccurrenceTestM
 
         # Call with nonexistent organization ID.
         result = get_issue_details(
-            issue_id=group.id,
+            issue_id=str(group.id),
             organization_id=99999,
             selected_event="latest",
         )
@@ -721,7 +721,7 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, OccurrenceTestM
         """Test returns None when group doesn't exist."""
         # Call with nonexistent group ID.
         result = get_issue_details(
-            issue_id=99999,
+            issue_id="99999",
             organization_id=self.organization.id,
             selected_event="latest",
         )
@@ -748,7 +748,7 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, OccurrenceTestM
 
         for et in ["oldest", "latest", "recommended"]:
             result = get_issue_details(
-                issue_id=group.id,
+                issue_id=str(group.id),
                 organization_id=self.organization.id,
                 selected_event=et,
             )
@@ -766,7 +766,7 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, OccurrenceTestM
         assert isinstance(group, Group)
 
         result = get_issue_details(
-            issue_id=group.id,
+            issue_id=str(group.id),
             organization_id=self.organization.id,
             selected_event="latest",
         )

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -1,8 +1,9 @@
 import uuid
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 import pytest
+from pydantic import BaseModel
 
 from sentry.models.group import Group
 from sentry.seer.explorer.tools import (
@@ -11,7 +12,7 @@ from sentry.seer.explorer.tools import (
     get_issue_details,
     get_trace_waterfall,
 )
-from sentry.seer.sentry_data_models import EAPTrace, IssueDetails
+from sentry.seer.sentry_data_models import EAPTrace
 from sentry.testutils.cases import APITransactionTestCase, SnubaTestCase, SpanTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.samples import load_data
@@ -562,6 +563,50 @@ class TestGetTraceWaterfall(APITransactionTestCase, SpanTestCase, SnubaTestCase)
         assert result is None
 
 
+class _ExplorerIssueProject(BaseModel):
+    id: int
+    slug: str
+
+
+class _ExplorerIssue(BaseModel):
+    """
+    A subset of BaseGroupSerializerResponse fields, required for Seer Explorer. In prod we send the full response.
+    """
+
+    id: int
+    shortId: str
+    title: str
+    culprit: str | None
+    permalink: str
+    level: str
+    status: str
+    substatus: str | None
+    platform: str | None
+    priority: str | None
+    type: str
+    issueType: str
+    issueCategory: str
+    hasSeen: bool
+    project: _ExplorerIssueProject
+
+    # Optionals
+    isUnhandled: bool | None = None
+    count: str | None = None
+    userCount: int | None = None
+    firstSeen: datetime | None = None
+    lastSeen: datetime | None = None
+
+
+class _SentryEventData(BaseModel):
+    """
+    Required fields for the serialized events used by Seer Explorer.
+    """
+
+    title: str
+    entries: list[dict]
+    tags: list[dict[str, str | None]] | None = None
+
+
 class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, OccurrenceTestMixin):
 
     @patch("sentry.models.group.get_recommended_event")
@@ -617,37 +662,18 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, OccurrenceTestM
 
             assert result is not None
             assert result["project_id"] == self.project.id
+            assert result["project_slug"] == self.project.slug
             assert result["tags_overview"] == mock_get_tags.return_value
 
-            # Validate structure and required fields of the main issue payload.
-            issue_dict = result["issue"]
-            assert isinstance(issue_dict, dict)
-            IssueDetails.parse_obj(issue_dict)
-            assert "id" in issue_dict
-            assert "shortId" in issue_dict
-            assert "status" in issue_dict
-            assert "substatus" in issue_dict
-            assert "culprit" in issue_dict
-            assert "level" in issue_dict
-            assert "issueType" in issue_dict
-            assert "issueCategory" in issue_dict
-            assert "hasSeen" in issue_dict
-            assert "assignedTo" in issue_dict
-            # count, userCount, firstSeen, lastSeen are optional.
+            # Validate fields of the main issue payload.
+            assert isinstance(result["issue"], dict)
+            _ExplorerIssue.parse_obj(result["issue"])
 
-            # Validate for some useful event fields.
-            event_dict = issue_dict["events"][0]
+            # Validate fields of the selected event.
+            event_dict = result["event"]
             assert isinstance(event_dict, dict)
-            assert "id" in event_dict
-            assert "title" in event_dict
-            assert "message" in event_dict
-            assert "eventID" in event_dict
-            assert "projectID" in event_dict
-            assert "user" in event_dict
-            assert "platform" in event_dict
-            assert "dateReceived" in event_dict
-            assert "type" in event_dict
-            assert "contexts" in event_dict
+            _SentryEventData.parse_obj(event_dict)
+            assert result["event_id"] == event_dict["id"]
 
             # Check correct event is returned based on selected_event_type.
             if selected_event == "oldest":
@@ -663,6 +689,7 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, OccurrenceTestM
 
             # Check event_trace_id matches mocked trace context.
             if event_dict["id"] == events[0].event_id:
+                assert events[0].trace_id == event0_trace_id
                 assert result["event_trace_id"] == event0_trace_id
             else:
                 assert result["event_trace_id"] is None
@@ -749,4 +776,4 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, OccurrenceTestM
         assert "event_trace_id" in result
         assert isinstance(result.get("project_id"), int)
         assert isinstance(result.get("issue"), dict)
-        IssueDetails.parse_obj(result.get("issue"))
+        _ExplorerIssue.parse_obj(result.get("issue", {}))


### PR DESCRIPTION
Deciding in https://github.com/getsentry/seer/pull/3699/files to branch off of autofix to a new IssueDetails model, which is a subset of the GroupSerializer response. The main change to this RPC is returning the serialized event as its own field, rather than in `issue.events`.

Includes type fixes for the fx params (avoid union type) and better postgres query pattern