### PR TITLE
ref(onboarding): Replace TracePropagationMessage with block

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage.tsx
@@ -1,22 +1,6 @@
-import {Alert} from 'sentry/components/core/alert';
 import {ExternalLink} from 'sentry/components/core/link';
 import type {ContentBlock} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {tct} from 'sentry/locale';
-
-export default function TracePropagationMessage() {
-  return (
-    <Alert type="info">
-      {tct(
-        `To see replays for backend errors, ensure that you have set up trace propagation. To learn more, [link:read the docs].`,
-        {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/product/explore/session-replay/web/getting-started/#replays-for-backend-errors" />
-          ),
-        }
-      )}
-    </Alert>
-  );
-}
 
 export const tracePropagationBlock: ContentBlock = {
   type: 'alert',

--- a/static/app/gettingStartedDocs/electron/electron.tsx
+++ b/static/app/gettingStartedDocs/electron/electron.tsx
@@ -1,7 +1,7 @@
 import {ExternalLink} from 'sentry/components/core/link';
 import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/crashReportCallout';
 import {widgetCalloutBlock} from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
-import TracePropagationMessage from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
+import {tracePropagationBlock} from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
 import type {
   ContentBlock,
   Docs,
@@ -180,10 +180,7 @@ const replayOnboarding: OnboardingConfig = {
             },
           ],
         },
-        {
-          type: 'custom',
-          content: <TracePropagationMessage />,
-        },
+        tracePropagationBlock,
       ],
     },
   ],


### PR DESCRIPTION
Replace the last usage of `TracePropagationMessage` with `tracePropagationBlock`.

- part of part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)