### PR TITLE
ref(content-blocks): Convert javascript utils

### DIFF
--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -548,57 +548,51 @@ const profilingOnboarding = getJavascriptFullStackOnboarding({
     'https://docs.sentry.io/platforms/javascript/guides/nextjs/profiling/browser-profiling/',
   nodeProfilingLink:
     'https://docs.sentry.io/platforms/javascript/guides/nextjs/profiling/node-profiling/',
-  getProfilingHeaderConfig: () => [
+  getProfilingHeaderContent: () => [
     {
-      description: tct(
+      type: 'text',
+      text: tct(
         'In Next.js you can configure document response headers via the headers option in [code:next.config.js]:',
         {
           code: <code />,
         }
       ),
-      code: [
+    },
+    {
+      type: 'code',
+      tabs: [
         {
           label: 'ESM',
-          value: 'esm',
           language: 'javascript',
           filename: 'next.config.js',
           code: `
 export default withSentryConfig({
   async headers() {
-    return [
-      {
-        source: "/:path*",
-        headers: [
-          {
-            key: "Document-Policy",
-            value: "js-profiling",
-          },
-        ],
-      },
-    ];
+    return [{
+      source: "/:path*",
+      headers: [{
+        key: "Document-Policy",
+        value: "js-profiling",
+      }],
+    }];
   },
   // ... other Next.js config options
 });`,
         },
         {
           label: 'CJS',
-          value: 'cjs',
           language: 'javascript',
           filename: 'next.config.js',
           code: `
 module.exports = withSentryConfig({
   async headers() {
-    return [
-      {
-        source: "/:path*",
-        headers: [
-          {
-            key: "Document-Policy",
-            value: "js-profiling",
-          },
-        ],
-      },
-    ];
+    return [{
+      source: "/:path*",
+      headers: [{
+        key: "Document-Policy",
+        value: "js-profiling",
+      }],
+    }];
   },
   // ... other Next.js config options
 });`,

--- a/static/app/utils/gettingStartedDocs/javascript.tsx
+++ b/static/app/utils/gettingStartedDocs/javascript.tsx
@@ -46,19 +46,21 @@ Sentry.init({
   profilesSampleRate: 1.0
 });`;
 
-const getDefaultProfilingHeaderConfig = () => [
+const getDefaultProfilingHeaderContent = (): ContentBlock[] => [
   {
-    description: tct(
+    type: 'text',
+    text: tct(
       "How you do this will depend on your server. If you're using a server like Express, you'll be able to use the [link:response.set] function.",
       {
         link: <ExternalLink href="https://expressjs.com/en/4x/api.html#res.set" />,
       }
     ),
-    language: 'javascript',
-    code: [
+  },
+  {
+    type: 'code',
+    tabs: [
       {
         label: 'JavaScript',
-        value: 'javascript',
         language: 'javascript',
         code: `
 app.get("/", (request, response) => {
@@ -101,26 +103,34 @@ export const getJavascriptProfilingOnboarding = <
   configure: params => [
     {
       title: t('Add Document-Policy: js-profiling header'),
-      description: tct(
-        'For the JavaScript browser profiler to start, the document response header needs to include a [code:Document-Policy] header key with the [code:js-profiling] value.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: getDefaultProfilingHeaderConfig(),
+          type: 'text',
+          text: tct(
+            'For the JavaScript browser profiler to start, the document response header needs to include a [code:Document-Policy] header key with the [code:js-profiling] value.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        ...getDefaultProfilingHeaderContent(),
+      ],
     },
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        'Set up the [code:browserTracingIntegration] and [code:browserProfilingIntegration] in your [code:Sentry.init()] call.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: [
+          type: 'text',
+          text: tct(
+            'Set up the [code:browserTracingIntegration] and [code:browserProfilingIntegration] in your [code:Sentry.init()] call.',
+            {
+              code: <code />,
+            }
+          ),
+        },
         {
-          language: 'javascript',
-          code: [
+          type: 'code',
+          tabs: [
             {
               label: 'Javascript',
               value: 'javascript',
@@ -130,7 +140,8 @@ export const getJavascriptProfilingOnboarding = <
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'For more detailed information, see the [link:browser profiling documentation].',
             {
               link: <ExternalLink href={docsLink} />,
@@ -143,9 +154,14 @@ export const getJavascriptProfilingOnboarding = <
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        'Verify that profiling is working correctly by simply using your application.'
-      ),
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Verify that profiling is working correctly by simply using your application.'
+          ),
+        },
+      ],
     },
   ],
 });
@@ -360,10 +376,13 @@ Sentry.init({
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        'To confirm that logs are working correctly, run your application and check the Sentry logs page for the collected logs.'
-      ),
       content: [
+        {
+          type: 'text',
+          text: t(
+            'To confirm that logs are working correctly, run your application and check the Sentry logs page for the collected logs.'
+          ),
+        },
         {
           type: 'code',
           language: 'jsx',
@@ -382,41 +401,42 @@ export const getJavascriptFullStackOnboarding = <
   basePackage,
   browserProfilingLink,
   nodeProfilingLink,
-  getProfilingHeaderConfig = getDefaultProfilingHeaderConfig,
+  getProfilingHeaderContent = getDefaultProfilingHeaderContent,
 }: {
   basePackage: string;
   browserProfilingLink: string;
   nodeProfilingLink: string;
-  getProfilingHeaderConfig?: (params: DocsParams) => Configuration[];
+  getProfilingHeaderContent?: (params: DocsParams) => ContentBlock[];
 }): OnboardingConfig<PlatformOptions> => ({
   install: () => [
     {
       type: StepType.INSTALL,
-      description: tct(
-        'To enable profiling, add [code:@sentry/profiling-node] to your imports and make sure [packageCode] is up-to-date. The minimum version of [packageCode] that supports node and browser profiling is [code:7.60.0].',
+      content: [
         {
-          code: <code />,
-          packageCode: <code>{basePackage}</code>,
-        }
-      ),
-      configurations: [
+          type: 'text',
+          text: tct(
+            'To enable profiling, add [code:@sentry/profiling-node] to your imports and make sure [packageCode] is up-to-date. The minimum version of [packageCode] that supports node and browser profiling is [code:7.60.0].',
+            {
+              code: <code />,
+              packageCode: <code>{basePackage}</code>,
+            }
+          ),
+        },
         {
-          code: [
+          type: 'code',
+          tabs: [
             {
               label: 'npm',
-              value: 'npm',
               language: 'bash',
               code: `npm install ${basePackage} @sentry/profiling-node --save`,
             },
             {
               label: 'yarn',
-              value: 'yarn',
               language: 'bash',
               code: `yarn add ${basePackage} @sentry/profiling-node`,
             },
             {
               label: 'pnpm',
-              value: 'pnpm',
               language: 'bash',
               code: `pnpm add ${basePackage} @sentry/profiling-node`,
             },
@@ -428,24 +448,26 @@ export const getJavascriptFullStackOnboarding = <
   configure: params => [
     {
       title: t('Configure Node Profiling'),
-      description: tct(
-        'Set up the [code:nodeProfilingIntegration] in your server-side [code:Sentry.init()] call.',
+      content: [
         {
-          code: <code />,
-        }
-      ),
-      configurations: [
+          type: 'text',
+          text: tct(
+            'Set up the [code:nodeProfilingIntegration] in your server-side [code:Sentry.init()] call.',
+            {
+              code: <code />,
+            }
+          ),
+        },
         {
-          language: 'javascript',
-          code: [
+          type: 'code',
+          tabs: [
             {
               label: 'Javascript',
-              value: 'javascript',
               language: 'javascript',
               code: `
-const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+  const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 
-Sentry.init({
+  Sentry.init({
   dsn: "${params.dsn.public}",
   integrations: [
     nodeProfilingIntegration(),
@@ -462,63 +484,69 @@ Sentry.init({
   // Set sampling rate for profiling - this is evaluated only once per SDK.init call
   profilesSampleRate: 1.0,`
   }
-});${
-                params.profilingOptions?.defaultProfilingMode === 'continuous'
-                  ? `
+  });${
+    params.profilingOptions?.defaultProfilingMode === 'continuous'
+      ? `
 
-// Profiling happens automatically after setting it up with \`Sentry.init()\`.
-// All spans (unless those discarded by sampling) will have profiling data attached to them.
-Sentry.startSpan({
+  // Profiling happens automatically after setting it up with \`Sentry.init()\`.
+  // All spans (unless those discarded by sampling) will have profiling data attached to them.
+  Sentry.startSpan({
   name: "My Span",
-}, () => {
+  }, () => {
   // The code executed here will be profiled
-});`
-                  : ''
-              }`,
+  });`
+      : ''
+  }`,
             },
           ],
         },
         {
-          description: tct(
-            'For more information see the [link:node profiling documentation].',
-            {
-              link: <ExternalLink href={`${nodeProfilingLink}`} />,
-            }
-          ),
+          type: 'text',
+          text: tct('For more information see the [link:node profiling documentation].', {
+            link: <ExternalLink href={`${nodeProfilingLink}`} />,
+          }),
         },
       ],
     },
     {
       title: t('Configure Browser Profiling'),
-      description: <BrowserProfilingBetaWarning />,
-      configurations: [
+      content: [
         {
-          description: tct(
+          type: 'custom',
+          content: <BrowserProfilingBetaWarning />,
+        },
+        {
+          type: 'text',
+          text: tct(
             'Set up the [code:browserProfilingIntegration] in your client-side [code:Sentry.init()] call.',
             {
               code: <code />,
             }
           ),
-          code: [
+        },
+        {
+          type: 'code',
+          tabs: [
             {
               label: 'Javascript',
-              value: 'javascript',
               language: 'javascript',
               code: browserProfilingSnippet(params),
             },
           ],
         },
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'For the JavaScript browser profiler to start, the document response header needs to include a [code:Document-Policy] header key with the [code:js-profiling] value.',
             {
               code: <code />,
             }
           ),
-          configurations: getProfilingHeaderConfig(params),
         },
+        ...getProfilingHeaderContent(params),
         {
-          description: tct(
+          type: 'text',
+          text: tct(
             'For more detailed information, see the [link:browser profiling documentation].',
             {
               link: <ExternalLink href={browserProfilingLink} />,
@@ -531,9 +559,14 @@ Sentry.startSpan({
   verify: () => [
     {
       type: StepType.VERIFY,
-      description: t(
-        'Verify that profiling is working correctly by simply using your application.'
-      ),
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Verify that profiling is working correctly by simply using your application.'
+          ),
+        },
+      ],
     },
   ],
 });

--- a/static/app/utils/gettingStartedDocs/javascript.tsx
+++ b/static/app/utils/gettingStartedDocs/javascript.tsx
@@ -3,7 +3,6 @@ import {ExternalLink} from 'sentry/components/core/link';
 import {
   StepType,
   type BasePlatformOptions,
-  type Configuration,
   type ContentBlock,
   type DocsParams,
   type OnboardingConfig,


### PR DESCRIPTION
- part of [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)