### PR TITLE
fix(sdk_crashes): Ignore SentrySDKInternal crash

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -140,6 +140,12 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                     module_pattern="*",
                     function_pattern="**SentrySDK crash**",
                 ),
+                # [SentrySDKInternal crash] is a testing function causing a crash.
+                # Therefore, we don't want to mark it a as a SDK crash.
+                FunctionAndModulePattern(
+                    module_pattern="*",
+                    function_pattern="**SentrySDKInternal crash**",
+                ),
                 # SentryCrashExceptionApplicationHelper._crashOnException calls abort() intentionally, which would cause false positives.
                 FunctionAndModulePattern(
                     module_pattern="*",

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_cocoa.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_cocoa.py
@@ -634,6 +634,14 @@ class CococaSDKFunctionTestMixin(BaseSDKCrashDetectionMixin):
             mock_sdk_crash_reporter,
         )
 
+    # "+[SentrySDKInternal crash]" is used for testing, so we must ignore it.
+    def test_sentrySDKInternal_not_reported(self, mock_sdk_crash_reporter: MagicMock) -> None:
+        self.execute_test(
+            get_crash_event(function="+[SentrySDKInternal crash]"),
+            False,
+            mock_sdk_crash_reporter,
+        )
+
     # "SentryCrashExceptionApplicationHelper _crashOnException" calls abort() intentionally, so we must ignore it.
     def test_sentrycrash_exception_application_helper_not_reported(
         self, mock_sdk_crash_reporter: MagicMock


### PR DESCRIPTION
The CocoaSDK recently migrated SentrySDK crash to SentrySDKInternal. We also need to ignore it to avoid false positives.

