### PR TITLE
feat(taskworker): Cache default fallback topic based on silo mode

### DIFF
--- a/tests/sentry/taskworker/test_router.py
+++ b/tests/sentry/taskworker/test_router.py
@@ -21,7 +21,7 @@ def test_default_router_topic_region_silo() -> None:
         assert topic == Topic.TASKWORKER
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases=["default", "control"])
 def test_default_router_topic_control_silo() -> None:
     with override_settings(SILO_MODE=SiloMode.CONTROL):
         router = DefaultRouter()

--- a/tests/sentry/taskworker/test_router.py
+++ b/tests/sentry/taskworker/test_router.py
@@ -1,0 +1,29 @@
+import pytest
+from django.test.utils import override_settings
+
+from sentry.conf.types.kafka_definition import Topic
+from sentry.silo.base import SiloMode
+from sentry.taskworker.router import DefaultRouter
+
+
+@pytest.mark.django_db
+def test_default_router_topic() -> None:
+    router = DefaultRouter()
+    topic = router.route_namespace("test.tasks.test_router.default")
+    assert topic == Topic.TASKWORKER
+
+
+@pytest.mark.django_db
+def test_default_router_topic_region_silo() -> None:
+    with override_settings(SILO_MODE=SiloMode.REGION):
+        router = DefaultRouter()
+        topic = router.route_namespace("test.tasks.test_router.region")
+        assert topic == Topic.TASKWORKER
+
+
+@pytest.mark.django_db
+def test_default_router_topic_control_silo() -> None:
+    with override_settings(SILO_MODE=SiloMode.CONTROL):
+        router = DefaultRouter()
+        topic = router.route_namespace("test.tasks.test_router.control")
+        assert topic == Topic.TASKWORKER_CONTROL


### PR DESCRIPTION
Defines and caches the default topic for fallback when routing tasks. The default topic is still `Topic.TASKWORKER` ("taskworker"), unless when the silo mode is `SiloMode.CONTROL`, then the default topic will be `Topic.TASKWORKER_CONTROL` ("taskworker-control").

Refs STREAM-511