### PR TITLE
fix(dashboards): Clear search input when returning to dataset selection in addFilter

### DIFF
--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -158,7 +158,7 @@ export interface ControlProps
    */
   menuFooter?:
     | React.ReactNode
-    | ((actions: {closeOverlay: () => void}) => React.ReactNode);
+    | ((actions: {closeOverlay: () => void; resetSearch: () => void}) => React.ReactNode);
   /**
    * Items to be displayed in the trailing (right) side of the menu's header.
    */
@@ -574,7 +574,10 @@ export function Control({
               {menuFooter && (
                 <MenuFooter>
                   {typeof menuFooter === 'function'
-                    ? menuFooter({closeOverlay: overlayState.close})
+                    ? menuFooter({
+                        closeOverlay: overlayState.close,
+                        resetSearch: () => updateSearch(''),
+                      })
                     : menuFooter}
                 </MenuFooter>
               )}

--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -79,14 +79,23 @@ function AddFilter({getSearchBarData, onAddFilter}: AddFilterProps) {
     : [];
 
   // Footer for filter key selection for adding filters and returning to dataset selection
-  const filterOptionsMenuFooter = ({closeOverlay}: {closeOverlay: () => void}) => (
+  const filterOptionsMenuFooter = ({
+    closeOverlay,
+    resetSearch,
+  }: {
+    closeOverlay: () => void;
+    resetSearch: () => void;
+  }) => (
     <FooterWrap>
       <Flex gap="md" justify="end">
         <Button
           size="xs"
           borderless
           icon={<IconArrow direction="left" />}
-          onClick={() => setIsSelectingFilterKey(false)}
+          onClick={() => {
+            resetSearch();
+            setIsSelectingFilterKey(false);
+          }}
         >
           {t('Back')}
         </Button>


### PR DESCRIPTION
Fixes bug where search input isn't reset when returning to dataset selection (in the addFilter component).

Before:

https://github.com/user-attachments/assets/7a556ed1-d9dc-464c-a688-1670045d6821

After:

https://github.com/user-attachments/assets/d33e8f62-c12a-4df2-b140-d46a1471df45

Fixes [DAIN-1004](https://linear.app/getsentry/issue/DAIN-1004/fix-bug-where-search-input-breaks-dataset-selection-in-addfilter)

