### PR TITLE
feat(tasks): Add tasks aliasing support for renaming and moving tasks

### DIFF
--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -87,6 +87,9 @@ def instrumented_task(
             compression_type=compression_type,
             silo_mode=silo_mode,
         )(func)
+        # If an alias is provided, register the task for both "name" and "alias" under namespace
+        # If an alias namespace is provided, register the task in both namespace and alias_namespace
+        # When both are provided, register tasks namespace."name" and alias_namespace."alias"
         if alias or alias_namespace:
             target_alias = alias if alias else name
             target_alias_namespace = alias_namespace if alias_namespace else namespace

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -55,6 +55,25 @@ def instrumented_task(
     - statsd metrics for duration and memory usage.
     - sentry sdk tagging.
     - hybrid cloud silo restrictions
+    - alias and alias namespace for renaming a task or moving it to a different namespace
+
+    Basic task definition:
+        @instrumented_task(
+            name="sentry.tasks.some_task",
+            namespace=some_namespace,
+        )
+        def func():
+            ...
+
+    Renaming a task and/or moving task to a different namespace:
+        @instrumented_task(
+            name="sentry.tasks.new_task_name",
+            namespace=new_namespace,
+            alias="sentry.tasks.previous_task_name",
+            alias_namespace=previous_namespace,
+        )
+        def func():
+            ...
     """
 
     def wrapped(func: Callable[P, R]) -> Task[P, R]:

--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -15,9 +15,11 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import TaskActivation
 from sentry_sdk.consts import OP, SPANDATA
 
 from sentry.conf.types.kafka_definition import Topic
+from sentry.silo.base import SiloMode
 from sentry.taskworker.constants import DEFAULT_PROCESSING_DEADLINE, CompressionType
 from sentry.taskworker.retry import Retry
 from sentry.taskworker.router import TaskRouter
+from sentry.taskworker.silolimiter import TaskSiloLimit
 from sentry.taskworker.task import P, R, Task
 from sentry.utils import metrics
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
@@ -89,6 +91,7 @@ class TaskNamespace:
         at_most_once: bool = False,
         wait_for_delivery: bool = False,
         compression_type: CompressionType = CompressionType.PLAINTEXT,
+        silo_mode: SiloMode | None = None,
     ) -> Callable[[Callable[P, R]], Task[P, R]]:
         """
         Register a task.
@@ -135,6 +138,9 @@ class TaskNamespace:
                 wait_for_delivery=wait_for_delivery,
                 compression_type=compression_type,
             )
+            if silo_mode:
+                silo_limiter = TaskSiloLimit(silo_mode)
+                task = silo_limiter(task)
             # TODO(taskworker) tasks should be registered into the registry
             # so that we can ensure task names are globally unique
             self._registered_tasks[name] = task

--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -63,6 +63,12 @@ class TaskNamespace:
             raise KeyError(f"No task registered with the name {name}. Check your imports")
         return self._registered_tasks[name]
 
+    def set(self, name: str, task: Task[Any, Any]) -> None:
+        """
+        Set a registered task by name
+        """
+        self._registered_tasks[name] = task
+
     def contains(self, name: str) -> bool:
         """
         Check if a task name has been registered

--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -65,12 +65,6 @@ class TaskNamespace:
             raise KeyError(f"No task registered with the name {name}. Check your imports")
         return self._registered_tasks[name]
 
-    def set(self, name: str, task: Task[Any, Any]) -> None:
-        """
-        Set a registered task by name
-        """
-        self._registered_tasks[name] = task
-
     def contains(self, name: str) -> bool:
         """
         Check if a task name has been registered

