### PR TITLE
fix(aci): Allow workflows to be saved when connected to an error monitor

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
@@ -90,7 +90,7 @@ def validate_detectors_exist_and_have_permissions(
     if missing_detector_ids:
         raise serializers.ValidationError(f"Some detectors do not exist: {missing_detector_ids}")
 
-    if not can_edit_detectors(detectors, request):
+    if not all(can_edit_detector_workflow_connections(detector, request) for detector in detectors):
         raise PermissionDenied
 
     return detectors

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -636,6 +636,8 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
         error_detector = self.create_detector(project=self.project, type=ErrorGroupType.slug)
         workflow_data = {**self.valid_workflow, "detectorIds": [error_detector.id]}
 
+        self.login_as(user=self.member_user)
+
         response = self.get_success_response(
             self.organization.slug,
             raw_data=workflow_data,


### PR DESCRIPTION
Followup to https://github.com/getsentry/sentry/pull/101468

In that PR I fixed things for the detector_workflow endpoints, but forgot to update a crucial line to allow this to work when creating/editing the workflow. With this change, you can now create an automation and connect it to a system-created detector.