### PR TITLE
feat(explorer): Send user and org context for new explorer runs

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -111,7 +111,6 @@ def _call_seer_explorer_chat(
         "insert_index": insert_index,
         "message_timestamp": message_timestamp,
         "on_page_context": on_page_context,
-        "user_org_context": user_org_context,
     }
     if user_org_context:
         payload["user_org_context"] = user_org_context

--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import orjson
 import requests
@@ -104,7 +105,7 @@ def _call_seer_explorer_chat(
 ):
     """Call Seer explorer chat endpoint."""
     path = "/v1/automation/explorer/chat"
-    payload = {
+    payload: dict[str, Any] = {
         "organization_id": organization.id,
         "run_id": run_id,
         "query": query,

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -317,9 +317,6 @@ class CollectUserOrgContextTest(APITestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.member = OrganizationMember.objects.get(
-            organization=self.organization, user_id=self.user.id
-        )
         self.project1 = self.create_project(
             organization=self.organization, teams=[self.team], slug="project-1"
         )
@@ -362,8 +359,11 @@ class CollectUserOrgContextTest(APITestCase):
     def test_collect_context_with_multiple_teams(self):
         """Test context collection for a user in multiple teams"""
         team2 = self.create_team(organization=self.organization, slug="team-2")
+        member = OrganizationMember.objects.get(
+            organization=self.organization, user_id=self.user.id
+        )
         with unguarded_write(using="default"):
-            self.member.teams.add(team2)
+            member.teams.add(team2)
 
         http_request = self.make_request(user=self.user)
         request = drf_request_from_request(http_request)
@@ -375,9 +375,12 @@ class CollectUserOrgContextTest(APITestCase):
 
     def test_collect_context_with_no_teams(self):
         """Test context collection for a member with no team membership"""
+        member = OrganizationMember.objects.get(
+            organization=self.organization, user_id=self.user.id
+        )
         # Remove user from all teams
         with unguarded_write(using="default"):
-            self.member.teams.clear()
+            member.teams.clear()
 
         http_request = self.make_request(user=self.user)
         request = drf_request_from_request(http_request)


### PR DESCRIPTION
Gathers context on the user chatting with Seer (if available), including their name, email, teams, projects, and org slug. Only does this querying when starting a new chat session for efficiency.