--- a/src/sentry/taskworker/silolimiter.py
+++ b/src/sentry/taskworker/silolimiter.py
@@ -1,0 +1,44 @@
+from collections.abc import Callable, Iterable
+from typing import Any, cast
+
+from sentry.silo.base import SiloLimit, SiloMode
+from sentry.taskworker.task import P, R, Task
+
+
+class TaskSiloLimit(SiloLimit):
+    """
+    Silo limiter for tasks
+
+    We don't want tasks to be spawned in the incorrect silo.
+    We can't reliably cause tasks to fail as not all tasks use
+    the ORM (which also has silo bound safety).
+    """
+
+    def handle_when_unavailable(
+        self,
+        original_method: Callable[P, R],
+        current_mode: SiloMode,
+        available_modes: Iterable[SiloMode],
+    ) -> Callable[P, R]:
+        def handle(*args: P.args, **kwargs: P.kwargs) -> Any:
+            name = original_method.__name__
+            message = f"Cannot call or spawn {name} in {current_mode},"
+            raise self.AvailabilityError(message)
+
+        return handle
+
+    def __call__(self, decorated_task: Task[P, R]) -> Task[P, R]:
+        # Replace the sentry.taskworker.Task interface used to schedule tasks.
+        replacements = {"delay", "apply_async"}
+        for attr_name in replacements:
+            task_attr = getattr(decorated_task, attr_name)
+            if callable(task_attr):
+                limited_attr = self.create_override(task_attr)
+                setattr(decorated_task, attr_name, limited_attr)
+
+        # Cast as the super class type is just Callable, but we know here
+        # we have Task instances.
+        limited_func = cast(Task[P, R], self.create_override(decorated_task))
+        if hasattr(decorated_task, "name"):
+            limited_func.name = decorated_task.name
+        return limited_func

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -6,7 +6,7 @@ from django.test import override_settings
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.constants import CompressionType
-from sentry.taskworker.namespaces import test_tasks
+from sentry.taskworker.namespaces import exampletasks, test_tasks
 from sentry.taskworker.registry import TaskRegistry
 from sentry.taskworker.retry import Retry, RetryError
 from sentry.taskworker.state import CurrentTaskState
@@ -69,6 +69,45 @@ def ignore_on_exception_task(param):
 )
 def exclude_on_exception_task(param):
     raise Exception(param)
+
+
+@instrumented_task(
+    name="tests.tasks.test_base.primary_task",
+    namespace=test_tasks,
+    alias="tests.tasks.test_base.alias_task",
+)
+def task_with_alias(param) -> str:
+    return f"Task with alias {param}"
+
+
+@instrumented_task(
+    name="tests.tasks.test_base.region_primary_task",
+    namespace=test_tasks,
+    alias="tests.tasks.test_base.region_alias_task",
+    silo_mode=SiloMode.REGION,
+)
+def region_task_with_alias(param) -> str:
+    return f"Region task with alias {param}"
+
+
+@instrumented_task(
+    name="tests.tasks.test_base.control_primary_task",
+    namespace=test_tasks,
+    alias="tests.tasks.test_base.control_alias_task",
+    silo_mode=SiloMode.CONTROL,
+)
+def control_task_with_alias(param) -> str:
+    return f"Control task with alias {param}"
+
+
+@instrumented_task(
+    name="tests.tasks.test_base.primary_task_primary_namespace",
+    namespace=test_tasks,
+    alias="tests.tasks.test_base.alias_task_alias_namespace",
+    alias_namespace=exampletasks,
+)
+def task_with_alias_and_alias_namespace(param) -> str:
+    return f"Task with alias and alias namespace {param}"
 
 
 @override_settings(SILO_MODE=SiloMode.REGION)
@@ -233,3 +272,55 @@ def test_retry_raise_if_no_retries_false(mock_current_task):
     mock_task_state.retries_remaining = True
     with pytest.raises(RetryError):
         task_that_raises_retry_error()
