### PR TITLE
fix(prevent): Use repo and org id not name

### DIFF
--- a/static/app/types/prevent.tsx
+++ b/static/app/types/prevent.tsx
@@ -3,15 +3,14 @@ export type PreventAIProvider = 'github';
 
 export type Sensitivity = 'low' | 'medium' | 'high' | 'critical';
 
-interface PreventAIRepo {
+export interface PreventAIRepo {
   fullName: string;
   id: string;
   name: string;
-  url: string;
 }
 
 export interface PreventAIOrg {
-  id: string;
+  githubOrganizationId: string;
   name: string;
   provider: PreventAIProvider;
   repos: PreventAIRepo[];

--- a/static/app/views/prevent/preventAI/hooks/usePreventAIOrgRepos.spec.tsx
+++ b/static/app/views/prevent/preventAI/hooks/usePreventAIOrgRepos.spec.tsx
@@ -5,7 +5,6 @@ import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary'
 
 import {
   usePreventAIOrgRepos,
-  type PreventAIOrgReposApiResponse,
   type PreventAIOrgReposResponse,
 } from './usePreventAIOrgRepos';
 
@@ -14,24 +13,7 @@ describe('usePreventAIOrgRepos', () => {
     preventAiConfigGithub: PreventAIConfigFixture(),
   });
 
-  const mockResponse: PreventAIOrgReposApiResponse = {
-    orgRepos: [
-      {
-        githubOrganizationId: 1,
-        name: 'repo1',
-        provider: 'github',
-        repos: [{id: '1', name: 'repo1', fullName: 'org-1/repo1'}],
-      },
-      {
-        githubOrganizationId: 2,
-        name: 'repo2',
-        provider: 'github',
-        repos: [{id: '2', name: 'repo2', fullName: 'org-2/repo2'}],
-      },
-    ],
-  };
-
-  const transformedMockResponse: PreventAIOrgReposResponse = {
+  const mockResponse: PreventAIOrgReposResponse = {
     orgRepos: [
       {
         githubOrganizationId: '1',
@@ -62,7 +44,7 @@ describe('usePreventAIOrgRepos', () => {
       organization: mockOrg,
     });
 
-    await waitFor(() => expect(result.current.data).toEqual(transformedMockResponse));
+    await waitFor(() => expect(result.current.data).toEqual(mockResponse));
     expect(result.current.isError).toBe(false);
     expect(result.current.isPending).toBe(false);
   });
@@ -91,19 +73,9 @@ describe('usePreventAIOrgRepos', () => {
       organization: mockOrg,
     });
 
-    await waitFor(() => expect(result.current.data).toEqual(transformedMockResponse));
+    await waitFor(() => expect(result.current.data).toEqual(mockResponse));
 
-    const newResponse = {
-      orgRepos: [
-        {
-          githubOrganizationId: 3,
-          name: 'repo3',
-          provider: 'github',
-          repos: [{id: '3', name: 'repo3', fullName: 'org-3/repo3'}],
-        },
-      ],
-    };
-    const transformedNewResponse: PreventAIOrgReposResponse = {
+    const newResponse: PreventAIOrgReposResponse = {
       orgRepos: [
         {
           githubOrganizationId: '3',
@@ -120,6 +92,6 @@ describe('usePreventAIOrgRepos', () => {
 
     result.current.refetch();
     await waitFor(() => expect(result.current.data?.orgRepos?.[0]?.name).toBe('repo3'));
-    expect(result.current.data).toEqual(transformedNewResponse);
+    expect(result.current.data).toEqual(newResponse);
   });
 });

--- a/static/app/views/prevent/preventAI/hooks/usePreventAIOrgRepos.tsx
+++ b/static/app/views/prevent/preventAI/hooks/usePreventAIOrgRepos.tsx
@@ -1,21 +1,6 @@
-import {useMemo} from 'react';
-
 import type {PreventAIOrg} from 'sentry/types/prevent';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-
-export interface PreventAIOrgReposApiResponse {
-  orgRepos: Array<{
-    githubOrganizationId: number;
-    name: string;
-    provider: 'github';
-    repos: Array<{
-      fullName: string;
-      id: string;
-      name: string;
-    }>;
-  }>;
-}
 
 export interface PreventAIOrgReposResponse {
   orgRepos: PreventAIOrg[];
@@ -28,38 +13,16 @@ interface PreventAIOrgsReposResult {
   refetch: () => void;
 }
 
-function transformApiResponse(
-  apiResponse: PreventAIOrgReposApiResponse | undefined
-): PreventAIOrgReposResponse | undefined {
-  if (!apiResponse) {
-    return undefined;
-  }
-
-  return {
-    orgRepos: apiResponse.orgRepos.map(org => ({
-      ...org,
-      githubOrganizationId: String(org.githubOrganizationId),
-    })),
-  };
-}
-
 export function usePreventAIOrgRepos(): PreventAIOrgsReposResult {
   const organization = useOrganization();
 
-  const {
-    data: rawData,
-    isPending,
-    isError,
-    refetch,
-  } = useApiQuery<PreventAIOrgReposApiResponse>(
+  const {data, isPending, isError, refetch} = useApiQuery<PreventAIOrgReposResponse>(
     [`/organizations/${organization.slug}/prevent/github/repos/`],
     {
       staleTime: 0,
       retry: false,
     }
   );
-
-  const data = useMemo(() => transformApiResponse(rawData), [rawData]);
 
   return {
     data,

--- a/static/app/views/prevent/preventAI/hooks/usePreventAIOrgRepos.tsx
+++ b/static/app/views/prevent/preventAI/hooks/usePreventAIOrgRepos.tsx
@@ -1,6 +1,21 @@
+import {useMemo} from 'react';
+
 import type {PreventAIOrg} from 'sentry/types/prevent';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+
+export interface PreventAIOrgReposApiResponse {
+  orgRepos: Array<{
+    githubOrganizationId: number;
+    name: string;
+    provider: 'github';
+    repos: Array<{
+      fullName: string;
+      id: string;
+      name: string;
+    }>;
+  }>;
+}
 
 export interface PreventAIOrgReposResponse {
   orgRepos: PreventAIOrg[];
@@ -13,16 +28,38 @@ interface PreventAIOrgsReposResult {
   refetch: () => void;
 }
 
+function transformApiResponse(
+  apiResponse: PreventAIOrgReposApiResponse | undefined
+): PreventAIOrgReposResponse | undefined {
+  if (!apiResponse) {
+    return undefined;
+  }
+
+  return {
+    orgRepos: apiResponse.orgRepos.map(org => ({
+      ...org,
+      githubOrganizationId: String(org.githubOrganizationId),
+    })),
+  };
+}
+
 export function usePreventAIOrgRepos(): PreventAIOrgsReposResult {
   const organization = useOrganization();
 
-  const {data, isPending, isError, refetch} = useApiQuery<PreventAIOrgReposResponse>(
+  const {
+    data: rawData,
+    isPending,
+    isError,
+    refetch,
+  } = useApiQuery<PreventAIOrgReposApiResponse>(
     [`/organizations/${organization.slug}/prevent/github/repos/`],
     {
       staleTime: 0,
       retry: false,
     }
   );
+
+  const data = useMemo(() => transformApiResponse(rawData), [rawData]);
 
   return {
     data,

--- a/static/app/views/prevent/preventAI/hooks/useUpdatePreventAIFeature.spec.tsx
+++ b/static/app/views/prevent/preventAI/hooks/useUpdatePreventAIFeature.spec.tsx
@@ -77,8 +77,8 @@ describe('useUpdatePreventAIFeature', () => {
     result.current.enableFeature({
       feature: 'vanilla',
       enabled: true,
-      orgName: 'org-1',
-      repoName: 'repo-1',
+      orgId: 'org-1',
+      repoId: 'repo-1',
       trigger: {on_command_phrase: true},
     });
 
@@ -105,8 +105,8 @@ describe('useUpdatePreventAIFeature', () => {
       result.current.enableFeature({
         feature: 'vanilla',
         enabled: true,
-        orgName: 'org-1',
-        repoName: 'repo-1',
+        orgId: 'org-1',
+        repoId: 'repo-1',
         trigger: {on_command_phrase: true},
       })
     ).rejects.toBeDefined();
@@ -131,8 +131,8 @@ describe('useUpdatePreventAIFeature', () => {
       result.current.enableFeature({
         feature: 'vanilla',
         enabled: true,
-        orgName: 'org-1',
-        repoName: 'repo-1',
+        orgId: 'org-1',
+        repoId: 'repo-1',
       })
     ).rejects.toThrow('Organization has no AI Code Review config');
   });
@@ -143,7 +143,7 @@ describe('useUpdatePreventAIFeature', () => {
       const updatedConfig = makePreventAIConfig(config, {
         feature: 'vanilla',
         enabled: true,
-        orgName: 'org-1',
+        orgId: 'org-1',
       });
       expect(
         updatedConfig.github_organizations?.['org-1']?.org_defaults?.vanilla?.enabled
@@ -159,8 +159,8 @@ describe('useUpdatePreventAIFeature', () => {
       const updatedConfig = makePreventAIConfig(config, {
         feature: 'test_generation',
         enabled: true,
-        orgName: 'org-1',
-        repoName: 'repo-123',
+        orgId: 'org-1',
+        repoId: 'repo-123',
         trigger: {on_command_phrase: true},
       });
       expect(
@@ -180,8 +180,8 @@ describe('useUpdatePreventAIFeature', () => {
       const updatedConfig = makePreventAIConfig(config, {
         feature: 'bug_prediction',
         enabled: false,
-        orgName: 'org-1',
-        repoName: 'repo-xyz',
+        orgId: 'org-1',
+        repoId: 'repo-xyz',
         trigger: {on_ready_for_review: true},
       });
       const feature =
@@ -196,8 +196,8 @@ describe('useUpdatePreventAIFeature', () => {
       const updatedConfig = makePreventAIConfig(config, {
         feature: 'bug_prediction',
         enabled: true,
-        orgName: 'org-1',
-        repoName: 'repo-xyz',
+        orgId: 'org-1',
+        repoId: 'repo-xyz',
         sensitivity: 'low',
       });
       const feature =

--- a/static/app/views/prevent/preventAI/hooks/useUpdatePreventAIFeature.tsx
+++ b/static/app/views/prevent/preventAI/hooks/useUpdatePreventAIFeature.tsx
@@ -11,9 +11,9 @@ import useOrganization from 'sentry/utils/useOrganization';
 interface UpdatePreventAIFeatureParams {
   enabled: boolean;
   feature: 'vanilla' | 'test_generation' | 'bug_prediction';
-  orgName: string;
-  // if repoName is provided, edit repo_overrides for that repo, otherwise edit org_defaults
-  repoName?: string;
+  orgId: string;
+  // if repoId is provided, edit repo_overrides for that repo, otherwise edit org_defaults
+  repoId?: string;
   sensitivity?: Sensitivity;
   trigger?: Partial<PreventAIFeatureTriggers>;
 }
@@ -46,8 +46,8 @@ export function useUpdatePreventAIFeature() {
 /**
  * Makes a new PreventAIConfig object with feature settings applied for the specified org and/or repo
  * 1. Deep clones the original config to prevent mutation
- * 2. Get the org config for the specified orgName or create it from default_org_config template if not exists
- * 3. If editing repo, get the repo override for the specified repoName or create it from org_defaults template if not exists
+ * 2. Get the org config for the specified org or create it from default_org_config template if not exists
+ * 3. If editing repo, get the repo override for the specified repo or create it from org_defaults template if not exists
  * 4. Modifies the specified feature's settings, preserves any unspecified settings.
  *
  * @param originalConfig Original PreventAIConfig object (will not be mutated)
@@ -61,16 +61,16 @@ export function makePreventAIConfig(
   const updatedConfig = structuredClone(originalConfig);
 
   const orgConfig =
-    updatedConfig.github_organizations[params.orgName] ??
+    updatedConfig.github_organizations[params.orgId] ??
     structuredClone(updatedConfig.default_org_config);
-  updatedConfig.github_organizations[params.orgName] = orgConfig;
+  updatedConfig.github_organizations[params.orgId] = orgConfig;
 
   let featureConfig = orgConfig.org_defaults;
-  if (params.repoName) {
-    let repoOverride = orgConfig.repo_overrides[params.repoName];
+  if (params.repoId) {
+    let repoOverride = orgConfig.repo_overrides[params.repoId];
     if (!repoOverride) {
       repoOverride = structuredClone(orgConfig.org_defaults);
-      orgConfig.repo_overrides[params.repoName] = repoOverride;
+      orgConfig.repo_overrides[params.repoId] = repoOverride;
     }
     featureConfig = repoOverride;
   }

--- a/static/app/views/prevent/preventAI/manageRepos.spec.tsx
+++ b/static/app/views/prevent/preventAI/manageRepos.spec.tsx
@@ -11,7 +11,7 @@ describe('PreventAIManageRepos', () => {
   const github: PreventAIProvider = 'github';
   const installedOrgs = [
     {
-      id: 'org-1',
+      githubOrganizationId: 'org-1',
       name: 'Org One',
       provider: github,
       repos: [
@@ -30,7 +30,7 @@ describe('PreventAIManageRepos', () => {
       ],
     },
     {
-      id: 'org-2',
+      githubOrganizationId: 'org-2',
       name: 'Org Two',
       provider: github,
       repos: [

--- a/static/app/views/prevent/preventAI/manageRepos.tsx
+++ b/static/app/views/prevent/preventAI/manageRepos.tsx
@@ -22,39 +22,41 @@ function ManageReposPage({installedOrgs}: {installedOrgs: PreventAIOrg[]}) {
   const theme = useTheme();
   const [isPanelOpen, setIsPanelOpen] = useState(false);
 
-  const [selectedOrgName, setSelectedOrgName] = useState(
-    () => installedOrgs[0]?.name ?? ''
+  const [selectedOrgId, setSelectedOrgId] = useState<string>(
+    () => installedOrgs[0]?.githubOrganizationId ?? ''
   );
-  const [selectedRepoName, setSelectedRepoName] = useState(
-    () => installedOrgs[0]?.repos?.[0]?.name ?? ''
+  const [selectedRepoId, setSelectedRepoId] = useState<string>(
+    () => installedOrgs[0]?.repos?.[0]?.id ?? ''
   );
 
   // If the selected org is not present in the list of orgs, use the first org
   const selectedOrg = useMemo(() => {
-    const found = installedOrgs.find(org => org.name === selectedOrgName);
+    const found = installedOrgs.find(org => org.githubOrganizationId === selectedOrgId);
     return found ?? installedOrgs[0];
-  }, [installedOrgs, selectedOrgName]);
+  }, [installedOrgs, selectedOrgId]);
 
   // Ditto for repos
   const selectedRepo = useMemo(() => {
-    const found = selectedOrg?.repos?.find(repo => repo.name === selectedRepoName);
+    const found = selectedOrg?.repos?.find(repo => repo.id === selectedRepoId);
     return found ?? selectedOrg?.repos?.[0];
-  }, [selectedOrg, selectedRepoName]);
+  }, [selectedOrg, selectedRepoId]);
 
   // When the org changes, if the selected repo is not present in the new org,
   // use the first repo in the new org
-  const setSelectedOrgNameWithCascadeRepoName = useCallback(
-    (orgName: string) => {
-      setSelectedOrgName(orgName);
-      const newSelectedOrgData = installedOrgs.find(org => org.name === orgName);
+  const setSelectedOrgIdWithCascadeRepoId = useCallback(
+    (orgId: string) => {
+      setSelectedOrgId(orgId);
+      const newSelectedOrgData = installedOrgs.find(
+        org => org.githubOrganizationId === orgId
+      );
       if (
         newSelectedOrgData &&
-        !newSelectedOrgData.repos.some(repo => repo.name === selectedRepoName)
+        !newSelectedOrgData.repos.some(repo => repo.id === selectedRepoId)
       ) {
-        setSelectedRepoName(newSelectedOrgData.repos[0]?.name ?? '');
+        setSelectedRepoId(newSelectedOrgData.repos[0]?.id ?? '');
       }
     },
-    [installedOrgs, selectedRepoName]
+    [installedOrgs, selectedRepoId]
   );
 
   const isOrgSelected = !!selectedOrg;
@@ -65,10 +67,10 @@ function ManageReposPage({installedOrgs}: {installedOrgs: PreventAIOrg[]}) {
       <Flex align="center" justify="between">
         <ManageReposToolbar
           installedOrgs={installedOrgs}
-          selectedOrg={selectedOrgName}
-          selectedRepo={selectedRepoName}
-          onOrgChange={setSelectedOrgNameWithCascadeRepoName}
-          onRepoChange={setSelectedRepoName}
+          selectedOrg={selectedOrgId}
+          selectedRepo={selectedRepoId}
+          onOrgChange={setSelectedOrgIdWithCascadeRepoId}
+          onRepoChange={setSelectedRepoId}
         />
         <Flex style={{transform: 'translateY(-70px)'}}>
           <Tooltip
@@ -136,13 +138,15 @@ function ManageReposPage({installedOrgs}: {installedOrgs: PreventAIOrg[]}) {
         />
       </Flex>
 
-      <ManageReposPanel
-        key={`${selectedOrgName || 'no-org'}-${selectedRepoName || 'no-repo'}`}
-        collapsed={!isPanelOpen}
-        onClose={() => setIsPanelOpen(false)}
-        orgName={selectedOrg?.name ?? ''}
-        repoName={selectedRepo?.name ?? ''}
-      />
+      {selectedOrg && selectedRepo && (
+        <ManageReposPanel
+          key={`${selectedOrgId || 'no-org'}-${selectedRepoId || 'no-repo'}`}
+          collapsed={!isPanelOpen}
+          onClose={() => setIsPanelOpen(false)}
+          org={selectedOrg}
+          repo={selectedRepo}
+        />
+      )}
     </Flex>
   );
 }

--- a/static/app/views/prevent/preventAI/manageReposPanel.spec.tsx
+++ b/static/app/views/prevent/preventAI/manageReposPanel.spec.tsx
@@ -2,7 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import type {PreventAIOrgConfig} from 'sentry/types/prevent';
+import type {PreventAIOrg, PreventAIOrgConfig, PreventAIRepo} from 'sentry/types/prevent';
 import ManageReposPanel, {
   getRepoConfig,
 } from 'sentry/views/prevent/preventAI/manageReposPanel';
@@ -13,12 +13,24 @@ jest.mock('sentry/views/prevent/preventAI/hooks/useUpdatePreventAIFeature', () =
 }));
 
 describe('ManageReposPanel', () => {
+  const mockOrg: PreventAIOrg = {
+    githubOrganizationId: 'org-1',
+    name: 'org-1',
+    provider: 'github',
+    repos: [],
+  };
+
+  const mockRepo: PreventAIRepo = {
+    id: 'repo-1',
+    name: 'repo-1',
+    fullName: 'org-1/repo-1',
+  };
+
   const defaultProps = {
     collapsed: false,
     onClose: jest.fn(),
-    repoName: 'repo-1',
-    orgName: 'org-1',
-    repoFullName: 'org-1/repo-1',
+    org: mockOrg,
+    repo: mockRepo,
   };
 
   beforeEach(() => {

--- a/static/app/views/prevent/preventAI/manageReposToolbar.spec.tsx
+++ b/static/app/views/prevent/preventAI/manageReposToolbar.spec.tsx
@@ -7,7 +7,7 @@ describe('ManageReposToolbar', () => {
   const github: PreventAIProvider = 'github';
   const installedOrgs: PreventAIOrg[] = [
     {
-      id: '1',
+      githubOrganizationId: '1',
       name: 'org-1',
       provider: github,
       repos: [
@@ -15,18 +15,16 @@ describe('ManageReposToolbar', () => {
           id: '1',
           name: 'repo-1',
           fullName: 'org-1/repo-1',
-          url: 'https://github.com/org-1/repo-1',
         },
         {
           id: '2',
           name: 'repo-2',
           fullName: 'org-1/repo-2',
-          url: 'https://github.com/org-1/repo-2',
         },
       ],
     },
     {
-      id: '2',
+      githubOrganizationId: '2',
       name: 'org-2',
       provider: github,
       repos: [
@@ -34,7 +32,6 @@ describe('ManageReposToolbar', () => {
           id: '3',
           name: 'repo-3',
           fullName: 'org-2/repo-3',
-          url: 'https://github.com/org-2/repo-3',
         },
       ],
     },
@@ -42,8 +39,8 @@ describe('ManageReposToolbar', () => {
 
   const defaultProps = {
     installedOrgs,
-    selectedOrg: 'org-1',
-    selectedRepo: 'repo-1',
+    selectedOrg: '1',
+    selectedRepo: '1',
     onOrgChange: jest.fn(),
     onRepoChange: jest.fn(),
   };
@@ -80,11 +77,11 @@ describe('ManageReposToolbar', () => {
     const orgOption = await screen.findByText('org-2');
     await userEvent.click(orgOption);
 
-    expect(defaultProps.onOrgChange).toHaveBeenCalledWith('org-2');
+    expect(defaultProps.onOrgChange).toHaveBeenCalledWith('2');
   });
 
   it('calls onRepoChange when repository is changed', async () => {
-    render(<ManageReposToolbar {...defaultProps} selectedRepo="repo-1" />);
+    render(<ManageReposToolbar {...defaultProps} selectedRepo="1" />);
     // Open the repo select dropdown
     const repoTrigger = await screen.findByRole('button', {name: /repo-1/i});
     await userEvent.click(repoTrigger);
@@ -93,13 +90,11 @@ describe('ManageReposToolbar', () => {
     const repoOption = await screen.findByText('repo-2');
     await userEvent.click(repoOption);
 
-    expect(defaultProps.onRepoChange).toHaveBeenCalledWith('repo-2');
+    expect(defaultProps.onRepoChange).toHaveBeenCalledWith('2');
   });
 
   it('shows only repos for the selected org', async () => {
-    render(
-      <ManageReposToolbar {...defaultProps} selectedOrg="org-2" selectedRepo="repo-3" />
-    );
+    render(<ManageReposToolbar {...defaultProps} selectedOrg="2" selectedRepo="3" />);
     // Open the repo select dropdown
     const repoTrigger = await screen.findByRole('button', {name: /repo-3/i});
     await userEvent.click(repoTrigger);

--- a/static/app/views/prevent/preventAI/manageReposToolbar.tsx
+++ b/static/app/views/prevent/preventAI/manageReposToolbar.tsx
@@ -15,25 +15,25 @@ function ManageReposToolbar({
   selectedRepo,
 }: {
   installedOrgs: PreventAIOrg[];
-  onOrgChange: (orgName: string) => void;
-  onRepoChange: (repoName: string) => void;
+  onOrgChange: (orgId: string) => void;
+  onRepoChange: (repoId: string) => void;
   selectedOrg: string;
   selectedRepo: string;
 }) {
   const organizationOptions = useMemo(
     () =>
       installedOrgs.map(org => ({
-        value: org.name,
+        value: org.githubOrganizationId,
         label: org.name,
       })),
     [installedOrgs]
   );
 
   const repositoryOptions = useMemo(() => {
-    const org = installedOrgs.find(o => o.name === selectedOrg);
+    const org = installedOrgs.find(o => o.githubOrganizationId === selectedOrg);
     return (
       org?.repos.map(repo => ({
-        value: repo.name,
+        value: repo.id,
         label: repo.name,
       })) ?? []
     );


### PR DESCRIPTION
Use the org id and repo id in the payloads instead of names for prevent ai config

Closes https://linear.app/getsentry/issue/PREVENT-400/see-where-we-can-use-ids-instead-of-the-names-in-the-query