### PR TITLE
feat(dashboards): Dashboard global filters UI refactor

### DIFF
--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -125,85 +125,83 @@ export default function FiltersBar({
           }}
         />
       </PageFilterBar>
-      <Fragment>
-        <FilterButtons gap="lg">
-          <ReleasesProvider organization={organization} selection={selection}>
-            <ReleasesSelectControl
-              handleChangeFilter={activeFilters => {
-                onDashboardFilterChange({
-                  ...activeFilters,
-                  [DashboardFilterKeys.GLOBAL_FILTER]: activeGlobalFilters,
-                });
-                trackAnalytics('dashboards2.filter.change', {
-                  organization,
-                  filter_type: 'release',
-                });
-              }}
-              selectedReleases={selectedReleases}
-              isDisabled={isEditingDashboard}
-            />
-          </ReleasesProvider>
 
-          {organization.features.includes('dashboards-global-filters') && (
-            <Fragment>
-              {activeGlobalFilters.map(filter => (
-                <FilterSelector
-                  key={filter.tag.key}
-                  globalFilter={filter}
-                  searchBarData={getSearchBarData(filter.dataset)}
-                  onUpdateFilter={updatedFilter => {
-                    updateGlobalFilters(
-                      activeGlobalFilters.map(f =>
-                        f.tag.key === updatedFilter.tag.key ? updatedFilter : f
-                      )
-                    );
-                  }}
-                  onRemoveFilter={removedFilter => {
-                    updateGlobalFilters(
-                      activeGlobalFilters.filter(f => f.tag.key !== removedFilter.tag.key)
-                    );
-                  }}
-                />
-              ))}
-              <AddFilter
-                globalFilters={activeGlobalFilters}
-                getSearchBarData={getSearchBarData}
-                onAddFilter={newFilter => {
-                  updateGlobalFilters([...activeGlobalFilters, newFilter]);
-                }}
-              />
-            </Fragment>
-          )}
-        </FilterButtons>
-        {hasUnsavedChanges && !isEditingDashboard && !isPreview && (
-          <FilterButtons gap="lg">
-            <Button
-              title={
-                !hasEditAccess && t('You do not have permission to edit this dashboard')
-              }
-              priority="primary"
-              onClick={async () => {
-                await onSave?.();
-                invalidateStarredDashboards();
+      <ReleasesProvider organization={organization} selection={selection}>
+        <ReleasesSelectControl
+          handleChangeFilter={activeFilters => {
+            onDashboardFilterChange({
+              ...activeFilters,
+              [DashboardFilterKeys.GLOBAL_FILTER]: activeGlobalFilters,
+            });
+            trackAnalytics('dashboards2.filter.change', {
+              organization,
+              filter_type: 'release',
+            });
+          }}
+          selectedReleases={selectedReleases}
+          isDisabled={isEditingDashboard}
+        />
+      </ReleasesProvider>
+
+      {organization.features.includes('dashboards-global-filters') && (
+        <Fragment>
+          {activeGlobalFilters.map(filter => (
+            <FilterSelector
+              key={filter.tag.key}
+              globalFilter={filter}
+              searchBarData={getSearchBarData(filter.dataset)}
+              onUpdateFilter={updatedFilter => {
+                updateGlobalFilters(
+                  activeGlobalFilters.map(f =>
+                    f.tag.key === updatedFilter.tag.key ? updatedFilter : f
+                  )
+                );
               }}
-              disabled={!hasEditAccess}
-              busy={shouldBusySaveButton}
-            >
-              {t('Save')}
-            </Button>
-            <Button
-              data-test-id="filter-bar-cancel"
-              onClick={() => {
-                onCancel?.();
-                setActiveGlobalFilters(filters.globalFilter ?? []);
-                onDashboardFilterChange(filters);
+              onRemoveFilter={removedFilter => {
+                updateGlobalFilters(
+                  activeGlobalFilters.filter(f => f.tag.key !== removedFilter.tag.key)
+                );
               }}
-            >
-              {t('Cancel')}
-            </Button>
-          </FilterButtons>
-        )}
-      </Fragment>
+            />
+          ))}
+          <AddFilter
+            globalFilters={activeGlobalFilters}
+            getSearchBarData={getSearchBarData}
+            onAddFilter={newFilter => {
+              updateGlobalFilters([...activeGlobalFilters, newFilter]);
+            }}
+          />
+        </Fragment>
+      )}
+
+      {hasUnsavedChanges && !isEditingDashboard && !isPreview && (
+        <ButtonBar>
+          <Button
+            title={
+              !hasEditAccess && t('You do not have permission to edit this dashboard')
+            }
+            priority="primary"
+            onClick={async () => {
+              await onSave?.();
+              invalidateStarredDashboards();
+            }}
+            disabled={!hasEditAccess}
+            busy={shouldBusySaveButton}
+          >
+            {t('Save')}
+          </Button>
+          <Button
+            data-test-id="filter-bar-cancel"
+            onClick={() => {
+              onCancel?.();
+              setActiveGlobalFilters(filters.globalFilter ?? []);
+              onDashboardFilterChange(filters);
+            }}
+          >
+            {t('Cancel')}
+          </Button>
+        </ButtonBar>
+      )}
       <ToggleOnDemand />
     </Wrapper>
   );
@@ -214,22 +212,10 @@ const Wrapper = styled('div')`
   flex-direction: row;
   gap: ${space(1.5)};
   margin-bottom: ${space(2)};
+  flex-wrap: wrap;
 
   & button[aria-haspopup] {
     height: 100%;
     width: 100%;
-  }
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    display: grid;
-    grid-auto-flow: row;
-  }
-`;
-
-const FilterButtons = styled(ButtonBar)`
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
-    display: flex;
-    align-items: flex-start;
-    gap: ${p => p.theme.space[p.gap!]};
   }
 `;

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -166,6 +166,7 @@ export default function FiltersBar({
                 />
               ))}
               <AddFilter
+                globalFilters={activeGlobalFilters}
                 getSearchBarData={getSearchBarData}
                 onAddFilter={newFilter => {
                   updateGlobalFilters([...activeGlobalFilters, newFilter]);

--- a/static/app/views/dashboards/globalFilter/addFilter.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.spec.tsx
@@ -38,7 +38,13 @@ describe('AddFilter', () => {
   });
 
   it('renders all dataset options', async () => {
-    render(<AddFilter getSearchBarData={getSearchBarData} onAddFilter={() => {}} />);
+    render(
+      <AddFilter
+        globalFilters={[]}
+        getSearchBarData={getSearchBarData}
+        onAddFilter={() => {}}
+      />
+    );
     await userEvent.click(screen.getByRole('button', {name: 'Add Global Filter'}));
     for (const dataset of DATASET_CHOICES.values()) {
       expect(screen.getByText(dataset)).toBeInTheDocument();
@@ -46,7 +52,13 @@ describe('AddFilter', () => {
   });
 
   it('retrieves filter keys for each dataset', async () => {
-    render(<AddFilter getSearchBarData={getSearchBarData} onAddFilter={() => {}} />);
+    render(
+      <AddFilter
+        globalFilters={[]}
+        getSearchBarData={getSearchBarData}
+        onAddFilter={() => {}}
+      />
+    );
 
     // Open the add global filter drop down
     await userEvent.click(screen.getByRole('button', {name: 'Add Global Filter'}));
@@ -66,7 +78,13 @@ describe('AddFilter', () => {
   });
 
   it('does not render unsupported filter keys', async () => {
-    render(<AddFilter getSearchBarData={getSearchBarData} onAddFilter={() => {}} />);
+    render(
+      <AddFilter
+        globalFilters={[]}
+        getSearchBarData={getSearchBarData}
+        onAddFilter={() => {}}
+      />
+    );
 
     // Open the dropdown and select an arbitrary dataset
     await userEvent.click(screen.getByRole('button', {name: 'Add Global Filter'}));
@@ -83,7 +101,13 @@ describe('AddFilter', () => {
 
   it('calls onAddFilter with expected global filter object', async () => {
     const onAddFilter = jest.fn();
-    render(<AddFilter getSearchBarData={getSearchBarData} onAddFilter={onAddFilter} />);
+    render(
+      <AddFilter
+        globalFilters={[]}
+        getSearchBarData={getSearchBarData}
+        onAddFilter={onAddFilter}
+      />
+    );
 
     // Open add global filter drop down
     await userEvent.click(screen.getByRole('button', {name: 'Add Global Filter'}));

--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -40,10 +40,11 @@ function getTagType(tag: Tag, dataset: WidgetType) {
 
 type AddFilterProps = {
   getSearchBarData: (widgetType: WidgetType) => SearchBarData;
+  globalFilters: GlobalFilter[];
   onAddFilter: (filter: GlobalFilter) => void;
 };
 
-function AddFilter({getSearchBarData, onAddFilter}: AddFilterProps) {
+function AddFilter({globalFilters, getSearchBarData, onAddFilter}: AddFilterProps) {
   const [selectedDataset, setSelectedDataset] = useState<WidgetType | null>(null);
   const [selectedFilterKey, setSelectedFilterKey] = useState<Tag | null>(null);
   const [isSelectingFilterKey, setIsSelectingFilterKey] = useState(false);
@@ -74,6 +75,7 @@ function AddFilter({getSearchBarData, onAddFilter}: AddFilterProps) {
           value: tag.key,
           label: prettifyTagKey(tag.key),
           trailingItems: <TagBadge>{getTagType(tag, selectedDataset)}</TagBadge>,
+          disabled: globalFilters.some(filter => filter.tag.key === tag.key),
         };
       })
     : [];

--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -122,7 +122,11 @@ function AddFilter({globalFilters, getSearchBarData, onAddFilter}: AddFilterProp
       searchable={isSelectingFilterKey}
       sizeLimit={50}
       closeOnSelect={false}
-      clearable={false}
+      onClose={() => {
+        setSelectedFilterKey(null);
+        setSelectedDataset(null);
+        setIsSelectingFilterKey(false);
+      }}
       value={selectedFilterKey?.key ?? ''}
       onChange={(option: SelectOption<string>) => {
         if (isSelectingFilterKey) {

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -1,10 +1,14 @@
 import {useEffect, useMemo, useState} from 'react';
+import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
+
+import {Flex} from '@sentry/scraps/layout';
 
 import {Button} from 'sentry/components/core/button';
 import {HybridFilter} from 'sentry/components/organizations/hybridFilter';
 import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {keepPreviousData, useQuery} from 'sentry/utils/queryClient';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {type SearchBarData} from 'sentry/views/dashboards/datasetConfig/base';
@@ -95,28 +99,34 @@ function FilterSelector({
       onChange={handleChange}
       sizeLimit={10}
       sizeLimitMessage={t('Use search to find more filter values…')}
-      onReset={() => {
-        setActiveFilterValues([]);
-        onUpdateFilter({
-          ...globalFilter,
-          value: '',
-        });
-      }}
       emptyMessage={
         isFetching ? t('Loading filter values...') : t('No filter values found')
       }
-      menuTitle={t('%s filter', getDatasetLabel(dataset))}
-      menuHeaderTrailingItems={
-        <Button
-          aria-label={t('Remove Filter')}
-          borderless
-          size="xs"
-          priority="link"
-          onClick={() => onRemoveFilter(globalFilter)}
-        >
-          {t('Remove')}
-        </Button>
-      }
+      menuTitle={t('%s Filter', getDatasetLabel(dataset))}
+      menuHeaderTrailingItems={({closeOverlay}: any) => (
+        <Flex gap="md">
+          {activeFilterValues.length > 0 && (
+            <StyledButton
+              aria-label={t('Clear Selections')}
+              size="zero"
+              borderless
+              onClick={() => {
+                handleChange([]);
+                closeOverlay();
+              }}
+            >
+              {t('Clear')}
+            </StyledButton>
+          )}
+          <StyledButton
+            aria-label={t('Remove Filter')}
+            size="zero"
+            onClick={() => onRemoveFilter(globalFilter)}
+          >
+            {t('Remove Filter')}
+          </StyledButton>
+        </Flex>
+      )}
       triggerProps={{
         children: (
           <FilterSelectorTrigger
@@ -132,3 +142,14 @@ function FilterSelector({
 }
 
 export default FilterSelector;
+
+const StyledButton = styled(Button)`
+  font-size: inherit;
+  font-weight: ${p => p.theme.fontWeight.normal};
+  color: ${p => p.theme.subText};
+  padding: 0 ${space(0.5)};
+  margin: ${p =>
+    p.theme.isChonk
+      ? `-${space(0.5)} -${space(0.5)}`
+      : `-${space(0.25)} -${space(0.25)}`};
+`;


### PR DESCRIPTION
Addresses UI feedback:
- Resets the addFilter component back to dataset selection upon closing the overlay.
- Disables filter key options in addFilter that already exist as global filters.
- Adds a clear button to the filter selector (displayed when options are selected).
- Wraps overflowing filters to a new line

<img width="497" height="272" alt="Screenshot 2025-10-20 at 12 49 47 PM" src="https://github.com/user-attachments/assets/ac7b5c8d-173c-4fa0-9d43-d60d9b4bf4f6" />
<img width="568" height="204" alt="Screenshot 2025-10-20 at 12 50 16 PM" src="https://github.com/user-attachments/assets/6efd2f39-4496-4077-8d9a-10313da26e86" />

<img width="1337" height="240" alt="Screenshot 2025-10-21 at 11 11 06 AM" src="https://github.com/user-attachments/assets/902f933d-7fae-4278-8287-8256b1462df2" />

Fixes [DAIN-1005](https://linear.app/getsentry/issue/DAIN-1005/refactor-global-filter-ui-to-address-feedback)
