### PR TITLE
feat(aci): Add dedicated counter for process_update executions

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -744,6 +744,7 @@ class SubscriptionProcessor:
                 tags={"dual_processing": self._has_workflow_engine_processing},
             ),
         ):
+            metrics.incr("incidents.alert_rules.process_update.start")
             detector = self.get_detector(self._has_workflow_engine_processing)
             comparison_delta = self.get_comparison_delta(detector)
             aggregation_value = self.get_aggregation_value(subscription_update, comparison_delta)

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
@@ -385,7 +385,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
         self.metrics.incr.reset_mock()
         self.send_update(self.rule, self.trigger.alert_threshold, timedelta(hours=1))
-        assert self.metrics.incr.call_count == 0
+        self.metrics.incr.assert_called_once_with("incidents.alert_rules.process_update.start")
 
     def test_no_alert(self) -> None:
         rule = self.rule
@@ -1808,7 +1808,7 @@ class ProcessUpdateComparisonAlertTest(ProcessUpdateTest):
         self.assert_no_active_incident(rule)
         self.assert_trigger_does_not_exist(trigger)
         self.assert_action_handler_called_with_actions(None, [])
-        assert self.metrics.incr.call_count == 0
+        self.metrics.incr.assert_called_once_with("incidents.alert_rules.process_update.start")
 
         processor = self.send_update(rule, 4, timedelta(minutes=-8), subscription=self.sub)
         # Shouldn't trigger, since there are 4 events in the comparison period, and 4/4 == 100%, so
@@ -1919,7 +1919,7 @@ class ProcessUpdateComparisonAlertTest(ProcessUpdateTest):
         self.assert_no_active_incident(rule)
         self.assert_trigger_does_not_exist(trigger)
         self.assert_action_handler_called_with_actions(None, [])
-        assert self.metrics.incr.call_count == 0
+        self.metrics.incr.assert_called_once_with("incidents.alert_rules.process_update.start")
 
         processor = self.send_update(rule, 4, timedelta(minutes=-8), subscription=self.sub)
         # Shouldn't trigger, since there are 4 events in the comparison period, and 4/4 == 100%, so
@@ -2016,7 +2016,7 @@ class ProcessUpdateComparisonAlertTest(ProcessUpdateTest):
         self.assert_no_active_incident(rule)
         self.assert_trigger_does_not_exist(trigger)
         self.assert_action_handler_called_with_actions(None, [])
-        assert self.metrics.incr.call_count == 0
+        self.metrics.incr.assert_called_once_with("incidents.alert_rules.process_update.start")
 
         processor = self.send_update(rule, 4, timedelta(minutes=-8), subscription=self.sub)
         # Shouldn't trigger, since there are 4 events in the comparison period, and 4/4== 100%
@@ -2128,7 +2128,7 @@ class ProcessUpdateComparisonAlertTest(ProcessUpdateTest):
         self.assert_no_active_incident(rule)
         self.assert_trigger_does_not_exist(trigger)
         self.assert_action_handler_called_with_actions(None, [])
-        assert self.metrics.incr.call_count == 0
+        self.metrics.incr.assert_called_once_with("incidents.alert_rules.process_update.start")
 
         processor = self.send_update(rule, 4, timedelta(minutes=-8), subscription=self.sub)
         # Shouldn't trigger, since there are 4 events in the comparison period, and 4/4 == 100%, so
@@ -2227,7 +2227,7 @@ class ProcessUpdateComparisonAlertTest(ProcessUpdateTest):
         self.assert_no_active_incident(rule)
         self.assert_trigger_does_not_exist(trigger)
         self.assert_action_handler_called_with_actions(None, [])
-        assert self.metrics.incr.call_count == 0
+        self.metrics.incr.assert_called_once_with("incidents.alert_rules.process_update.start")
 
         processor = self.send_update(rule, 4, timedelta(minutes=-8), subscription=self.sub)
         # Shouldn't trigger, since there are 4 events in the comparison period, and 4/4 == 100%, so

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -330,11 +330,13 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
         )
         mock_metrics.incr.assert_has_calls(
             [
+                call("incidents.alert_rules.process_update.start"),
                 call(
                     "incidents.alert_rules.threshold.alert",
                     tags={"detection_type": "static"},
                 ),
                 call("incidents.alert_rules.trigger", tags={"type": "fire"}),
+                call("incidents.alert_rules.process_update.start"),
                 call(
                     "incidents.alert_rules.threshold.resolve",
                     tags={"detection_type": "static"},


### PR DESCRIPTION
Thus far we've been using incidents.alert_rules.process_update.count as our top-level count, but it is consistently higher than the sum of all known branches of code execution.
This could be the result of some surprising flow of execution we haven't accounted for, but it also seems possible it is a consequence of distribution aggregation going through some extra stages in our metrics pipeline and being sampled differently.

To resolve the question, we can add a simple counter which should behave similarly to the other counters; if it is consistent with the timer counter, something interesting is happening, and if not, it's a metrics artifact and we're really at 100% single processing.
