### PR TITLE
chore(explorer): Combine the span details and trace waterfall tools

### DIFF
--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -42,17 +42,16 @@ const TOOL_FORMATTERS: Record<string, ToolFormatter> = {
   },
 
   get_trace_waterfall: (args, isLoading) => {
-    const id = args.trace_id || '';
+    const traceId = args.trace_id || '';
+    const spanId = args.span_id;
+    if (spanId) {
+      return isLoading
+        ? `Digging into span ${spanId.slice(0, 8)}...`
+        : `Dug into span ${spanId.slice(0, 8)}`;
+    }
     return isLoading
-      ? `Viewing waterfall for trace ${id.slice(0, 8)}...`
-      : `Viewed waterfall for trace ${id.slice(0, 8)}`;
-  },
-
-  get_span_details: (args, isLoading) => {
-    const spanId = args.span_id || '';
-    return isLoading
-      ? `Digging into span ${spanId.slice(0, 8)}...`
-      : `Dug into span ${spanId.slice(0, 8)}`;
+      ? `Viewing waterfall for trace ${traceId.slice(0, 8)}...`
+      : `Viewed waterfall for trace ${traceId.slice(0, 8)}`;
   },
 };
 
@@ -142,7 +141,7 @@ export function buildToolLinkUrl(
       };
     }
     case 'get_trace_waterfall': {
-      const {trace_id, timestamp} = toolLink.params;
+      const {trace_id, span_id, timestamp} = toolLink.params;
       if (!trace_id) {
         return null;
       }
@@ -150,25 +149,9 @@ export function buildToolLinkUrl(
       const pathname = `/explore/traces/trace/${trace_id}/`;
       const query: Record<string, string> = {};
 
-      if (timestamp) {
-        query.timestamp = timestamp;
+      if (span_id) {
+        query.node = `span-${span_id}`;
       }
-
-      return {
-        pathname,
-        query,
-      };
-    }
-    case 'get_span_details': {
-      const {trace_id, span_id, timestamp} = toolLink.params;
-      if (!trace_id || !span_id) {
-        return null;
-      }
-
-      const pathname = `/explore/traces/trace/${trace_id}/`;
-      const query: Record<string, string> = {
-        node: `span-${span_id}`,
-      };
 
       if (timestamp) {
         query.timestamp = timestamp;


### PR DESCRIPTION
Frontend changes to reflect that the span details tool is now part of the trace waterfall tool.

Backend: https://github.com/getsentry/seer/pull/3701