+
+
+def test_instrumented_task_with_alias_same_namespace() -> None:
+    assert test_tasks.contains("tests.tasks.test_base.primary_task")
+    task_result = task_with_alias("test")
+    assert task_result == "Task with alias test"
+
+    assert test_tasks.contains("tests.tasks.test_base.alias_task")
+    alias_task_result = test_tasks.get("tests.tasks.test_base.alias_task")("test")
+    assert alias_task_result == "Task with alias test"
+
+    assert task_result == alias_task_result
+
+
+def test_instrumented_task_with_alias_different_namespaces() -> None:
+    assert test_tasks.contains("tests.tasks.test_base.primary_task_primary_namespace")
+    task_result = task_with_alias_and_alias_namespace("test")
+    assert task_result == "Task with alias and alias namespace test"
+
+    assert exampletasks.contains("tests.tasks.test_base.alias_task_alias_namespace")
+    alias_task_result = exampletasks.get("tests.tasks.test_base.alias_task_alias_namespace")("test")
+    assert alias_task_result == "Task with alias and alias namespace test"
+
+    assert task_result == alias_task_result
+
+
+@override_settings(SILO_MODE=SiloMode.REGION)
+def test_instrumented_task_with_alias_silo_limit_call_region() -> None:
+    assert test_tasks.contains("tests.tasks.test_base.region_primary_task")
+    assert region_task_with_alias("test") == "Region task with alias test"
+
+    assert test_tasks.contains("tests.tasks.test_base.region_alias_task")
+    assert region_task_with_alias("test") == "Region task with alias test"
+
+    assert test_tasks.contains("tests.tasks.test_base.control_primary_task")
+    with pytest.raises(SiloLimit.AvailabilityError):
+        control_task_with_alias("test")
+
+    assert test_tasks.contains("tests.tasks.test_base.control_alias_task")
+    with pytest.raises(SiloLimit.AvailabilityError):
+        test_tasks.get("tests.tasks.test_base.control_alias_task")("test")
+
+
+@override_settings(SILO_MODE=SiloMode.CONTROL)
+def test_instrumented_task_with_alias_silo_limit_call_control() -> None:
+    assert test_tasks.contains("tests.tasks.test_base.region_primary_task")
+    with pytest.raises(SiloLimit.AvailabilityError):
+        region_task_with_alias("test")
+
+    assert test_tasks.contains("tests.tasks.test_base.region_alias_task")
+    with pytest.raises(SiloLimit.AvailabilityError):
+        test_tasks.get("tests.tasks.test_base.region_alias_task")("test")

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -276,14 +276,10 @@ def test_retry_raise_if_no_retries_false(mock_current_task):
 
 def test_instrumented_task_with_alias_same_namespace() -> None:
     assert test_tasks.contains("tests.tasks.test_base.primary_task")
-    task_result = task_with_alias("test")
-    assert task_result == "Task with alias test"
+    assert task_with_alias("test") == "Task with alias test"
 
     assert test_tasks.contains("tests.tasks.test_base.alias_task")
-    alias_task_result = test_tasks.get("tests.tasks.test_base.alias_task")("test")
-    assert alias_task_result == "Task with alias test"
-
-    assert task_result == alias_task_result
+    assert test_tasks.get("tests.tasks.test_base.alias_task")("test") == "Task with alias test"
 
 
 def test_instrumented_task_with_alias_different_namespaces() -> None:
@@ -292,10 +288,10 @@ def test_instrumented_task_with_alias_different_namespaces() -> None:
     assert task_result == "Task with alias and alias namespace test"
 
     assert exampletasks.contains("tests.tasks.test_base.alias_task_alias_namespace")
-    alias_task_result = exampletasks.get("tests.tasks.test_base.alias_task_alias_namespace")("test")
-    assert alias_task_result == "Task with alias and alias namespace test"
-
-    assert task_result == alias_task_result
+    assert (
+        exampletasks.get("tests.tasks.test_base.alias_task_alias_namespace")("test")
+        == "Task with alias and alias namespace test"
+    )
 
 
 @override_settings(SILO_MODE=SiloMode.REGION)
@@ -304,7 +300,10 @@ def test_instrumented_task_with_alias_silo_limit_call_region() -> None:
     assert region_task_with_alias("test") == "Region task with alias test"
 
     assert test_tasks.contains("tests.tasks.test_base.region_alias_task")
-    assert region_task_with_alias("test") == "Region task with alias test"
+    assert (
+        test_tasks.get("tests.tasks.test_base.region_alias_task")("test")
+        == "Region task with alias test"
+    )
 
     assert test_tasks.contains("tests.tasks.test_base.control_primary_task")
     with pytest.raises(SiloLimit.AvailabilityError):


### PR DESCRIPTION
Adds task name aliasing and task namespace aliasing in `instrumented_task()` to allow renaming and moving tasks within a single change. By registering a task under both its primary name and an optional alias name, workers can resolve task activations in `_get_known_task` using either name during rolling deployments.

Refs STREAM-512