### PR TITLE
chore(design): remove profiling summary design flag

### DIFF
--- a/static/app/views/profiling/profileSummary/profileSummaryPage.spec.tsx
+++ b/static/app/views/profiling/profileSummary/profileSummaryPage.spec.tsx
@@ -61,9 +61,7 @@ describe('ProfileSummaryPage', () => {
     });
 
     render(<ProfileSummaryPage />, {
-      organization: OrganizationFixture({
-        features: ['profiling-summary-redesign'],
-      }),
+      organization: OrganizationFixture(),
       initialRouterConfig: {
         location: {
           pathname: '/profiling/summary/project-slug',


### PR DESCRIPTION
Remove `profiling-summary-design` flag, since it isn't used anywhere and hasn't been touched in >a year