### PR TITLE
feat(replay): Adding Tap on Replay Search

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2809,6 +2809,13 @@ export enum ReplayClickFieldKey {
   CLICK_TEXT_CONTENT = 'click.textContent',
   CLICK_TITLE = 'click.title',
   CLICK_COMPONENT_NAME = 'click.component_name',
+  CLICK_TEST = 'click.test',
+}
+
+export enum ReplayTapFieldKey {
+  TAP_MESSAGE = 'tap.message',
+  TAP_VIEW_ID = 'tap.view_id',
+  TAP_VIEW_CLASS = 'tap.view_class',
 }
 
 /**
@@ -3041,6 +3048,13 @@ export const REPLAY_CLICK_FIELDS = [
   ReplayClickFieldKey.CLICK_TITLE,
   ReplayClickFieldKey.CLICK_TESTID,
   ReplayClickFieldKey.CLICK_COMPONENT_NAME,
+  ReplayClickFieldKey.CLICK_TEST,
+];
+
+export const REPLAY_TAP_FIELDS = [
+  ReplayTapFieldKey.TAP_MESSAGE,
+  ReplayTapFieldKey.TAP_VIEW_ID,
+  ReplayTapFieldKey.TAP_VIEW_CLASS,
 ];
 
 // This is separated out from REPLAY_FIELD_DEFINITIONS so that it is feature-flaggable
@@ -3113,6 +3127,29 @@ const REPLAY_CLICK_FIELD_DEFINITIONS: Record<ReplayClickFieldKey, FieldDefinitio
   },
   [ReplayClickFieldKey.CLICK_COMPONENT_NAME]: {
     desc: t('the name of the frontend component that was clicked'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [ReplayClickFieldKey.CLICK_TEST]: {
+    desc: t('im testing'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+};
+
+const REPLAY_TAP_FIELD_DEFINITIONS: Record<ReplayTapFieldKey, FieldDefinition> = {
+  [ReplayTapFieldKey.TAP_MESSAGE]: {
+    desc: t('`Message` of an element that was tapped'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [ReplayTapFieldKey.TAP_VIEW_CLASS]: {
+    desc: t('`View Class` of an element that was tapped'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [ReplayTapFieldKey.TAP_VIEW_ID]: {
+    desc: t('`View ID` of an element that was tapped'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
@@ -3231,6 +3268,11 @@ export const getFieldDefinition = (
       if (REPLAY_CLICK_FIELD_DEFINITIONS.hasOwnProperty(key)) {
         return REPLAY_CLICK_FIELD_DEFINITIONS[
           key as keyof typeof REPLAY_CLICK_FIELD_DEFINITIONS
+        ];
+      }
+      if (REPLAY_TAP_FIELD_DEFINITIONS.hasOwnProperty(key)) {
+        return REPLAY_TAP_FIELD_DEFINITIONS[
+          key as keyof typeof REPLAY_TAP_FIELD_DEFINITIONS
         ];
       }
       if (REPLAY_FIELDS.includes(key as FieldKey)) {

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2809,10 +2809,9 @@ export enum ReplayClickFieldKey {
   CLICK_TEXT_CONTENT = 'click.textContent',
   CLICK_TITLE = 'click.title',
   CLICK_COMPONENT_NAME = 'click.component_name',
-  CLICK_TEST = 'click.test',
 }
 
-export enum ReplayTapFieldKey {
+enum ReplayTapFieldKey {
   TAP_MESSAGE = 'tap.message',
   TAP_VIEW_ID = 'tap.view_id',
   TAP_VIEW_CLASS = 'tap.view_class',
@@ -3048,7 +3047,6 @@ export const REPLAY_CLICK_FIELDS = [
   ReplayClickFieldKey.CLICK_TITLE,
   ReplayClickFieldKey.CLICK_TESTID,
   ReplayClickFieldKey.CLICK_COMPONENT_NAME,
-  ReplayClickFieldKey.CLICK_TEST,
 ];
 
 export const REPLAY_TAP_FIELDS = [
@@ -3127,11 +3125,6 @@ const REPLAY_CLICK_FIELD_DEFINITIONS: Record<ReplayClickFieldKey, FieldDefinitio
   },
   [ReplayClickFieldKey.CLICK_COMPONENT_NAME]: {
     desc: t('the name of the frontend component that was clicked'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [ReplayClickFieldKey.CLICK_TEST]: {
-    desc: t('im testing'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -99,14 +99,14 @@ const getFilterKeySections = (tags: TagCollection): FilterKeySection[] => {
       children: Object.keys(REPLAY_CLICK_FIELDS_AS_TAGS),
     },
     {
-      value: FieldKind.TAG,
-      label: t('Tags'),
-      children: orderedTagKeys,
-    },
-    {
       value: 'replay_tap_field',
       label: t('Tap Fields'),
       children: Object.keys(REPLAY_TAP_FIELDS_AS_TAGS),
+    },
+    {
+      value: FieldKind.TAG,
+      label: t('Tags'),
+      children: orderedTagKeys,
     },
   ];
 };

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -19,6 +19,7 @@ import {
   REPLAY_CLICK_FIELDS,
   REPLAY_FIELDS,
   REPLAY_TAG_ALIASES,
+  REPLAY_TAP_FIELDS,
 } from 'sentry/utils/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
@@ -41,6 +42,7 @@ function fieldDefinitionsToTagCollection(fieldKeys: string[]): TagCollection {
 
 const REPLAY_FIELDS_AS_TAGS = fieldDefinitionsToTagCollection(REPLAY_FIELDS);
 const REPLAY_CLICK_FIELDS_AS_TAGS = fieldDefinitionsToTagCollection(REPLAY_CLICK_FIELDS);
+const REPLAY_TAP_FIELDS_AS_TAGS = fieldDefinitionsToTagCollection(REPLAY_TAP_FIELDS);
 /**
  * Excluded from the display but still valid search queries. browser.name,
  * device.name, etc are effectively the same and included from REPLAY_FIELDS.
@@ -57,6 +59,7 @@ function getReplayFilterKeys(supportedTags: TagCollection): TagCollection {
   return {
     ...REPLAY_FIELDS_AS_TAGS,
     ...REPLAY_CLICK_FIELDS_AS_TAGS,
+    ...REPLAY_TAP_FIELDS_AS_TAGS,
     ...Object.fromEntries(
       Object.keys(supportedTags)
         .filter(key => !EXCLUDED_TAGS.includes(key))
@@ -76,7 +79,8 @@ const getFilterKeySections = (tags: TagCollection): FilterKeySection[] => {
     tag =>
       !EXCLUDED_TAGS.includes(tag.key) &&
       !REPLAY_FIELDS.map(String).includes(tag.key) &&
-      !REPLAY_CLICK_FIELDS.map(String).includes(tag.key)
+      !REPLAY_CLICK_FIELDS.map(String).includes(tag.key) &&
+      !REPLAY_TAP_FIELDS.map(String).includes(tag.key)
   );
 
   const orderedTagKeys = orderBy(customTags, ['totalValues', 'key'], ['desc', 'asc']).map(
@@ -98,6 +102,11 @@ const getFilterKeySections = (tags: TagCollection): FilterKeySection[] => {
       value: FieldKind.TAG,
       label: t('Tags'),
       children: orderedTagKeys,
+    },
+    {
+      value: 'replay_tap_field',
+      label: t('Tap Fields'),
+      children: Object.keys(REPLAY_TAP_FIELDS_AS_TAGS),
     },
   ];
 };


### PR DESCRIPTION
This PR adds taps to the replay search:

<img width="1606" height="399" alt="image" src="https://github.com/user-attachments/assets/94e490b8-7309-4abf-8208-2cc7c107e52f" />


Relates To: https://linear.app/getsentry/issue/REPLAY-774/add-tap-search-functionality-to-frontend