### PR TITLE
ref(content-blocks): Remove old doc types and handling

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/step.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/step.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import {Fragment, useState} from 'react';
+import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout/flex';
@@ -7,12 +7,7 @@ import {Flex} from '@sentry/scraps/layout/flex';
 import {Button, ButtonBar} from 'sentry/components/core/button';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
 import {
-  OnboardingCodeSnippet,
-  TabbedCodeSnippet,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
-import {
   StepType,
-  type Configuration,
   type OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {IconChevron} from 'sentry/icons';
@@ -25,91 +20,20 @@ export const StepTitles: Record<StepType, string> = {
   [StepType.VERIFY]: t('Verify'),
 };
 
-function getConfiguration({
-  description,
-  code,
-  language,
-  additionalInfo,
-  onCopy,
-  onSelectAndCopy,
-}: Configuration) {
-  return (
-    <Configuration>
-      {description && <Description>{description}</Description>}
-      {Array.isArray(code) ? (
-        <TabbedCodeSnippet
-          tabs={code}
-          onCopy={onCopy}
-          onSelectAndCopy={onSelectAndCopy}
-        />
-      ) : (
-        language &&
-        code && (
-          <OnboardingCodeSnippet
-            language={language}
-            onCopy={onCopy}
-            onSelectAndCopy={onSelectAndCopy}
-          >
-            {code}
-          </OnboardingCodeSnippet>
-        )
-      )}
-      {additionalInfo && <AdditionalInfo>{additionalInfo}</AdditionalInfo>}
-    </Configuration>
-  );
-}
-
 export function Step({
   title,
   type,
-  configurations,
   content,
-  additionalInfo,
-  description,
   onOptionalToggleClick,
   collapsible = false,
   trailingItems,
-  codeHeader,
   ...props
 }: Omit<React.HTMLAttributes<HTMLDivElement>, 'content'> & OnboardingStep) {
   const [showOptionalConfig, setShowOptionalConfig] = useState(false);
 
-  const config = content ? (
+  const config = (
     <ContentWrapper>
       <ContentBlocksRenderer contentBlocks={content} />
-    </ContentWrapper>
-  ) : (
-    <ContentWrapper>
-      {description && <Description>{description}</Description>}
-
-      {!!configurations?.length &&
-        configurations.map((configuration, index) => {
-          if (configuration.configurations) {
-            return (
-              <Fragment key={index}>
-                {getConfiguration(configuration)}
-                {configuration.configurations.map(
-                  (nestedConfiguration, nestedConfigurationIndex) => (
-                    <Fragment key={nestedConfigurationIndex}>
-                      {nestedConfigurationIndex ===
-                      (configuration.configurations?.length ?? 1) - 1
-                        ? codeHeader
-                        : null}
-                      {getConfiguration(nestedConfiguration)}
-                    </Fragment>
-                  )
-                )}
-              </Fragment>
-            );
-          }
-          return (
-            <Fragment key={index}>
-              {index === configurations.length - 1 ? codeHeader : null}
-              {getConfiguration(configuration)}
-            </Fragment>
-          );
-        })}
-      {additionalInfo && <GeneralAdditionalInfo>{additionalInfo}</GeneralAdditionalInfo>}
     </ContentWrapper>
   );
 
@@ -157,7 +81,6 @@ export function Step({
 // NOTE: We intentionally avoid using flex or grid here
 // as it leads to weird text selection behavior in Safari
 // see https://github.com/getsentry/sentry/issues/79958
-
 const CONTENT_SPACING = space(2);
 
 const ContentWrapper = styled('div')`
@@ -166,39 +89,6 @@ const ContentWrapper = styled('div')`
 
 const StepTitle = styled('h4')`
   margin-bottom: 0 !important;
-`;
-
-const Configuration = styled('div')`
-  :not(:last-child) {
-    margin-bottom: ${CONTENT_SPACING};
-  }
-`;
-
-const Description = styled('div')`
-  code:not([class*='language-']) {
-    color: ${p => p.theme.pink400};
-  }
-
-  :not(:last-child) {
-    margin-bottom: ${CONTENT_SPACING};
-  }
-
-  && > p,
-  && > h4,
-  && > h5,
-  && > h6 {
-    &:not(:last-child) {
-      margin-bottom: ${CONTENT_SPACING};
-    }
-  }
-`;
-
-const AdditionalInfo = styled(Description)`
-  margin-top: ${CONTENT_SPACING};
-`;
-
-const GeneralAdditionalInfo = styled(Description)`
-  margin-top: ${CONTENT_SPACING};
 `;
 
 const OptionalConfigWrapper = styled('div')<{expanded: boolean}>`

--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -2,7 +2,6 @@ import type React from 'react';
 
 import type {Client} from 'sentry/api';
 import type {ContentBlock} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/types';
-import type {CodeSnippetTab} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
 import type {ReleaseRegistrySdk} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
 import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey, Project, ProjectKey} from 'sentry/types/project';
@@ -14,39 +13,6 @@ type WithGeneratorProperties<T extends Record<string, any>, Params> = {
   [key in keyof T]: GeneratorFunction<T[key], Params>;
 };
 
-export type Configuration = {
-  /**
-   * Additional information to be displayed below the code snippet
-   */
-  additionalInfo?: React.ReactNode;
-  /**
-   * The code snippet to display
-   */
-  code?: string | CodeSnippetTab[];
-  /**
-   * Nested configurations provide a convenient way to accommodate diverse layout styles, like the Spring Boot configuration.
-   * @deprecated Use `content` instead
-   */
-  configurations?: Configuration[];
-
-  /**
-   * A brief description of the configuration
-   */
-  description?: React.ReactNode;
-  /**
-   * The language of the code to be rendered (python, javascript, etc)
-   */
-  language?: string;
-  /**
-   * A callback to be invoked when the configuration is copied to the clipboard
-   */
-  onCopy?: () => void;
-  /**
-   * A callback to be invoked when the configuration is selected and copied to the clipboard
-   */
-  onSelectAndCopy?: () => void;
-};
-
 export enum StepType {
   INSTALL = 'install',
   CONFIGURE = 'configure',
@@ -55,33 +21,13 @@ export enum StepType {
 
 interface BaseStepProps {
   /**
-   * Additional information to be displayed below the configurations
-   * @deprecated Use `content` instead
+   * The content blocks to display
    */
-  additionalInfo?: React.ReactNode;
-  /**
-   * Content that goes directly above the code snippet
-   * @deprecated Use `content` instead
-   */
-  codeHeader?: React.ReactNode;
+  content: ContentBlock[];
   /**
    * Whether the step instructions are collapsible
    */
   collapsible?: boolean;
-  /**
-   * An array of configurations to be displayed
-   * @deprecated Use `content` instead
-   */
-  configurations?: Configuration[];
-  /**
-   * The content blocks to display
-   */
-  content?: ContentBlock[];
-  /**
-   * A brief description of the step
-   * @deprecated Use `content` instead
-   */
-  description?: React.ReactNode | React.ReactNode[];
   /**
    * Fired when the optional toggle is clicked.
    * Useful for when we want to fire analytics events.

--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -8,14 +8,10 @@ import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
-import {
-  OnboardingCodeSnippet,
-  TabbedCodeSnippet,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
 import {StepTitles} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {
-  Configuration,
   DocsParams,
+  OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
@@ -44,34 +40,6 @@ export function SetupTitle({project}: {project: Project}) {
         ),
       })}
     </BodyTitle>
-  );
-}
-
-function ConfigurationRenderer({configuration}: {configuration: Configuration}) {
-  const subConfigurations = configuration.configurations ?? [];
-
-  return (
-    <ConfigurationWrapper>
-      {configuration.description && (
-        <DescriptionWrapper>{configuration.description}</DescriptionWrapper>
-      )}
-      {typeof configuration.code === 'string' ||
-      (Array.isArray(configuration.code) && configuration.code.length > 0) ? (
-        Array.isArray(configuration.code) ? (
-          <TabbedCodeSnippet tabs={configuration.code} />
-        ) : (
-          <OnboardingCodeSnippet language={configuration.language}>
-            {configuration.code}
-          </OnboardingCodeSnippet>
-        )
-      ) : null}
-      {subConfigurations.map((subConfiguration, index) => (
-        <ConfigurationRenderer key={index} configuration={subConfiguration} />
-      ))}
-      {configuration.additionalInfo && (
-        <AdditionalInfo>{configuration.additionalInfo}</AdditionalInfo>
-      )}
-    </ConfigurationWrapper>
   );
 }
 
@@ -160,7 +128,7 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
   // TODO: Is there a reason why we are only selecting a few steps?
   const steps = [install[0], configure[0], configure[1], verify[0]]
     // Filter optional steps
-    .filter(step => !!step && !step.collapsible);
+    .filter((step): step is OnboardingStep => !!step && !step.collapsible);
 
   return (
     <AuthTokenGeneratorProvider projectSlug={project?.slug}>
@@ -189,30 +157,13 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
               }}
             >
               {steps.map((step, index) => {
-                const title = step?.title ?? StepTitles[step?.type ?? 'install'];
+                const title = step.title ?? StepTitles[step.type ?? 'install'];
                 return (
                   <GuidedSteps.Step key={index} stepKey={title} title={title}>
-                    {step?.content ? (
-                      <ContentBlocksRenderer
-                        contentBlocks={step.content}
-                        spacing={space(1)}
-                      />
-                    ) : (
-                      <div>
-                        {step?.description ? (
-                          <DescriptionWrapper>{step.description}</DescriptionWrapper>
-                        ) : null}
-                        {step?.configurations?.map((configuration, configIndex) => (
-                          <ConfigurationRenderer
-                            key={configIndex}
-                            configuration={configuration}
-                          />
-                        ))}
-                        {step?.additionalInfo ? (
-                          <AdditionalInfo>{step.additionalInfo}</AdditionalInfo>
-                        ) : null}
-                      </div>
-                    )}
+                    <ContentBlocksRenderer
+                      contentBlocks={step.content}
+                      spacing={space(1)}
+                    />
                     {index === steps.length - 1 ? (
                       <FirstEventIndicator
                         organization={organization}
@@ -352,18 +303,6 @@ const IndicatorWrapper = styled('div')`
   width: 300px;
   max-width: 100%;
   margin-bottom: ${space(1)};
-`;
-
-const ConfigurationWrapper = styled('div')`
-  margin-bottom: ${space(1)};
-`;
-
-const DescriptionWrapper = styled('div')`
-  margin-bottom: ${space(1)};
-`;
-
-const AdditionalInfo = styled(DescriptionWrapper)`
-  margin-top: ${space(2)};
 `;
 
 const FirstEventWrapper = styled('div')`

--- a/static/app/utils/gettingStartedDocs/node.tsx
+++ b/static/app/utils/gettingStartedDocs/node.tsx
@@ -805,7 +805,19 @@ const server = Sentry.wrapMcpServerWithSentry(new McpServer({
       ],
     },
   ],
-  verify: () => [],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Verify that MCP monitoring is working correctly by triggering some MCP server interactions in your application.'
+          ),
+        },
+      ],
+    },
+  ],
 });
 
 function getNodeLogsConfigureSnippet(

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -9,15 +9,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
-import {
-  OnboardingCodeSnippet,
-  TabbedCodeSnippet,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
-import type {
-  Configuration,
-  ContentBlock,
-  DocsParams,
-} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
   ProductSolution,
   StepType,
@@ -54,45 +46,6 @@ type OnboardingProps = {
   organization: Organization;
   project: Project;
 };
-
-function ConfigurationRenderer({configuration}: {configuration: Configuration}) {
-  const subConfigurations = configuration.configurations ?? [];
-  return (
-    <ConfigurationWrapper>
-      {configuration.description && (
-        <DescriptionWrapper>{configuration.description}</DescriptionWrapper>
-      )}
-      {configuration.code ? (
-        Array.isArray(configuration.code) ? (
-          <TabbedCodeSnippet tabs={configuration.code} />
-        ) : (
-          <OnboardingCodeSnippet language={configuration.language}>
-            {configuration.code}
-          </OnboardingCodeSnippet>
-        )
-      ) : null}
-      {subConfigurations.map((subConfiguration, index) => (
-        <ConfigurationRenderer key={index} configuration={subConfiguration} />
-      ))}
-      {configuration.additionalInfo && (
-        <AdditionalInfo>{configuration.additionalInfo}</AdditionalInfo>
-      )}
-    </ConfigurationWrapper>
-  );
-}
-
-function RenderBlocksOrFallback({
-  contentBlocks,
-  children,
-}: {
-  children: React.ReactNode;
-  contentBlocks?: ContentBlock[];
-}) {
-  if (contentBlocks && contentBlocks.length > 0) {
-    return <ContentBlocksRenderer spacing={space(1)} contentBlocks={contentBlocks} />;
-  }
-  return children;
-}
 
 function OnboardingPanel({
   project,
@@ -306,9 +259,7 @@ function Onboarding({organization, project}: OnboardingProps) {
           const title = step.title ?? STEP_TITLES[step.type];
           return (
             <GuidedSteps.Step key={title} stepKey={title} title={title}>
-              <RenderBlocksOrFallback contentBlocks={step.content}>
-                <ConfigurationRenderer configuration={step} />
-              </RenderBlocksOrFallback>
+              <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
               {index === steps.length - 1 ? (
                 <GuidedSteps.ButtonWrapper>
                   <GuidedSteps.BackButton size="md" />
@@ -418,40 +369,6 @@ const Arcade = styled('iframe')`
   border: 0;
 `;
 
-const CONTENT_SPACING = space(1);
-
-const ConfigurationWrapper = styled('div')`
-  margin-bottom: ${CONTENT_SPACING};
-`;
-
-const DescriptionWrapper = styled('div')`
-  code:not([class*='language-']) {
-    color: ${p => p.theme.pink400};
-  }
-
-  :not(:last-child) {
-    margin-bottom: ${CONTENT_SPACING};
-  }
-
-  && > h4,
-  && > h5,
-  && > h6 {
-    font-size: ${p => p.theme.fontSize.xl};
-    font-weight: ${p => p.theme.fontWeight.bold};
-    line-height: 34px;
-  }
-
-  && > * {
-    margin: 0;
-    &:not(:last-child) {
-      margin-bottom: ${CONTENT_SPACING};
-    }
-  }
-`;
-
-const AdditionalInfo = styled(DescriptionWrapper)`
-  margin-top: ${CONTENT_SPACING};
-`;
 type LogsTabOnboardingProps = {
   organization: Organization;
   project: Project;

--- a/static/app/views/insights/agents/views/onboarding.tsx
+++ b/static/app/views/insights/agents/views/onboarding.tsx
@@ -9,13 +9,8 @@ import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
-import {
-  OnboardingCodeSnippet,
-  TabbedCodeSnippet,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
 import {StepTitles} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {
-  Configuration,
   DocsParams,
   OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -112,31 +107,6 @@ function WaitingIndicator({project}: {project: Project}) {
   );
 }
 
-function ConfigurationRenderer({configuration}: {configuration: Configuration}) {
-  const subConfigurations = configuration.configurations ?? [];
-
-  return (
-    <ConfigurationWrapper>
-      {configuration.description && (
-        <DescriptionWrapper>{configuration.description}</DescriptionWrapper>
-      )}
-      {Array.isArray(configuration.code) && configuration.code.length > 0 ? (
-        <TabbedCodeSnippet tabs={configuration.code} />
-      ) : typeof configuration.code === 'string' ? (
-        <OnboardingCodeSnippet language={configuration.language}>
-          {configuration.code}
-        </OnboardingCodeSnippet>
-      ) : null}
-      {subConfigurations.map((subConfiguration, index) => (
-        <ConfigurationRenderer key={index} configuration={subConfiguration} />
-      ))}
-      {configuration.additionalInfo && (
-        <AdditionalInfo>{configuration.additionalInfo}</AdditionalInfo>
-      )}
-    </ConfigurationWrapper>
-  );
-}
-
 function StepRenderer({
   project,
   step,
@@ -151,11 +121,7 @@ function StepRenderer({
       stepKey={step.type || step.title}
       title={step.title || (step.type && StepTitles[step.type])}
     >
-      {step.content ? (
-        <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
-      ) : (
-        <ConfigurationRenderer configuration={step} />
-      )}
+      <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
       <GuidedSteps.ButtonWrapper>
         <GuidedSteps.BackButton size="md" />
         <GuidedSteps.NextButton size="md" />
@@ -498,10 +464,6 @@ const Divider = styled('hr')`
 
 const CONTENT_SPACING = space(1);
 
-const ConfigurationWrapper = styled('div')`
-  margin-bottom: ${CONTENT_SPACING};
-`;
-
 const DescriptionWrapper = styled('div')`
   code:not([class*='language-']) {
     color: ${p => p.theme.pink400};
@@ -525,10 +487,6 @@ const DescriptionWrapper = styled('div')`
       margin-bottom: ${CONTENT_SPACING};
     }
   }
-`;
-
-const AdditionalInfo = styled(DescriptionWrapper)`
-  margin-top: ${CONTENT_SPACING};
 `;
 
 const OptionsWrapper = styled('div')`

--- a/static/app/views/insights/mcp/views/onboarding.tsx
+++ b/static/app/views/insights/mcp/views/onboarding.tsx
@@ -10,13 +10,8 @@ import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
-import {
-  OnboardingCodeSnippet,
-  TabbedCodeSnippet,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
 import {StepTitles} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {
-  Configuration,
   DocsParams,
   OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -114,31 +109,6 @@ function WaitingIndicator({project}: {project: Project}) {
   );
 }
 
-function ConfigurationRenderer({configuration}: {configuration: Configuration}) {
-  const subConfigurations = configuration.configurations ?? [];
-
-  return (
-    <ConfigurationWrapper>
-      {configuration.description && (
-        <DescriptionWrapper>{configuration.description}</DescriptionWrapper>
-      )}
-      {Array.isArray(configuration.code) && configuration.code.length > 0 ? (
-        <TabbedCodeSnippet tabs={configuration.code} />
-      ) : typeof configuration.code === 'string' ? (
-        <OnboardingCodeSnippet language={configuration.language}>
-          {configuration.code}
-        </OnboardingCodeSnippet>
-      ) : null}
-      {subConfigurations.map((subConfiguration, index) => (
-        <ConfigurationRenderer key={index} configuration={subConfiguration} />
-      ))}
-      {configuration.additionalInfo && (
-        <AdditionalInfo>{configuration.additionalInfo}</AdditionalInfo>
-      )}
-    </ConfigurationWrapper>
-  );
-}
-
 function StepRenderer({
   project,
   step,
@@ -153,11 +123,7 @@ function StepRenderer({
       stepKey={step.type || step.title}
       title={step.title || (step.type && StepTitles[step.type])}
     >
-      {step.content ? (
-        <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
-      ) : (
-        <ConfigurationRenderer configuration={step} />
-      )}
+      <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
       <GuidedSteps.ButtonWrapper>
         <GuidedSteps.BackButton size="md" />
         <GuidedSteps.NextButton size="md" />
@@ -469,10 +435,6 @@ const Arcade = styled('iframe')`
 
 const CONTENT_SPACING = space(1);
 
-const ConfigurationWrapper = styled('div')`
-  margin-bottom: ${CONTENT_SPACING};
-`;
-
 const DescriptionWrapper = styled('div')`
   code:not([class*='language-']) {
     color: ${p => p.theme.pink400};
@@ -496,8 +458,4 @@ const DescriptionWrapper = styled('div')`
       margin-bottom: ${CONTENT_SPACING};
     }
   }
-`;
-
-const AdditionalInfo = styled(DescriptionWrapper)`
-  margin-top: ${CONTENT_SPACING};
 `;

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -28,15 +28,7 @@ import FeatureTourModal, {
 } from 'sentry/components/modals/featureTourModal';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
-import {
-  OnboardingCodeSnippet,
-  TabbedCodeSnippet,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
-import type {
-  Configuration,
-  ContentBlock,
-  DocsParams,
-} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
   ProductSolution,
   StepType,
@@ -344,45 +336,6 @@ const ButtonList = styled(ButtonBar)`
   margin-bottom: 16px;
 `;
 
-function ConfigurationRenderer({configuration}: {configuration: Configuration}) {
-  const subConfigurations = configuration.configurations ?? [];
-  return (
-    <ConfigurationWrapper>
-      {configuration.description && (
-        <DescriptionWrapper>{configuration.description}</DescriptionWrapper>
-      )}
-      {configuration.code ? (
-        Array.isArray(configuration.code) ? (
-          <TabbedCodeSnippet tabs={configuration.code} />
-        ) : (
-          <OnboardingCodeSnippet language={configuration.language}>
-            {configuration.code}
-          </OnboardingCodeSnippet>
-        )
-      ) : null}
-      {subConfigurations.map((subConfiguration, index) => (
-        <ConfigurationRenderer key={index} configuration={subConfiguration} />
-      ))}
-      {configuration.additionalInfo && (
-        <AdditionalInfo>{configuration.additionalInfo}</AdditionalInfo>
-      )}
-    </ConfigurationWrapper>
-  );
-}
-
-function RenderBlocksOrFallback({
-  contentBlocks,
-  children,
-}: {
-  children: React.ReactNode;
-  contentBlocks?: ContentBlock[];
-}) {
-  if (contentBlocks && contentBlocks.length > 0) {
-    return <ContentBlocksRenderer spacing={space(1)} contentBlocks={contentBlocks} />;
-  }
-  return children;
-}
-
 function OnboardingPanel({
   project,
   children,
@@ -637,9 +590,7 @@ export function Onboarding({organization, project}: OnboardingProps) {
           const title = step.title ?? STEP_TITLES[step.type];
           return (
             <GuidedSteps.Step key={title} stepKey={title} title={title}>
-              <RenderBlocksOrFallback contentBlocks={step.content}>
-                <ConfigurationRenderer configuration={step} />
-              </RenderBlocksOrFallback>
+              <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
               {index === steps.length - 1 ? (
                 <Fragment>
                   {eventWaitingIndicator}
@@ -810,39 +761,4 @@ const Arcade = styled('iframe')`
   margin-top: ${space(3)};
   height: 522px;
   border: 0;
-`;
-
-const CONTENT_SPACING = space(1);
-
-const ConfigurationWrapper = styled('div')`
-  margin-bottom: ${CONTENT_SPACING};
-`;
-
-const DescriptionWrapper = styled('div')`
-  code:not([class*='language-']) {
-    color: ${p => p.theme.pink400};
-  }
-
-  :not(:last-child) {
-    margin-bottom: ${CONTENT_SPACING};
-  }
-
-  && > h4,
-  && > h5,
-  && > h6 {
-    font-size: ${p => p.theme.fontSize.xl};
-    font-weight: ${p => p.theme.fontWeight.bold};
-    line-height: 34px;
-  }
-
-  && > * {
-    margin: 0;
-    &:not(:last-child) {
-      margin-bottom: ${CONTENT_SPACING};
-    }
-  }
-`;
-
-const AdditionalInfo = styled(DescriptionWrapper)`
-  margin-top: ${CONTENT_SPACING};
 `;

--- a/static/app/views/profiling/onboarding.tsx
+++ b/static/app/views/profiling/onboarding.tsx
@@ -7,15 +7,10 @@ import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
-import {
-  OnboardingCodeSnippet,
-  TabbedCodeSnippet,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
 import {StepTitles} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   DocsPageLocation,
   ProductSolution,
-  type Configuration,
   type DocsParams,
   type OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -90,32 +85,6 @@ function WaitingIndicator({
   );
 }
 
-function ConfigurationRenderer({configuration}: {configuration: Configuration}) {
-  const subConfigurations = configuration.configurations ?? [];
-  return (
-    <ConfigurationWrapper>
-      {configuration.description && (
-        <DescriptionWrapper>{configuration.description}</DescriptionWrapper>
-      )}
-      {configuration.code ? (
-        Array.isArray(configuration.code) ? (
-          <TabbedCodeSnippet tabs={configuration.code} />
-        ) : (
-          <OnboardingCodeSnippet language={configuration.language}>
-            {configuration.code}
-          </OnboardingCodeSnippet>
-        )
-      ) : null}
-      {subConfigurations.map((subConfiguration, index) => (
-        <ConfigurationRenderer key={index} configuration={subConfiguration} />
-      ))}
-      {configuration.additionalInfo && (
-        <AdditionalInfo>{configuration.additionalInfo}</AdditionalInfo>
-      )}
-    </ConfigurationWrapper>
-  );
-}
-
 function StepRenderer({
   project,
   step,
@@ -131,11 +100,7 @@ function StepRenderer({
 
   return (
     <GuidedSteps.Step stepKey={type || title} title={title || (type && StepTitles[type])}>
-      {step.content ? (
-        <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
-      ) : (
-        <ConfigurationRenderer configuration={step} />
-      )}
+      <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
       <GuidedSteps.ButtonWrapper>
         <GuidedSteps.BackButton size="md" />
         <GuidedSteps.NextButton size="md" />
@@ -464,10 +429,6 @@ const Arcade = styled('iframe')`
 
 const CONTENT_SPACING = space(1);
 
-const ConfigurationWrapper = styled('div')`
-  margin-bottom: ${CONTENT_SPACING};
-`;
-
 const DescriptionWrapper = styled('div')`
   code:not([class*='language-']) {
     color: ${p => p.theme.pink400};
@@ -491,8 +452,4 @@ const DescriptionWrapper = styled('div')`
       margin-bottom: ${CONTENT_SPACING};
     }
   }
-`;
-
-const AdditionalInfo = styled(DescriptionWrapper)`
-  margin-top: ${CONTENT_SPACING};
 `;


### PR DESCRIPTION
Remove deprecated in-product doc type definitions.
Remove code which was handling deprecated doc definitions.

- closes [TET-761: Docs: Move from configuration objects to content blocks](https://linear.app/getsentry/issue/TET-761/docs-move-from-configuration-objects-to-content-blocks)