### PR TITLE
chore(search-bar): Remove operator flow changes

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -357,7 +357,7 @@ describe('SearchQueryBuilder', () => {
       ).not.toBeInTheDocument();
       await userEvent.type(
         screen.getByRole('combobox', {name: 'Add a search term'}),
-        'foo a:{enter}b{enter}'
+        'foo a:b{enter}'
       );
 
       await waitFor(() => expect(mockOnChange).toHaveBeenCalled());
@@ -785,14 +785,13 @@ describe('SearchQueryBuilder', () => {
     });
 
     it('escapes values with spaces and reserved characters', async () => {
-      render(<SearchQueryBuilder {...defaultProps} initialQuery="" />, {
-        organization: {features: ['search-query-builder-input-flow-changes']},
-      });
-      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
+      render(<SearchQueryBuilder {...defaultProps} initialQuery="" />);
 
-      await userEvent.keyboard('assigned:');
-      await userEvent.click(screen.getByRole('option', {name: 'is'}));
-      await userEvent.keyboard('some" value{enter}');
+      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
+      await userEvent.type(
+        screen.getByRole('combobox', {name: 'Add a search term'}),
+        'assigned:some" value{enter}'
+      );
 
       // Value should be surrounded by quotes and escaped
       expect(
@@ -915,21 +914,15 @@ describe('SearchQueryBuilder', () => {
     it('can add an unsupported filter key and value', async () => {
       const mockOnChange = jest.fn();
       render(
-        <SearchQueryBuilder {...defaultProps} onChange={mockOnChange} initialQuery="" />,
-        {organization: {features: ['search-query-builder-input-flow-changes']}}
+        <SearchQueryBuilder {...defaultProps} onChange={mockOnChange} initialQuery="" />
       );
       await userEvent.click(getLastInput());
 
       // Typing "foo", then " a:b" should add the "foo" text followed by a new token "a:b"
       await userEvent.type(
         screen.getByRole('combobox', {name: 'Add a search term'}),
-        'foo '
+        'foo a:b{enter}'
       );
-
-      await userEvent.keyboard('a:');
-      expect(await screen.findByRole('option', {name: 'is'})).toHaveFocus();
-      await userEvent.keyboard('{enter}');
-      await userEvent.keyboard('b{enter}');
 
       expect(await screen.findByRole('row', {name: 'foo'})).toBeInTheDocument();
       expect(await screen.findByRole('row', {name: 'a:b'})).toBeInTheDocument();
@@ -982,7 +975,6 @@ describe('SearchQueryBuilder', () => {
       render(<SearchQueryBuilder {...defaultProps} onChange={mockOnChange} />, {
         organization: {
           features: [
-            'search-query-builder-input-flow-changes',
             'search-query-builder-wildcard-operators',
             'search-query-builder-default-to-contains',
           ],
@@ -998,11 +990,6 @@ describe('SearchQueryBuilder', () => {
       ).toBeInTheDocument();
       // onChange should not be called until exiting edit mode
       expect(mockOnChange).not.toHaveBeenCalled();
-
-      // Should have focus on the operator option
-      const operatorOption = await screen.findByRole('option', {name: 'contains'});
-      expect(operatorOption).toHaveFocus();
-      await userEvent.click(operatorOption);
 
       await userEvent.click(await screen.findByRole('option', {name: 'Firefox'}));
 
@@ -1037,9 +1024,7 @@ describe('SearchQueryBuilder', () => {
     });
 
     it('can add a filter after some free text', async () => {
-      render(<SearchQueryBuilder {...defaultProps} />, {
-        organization: {features: ['search-query-builder-input-flow-changes']},
-      });
+      render(<SearchQueryBuilder {...defaultProps} />);
 
       await userEvent.click(getLastInput());
 
@@ -1050,11 +1035,6 @@ describe('SearchQueryBuilder', () => {
       await userEvent.type(screen.getByRole('combobox'), 'some free text brow');
       await userEvent.click(screen.getByRole('option', {name: 'browser.name'}));
       jest.restoreAllMocks();
-
-      // Should have focus on the operator option
-      const operatorOption = await screen.findByRole('option', {name: 'is'});
-      expect(operatorOption).toHaveFocus();
-      await userEvent.click(operatorOption);
 
       // Filter value should have focus
       expect(await screen.findByLabelText('Edit filter value')).toHaveFocus();
@@ -1140,7 +1120,6 @@ describe('SearchQueryBuilder', () => {
       render(<SearchQueryBuilder {...defaultProps} />, {
         organization: {
           features: [
-            'search-query-builder-input-flow-changes',
             'search-query-builder-wildcard-operators',
             'search-query-builder-default-to-contains',
           ],
@@ -1178,7 +1157,6 @@ describe('SearchQueryBuilder', () => {
       render(<SearchQueryBuilder {...defaultProps} />, {
         organization: {
           features: [
-            'search-query-builder-input-flow-changes',
             'search-query-builder-wildcard-operators',
             'search-query-builder-default-to-contains',
           ],
@@ -1190,7 +1168,6 @@ describe('SearchQueryBuilder', () => {
         screen.getByRole('combobox', {name: 'Add a search term'}),
         'message:'
       );
-      await userEvent.keyboard('{enter}');
       await userEvent.click(screen.getByRole('option', {name: '[Filtered]'}));
 
       expect(
@@ -3569,34 +3546,22 @@ describe('SearchQueryBuilder', () => {
       });
 
       it('focuses on the filter value when user selects an aggregate filter with no arguments', async () => {
-        render(<SearchQueryBuilder {...aggregateDefaultProps} />, {
-          organization: {features: ['search-query-builder-input-flow-changes']},
-        });
+        render(<SearchQueryBuilder {...aggregateDefaultProps} />, {});
 
         await userEvent.click(getLastInput());
         await userEvent.keyboard('count');
         await userEvent.click(screen.getByRole('option', {name: 'count()'}));
         expect(screen.getByLabelText('count():>100')).toBeInTheDocument();
 
-        const gtOption = screen.getByRole('option', {name: '>'});
-        expect(gtOption).toHaveFocus();
-        await userEvent.click(gtOption);
-
         expect(screen.getByLabelText('Edit filter value')).toHaveFocus();
       });
 
       it('focuses on the filter value when user input looks like an aggregate filter with no arguments', async () => {
-        render(<SearchQueryBuilder {...aggregateDefaultProps} />, {
-          organization: {features: ['search-query-builder-input-flow-changes']},
-        });
+        render(<SearchQueryBuilder {...aggregateDefaultProps} />, {});
 
         await userEvent.click(getLastInput());
         await userEvent.keyboard('count(');
         expect(screen.getByLabelText('count():>100')).toBeInTheDocument();
-
-        const gtOption = screen.getByRole('option', {name: '>'});
-        expect(gtOption).toHaveFocus();
-        await userEvent.click(gtOption);
 
         expect(screen.getByLabelText('Edit filter value')).toHaveFocus();
       });

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -133,12 +133,11 @@ function countPreviousItemsOfType({
 function calculateNextFocusForFilter(
   state: ListState<ParseResultToken>,
   definition: FieldDefinition | null,
-  key: string | null,
-  hasInputChangeFlows: boolean
+  key: string | null
 ): FocusOverride {
   const numPreviousFilterItems = countPreviousItemsOfType({state, type: Token.FILTER});
 
-  let part: FocusOverride['part'] = hasInputChangeFlows ? 'op' : 'value';
+  let part: FocusOverride['part'] = 'value';
   if (
     definition &&
     definition.kind === FieldKind.FUNCTION &&
@@ -259,9 +258,6 @@ function SearchQueryBuilderInputInternal({
   const [selectionIndex, setSelectionIndex] = useState(0);
 
   const organization = useOrganization();
-  const hasInputChangeFlows = organization.features.includes(
-    'search-query-builder-input-flow-changes'
-  );
   const hasWildcardOperators =
     organization.features.includes('search-query-builder-wildcard-operators') &&
     organization.features.includes('search-query-builder-default-to-contains');
@@ -481,8 +477,7 @@ function SearchQueryBuilderInputInternal({
             focusOverride: calculateNextFocusForFilter(
               state,
               getFieldDefinition(value),
-              value,
-              hasInputChangeFlows
+              value
             ),
             shouldCommitQuery: false,
           });
@@ -585,8 +580,7 @@ function SearchQueryBuilderInputInternal({
                   focusOverride: calculateNextFocusForFilter(
                     state,
                     getFieldDefinition(filterValue),
-                    null,
-                    hasInputChangeFlows
+                    null
                   ),
                   shouldCommitQuery: false,
                 });
@@ -629,8 +623,7 @@ function SearchQueryBuilderInputInternal({
               focusOverride: calculateNextFocusForFilter(
                 state,
                 getFieldDefinition(filterKey),
-                filterKey,
-                hasInputChangeFlows
+                filterKey
               ),
               shouldCommitQuery: false,
             });

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -24,7 +24,7 @@ import AutomationsList from 'sentry/views/automations/list';
 
 describe('AutomationsList', () => {
   const organization = OrganizationFixture({
-    features: ['workflow-engine-ui', 'search-query-builder-input-flow-changes'],
+    features: ['workflow-engine-ui'],
   });
   const project = ProjectFixture({id: '1', slug: 'project-1'});
   const detector = MetricDetectorFixture({
@@ -177,7 +177,6 @@ describe('AutomationsList', () => {
       // Click through menus to select action:slack
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
       await userEvent.click(await screen.findByRole('option', {name: 'action'}));
-      await userEvent.click(await screen.findByRole('option', {name: 'is'}));
       await userEvent.click(await screen.findByRole('option', {name: 'slack'}));
 
       await screen.findByText('Slack Automation');
@@ -424,7 +423,6 @@ describe('AutomationsList', () => {
       // Click through menus to select action:slack
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
       await userEvent.click(await screen.findByRole('option', {name: 'action'}));
-      await userEvent.click(await screen.findByRole('option', {name: 'is'}));
       await userEvent.click(await screen.findByRole('option', {name: 'slack'}));
 
       // Wait for filtered results to load

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -21,8 +21,7 @@ function renderWithProvider({
   return render(
     <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
       <SpansSearchBar widgetQuery={widgetQuery} onSearch={onSearch} onClose={onClose} />
-    </TraceItemAttributeProvider>,
-    {organization: {features: ['search-query-builder-input-flow-changes']}}
+    </TraceItemAttributeProvider>
   );
 }
 
@@ -127,9 +126,10 @@ describe('SpansSearchBar', () => {
     const searchInput = await screen.findByRole('combobox', {
       name: 'Add a search term',
     });
-    await userEvent.type(searchInput, 'span.op:');
+    await userEvent.type(searchInput, 'span.op:function');
+
+    // It takes two enters. One to enter the search term, and one to submit the search.
     await userEvent.keyboard('{enter}');
-    await userEvent.keyboard('function');
     await userEvent.keyboard('{enter}');
 
     await waitFor(() => {

--- a/static/app/views/detectors/list.spec.tsx
+++ b/static/app/views/detectors/list.spec.tsx
@@ -25,7 +25,7 @@ import DetectorsList from 'sentry/views/detectors/list';
 
 describe('DetectorsList', () => {
   const organization = OrganizationFixture({
-    features: ['workflow-engine-ui', 'search-query-builder-input-flow-changes'],
+    features: ['workflow-engine-ui'],
     access: ['org:write'],
   });
 
@@ -169,9 +169,6 @@ describe('DetectorsList', () => {
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
       await userEvent.click(await screen.findByRole('option', {name: 'type'}));
 
-      const isOption = await screen.findByRole('option', {name: 'is'});
-      await userEvent.click(isOption);
-
       const options = await screen.findAllByRole('option');
       expect(options).toHaveLength(4);
       expect(options[0]).toHaveTextContent('error');
@@ -204,12 +201,9 @@ describe('DetectorsList', () => {
       const searchInput = await screen.findByRole('combobox', {
         name: 'Add a search term',
       });
-      await userEvent.type(searchInput, 'assignee:');
+      await userEvent.type(searchInput, 'assignee:test@example.com');
 
       await userEvent.keyboard('{enter}');
-
-      await userEvent.keyboard('test@example.com');
-
       await userEvent.keyboard('{enter}');
 
       await screen.findByText('Assigned Detector');
@@ -500,9 +494,10 @@ describe('DetectorsList', () => {
       const searchInput = await screen.findByRole('combobox', {
         name: 'Add a search term',
       });
-      await userEvent.type(searchInput, 'assignee:');
+      await userEvent.type(searchInput, 'assignee:test@example.com');
+
+      // It takes two enters. One to enter the search term, and one to submit the search.
       await userEvent.keyboard('{enter}');
-      await userEvent.keyboard('test@example.com');
       await userEvent.keyboard('{enter}');
 
       // Wait for filtered results to load

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
@@ -25,9 +25,7 @@ jest.mock('sentry/views/issueDetails/utils', () => ({
 }));
 
 describe('EventDetailsHeader', () => {
-  const organization = OrganizationFixture({
-    features: ['search-query-builder-input-flow-changes'],
-  });
+  const organization = OrganizationFixture();
   const project = ProjectFixture({
     environments: ['production', 'staging', 'development'],
   });
@@ -139,8 +137,7 @@ describe('EventDetailsHeader', () => {
 
     const search = await screen.findByPlaceholderText('Filter events\u2026');
     await userEvent.type(search, `${tagKey}:`, {delay: null});
-    await userEvent.click(screen.getByRole('option', {name: 'is'}));
-    await userEvent.keyboard(`${tagValue}{enter}`, {delay: null});
+    await userEvent.keyboard(`${tagValue}{enter}{enter}`, {delay: null});
     await waitFor(() => {
       expect(mockUseNavigate).toHaveBeenCalledWith(
         expect.objectContaining(locationQuery),

--- a/static/app/views/issueDetails/streamline/eventSearch.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventSearch.spec.tsx
@@ -11,9 +11,7 @@ import {EventSearch} from 'sentry/views/issueDetails/streamline/eventSearch';
 const mockHandleSearch = jest.fn();
 
 describe('EventSearch', () => {
-  const organization = OrganizationFixture({
-    features: ['search-query-builder-input-flow-changes'],
-  });
+  const organization = OrganizationFixture();
   const project = ProjectFixture({
     environments: ['production', 'staging', 'developement'],
   });
@@ -49,11 +47,10 @@ describe('EventSearch', () => {
   });
 
   it('handles basic inputs for tags', async () => {
-    render(<EventSearch {...defaultProps} />, {organization});
+    render(<EventSearch {...defaultProps} />);
     const search = screen.getByRole('combobox', {name: 'Add a search term'});
     expect(search).toBeInTheDocument();
     await userEvent.type(search, `${tagKey}:`);
-    await userEvent.click(screen.getByRole('option', {name: 'is'}));
     await userEvent.keyboard(`${tagValue}{enter}{enter}`);
 
     await waitFor(() => {

--- a/static/app/views/issueList/searchBar.spec.tsx
+++ b/static/app/views/issueList/searchBar.spec.tsx
@@ -147,14 +147,11 @@ describe('IssueListSearchBar', () => {
         body: tagValueResponse,
       });
 
-      render(<IssueListSearchBar {...newDefaultProps} />, {
-        organization: {features: ['search-query-builder-input-flow-changes']},
-      });
+      render(<IssueListSearchBar {...newDefaultProps} />);
 
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
       await userEvent.paste(tagKey, {delay: null});
       await userEvent.click(screen.getByRole('option', {name: tagKey}));
-      await userEvent.click(screen.getByRole('option', {name: 'is'}));
       expect(await screen.findByRole('option', {name: tagValue})).toBeInTheDocument();
 
       await waitFor(() => {

--- a/static/app/views/projectDetail/projectFilters.spec.tsx
+++ b/static/app/views/projectDetail/projectFilters.spec.tsx
@@ -27,8 +27,7 @@ describe('ProjectDetail > ProjectFilters', () => {
         onSearch={onSearch}
         tagValueLoader={tagValueLoader}
         relativeDateOptions={{}}
-      />,
-      {organization: {features: ['search-query-builder-input-flow-changes']}}
+      />
     );
 
     await userEvent.click(
@@ -43,7 +42,6 @@ describe('ProjectDetail > ProjectFilters', () => {
     expect(screen.getByRole('option', {name: 'release.version'})).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('option', {name: 'release.version'}));
-    await userEvent.click(screen.getByRole('option', {name: 'is'}));
 
     await screen.findByText('sentry@0.5.3');
   });

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -19,9 +19,7 @@ import {ReleasesDisplayOption} from 'sentry/views/releases/list/releasesDisplayO
 import {ReleasesStatusOption} from 'sentry/views/releases/list/releasesStatusOptions';
 
 describe('ReleasesList', () => {
-  const organization = OrganizationFixture({
-    features: ['search-query-builder-input-flow-changes'],
-  });
+  const organization = OrganizationFixture();
   const projects = [ProjectFixture({features: ['releases']})];
   const semverVersionInfo = {
     buildHash: null,
@@ -545,7 +543,6 @@ describe('ReleasesList', () => {
 
     await userEvent.clear(smartSearchBar);
     await userEvent.click(screen.getByRole('option', {name: 'release.version'}));
-    await userEvent.click(screen.getByRole('option', {name: 'is'}));
 
     expect(await screen.findByText('sentry@0.5.3')).toBeInTheDocument();
   });


### PR DESCRIPTION
This PR removes the functional flow changes made to the FE during the search experience where we would focus the operator after selecting the key value. Instead we're just going to stick with the changes where the default operator is `contains`.

Ticket: EXP-550