### PR TITLE
fix(eco): Fixes routing to region for github issue created/deleted webhooks

### DIFF
--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -61,7 +61,11 @@ class GithubRequestParser(BaseRequestParser):
         except orjson.JSONDecodeError:
             return HttpResponse(status=400)
 
-        if event.get("installation") and event.get("action") in {"created", "deleted"}:
+        if (
+            event.get("installation")
+            and not event.get("issue")
+            and event.get("action") in {"created", "deleted"}
+        ):
             self.try_forward_to_codecov(event=event)
             return self.get_response_from_control_silo()
 


### PR DESCRIPTION
We recently expanded Github webhook events to include issue events. Unfortunately, there's not good differentiation between installation and issue created/deleted webhooks, so our handling code has been breaking with Silo errors.

For reference:
[Github Installation Deleted Docs](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=deleted#installation)
[Github Issue Deleted Docs](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=deleted#issues)

Fixes SENTRY-5ADE

